### PR TITLE
fix: add missing whitespace around arithmetic operator in migration file

### DIFF
--- a/src/api/migrations/versions/9cfc776b11f4_add_shifu_migration.py
+++ b/src/api/migrations/versions/9cfc776b11f4_add_shifu_migration.py
@@ -23,7 +23,7 @@ def upgrade():
         old_shifu_bid = course_id[0]
         old_course = AICourse.query.filter(AICourse.course_id == old_shifu_bid).first()
         print(
-            f"migrate shifu draft to shifu draft v2, shifu_bid: {old_shifu_bid}, {old_course.course_name}, {i+1}/{len(old_shifu_bids)}"
+            f"migrate shifu draft to shifu draft v2, shifu_bid: {old_shifu_bid}, {old_course.course_name}, {i + 1}/{len(old_shifu_bids)}"
         )
         migrate_shifu_draft_to_shifu_draft_v2(current_app, old_shifu_bid)
 


### PR DESCRIPTION
## Summary
- Fixed Flake8 E226 error in migration file
- Added proper spacing around the `+` operator in line 26

## Test plan
- [x] Run `pre-commit run --all-files` to verify all checks pass
- [x] Flake8 check now passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of print statement formatting in migration output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->