### PR TITLE
Fix the authentication of image uploads

### DIFF
--- a/src/cook-web/src/lib/file.ts
+++ b/src/cook-web/src/lib/file.ts
@@ -54,7 +54,6 @@ export const uploadFile = async (
       if (token) {
         xhr.setRequestHeader("Authorization", `Bearer ${token}`);
         xhr.setRequestHeader("Token", token);
-        xhr.setRequestHeader("X-API-MODE", "admin");
         xhr.setRequestHeader("X-Request-ID", uuidv4().replace(/-/g, ''));
       }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Removed the "X-API-MODE: admin" header from image upload requests to fix authentication issues.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted file upload behavior to no longer include the "X-API-MODE: admin" header when uploading files using certain browsers or environments. This change may improve compatibility for some users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->