### PR TITLE
fix: saved block missing after adding new block to outline

### DIFF
--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -194,6 +194,7 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         updated_user_id=user_id,
                         status=STATUS_DRAFT,
                     )
+                    app.logger.info(f"new block : {block_model.script_id}")
                     profile = update_block_model(block_model, block_dto)
                     if profile:
                         profile_item = save_profile_item_defination(
@@ -214,6 +215,7 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                     block_model.updated_user_id = user_id
                     block_model.status = STATUS_DRAFT
                     db.session.add(block_model)
+                    app.logger.info(f"new block : {block_model.id}")
                     block_models.append(block_model)
                     save_block_ids.append(block_model.script_id)
                 else:
@@ -239,6 +241,7 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         new_block.script_index = block_index
                         new_block.lesson_id = current_outline_id
                         change_block_status_to_history(block_model, user_id, time)
+                        app.logger.info(f"update block : {new_block.id} {new_block.status}")
                         db.session.add(new_block)
                         block_models.append(new_block)
                         new_check_str = new_block.get_str_to_check()

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -165,8 +165,10 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
             if type == "block":
                 block_dto = convert_dict_to_block_dto(block)
                 block_model = None
+                block_id = generate_id(app)
                 app.logger.info(f"block_dto id : {block_dto.block_id}")
                 if block_dto.block_id is not None and block_dto.block_id != "":
+                    block_id = block_dto.block_id
                     check_block = next(
                         (b for b in blocks if b.script_id == block_dto.block_id), None
                     )
@@ -176,14 +178,16 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         app.logger.warning(
                             f"block_dto id not found : {block_dto.block_id}"
                         )
+                        
                 if block_model is None:
                     # add new block
                     block_model = AILessonScript(
-                        script_id=generate_id(app),
+                        script_id=block_id,
                         script_index=block_index,
                         script_name=block_dto.block_name,
                         script_desc=block_dto.block_desc,
                         script_type=block_dto.block_type,
+                        lesson_id=current_outline_id,
                         created=time,
                         created_user_id=user_id,
                         updated=time,

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -23,6 +23,7 @@ from .utils import change_block_status_to_history, get_original_outline_tree
 import queue
 from flaskr.dao import redis_client
 
+
 def get_block_list(app, user_id: str, outline_id: str):
     with app.app_context():
         lesson = AILesson.query.filter(
@@ -116,7 +117,9 @@ def get_block(app, user_id: str, outline_id: str, block_id: str):
 
 
 # save block list
-def save_block_list_internal (app, user_id: str, outline_id: str, block_list: list[BlockDto]):
+def save_block_list_internal(
+    app, user_id: str, outline_id: str, block_list: list[BlockDto]
+):
     with app.app_context():
         time = datetime.now()
         app.logger.info(f"save_block_list: {outline_id}")
@@ -243,7 +246,9 @@ def save_block_list_internal (app, user_id: str, outline_id: str, block_list: li
                         change_block_status_to_history(block_model, user_id, time)
 
                         db.session.add(new_block)
-                        app.logger.info(f"update block : {new_block.id} {new_block.status}")
+                        app.logger.info(
+                            f"update block : {new_block.id} {new_block.status}"
+                        )
                         block_models.append(new_block)
                         new_check_str = new_block.get_str_to_check()
                         if old_check_str != new_check_str:
@@ -265,6 +270,8 @@ def save_block_list_internal (app, user_id: str, outline_id: str, block_list: li
             generate_block_dto(block_model, profile_items)
             for block_model in block_models
         ]
+
+
 def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDto]):
     timeout = 5 * 60
     blocking_timeout = 1
@@ -285,6 +292,7 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
         app.logger.error("lockfail")
         return []
     return
+
 
 def add_block(app, user_id: str, outline_id: str, block: BlockDto, block_index: int):
     with app.app_context():

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -150,10 +150,10 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
             if node.children and len(node.children) > 0:
                 for child in node.children:
                     q.put(child)
-        app.logger.info(f"sub_outline_ids : {sub_outline_ids}")
+        app.logger.info(f"new sub_outline_ids : {sub_outline_ids}")
         # get all blocks
         blocks = get_existing_blocks(app, sub_outline_ids)
-        app.logger.info(f"blocks : {len(blocks)}")
+        app.logger.info(f"new blocks : {len(blocks)}")
         block_index = 1
         current_outline_id = outline_id
         block_models = []

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -241,10 +241,9 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         new_block.script_index = block_index
                         new_block.lesson_id = current_outline_id
                         change_block_status_to_history(block_model, user_id, time)
-                        app.logger.info(
-                            f"update block : {new_block.id} {new_block.status}"
-                        )
+
                         db.session.add(new_block)
+                        app.logger.info(f"update block : {new_block.id} {new_block.status}")
                         block_models.append(new_block)
                         new_check_str = new_block.get_str_to_check()
                         if old_check_str != new_check_str:

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -19,7 +19,7 @@ from flaskr.service.lesson.const import (
     STATUS_DELETE,
 )
 from flaskr.service.check_risk.funcs import check_text_with_risk_control
-from .utils import change_block_status_to_history,get_original_outline_tree
+from .utils import change_block_status_to_history, get_original_outline_tree
 import queue
 
 

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -308,6 +308,8 @@ def add_block(app, user_id: str, outline_id: str, block: BlockDto, block_index: 
         if not outline:
             raise_error("SCENARIO.OUTLINE_NOT_FOUND")
         block_dto = convert_dict_to_block_dto({"type": "block", "properties": block})
+        # add 1 to the block index / 1 is the index of the block in the outline
+        block_index = block_index + 1
         block_model = AILessonScript(
             script_id=generate_id(app),
             script_index=block_index,

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -178,7 +178,7 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         app.logger.warning(
                             f"block_dto id not found : {block_dto.block_id}"
                         )
-                        
+
                 if block_model is None:
                     # add new block
                     block_model = AILessonScript(

--- a/src/api/flaskr/service/scenario/block_funcs.py
+++ b/src/api/flaskr/service/scenario/block_funcs.py
@@ -241,7 +241,9 @@ def save_block_list(app, user_id: str, outline_id: str, block_list: list[BlockDt
                         new_block.script_index = block_index
                         new_block.lesson_id = current_outline_id
                         change_block_status_to_history(block_model, user_id, time)
-                        app.logger.info(f"update block : {new_block.id} {new_block.status}")
+                        app.logger.info(
+                            f"update block : {new_block.id} {new_block.status}"
+                        )
                         db.session.add(new_block)
                         block_models.append(new_block)
                         new_check_str = new_block.get_str_to_check()

--- a/src/api/flaskr/service/scenario/utils.py
+++ b/src/api/flaskr/service/scenario/utils.py
@@ -178,8 +178,11 @@ def change_block_status_to_history(
     block_info: AILessonScript, user_id: str, time: datetime
 ):
     from flask import current_app as app
-    app.logger.info(f"change_block_status_to_history: {block_info.id} {block_info.status}")
-    
+
+    app.logger.info(
+        f"change_block_status_to_history: {block_info.id} {block_info.status}"
+    )
+
     if block_info.status != STATUS_PUBLISH:
         # if the block is not publish, then we need to change the status to history
         block_info.status = STATUS_HISTORY

--- a/src/api/flaskr/service/scenario/utils.py
+++ b/src/api/flaskr/service/scenario/utils.py
@@ -177,6 +177,7 @@ def change_outline_status_to_history(
 def change_block_status_to_history(
     block_info: AILessonScript, user_id: str, time: datetime
 ):
+    
     if block_info.status != STATUS_PUBLISH:
         # if the block is not publish, then we need to change the status to history
         block_info.status = STATUS_HISTORY

--- a/src/api/flaskr/service/scenario/utils.py
+++ b/src/api/flaskr/service/scenario/utils.py
@@ -177,6 +177,8 @@ def change_outline_status_to_history(
 def change_block_status_to_history(
     block_info: AILessonScript, user_id: str, time: datetime
 ):
+    from flask import current_app as app
+    app.logger.info(f"change_block_status_to_history: {block_info.id} {block_info.status}")
     
     if block_info.status != STATUS_PUBLISH:
         # if the block is not publish, then we need to change the status to history

--- a/src/cook-web/src/components/outline-tree/index.tsx
+++ b/src/cook-web/src/components/outline-tree/index.tsx
@@ -114,12 +114,12 @@ const MinimalTreeItemComponent = React.forwardRef<
         }
 
         if (props.item.depth == 0) {
-            actions.setCurrentNode(props.item);
+            await actions.setCurrentNode(props.item);
             actions.setBlocks([]);
             return;
         }
 
-        actions.setCurrentNode(props.item);
+        await actions.setCurrentNode(props.item);
         await actions.loadBlocks(props.item.id || "");
     }
 

--- a/src/cook-web/src/lib/request.ts
+++ b/src/cook-web/src/lib/request.ts
@@ -115,7 +115,6 @@ export class Request {
       const res = await response.json();
       // check if there is a code property, use Object API
       if (Object.prototype.hasOwnProperty.call(res, 'code')) {
-        console.debug(res);
         if (res.code == 0) {
           return res.data;
         } if (res.code == 1001 || res.code == 1005) {
@@ -127,7 +126,6 @@ export class Request {
       return res;
     } catch (error: any) {
       // handle exceptions, such as reporting errors, displaying error prompts, etc.
-      console.debug(url, error);
       console.error('Request failed:', error.message);
       fail(error.message)
       throw error;

--- a/src/cook-web/src/lib/request.ts
+++ b/src/cook-web/src/lib/request.ts
@@ -115,7 +115,7 @@ export class Request {
       const res = await response.json();
       // check if there is a code property, use Object API
       if (Object.prototype.hasOwnProperty.call(res, 'code')) {
-        console.log(res);
+        console.debug(res);
         if (res.code == 0) {
           return res.data;
         } if (res.code == 1001 || res.code == 1005) {
@@ -127,7 +127,7 @@ export class Request {
       return res;
     } catch (error: any) {
       // handle exceptions, such as reporting errors, displaying error prompts, etc.
-      console.log(url, error);
+      console.debug(url, error);
       console.error('Request failed:', error.message);
       fail(error.message)
       throw error;

--- a/src/cook-web/src/store/useScenario.tsx
+++ b/src/cook-web/src/store/useScenario.tsx
@@ -282,6 +282,10 @@ export const ScenarioProvider: React.FC<{ children: ReactNode }> = ({ children }
         }
     }
     const saveBlocks = async () => {
+        if (isLoading) {
+            console.log('isLoading')
+            return;
+        }
         const list = buildBlockList(blocks);
         try {
             setError(null);
@@ -381,10 +385,13 @@ export const ScenarioProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
 
     const saveCurrentBlocks = useCallback(async (outline: string, blocks: Block[], blockContentTypes: Record<string, any>, blockContentProperties: Record<string, any>, blockUITypes: Record<string, any>, blockUIProperties: Record<string, any>) => {
-        console.log('yyy')
+        if (isLoading) {
+            return;
+        } else {
+            console.debug('auto save')
+        }
         setIsSaving(true);
         setError(null);
-        setIsSaving(true);
         try {
             setError(null);
             const blockList = buildBlockListWithAllInfo(blocks, blockContentTypes, blockContentProperties, blockUITypes, blockUIProperties);

--- a/src/cook-web/src/store/useScenario.tsx
+++ b/src/cook-web/src/store/useScenario.tsx
@@ -283,7 +283,6 @@ export const ScenarioProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
     const saveBlocks = async () => {
         if (isLoading) {
-            console.log('isLoading')
             return;
         }
         const list = buildBlockList(blocks);
@@ -387,8 +386,6 @@ export const ScenarioProvider: React.FC<{ children: ReactNode }> = ({ children }
     const saveCurrentBlocks = useCallback(async (outline: string, blocks: Block[], blockContentTypes: Record<string, any>, blockContentProperties: Record<string, any>, blockUITypes: Record<string, any>, blockUIProperties: Record<string, any>) => {
         if (isLoading) {
             return;
-        } else {
-            console.debug('auto save')
         }
         setIsSaving(true);
         setError(null);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed an issue where blocks were missing when switching nodes in the cook editor by ensuring block loading and saving actions wait for completion.

- **Bug Fixes**
  - Made setCurrentNode and block loading actions asynchronous to prevent missing blocks.
  - Added checks to avoid saving blocks while loading is in progress.

<!-- End of auto-generated description by mrge. -->

