### PR TITLE
Revert "fix(config): ensure values are loaded from OS environment variables"

### DIFF
--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1094,10 +1094,6 @@ class Config(FlaskConfig):
         if value is not None:
             return value
 
-        value = os.environ.get(key, None)
-        if value is not None:
-            return value
-
         # Fallback to parent Flask config
         return self.parent.get(key, default)
 


### PR DESCRIPTION
This PR reverts commit a21f4752cca9a86a901c5fc7e522faefc0df4aaa from PR #731.

## Changes
- Reverts the configuration changes that ensured values are loaded from OS environment variables

## Reason for Revert
The functionality for loading values from OS environment variables is already implemented through the parent class, making these changes redundant and unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration resolution: runtime environment variables no longer override application settings. Values now resolve strictly from the configured sources established at initialization.
  * Impact: If you relied on setting or changing environment variables at runtime to affect configuration, this will no longer take effect. Adjust your configuration via the supported configuration sources before startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->