### PR TITLE
fix: correct file handler to use log_file variable

### DIFF
--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -151,9 +151,7 @@ def init_log(app: Flask) -> Flask:
     log_dir = os.path.dirname(log_file)
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
-    file_handler = TimedRotatingFileHandler(
-        app.config["LOGGING_PATH"], when="midnight", backupCount=7
-    )
+    file_handler = TimedRotatingFileHandler(log_file, when="midnight", backupCount=7)
     file_handler.setFormatter(formatter)
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(color_formatter)  # use color formatter


### PR DESCRIPTION
## Summary
Fix log file handler configuration to use the correct variable reference

## Problem
`TimedRotatingFileHandler` directly accesses `app.config["LOGGING_PATH"]`, which causes a KeyError when `LOGGING_PATH` is not set in the config

## Solution  
Use the `log_file` variable that already handles the default value through `app.config.get("LOGGING_PATH", "logs/ai-shifu.log")`

## Changes
- Update `TimedRotatingFileHandler` to use `log_file` variable instead of directly accessing `app.config["LOGGING_PATH"]`

## Impact
- Improves code robustness by avoiding potential KeyError
- Maintains code consistency as `log_file` variable already contains the default value handling logic

## Test plan
- [x] Verify default path `logs/ai-shifu.log` is used when LOGGING_PATH is not configured
- [x] Verify configured path is used when LOGGING_PATH is set
- [ ] Confirm log rotation continues to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)