### PR TITLE
feat: change release workflow from push-based to tag-based trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
 
           if [ -n "$PREV_TAG" ]; then
             echo "📋 Previous tag: $PREV_TAG"
-            # Generate changelog between previous tag and current tag
-            CHANGELOG_CONTENT=$(cz changelog --start-rev=$PREV_TAG --end-rev=${{ steps.version.outputs.tag }} --dry-run 2>/dev/null || echo "## Changes\n\nAutomated release based on conventional commits")
+            # Generate incremental changelog (works better with commitizen)
+            CHANGELOG_CONTENT=$(cz changelog --incremental --dry-run 2>/dev/null | sed -n '/## Unreleased/,/## v[0-9]/p' | sed '$d' | sed '/^$/d' || echo "## Changes\n\nAutomated release based on conventional commits")
           else
             echo "📋 No previous tag found, generating full changelog"
-            CHANGELOG_CONTENT=$(cz changelog --unreleased-version=${{ steps.version.outputs.version }} --dry-run 2>/dev/null || echo "## Changes\n\nInitial automated release")
+            CHANGELOG_CONTENT=$(cz changelog --incremental --dry-run 2>/dev/null || echo "## Changes\n\nInitial automated release")
           fi
 
           # Store changelog content


### PR DESCRIPTION
## Summary
- Convert release workflow from automatic triggers on main branch pushes to manual tag-based releases
- Simplify workflow architecture by removing complex version bump logic
- Extract version information directly from git tags using GITHUB_REF
- Maintain all existing functionality while improving release control

## Key Changes
- 🏷️ **Trigger Change**: `push: branches: [main]` → `push: tags: ['v*.*.*']`
- 🎯 **Simplified Logic**: Remove complex commitizen version bump calculations
- 📋 **Tag-based Versioning**: Extract version from pushed tags instead of calculating
- 🔄 **Streamlined Process**: Tag creation → Workflow trigger → Build & Deploy
- 📝 **Changelog Generation**: Still generates changelogs from conventional commits
- 🐳 **Docker Builds**: All existing Docker build functionality preserved

## Benefits
- ✅ **Better Release Control**: Manual tag creation prevents accidental releases
- ✅ **Reduced Complexity**: Simpler workflow with fewer failure points  
- ✅ **Improved Reliability**: Tag-based triggers are more predictable
- ✅ **Maintained Functionality**: All existing features still work

## Testing
- ✅ Workflow syntax validated with `yamllint` and Python YAML parser
- ✅ Local testing completed using `act` with simulated tag push events
- ✅ Job dependencies verified (release → build-docker)
- ✅ Matrix build strategy tested for all services (api, web, cook-web)

## Usage
After this PR is merged, releases will be created using:
```bash
# Create and push a release tag
git tag v1.2.3 -m "Release v1.2.3"
git push origin v1.2.3

# Or use the provided script for automated version bumping
./scripts/create-release-tag.sh auto
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now trigger from semantic version tags (vX.Y.Z) and include an auto-generated changelog in the GitHub Release body.
  * Manual release trigger (workflow_dispatch) remains available.
  * Release metadata now exposes version and tag derived from the pushed tag.

* **Chores**
  * Simplified release flow by removing bump-driven steps and pre-commit; dependency install streamlined.
  * Docker images build on every release run (no conditional gating).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->