### PR TITLE
fix: prevent send during IME composition

### DIFF
--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
@@ -30,8 +30,8 @@ export const ChatInputSmsCode = ({ onClick, type, props }) => {
             onChange={v => setInput(v)}
             placeholder=""
             className={styles.inputField}
-            onKeyDown={(e) => {
-              if ((e.nativeEvent as any).isComposing) {
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.nativeEvent.isComposing) {
                 return;
               }
               if (e.key === 'Enter' && !e.shiftKey) {

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
@@ -30,10 +30,7 @@ export const ChatInputSmsCode = ({ onClick, type, props }) => {
             onChange={v => setInput(v)}
             placeholder=""
             className={styles.inputField}
-            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-              if (e.nativeEvent.isComposing) {
-                return;
-              }
+            onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 onSendClick();

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx
@@ -31,6 +31,9 @@ export const ChatInputSmsCode = ({ onClick, type, props }) => {
             placeholder=""
             className={styles.inputField}
             onKeyDown={(e) => {
+              if ((e.nativeEvent as any).isComposing) {
+                return;
+              }
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 onSendClick();

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
@@ -110,7 +110,7 @@ export const ChatInputText = ({ onClick, type, disabled = false, props = {} }: C
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (isComposing) {
+    if (isComposing || (e.nativeEvent as any).isComposing) {
       return;
     }
 

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
@@ -110,7 +110,7 @@ export const ChatInputText = ({ onClick, type, disabled = false, props = {} }: C
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (isComposing || (e.nativeEvent as any).isComposing) {
+    if (isComposing || e.isComposing) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- check `isComposing` state using native event in ChatInputText
- check composition state in ChatInputSmsCode

## Testing
- `pre-commit run --files src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInputSmsCode.tsx` *(fails: command not found)*
- `pnpm install` *(fails: cannot download packages)*
- `pnpm test` *(fails: cannot download packages)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of input for languages requiring input method editors (IME), preventing premature message submission while users are still composing characters. This ensures smoother chat input for users typing in languages such as Chinese, Japanese, or Korean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->