### PR TITLE
chore: add JSON formatter pre-commit hook for i18n files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,9 @@ repos:
         exclude: ^src/web/pnpm-lock\.yaml$
     -   id: trailing-whitespace
         exclude: ^src/web/pnpm-lock\.yaml$
+    -   id: pretty-format-json
+        args: ['--autofix', '--indent=2', '--no-ensure-ascii']
+        files: ^(src/web/public/locales/.*\.json|src/cook-web/public/locales/.*\.json|src/api/i18n/.*\.json)$
     -   id: flake8
         args: [--max-line-length=200,--ignore=F403,--ignore=W503]
 -   repo: https://github.com/psf/black

--- a/src/api/.vscode/settings.json
+++ b/src/api/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/geyunfei/dev/agiclass/ai-shifu/src/api/.venv/bin/python"
-}


### PR DESCRIPTION
## Summary

- Add `pretty-format-json` hook to pre-commit configuration that specifically targets i18n JSON files
- Automatically formats JSON files with consistent 2-space indentation and proper encoding
- Targets translation files in `src/web/public/locales/`, `src/cook-web/public/locales/`, and `src/api/i18n/` directories
- Removes obsolete VS Code settings file from API directory

## Test plan

- [x] Pre-commit hooks run successfully on commit
- [x] JSON formatter hook is properly configured to target only i18n files
- [x] Commit includes clean removal of unused VS Code configuration
- [ ] Verify hook works correctly when i18n JSON files are modified

🤖 Generated with [Claude Code](https://claude.ai/code)