### PR TITLE
fix: correct typo USER_STATE_UNTEGISTERED to USER_STATE_UNREGISTERED

### DIFF
--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -2,14 +2,14 @@ from ...common.swagger import register_schema_to_swagger
 from pydantic import BaseModel, Field
 import math
 
-USER_STATE_UNTEGISTERED = 0
+USER_STATE_UNREGISTERED = 0
 USER_STATE_REGISTERED = 1
 USER_STATE_TRAIL = 2
 USER_STATE_PAID = 3
 
 
 USE_STATE_VALUES = {
-    USER_STATE_UNTEGISTERED: "未注册",
+    USER_STATE_UNREGISTERED: "未注册",
     USER_STATE_REGISTERED: "已注册",
     USER_STATE_TRAIL: "试用",
     USER_STATE_PAID: "已付费",

--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -17,7 +17,7 @@ from flaskr.api.sms.aliyun import send_sms_code_ali
 from flaskr.service.order.models import AICourseLessonAttend
 from ..common.dtos import (
     USER_STATE_REGISTERED,
-    USER_STATE_UNTEGISTERED,
+    USER_STATE_UNREGISTERED,
     UserInfo,
     UserToken,
 )
@@ -456,7 +456,7 @@ def verify_sms_code(
             )
             if (
                 user_info.user_state is None
-                or user_info.user_state == USER_STATE_UNTEGISTERED  # noqa W503
+                or user_info.user_state == USER_STATE_UNREGISTERED  # noqa W503
             ):
                 user_info.user_state = USER_STATE_REGISTERED
             user_info.mobile = phone
@@ -466,7 +466,7 @@ def verify_sms_code(
             # When there is an install ui, the logic here should be removed
             init_first_course(app, user_info.user_id)
 
-        if user_info.user_state == USER_STATE_UNTEGISTERED:
+        if user_info.user_state == USER_STATE_UNREGISTERED:
             user_info.mobile = phone
             user_info.user_state = USER_STATE_REGISTERED
             user_info.user_language = language
@@ -552,7 +552,7 @@ def verify_mail_code(
             )
             if (
                 user_info.user_state is None
-                or user_info.user_state == USER_STATE_UNTEGISTERED  # noqa W503
+                or user_info.user_state == USER_STATE_UNREGISTERED  # noqa W503
             ):
                 user_info.user_state = USER_STATE_REGISTERED
             user_info.email = mail
@@ -562,7 +562,7 @@ def verify_mail_code(
             # When there is an install ui, the logic here should be removed
             init_first_course(app, user_info.user_id)
 
-        if user_info.user_state == USER_STATE_UNTEGISTERED:
+        if user_info.user_state == USER_STATE_UNREGISTERED:
             user_info.email = mail
             user_info.user_state = USER_STATE_REGISTERED
             user_info.user_language = language
@@ -593,7 +593,7 @@ def init_first_course(app: Flask, user_id: str):
     Check if there is only one user and one course. If so, update the creator of the course
     """
     # Check the number of users
-    user_count = User.query.filter(User.user_state != USER_STATE_UNTEGISTERED).count()
+    user_count = User.query.filter(User.user_state != USER_STATE_UNREGISTERED).count()
     if user_count != 1:
         return
 

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -10,7 +10,7 @@ from ...common.config import get_config
 from ..common.models import raise_error, raise_error_with_args
 
 from .utils import generate_token
-from ...service.common.dtos import USER_STATE_UNTEGISTERED, UserInfo, UserToken
+from ...service.common.dtos import USER_STATE_UNREGISTERED, UserInfo, UserToken
 from ...service.user.models import User, UserConversion
 from ...dao import db
 from ...api.wechat import get_wechat_access_token
@@ -79,7 +79,7 @@ def generate_temp_user(
                 conversion_source=user_source,
                 conversion_status=0,
             )
-            new_user = User(user_id=user_id, user_state=USER_STATE_UNTEGISTERED)
+            new_user = User(user_id=user_id, user_state=USER_STATE_UNREGISTERED)
             new_user.user_language = language
             new_user.user_open_id = wx_openid
             db.session.add(new_convert_user)


### PR DESCRIPTION
## Summary
- Fixed spelling error in constant name `USER_STATE_UNTEGISTERED` → `USER_STATE_UNREGISTERED`
- Updated all occurrences across 3 files in the API service layer
- No database impact - constant value remains 0

## Test plan
- [x] Run pre-commit hooks - all pass
- [x] Verify no remaining instances of the typo
- [ ] Run API tests to ensure functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the user state constant from "UNTEGISTERED" to "UNREGISTERED" across the application to ensure consistent and accurate user state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->