### PR TITLE
fix: shorten admin title translation

### DIFF
--- a/src/i18n/en-US/common/core.json
+++ b/src/i18n/en-US/common/core.json
@@ -1,7 +1,7 @@
 {
   "__namespace__": "common.core",
   "all": "All",
-  "adminTitle": "Management Background",
+  "adminTitle": "Admin",
   "cancel": "Cancel",
   "companyAddress": "Room 163, 19th Floor, Donghuan Building, Wangjing, Chaoyang District, Beijing",
   "companyName": "Beijing Chanchanshanmu Technology Co., Ltd.",


### PR DESCRIPTION
## Summary
- shorten the en-US adminTitle translation to "Admin" to better match 中文 copy

## Testing
- pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the admin section title from a verbose label to the concise "Admin" to improve clarity and consistency across the interface, reduce visual clutter, and streamline navigation labels for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->