### PR TITLE
fix: use tag-based trigger for Docker workflow reliability

### DIFF
--- a/.github/workflows/upload-image.yml
+++ b/.github/workflows/upload-image.yml
@@ -1,8 +1,9 @@
 name: Build and Push API & Web
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
 
 concurrency:
   group: build-push-${{ github.head_ref || github.run_id }}
@@ -48,8 +49,8 @@ jobs:
 
       - name: Set Tag Version
         run: |
-          # Extract version from release tag
-          TAG_VERSION="${{ github.event.release.tag_name }}"
+          # Extract version from git tag
+          TAG_VERSION="${{ github.ref_name }}"
           echo "TAG_VERSION=\"$TAG_VERSION\"" >> $GITHUB_ENV
           echo "RELEASE_BUILD=true" >> $GITHUB_ENV
           echo "🏷️ Building with tag: $TAG_VERSION"

--- a/.github/workflows/upload-image.yml
+++ b/.github/workflows/upload-image.yml
@@ -35,6 +35,10 @@ jobs:
             context: "src/cook-web"
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -91,7 +95,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: "{{defaultContext}}:${{ matrix.context }}"
+          context: "${{ matrix.context }}"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- Change Docker workflow trigger from `release: [published]` to `push: tags`
- Add explicit checkout step with PAT_TOKEN support
- Improve reliability and eliminate GitHub Actions token limitations

## Problem
The Docker workflow (`upload-image.yml`) wasn't triggering after releases due to:
1. **GitHub Actions limitations**: `GITHUB_TOKEN`-created releases don't trigger other workflows
2. **Complex event chain**: Release creation → published event → Docker trigger
3. **Missing checkout**: No explicit source code checkout for Docker builds

## Solution
**More Reliable Approach: Tag-based triggering**
```yaml
on:
  push:
    tags:
      - 'v*.*.*'
```

**Why this is better:**
- ✅ **Direct trigger**: Git tag push directly triggers workflow
- ✅ **No token issues**: Bypasses GITHUB_TOKEN limitations entirely  
- ✅ **Simpler chain**: Release workflow creates tag → tag push → Docker workflow
- ✅ **More predictable**: Tag push is a fundamental git operation that always works

**Additional fixes:**
- Added explicit `actions/checkout@v4` with PAT_TOKEN support
- Use `github.ref_name` instead of `github.event.release.tag_name`
- Simplified Docker build context path

## Workflow
1. 🚀 Push to main → Release workflow runs
2. 🏷️ Release workflow creates git tag (e.g., `v0.6.3`)  
3. 📤 Tag push automatically triggers Docker workflow
4. 🐳 Docker images built and pushed to registries

## Test plan
- [ ] Merge this PR to main
- [ ] Make a commit to main to trigger release workflow
- [ ] Verify Docker workflow auto-triggers when tag is created
- [ ] Check Docker images are built and pushed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)