### PR TITLE
feat: add redis caching for shifu struct and outline

### DIFF
--- a/src/api/flaskr/service/shifu/cache.py
+++ b/src/api/flaskr/service/shifu/cache.py
@@ -1,0 +1,70 @@
+"""Redis based cache utilities for shifu structs and outlines.
+
+This module provides helper functions to cache shifu structs and outline
+trees in Redis with concurrency control. It exposes utilities to build
+cache keys, fetch or populate cache values under a Redis lock and remove
+cached entries when data is updated.
+
+Author: yfge (added by open-source contributor)
+"""
+
+from typing import Callable
+
+from flaskr.dao import redis_client
+from flaskr.common.config import get_config
+
+
+def _prefix() -> str:
+    """Return configured Redis key prefix."""
+    return get_config("REDIS_KEY_PREFIX", "ai-shifu:")
+
+
+STRUCT_PREFIX = _prefix() + "shifu_struct:"
+OUTLINE_PREFIX = _prefix() + "shifu_outline:"
+
+
+def struct_cache_key(shifu_bid: str, is_preview: bool) -> str:
+    """Build cache key for shifu struct."""
+    mode = "preview" if is_preview else "pub"
+    return f"{STRUCT_PREFIX}{mode}:{shifu_bid}"
+
+
+def outline_cache_key(shifu_bid: str, is_preview: bool) -> str:
+    """Build cache key for shifu outline tree."""
+    mode = "preview" if is_preview else "pub"
+    return f"{OUTLINE_PREFIX}{mode}:{shifu_bid}"
+
+
+def get_or_set(key: str, loader: Callable[[], str], expire: int) -> str:
+    """Get a cache entry or populate it using loader under a Redis lock."""
+    cached = redis_client.get(key)
+    if cached is not None:
+        return cached.decode("utf-8") if isinstance(cached, bytes) else cached
+
+    lock = redis_client.lock(key + ":lock", timeout=5, blocking_timeout=5)
+    acquired = lock.acquire(blocking=False)
+    try:
+        if acquired:
+            cached = redis_client.get(key)
+            if cached is not None:
+                return cached.decode("utf-8") if isinstance(cached, bytes) else cached
+            value = loader()
+            if value is not None:
+                redis_client.set(key, value, ex=expire)
+            return value
+        # Lock not acquired, fall back to direct load
+        return loader()
+    finally:
+        if acquired:
+            try:
+                lock.release()
+            except Exception:
+                pass
+
+
+def delete_shifu_cache(shifu_bid: str) -> None:
+    """Remove cached struct and outline for given shifu."""
+    redis_client.delete(struct_cache_key(shifu_bid, False))
+    redis_client.delete(struct_cache_key(shifu_bid, True))
+    redis_client.delete(outline_cache_key(shifu_bid, False))
+    redis_client.delete(outline_cache_key(shifu_bid, True))

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -25,6 +25,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 from flaskr.service.shifu.shifu_block_funcs import __get_block_list_internal
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.shifu_struct_manager import get_shifu_outline_tree
+from flaskr.service.shifu.cache import delete_shifu_cache
 from flaskr.common import get_config
 from flaskr.util import generate_id
 from datetime import datetime
@@ -188,6 +189,8 @@ def publish_shifu_draft(app, user_id: str, shifu_id: str):
         thread.daemon = True  # Ensure thread doesn't prevent app shutdown
         thread.start()
         db.session.commit()
+        delete_shifu_cache(shifu_id)
+        get_shifu_outline_tree(app, shifu_id)
         return get_config("WEB_URL", "UNCONFIGURED") + "/c/" + shifu_id
 
 


### PR DESCRIPTION
## Summary
- add reusable Redis cache utilities with locking
- cache shifu struct and outline queries
- clear and rebuild caches on publish

## Testing
- `pre-commit run --files src/api/flaskr/service/shifu/cache.py src/api/flaskr/service/shifu/shifu_struct_manager.py src/api/flaskr/service/shifu/shifu_publish_funcs.py` *(failed: `fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403`)*
- `pytest src/api/tests/test_redislock.py` *(failed: `KeyError: 'LOGGING_PATH'`)*

------
https://chatgpt.com/codex/tasks/task_e_6897002be7348324ab9e0a92c1b0ccee