### PR TITLE
fix: check last script issue of new course

### DIFF
--- a/src/api/flaskr/service/study/utils.py
+++ b/src/api/flaskr/service/study/utils.py
@@ -781,7 +781,7 @@ def check_script_is_last_script(
                 AILessonScript.lesson_id == last_lesson.lesson_id,
                 AILessonScript.status == 1,
             )
-            .order_by(AILessonScript.id.desc())
+            .order_by(AILessonScript.script_index.desc())
             .first()
         )
         if (


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed an issue where the last script of a new course was not checked correctly due to ordering by ID instead of script index.

<!-- End of auto-generated description by mrge. -->

