### PR TITLE
feat: add default charset to mysql connection string

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -97,7 +97,7 @@ REACT_APP_ALWAYS_SHOW_LESSON_TREE="true"
 ##########
 
 # MySQL settings. If you don't know what they are, don't modify them.
-SQLALCHEMY_DATABASE_URI="mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu"
+SQLALCHEMY_DATABASE_URI="mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4"
 SQLALCHEMY_POOL_SIZE=20
 SQLALCHEMY_POOL_TIMEOUT=30
 SQLALCHEMY_POOL_RECYCLE=3600

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -31,6 +31,8 @@ def init_db(app: Flask):
             + str(app.config["MYSQL_PORT"])
             + "/"
             + app.config["MYSQL_DB"]
+            + "?charset="
+            + app.config.get("MYSQL_CHARSET", "utf8mb4")
         )
     else:
         app.logger.info("init dbconfig from config")


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures proper Unicode/emoji handling by defaulting MySQL connections to utf8mb4 charset.

* **New Features**
  * Adds support for configuring MySQL charset via an environment variable (defaults to utf8mb4).

* **Documentation**
  * Updates example environment configuration to include the charset in the database connection URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->