### PR TITLE
fix: remove unnecessary Node.js setup from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions release workflow failure by removing unnecessary Node.js setup step that was causing cache errors.

## Problem
The release workflow was failing with error: "Dependencies lock file is not found in /home/runner/work/ai-shifu/ai-shifu"

Root cause: The workflow used `cache: 'npm'` in Node.js setup but no npm lock file exists in project root.

## Solution
- Removed the unnecessary Node.js setup step from release workflow
- The workflow only uses Python tools (commitizen, pre-commit) for release automation
- Project uses different package managers in subdirectories:
  - `pnpm` in `src/web/` (has `pnpm-lock.yaml`)
  - `npm` in `src/cook-web/` (has `package-lock.json`)

## Test Plan
- [x] YAML syntax validation passes
- [x] Local dry run with `act` shows all steps complete successfully
- [ ] Workflow runs successfully on GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)