### PR TITLE
fix: add GitHub token authentication to Claude Code workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Add `github_token` parameter to claude.yml and claude-code-review.yml workflows
- Provides fallback authentication when OIDC token generation fails
- Resolves authentication errors in GitHub Actions

## Context
The Claude Code GitHub Actions were failing with OIDC token authentication errors despite having the correct `id-token: write` permission. Adding the GitHub token provides a reliable fallback authentication method.

## Changes
- Modified `.github/workflows/claude.yml` to include `github_token: ${{ secrets.GITHUB_TOKEN }}`
- Modified `.github/workflows/claude-code-review.yml` to include `github_token: ${{ secrets.GITHUB_TOKEN }}`

## Test plan
- [ ] Verify GitHub Actions run successfully after merging
- [ ] Confirm Claude Code bot can respond to mentions in issues/PRs
- [ ] Ensure automated code reviews work on new PRs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to include an additional authentication parameter for code review automation. No changes to application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->