### PR TITLE
fix: include coupon redemptions in course revenue

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2029,6 +2029,7 @@ def get_operator_course_detail(
         redeemed_coupon_orders = (
             db.session.query(CouponUsage.order_bid.label("order_bid"))
             .filter(
+                CouponUsage.shifu_bid == normalized_shifu_bid,
                 CouponUsage.deleted == 0,
                 CouponUsage.status == COUPON_STATUS_USED,
             )

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
 from flask import Flask
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, case, or_
 
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_config
@@ -25,6 +25,8 @@ from flaskr.service.common.dtos import PageNationDTO
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
+from flaskr.service.promo.consts import COUPON_STATUS_USED
+from flaskr.service.promo.models import CouponUsage
 from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseChapterDetailDTO,
     AdminOperationCourseDetailBasicInfoDTO,
@@ -2024,12 +2026,36 @@ def get_operator_course_detail(
             .scalar()
             or 0
         )
+        redeemed_coupon_orders = (
+            db.session.query(CouponUsage.order_bid.label("order_bid"))
+            .filter(
+                CouponUsage.deleted == 0,
+                CouponUsage.status == COUPON_STATUS_USED,
+            )
+            .distinct()
+            .subquery()
+        )
+        order_amount_expr = case(
+            (Order.paid_price > 0, Order.paid_price),
+            (
+                and_(
+                    redeemed_coupon_orders.c.order_bid.isnot(None),
+                    Order.payable_price > 0,
+                ),
+                Order.payable_price,
+            ),
+            else_=0,
+        )
         order_summary = (
             db.session.query(
                 db.func.count(Order.id).label("order_count"),
-                db.func.coalesce(db.func.sum(Order.paid_price), 0).label(
+                db.func.coalesce(db.func.sum(order_amount_expr), 0).label(
                     "order_amount"
                 ),
+            )
+            .outerjoin(
+                redeemed_coupon_orders,
+                redeemed_coupon_orders.c.order_bid == Order.order_bid,
             )
             .filter(
                 Order.shifu_bid == normalized_shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -201,8 +201,14 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     learner_count: int = Field(
         ..., description="Distinct learner count", required=False
     )
-    order_count: int = Field(..., description="Paid order count", required=False)
-    order_amount: str = Field(..., description="Paid order amount", required=False)
+    order_count: int = Field(
+        ..., description="Successful order count", required=False
+    )
+    order_amount: str = Field(
+        ...,
+        description="Collected amount including full coupon redemptions",
+        required=False,
+    )
     follow_up_count: int = Field(
         ..., description="Follow-up question count", required=False
     )

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -201,9 +201,7 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     learner_count: int = Field(
         ..., description="Distinct learner count", required=False
     )
-    order_count: int = Field(
-        ..., description="Successful order count", required=False
-    )
+    order_count: int = Field(..., description="Successful order count", required=False)
     order_amount: str = Field(
         ...,
         description="Collected amount including full coupon redemptions",

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -23,6 +23,8 @@ from flaskr.service.learn.models import (
 )
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS, ORDER_STATUS_TO_BE_PAID
 from flaskr.service.order.models import Order
+from flaskr.service.promo.consts import COUPON_STATUS_USED
+from flaskr.service.promo.models import CouponUsage
 from flaskr.service.shifu.consts import (
     BLOCK_TYPE_CONTENT_VALUE,
     BLOCK_TYPE_MDASK_VALUE,
@@ -53,6 +55,7 @@ def _clear_tables() -> None:
     db.session.query(LearnLessonFeedback).delete()
     db.session.query(LearnGeneratedBlock).delete()
     db.session.query(LearnProgressRecord).delete()
+    db.session.query(CouponUsage).delete()
     db.session.query(Order).delete()
     db.session.query(UserToken).delete()
     db.session.query(AiCourseAuth).delete()
@@ -199,6 +202,28 @@ def _seed_paid_order(
             status=ORDER_STATUS_SUCCESS,
             created_at=created_at,
             updated_at=created_at,
+        )
+    )
+
+
+def _seed_coupon_usage(
+    *,
+    coupon_usage_bid: str,
+    order_bid: str,
+    shifu_bid: str,
+    user_bid: str,
+    code: str = "FULLREDEEM",
+) -> None:
+    db.session.add(
+        CouponUsage(
+            coupon_usage_bid=coupon_usage_bid,
+            coupon_bid=f"coupon-{coupon_usage_bid}",
+            user_bid=user_bid,
+            shifu_bid=shifu_bid,
+            order_bid=order_bid,
+            code=code,
+            status=COUPON_STATUS_USED,
+            deleted=0,
         )
     )
 
@@ -1277,6 +1302,83 @@ def test_admin_operation_course_users_route_applies_filters(
     item = payload["data"]["items"][0]
     assert item["user_bid"] == "student-1"
     assert item["total_paid_amount"] == "299"
+
+
+def test_admin_operation_course_detail_metrics_include_full_coupon_redemptions(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.admin.get_course_visit_count_30d",
+        lambda _app, _shifu_bid: 0,
+    )
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        db.session.add_all(
+            [
+                Order(
+                    order_bid="order-direct-paid",
+                    shifu_bid="course-detail",
+                    user_bid="user-direct-paid",
+                    payable_price=Decimal("88.00"),
+                    paid_price=Decimal("88.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-full-coupon",
+                    shifu_bid="course-detail",
+                    user_bid="user-full-coupon",
+                    payable_price=Decimal("66.00"),
+                    paid_price=Decimal("0.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-activation",
+                    shifu_bid="course-detail",
+                    user_bid="user-activation",
+                    payable_price=Decimal("0.00"),
+                    paid_price=Decimal("0.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+            ]
+        )
+        _seed_coupon_usage(
+            coupon_usage_bid="coupon-usage-full-coupon",
+            order_bid="order-full-coupon",
+            shifu_bid="course-detail",
+            user_bid="user-full-coupon",
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/detail",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["metrics"]["order_count"] == 3
+    assert payload["data"]["metrics"]["order_amount"] == "154"
 
 
 @pytest.mark.parametrize(

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -70,7 +70,7 @@
     "metricsLabels": {
       "followUpCount": "Ask",
       "learnerCount": "Learners",
-      "orderAmount": "Gross Revenue",
+      "orderAmount": "Collected Revenue (Incl. Coupon Codes)",
       "orderCount": "Orders",
       "ratingScore": "Rating",
       "visitCount30d": "Visitors (30d)"

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -70,7 +70,7 @@
     "metricsLabels": {
       "followUpCount": "追问数",
       "learnerCount": "学习人数",
-      "orderAmount": "流水总额",
+      "orderAmount": "实收总额（含兑换码）",
       "orderCount": "订单数",
       "ratingScore": "评分",
       "visitCount30d": "近30天访问人数"


### PR DESCRIPTION
## Summary
- include full coupon redemption orders in the operator course detail revenue metric
- keep successful activation and Open API orders counted in `order_count` while excluding zero-payable records from `order_amount`
- rename the metric label to an English-only description for collected revenue including coupon redemptions and add backend coverage for the aggregation logic

## Verification
- cd src/api && pytest -q tests/service/shifu/test_admin_course_detail.py -k "latest_detail or include_full_coupon_redemptions or returns_course_related_users or applies_filters"
- JSON parse check for updated i18n files

## Notes
- full-file backend/frontend tests still have pre-existing unrelated failures and were not expanded in this change