### PR TITLE
fix: change default login redirect from /c to /main in cook-web

### DIFF
--- a/src/cook-web/src/app/login/page.tsx
+++ b/src/cook-web/src/app/login/page.tsx
@@ -46,7 +46,7 @@ export default function AuthPage() {
   const handleAuthSuccess = () => {
     let redirect = searchParams.get('redirect');
     if (!redirect || redirect.charAt(0) !== '/') {
-      redirect = '/c';
+      redirect = '/main';
     }
     // Using push for navigation keeps a history, so when users click the back button, they'll return to the login page.
     // router.push('/main')


### PR DESCRIPTION
## Summary
• Changes the default redirect path after successful login from `/c` to `/main` in cook-web
• Updates the login page component to align with current application structure
• Improves user experience by directing users to the main interface after authentication

## Test plan
- [ ] Verify login functionality still works correctly
- [ ] Test that users are redirected to `/main` after successful login
- [ ] Ensure redirect parameter in URL still takes precedence when specified
- [ ] Test that invalid redirect parameters are properly handled

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default post-login destination to the main page when no redirect is provided or the redirect is invalid.
  * Users who sign in without a valid redirect now land on the primary dashboard reliably, improving navigation consistency after authentication.
  * This change affects only the fallback path; custom redirects that start with “/” continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->