### PR TITLE
fix: input content cleared when switching between ask and input modes

### DIFF
--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInteractionArea.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/ChatInteractionArea.tsx
@@ -25,11 +25,15 @@ export const ChatInteractionArea = ({
   const elemRef = useRef();
   const { t } = useTranslation();
   const [isInputVisible, setInputVisible] = useState(false);
+  const [askContent, setAskContent] = useState('');
+  const [inputValue, setInputValue] = useState('');
 
   const onSendFunc = (type, display, val) => {
     if (disabled) {
       return;
     }
+    setInputValue('');
+    setAskContent('');
     onSend?.(type, display, val, props.scriptId);
   };
 
@@ -42,6 +46,8 @@ export const ChatInteractionArea = ({
           type={type}
           props={props}
           onClick={onSendFunc}
+          initialValue={inputValue}
+          onInputChange={setInputValue}
         />
       );
     }
@@ -65,6 +71,8 @@ export const ChatInteractionArea = ({
   const onSendAsk = (type, display, val) => {
     setInputVisible(false);
     onSendFunc?.(INTERACTION_TYPE.ASK, true, val);
+    setInputValue('');
+    setAskContent('');
   };
 
   useEffect(() => {
@@ -99,6 +107,8 @@ export const ChatInteractionArea = ({
                 type="text"
                 props={{ content: t('chat.askContent') }}
                 visible={isInputVisible}
+                initialValue={askContent}
+                onInputChange={setAskContent}
               />
             )}
           </div>

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
@@ -20,6 +20,8 @@ interface ChatInputProps {
   onClick?: (outputType: string, isValid: boolean, value: string) => void;
   type?: string;
   disabled?: boolean;
+  initialValue?: string;
+  onInputChange?: (value: string) => void;
   props?: {
     content?: {
       content?: string;
@@ -27,9 +29,9 @@ interface ChatInputProps {
   };
 }
 
-export const ChatInputText = ({ onClick, type, disabled = false, props = {} }: ChatInputProps) => {
+export const ChatInputText = ({ onClick, initialValue, onInputChange, type, disabled = false, props = {} }: ChatInputProps) => {
   const { t } = useTranslation();
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState(initialValue || '');
   const [messageApi, contextHolder] = message.useMessage();
   const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -107,6 +109,7 @@ export const ChatInputText = ({ onClick, type, disabled = false, props = {} }: C
   const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setInput(value);
+    onInputChange?.(value);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatInput/InputComponents/ChatInputText.tsx
@@ -33,6 +33,10 @@ export const ChatInputText = ({ onClick, initialValue, onInputChange, type, disa
   const { t } = useTranslation();
   const [input, setInput] = useState(initialValue || '');
   const [messageApi, contextHolder] = message.useMessage();
+
+  useEffect(() => {
+    setInput(initialValue || '');
+  }, [initialValue]);
   const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const placeholder = props?.content?.content || t('chat.chatInputPlaceholder');


### PR DESCRIPTION
# Summary

 
fix: input content cleared when switching between ask and input modes 
> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [AI-Shifu Documentation](https://github.com/ai-shifu/ai-shifu-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Input fields in the chat interface now retain and display their current values, providing a more consistent and controlled typing experience.
  - Input fields are automatically cleared after sending a message or an "ask" interaction.

- **Enhancements**
  - The chat input component now supports initializing with a predefined value and can notify when input changes, allowing for improved integration with other features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->