### PR TITLE
chore: add logs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,9 @@ docker/mysql_data/
 docker/redis_data/
 docker/milvus_data/
 
+# Logs
+src/api/logs/
+
 ###############################################################################
 # Never ignore these files (exceptions to above rules)
 ###############################################################################


### PR DESCRIPTION
## Summary
- Add `src/api/logs/` to .gitignore to prevent log files from being accidentally committed to version control

## Test plan
- [x] Verify .gitignore change is properly formatted
- [x] Confirm pre-commit hooks pass
- [x] Test that log files in src/api/logs/ are now ignored by git

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated repository ignore settings to exclude certain log directories from version control.
  - No changes to application features, behavior, performance, or APIs.
  - End-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->