### PR TITLE
fix: fix missing i18n placeholders and optimize translation keys in CreateShifuDialog

### DIFF
--- a/src/cook-web/public/locales/en-US.json
+++ b/src/cook-web/public/locales/en-US.json
@@ -184,13 +184,15 @@
   },
   "createShifuDialog": {
     "create": "Create",
-    "createBlankShifu": "Create New Shifu",
     "creating": "Creating...",
-    "shifuDescription": "Shifu Description",
-    "shifuDescriptionMaxLength": "Shifu description cannot exceed 500 characters",
-    "shifuName": "Shifu Name",
-    "shifuNameEmpty": "Shifu name cannot be empty",
-    "shifuNameMaxLength": "Shifu name cannot exceed 20 characters"
+    "descriptionLabel": "Shifu Description",
+    "descriptionMaxLength": "Shifu description cannot exceed 500 characters",
+    "descriptionPlaceholder": "Please input shifu description",
+    "nameLabel": "Shifu Name",
+    "nameMaxLength": "Shifu name cannot exceed 20 characters",
+    "namePlaceholder": "Please input shifu name",
+    "nameRequired": "Shifu name cannot be empty",
+    "title": "Create New Shifu"
   },
   "errors": {
     "noPermission": "You don't have permission to access this content"

--- a/src/cook-web/public/locales/zh-CN.json
+++ b/src/cook-web/public/locales/zh-CN.json
@@ -184,13 +184,15 @@
   },
   "createShifuDialog": {
     "create": "创建",
-    "createBlankShifu": "创建新师傅",
     "creating": "创建中...",
-    "shifuDescription": "师傅描述",
-    "shifuDescriptionMaxLength": "师傅描述不能超过500个字符",
-    "shifuName": "师傅名称",
-    "shifuNameEmpty": "师傅名称不能为空",
-    "shifuNameMaxLength": "师傅名称不能超过20个字符"
+    "descriptionLabel": "师傅描述",
+    "descriptionMaxLength": "师傅描述不能超过500个字符",
+    "descriptionPlaceholder": "请输入师傅描述",
+    "nameLabel": "师傅名称",
+    "nameMaxLength": "师傅名称不能超过20个字符",
+    "namePlaceholder": "请输入师傅名称",
+    "nameRequired": "师傅名称不能为空",
+    "title": "创建新师傅"
   },
   "errors": {
     "noPermission": "您当前没有权限访问此内容"

--- a/src/cook-web/src/components/create-shifu-dialog/CreateShifuDialog.tsx
+++ b/src/cook-web/src/components/create-shifu-dialog/CreateShifuDialog.tsx
@@ -41,11 +41,11 @@ export const CreateShifuDialog = ({
   const formSchema = z.object({
     name: z
       .string()
-      .min(1, t('createShifuDialog.shifuNameEmpty'))
-      .max(20, t('createShifuDialog.shifuNameMaxLength')),
+      .min(1, t('createShifuDialog.nameRequired'))
+      .max(20, t('createShifuDialog.nameMaxLength')),
     description: z
       .string()
-      .max(500, t('createShifuDialog.shifuDescriptionMaxLength'))
+      .max(500, t('createShifuDialog.descriptionMaxLength'))
       .optional(),
     avatar: z.string().default(''),
   });
@@ -78,7 +78,7 @@ export const CreateShifuDialog = ({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('createShifuDialog.createBlankShifu')}</DialogTitle>
+          <DialogTitle>{t('createShifuDialog.title')}</DialogTitle>
         </DialogHeader>
         <Form {...form}>
           <form
@@ -95,14 +95,12 @@ export const CreateShifuDialog = ({
                       color: '#000000',
                     }}
                   >
-                    {t('createShifuDialog.shifuName')}
+                    {t('createShifuDialog.nameLabel')}
                   </FormLabel>
                   <FormControl>
                     <Input
                       autoComplete='off'
-                      placeholder={t(
-                        'create-shifu-dialog.please-input-shifu-name',
-                      )}
+                      placeholder={t('createShifuDialog.namePlaceholder')}
                       {...field}
                     />
                   </FormControl>
@@ -120,13 +118,13 @@ export const CreateShifuDialog = ({
                       color: '#000000',
                     }}
                   >
-                    {t('createShifuDialog.shifuDescription')}
+                    {t('createShifuDialog.descriptionLabel')}
                   </FormLabel>
                   <FormControl>
                     <Textarea
                       autoComplete='off'
                       placeholder={t(
-                        'create-shifu-dialog.please-input-shifu-description',
+                        'createShifuDialog.descriptionPlaceholder',
                       )}
                       {...field}
                     />


### PR DESCRIPTION
## Summary
- Fixed missing placeholder translations in CreateShifuDialog that were causing translation keys to be displayed instead of actual text
- Optimized translation key naming for better maintainability and consistency
- Added back placeholder translations that were accidentally removed in commit a8ac203e

## Changes
- **Translation Keys Optimization:**
  - Renamed keys to be more concise: `shifuName` → `nameLabel`, `pleaseInputShifuName` → `namePlaceholder`, etc.
  - Used consistent naming pattern: `label`, `placeholder`, `required`, `maxLength`
  - Sorted keys alphabetically for better organization

- **Bug Fix:**
  - Added missing `namePlaceholder` and `descriptionPlaceholder` translations
  - Fixed component to use correct camelCase keys instead of kebab-case

## Test Plan
- [x] Verified CreateShifuDialog displays proper Chinese text instead of translation keys
- [x] Verified English translations work correctly
- [x] Tested form validation messages display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added placeholder text for name and description input fields in the "Create Shifu" dialog.

* **Style**
  * Improved clarity and consistency of field labels and validation messages in the "Create Shifu" dialog for both English and Chinese languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->