### PR TITLE
Fix api path spelling

### DIFF
--- a/src/cook-web/src/components/render-ui/goto.tsx
+++ b/src/cook-web/src/components/render-ui/goto.tsx
@@ -72,7 +72,7 @@ export default function Goto(props: ButtonProps) {
         })
     }
     const loadProfileItemDefinations = async () => {
-        const list = await api.getProfileItemDefinations({
+        const list = await api.getProfileItemDefinitions({
             parent_id: currentScenario?.id
         })
         setProfileItemDefinations(list)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed a spelling error in the API path and related function names for getting profile item definitions to prevent API call failures.

<!-- End of auto-generated description by mrge. -->

