### PR TITLE
fix(cook-web): rerun completed lessons after reset when records are cleared

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -29,6 +29,7 @@
 - `skills/module-augmentation-guardrails/SKILL.md`
 - `skills/hook-contract-refactor-safety/SKILL.md`
 - `skills/chat-system-interaction-button-overrides/SKILL.md`
+- `skills/lesson-reset-run-gating/SKILL.md`
 
 ## Usage Rules
 

--- a/src/cook-web/skills/README.md
+++ b/src/cook-web/skills/README.md
@@ -11,3 +11,4 @@
 - `module-augmentation-guardrails`
 - `hook-contract-refactor-safety`
 - `chat-system-interaction-button-overrides`
+- `lesson-reset-run-gating`

--- a/src/cook-web/skills/lesson-reset-run-gating/SKILL.md
+++ b/src/cook-web/skills/lesson-reset-run-gating/SKILL.md
@@ -1,0 +1,26 @@
+# lesson-reset-run-gating
+
+## 适用场景
+
+- 排查课程目录里的“重修/重置”按钮点击后，没有进入“思考中”也没有发送 `/run` 请求。
+- 排查课节重置后，目录状态已变化，但聊天区没有自动重新开始生成内容。
+
+## 核心检查点
+
+- 先确认目录按钮只是触发重置链路，不是直接调用 `/run`；真正的自动开跑通常发生在 `useChatLogicHook` 的 `refreshData` 里。
+- 重点检查 `lessonStatus` 是否仍然是 `completed`。如果 `isCompletedLesson` 为 `true`，`refreshData` 在空记录和非交互结尾两条分支里都会跳过 `runRef.current`。
+- 处理这类问题时优先修正课节树中的本地状态，例如在确认重修后把目标课节手动更新为 `not_started`，而不是在聊天 hook 里强行绕过 completed 守卫。
+- 重点检查 `resetedLessonId`、当前 `lessonId`、树刷新后的 `selectedLessonId` 三者的时序。若订阅回调触发时 `curr !== lessonId`，当前 hook 不会执行 `refreshData`；后续当 `lessonId` 切到被重置课节时，`resetedLessonId === lessonId` 又会让另一个 effect 直接 return。
+
+## 建议排查顺序
+
+1. 从目录按钮组件确认是否只做 `resetChapter`、`updateLessonId` 和 reset 事件派发。
+2. 查看 store 中 `resetedLessonId` 的写入时机，以及聊天 hook 里基于它的订阅和 effect 条件。
+3. 查看 `refreshData` 中调用 `runRef.current` 的守卫条件，尤其是 `isCompletedLesson`。
+4. 对照树刷新逻辑，确认 `lessonStatus` 的新值何时传入 `useChatLogicHook`，避免旧状态先参与重置后的首轮判断；必要时在 reset 事件里先做本地状态矫正。
+
+## 回归关注点
+
+- 当前选中的课节点击重修后，是否稳定进入“思考中”。
+- 非当前课节点击重修并切换过去后，是否会自动拉起 `/run`。
+- 已完成课节和进行中课节两种状态下，重修后的行为是否一致。

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -49,18 +49,24 @@ declare global {
   var __chatHookMockUpdateResetedLessonId__: jest.Mock | undefined;
 }
 
+const mockCourseStoreState = {
+  resetedLessonId: null as string | null,
+  updateResetedChapterId: undefined as jest.Mock | undefined,
+  updateResetedLessonId: undefined as jest.Mock | undefined,
+};
+
 jest.mock('@/c-store/useCourseStore', () => ({
   useCourseStore: (() => {
     globalThis.__chatHookMockUpdateResetedChapterId__ = jest.fn();
     globalThis.__chatHookMockUpdateResetedLessonId__ = jest.fn();
-    const state = {
-      resetedLessonId: null as string | null,
-      updateResetedChapterId: globalThis.__chatHookMockUpdateResetedChapterId__,
-      updateResetedLessonId: globalThis.__chatHookMockUpdateResetedLessonId__,
-    };
+    mockCourseStoreState.resetedLessonId = null;
+    mockCourseStoreState.updateResetedChapterId =
+      globalThis.__chatHookMockUpdateResetedChapterId__;
+    mockCourseStoreState.updateResetedLessonId =
+      globalThis.__chatHookMockUpdateResetedLessonId__;
     return Object.assign(
-      (selector?: (store: typeof state) => unknown) =>
-        selector ? selector(state) : state,
+      (selector?: (store: typeof mockCourseStoreState) => unknown) =>
+        selector ? selector(mockCourseStoreState) : mockCourseStoreState,
       {
         subscribe: jest.fn(() => jest.fn()),
       },
@@ -189,6 +195,7 @@ describe('useChatLogicHook stream cleanup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     activeRun = undefined;
+    mockCourseStoreState.resetedLessonId = null;
 
     mockGetLessonStudyRecord.mockResolvedValue({
       mdflow: '',
@@ -976,6 +983,48 @@ describe('useChatLogicHook stream cleanup', () => {
       status_value: 'completed',
     });
     expect(mockGetRunMessage).toHaveBeenCalledTimes(initialRunCount);
+  });
+
+  it('waits for reset status to leave completed before rerunning reset lesson', async () => {
+    const { result, rerender } = renderHook(
+      ({ lessonStatus }) =>
+        useChatLogicHook({
+          ...buildBaseParams(),
+          lessonStatus,
+        }),
+      {
+        wrapper,
+        initialProps: {
+          lessonStatus: 'completed',
+        },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetRunMessage).not.toHaveBeenCalled();
+
+    mockCourseStoreState.resetedLessonId = 'lesson-1';
+    rerender({ lessonStatus: 'completed' });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetRunMessage).not.toHaveBeenCalled();
+
+    rerender({ lessonStatus: 'not_started' });
+
+    await waitFor(() =>
+      expect(mockGetRunMessage).toHaveBeenCalledWith(
+        'shifu-1',
+        'lesson-1',
+        false,
+        expect.objectContaining({
+          input: '',
+          input_type: SSE_INPUT_TYPE.NORMAL,
+          listen: false,
+        }),
+        expect.any(Function),
+      ),
+    );
+    expect(globalThis.__chatHookMockUpdateResetedLessonId__).toHaveBeenCalled();
   });
 
   it('does not treat the latest interaction as regenerate when helper rows are trailing', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -212,7 +212,6 @@ function useChatLogicHook({
 }: UseChatSessionParams): UseChatSessionResult {
   const { t, i18n, ready } = useTranslation();
   const { mobileStyle } = useContext(AppContext);
-  const isCompletedLesson = lessonStatus === LESSON_STATUS_VALUE.COMPLETED;
 
   const { updateUserInfo } = useUserStore(
     useShallow(state => ({
@@ -228,6 +227,7 @@ function useChatLogicHook({
         updateResetedLessonId: state.updateResetedLessonId,
       })),
     );
+  const isCompletedLesson = lessonStatus === LESSON_STATUS_VALUE.COMPLETED;
 
   const [contentList, setContentList] = useState<ChatContentItem[]>([]);
   const [currentStreamingElementBid, setCurrentStreamingElementBid] =
@@ -1867,36 +1867,6 @@ function useChatLogicHook({
   }, [chapterId, loadedChapterId]);
 
   useEffect(() => {
-    const unsubscribe = useCourseStore.subscribe(
-      state => state.resetedLessonId,
-      async curr => {
-        if (!curr) {
-          return;
-        }
-        setIsLoading(true);
-        if (curr === lessonId) {
-          sseRef.current?.close();
-          await refreshData();
-          // updateResetedChapterId(null);
-          // @ts-expect-error resetedLessonId can be null per store design
-          updateResetedLessonId(null);
-        }
-        setIsLoading(false);
-      },
-    );
-
-    return () => {
-      unsubscribe();
-    };
-  }, [
-    loadedChapterId,
-    refreshData,
-    updateResetedLessonId,
-    resetedLessonId,
-    lessonId,
-  ]);
-
-  useEffect(() => {
     const unsubscribe = useUserStore.subscribe(
       state => state.isLoggedIn,
       isLoggedIn => {
@@ -1914,13 +1884,30 @@ function useChatLogicHook({
   }, [chapterId, refreshData]);
 
   useEffect(() => {
-    sseRef.current?.close();
-    if (!lessonId || resetedLessonId === lessonId) {
+    if (!lessonId) {
       return;
     }
-    refreshData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lessonId, resetedLessonId]);
+
+    if (resetedLessonId === lessonId) {
+      if (isCompletedLesson) {
+        return;
+      }
+
+      sseRef.current?.close();
+      void refreshData().finally(() => {
+        // @ts-expect-error resetedLessonId can be null per store design
+        updateResetedLessonId(null);
+      });
+      return;
+    }
+
+    sseRef.current?.close();
+    void refreshData();
+  }, [
+    isCompletedLesson,
+    lessonId,
+    resetedLessonId,
+  ]);
 
   useEffect(() => {
     const onGoToNavigationNode = (

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -1903,11 +1903,7 @@ function useChatLogicHook({
 
     sseRef.current?.close();
     void refreshData();
-  }, [
-    isCompletedLesson,
-    lessonId,
-    resetedLessonId,
-  ]);
+  }, [isCompletedLesson, lessonId, resetedLessonId]);
 
   useEffect(() => {
     const onGoToNavigationNode = (

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -29,6 +29,7 @@ import { useDisclosure } from '@/c-common/hooks/useDisclosure';
 import { useLessonTree } from './hooks/useLessonTree';
 import { updateWxcode } from '@/c-api/user';
 import { shifu } from '@/c-service/Shifu';
+import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import {
   buildLoginRedirectPath,
   getLessonIdFromQuery,
@@ -552,6 +553,10 @@ export default function ChatPage() {
     const resetChapterEventHandler = async e => {
       const targetLessonId = e.detail.lesson_id;
       await reloadTree(e.detail.chapter_id, targetLessonId);
+      updateLesson(targetLessonId, {
+        status: LESSON_STATUS_VALUE.PREPARE_LEARNING,
+        status_value: LESSON_STATUS_VALUE.PREPARE_LEARNING,
+      });
       updateSelectedLesson(targetLessonId, true);
       onGoChapter(targetLessonId);
       if (mobileStyle) {


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lesson reset functionality to properly transition completed lessons into a "thinking" state and trigger the automatic run command.
  * Improved lesson status handling to ensure reset lessons are correctly updated to a learning preparation state.

* **Tests**
  * Added test coverage for lesson reset behavior with completed lessons.

* **Documentation**
  * Added troubleshooting guide for lesson reset and run gating issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->