### PR TITLE
feat: add regenerate button to chat message operations

### DIFF
--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.module.scss
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.module.scss
@@ -162,7 +162,6 @@
   align-items: center;
   gap: 8px;
   margin-left: 8px;
-  padding: 4px 0;
 
   .actionButton {
     color: var(--color-21);

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.module.scss
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.module.scss
@@ -156,16 +156,30 @@
 }
 
 .messageContentOperation {
-  display:flex;
+  display: flex;
   flex-direction: row;
   flex-wrap: nowrap;
-  justify-content:space-around;
-  width: 50px;
-  margin-left: 5px;
-}
+  align-items: center;
+  gap: 8px;
+  margin-left: 8px;
+  padding: 4px 0;
 
-.brandcolor {
-  color: var(--color-21);
+  .actionButton {
+    color: var(--color-21);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    padding: 4px;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: rgba(var(--color-21-rgb), 0.1);
+      transform: scale(1.1);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+  }
 }
 
 :global(.scroll-more) {

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.tsx
@@ -1,6 +1,6 @@
 import '@ai-shifu/chatui/dist/index.css';
 import Chat, { useMessages } from '@ai-shifu/chatui';
-import { LikeOutlined, DislikeOutlined, LikeFilled, DislikeFilled } from '@ant-design/icons';
+import { LikeOutlined, DislikeOutlined, LikeFilled, DislikeFilled, RedoOutlined } from '@ant-design/icons';
 import {
   useEffect,
   forwardRef,
@@ -770,6 +770,11 @@ export const ChatComponents = forwardRef(
           });
         };
 
+        const regenerateClick = async () => {
+          const scriptId = msg.logid;
+          handleSend(INTERACTION_OUTPUT_TYPE.TEXT, false, '', scriptId);
+        };
+
         const currentInteractionType =
           interactionTypes[msg.id] ?? msg.interaction_type;
 
@@ -785,10 +790,11 @@ export const ChatComponents = forwardRef(
             ) : (
               <DislikeOutlined className={styles.brandcolor} onClick={disClick} />
             )}
+            <RedoOutlined className={styles.brandcolor} onClick={regenerateClick} />
           </div>
         );
       },
-      [interactionTypes, setInteractionTypes]
+      [interactionTypes, setInteractionTypes, handleSend]
     );
 
 

--- a/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.tsx
+++ b/src/web/src/Pages/NewChatPage/Components/ChatUi/ChatComponents.tsx
@@ -781,16 +781,16 @@ export const ChatComponents = forwardRef(
         return (
           <div className={styles.messageContentOperation}>
             {currentInteractionType === 1 ? (
-              <LikeFilled className={styles.brandcolor} onClick={likeClick} />
+              <LikeFilled className={styles.actionButton} onClick={likeClick} />
             ) : (
-              <LikeOutlined className={styles.brandcolor} onClick={likeClick} />
+              <LikeOutlined className={styles.actionButton} onClick={likeClick} />
             )}
             {currentInteractionType === 2 ? (
-              <DislikeFilled className={styles.brandcolor} onClick={disClick} />
+              <DislikeFilled className={styles.actionButton} onClick={disClick} />
             ) : (
-              <DislikeOutlined className={styles.brandcolor} onClick={disClick} />
+              <DislikeOutlined className={styles.actionButton} onClick={disClick} />
             )}
-            <RedoOutlined className={styles.brandcolor} onClick={regenerateClick} />
+            <RedoOutlined className={styles.actionButton} onClick={regenerateClick} />
           </div>
         );
       },


### PR DESCRIPTION
## Summary
- Add regenerate button next to like/dislike buttons in chat messages
- Button uses RedoOutlined icon from Ant Design
- Clicking regenerate calls the /api/study/run endpoint with original script ID to regenerate message content

## Test plan
- [ ] Verify regenerate button appears after like/dislike buttons
- [ ] Test regenerate functionality works correctly
- [ ] Ensure button styling matches existing buttons

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "regenerate" icon to chat messages, allowing users to resend and regenerate message responses with a single click.
- **Style**
  - Improved layout and styling of message operation controls with enhanced spacing and interactive button effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->