### PR TITLE
fix: fix outline modification failure after publish

### DIFF
--- a/src/api/flaskr/service/scenario/adapter.py
+++ b/src/api/flaskr/service/scenario/adapter.py
@@ -418,6 +418,6 @@ def generate_block_dto(block: AILessonScript, profile_items: list[ProfileItem]):
         app.logger.info(f"items: {items}")
         app.logger.info(f"block.script_ui_content: {block.script_ui_content}")
         ret.block_ui = OptionDto(
-            block.script_ui_content, block.script_ui_content, profile_key, items
+            profile_key, profile_key, profile_key, items
         )
     return ret

--- a/src/api/flaskr/service/scenario/funcs.py
+++ b/src/api/flaskr/service/scenario/funcs.py
@@ -277,8 +277,23 @@ def publish_scenario(app, user_id, scenario_id: str):
                     )
                 elif to_publish_lesson.status == STATUS_PUBLISH:
                     to_publish_lesson.status = STATUS_PUBLISH
+                    AILesson.query.filter(
+                        AILesson.lesson_id == to_publish_lesson.lesson_id,
+                        AILesson.status.in_([STATUS_PUBLISH]),
+                        AILesson.id != to_publish_lesson.id,
+                    ).update(
+                        {"status": STATUS_HISTORY, "updated_user_id": user_id, "updated": datetime.now(),}
+                    )
+                    
                 elif to_publish_lesson.status == STATUS_DRAFT:
                     to_publish_lesson.status = STATUS_PUBLISH
+                    AILesson.query.filter(
+                        AILesson.lesson_id == to_publish_lesson.lesson_id,
+                        AILesson.status.in_([STATUS_PUBLISH]),
+                        AILesson.id != to_publish_lesson.id,
+                    ).update(
+                        {"status": STATUS_HISTORY, "updated_user_id": user_id, "updated": datetime.now(),}
+                    )
                 to_publish_lesson.updated_user_id = user_id
                 to_publish_lesson.updated = datetime.now()
                 db.session.add(to_publish_lesson)
@@ -301,8 +316,23 @@ def publish_scenario(app, user_id, scenario_id: str):
 
                     elif block_script.status == STATUS_DRAFT:
                         block_script.status = STATUS_PUBLISH
+                        AILessonScript.query.filter(
+                            AILessonScript.script_id == block_script.script_id,
+                            AILessonScript.status.in_([STATUS_PUBLISH]),
+                            AILessonScript.id != block_script.id,
+                        ).update(
+                            {"status": STATUS_HISTORY, "updated_user_id": user_id, "updated": datetime.now(),}
+                        )
+
                     elif block_script.status == STATUS_PUBLISH:
                         block_script.status = STATUS_PUBLISH
+                        AILessonScript.query.filter(
+                            AILessonScript.script_id == block_script.script_id,
+                            AILessonScript.status.in_([STATUS_PUBLISH]),
+                            AILessonScript.id != block_script.id,
+                        ).update(
+                            {"status": STATUS_HISTORY, "updated_user_id": user_id, "updated": datetime.now(),}
+                        )
                     block_script.updated_user_id = user_id
                     block_script.updated = datetime.now()
                     db.session.add(block_script)

--- a/src/api/flaskr/service/scenario/unit_funcs.py
+++ b/src/api/flaskr/service/scenario/unit_funcs.py
@@ -240,8 +240,8 @@ def modify_unit(
         if unit_name and len(unit_name) > 20:
             raise_error("SCENARIO.UNIT_NAME_TOO_LONG")
         unit = AILesson.query.filter(
-            AILesson.lesson_id == unit_id, AILesson.status.in_([STATUS_DRAFT])
-        ).first()
+            AILesson.lesson_id == unit_id, AILesson.status.in_([STATUS_DRAFT, STATUS_PUBLISH])
+        ).order_by(AILesson.id.desc()).first()
         if not unit:
             raise_error("SCENARIO.UNIT_NOT_FOUND")
         if unit:

--- a/src/api/flaskr/service/scenario/utils.py
+++ b/src/api/flaskr/service/scenario/utils.py
@@ -119,14 +119,16 @@ def get_existing_blocks(app: Flask, outline_ids: list[str]):
         )
         .group_by(AILessonScript.script_id)
     )
-    blocks = (
+    
+    query  = (
         AILessonScript.query.filter(
             AILessonScript.id.in_(subquery),
             AILessonScript.status.in_([STATUS_PUBLISH, STATUS_DRAFT]),
         )
         .order_by(AILessonScript.script_index.asc())
-        .all()
+       
     )
+    blocks = query.all()
     return blocks
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed an issue where modifying the outline or unit name failed after publishing. Now, both draft and published units can be updated as expected.

- **Bug Fixes**
  - Updated unit lookup to include both draft and published statuses.
  - Ensured old published lessons and scripts are marked as history when a new version is published.

<!-- End of auto-generated description by mrge. -->

