### PR TITLE
fix: add default labels and null safety for UI components

### DIFF
--- a/src/api/flaskr/service/study/ui/input_branch.py
+++ b/src/api/flaskr/service/study/ui/input_branch.py
@@ -21,6 +21,7 @@ from flaskr.dao import db
 from flaskr.service.user.models import User
 from flaskr.util.uuid import generate_id
 from flaskr.service.study.utils import get_script_ui_label
+from flaskr.i18n import _
 
 
 @register_ui_handler(UI_TYPE_BRANCH)
@@ -106,9 +107,12 @@ def handle_input_branch(
                 branch_value, jump_rule
             )
         )
+    msg = get_script_ui_label(app, script_info.script_ui_content)
+    if not msg or msg == "":
+        msg = _("COMMON.CONTINUE")
     btn = [
         {
-            "label": get_script_ui_label(app, script_info.script_ui_content),
+            "label": msg,
             "value": script_info.script_ui_content,
             "type": INPUT_TYPE_BRANCH,
         }

--- a/src/api/flaskr/service/study/ui/input_button.py
+++ b/src/api/flaskr/service/study/ui/input_button.py
@@ -30,6 +30,8 @@ def handle_input_button(
 
     # if is json
     msg = get_script_ui_label(app, msg)
+    if not msg or msg == "":
+        msg = _("COMMON.CONTINUE")
 
     btn = [
         {

--- a/src/api/flaskr/service/study/ui/input_checkcode.py
+++ b/src/api/flaskr/service/study/ui/input_checkcode.py
@@ -9,6 +9,7 @@ from flaskr.service.study.utils import check_phone_number, get_script_ui_label
 from flaskr.service.user.common import send_sms_code_without_check
 from flaskr.service.study.dtos import ScriptDTO
 from flaskr.service.user.models import User
+from flaskr.i18n import _
 
 
 @register_ui_handler(UI_TYPE_CHECKCODE)
@@ -23,7 +24,10 @@ def handle_input_checkcode(
 ) -> ScriptDTO:
     if check_phone_number(app, user_info, input):
         expires = send_sms_code_without_check(app, user_info, input)
-        expires["content"] = get_script_ui_label(app, script_info.script_ui_content)
+        msg = get_script_ui_label(app, script_info.script_ui_content)
+        if not msg or msg == "":
+            msg = _("COMMON.CHECKCODE")
+        expires["content"] = msg
         return ScriptDTO(
             INPUT_TYPE_CHECKCODE,
             expires,
@@ -31,9 +35,12 @@ def handle_input_checkcode(
         )
     else:
         app.logger.info("handle_input_checkcode input is not phone number:" + input)
+        msg = get_script_ui_label(app, script_info.script_ui_content)
+        if not msg or msg == "":
+            msg = _("COMMON.CHECKCODE")
         return ScriptDTO(
             INPUT_TYPE_CHECKCODE,
-            script_info.script_ui_content,
+            msg,
             script_info.lesson_id,
             script_info.script_id,
         )

--- a/src/api/flaskr/service/study/ui/input_content.py
+++ b/src/api/flaskr/service/study/ui/input_content.py
@@ -27,6 +27,8 @@ def handle_input_content(
         msg = _("COMMON.CONTINUE")  # Assign default message if msg is empty
 
     msg = get_script_ui_label(app, msg)
+    if not msg or msg == "":
+        msg = _("COMMON.CONTINUE")
 
     btn = [
         {

--- a/src/api/flaskr/service/study/ui/input_login.py
+++ b/src/api/flaskr/service/study/ui/input_login.py
@@ -27,6 +27,8 @@ def handle_require_login(
     if not title:
         title = _("COMMON.LOGIN")
     title = get_script_ui_label(app, title)
+    if not title or title == "":
+        title = _("COMMON.LOGIN")
     btn = [
         {
             "label": title,

--- a/src/api/flaskr/service/study/ui/input_phone.py
+++ b/src/api/flaskr/service/study/ui/input_phone.py
@@ -8,6 +8,7 @@ from flaskr.service.study.plugin import register_ui_handler
 from flaskr.service.study.dtos import ScriptDTO
 from flaskr.service.user.models import User
 from flaskr.service.study.utils import get_script_ui_label
+from flaskr.i18n import _
 
 
 @register_ui_handler(UI_TYPE_PHONE)
@@ -20,9 +21,12 @@ def handle_input_phone(
     trace,
     trace_args,
 ) -> ScriptDTO:
+    msg = get_script_ui_label(app, script_info.script_ui_content)
+    if not msg or msg == "":
+        msg = _("COMMON.PHONE")
     return ScriptDTO(
         INPUT_TYPE_PHONE,
-        get_script_ui_label(app, script_info.script_ui_content),
+        msg,
         script_info.lesson_id,
         script_info.script_id,
     )

--- a/src/api/flaskr/service/study/ui/input_text.py
+++ b/src/api/flaskr/service/study/ui/input_text.py
@@ -6,6 +6,7 @@ from flaskr.service.study.plugin import register_ui_handler
 from flaskr.service.study.dtos import ScriptDTO
 from flaskr.service.user.models import User
 from flaskr.service.study.utils import get_script_ui_label
+from flaskr.i18n import _
 
 
 @register_ui_handler(UI_TYPE_INPUT)
@@ -18,9 +19,12 @@ def handle_input_text(
     trace,
     trace_args,
 ) -> ScriptDTO:
+    msg = get_script_ui_label(app, script_info.script_ui_content)
+    if not msg or msg == "":
+        msg = _("COMMON.INPUT")
     return ScriptDTO(
         "input",
-        {"content": get_script_ui_label(app, script_info.script_ui_content)},
+        {"content": msg},
         script_info.lesson_id,
         script_info.script_id,
     )

--- a/src/api/flaskr/service/study/ui/input_topay.py
+++ b/src/api/flaskr/service/study/ui/input_topay.py
@@ -28,6 +28,8 @@ def handle_input_to_pay(
         if not title:
             title = _("COMMON.CHECKOUT")
         title = get_script_ui_label(app, title)
+        if not title or title == "":
+            title = _("COMMON.CHECKOUT")
         btn = [{"label": title, "value": order.order_id}]
         return ScriptDTO("order", {"buttons": btn}, script_info.script_id)
     else:

--- a/src/api/flaskr/service/study/ui/ui_continue.py
+++ b/src/api/flaskr/service/study/ui/ui_continue.py
@@ -24,6 +24,8 @@ def make_continue_ui(
         msg = _("COMMON.CONTINUE")  # Assign default message if msg is empty
 
     msg = get_script_ui_label(app, msg)
+    if not msg or msg == "":
+        msg = _("COMMON.CONTINUE")
     btn = [
         {
             "label": msg,

--- a/src/api/flaskr/service/study/utils.py
+++ b/src/api/flaskr/service/study/utils.py
@@ -908,7 +908,7 @@ def get_script_ui_label(app, text):
         for k, v in text.items():
             if v and v != "":
                 return v
-    if text.startswith("{"):
+    if text and text.strip().startswith("{"):
         try:
             json_obj = json.loads(text)
             label = json_obj.get(get_current_language(), "")


### PR DESCRIPTION
- Add null/empty checks in get_script_ui_label to prevent AttributeError
- Provide fallback default labels for UI components when content is empty
- Ensure all input components display meaningful labels using i18n strings
- Fixes issue where UI elements could display without proper labels

Affected components:
- input_branch, input_button, input_checkcode, input_content
- input_login, input_phone, input_text, input_topay, ui_continue

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
