### PR TITLE
fix: format picture URL to markdown format

### DIFF
--- a/src/cook-web/src/components/cm-editor/components/image-inject.tsx
+++ b/src/cook-web/src/components/cm-editor/components/image-inject.tsx
@@ -10,7 +10,7 @@ type ImageInjectProps = {
 const ImageInject: React.FC<ImageInjectProps> = ({ onSelect }) => {
   const [imageUrl, setImageUrl] = useState<string>('')
   const handleSelect = () => {
-    onSelect?.(imageUrl)
+    onSelect?.("![image](" + imageUrl + ")")
   }
   return (
     <div>

--- a/src/cook-web/src/components/file-uploader/image-uploader.tsx
+++ b/src/cook-web/src/components/file-uploader/image-uploader.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card } from '@/components/ui/card'
 import { uploadFile } from '@/lib/file'
-import { SITE_HOST } from '@/config/site'
+import { getSiteHost } from "@/config/runtime-config";
 
 type ImageUploaderProps = {
   value?: string
@@ -25,6 +25,7 @@ const ImageUploader:React.FC<ImageUploaderProps> = ({
   const [fileName, setFileName] = useState<string>('')
   const [uploadProgress, setUploadProgress] = useState(0)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const siteHost = getSiteHost()
 
   const resetState = () => {
     setImageUrl('')
@@ -40,7 +41,7 @@ const ImageUploader:React.FC<ImageUploaderProps> = ({
     try {
       const response = await uploadFile(
         file,
-        `${SITE_HOST}/api/scenario/upfile`,
+        `${siteHost}/api/scenario/upfile`,
         undefined,
         undefined,
         progress => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated picture URL formatting to use markdown, and refactored the cook editor build and deployment to use a new cook-web service name and directory. Also added and improved APIs for scenario editing, chapters, units, blocks, tags, and knowledge base (RAG) management.

- **Refactors**
  - Changed all references from "cook" to "cook-web" in Docker, deployment, and build scripts.
  - Updated nginx configs to route cook-web traffic to the correct service and port.
  - Cleaned up and reorganized environment variables and documentation.

- **New Features**
  - Added APIs for scenario, chapter, unit, and block management to support the new course editor.
  - Introduced knowledge base (RAG) and tag APIs for enhanced content and metadata handling.
  - Improved user profile and authentication APIs, including support for email codes and profile customization.

<!-- End of auto-generated description by mrge. -->

