### PR TITLE
fix: block content not saved when switching type between AI and solid

### DIFF
--- a/src/api/flaskr/service/shifu/adapter.py
+++ b/src/api/flaskr/service/shifu/adapter.py
@@ -140,7 +140,7 @@ def update_block_model(
                 block_model.script_temprature = block_dto.block_content.temprature
         elif isinstance(block_dto.block_content, SolidContentDto):
             block_model.script_type = SCRIPT_TYPE_FIX
-            block_model.script_prompt = block_dto.block_content.content
+            block_model.script_prompt = block_dto.block_content.prompt
         elif isinstance(block_dto.block_content, SystemPromptDto):
             block_model.script_type = SCRIPT_TYPE_SYSTEM
             block_model.script_prompt = block_dto.block_content.prompt
@@ -298,7 +298,8 @@ def generate_block_dto(block: AILessonScript, profile_items: list[ProfileItem]):
 
     if block.script_type == SCRIPT_TYPE_FIX:
         ret.block_content = SolidContentDto(
-            block.script_prompt, get_profiles(block.script_profile)
+            prompt=block.script_prompt,
+            profiles=get_profiles(block.script_profile),
         )
         ret.block_type = "solid"
     elif block.script_type == SCRIPT_TYPE_PROMPT:

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -198,16 +198,17 @@ class OutlineDto:
 
 @register_schema_to_swagger
 class SolidContentDto:
-    content: str
+    prompt: str
+    profiles: list[str]
 
-    def __init__(self, content: str = None, profiles: list[str] = None):
-        self.content = content
+    def __init__(self, prompt: str = None, profiles: list[str] = None):
+        self.prompt = prompt
         self.profiles = profiles
 
     def __json__(self):
         return {
             "properties": {
-                "content": self.content,
+                "prompt": self.prompt,
                 "profiles": self.profiles,
             },
             "type": __class__.__name__.replace("Dto", "").lower(),

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -203,7 +203,7 @@ class SolidContentDto:
 
     def __init__(self, prompt: str = None, profiles: list[str] = None):
         self.prompt = prompt
-        self.profiles = profiles
+        self.profiles = profiles if profiles is not None else []
 
     def __json__(self):
         return {

--- a/src/cook-web/src/components/render-block/ai.tsx
+++ b/src/cook-web/src/components/render-block/ai.tsx
@@ -20,7 +20,7 @@ interface AIBlock {
 }
 
 export default function AI(props: AIBlock) {
-
+    console.log(props.properties)
     return (
         <CMEditor
             content={props.properties.prompt}

--- a/src/cook-web/src/components/render-block/ai.tsx
+++ b/src/cook-web/src/components/render-block/ai.tsx
@@ -20,7 +20,6 @@ interface AIBlock {
 }
 
 export default function AI(props: AIBlock) {
-    console.log(props.properties)
     return (
         <CMEditor
             content={props.properties.prompt}

--- a/src/cook-web/src/components/render-block/index.tsx
+++ b/src/cook-web/src/components/render-block/index.tsx
@@ -48,7 +48,6 @@ export const RenderBlockContent = ({ id, type, properties }) => {
         if (opt) {
             opt.properties.prompt = properties.prompt
         }
-        console.log('opt', opt)
         actions.setBlockContentTypesById(id, type)
         actions.setBlockContentPropertiesById(id, opt?.properties || {} as any, true)
     }

--- a/src/cook-web/src/components/render-block/index.tsx
+++ b/src/cook-web/src/components/render-block/index.tsx
@@ -20,6 +20,7 @@ export const RenderBlockContent = ({ id, type, properties }) => {
     const [showDeleteDialog, setShowDeleteDialog] = useState(false)
     const ContentTypes = useContentTypes()
 
+
     const onPropertiesChange = async (properties) => {
         await actions.setBlockContentPropertiesById(id, properties)
         const p = {
@@ -33,7 +34,7 @@ export const RenderBlockContent = ({ id, type, properties }) => {
         if (type == 'ai' && properties.prompt == '') {
             setError(t('render-block.ai-content-empty'))
             return;
-        } else if (type == 'solidcontent' && properties.content == '') {
+        } else if (type == 'solidcontent' && properties.prompt == '') {
             setError(t('render-block.solid-content-empty'))
             return;
         }
@@ -44,6 +45,10 @@ export const RenderBlockContent = ({ id, type, properties }) => {
 
     const onContentTypeChange = (id: string, type: string) => {
         const opt = ContentTypes.find(p => p.type === type);
+        if (opt) {
+            opt.properties.prompt = properties.prompt
+        }
+        console.log('opt', opt)
         actions.setBlockContentTypesById(id, type)
         actions.setBlockContentPropertiesById(id, opt?.properties || {} as any, true)
     }
@@ -52,12 +57,11 @@ export const RenderBlockContent = ({ id, type, properties }) => {
     }
     const onSave = async () => {
         setError('')
-        // check if the block is empty
         const block = blocks.find((item) => item.properties.block_id == id);
         if (type == 'ai' && block && properties.prompt == '') {
             setError(t('render-block.ai-content-empty'))
             return;
-        } else if (type == 'solidcontent' && block && properties.content == '') {
+        } else if (type == 'solidcontent' && block && properties.prompt == '') {
             setError(t('render-block.solid-content-empty'))
             return;
         }
@@ -83,7 +87,7 @@ export const RenderBlockContent = ({ id, type, properties }) => {
                     <div className='rounded-t-md p-2 flex flex-row items-center py-1 justify-between'>
                         <Select
                             value={blockContentTypes[id]}
-                            onValueChange={onContentTypeChange.bind(null, id)}
+                            onValueChange={(value) => onContentTypeChange(id, value)}
                         >
                             <SelectTrigger className="h-8 w-[120px]">
                                 <SelectValue placeholder={t('render-block.select-content-type')} />
@@ -167,7 +171,7 @@ export const useContentTypes = () =>
             type: 'solidcontent',
             name: t('render-block.solid-content'),
             properties: {
-                "content": "",
+                "prompt": "",
                 "profiles": [],
             }
             }

--- a/src/cook-web/src/components/render-block/solid-content.tsx
+++ b/src/cook-web/src/components/render-block/solid-content.tsx
@@ -19,11 +19,6 @@ interface SolideContnet {
 
 export default function SolidContent(props: SolideContnet) {
     console.log(props.properties)
-    if (props.properties.prompt) {
-        delete props.properties.model;
-        delete props.properties.temprature;
-        delete props.properties.other_conf;
-    }
 
     return (
         <CMEditor

--- a/src/cook-web/src/components/render-block/solid-content.tsx
+++ b/src/cook-web/src/components/render-block/solid-content.tsx
@@ -2,7 +2,6 @@ import CMEditor from '@/components/cm-editor';
 
 
 interface SolideContnetProps {
-    content: string;
     profiles: string[];
     prompt?: string;
     model?: string;
@@ -19,9 +18,8 @@ interface SolideContnet {
 }
 
 export default function SolidContent(props: SolideContnet) {
+    console.log(props.properties)
     if (props.properties.prompt) {
-        props.properties.content = props.properties.prompt;
-        delete props.properties.prompt;
         delete props.properties.model;
         delete props.properties.temprature;
         delete props.properties.other_conf;
@@ -29,11 +27,11 @@ export default function SolidContent(props: SolideContnet) {
 
     return (
         <CMEditor
-            content={props.properties.content}
+            content={props.properties.prompt}
             profiles={props.properties.profiles}
             isEdit={props.isEdit}
             onChange={(value, isEdit) => {
-                props.onChange({ ...props.properties, content: value })
+                props.onChange({ ...props.properties, prompt: value })
                 if (props.onEditChange) {
                     props.onEditChange(isEdit)
                 }


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [AI-Shifu Documentation](https://github.com/ai-shifu/ai-shifu-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Standardized the use of the "prompt" property instead of "content" for solid content blocks across the application.
- **New Features**
	- Added support for a "profiles" attribute in solid content blocks.
- **Style**
	- Added debug logging for properties in relevant components to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->