### PR TITLE
fix: add null check for last script

### DIFF
--- a/src/api/flaskr/service/study/funcs.py
+++ b/src/api/flaskr/service/study/funcs.py
@@ -391,6 +391,9 @@ def get_study_record(app: Flask, user_id: str, lesson_id: str) -> StudyRecordDTO
             .order_by(AILessonScript.id.desc())
             .first()
         )
+        if last_script is None:
+            ret.ui = []
+            return ret
         last_lesson_id = last_script.lesson_id
         lesson_id = last_lesson_id
         last_attends = [i for i in attend_infos if i.lesson_id == last_lesson_id]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a null check for the last script in study record retrieval to prevent errors when no script is found.

<!-- End of auto-generated description by mrge. -->

