### PR TITLE
feat: simplify 404 page by removing countdown and using direct navigation

### DIFF
--- a/src/web/src/Pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/web/src/Pages/NotFoundPage/NotFoundPage.tsx
@@ -1,49 +1,32 @@
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'antd';
-import { useNavigate } from 'react-router-dom';
 import styles from './NotFoundPage.module.scss';
-import logoColor from 'Assets/logos/logo-color-392.png'
+import logo from 'Assets/logos/logo-color-392.png';
 import { useEnvStore } from 'stores/envStore';
+
 const NotFoundPage = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const [countdown, setCountdown] = useState(5);
   const siteUrl = useEnvStore((state) => state.siteUrl);
-  useEffect(() => {
-    if (countdown === 0) {
-      if (siteUrl) {
-        window.location.href = siteUrl;
-      } else {
-        window.location.href = '/c/';
-      }
-    }
-    const timer = setTimeout(() => {
-      setCountdown(countdown - 1);
-    }, 1000);
 
-    return () => clearTimeout(timer);
-  }, [countdown, navigate]);
+  const handleBackToHome = () => {
+    if (siteUrl) {
+      window.location.href = siteUrl;
+    } else {
+      // Default fallback if siteUrl is not set
+      window.location.href = '/c/';
+    }
+  };
 
   return (
     <div className={styles.notFoundPage}>
       <div className={styles.content}>
         <div className={styles.inline}>
-          <img src={logoColor} alt="logo" />
+          <img src={logo} alt="logo" />
           <h1>404</h1>
         </div>
         <p>{t('error.pageNotFound')}</p>
-        <p>{t('common.redirectInSeconds', { seconds: countdown })}</p>
-        <Button
-          type="primary"
-          onClick={() => {
-            if (siteUrl) {
-              window.location.href = siteUrl;
-            } else {
-              window.location.href = '/c/';
-            }
-          }}
-        >
+        <Button type="primary" onClick={handleBackToHome}>
           {t('common.backToHome')}
         </Button>
       </div>


### PR DESCRIPTION
Countdown is too smart.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Simplified the 404 page by removing the countdown timer and letting users go back to the home page with a single button click.

<!-- End of auto-generated description by mrge. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the "Not Found" page by removing the automatic redirect and countdown timer. Users are now redirected to the home page only when they click the "Back to Home" button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->