### PR TITLE
Display outline name in gogo

### DIFF
--- a/src/cook-web/src/components/outline-selector/index.tsx
+++ b/src/cook-web/src/components/outline-selector/index.tsx
@@ -5,6 +5,7 @@ import { Outline } from '@/types/scenario';
 import { cn } from '@/lib/utils';
 import { useScenario } from '@/store/useScenario';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../ui/dropdown-menu';
+import { useEffect } from 'react';
 interface ICataTreeProps {
     currentNode?: Outline;
     items: TreeItems<Outline>;
@@ -15,14 +16,11 @@ interface ICataTreeProps {
 export const CataTree = React.memo((props: ICataTreeProps) => {
     const { items, onChange, } = props;
     const onItemsChanged = (data: TreeItems<Outline>) => {
-
         onChange?.(data);
     }
-
     const onSelect = (node: Outline) => {
         props.onSelect?.(node);
     }
-
     return (
         <SortableTree
             disableSorting={true}
@@ -86,15 +84,36 @@ export default function OutlineSelector({ value, chapters = [], onSelect }: { va
     "use client"
     const [nodes, setNodes] = useState(chapters);
     const [open, setOpen] = useState(false);
+    const [selectedNode, setSelectedNode] = useState<Outline | null>(null);
     const onNodeSelect = (node: Outline) => {
         setOpen(false);
         onSelect?.(node);
+        setSelectedNode(node);
+        value = node.id;
     }
+    useEffect(() => {
+        console.log("value", value);
+        for (const chapter of chapters) {
+            if (chapter.id === value) {
+                setSelectedNode(chapter);
+                console.log("chapter", chapter);
+                break;
+            }
+            for (const child of chapter.children || []) {
+                if (child.id === value) {
+                    setSelectedNode(child);
+                    console.log("child", child);
+                    break;
+                }
+            }
+
+        }
+    }, [value,chapters]);
     return (
         <DropdownMenu open={open} onOpenChange={setOpen}>
             <DropdownMenuTrigger>
                 {
-                    value || "选择章节"
+                    selectedNode ? (selectedNode.no + ":" + selectedNode.name) : "选择章节"
                 }
             </DropdownMenuTrigger>
             <DropdownMenuContent align='start'>

--- a/src/cook-web/src/components/outline-selector/index.tsx
+++ b/src/cook-web/src/components/outline-selector/index.tsx
@@ -92,18 +92,15 @@ export default function OutlineSelector({ value, chapters = [], onSelect }: { va
         value = node.id;
     }
     useEffect(() => {
-        console.log("value", value);
         for (const chapter of chapters) {
             if (chapter.id === value) {
                 setSelectedNode(chapter);
-                console.log("chapter", chapter);
-                break;
+                return;
             }
             for (const child of chapter.children || []) {
                 if (child.id === value) {
                     setSelectedNode(child);
-                    console.log("child", child);
-                    break;
+                    return;
                 }
             }
 

--- a/src/cook-web/src/components/render-ui/goto.tsx
+++ b/src/cook-web/src/components/render-ui/goto.tsx
@@ -40,6 +40,7 @@ export default function Goto(props: GotoProps) {
         chapters,
         currentScenario
     } = useScenario();
+    
     const [profileItemDefinations, setProfileItemDefinations] = useState<ProfileItemDefination[]>([]);
     const [profileItemId, setProfileItemId] = useState("");
     const [profileItemName, setProfileItemName] = useState("");
@@ -159,7 +160,7 @@ export default function Goto(props: GotoProps) {
                     {
                         properties.goto_settings.items.map((item, index) => {
                             return (
-                                <div className='flex flex-row items-center space-x-2' key={index}>
+                                <div className='flex flex-row items-center space-x-2' key={`${item.value}-${index}`}>
                                     <span className='w-40'>{item.value}</span>
                                     <span className='px-2'>跳转到</span>
                                     <span>

--- a/src/cook-web/src/components/render-ui/goto.tsx
+++ b/src/cook-web/src/components/render-ui/goto.tsx
@@ -6,7 +6,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { useScenario } from '@/store'
 import { Outline } from '@/types/scenario'
 import api from '@/api'
-
 interface ColorSetting {
     color: string;
     text_color: string;
@@ -78,7 +77,6 @@ export default function Goto(props: GotoProps) {
         if (profileItemDefinations.length > 0) {
             const selectedItem = profileItemDefinations.find((item) => item.profile_key === properties.goto_settings.profile_key);
             if (selectedItem) {
-                console.log('loadProfileItemDefinations', selectedItem)
                 setProfileItemId(selectedItem.profile_id);
             }
         }
@@ -92,7 +90,6 @@ export default function Goto(props: GotoProps) {
         const list = await api.getProfileItemOptionList({
             parent_id: profileItemId
         })
-        console.log(list)
         props.onChange({
             ...properties,
             goto_settings: {
@@ -108,16 +105,6 @@ export default function Goto(props: GotoProps) {
         })
         setProfileItemDefinations(list)
     }
-    useEffect(() => {
-        console.log('current profileItemId:', profileItemId);
-    }, [profileItemId]);
-    // const addProfileItem = async () => {
-    //     await api.addProfileItem({
-    //         parent_id: currentScenario?.id,
-    //         profile_key: profileItemName
-    //     })
-    //     loadProfileItemDefinations();
-    // }
     useEffect(() => {
         init();
     }, [])
@@ -163,12 +150,6 @@ export default function Goto(props: GotoProps) {
                         }
                     </SelectContent>
                 </Select>
-                    {/* <Input value={profileItemName} onChange={(e) => {
-                        setProfileItemName(e.target.value)
-                    }}></Input>
-                    <Button onClick={addProfileItem} className='h-8'>
-                        添加变量
-                    </Button> */}
             </div>
             <div className='flex flex-row items-start py-2'>
                 <div className='flex flex-row whitespace-nowrap'>

--- a/src/cook-web/src/store/useScenario.tsx
+++ b/src/cook-web/src/store/useScenario.tsx
@@ -171,6 +171,7 @@ export const ScenarioProvider: React.FC<{ children: ReactNode }> = ({ children }
                     id: chapter.id,
                     name: chapter.name,
                     children: chapter.children,
+                    no: chapter.no,
                 }
             })
             if (list.length > 0) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
The outline selector and goto components now display both the lesson number and name, making it easier to identify chapters.

- **UI Improvements**
  - Updated dropdowns to show lesson number and name together.
  - Cleaned up unused code in the goto component.

<!-- End of auto-generated description by mrge. -->

