### PR TITLE
fix: remove duplicate extra column from PingxxOrder model

### DIFF
--- a/src/api/flaskr/service/order/models.py
+++ b/src/api/flaskr/service/order/models.py
@@ -134,7 +134,6 @@ class PingxxOrder(db.Model):
     pingxx_id = Column(String(36), nullable=False, default="", comment="Pingxx ID")
     channel = Column(String(36), nullable=False, default="", comment="Payment channel")
     amount = Column(BIGINT, nullable=False, default="0.00", comment="Payment amount")
-    extra = Column(Text, nullable=False, comment="Extra information")
     currency = Column(String(36), nullable=False, default="CNY", comment="Currency")
     subject = Column(String(255), nullable=False, default="", comment="Payment subject")
     body = Column(String(255), nullable=False, default="", comment="Payment body")


### PR DESCRIPTION
# Summary

This bug is found and fixed by ChatGPT Codex

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [AI-Shifu Documentation](https://github.com/ai-shifu/ai-shifu-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [ ] I've ran the following commands to run pre-commit checks and front-end linting:
    * `pre-commit run --all-files`(api)
    * `cd src/web && npm run lint`(frontend)
    * `cd src/cook-web && npm run lint`(cook-web)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with duplicate "Extra information" fields in order details, ensuring only one field is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->