### PR TITLE
fix: remove unused registerMethod variables (follow-up)

### DIFF
--- a/src/cook-web/src/app/login/page.tsx
+++ b/src/cook-web/src/app/login/page.tsx
@@ -40,8 +40,6 @@ export default function AuthPage() {
   const [loginMethod, setLoginMethod] = useState<'phone' | 'email'>(
     defaultMethod as 'phone' | 'email',
   );
-  // Email-only registration since phone now auto-registers
-  const [registerMethod, setRegisterMethod] = useState<'email'>('email');
   const [language, setLanguage] = useState(browserLanguage);
 
   const searchParams = useSearchParams();


### PR DESCRIPTION
## Summary
Fixed ESLint errors by removing unused `registerMethod` and `setRegisterMethod` variables that were left behind after removing phone registration functionality.

## Changes
- Removed unused `registerMethod` state variable
- Removed unused `setRegisterMethod` state setter

## Related
Follow-up fix for the phone login/registration merge feature.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused state variable from the login page for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->