### PR TITLE
refactor: remove state field from UserInfo API responses

### DIFF
--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -23,7 +23,6 @@ class UserInfo:
     name: str
     email: str
     mobile: str
-    user_state: str
     language: str
     user_avatar: str
     has_password: bool
@@ -37,7 +36,6 @@ class UserInfo:
         name,
         email,
         mobile,
-        user_state,
         wx_openid,
         language,
         has_password,
@@ -50,7 +48,6 @@ class UserInfo:
         self.name = name
         self.email = email
         self.mobile = mobile
-        self.user_state = USE_STATE_VALUES[user_state]
         self.wx_openid = wx_openid
         self.language = language
         self.user_avatar = user_avatar
@@ -65,7 +62,6 @@ class UserInfo:
             "name": self.name,
             "email": self.email,
             "mobile": self.mobile,
-            "state": self.user_state,
             "openid": self.wx_openid,
             "language": self.language,
             "avatar": self.user_avatar,

--- a/src/cook-web/src/components/user-profile/index.tsx
+++ b/src/cook-web/src/components/user-profile/index.tsx
@@ -15,7 +15,6 @@ interface UserInfo {
     name: string;
     email: string;
     mobile: string;
-    state: string;
     openid: string;
     language: string;
     avatar: string;

--- a/src/web/src/common/hooks/useTracking.ts
+++ b/src/web/src/common/hooks/useTracking.ts
@@ -6,22 +6,17 @@ import { FRAME_LAYOUT_MOBILE } from 'constants/uiConstants';
 import { getScriptInfo } from 'Api/lesson';
 export { EVENT_NAMES } from 'common/tools/tracking';
 
-const USER_STATE_DICT = {
-  '未注册': 'guest',
-  '已注册': 'user',
-  '已付费': 'member',
-};
 export const useTracking = () => {
   const { frameLayout } = useUiLayoutStore((state) => state);
   const { userInfo } = useUserStore((state) => state);
 
   const getEventBasicData = useCallback(() => {
     return {
-      user_type: userInfo?.state ? USER_STATE_DICT[userInfo.state] : 'guest',
+      user_type: userInfo?.mobile ? 'user' : 'guest',
       user_id: userInfo?.user_id || 0,
       device: frameLayout === FRAME_LAYOUT_MOBILE ? 'H5' : 'Web',
     };
-  }, [frameLayout, userInfo?.state, userInfo?.user_id]);
+  }, [frameLayout, userInfo?.mobile, userInfo?.user_id]);
 
   const trackEvent = useCallback(async (eventName, eventData) => {
     try {


### PR DESCRIPTION
## Summary
- Removed the `state` field from UserInfo API responses to simplify the API interface
- Updated frontend code to use alternative methods for user type detection
- Database schema remains unchanged - this only affects the API response structure

## Changes Made
1. **Backend API Changes**:
   - Removed `state` field from UserInfo DTO's `__json__` method
   - Removed `state` field from UserInfo class definition
   - Removed all `user_state` parameters from UserInfo constructor calls

2. **Frontend Changes**:
   - Updated tracking logic to use `mobile` field instead of `state` to determine user type
   - Removed `state` field from TypeScript UserInfo interface definitions

## Test Plan
- [ ] Verify that the info API endpoint no longer returns the `state` field
- [ ] Confirm that user tracking analytics still work correctly with the new logic
- [ ] Test that existing functionality is not affected by this change

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the user state attribute from user information displays and tracking logic.
  * Updated user type determination in tracking to rely on mobile presence instead of user state.
* **Chores**
  * Cleaned up related code and interface properties associated with user state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->