### PR TITLE
fix: remove unnecessary class from image container in ShifuSettingDialog

### DIFF
--- a/src/cook-web/src/components/shifu-setting/index.tsx
+++ b/src/cook-web/src/components/shifu-setting/index.tsx
@@ -368,7 +368,7 @@ export default function ShifuSettingDialog({ shifuId, onSave }: { shifuId: strin
                                 <div className="col-span-3">
                                     {uploadedImageUrl ? (
                                         <div className="mb-2">
-                                            <div className="relative w-24 l h-24 bg-gray-100 rounded-lg overflow-hidden">
+                                            <div className="relative w-24 h-24 bg-gray-100 rounded-lg overflow-hidden">
                                                 <img
                                                     src={uploadedImageUrl}
                                                     alt={t('shifu-setting.shifu-avatar')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a CSS class name to ensure proper styling of the uploaded image preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->