### PR TITLE
fix: change children count to zero when saving outlineitem

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -346,7 +346,8 @@ def save_outline_history(
         item = q.get()
         if item.bid == outline_bid:
             item.id = id
-            item.child_count = child_count
+            if child_count > 0:
+                item.child_count = child_count
             break
         for child in item.children:
             q.put(child)


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced outline history management to better preserve existing data when updating outline information, improving data integrity during history saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->