### PR TITLE
fix: image url not be coverted to markdown

### DIFF
--- a/src/cook-web/src/components/file-uploader/image-uploader.tsx
+++ b/src/cook-web/src/components/file-uploader/image-uploader.tsx
@@ -68,7 +68,8 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ value, onChange }) => {
         throw new Error(t('file-uploader.upload-failed'))
       }
 
-      setImageUrl(res.data)
+      const markDownContent = `![${file.name}](${res.data})`
+      setImageUrl(markDownContent)
       setFileName(file.name)
       const img = new Image()
       img.src = res.data


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated image upload behavior to use Markdown image syntax for uploaded images, displaying both filename and URL together.
- **Impact**
  - Uploaded images may now appear differently or include additional information when displayed or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->