### PR TITLE
Revert prettier hook from pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,6 @@ repos:
     rev: 25.1.0
     hooks:
     -   id: black
--   repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-    -   id: prettier
-        files: ^src/cook-web/
-        types_or: [javascript, jsx, ts, tsx, css, scss, json, markdown, mdx]
-        args: ['--config', 'src/cook-web/.prettierrc']
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3  # use latest stable version
     hooks:


### PR DESCRIPTION
## Summary
- Reverts commit 75c16767 which added prettier hook to cook-web pre-commit configuration
- Removes prettier hook that was causing issues

## Changes
- Removed prettier configuration from `.pre-commit-config.yaml`

🤖 Generated with [Claude Code](https://claude.ai/code)