### PR TITLE
feat(next.config): disable image optimization to avoid Sharp dependence

### DIFF
--- a/src/cook-web/next.config.ts
+++ b/src/cook-web/next.config.ts
@@ -21,8 +21,6 @@ const nextConfig: NextConfig = {
   // Disable image optimization to avoid Sharp dependency
   images: {
     unoptimized: true,
-    loader: 'custom',
-    loaderFile: './src/lib/image-loader.ts',
   },
 
   // 仅 Turbopack dev 时生效

--- a/src/cook-web/src/lib/image-loader.ts
+++ b/src/cook-web/src/lib/image-loader.ts
@@ -1,3 +1,0 @@
-export default function imageLoader({ src }: { src: string }) {
-  return src;
-}


### PR DESCRIPTION
Add the images configuration in.ts, set unoptimized to true,

And configure a custom image loader to resolve Sharp dependency issues.

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application configuration for standalone build output mode.
  * Disabled image optimization in application settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->