### PR TITLE
fix: bind google oauth to existing temp userfix: reuse temp user for google login

### DIFF
--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -555,12 +555,19 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/oauth/google/callback", methods=["GET"])
     @bypass_token_validation
+    @optional_token_validation
     def google_oauth_callback():
         provider = get_provider("google")
+        current_user = getattr(request, "user", None)
+        current_user_id = None
+        if current_user is not None:
+            current_user_id = getattr(current_user, "user_id", None)
+
         callback_request = OAuthCallbackRequest(
             state=request.args.get("state"),
             code=request.args.get("code"),
             raw_request_args=request.args.to_dict(flat=True),
+            current_user_id=current_user_id,
         )
         try:
             auth_result = provider.handle_oauth_callback(app, callback_request)

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -56,6 +56,10 @@ class OAuthCallbackRequest(_BaseDTO):
     raw_request_args: Dict[str, Any] = Field(
         default_factory=dict, description="Complete callback request arguments"
     )
+    current_user_id: Optional[str] = Field(
+        None,
+        description="User ID resolved from temporary token, if any",
+    )
 
 
 class AuthResult(_BaseDTO):


### PR DESCRIPTION
———

  Summary

  - Ensure Google OAuth login reuses the existing temporary user created via /user/require_tmp instead of creating a separate account.
  - When a user completes Google login, the backend now upgrades the temp user to a registered user and binds Google/email credentials on that same user.

  Changes

  - src/api/flaskr/route/user.py:google_oauth_callback
      - Add @optional_token_validation so the current temp token (from /user/require_tmp) is resolved into request.user.
      - Pass current_user_id into OAuthCallbackRequest so providers can see which temp user initiated the flow.
  - src/api/flaskr/service/user/auth/base.py:OAuthCallbackRequest
      - Add current_user_id: Optional[str] field to carry the user ID resolved from the temp token.
  - src/api/flaskr/service/user/auth/providers/google.py:GoogleAuthProvider.handle_oauth_callback
      - Load origin_aggregate from request.current_user_id when present.
      - When no existing Google/email account is found, fall back to origin_aggregate so the temp user is reused instead of creating a new user.
      - When updating an existing aggregate, also upsert_credential for the email provider to ensure the email credential is stored and verified according to Google’s email_verified flag.
      - When creating a new user via ensure_user_for_identifier, prefer origin_user_id as user_bid so the temp user is upgraded in-place.

  Behavior before

  - Frontend called /user/require_tmp to create a temp user and stored its token.
  - Google OAuth was completed without using that temp user ID explicitly; the backend could create or reuse a user independent of the temp user, leading to:
      - Multiple user records for the same person in some flows.
      - Temp user’s study data not obviously connected to the final Google account.

  Behavior after

  - The Google callback receives the same token (via Token header) that came from /user/require_tmp.
  - The backend resolves that token to current_user_id and passes it into the Google auth provider.
  - The provider now:
      - Reuses the existing Google/email user if present (unchanged behavior).
      - Otherwise, reuses the temp user (current_user_id) as the base user and upgrades it to USER_STATE_REGISTERED, binding email + Google credentials.
  - This means “temp user → Google login” becomes a clean upgrade path instead of creating a separate user.

  Testing

  - Manual:
      - Start backend with valid Google OAuth config.
      - Open Cook Web as a fresh user (no token) to generate a temp user via /user/require_tmp.
      - Complete Google OAuth login from the UI.
      - Verify:
          - The Google callback is called with Token header.
          - The same user record (based on current_user_id) is upgraded to registered and has Google/email credentials.
  - Automated:
      - pre-commit run (passes).
      - (Optional) Run pytest for user/auth modules if CI is configured for them.

  Notes / Migration

  - This change does not introduce DB schema changes.
  - Existing Google/email users continue to work as before; only the “no existing account + having a temp user token” path now reuses the temp user instead of creating a new record.

  ———

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth login reliability with enhanced database transaction handling to ensure data consistency during authentication operations.
  * Added support for linking OAuth accounts to existing user profiles, enabling seamless account integration and providing a unified user experience across different authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->