### PR TITLE
doc: add DeepSeek API URL to .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,6 +28,7 @@ GLM_API_KEY=""
 
 # DeepSeek
 DEEPSEEK_API_KEY=""
+DEEPSEEK_API_URL=""
 
 # Alibaba CLoud Qwen
 QWEN_API_KEY=""

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,12 +15,12 @@ ERNIE_API_ID=""
 ERNIE_API_SECRET=""
 ERNIE_API_KEY=""
 
-# ARK
+# ByteDance Volcengine Ark
 ARK_API_KEY=""
 ARK_ACCESS_KEY_ID=""
 ARK_SECRET_ACCESS_KEY=""
 
-# SILICON
+# SiliconFlow
 SILICON_API_KEY=""
 
 # Zhipu BigModel


### PR DESCRIPTION
@yfge Do **NOT** squash this PR. The two commits are packed well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable for configuring the DeepSeek API URL.
  - Updated comments for API keys to enhance clarity regarding their associated services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->