### PR TITLE
fix: two errors when running api project on Windows

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -62,9 +62,9 @@ def create_app() -> Flask:
     from flaskr.framework.plugin.load_plugin import load_plugins_from_dir
     from flaskr.framework.plugin.plugin_manager import plugin_manager
 
-    load_plugins_from_dir(app, "flaskr/service/")
+    load_plugins_from_dir(app, os.path.join("flaskr", "service"))
     try:
-        load_plugins_from_dir(app, "flaskr/plugins", plugin_manager)
+        load_plugins_from_dir(app, os.path.join("flaskr", "plugins"), plugin_manager)
     except Exception as e:
         app.logger.warning(f"load plugins error: {e}")
 

--- a/src/api/flaskr/service/lesson/funs.py
+++ b/src/api/flaskr/service/lesson/funs.py
@@ -384,7 +384,7 @@ def update_lesson_info(
             kwargs["app_secret"] = app_secret
         while True:
             if file_name:
-                with open(file_name, "r", encoding='UTF-8') as json_file:
+                with open(file_name, "r", encoding="UTF-8") as json_file:
                     json_data = json_file.read()
                     resp = json.loads(json_data)
             else:

--- a/src/api/flaskr/service/lesson/funs.py
+++ b/src/api/flaskr/service/lesson/funs.py
@@ -384,7 +384,7 @@ def update_lesson_info(
             kwargs["app_secret"] = app_secret
         while True:
             if file_name:
-                with open(file_name, "r") as json_file:
+                with open(file_name, "r", encoding='UTF-8') as json_file:
                     json_data = json_file.read()
                     resp = json.loads(json_data)
             else:


### PR DESCRIPTION
# Summary

Fix
1. windows system error: No module named 'flaskr/service/active'
2. "UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 203: illegal multibyte sequence." in flaskr/service/lesson/funs.py

# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [x] This change requires a documentation update, included: [AI-Shifu Documentation](https://github.com/ai-shifu/ai-shifu-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I've ran the following commands to run pre-commit checks and front-end linting:
    * `pre-commit run --all-files`(api)
    * `cd src/web && npm run lint`(frontend)
    * `cd src/cook-web && npm run lint`(cook-web)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin loading reliability by ensuring directory paths are constructed in a platform-independent way.
  - Ensured consistent reading of lesson information files by explicitly using UTF-8 encoding, preventing potential decoding errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->