### PR TITLE
chore: add milvus_data directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ src/cook/auth_config.yml
 docker/cook_data/
 docker/mysql_data/
 docker/redis_data/
+docker/milvus_data/
 
 ###############################################################################
 # Never ignore these files (exceptions to above rules)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added docker/milvus_data/ to .gitignore to prevent local Milvus data files from being tracked.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated ignore rules to exclude an additional Docker data directory from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->