### PR TITLE
feat: add Umami identify() for user tracking

### DIFF
--- a/src/cook-web/src/c-common/hooks/useTracking.ts
+++ b/src/cook-web/src/c-common/hooks/useTracking.ts
@@ -24,7 +24,7 @@ export const useTracking = () => {
       }
       // Identify user with their unique ID, or clear identification if no user
       umami.identify(userInfo?.user_id || null);
-    } catch (error) {
+    } catch {
       // Silently fail - tracking errors should not affect user experience
       // Uncomment for debugging: console.error('Umami identify error:', error);
     }

--- a/src/web/src/common/hooks/useTracking.ts
+++ b/src/web/src/common/hooks/useTracking.ts
@@ -24,7 +24,7 @@ export const useTracking = () => {
       }
       // Identify user with their unique ID, or clear identification if no user
       umami.identify(userInfo?.user_id || null);
-    } catch (error) {
+    } catch {
       // Silently fail - tracking errors should not affect user experience
       // Uncomment for debugging: console.error('Umami identify error:', error);
     }


### PR DESCRIPTION
## Summary
- Add `umami.identify()` function to track users with their unique user_id
- Automatically identify users when userInfo changes  
- Clear identification when user logs out

## Changes
- Updated `src/web/src/common/hooks/useTracking.ts` to add user identification
- Updated `src/cook-web/src/c-common/hooks/useTracking.ts` with the same functionality
- Kept existing `user_id` in event data for backward compatibility

## Test plan
- [x] User login triggers `umami.identify()` with user_id
- [x] User logout clears identification
- [x] Existing event tracking continues to work with user_id in event data

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Analytics now synchronizes user identification with account changes for more accurate reporting.
  * Identification is cleared when no user is present and updated automatically when user info changes.
  * No changes to existing event-tracking behavior or public APIs.
  * This enhancement is silent and does not affect the user interface or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->