### PR TITLE
Revert "fix: resolve ESLint warnings by replacing img tags with Next.js Image (#579)"

### DIFF
--- a/src/cook-web/src/app/main/page.tsx
+++ b/src/cook-web/src/app/main/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useState, useRef, useEffect } from 'react';
-import Image from 'next/image';
 import { PlusIcon, StarIcon as StarOutlineIcon, RectangleStackIcon as RectangleStackOutlineIcon } from '@heroicons/react/24/outline';
 import { TrophyIcon, RectangleStackIcon, StarIcon } from '@heroicons/react/24/solid';
 import api from "@/api";
@@ -33,7 +32,7 @@ const ShifuCard = ({ id, image, title, description, isFavorite }: ShifuCardProps
                     <div className='flex flex-row items-center mb-2'>
                         <div className="p-2 h-10 w-10 rounded-lg bg-purple-50 mr-4 flex items-center justify-center shrink-0">
                             {
-                                image && <Image src={image} alt="recipe" fill className="object-cover rounded-lg" />
+                                image && <img src={image} alt="recipe" className="w-full h-full object-cover rounded-lg" />
                             }
                             {
                                 !image && <TrophyIcon className="w-6 h-6 text-purple-600" />

--- a/src/cook-web/src/components/file-uploader/image-uploader.tsx
+++ b/src/cook-web/src/components/file-uploader/image-uploader.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type React from 'react'
-import Image from 'next/image'
 
 import { useState, useRef, useEffect } from 'react'
 import { Upload } from 'lucide-react'
@@ -83,8 +82,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ value, onChange }) => {
       setResourceUrl(res.data)
       setResourceTitle(file.name)
       setResourceScale(100)
-      // Use `window.Image` to avoid conflicts with Next.js's `Image` component.
-      const img = new window.Image()
+      const img = new Image()
       img.src = res.data
     } catch (error) {
       console.error('Error uploading image:', error)
@@ -234,11 +232,9 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ value, onChange }) => {
         </>
       ) : (
         <div className='flex flex-col items-center'>
-          <Image
+          <img
             src={resourceUrl || '/placeholder.svg'}
             alt='Uploaded image'
-            width={400}
-            height={400}
             className='max-w-full max-h-[400px] object-contain mb-4'
           />
           <div className='flex items-center w-full mb-2'>{resourceUrl}</div>

--- a/src/cook-web/src/components/header/index.tsx
+++ b/src/cook-web/src/components/header/index.tsx
@@ -1,6 +1,5 @@
 "use client"
 import React, { useState } from 'react';
-import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { useShifu } from '@/store';
@@ -67,11 +66,9 @@ const Header = () => {
                     {
                         currentShifu?.shifu_avatar ? (
                             <div className="bg-blue-100 flex items-center justify-center h-10 w-10 rounded-md p-1 mr-2 overflow-hidden">
-                                <Image
+                                <img
                                     src={currentShifu?.shifu_avatar}
                                     alt="Profile"
-                                    width={40}
-                                    height={40}
                                     className="rounded"
                                 />
                             </div>

--- a/src/cook-web/src/components/shifu-setting/index.tsx
+++ b/src/cook-web/src/components/shifu-setting/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import Image from 'next/image';
 import { Copy, Check, SlidersVertical, Plus } from "lucide-react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -370,11 +369,10 @@ export default function ShifuSettingDialog({ shifuId, onSave }: { shifuId: strin
                                     {uploadedImageUrl ? (
                                         <div className="mb-2">
                                             <div className="relative w-24 h-24 bg-gray-100 rounded-lg overflow-hidden">
-                                                <Image
+                                                <img
                                                     src={uploadedImageUrl}
                                                     alt={t('shifu-setting.shifu-avatar')}
-                                                    fill
-                                                    className="object-cover"
+                                                    className="w-full h-full object-cover"
                                                 />
                                                 <button
                                                     type="button"


### PR DESCRIPTION
This reverts commit 74a67a366f783033c40977624af0571c88a76a41.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced all instances of the Next.js `Image` component with standard HTML `<img>` elements across various sections, including image uploads, user avatars, and image previews. This change maintains image display and styling while switching to native HTML tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->