### PR TITLE
fix: resolve Shifu settings dialog issue due to load error

### DIFF
--- a/src/api/flaskr/service/scenario/funcs.py
+++ b/src/api/flaskr/service/scenario/funcs.py
@@ -446,7 +446,8 @@ def get_scenario_detail(app, user_id: str, scenario_id: str):
     with app.app_context():
         scenario = (
             AICourse.query.filter(
-                AICourse.course_id == scenario_id, AICourse.status.in_([STATUS_PUBLISH,STATUS_DRAFT])
+                AICourse.course_id == scenario_id,
+                AICourse.status.in_([STATUS_PUBLISH, STATUS_DRAFT]),
             )
             .order_by(AICourse.id.desc())
             .first()

--- a/src/api/flaskr/service/scenario/funcs.py
+++ b/src/api/flaskr/service/scenario/funcs.py
@@ -446,7 +446,7 @@ def get_scenario_detail(app, user_id: str, scenario_id: str):
     with app.app_context():
         scenario = (
             AICourse.query.filter(
-                AICourse.course_id == scenario_id, AICourse.status.in_([STATUS_PUBLISH])
+                AICourse.course_id == scenario_id, AICourse.status.in_([STATUS_PUBLISH,STATUS_DRAFT])
             )
             .order_by(AICourse.id.desc())
             .first()

--- a/src/cook-web/src/components/course-setting/index.tsx
+++ b/src/cook-web/src/components/course-setting/index.tsx
@@ -175,6 +175,7 @@ export default function CourseCreationDialog({ scenarioId, onSave }: { scenarioI
     // Handle form submission
     const onSubmit = async (data) => {
         // Combine form data with keywords and image
+        console.log("data", data)
         const fullFormData = {
             ...data,
             keywords,
@@ -489,6 +490,9 @@ export default function CourseCreationDialog({ scenarioId, onSave }: { scenarioI
                             <Button
                                 type="submit"
                                 className="bg-purple-600 hover:bg-purple-700 text-white"
+                                onClick={() => {
+                                    onSubmit(form.getValues())
+                                }}
                             >
                                 保存
                             </Button>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed an issue where the Shifu settings dialog failed to load due to missing draft course support and form submission errors.

- **Bug Fixes**
  - Allowed loading of both published and draft courses in the backend.
  - Fixed form submission in the settings dialog to prevent errors.

<!-- End of auto-generated description by mrge. -->

