### PR TITLE
fix: correct spelling of 'userAgreement' in multiple files

### DIFF
--- a/src/web/public/locales/en-US.json
+++ b/src/web/public/locales/en-US.json
@@ -42,7 +42,7 @@
     "loginTitle": "Login",
     "loginFeedback": "Submit feedback",
     "msgHaveRead": "I have read and agreed to ",
-    "msgAggrement": "The Service Agreement",
+    "msgAgreement": "The Service Agreement",
     "msgAnd": " and ",
     "msgPrivacyPolicy": "The Privacy Policy",
     "msgToAgree": "Please check to agree to the terms",
@@ -91,7 +91,7 @@
     "icp": "Beijing ICP No.2024076754 -2",
     "gongan": "Beijing Public Security No.11010502055644 ",
     "feedbackTitle": "Submit Feedback",
-    "userAggrement": "Service Agreement",
+    "userAgreement": "Service Agreement",
     "privacyPolicy": "Privacy Policy",
     "contactUs": "Contact Us",
     "shortcut": "Shortcut"

--- a/src/web/public/locales/zh-CN.json
+++ b/src/web/public/locales/zh-CN.json
@@ -42,7 +42,7 @@
     "loginTitle": "登录",
     "loginFeedback": "提交反馈",
     "msgHaveRead": "我已阅读并同意",
-    "msgAggrement": "服务协议",
+    "msgAgreement": "服务协议",
     "msgAnd": "&",
     "msgPrivacyPolicy": "隐私政策",
     "msgToAgree": "请勾选同意协议",
@@ -91,7 +91,7 @@
     "icp": "京ICP备2024076754号-2",
     "gongan": "京公网安备11010502055644号",
     "feedbackTitle": "提交反馈",
-    "userAggrement": "服务协议",
+    "userAgreement": "服务协议",
     "privacyPolicy": "隐私协议",
     "contactUs": "联系我们",
     "shortcut": "快捷键"

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/GlobalInfoButton.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/GlobalInfoButton.tsx
@@ -60,11 +60,11 @@ const GlobalInfoButton = ({ className }) => {
     },
     {
       key: '3',
-      label: t('navigation.userAggrement'),
+      label: t('navigation.userAgreement'),
       icon: <img className={styles.rowIcon} src={OpenLinkIcon} alt="icon" />,
       onClick: () => {
         onPopoverClose();
-        window.open('/useraggrement');
+        window.open('/useragreement');
       },
     },
     {

--- a/src/web/src/Pages/NewChatPage/Components/Login/LoginModal.module.scss
+++ b/src/web/src/Pages/NewChatPage/Components/Login/LoginModal.module.scss
@@ -46,13 +46,13 @@
     }
   }
 
-  .aggrementWrapper {
+  .agreementWrapper {
     display: flex;
     flex-flow: column;
     align-items: center;
     font-size: var(--font-size-5);
 
-    .aggrement {
+    .agreement {
       display: flex;
       flex-flow: row wrap;
 

--- a/src/web/src/Pages/NewChatPage/Components/Login/LoginModal.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/Login/LoginModal.tsx
@@ -32,7 +32,7 @@ export const LoginModal = ({
   const [verifyCodeForm] = Form.useForm();
   const [modalStep, setModalStep] = useState(MODAL_STEP.MOBILE);
   const [countDown, sendCode] = useSendCode({});
-  const [aggrement, setAggrement] = useState(false);
+  const [agreement, setAgreement] = useState(false);
   const [verifyCodeImage, setVerifyCodeImage] = useState('');
   const [messageApi, contextHolder] = message.useMessage();
   const login = useUserStore((state) => state.login);
@@ -83,7 +83,7 @@ export const LoginModal = ({
     try {
       const { smsCode } = await codeForm.validateFields();
 
-      if (!aggrement) {
+      if (!agreement) {
         messageApi.error(t('user.msgToAgree'));
         return;
       }
@@ -237,18 +237,18 @@ export const LoginModal = ({
           style={{ display: 'none' }}
         ></div>
       </div>
-      <div className={styles.aggrementWrapper}>
-        <div className={styles.aggrement}>
+      <div className={styles.agreementWrapper}>
+        <div className={styles.agreement}>
           <Checkbox
             className={styles.checkbox}
-            onChange={(e) => setAggrement(e.target.checked)}
+            onChange={(e) => setAgreement(e.target.checked)}
           >
             {t('user.msgHaveRead')}
             <span
               className={styles.link}
             >
-              <a href="/useraggrement" target="_blank" rel="noreferrer">
-                {t('user.msgAggrement')}
+              <a href="/useragreement" target="_blank" rel="noreferrer">
+                {t('user.msgAgreement')}
               </a>
               {t('user.msgAnd')}
               <a

--- a/src/web/src/Pages/NewChatPage/Components/NavDrawer/FilingModal.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/NavDrawer/FilingModal.tsx
@@ -54,10 +54,10 @@ export const FillingModal = ({
             type="link"
             className={styles.actionBtn}
             onClick={(e) => {
-              window.open('/useraggrement');
+              window.open('/useragreement');
             }}
           >
-            {t('navigation.userAggrement')}
+            {t('navigation.userAgreement')}
           </Button>
           <div>|</div>
           <Button

--- a/src/web/src/Pages/NewChatPage/Components/Pay/PayModalFooter.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/Pay/PayModalFooter.tsx
@@ -10,7 +10,7 @@ export const PayModalFooter = ({ className }) => {
       <div className={styles.protocalLinks}>
         <a
           className={styles.protocalLink}
-          href="/useraggrement"
+          href="/useragreement"
           target="_blank"
           referrerPolicy="no-referrer"
         >

--- a/src/web/src/Router/index.tsx
+++ b/src/web/src/Router/index.tsx
@@ -14,7 +14,7 @@ const routes = [
     element: <Navigate to='/c/'></Navigate>,
   },
   {
-    path: '/useraggrement',
+    path: '/useragreement',
     element: <UserAgreementPage />
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typographical errors in user agreement labels, ensuring that all displayed text and navigation links now use the proper spelling of "Agreement."
  
- **Style**
  - Adjusted styling and layout elements for consistency with the corrected user agreement terminology, enhancing clarity and overall user interface cohesion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->