### PR TITLE
fix: reset auth token on expiration

### DIFF
--- a/src/cook-web/src/store/useUserStore.ts
+++ b/src/cook-web/src/store/useUserStore.ts
@@ -12,6 +12,7 @@ import { clearGoogleOAuthSession } from '@/lib/google-oauth-session';
 // Helper function to register as guest user
 const registerAsGuest = async (): Promise<string> => {
   // Always fetch a fresh guest token to avoid expiration issues
+  tokenTool.remove();
   const res = await registerTmp({ temp_id: genUuid() });
   const token = res.token;
   tokenTool.set({ token, faked: true });
@@ -87,21 +88,39 @@ export const useUserStore = create<
 
     // Public API: Logout user
     logout: async (reload = true) => {
-      clearGoogleOAuthSession();
-      await registerAsGuest();
-      set(() => ({
-        userInfo: null,
-      }));
+      let didTriggerReload = false;
+      const resetLogoutFlag = () => {
+        if (typeof window !== 'undefined') {
+          window.__IS_LOGGING_OUT__ = false;
+        }
+      };
 
-      get()._updateUserStatus();
+      if (typeof window !== 'undefined') {
+        window.__IS_LOGGING_OUT__ = true;
+      }
 
-      if (reload) {
-        const url = removeParamFromUrl(window.location.href, [
-          'code',
-          'state',
-          'redirect',
-        ]);
-        window.location.assign(url);
+      try {
+        clearGoogleOAuthSession();
+        await registerAsGuest();
+        set(() => ({
+          userInfo: null,
+        }));
+
+        get()._updateUserStatus();
+
+        if (reload && typeof window !== 'undefined') {
+          const url = removeParamFromUrl(window.location.href, [
+            'code',
+            'state',
+            'redirect',
+          ]);
+          window.location.assign(url);
+          didTriggerReload = true;
+        }
+      } finally {
+        if (!didTriggerReload) {
+          resetLogoutFlag();
+        }
       }
     },
 
@@ -157,7 +176,10 @@ export const useUserStore = create<
           // @ts-expect-error EXPECT
           // Only reset to guest if it's a clear authentication error (not network or server issues)
           if (err.status === 403 || err.code === 1005 || err.code === 1001) {
-            await registerAsGuest();
+            const tokenDataAfterFailure = tokenTool.get();
+            if (!tokenDataAfterFailure.faked) {
+              await registerAsGuest();
+            }
             set(() => ({
               userInfo: null,
             }));


### PR DESCRIPTION
## Summary
- clear any stale token before requesting a guest token so require_tmp requests never fail auth
- guard logout in user store and auto-trigger it for auth errors to keep token + require_tmp in sync even in prod builds

## Testing
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error detection and initiated automatic recovery flows for better handling of authentication failures
  * Prevented concurrent logout operations to eliminate double redirects and race conditions during session termination
  * Enhanced guest token management logic to avoid redundant token generation when authentication fails during initialization
  * Strengthened overall authentication state management and logout sequences to improve system stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->