### PR TITLE
fix: validate bilibili.com domain properly to prevent URL substring bypass

### DIFF
--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -904,9 +904,9 @@ def get_video_info(app, user_id: str, url: str) -> dict:
     with app.app_context():
         try:
             parsed_url = urlparse(url)
-            domain = parsed_url.netloc
+            domain = parsed_url.hostname
 
-            if "bilibili.com" in domain:
+            if domain == "bilibili.com" or (domain and domain.endswith(".bilibili.com")):
                 bv_pattern = r"/video/(BV\w+)"
                 match = re.search(bv_pattern, url)
                 if not match:

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -906,7 +906,9 @@ def get_video_info(app, user_id: str, url: str) -> dict:
             parsed_url = urlparse(url)
             domain = parsed_url.hostname
 
-            if domain == "bilibili.com" or (domain and domain.endswith(".bilibili.com")):
+            if domain == "bilibili.com" or (
+                domain and domain.endswith(".bilibili.com")
+            ):
                 bv_pattern = r"/video/(BV\w+)"
                 match = re.search(bv_pattern, url)
                 if not match:


### PR DESCRIPTION
Potential fix for [https://github.com/ai-shifu/ai-shifu/security/code-scanning/3](https://github.com/ai-shifu/ai-shifu/security/code-scanning/3)

To fix the issue, we need to ensure that the domain is explicitly validated as either `bilibili.com` or a valid subdomain of it. This can be achieved by using `urlparse` to extract the hostname and then checking if it matches `bilibili.com` or ends with `.bilibili.com`. This approach ensures that only the intended domain and its subdomains are allowed, preventing malicious domains from bypassing the check.

The changes will be made in the `get_video_info` function, specifically replacing the substring check `"bilibili.com" in domain` with a more robust validation using `urlparse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in identifying Bilibili video URLs, ensuring more precise domain validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->