### PR TITLE
fix: improve update-i18n script and fix translation key references

### DIFF
--- a/src/cook-web/public/locales/en-US.json
+++ b/src/cook-web/public/locales/en-US.json
@@ -418,6 +418,7 @@
     "addKeyword": "Add Keyword",
     "cancel": "Cancel",
     "fileSizeLimit": "File size cannot exceed 2MB",
+    "imageFormatHint": "Support JPG and PNG format, file size cannot exceed 2MB",
     "inputKeywords": "Input Keywords",
     "keywords": "Keywords",
     "learningUrl": "Learning URL",

--- a/src/cook-web/public/locales/zh-CN.json
+++ b/src/cook-web/public/locales/zh-CN.json
@@ -418,6 +418,7 @@
     "addKeyword": "添加关键词",
     "cancel": "取消",
     "fileSizeLimit": "文件大小不能超过2MB",
+    "imageFormatHint": "只支持jpg和png格式，文件大小不能超过2MB",
     "inputKeywords": "输入关键词",
     "keywords": "关键词",
     "learningUrl": "学习地址",

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/ResetChapterButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/ResetChapterButton.tsx
@@ -42,8 +42,8 @@ export const ResetChapterButton = ({
     async e => {
       setShowConfirm(true);
       // Modal.confirm({
-      //   title: t('lesson.reset.resetConfirmTitle'),
-      //   content: t('lesson.reset.resetConfirmContent'),
+      //   title: t('lesson.reset.confirmTitle'),
+      //   content: t('lesson.reset.confirmContent'),
       //   onOk: async () => {
       //     await resetChapter(chapterId);
       //     updateLessonId(lessonId);
@@ -95,7 +95,7 @@ export const ResetChapterButton = ({
         className={cn(className, 'size-max', 'px-2', 'rounded-full')}
         onClick={onButtonClick}
       >
-        {t('lesson.reset.resetTitle')}
+        {t('lesson.reset.title')}
       </Button>
       <Dialog
         open={showConfirm}
@@ -103,9 +103,9 @@ export const ResetChapterButton = ({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('lesson.reset.resetConfirmTitle')}</DialogTitle>
+            <DialogTitle>{t('lesson.reset.confirmTitle')}</DialogTitle>
             <DialogDescription>
-              {t('lesson.reset.resetConfirmContent')}
+              {t('lesson.reset.confirmContent')}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/CouponCodeModal.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/CouponCodeModal.tsx
@@ -31,7 +31,7 @@ export const CouponCodeModal = ({ open = false, onCancel, onOk }) => {
 
   const formSchema = z.object({
     couponCode: z.string().min(1, {
-      message: t('groupon.grouponInputMsg'),
+      message: t('groupon.inputMessage'),
     }),
   });
 
@@ -69,7 +69,7 @@ export const CouponCodeModal = ({ open = false, onCancel, onOk }) => {
             onPointerDownOutside={evt => evt.preventDefault()}
           >
             <DialogHeader>
-              <DialogTitle>{t('groupon.grouponTitle')}</DialogTitle>
+              <DialogTitle>{t('groupon.title')}</DialogTitle>
             </DialogHeader>
 
             <FormField
@@ -79,7 +79,7 @@ export const CouponCodeModal = ({ open = false, onCancel, onOk }) => {
                 <FormItem>
                   <FormControl>
                     <Input
-                      placeholder={t('groupon.grouponPlaceholder')}
+                      placeholder={t('groupon.placeholder')}
                       {...field}
                     />
                   </FormControl>

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
@@ -362,8 +362,8 @@ export const PayModal = ({
                           className={styles.couponCodeButton}
                         >
                           {!couponCode
-                            ? t('groupon.grouponUse')
-                            : t('groupon.grouponModify')}
+                            ? t('groupon.useOtherPayment')
+                            : t('groupon.modify')}
                         </Button>
                       </div>
                     </>

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
@@ -320,8 +320,8 @@ export const PayModalM = ({
                             onClick={onCouponCodeButtonClick}
                           >
                             {!couponCode
-                              ? t('groupon.grouponUse')
-                              : t('groupon.grouponModify')}
+                              ? t('groupon.useOtherPayment')
+                              : t('groupon.modify')}
                           </MainButtonM>
                         </div>
                         <PayModalFooter className={styles.payModalFooter} />

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -453,9 +453,7 @@ export default function ShifuSettingDialog({
                   />
 
                   <p className='text-xs text-gray-500 mt-1'>
-                    {t(
-                      'shifu-setting.support-jpg-png-format-file-less-than-2mb',
-                    )}
+                    {t('shifuSetting.imageFormatHint')}
                   </p>
 
                   {isUploading && (


### PR DESCRIPTION
## Summary

- Enhanced update-i18n script to detect all translation key usage patterns
- Fixed incorrect translation key references throughout the codebase
- Added missing translation for image format hint in ShifuSetting component

## Problem

1. The update-i18n script was incorrectly removing valid translation keys that were actually being used in the codebase, including:
   - `errorSaveFailed` (used in setError calls)
   - `descriptionPlaceholder` (used in multiline t() calls)
   - `secondsLater` (used with interpolation parameters)
   - `profileSelectModal.addVariable` (used in JSX attributes)

2. Several components were using incorrect translation key formats:
   - `groupon.grouponInputMsg` → `groupon.inputMessage`
   - `groupon.grouponTitle` → `groupon.title`
   - `groupon.grouponPlaceholder` → `groupon.placeholder`
   - `groupon.grouponUse` → `groupon.useOtherPayment`
   - `groupon.grouponModify` → `groupon.modify`
   - `lesson.reset.resetTitle` → `lesson.reset.title`
   - `lesson.reset.resetConfirmTitle` → `lesson.reset.confirmTitle`
   - `lesson.reset.resetConfirmContent` → `lesson.reset.confirmContent`

3. Missing translation for image upload format hint

## Solution

### Enhanced update-i18n.js script to:
1. Detect translation keys in `setError()` function calls
2. Handle multiline `t()` function calls by normalizing content
3. Support `t()` calls with interpolation parameters (e.g., `{ count: countdown }`)
4. Properly match `t()` calls in JSX attributes

### Fixed translation key references:
- Updated all components to use the correct, standardized translation key format
- Removed redundant prefixes in translation keys
- Ensured consistency across the codebase

### Added missing translations:
- Added `imageFormatHint` translation for ShifuSetting component
- Replaced overly long key `support-jpg-png-format-file-less-than-2mb` with cleaner `imageFormatHint`

## Test plan

- [x] Run `npm run update-i18n` in cook-web
- [x] Verify that previously deleted keys are now preserved
- [x] Confirm all components display correct translations
- [x] Check that all translation keys are properly detected by the script

🤖 Generated with [Claude Code](https://claude.ai/code)