### PR TITLE
fix: resolve version calculation issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
@@ -47,6 +48,28 @@ jobs:
             git config --global init.templateDir ""
           else
             pre-commit install
+          fi
+
+      - name: Debug git tags availability
+        run: |
+          echo "🏷️ All available tags:"
+          git tag -l --sort=-version:refname || echo "No tags found"
+          echo ""
+          echo "🔍 Semantic version tags (v*.*.*):"
+          git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" || echo "No semantic version tags found"
+          echo ""
+          echo "📋 Latest semantic version tag:"
+          LATEST_TAG=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 || echo "")
+          echo "LATEST_TAG='${LATEST_TAG}'"
+          echo ""
+          echo "🧪 Test version calculation:"
+          if [ -n "$LATEST_TAG" ]; then
+            CURRENT_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+            NEW_VERSION=$(echo "$CURRENT_VERSION" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
+            echo "CURRENT_VERSION='$CURRENT_VERSION'"
+            echo "CALCULATED_NEW_VERSION='$NEW_VERSION'"
+          else
+            echo "No semantic version tags found - would start from 0.1.0"
           fi
 
       - name: Check branch protection status
@@ -104,7 +127,7 @@ jobs:
             echo "✅ No previous tags found - this will be the initial release"
           else
             # Fallback: check recent commits manually for conventional commit types
-            RECENT_COMMITS=$(git log --oneline --since="$(git describe --tags --abbrev=0 2>/dev/null | xargs git log -1 --format=%cd --date=iso || echo '1 week ago')" --grep="^feat:" --grep="^fix:" --grep="^BREAKING CHANGE:" --extended-regexp)
+            RECENT_COMMITS=$(git log --oneline --since="$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 | xargs git log -1 --format=%cd --date=iso || echo '1 week ago')" --grep="^feat:" --grep="^fix:" --grep="^BREAKING CHANGE:" --extended-regexp)
             if [ -n "$RECENT_COMMITS" ]; then
               echo "bump_needed=true" >> $GITHUB_OUTPUT
               echo "✅ Version bump needed based on manual commit analysis"
@@ -124,14 +147,14 @@ jobs:
               NEW_VERSION=$(echo "$DRY_RUN_OUTPUT" | grep "bump: version" | sed 's/.*→ //' | tr -d ' ')
             else
               # Calculate next version manually if commitizen didn't provide it
-              CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.5.0")
+              CURRENT_VERSION=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 | sed 's/^v//' || echo "0.5.0")
               NEW_VERSION=$(echo "$CURRENT_VERSION" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
             fi
             echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
             echo "📋 New version will be: $NEW_VERSION"
 
             # Generate changelog content
-            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            LAST_TAG=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 || echo "")
             if [ -n "$LAST_TAG" ]; then
               CHANGELOG_CONTENT=$(cz changelog --start-rev=$LAST_TAG --unreleased-version=$NEW_VERSION --dry-run 2>/dev/null || echo "## Changes\n\nAutomated release based on conventional commits")
             else
@@ -153,7 +176,7 @@ jobs:
               if git tag -l | grep -q "^v$NEW_VERSION$"; then
                 echo "⚠️ Tag v$NEW_VERSION already exists, skipping tag creation"
               else
-                git tag "v$NEW_VERSION" -m "bump: version $(git describe --tags --abbrev=0 2>/dev/null || echo '1.0.0') → $NEW_VERSION"
+                git tag "v$NEW_VERSION" -m "bump: version $(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 | sed 's/^v//' || echo '1.0.0') → $NEW_VERSION"
                 echo "✅ Manual tag created: v$NEW_VERSION"
               fi
             else
@@ -204,7 +227,7 @@ jobs:
               echo "📋 Using latest git tag version: $VERSION"
             else
               # Fallback: try to get any semantic version tag
-              VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "1.0.0")
+              VERSION=$(git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1 | sed 's/^v//' || echo "1.0.0")
               echo "📋 Using fallback version: $VERSION"
             fi
           fi


### PR DESCRIPTION
## 问题描述

GitHub Actions 发布工作流中版本计算错误，应该计算为 0.6.1 但实际显示为 0.1.0。

## 根本原因

1. **标签获取问题**: `actions/checkout@v4` 默认 `fetch-tags: false`，可能导致标签获取不完整
2. **版本计算逻辑错误**: 使用 `git describe --tags --abbrev=0` 会获取最近的标签，而不是语义版本标签，导致错误地使用了 `last-old-cook` 标签而非 `v0.6.0`

## 解决方案

### 1. 修复标签获取
```yaml
- name: Check out repository
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
    fetch-tags: true  # ✅ 确保获取所有标签
    token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
```

### 2. 修复版本计算逻辑
将所有使用 `git describe --tags --abbrev=0` 的地方替换为：
```bash
git tag -l --sort=-version:refname | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | head -1
```

这确保：
- 只考虑符合 `v*.*.*` 格式的语义版本标签
- 忽略 `last-old-cook`、`0.6-beta` 等非标准标签
- 正确识别 `v0.6.0` 为最新版本

### 3. 添加调试步骤
添加详细的调试输出来验证：
- 标签是否正确获取
- 语义版本过滤是否工作
- 版本计算是否正确

## 修改文件

- `.github/workflows/release.yml`: 更新版本计算逻辑和标签获取配置

## 测试结果

本地测试确认：
- **修复前**: `git describe --tags --abbrev=0` → `last-old-cook` → 版本 0.1.0 ❌
- **修复后**: 语义版本过滤 → `v0.6.0` → 版本 0.6.1 ✅

## 预期结果

合并后，下一次发布将：
1. 正确识别当前版本为 0.6.0
2. 计算新版本为 0.6.1（而不是错误的 0.1.0）
3. 生成正确的 changelog 和发布信息

🤖 Generated with [Claude Code](https://claude.ai/code)