### PR TITLE
feat: add in-memory redis for tests

### DIFF
--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -1,20 +1,14 @@
+import os
 import pytest
-from app import create_app
-from flask_migrate import upgrade
 
-
-# Path: test/test_flaskr.py
-# Compare this snippet from flaskr/plugin/test.py:
-# from ..service.schedule import *
-#
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def app():
+    os.environ.setdefault("REDIS_MOCK", "true")
+    os.environ.setdefault("LOGGING_PATH", "/tmp/test.log")
+    os.environ.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    from app import create_app
 
     app = create_app()
-
-    with app.app_context():
-        upgrade("migrations")
-
     yield app
 
 


### PR DESCRIPTION
## Summary
- add REDIS_MOCK option to initialize an in-memory Redis client for tests
- create pytest fixtures and thread-based redis lock test using the mock client

## Testing
- `pytest src/api/tests/test_redislock.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'objprint')*


------
https://chatgpt.com/codex/tasks/task_e_6896edb76d908324ae213a3b63b8e410