### PR TITLE
feat: add history message limit setting when asking

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -56,7 +56,7 @@ DEFAULT_LLM_MODEL=""
 DEFAULT_LLM_TEMPERATURE=0.3
 
 # (Optional) The count of history messages to append to LLM's context in ask
-ASK_MESSAGE_LIMIT=10
+ASK_MAX_HISTORY_LEN=10
 
 
 ###################

--- a/src/api/flaskr/service/study/input/handle_input_ask.py
+++ b/src/api/flaskr/service/study/input/handle_input_ask.py
@@ -59,11 +59,11 @@ def _handle_input_ask(
     context = RunScriptContext.get_current_context(app)
     app.logger.info("follow_up_info:{}".format(follow_up_info.__json__()))
 
-    raw_ask_message_limit = app.config.get("ASK_MESSAGE_LIMIT", 10)
+    raw_ask_max_history_len = app.config.get("ASK_MAX_HISTORY_LEN", 10)
     try:
-        ask_message_limit = int(raw_ask_message_limit)
+        ask_max_history_len = int(raw_ask_max_history_len)
     except ValueError:
-        ask_message_limit = 10
+        ask_max_history_len = 10
 
     # Query historical conversation records, ordered by time
     history_scripts = (
@@ -71,7 +71,7 @@ def _handle_input_ask(
             AICourseLessonAttendScript.attend_id == attend_id,
         )
         .order_by(AICourseLessonAttendScript.id.desc())
-        .limit(ask_message_limit)
+        .limit(ask_max_history_len)
         .all()
     )
 


### PR DESCRIPTION
…igure ask history message limit

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ASK_MAX_HISTORY_LEN (default 10) to control how many past messages are included in the Ask flow.

- **Improvements**
  - Ask now retrieves the most recent N messages and preserves chronological order for more consistent responses.
  - Limits processed history items for potential performance gains.

- **Documentation**
  - Added ASK_MAX_HISTORY_LEN to the Docker environment example with a descriptive comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->