### PR TITLE
revert: concurrency control mechanism for Q&A requests (#1534)

### DIFF
--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -20,7 +20,6 @@ from flaskr.service.learn.learn_dtos import (
 )
 from flaskr.common.cache_provider import cache as cache_provider
 from flaskr.dao import db
-from flaskr.service.learn.const import INPUT_TYPE_ASK
 from flaskr.service.shifu.shifu_struct_manager import (
     get_shifu_dto,
     get_outline_item_dto,
@@ -45,87 +44,6 @@ from flaskr.common.shifu_context import (
 
 RUN_SCRIPT_TIMEOUT_SECONDS = 5 * 60
 RUN_SCRIPT_STATUS_REFRESH_SECONDS = 30
-
-# Max parallel ask (follow-up) requests per (user, outline). Hard-coded for easy tuning.
-MAX_PARALLEL_ASK_COUNT = 3
-
-# Lua scripts for atomic ask semaphore operations
-_LUA_ACQUIRE_ASK_SLOT = """
-local key = KEYS[1]
-local max_count = tonumber(ARGV[1])
-local ttl = tonumber(ARGV[2])
-local current = tonumber(redis.call('get', key) or '0')
-if current < max_count then
-    redis.call('set', key, current + 1, 'EX', ttl)
-    return 1
-end
-return 0
-"""
-
-_LUA_RELEASE_ASK_SLOT = """
-local key = KEYS[1]
-local current = tonumber(redis.call('get', key) or '0')
-if current > 0 then
-    redis.call('decr', key)
-end
-return 1
-"""
-
-
-def _get_ask_sem_key(app: Flask, user_bid: str, outline_bid: str) -> str:
-    return (
-        app.config.get("REDIS_KEY_PREFIX", "")
-        + ":ask_sem:"
-        + user_bid
-        + ":"
-        + outline_bid
-    )
-
-
-def _ask_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
-    """Try to acquire an ask semaphore slot. Returns True if slot acquired."""
-    try:
-        from flaskr.dao import redis_client
-
-        if redis_client is None:
-            return True  # fail open when Redis is unavailable
-        result = redis_client.eval(
-            _LUA_ACQUIRE_ASK_SLOT,
-            1,
-            _get_ask_sem_key(app, user_bid, outline_bid),
-            str(MAX_PARALLEL_ASK_COUNT),
-            str(RUN_SCRIPT_TIMEOUT_SECONDS),
-        )
-        return bool(result)
-    except Exception as exc:
-        app.logger.warning(
-            "ask_sem_acquire failed, failing open: user_bid=%s outline_bid=%s error=%s",
-            user_bid,
-            outline_bid,
-            repr(exc),
-        )
-        return True  # fail open
-
-
-def _ask_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
-    """Release an ask semaphore slot."""
-    try:
-        from flaskr.dao import redis_client
-
-        if redis_client is None:
-            return
-        redis_client.eval(
-            _LUA_RELEASE_ASK_SLOT,
-            1,
-            _get_ask_sem_key(app, user_bid, outline_bid),
-        )
-    except Exception as exc:
-        app.logger.warning(
-            "ask_sem_release failed: user_bid=%s outline_bid=%s error=%s",
-            user_bid,
-            outline_bid,
-            repr(exc),
-        )
 
 
 def _get_run_script_lock_key(app: Flask, user_bid: str, outline_bid: str) -> str:
@@ -416,37 +334,23 @@ def run_script(
         user_bid=user_bid,
     )
     stream_element_adapter = element_adapter
-    is_ask = input_type == INPUT_TYPE_ASK
-    if is_ask:
-        # Ask (follow-up) requests use a counting semaphore instead of the main mutex
-        # so they can run in parallel with the main lesson stream (up to MAX_PARALLEL_ASK_COUNT).
-        lock = None
-        acquired = _ask_sem_acquire(app, user_bid, outline_bid)
-        if not acquired:
-            app.logger.warning(
-                "ask semaphore full: user_bid=%s outline_bid=%s max=%s",
+    lock = cache_provider.lock(
+        lock_key, timeout=timeout, blocking_timeout=blocking_timeout
+    )
+    acquired = False
+    for attempt in range(lock_retry_count + 1):
+        if lock.acquire(blocking=True):
+            acquired = True
+            break
+        if attempt < lock_retry_count:
+            app.logger.info(
+                "run_script lock busy, retrying: user_bid=%s outline_bid=%s attempt=%s/%s",
                 user_bid,
                 outline_bid,
-                MAX_PARALLEL_ASK_COUNT,
+                attempt + 1,
+                lock_retry_count + 1,
             )
-    else:
-        lock = cache_provider.lock(
-            lock_key, timeout=timeout, blocking_timeout=blocking_timeout
-        )
-        acquired = False
-        for attempt in range(lock_retry_count + 1):
-            if lock.acquire(blocking=True):
-                acquired = True
-                break
-            if attempt < lock_retry_count:
-                app.logger.info(
-                    "run_script lock busy, retrying: user_bid=%s outline_bid=%s attempt=%s/%s",
-                    user_bid,
-                    outline_bid,
-                    attempt + 1,
-                    lock_retry_count + 1,
-                )
-                time.sleep(lock_retry_sleep_seconds)
+            time.sleep(lock_retry_sleep_seconds)
 
     if acquired:
         stop_event = threading.Event()
@@ -522,9 +426,6 @@ def run_script(
         status_last_refreshed_at = 0.0
 
         def _refresh_run_script_status(force: bool = False) -> None:
-            # Ask requests do not own the run-script status slot; skip tracking.
-            if is_ask:
-                return
             nonlocal status_last_refreshed_at
             now = time.time()
             if (
@@ -650,12 +551,9 @@ def run_script(
             if producer_thread.is_alive():
                 app.logger.warning("run_script producer thread did not stop in time")
 
-            if is_ask:
-                _ask_sem_release(app, user_bid, outline_bid)
-            else:
-                with contextlib.suppress(Exception):
-                    lock.release()
-                _clear_run_script_status(app, user_bid, outline_bid)
+            with contextlib.suppress(Exception):
+                lock.release()
+            _clear_run_script_status(app, user_bid, outline_bid)
 
         if stream_error and not client_disconnected:
             if isinstance(stream_error, Exception):
@@ -725,8 +623,7 @@ def run_script(
             last_stream_done_is_terminal = True if use_element_protocol else None
     else:
         app.logger.warning(
-            "run_script acquisition failed (is_ask=%s): user_bid=%s outline_bid=%s",
-            is_ask,
+            "run_script lock acquisition failed: user_bid=%s outline_bid=%s",
             user_bid,
             outline_bid,
         )

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Maximize2, Minimize2, X } from 'lucide-react';
 import { ContentRender, MarkdownFlowInput } from 'markdown-flow-ui/renderer';
 import {
+  checkIsRunning,
   getRunMessage,
   SSE_INPUT_TYPE,
   SSE_OUTPUT_TYPE,
@@ -202,6 +203,11 @@ export default function AskBlock({
     }
 
     if (!question) {
+      return;
+    }
+    const runningRes = await checkIsRunning(shifu_bid, outline_bid);
+    if (runningRes.is_running) {
+      showOutputInProgressToast();
       return;
     }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2085,15 +2085,7 @@ function useChatLogicHook({
       blockBid: string,
       options?: { skipConfirm?: boolean },
     ) => {
-      // Detect re-selection early so we can bypass streaming guards for it.
-      // Re-selection = user clicked an interaction that is NOT the last actionable element.
-      const earlyLastActionable = resolveLastActionableElementBid(
-        contentListRef.current,
-      );
-      const isReGenerate =
-        Boolean(earlyLastActionable) && blockBid !== earlyLastActionable;
-
-      if (!isReGenerate && isStreamingRef.current) {
+      if (isStreamingRef.current) {
         showOutputInProgressToast();
         return;
       }
@@ -2238,16 +2230,24 @@ function useChatLogicHook({
         return;
       }
 
-      if (!isReGenerate) {
-        const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
-          () => {
-            return null;
-          },
-        );
-        if (runningRes?.is_running) {
-          showOutputInProgressToast();
-          return;
-        }
+      const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
+        () => {
+          return null;
+        },
+      );
+      if (runningRes?.is_running) {
+        showOutputInProgressToast();
+        return;
+      }
+
+      let isReGenerate = false;
+      const currentList = contentListRef.current;
+      if (currentList.length > 0) {
+        const lastActionableElementBid =
+          resolveLastActionableElementBid(currentList);
+        isReGenerate =
+          Boolean(lastActionableElementBid) &&
+          blockBid !== lastActionableElementBid;
       }
 
       if (isReGenerate && !options?.skipConfirm) {


### PR DESCRIPTION
## Summary
- Reverts #1534 ("feat: add a concurrency control mechanism for Q & A requests") due to issues found in the feature.
- Subsequent PRs (#1532, #1533, #1535, #1525, #1527 …) remain unaffected.
- Conflict-sensitive fix from #1535 (trailing interaction elements after lesson completion) has been verified as preserved.

## Test plan
- [ ] Verify Q&A flow works as before the #1534 feature.
- [ ] Confirm chat trailing interaction fix from #1535 still works.
- [ ] Run `cd src/cook-web && npm run type-check && npm run lint`.
- [ ] Run `cd src/api && pytest -q` on touched backend paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Implemented additional validation checks to prevent submitting requests while a script is already running
* Enhanced concurrency control for script execution to improve stability and reliability
* Improved detection of in-progress operations to prevent duplicate submissions
* Simplified execution locking mechanism for more consistent request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->