### PR TITLE
fix: change demo shifu auth from all to view for new creators

### DIFF
--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -91,12 +91,12 @@ def _ensure_creator_permissions(app: Flask, shifu_bid: str):
                 course_auth_id=generate_id(app),
                 user_id=user.user_bid,
                 course_id=shifu_bid,
-                auth_type=json.dumps(["view", "edit", "publish"]),
+                auth_type=json.dumps(["view"]),
                 status=1,
             )
             db.session.add(auth)
         else:
-            auth.auth_type = json.dumps(["view", "edit", "publish"])
+            auth.auth_type = json.dumps(["view"])
             auth.status = 1
         db.session.commit()
 

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -292,7 +292,7 @@ def ensure_admin_creator_and_demo_permissions(
         # No demo courses configured; nothing more to do
         return
 
-    full_auth_types = json.dumps(["view", "edit", "publish"])
+    full_auth_types = json.dumps(["view"])
 
     for shifu_bid in demo_ids:
         auth = AiCourseAuth.query.filter(


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted demo course access permissions to view-only, reducing from previous broader permission levels. This change applies to both new and existing permission records, ensuring users have appropriate access constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->