### PR TITLE
feat: grant creator and demo access on admin login

### DIFF
--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -496,6 +496,18 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         ),
         group="auth",
     ),
+    "ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO": EnvVar(
+        name="ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO",
+        default=False,
+        type=bool,
+        description=(
+            "When enabled, users logging in from the admin interface are "
+            "automatically marked as creators and granted demo course "
+            "permissions (DEMO_SHIFU_BID / DEMO_EN_SHIFU_BID if configured). "
+            "Intended for demo and staging environments only."
+        ),
+        group="auth",
+    ),
     # Payment Providers
     "PINGXX_SECRET_KEY": EnvVar(
         name="PINGXX_SECRET_KEY",

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -281,6 +281,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             sms_code = request.get_json().get("sms_code", None)
             course_id = request.get_json().get("course_id", None)
             language = request.get_json().get("language", None)
+            login_context = request.get_json().get("login_context", None)
             user_id = (
                 None if getattr(request, "user", None) is None else request.user.user_id
             )
@@ -288,7 +289,15 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
                 raise_param_error("mobile")
             if not sms_code:
                 raise_param_error("sms_code")
-            ret = verify_sms_code(app, user_id, mobile, sms_code, course_id, language)
+            ret = verify_sms_code(
+                app,
+                user_id,
+                mobile,
+                sms_code,
+                course_id,
+                language,
+                login_context,
+            )
             db.session.commit()
             resp = make_response(make_common_response(ret))
             return resp
@@ -531,6 +540,9 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         redirect_uri = request.args.get("redirect_uri")
         if redirect_uri:
             metadata["redirect_uri"] = redirect_uri
+        login_context = request.args.get("login_context")
+        if login_context:
+            metadata["login_context"] = login_context
         result = provider.begin_oauth(app, metadata)
         dto = OAuthStartDTO(
             authorization_url=result["authorization_url"],

--- a/src/api/flaskr/service/user/auth/providers/phone.py
+++ b/src/api/flaskr/service/user/auth/providers/phone.py
@@ -43,6 +43,7 @@ class PhoneAuthProvider(AuthProvider):
             request.code,
             course_id=request.metadata.get("course_id"),
             language=request.metadata.get("language"),
+            login_context=request.metadata.get("login_context"),
         )
 
         aggregate = load_user_aggregate(user_token.userInfo.user_id)

--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -221,6 +221,7 @@ def verify_sms_code(
     chekcode: str,
     course_id: str = None,
     language: str = None,
+    login_context: Optional[str] = None,
 ) -> UserToken:
     provider = get_provider("phone")
     request = VerificationRequest(
@@ -230,6 +231,7 @@ def verify_sms_code(
             "user_id": user_id,
             "course_id": course_id,
             "language": language,
+            "login_context": login_context,
         },
     )
     auth_result = provider.verify(app, request)

--- a/src/cook-web/src/app/login/page.tsx
+++ b/src/cook-web/src/app/login/page.tsx
@@ -133,6 +133,11 @@ export default function AuthPage() {
     return redirect;
   }, [searchParams]);
 
+  const loginContext = useMemo(() => {
+    const redirectPath = resolveRedirectPath();
+    return redirectPath.startsWith('/admin') ? 'admin' : 'default';
+  }, [resolveRedirectPath]);
+
   const handleAuthSuccess = () => {
     router.replace(resolveRedirectPath());
   };
@@ -289,7 +294,12 @@ export default function AuthPage() {
     (method: LoginMethod) => {
       switch (method) {
         case 'phone':
-          return <PhoneLogin onLoginSuccess={handleAuthSuccess} />;
+          return (
+            <PhoneLogin
+              onLoginSuccess={handleAuthSuccess}
+              loginContext={loginContext}
+            />
+          );
         case 'email':
           return <EmailLogin onLoginSuccess={handleAuthSuccess} />;
         case 'google':

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -19,9 +19,10 @@ import type { UserInfo } from '@/c-types';
 import { tokenTool } from '@/c-service/storeUtil';
 interface PhoneLoginProps {
   onLoginSuccess: (userInfo: UserInfo) => void;
+  loginContext?: string;
 }
 
-export function PhoneLogin({ onLoginSuccess }: PhoneLoginProps) {
+export function PhoneLogin({ onLoginSuccess, loginContext }: PhoneLoginProps) {
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState('');
@@ -33,6 +34,7 @@ export function PhoneLogin({ onLoginSuccess }: PhoneLoginProps) {
   const { t } = useTranslation();
   const { loginWithSmsCode, sendSmsCode } = useAuth({
     onSuccess: onLoginSuccess,
+    loginContext,
   });
   const validatePhone = (phone: string) => {
     if (!phone) {

--- a/src/cook-web/src/hooks/useAuth.ts
+++ b/src/cook-web/src/hooks/useAuth.ts
@@ -21,6 +21,7 @@ interface LoginResponse extends ApiResponse {
 interface UseAuthOptions {
   onSuccess?: (userInfo: UserInfo) => void;
   onError?: (error: any) => void;
+  loginContext?: string;
 }
 
 export function useAuth(options: UseAuthOptions = {}) {
@@ -100,7 +101,12 @@ export function useAuth(options: UseAuthOptions = {}) {
   ) => {
     try {
       const response = await callWithTokenRefresh(() =>
-        apiService.verifySmsCode({ mobile, sms_code, language }),
+        apiService.verifySmsCode({
+          mobile,
+          sms_code,
+          language,
+          login_context: options.loginContext,
+        }),
       );
 
       const success = await processLoginResponse(response);

--- a/src/cook-web/src/hooks/useGoogleAuth.ts
+++ b/src/cook-web/src/hooks/useGoogleAuth.ts
@@ -103,6 +103,10 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
         }
 
         const redirectTarget = redirectPath || '/admin';
+        const loginContext =
+          redirectTarget && redirectTarget.startsWith('/admin')
+            ? 'admin'
+            : 'default';
         setGoogleOAuthRedirect(redirectTarget);
 
         const redirectUri = buildRedirectUri(redirectUriOverride);
@@ -110,7 +114,10 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
         await ensureGuestToken();
 
         const response = await callWithTokenRefresh(() =>
-          apiService.googleOauthStart({ redirect_uri: redirectUri }),
+          apiService.googleOauthStart({
+            redirect_uri: redirectUri,
+            login_context: loginContext,
+          }),
         );
         const payload = extractData<OAuthStartPayload>(response);
 


### PR DESCRIPTION
## Summary

When a user logs in via the Cook Web admin entry, and the new backend flag
`ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO` is enabled, automatically:

- mark the user as a creator (`is_creator = 1`)
- grant full permissions (view, edit, publish) on the configured demo courses

This applies to both phone-based login and Google OAuth login.

## Changes

### Backend (`src/api`)

- Add config flag `ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO` in
  `flaskr/common/config.py` (group `auth`).
- Introduce `ensure_admin_creator_and_demo_permissions` in
  `flaskr/service/user/utils.py`:
  - Marks the user as creator via `mark_user_roles`.
  - Reads `DEMO_SHIFU_BID` and `DEMO_EN_SHIFU_BID` from dynamic config and
    upserts `AiCourseAuth` with `["view","edit","publish"]` for those courses.
- Extend phone login flow:
  - `flaskr/service/user/common.py::verify_sms_code` now accepts `login_context`
    and passes it through to the phone provider.
  - `flaskr/service/user/auth/providers/phone.py` passes `login_context` down
    to `verify_phone_code`.
  - `flaskr/service/user/phone_flow.py::verify_phone_code` accepts
    `login_context` and calls
    `ensure_admin_creator_and_demo_permissions(app, target_aggregate.user_bid, login_context)`.
- Extend Google OAuth flow:
  - `flaskr/route/user.py::google_oauth_start` reads `login_context` from
    query and passes it as metadata to the provider.
  - `flaskr/service/user/auth/providers/google.py`:
    - Stores `login_context` in the OAuth state payload together with
      `redirect_uri`.
    - Restores `login_context` in the callback and calls
      `ensure_admin_creator_and_demo_permissions` after issuing the token.
- Extend user routes:
  - `/user/verify_sms_code` accepts optional `login_context` in the request
    body and forwards it into `verify_sms_code`.

### Frontend (`src/cook-web`)

- `src/hooks/useAuth.ts`:
  - `useAuth` now accepts `loginContext?: string`.
  - `loginWithSmsCode` passes `login_context` to `verifySmsCode` API.
- `src/components/auth/PhoneLogin.tsx`:
  - Accepts a new `loginContext` prop and wires it through to `useAuth`.
- `src/app/login/page.tsx`:
  - Derives `loginContext` from the `redirect` query:
    - `redirect` starting with `/admin` → `loginContext = 'admin'`
    - otherwise → `loginContext = 'default'`
  - Passes `loginContext` into `PhoneLogin`.
- `src/hooks/useGoogleAuth.ts`:
  - Derives `loginContext` from `redirectTarget` in `startGoogleLogin`
    using the same rule as above.
  - Sends `login_context` as a query parameter to
    `/api/user/oauth/google` so that the backend can persist it in the
    OAuth state.

## How it works

- When `ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO=false` (default), behavior is
  unchanged for all login flows.
- When `ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO=true`:
  - Phone login from the admin entry (`/login?redirect=/admin...`) will:
    - decode the user token as usual,
    - mark the user as creator,
    - grant demo course permissions if `DEMO_SHIFU_BID` / `DEMO_EN_SHIFU_BID`
      are configured.
  - Google OAuth login started from the admin entry behaves the same, using
    the `login_context` stored in the OAuth state.

## Deployment & Config

1. Ensure demo shifus are imported and config keys exist by running:
   - `FLASK_APP=app.py flask update_demo_shifu`
2. In the API environment, set:
   - `ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO=true`
3. Restart the backend service.

After that, any user logging in via the admin UI (SMS or Google) will
automatically become a creator with full access to the demo courses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication system with context-aware login handling for admin and standard user flows.
  * Implemented automatic creator status and demo course permission assignment for admin users during authentication.
  * Added login context support across phone and Google OAuth authentication methods.

* **Chores**
  * Added new configuration option to control automatic admin privilege granting on login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->