### PR TITLE
feat: expose generated block metadata endpoint

### DIFF
--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -381,3 +381,31 @@ class RunStatusDTO(BaseModel):
             "is_running": self.is_running,
             "running_time": self.running_time,
         }
+
+
+@register_schema_to_swagger
+class GeneratedInfoDTO(BaseModel):
+    position: int = Field(..., description="generated block position", required=False)
+    outline_name: str = Field(..., description="outline item name", required=False)
+    is_trial_lesson: bool = Field(
+        ..., description="whether the outline item is a trial lesson", required=False
+    )
+
+    def __init__(
+        self,
+        position: int,
+        outline_name: str,
+        is_trial_lesson: bool,
+    ):
+        super().__init__(
+            position=position,
+            outline_name=outline_name,
+            is_trial_lesson=is_trial_lesson,
+        )
+
+    def __json__(self):
+        return {
+            "position": self.position,
+            "outline_name": self.outline_name,
+            "is_trial_lesson": self.is_trial_lesson,
+        }

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -8,6 +8,7 @@ from flaskr.service.learn.learn_funcs import (
     get_learn_record,
     handle_reaction,
     reset_learn_record,
+    get_generated_content,
 )
 from flaskr.service.learn.runscript_v2 import run_script, get_run_status
 
@@ -330,6 +331,51 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         )
         return make_common_response(
             handle_reaction(app, shifu_bid, user_bid, generated_block_bid, action)
+        )
+
+    @app.route(
+        path_prefix + "/shifu/<shifu_bid>/generated-contents/<generated_block_bid>",
+        methods=["GET"],
+    )
+    def get_generated_content_api(shifu_bid: str, generated_block_bid: str):
+        """
+        get the content of the generated block
+        ---
+        tags:
+            - learn
+        parameters:
+            - name: shifu_bid
+              type: string
+              required: true
+            - name: generated_block_bid
+              type: string
+              required: true
+        responses:
+            200:
+                description: get the content of the generated block success
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                code:
+                                    type: integer
+                                    description: code
+                                message:
+                                    type: string
+                                    description: message
+                                data:
+                                    $ref: "#/components/schemas/GeneratedInfoDTO"
+        """
+        user_bid = request.user.user_id
+        preview_mode = request.args.get("preview_mode", "False")
+        app.logger.info(
+            f"get generated content, shifu_bid: {shifu_bid}, generated_block_bid: {generated_block_bid}, preview_mode: {preview_mode}"
+        )
+        preview_mode = preview_mode.lower() == "true"
+        return make_common_response(
+            get_generated_content(
+                app, shifu_bid, generated_block_bid, user_bid, preview_mode
+            )
         )
 
     return app

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.tsx
@@ -368,7 +368,7 @@ export const ChatComponents = forwardRef<any, any>(
               RESP_EVENT_TYPE.REQUIRE_LOGIN,
             ].includes(response.type)
           ) {
-            trackTrailProgress(scriptId);
+            trackTrailProgress(courseId, scriptId);
           }
 
           try {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -74,7 +74,7 @@ export interface UseChatSessionParams {
   chapterId?: string;
   previewMode?: boolean;
   trackEvent: (name: string, payload?: Record<string, any>) => void;
-  trackTrailProgress: (generatedBlockBid: string) => void;
+  trackTrailProgress: (courseId: string, generatedBlockBid: string) => void;
   lessonUpdate?: (params: Record<string, any>) => void;
   chapterUpdate?: (params: Record<string, any>) => void;
   updateSelectedLesson: (lessonId: string, forceExpand?: boolean) => void;
@@ -333,8 +333,8 @@ function useChatLogicHook({
             const blockId = nid;
             // const blockId = currentBlockIdRef.current;
 
-            if (nid && [SSE_OUTPUT_TYPE.BREAK].includes(response.type)) {
-              trackTrailProgress(nid);
+            if (blockId && [SSE_OUTPUT_TYPE.BREAK].includes(response.type)) {
+              trackTrailProgress(shifuBid, blockId);
             }
 
             if (response.type === SSE_OUTPUT_TYPE.INTERACTION) {

--- a/src/cook-web/src/c-api/lesson.ts
+++ b/src/cook-web/src/c-api/lesson.ts
@@ -9,10 +9,10 @@ export const getLessonTree = async (courseId: string, previewMode: boolean) => {
   );
 };
 
-export const getScriptInfo = async (scriptId: string) => {
+export const getScriptInfo = async (courseId: string, scriptId: string) => {
   const preview_mode = useSystemStore.getState().previewMode;
   return request.get(
-    `/api/study/query-script-into?script_id=${scriptId}&preview_mode=${preview_mode}`,
+    `/api/learn/shifu/${courseId}/generated-contents/${scriptId}?preview_mode=${preview_mode}`,
   );
 };
 

--- a/src/cook-web/src/c-common/hooks/useTracking.ts
+++ b/src/cook-web/src/c-common/hooks/useTracking.ts
@@ -108,9 +108,9 @@ export const useTracking = () => {
   );
 
   const trackTrailProgress = useCallback(
-    async scriptId => {
+    async (courseId: string, scriptId: string) => {
       try {
-        const { data: scriptInfo } = await getScriptInfo(scriptId);
+        const { data: scriptInfo } = await getScriptInfo(courseId, scriptId);
 
         // Check whether this script is part of a trial lesson
         if (!scriptInfo?.is_trial_lesson) {
@@ -118,8 +118,8 @@ export const useTracking = () => {
         }
 
         trackEvent(EVENT_NAMES.TRIAL_PROGRESS, {
-          progress_no: scriptInfo.script_index,
-          progress_desc: scriptInfo.script_name,
+          progress_no: scriptInfo.position,
+          progress_desc: scriptInfo.outline_name,
         });
       } catch {}
     },


### PR DESCRIPTION
## Summary
- add GeneratedInfoDTO and service method for generated block metadata
- expose GET /api/learn/shifu/<shifu_bid>/generated-contents/<generated_block_bid>
- consume the endpoint in Cook Web tracking to keep trial analytics

## Testing
- pre-commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new endpoint to retrieve generated content information with course-scoped identifiers
  * Enhanced progress tracking to capture both course and content context

* **Documentation**
  * Reorganized API path structure for fetching generated content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->