### PR TITLE
fix: track guest course visits in Umami

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/courseVisitTracking.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/courseVisitTracking.test.ts
@@ -1,28 +1,15 @@
 import {
   buildCourseVisitEventName,
-  buildCourseVisitSessionKey,
   trackCourseVisitIfNeeded,
 } from './courseVisitTracking';
 
 describe('courseVisitTracking', () => {
-  test('builds a stable event name and session key from the course bid', () => {
+  test('builds a stable event name from the course bid', () => {
     expect(buildCourseVisitEventName('course-1')).toBe('course_visit_course-1');
-    expect(buildCourseVisitSessionKey('course-1')).toBe(
-      'course_visit:course-1',
-    );
   });
 
-  test('tracks once per session for logged-in learner visits', async () => {
+  test('tracks a logged-in learner visit with auth metadata', async () => {
     const trackEvent = jest.fn().mockResolvedValue(undefined);
-    const storage = (() => {
-      const map = new Map<string, string>();
-      return {
-        getItem: (key: string) => map.get(key) ?? null,
-        setItem: (key: string, value: string) => {
-          map.set(key, value);
-        },
-      };
-    })();
 
     await expect(
       trackCourseVisitIfNeeded({
@@ -31,32 +18,20 @@ describe('courseVisitTracking', () => {
         previewMode: false,
         shifuBid: 'course-1',
         entryType: 'catalog',
-        storage,
         trackEvent,
       }),
     ).resolves.toBe(true);
-
-    await expect(
-      trackCourseVisitIfNeeded({
-        initialized: true,
-        isLoggedIn: true,
-        previewMode: false,
-        shifuBid: 'course-1',
-        entryType: 'catalog',
-        storage,
-        trackEvent,
-      }),
-    ).resolves.toBe(false);
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(trackEvent).toHaveBeenCalledWith('course_visit_course-1', {
       shifu_bid: 'course-1',
       entry_type: 'catalog',
+      auth_state: 'logged_in',
       preview_mode: false,
     });
   });
 
-  test('skips guests and preview mode', async () => {
+  test('tracks guest visits too', async () => {
     const trackEvent = jest.fn().mockResolvedValue(undefined);
 
     await expect(
@@ -65,8 +40,29 @@ describe('courseVisitTracking', () => {
         isLoggedIn: false,
         previewMode: false,
         shifuBid: 'course-1',
+        entryType: 'deep_link',
+        trackEvent,
+      }),
+    ).resolves.toBe(true);
+
+    expect(trackEvent).toHaveBeenCalledWith('course_visit_course-1', {
+      shifu_bid: 'course-1',
+      entry_type: 'deep_link',
+      auth_state: 'guest',
+      preview_mode: false,
+    });
+  });
+
+  test('skips uninitialized users and preview mode', async () => {
+    const trackEvent = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      trackCourseVisitIfNeeded({
+        initialized: false,
+        isLoggedIn: false,
+        previewMode: false,
+        shifuBid: 'course-1',
         entryType: 'catalog',
-        storage: null,
         trackEvent,
       }),
     ).resolves.toBe(false);
@@ -78,7 +74,6 @@ describe('courseVisitTracking', () => {
         previewMode: true,
         shifuBid: 'course-1',
         entryType: 'deep_link',
-        storage: null,
         trackEvent,
       }),
     ).resolves.toBe(false);
@@ -86,20 +81,10 @@ describe('courseVisitTracking', () => {
     expect(trackEvent).not.toHaveBeenCalled();
   });
 
-  test('marks the session once tracking is attempted', async () => {
+  test('returns false when the tracking call fails', async () => {
     const trackEvent = jest
       .fn()
-      .mockRejectedValueOnce(new Error('track failed'))
-      .mockResolvedValueOnce(undefined);
-    const storage = (() => {
-      const map = new Map<string, string>();
-      return {
-        getItem: (key: string) => map.get(key) ?? null,
-        setItem: (key: string, value: string) => {
-          map.set(key, value);
-        },
-      };
-    })();
+      .mockRejectedValueOnce(new Error('track failed'));
 
     await expect(
       trackCourseVisitIfNeeded({
@@ -108,23 +93,9 @@ describe('courseVisitTracking', () => {
         previewMode: false,
         shifuBid: 'course-1',
         entryType: 'catalog',
-        storage,
-        trackEvent,
-      }),
-    ).resolves.toBe(true);
-
-    await expect(
-      trackCourseVisitIfNeeded({
-        initialized: true,
-        isLoggedIn: true,
-        previewMode: false,
-        shifuBid: 'course-1',
-        entryType: 'catalog',
-        storage,
         trackEvent,
       }),
     ).resolves.toBe(false);
-
     expect(trackEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/courseVisitTracking.ts
+++ b/src/cook-web/src/app/c/[[...id]]/courseVisitTracking.ts
@@ -15,18 +15,12 @@ export const buildCourseVisitEventName = (shifuBid: string) => {
   return `${COURSE_VISIT_EVENT_PREFIX}${normalized.slice(0, suffixLimit)}`;
 };
 
-export const buildCourseVisitSessionKey = (shifuBid: string) =>
-  `course_visit:${normalizeCourseVisitId(shifuBid)}`;
-
-type SessionStorageLike = Pick<Storage, 'getItem' | 'setItem'>;
-
 type TrackCourseVisitParams = {
   initialized: boolean;
   isLoggedIn: boolean;
   previewMode: boolean;
   shifuBid: string;
   entryType: 'catalog' | 'deep_link';
-  storage?: SessionStorageLike | null;
   trackEvent: (
     eventName: string,
     eventData?: Record<string, unknown>,
@@ -39,44 +33,22 @@ export const trackCourseVisitIfNeeded = async ({
   previewMode,
   shifuBid,
   entryType,
-  storage,
   trackEvent,
 }: TrackCourseVisitParams): Promise<boolean> => {
   const normalizedShifuBid = normalizeCourseVisitId(shifuBid);
-  if (!initialized || !isLoggedIn || previewMode || !normalizedShifuBid) {
+  if (!initialized || previewMode || !normalizedShifuBid) {
     return false;
   }
 
-  const sessionKey = buildCourseVisitSessionKey(normalizedShifuBid);
-  let shouldTrack = true;
-
-  if (storage) {
-    try {
-      shouldTrack = !storage.getItem(sessionKey);
-    } catch {
-      shouldTrack = true;
-    }
-  }
-
-  if (!shouldTrack) {
-    return false;
-  }
-
-  let attempted = false;
   try {
-    attempted = true;
     await trackEvent(buildCourseVisitEventName(normalizedShifuBid), {
       shifu_bid: normalizedShifuBid,
       entry_type: entryType,
+      auth_state: isLoggedIn ? 'logged_in' : 'guest',
       preview_mode: false,
     });
-  } catch {}
-
-  if (attempted && storage) {
-    try {
-      storage.setItem(sessionKey, '1');
-    } catch {}
+    return true;
+  } catch {
+    return false;
   }
-
-  return attempted;
 };

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -2,7 +2,7 @@
 
 import styles from './page.module.scss';
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from 'react-i18next';
@@ -76,6 +76,8 @@ const getIsLandscapeViewport = () => {
 export default function ChatPage() {
   const { t, i18n } = useTranslation();
   const { trackEvent } = useTracking();
+  const attemptedCourseVisitKeyRef = useRef<string | null>(null);
+  const pendingCourseVisitKeyRef = useRef<string | null>(null);
 
   /**
    * User info and init part
@@ -328,14 +330,36 @@ export default function ChatPage() {
       return;
     }
 
+    const entryType = urlLessonId ? 'deep_link' : 'catalog';
+    const authState = isLoggedIn ? 'logged_in' : 'guest';
+    const visitAttemptKey = `${courseId}:${entryType}:${previewMode ? 'preview' : 'live'}:${authState}`;
+
+    if (
+      attemptedCourseVisitKeyRef.current === visitAttemptKey ||
+      pendingCourseVisitKeyRef.current === visitAttemptKey
+    ) {
+      return;
+    }
+
+    pendingCourseVisitKeyRef.current = visitAttemptKey;
+
     void trackCourseVisitIfNeeded({
       initialized,
       isLoggedIn,
       previewMode,
       shifuBid: courseId,
-      entryType: urlLessonId ? 'deep_link' : 'catalog',
-      storage: window.sessionStorage,
+      entryType,
       trackEvent,
+    })
+      .then(tracked => {
+        if (tracked) {
+          attemptedCourseVisitKeyRef.current = visitAttemptKey;
+        }
+      })
+      .finally(() => {
+        if (pendingCourseVisitKeyRef.current === visitAttemptKey) {
+          pendingCourseVisitKeyRef.current = null;
+        }
     });
   }, [
     courseId,

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -78,6 +78,9 @@ export default function ChatPage() {
   const { trackEvent } = useTracking();
   const attemptedCourseVisitKeyRef = useRef<string | null>(null);
   const pendingCourseVisitKeyRef = useRef<string | null>(null);
+  const initialCourseVisitEntryTypeRef = useRef<'catalog' | 'deep_link' | null>(
+    null,
+  );
 
   /**
    * User info and init part
@@ -330,7 +333,13 @@ export default function ChatPage() {
       return;
     }
 
-    const entryType = urlLessonId ? 'deep_link' : 'catalog';
+    if (!initialCourseVisitEntryTypeRef.current) {
+      initialCourseVisitEntryTypeRef.current = urlLessonId
+        ? 'deep_link'
+        : 'catalog';
+    }
+
+    const entryType = initialCourseVisitEntryTypeRef.current;
     const authState = isLoggedIn ? 'logged_in' : 'guest';
     const visitAttemptKey = `${courseId}:${entryType}:${previewMode ? 'preview' : 'live'}:${authState}`;
 

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -360,7 +360,7 @@ export default function ChatPage() {
         if (pendingCourseVisitKeyRef.current === visitAttemptKey) {
           pendingCourseVisitKeyRef.current = null;
         }
-    });
+      });
   }, [
     courseId,
     courseName,


### PR DESCRIPTION
## What
- track course visit events for both guest and logged-in learners
- keep auth state in event payload for Umami filtering
- limit duplicate sends to the current page lifecycle instead of session storage

## Testing
- npx jest --runTestsByPath "src/app/c/[[...id]]/courseVisitTracking.test.ts"
- npx eslint "src/app/c/[[...id]]/page.tsx"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized course visit tracking with enhanced deduplication logic to reduce unnecessary tracking events and improve system performance

* **Bug Fixes**
  * Improved course visit tracking reliability with proper error handling and better support for tracking both authenticated and guest user visits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->