### PR TITLE
fix: enable Docker workflow triggers by using PAT token for GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,7 @@ jobs:
         if: steps.bump-version.outputs.bump_needed == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
           body: |


### PR DESCRIPTION
## Summary
- Fix Docker image upload workflow not triggering after automated releases
- Add explicit PAT_TOKEN usage to GitHub release creation action
- Resolve GitHub Actions limitation that prevents GITHUB_TOKEN-created events from triggering other workflows

## Problem
The Docker workflow (`upload-image.yml`) wasn't auto-triggering after releases because:
1. Recent releases (v0.6.0, v0.6.1, v0.1.0) were created by `github-actions[bot]` using default `GITHUB_TOKEN`
2. GitHub Actions intentionally prevents `GITHUB_TOKEN`-created events from triggering other workflows to avoid infinite loops
3. Historical beta releases worked because they were created manually or with different tokens

## Solution
- Modified `.github/workflows/release.yml` to explicitly specify `token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}` in the `softprops/action-gh-release@v2` action
- This ensures releases created by automation can properly trigger the Docker image upload workflow
- Maintains backward compatibility with `GITHUB_TOKEN` fallback

## Test plan
- [ ] Merge this PR to main
- [ ] Trigger a new release (either manually or via push to main)
- [ ] Verify that the Docker workflow (`upload-image.yml`) auto-triggers after release publication
- [ ] Check that Docker images are built and pushed to registries

🤖 Generated with [Claude Code](https://claude.ai/code)