### PR TITLE
fix: skip payment order creation in preview mode

### DIFF
--- a/src/api/flaskr/service/study/output/handle_output_payment.py
+++ b/src/api/flaskr/service/study/output/handle_output_payment.py
@@ -26,17 +26,18 @@ def _handle_output_payment(
     trace: StatefulTraceClient,
     is_preview: bool = False,
 ) -> ScriptDTO:
-    order = init_buy_record(app, user_info.user_id, outline_item_info.shifu_bid)
-    if order.status != ORDER_STATUS_SUCCESS:
-        payment: PaymentDTO = block_dto.block_content
-        title = payment.label
-        title = get_script_ui_label(app, title)
-        if not title:
-            title = _("COMMON.CHECKOUT")
-        btn = [{"label": title, "value": order.order_id}]
-        return ScriptDTO(
-            "order", {"buttons": btn}, outline_item_info.bid, block_dto.bid
-        )
+    if not is_preview:
+        order = init_buy_record(app, user_info.user_id, outline_item_info.shifu_bid)
+        if order.status != ORDER_STATUS_SUCCESS:
+            payment: PaymentDTO = block_dto.block_content
+            title = payment.label
+            title = get_script_ui_label(app, title)
+            if not title:
+                title = _("COMMON.CHECKOUT")
+            btn = [{"label": title, "value": order.order_id}]
+            return ScriptDTO(
+                "order", {"buttons": btn}, outline_item_info.bid, block_dto.bid
+            )
     else:
         title = _("COMMON.CONTINUE")
         btn = [


### PR DESCRIPTION
## Summary
• Skip payment order initialization when `is_preview=True` to prevent creating unnecessary orders during preview sessions
• Wrap payment order creation logic in `if not is_preview:` condition

## Test plan
- [ ] Test preview mode to ensure no payment orders are created
- [ ] Test normal mode to ensure payment orders are still created correctly
- [ ] Verify existing payment flow functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)