### PR TITLE
feat: add legacy tag format compatibility for automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,17 @@ jobs:
       - name: Get current version
         id: version
         run: |
-          VERSION=$(python -c "import json; print(json.load(open('cz.json'))['commitizen']['version'])")
+          if [ "${{ steps.bump-version.outputs.bump_needed }}" = "true" ]; then
+            # Use the new version from bump step
+            VERSION="${{ steps.bump-version.outputs.new_version }}"
+            echo "📋 Using new version from bump: $VERSION"
+          else
+            # Use version from cz.json
+            VERSION=$(python -c "import json; print(json.load(open('cz.json'))['commitizen']['version'])")
+            echo "📋 Using current version from config: $VERSION"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-          echo "📋 Current version: $VERSION"
 
       - name: Create GitHub Release
         if: steps.bump-version.outputs.bump_needed == 'true'

--- a/cz.json
+++ b/cz.json
@@ -5,6 +5,10 @@
     "version_scheme": "semver",
     "version": "0.5.0",
     "update_changelog_on_bump": true,
-    "major_version_zero": true
+    "major_version_zero": true,
+    "legacy_tag_formats": [
+      "v$major.$minor-beta",
+      "$major.$minor-beta"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

This PR adds support for existing beta tag formats in the automated release workflow, enabling proper version bumping based on conventional commits.

## Problem

The current release workflow cannot detect version bumps because:
- Commitizen expects semantic version tags (e.g., `v0.5.0`)
- Repository has beta format tags (e.g., `v0.5-beta`, `0.6-beta`)
- This mismatch prevents automatic version detection and tag generation

## Solution

### 🔧 Legacy Tag Format Support
Added `legacy_tag_formats` configuration to `cz.json`:
```json
"legacy_tag_formats": [
  "v$major.$minor-beta",  // Supports v0.5-beta format
  "$major.$minor-beta"    // Supports 0.6-beta format  
]
```

### 📈 Improved Version Detection
Enhanced GitHub Actions workflow to:
- Use bumped version when available (prioritize new version)
- Fall back to config version for consistency
- Maintain proper version flow in release process

## Test Results ✅

### Before Fix:
```bash
$ cz bump --dry-run
[NO_COMMITS_FOUND] No new commits found.
# Could not detect baseline version from existing tags
```

### After Fix:
```bash
$ cz bump --dry-run --yes
bump: version 0.5.0 → 0.6.0
tag to create: v0.6.0
increment detected: MINOR
# Properly detects version bump based on conventional commits
```

## Compatibility Analysis

### Existing Tags (Upstream):
- `v0.1-beta` → `v0.5-beta` ✅ Supported
- `0.6-beta` ✅ Supported  
- `last-old-cook` (ignored, not version format)

### New Behavior:
- ✅ Detects existing beta tags as version baseline
- ✅ Generates semantic version tags (e.g., `v0.6.0`)
- ✅ Maintains backward compatibility
- ✅ Enables automated releases based on conventional commits

## Benefits

1. **Automated Version Bumping**: Based on `feat:`, `fix:`, `BREAKING CHANGE:` commits
2. **Backward Compatibility**: Respects existing tag history
3. **Semantic Versioning**: Generates proper semantic version tags going forward
4. **Release Automation**: Enables fully automated release workflow

## Next Steps

After merge, the release workflow will:
1. Automatically detect conventional commits
2. Calculate appropriate version bump (patch/minor/major)
3. Generate semantic version tags (e.g., `v0.6.0`)
4. Create GitHub releases with detailed changelogs
5. Maintain compatibility with existing beta tag history

🤖 Generated with [Claude Code](https://claude.ai/code)