### PR TITLE
fix: convert UserProfileLabelDTO to dict list for profile updates

### DIFF
--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -310,7 +310,17 @@ def verify_sms_code(
                 .first()
             )
         elif user_id != user_info.user_id and course_id is not None:
-            new_profiles = get_user_profile_labels(app, user_id, course_id)
+            new_profiles_dto = get_user_profile_labels(app, user_id, course_id)
+            new_profiles = [
+                {
+                    "key": profile.key,
+                    "value": profile.value,
+                    "label": profile.label,
+                    "type": profile.type,
+                    "items": profile.items,
+                }
+                for profile in new_profiles_dto.profiles
+            ]
             update_user_profile_with_lable(
                 app, user_info.user_id, new_profiles, False, course_id
             )
@@ -406,7 +416,17 @@ def verify_mail_code(
                 .first()
             )
         elif user_id != user_info.user_id and course_id is not None:
-            new_profiles = get_user_profile_labels(app, user_id, course_id)
+            new_profiles_dto = get_user_profile_labels(app, user_id, course_id)
+            new_profiles = [
+                {
+                    "key": profile.key,
+                    "value": profile.value,
+                    "label": profile.label,
+                    "type": profile.type,
+                    "items": profile.items,
+                }
+                for profile in new_profiles_dto.profiles
+            ]
             update_user_profile_with_lable(
                 app, user_info.user_id, new_profiles, False, course_id
             )


### PR DESCRIPTION
## Summary

Fixed `TypeError: tuple indices must be integers or slices, not str` in SMS/email verification flow when updating user profiles.

### Root Cause
The `get_user_profile_labels()` function returns a `UserProfileLabelDTO` object, but `update_user_profile_with_lable()` expects a list of dictionaries. The code was passing the DTO object directly, causing a type mismatch when trying to access dictionary keys.

### Changes
- Convert `UserProfileLabelDTO.profiles` (list of DTO objects) to list of dictionaries before passing to `update_user_profile_with_lable()`
- Applied fix to both `verify_sms_code()` and `verify_mail_code()` functions in `src/api/flaskr/service/user/common.py`

### Test Plan
- [x] Code compiles without errors
- [ ] Test SMS verification flow with profile migration
- [ ] Test email verification flow with profile migration
- [ ] Verify no regression in existing user profile updates

### Related Error
```
TypeError: tuple indices must be integers or slices, not str
  File "/app/flaskr/service/profile/funcs.py", line 437, in update_user_profile_with_lable
    nickname = [p for p in profiles if p["key"] == "sys_user_nickname"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures user profile information updates correctly after SMS or email code verification when confirming codes for another user within a course context.
* **Refactor**
  * Streamlined profile data handling during verification to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->