### PR TITLE
fix: update prod compose env

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,9 +1,3 @@
-x-environment: &default-env
-  REDIS_HOST: ai-shifu-redis
-  SQLALCHEMY_DATABASE_URI: mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4
-  SECRET_KEY: ai-shifu
-  UNIVERSAL_VERIFICATION_CODE: 1024
-
 services:
   ai-shifu-api:
     container_name: ai-shifu-api
@@ -14,7 +8,6 @@ services:
     entrypoint: ["sh", "-c", "until timeout 1 bash -c 'cat < /dev/null > /dev/tcp/ai-shifu-mysql/3306'; do sleep 1; done && flask db upgrade && exec gunicorn -w 4 -b 0.0.0.0:5800 'app:app' --timeout 300 --log-level info --access-logfile /var/log/app.log --capture-output"]
     env_file:
       - ./.env
-    environment: *default-env
     depends_on:
       - ai-shifu-mysql
       - ai-shifu-redis
@@ -41,12 +34,11 @@ services:
     restart: unless-stopped
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
-
   ai-shifu-mysql:
     container_name: ai-shifu-mysql
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ai-shifu
+      MYSQL_DATABASE: ai-shifu
     image: mysql:8.0
     ports:
       - "3306:3306"


### PR DESCRIPTION
## Summary
- drop the shared default environment block so the API relies solely on .env
- pin the MySQL root password and database name inside the prod compose file

## Testing
- pre-commit run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration for improved environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->