### PR TITLE
feat: set default shifu price to 0.50 in frontend

### DIFF
--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -101,7 +101,7 @@ export default function ShifuSettingDialog({
       .max(20000, t('module.shifuSetting.shifuPromptMaxLength')),
     price: z
       .string()
-      .min(0.5, t('module.shifuSetting.shifuPriceEmpty'))
+      .min(MIN_SHIFU_PRICE, t('module.shifuSetting.shifuPriceEmpty'))
       .regex(/^\d+(\.\d{1,2})?$/, t('module.shifuSetting.shifuPriceFormat')),
     temperature: z
       .string()
@@ -126,7 +126,7 @@ export default function ShifuSettingDialog({
       description: '',
       model: '',
       systemPrompt: '',
-      price: '',
+      price: MIN_SHIFU_PRICE.toFixed(2),
       temperature: '',
     },
   });
@@ -245,7 +245,7 @@ export default function ShifuSettingDialog({
       form.reset({
         name: result.name,
         description: result.description,
-        price: (result.price ?? 0).toFixed(2),
+        price: (result.price || MIN_SHIFU_PRICE).toFixed(2),
         model: result.model || '',
         previewUrl: result.preview_url,
         url: result.url,


### PR DESCRIPTION
## Summary

- Set the default price field value to **0.50** in the shifu settings dialog to improve user experience
- This is a **frontend-only change** that does not modify backend behavior or database defaults

## Changes

1. **Form default value** (`ShifuSetting.tsx:129`): Set `defaultValues.price` to `'0.50'`
2. **API data handling** (`ShifuSetting.tsx:248`): Changed nullish coalescing operator (`??`) to logical OR (`||`) to handle backend price value of `0`, ensuring it displays as `0.50` instead of `0.00`

## Technical Details

The issue occurred because:
- When a new shifu is created, the backend stores `price = 0` (database default)
- The frontend fetches shifu details and uses `form.reset()` with API data
- Using `result.price ?? 0` doesn't work because `0` is not `null`/`undefined`
- Changed to `result.price || 0.5` to treat `0` as a falsy value and use `0.5` as default

## Test Plan

- [x] Open shifu settings for a newly created shifu → price field displays "0.50"
- [x] Open shifu settings for existing shifu with price = 0 → displays "0.50"
- [x] Open shifu settings for existing shifu with price > 0 → displays actual price
- [ ] Save shifu with price < 0.50 → validation error appears
- [ ] Save shifu with price ≥ 0.50 → saves successfully

## Screenshots

Before: Price field showed "0.00"
After: Price field shows "0.50"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default and fallback price values now use the app's minimum shifu price (displayed with two decimals) when creating or loading settings.
  * Price validation consistently enforces the minimum allowable price and ensures values are formatted to two decimal places.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->