### PR TITLE
fix: resolve SCM versioning issues and improve branch protection handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,27 +60,6 @@ jobs:
             echo "Branch is protected, will need special handling"
           fi
 
-      - name: Sync cz.json version with git tags
-        run: |
-          echo "🔄 Syncing cz.json version with latest git tag..."
-          LATEST_TAG=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
-          if [ -n "$LATEST_TAG" ]; then
-            LATEST_VERSION=${LATEST_TAG#v}  # Remove 'v' prefix
-            echo "📋 Latest git tag version: $LATEST_VERSION"
-            # Update cz.json version
-            python -c "
-            import json
-            with open('cz.json', 'r') as f:
-                config = json.load(f)
-            config['commitizen']['version'] = '$LATEST_VERSION'
-            with open('cz.json', 'w') as f:
-                json.dump(config, f, indent=2)
-            "
-            echo "✅ Updated cz.json version to $LATEST_VERSION"
-          else
-            echo "⚠️ No semantic version tags found, keeping cz.json version as-is"
-          fi
-
       - name: Bump version automatically
         id: bump-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Bump version automatically
         id: bump-version
         run: |
+          # Git-tag-based versioning: Version is determined entirely by git tags
+          # No cz.json version updates needed - everything is tag-driven
+
           echo "🔍 Checking for conventional commits that warrant version bump..."
           echo "📋 Current commitizen config:"
           cz info || echo "⚠️ Commitizen info failed"
@@ -74,7 +77,7 @@ jobs:
           git tag -l --sort=-version:refname | head -5
 
           echo "📝 Recent commits:"
-          git log --oneline -10
+          git log --oneline -5
 
           # Try commitizen dry-run with error handling
           if DRY_RUN_OUTPUT=$(cz bump --dry-run 2>&1); then
@@ -107,10 +110,11 @@ jobs:
             echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
 
-            # Create git tag using commitizen with robust error handling
-            echo "🏷️ Creating git tag..."
+            # Create ONLY git tag - no file modifications needed
+            # All version info comes from git tags via dynamic version detection
+            echo "Creating git tag..."
 
-            # Try commitizen bump with enhanced error handling
+            # Try commitizen bump with error handling
             if ! cz bump --yes; then
               echo "⚠️ Commitizen bump failed, trying manual tag creation..."
 
@@ -118,11 +122,7 @@ jobs:
               if git tag -l | grep -q "^v$NEW_VERSION$"; then
                 echo "⚠️ Tag v$NEW_VERSION already exists, skipping tag creation"
               else
-                # Get current version for bump message
-                CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
-                git tag "v$NEW_VERSION" -m "bump: version $CURRENT_VERSION → $NEW_VERSION
-
-                🤖 Generated with [Claude Code](https://claude.ai/code)"
+                git tag "v$NEW_VERSION" -m "bump: version $(git describe --tags --abbrev=0 2>/dev/null || echo '0.0.0') → $NEW_VERSION"
                 echo "✅ Manual tag created: v$NEW_VERSION"
               fi
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,27 @@ jobs:
             echo "Branch is protected, will need special handling"
           fi
 
+      - name: Sync cz.json version with git tags
+        run: |
+          echo "🔄 Syncing cz.json version with latest git tag..."
+          LATEST_TAG=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+          if [ -n "$LATEST_TAG" ]; then
+            LATEST_VERSION=${LATEST_TAG#v}  # Remove 'v' prefix
+            echo "📋 Latest git tag version: $LATEST_VERSION"
+            # Update cz.json version
+            python -c "
+            import json
+            with open('cz.json', 'r') as f:
+                config = json.load(f)
+            config['commitizen']['version'] = '$LATEST_VERSION'
+            with open('cz.json', 'w') as f:
+                json.dump(config, f, indent=2)
+            "
+            echo "✅ Updated cz.json version to $LATEST_VERSION"
+          else
+            echo "⚠️ No semantic version tags found, keeping cz.json version as-is"
+          fi
+
       - name: Bump version automatically
         id: bump-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,23 +129,13 @@ jobs:
               echo "✅ Commitizen tag created successfully"
             fi
 
-            # Push based on branch protection status with enhanced error handling
-            if [ "${{ steps.branch-protection.outputs.can_push_directly }}" = "true" ]; then
-              echo "🚀 Pushing directly to main branch..."
-              git push origin main --follow-tags
-            else
-              echo "🔒 Branch is protected, using alternative push strategy..."
-              # Try with different authentication methods
-              git push origin main --follow-tags || {
-                echo "⚠️ Standard push failed, trying with force-with-lease..."
-                git push origin main --follow-tags --force-with-lease || {
-                  echo "❌ All push attempts failed. This might be due to branch protection rules."
-                  echo "💡 Please check repository settings or use a Personal Access Token (PAT_TOKEN)."
-                  echo "💡 You can also temporarily disable branch protection for releases."
-                  exit 1
-                }
-              }
-            fi
+            # Push tag explicitly (SCM provider doesn't create commits, so --follow-tags won't work)
+            echo "🚀 Pushing tag v$NEW_VERSION to origin..."
+            git push origin "v$NEW_VERSION"
+
+            # Note: With SCM provider, commitizen only creates tags, no commits to push
+            # Tag has already been pushed explicitly above
+            echo "✅ Release tag v$NEW_VERSION pushed successfully"
           else
             echo "bump_needed=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No version bump needed based on commit messages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
               echo "📋 Using latest git tag version: $VERSION"
             else
               # Fallback: try to get any semantic version tag
-              VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.6.0")
+              VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "1.0.0")
               echo "📋 Using fallback version: $VERSION"
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,16 @@ jobs:
             VERSION="${{ steps.bump-version.outputs.new_version }}"
             echo "📋 Using new version from bump: $VERSION"
           else
-            # Use version from cz.json
-            VERSION=$(python -c "import json; print(json.load(open('cz.json'))['commitizen']['version'])")
-            echo "📋 Using current version from config: $VERSION"
+            # Get latest version from git tags
+            LATEST_TAG=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+            if [ -n "$LATEST_TAG" ]; then
+              VERSION=${LATEST_TAG#v}  # Remove 'v' prefix
+              echo "📋 Using latest git tag version: $VERSION"
+            else
+              # Fallback: try to get any semantic version tag
+              VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.6.0")
+              echo "📋 Using fallback version: $VERSION"
+            fi
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,21 +122,31 @@ jobs:
               if git tag -l | grep -q "^v$NEW_VERSION$"; then
                 echo "⚠️ Tag v$NEW_VERSION already exists, skipping tag creation"
               else
-                git tag "v$NEW_VERSION" -m "bump: version $(git describe --tags --abbrev=0 2>/dev/null || echo '0.0.0') → $NEW_VERSION"
+                git tag "v$NEW_VERSION" -m "bump: version $(git describe --tags --abbrev=0 2>/dev/null || echo '1.0.0') → $NEW_VERSION"
                 echo "✅ Manual tag created: v$NEW_VERSION"
               fi
             else
               echo "✅ Commitizen tag created successfully"
             fi
 
+            # Push based on branch protection status
+            if [ "${{ steps.branch-protection.outputs.can_push_directly }}" = "true" ]; then
+              echo "🚀 Pushing tag directly to main branch..."
+              git push origin "v$NEW_VERSION"
+            else
+              echo "⚠️ Branch is protected, using alternative push strategy..."
+              # Try with different authentication methods
+              git push origin "v$NEW_VERSION" || {
+                echo "🔄 Standard tag push failed, trying with force-with-lease..."
+                git push origin "v$NEW_VERSION" --force-with-lease || {
+                  echo "❌ All push attempts failed. This might be due to branch protection rules."
+                  echo "Please check repository settings or use a Personal Access Token (PAT_TOKEN)."
+                  echo "You can also temporarily disable branch protection for releases."
+                  exit 1
+                }
+              }
+            fi
 
-
-            # Push tag explicitly (SCM provider doesn't create commits, so --follow-tags won't work)
-            echo "🚀 Pushing tag v$NEW_VERSION to origin..."
-            git push origin "v$NEW_VERSION"
-
-            # Note: With SCM provider, commitizen only creates tags, no commits to push
-            # Tag has already been pushed explicitly above
             echo "✅ Release tag v$NEW_VERSION pushed successfully"
           else
             echo "bump_needed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,25 +107,45 @@ jobs:
             echo "$CHANGELOG_CONTENT" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
 
-            # Only create the git tag, no commits to main branch
-            if ! cz bump --yes --check-consistency --dry-run; then
-              echo "⚠️ Commitizen bump would fail, trying manual tag creation..."
+            # Create git tag using commitizen with robust error handling
+            echo "🏷️ Creating git tag..."
+
+            # Try commitizen bump with enhanced error handling
+            if ! cz bump --yes; then
+              echo "⚠️ Commitizen bump failed, trying manual tag creation..."
+
+              # Manual tag creation as fallback
               if git tag -l | grep -q "^v$NEW_VERSION$"; then
                 echo "⚠️ Tag v$NEW_VERSION already exists, skipping tag creation"
               else
-                git tag "v$NEW_VERSION" -m "Release v$NEW_VERSION
+                # Get current version for bump message
+                CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+                git tag "v$NEW_VERSION" -m "bump: version $CURRENT_VERSION → $NEW_VERSION
 
                 🤖 Generated with [Claude Code](https://claude.ai/code)"
                 echo "✅ Manual tag created: v$NEW_VERSION"
               fi
             else
-              echo "✅ Using commitizen for tag creation..."
-              cz bump --yes --check-consistency --no-verify
+              echo "✅ Commitizen tag created successfully"
             fi
 
-            # Push only the tag, not commits
-            echo "🏷️ Pushing release tag..."
-            git push origin "v$NEW_VERSION"
+            # Push based on branch protection status with enhanced error handling
+            if [ "${{ steps.branch-protection.outputs.can_push_directly }}" = "true" ]; then
+              echo "🚀 Pushing directly to main branch..."
+              git push origin main --follow-tags
+            else
+              echo "🔒 Branch is protected, using alternative push strategy..."
+              # Try with different authentication methods
+              git push origin main --follow-tags || {
+                echo "⚠️ Standard push failed, trying with force-with-lease..."
+                git push origin main --follow-tags --force-with-lease || {
+                  echo "❌ All push attempts failed. This might be due to branch protection rules."
+                  echo "💡 Please check repository settings or use a Personal Access Token (PAT_TOKEN)."
+                  echo "💡 You can also temporarily disable branch protection for releases."
+                  exit 1
+                }
+              }
+            fi
           else
             echo "bump_needed=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No version bump needed based on commit messages"

--- a/cz.json
+++ b/cz.json
@@ -1,7 +1,7 @@
 {
   "commitizen": {
     "name": "cz_conventional_commits",
-    "tag_format": "v$major.$minor.$patch",
+    "tag_format": "v$version",
     "version": "0.6.0",
     "update_changelog_on_bump": true,
     "annotated_tag": true,

--- a/cz.json
+++ b/cz.json
@@ -3,7 +3,7 @@
     "name": "cz_conventional_commits",
     "tag_format": "v$version",
     "version_scheme": "semver",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "update_changelog_on_bump": true,
     "major_version_zero": true,
     "legacy_tag_formats": [

--- a/cz.json
+++ b/cz.json
@@ -1,17 +1,13 @@
 {
   "commitizen": {
     "name": "cz_conventional_commits",
-    "tag_format": "v$version",
-    "version": "0.6.0",
+    "tag_format": "v$major.$minor.$patch",
+    "version_provider": "scm",
     "update_changelog_on_bump": true,
     "annotated_tag": true,
     "gpg_sign": false,
     "bump_message": "bump: version $current_version → $new_version",
     "major_version_zero": true,
-    "legacy_tag_formats": [
-      "v$major.$minor-beta",
-      "$major.$minor-beta"
-    ],
     "style": [
       ["qmark", "fg:#ff9d00 bold"],
       ["question", "bold"],

--- a/cz.json
+++ b/cz.json
@@ -7,7 +7,6 @@
     "annotated_tag": true,
     "gpg_sign": false,
     "bump_message": "bump: version $current_version → $new_version",
-    "major_version_zero": true,
     "style": [
       ["qmark", "fg:#ff9d00 bold"],
       ["question", "bold"],

--- a/cz.json
+++ b/cz.json
@@ -1,7 +1,7 @@
 {
   "commitizen": {
     "name": "cz_conventional_commits",
-    "tag_format": "v$version",
+    "tag_format": "v$major.$minor.$patch",
     "version": "0.6.0",
     "update_changelog_on_bump": true,
     "annotated_tag": true,

--- a/cz.json
+++ b/cz.json
@@ -2,13 +2,27 @@
   "commitizen": {
     "name": "cz_conventional_commits",
     "tag_format": "v$version",
-    "version_scheme": "semver",
     "version": "0.6.0",
     "update_changelog_on_bump": true,
+    "annotated_tag": true,
+    "gpg_sign": false,
+    "bump_message": "bump: version $current_version → $new_version",
     "major_version_zero": true,
     "legacy_tag_formats": [
       "v$major.$minor-beta",
       "$major.$minor-beta"
+    ],
+    "style": [
+      ["qmark", "fg:#ff9d00 bold"],
+      ["question", "bold"],
+      ["answer", "fg:#ff9d00 bold"],
+      ["pointer", "fg:#ff9d00 bold"],
+      ["highlighted", "fg:#ff9d00 bold"],
+      ["selected", "fg:#cc5454"],
+      ["separator", "fg:#cc5454"],
+      ["instruction", ""],
+      ["text", ""],
+      ["disabled", "fg:#858585 italic"]
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Remove `major_version_zero` from commitizen config to align with reference implementation  
- Update default fallback version from 0.0.0 to 1.0.0 as requested
- Restore branch protection logic for tag pushing with proper error handling
- Add retry mechanisms with force-with-lease for protected branches

## Test Plan

- [ ] Verify commitizen dry-run works without errors
- [ ] Test version detection from git tags
- [ ] Confirm workflow handles branch protection correctly
- [ ] Validate tag push with retry mechanisms

This addresses the GitHub Actions workflow failures by aligning our SCM-based versioning approach with the markdown-flow-agent-py reference implementation while maintaining the pure SCM approach without hardcoded versions in cz.json.

🤖 Generated with [Claude Code](https://claude.ai/code)