### PR TITLE
feat: enhance Umami user identification with selected session data

### DIFF
--- a/src/cook-web/src/c-common/hooks/useTracking.ts
+++ b/src/cook-web/src/c-common/hooks/useTracking.ts
@@ -22,13 +22,29 @@ export const useTracking = () => {
       if (!umami) {
         return;
       }
-      // Identify user with their unique ID, or clear identification if no user
-      umami.identify(userInfo?.user_id || null);
+
+      // Build session data with only safe fields
+      const sessionData: Record<string, any> = {};
+      if (userInfo?.name) sessionData.nickname = userInfo.name;
+      if (userInfo?.state) sessionData.user_state = userInfo.state;
+      if (userInfo?.language) sessionData.language = userInfo.language;
+
+      // Identify user with their unique ID and session data
+      if (userInfo?.user_id) {
+        if (Object.keys(sessionData).length > 0) {
+          umami.identify(userInfo.user_id, sessionData);
+        } else {
+          umami.identify(userInfo.user_id);
+        }
+      } else {
+        // Clear identification if no user
+        umami.identify(null);
+      }
     } catch {
       // Silently fail - tracking errors should not affect user experience
       // Uncomment for debugging: console.error('Umami identify error:', error);
     }
-  }, [userInfo?.user_id]);
+  }, [userInfo?.user_id, userInfo?.name, userInfo?.state, userInfo?.language]);
 
   const getEventBasicData = useCallback(() => {
     return {

--- a/src/cook-web/src/c-common/hooks/useTracking.ts
+++ b/src/cook-web/src/c-common/hooks/useTracking.ts
@@ -24,7 +24,7 @@ export const useTracking = () => {
       }
 
       // Build session data with only safe fields
-      const sessionData: Record<string, any> = {};
+      const sessionData: { nickname?: string; user_state?: string; language?: string } = {};
       if (userInfo?.name) sessionData.nickname = userInfo.name;
       if (userInfo?.state) sessionData.user_state = userInfo.state;
       if (userInfo?.language) sessionData.language = userInfo.language;

--- a/src/cook-web/src/c-common/hooks/useTracking.ts
+++ b/src/cook-web/src/c-common/hooks/useTracking.ts
@@ -24,7 +24,11 @@ export const useTracking = () => {
       }
 
       // Build session data with only safe fields
-      const sessionData: { nickname?: string; user_state?: string; language?: string } = {};
+      const sessionData: {
+        nickname?: string;
+        user_state?: string;
+        language?: string;
+      } = {};
       if (userInfo?.name) sessionData.nickname = userInfo.name;
       if (userInfo?.state) sessionData.user_state = userInfo.state;
       if (userInfo?.language) sessionData.language = userInfo.language;

--- a/src/web/src/common/hooks/useTracking.ts
+++ b/src/web/src/common/hooks/useTracking.ts
@@ -22,13 +22,29 @@ export const useTracking = () => {
       if (!umami) {
         return;
       }
-      // Identify user with their unique ID, or clear identification if no user
-      umami.identify(userInfo?.user_id || null);
+
+      // Build session data with only safe fields
+      const sessionData: Record<string, any> = {};
+      if (userInfo?.name) sessionData.nickname = userInfo.name;
+      if (userInfo?.state) sessionData.user_state = userInfo.state;
+      if (userInfo?.language) sessionData.language = userInfo.language;
+
+      // Identify user with their unique ID and session data
+      if (userInfo?.user_id) {
+        if (Object.keys(sessionData).length > 0) {
+          umami.identify(userInfo.user_id, sessionData);
+        } else {
+          umami.identify(userInfo.user_id);
+        }
+      } else {
+        // Clear identification if no user
+        umami.identify(null);
+      }
     } catch {
       // Silently fail - tracking errors should not affect user experience
       // Uncomment for debugging: console.error('Umami identify error:', error);
     }
-  }, [userInfo?.user_id]);
+  }, [userInfo?.user_id, userInfo?.name, userInfo?.state, userInfo?.language]);
 
   const getEventBasicData = useCallback(() => {
     return {

--- a/src/web/src/common/hooks/useTracking.ts
+++ b/src/web/src/common/hooks/useTracking.ts
@@ -24,7 +24,7 @@ export const useTracking = () => {
       }
 
       // Build session data with only safe fields
-      const sessionData: Record<string, any> = {};
+      const sessionData: { nickname?: string; user_state?: string; language?: string } = {};
       if (userInfo?.name) sessionData.nickname = userInfo.name;
       if (userInfo?.state) sessionData.user_state = userInfo.state;
       if (userInfo?.language) sessionData.language = userInfo.language;


### PR DESCRIPTION
## Summary
- Enhanced Umami user identification to include additional session data for better analytics
- Added nickname (mapped from userInfo.name), user_state, and language to the identify call
- Implemented security-conscious approach by only sending non-sensitive fields

## Changes
- Modified both `useTracking.ts` hooks in web and cook-web frontends
- Built sessionData object with only safe fields (nickname, user_state, language)
- Excluded sensitive data like mobile, email, wx_openid, admin flags
- Added proper TypeScript typing for the sessionData object
- Handles cases where userInfo fields might not exist

## Security Considerations
✅ **Included fields**: nickname, user_state, language
❌ **Excluded fields**: mobile, email, wx_openid, is_admin, is_creator, user_avatar, token

This implementation provides meaningful user segmentation data to Umami while protecting user privacy and following security best practices.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analytics identification: signed-in users are linked to sessions and safe fields (nickname, user state, language) are included only when present.
  * Identification is cleared when a user signs out or lacks an ID to prevent session carryover.
  * Identification now reacts more reliably to user info changes.

* **Bug Fixes**
  * Safer runtime checks and silent error handling to avoid impacting user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->