### PR TITLE
chore: upgrade pre-commit-hooks to v6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   skip: [eslint]  # Skip ESLint hooks in pre-commit.ci since not work
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
         exclude: ^src/web/pnpm-lock\.yaml$
@@ -16,9 +16,12 @@ repos:
     -   id: pretty-format-json
         args: ['--autofix', '--indent=2', '--no-ensure-ascii', '--top-keys=langName']
         files: ^(src/web/public/locales/.*\.json|src/cook-web/public/locales/.*\.json)$
+    -   id: requirements-txt-fixer
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
     -   id: flake8
         args: [--max-line-length=200,--ignore=F403,--ignore=W503]
-    -   id: requirements-txt-fixer
 -   repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:


### PR DESCRIPTION
## Summary
- Upgraded pre-commit-hooks from v2.3.0 to v6.0.0 for latest improvements and bug fixes
- Moved flake8 to its dedicated repository (PyCQA/flake8) as per upstream changes
- All existing hook configurations remain intact

## Test plan
- [x] Pre-commit hooks run successfully locally
- [x] All hooks pass with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded pre-commit tooling to improve reliability and coverage of local checks.
  * Added automatic formatting and validation for requirements files to keep dependencies consistent.
  * Enabled enhanced linting via flake8 to enforce stricter code quality standards.
  * Consolidated configuration so contributors get consistent, faster feedback during development.
  * No user-facing behavior changes; these updates streamline contributor workflows and help prevent formatting and style issues before commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->