### PR TITLE
feat: use react-textarea-autosize on prompt textarea

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -46,6 +46,7 @@
         "react-i18next": "^15.5.1",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^15.6.1",
+        "react-textarea-autosize": "^8.5.9",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -9966,6 +9967,22 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmmirror.com/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -11682,6 +11699,48 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -51,6 +51,7 @@
     "react-i18next": "^15.5.1",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
+    "react-textarea-autosize": "^8.5.9",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/cook-web/src/components/chapter-setting/index.tsx
+++ b/src/cook-web/src/components/chapter-setting/index.tsx
@@ -3,9 +3,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Button } from '@/components/button';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import { SlidersHorizontal } from 'lucide-react';
+import { TextareaAutosize } from '@/components/ui/textarea-autosize';
 import api from '@/api';
 import Loading from '../loading';
 
@@ -112,19 +112,11 @@ const ChapterSettingsDialog = ({ unitId, onOpenChange }: { unitId: string; onOpe
 
                             <div className="flex space-x-4">
                                 <div className="w-24 text-sm mt-2">{t('chapter-setting.system-prompt')}</div>
-                                <Textarea
+                                <TextareaAutosize
                                     placeholder={t('chapter-setting.please-input')}
                                     value={systemPrompt}
                                     onChange={(e) => setSystemPrompt(e.target.value)}
-                                    className="min-h-24 bg-white resize-none"
-                                    style={{
-                                        height: 'auto'
-                                    }}
-                                    onInput={(e) => {
-                                        const target = e.target as HTMLTextAreaElement;
-                                        target.style.height = 'auto';
-                                        target.style.height = target.scrollHeight + 'px';
-                                    }}
+                                    className="min-h-24 bg-white"
                                 />
                             </div>
 

--- a/src/cook-web/src/components/render-ui/textinput.tsx
+++ b/src/cook-web/src/components/render-ui/textinput.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Input } from '../ui/input'
-import { Textarea } from '../ui/textarea'
+import { TextareaAutosize } from '@/components/ui/textarea-autosize'
 import InputNumber from '@/components/input-number'
 import ModelList from '@/components/model-list'
 import { Button } from '../ui/button'
@@ -104,7 +104,10 @@ export default function TextInput(props: ButtonProps) {
                 <label htmlFor="" className='whitespace-nowrap w-[70px] shrink-0'>
                     {t('textinput.prompt')}
                 </label>
-                <Textarea value={tempProperties.prompt.properties.prompt} onChange={onValueChange} className="w-full"></Textarea>
+                <TextareaAutosize
+                    value={tempProperties.prompt.properties.prompt}
+                    onChange={onValueChange}
+                />
             </div>
             <div className='flex flex-row items-center space-x-1'>
                 <label htmlFor="" className='whitespace-nowrap w-[70px] shrink-0'>

--- a/src/cook-web/src/components/ui/textarea-autosize.tsx
+++ b/src/cook-web/src/components/ui/textarea-autosize.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import TextareaAutosizeLib from "react-textarea-autosize"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaAutosizeProps
+  extends React.ComponentProps<typeof TextareaAutosizeLib> {
+  className?: string
+}
+
+const TextareaAutosize = React.forwardRef<
+  React.ElementRef<typeof TextareaAutosizeLib>,
+  TextareaAutosizeProps
+>(({ className, minRows = 3, maxRows = 10, ...props }, ref) => {
+  return (
+    <TextareaAutosizeLib
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 resize-none",
+        className
+      )}
+      minRows={minRows}
+      maxRows={maxRows}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+TextareaAutosize.displayName = "TextareaAutosize"
+
+export { TextareaAutosize }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Text input areas for prompts now automatically expand and contract based on content, providing a smoother and more flexible editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->