### PR TITLE
Fix log path handling in logging setup

### DIFF
--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -154,7 +154,7 @@ def init_log(app: Flask) -> Flask:
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
     file_handler = TimedRotatingFileHandler(
-        app.config["LOGGING_PATH"], when="midnight", backupCount=7
+        log_file, when="midnight", backupCount=7
     )
     file_handler.setFormatter(formatter)
     console_handler = logging.StreamHandler()

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -153,9 +153,7 @@ def init_log(app: Flask) -> Flask:
     log_dir = os.path.dirname(log_file)
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
-    file_handler = TimedRotatingFileHandler(
-        log_file, when="midnight", backupCount=7
-    )
+    file_handler = TimedRotatingFileHandler(log_file, when="midnight", backupCount=7)
     file_handler.setFormatter(formatter)
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(color_formatter)  # use color formatter


### PR DESCRIPTION
## Summary
- Use `log_file` variable when constructing `TimedRotatingFileHandler` to respect default logging path and avoid missing key error

## Testing
- `SQLALCHEMY_DATABASE_URI="sqlite://" pytest` *(fails: KeyError: 'REDIS_HOST')*

------
https://chatgpt.com/codex/tasks/task_e_6896ebf6f3b483249aebc6fcedd4804b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the usage of the log file path variable for improved code clarity. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->