### PR TITLE
fix: handle None generated_block in context_v2 to prevent AttributeError

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -732,7 +732,9 @@ class RunScriptContextV2:
                         if not self._is_paid:
                             yield RunMarkdownFlowDTO(
                                 outline_bid=run_script_info.outline_bid,
-                                generated_block_bid=generated_block.generated_block_bid,
+                                generated_block_bid=generated_block.generated_block_bid
+                                if generated_block
+                                else "",
                                 type=GeneratedType.INTERACTION,
                                 content=block.content,
                             )
@@ -755,7 +757,9 @@ class RunScriptContextV2:
                         else:
                             yield RunMarkdownFlowDTO(
                                 outline_bid=run_script_info.outline_bid,
-                                generated_block_bid=generated_block.generated_block_bid,
+                                generated_block_bid=generated_block.generated_block_bid
+                                if generated_block
+                                else "",
                                 type=GeneratedType.INTERACTION,
                                 content=block.content,
                             )


### PR DESCRIPTION
## Summary

- Fix AttributeError when `generated_block` is None for unpaid users
- Add conditional checks to safely access `generated_block.generated_block_bid`
- Return empty string when `generated_block` is None

## Problem

When a user is not paid, `generated_block` may be `None`, which causes an `AttributeError` when trying to access `generated_block.generated_block_bid`.

## Solution

Added conditional checks using ternary operator:
```python
generated_block_bid=generated_block.generated_block_bid if generated_block else ""
```

This ensures that when `generated_block` is `None`, we return an empty string instead of raising an error.

## Files Changed

- `src/api/flaskr/service/learn/context_v2.py`: Added None checks at lines 735-737 and 758-760

## Test Plan

- [ ] Verify unpaid users can view payment-related interactions without errors
- [ ] Verify paid users continue to work as before
- [ ] Check that `generated_block_bid` is properly set when `generated_block` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare error that could interrupt interactive flows when payment or login prompts appeared.
  * Ensures these prompts render reliably without crashing due to missing data.
  * Improves stability and continuity of interactions when users are not yet paid or logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->