### PR TITLE
fix: hide global info button

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import ChatComponents from './NewChatComp';
 import UserSettings from '../Settings/UserSettings';
 import { FRAME_LAYOUT_MOBILE } from '@/c-constants/uiConstants';
-import GlobalInfoButton from './GlobalInfoButton';
 import { useSystemStore } from '@/c-store/useSystemStore';
 import { useUiLayoutStore } from '@/c-store';
 
@@ -78,7 +77,6 @@ export const ChatUi = ({
         />
       )}
 
-      <GlobalInfoButton className={styles.globalInfoButton} />
       <div className={styles.footer}>
         <span className={styles.footerText}>
           {t('module.chat.aiGenerated')}


### PR DESCRIPTION
## Summary
- hide GlobalInfoButton component by removing it from ChatUi
aiming to disable the info button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a UI button from the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->