### PR TITLE
refactor: share admin pagination component

### DIFF
--- a/docs/admin-pagination-component.md
+++ b/docs/admin-pagination-component.md
@@ -1,0 +1,28 @@
+# Admin Pagination Component
+
+## Goal
+
+Reduce repeated pagination UI code across admin list pages by extracting a shared
+component for the existing page-number pagination pattern.
+
+## Scope
+
+- Add a shared `AdminPagination` component for the admin pages that already use
+  the same first-page / ellipsis / trailing-page navigation pattern.
+- Migrate the following pages to the shared component:
+  - `src/cook-web/src/app/admin/orders/page.tsx`
+  - `src/cook-web/src/app/admin/operations/page.tsx`
+  - `src/cook-web/src/app/admin/operations/users/page.tsx`
+  - `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
+- Keep request logic, page state, and API contracts inside each page.
+
+## Non-Goals
+
+- Do not change the infinite-scroll behavior on `src/cook-web/src/app/admin/page.tsx`.
+- Do not refactor the dashboard pagination variant in the same step.
+
+## Plan
+
+1. Add a shared admin pagination component on top of the existing UI pagination primitives.
+2. Replace the duplicated rendering helpers in the four matching admin pages.
+3. Add focused tests for the shared pagination behavior.

--- a/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AdminPagination } from './AdminPagination';
+
+describe('AdminPagination', () => {
+  test('hides pagination when only one page is available', () => {
+    render(
+      <AdminPagination
+        pageIndex={1}
+        pageCount={1}
+        onPageChange={jest.fn()}
+        prevLabel='Previous'
+        nextLabel='Next'
+        hideWhenSinglePage
+      />,
+    );
+
+    expect(
+      screen.queryByRole('navigation', { name: 'pagination' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('disables previous on the first page and moves forward', () => {
+    const onPageChange = jest.fn();
+
+    render(
+      <AdminPagination
+        pageIndex={1}
+        pageCount={6}
+        onPageChange={onPageChange}
+        prevLabel='Previous'
+        nextLabel='Next'
+      />,
+    );
+
+    const previousLink = screen.getByRole('link', { name: /previous/i });
+    const nextLink = screen.getByRole('link', { name: /next/i });
+
+    expect(previousLink).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(previousLink);
+    fireEvent.click(nextLink);
+
+    expect(onPageChange).toHaveBeenCalledTimes(1);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  test('renders condensed page links around the current page', () => {
+    render(
+      <AdminPagination
+        pageIndex={5}
+        pageCount={10}
+        onPageChange={jest.fn()}
+        prevLabel='Previous'
+        nextLabel='Next'
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '4' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '5' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: '6' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '10' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '2' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '8' })).not.toBeInTheDocument();
+  });
+
+  test('disables next on the last page and still allows jumping backward', () => {
+    const onPageChange = jest.fn();
+
+    render(
+      <AdminPagination
+        pageIndex={10}
+        pageCount={10}
+        onPageChange={onPageChange}
+        prevLabel='Previous'
+        nextLabel='Next'
+      />,
+    );
+
+    const nextLink = screen.getByRole('link', { name: /next/i });
+
+    expect(nextLink).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(nextLink);
+    fireEvent.click(screen.getByRole('link', { name: '9' }));
+
+    expect(onPageChange).toHaveBeenCalledTimes(1);
+    expect(onPageChange).toHaveBeenCalledWith(9);
+  });
+
+  test('renders a simple two-page navigation without ellipsis or duplicate links', () => {
+    const onPageChange = jest.fn();
+
+    render(
+      <AdminPagination
+        pageIndex={1}
+        pageCount={2}
+        onPageChange={onPageChange}
+        prevLabel='Previous'
+        nextLabel='Next'
+      />,
+    );
+
+    expect(screen.getAllByRole('link', { name: '1' })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: '2' })).toHaveLength(1);
+    expect(
+      screen.queryByText((_, element) =>
+        element?.textContent === 'More pages',
+      ),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('link', { name: '1' }));
+    fireEvent.click(screen.getByRole('link', { name: '2' }));
+
+    expect(onPageChange).toHaveBeenCalledTimes(1);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
@@ -37,6 +37,8 @@ describe('AdminPagination', () => {
     const nextLink = screen.getByRole('link', { name: /next/i });
 
     expect(previousLink).toHaveAttribute('aria-disabled', 'true');
+    expect(previousLink).toHaveAttribute('tabindex', '-1');
+    expect(previousLink).toHaveAttribute('aria-label', 'Previous');
 
     fireEvent.click(previousLink);
     fireEvent.click(nextLink);
@@ -58,10 +60,10 @@ describe('AdminPagination', () => {
 
     expect(screen.getByRole('link', { name: '1' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '4' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '5' })).toHaveAttribute(
-      'aria-current',
-      'page',
-    );
+    const currentPageLink = screen.getByRole('link', { name: '5' });
+    expect(currentPageLink).toHaveAttribute('aria-current', 'page');
+    expect(currentPageLink).toHaveAttribute('tabindex', '-1');
+    expect(currentPageLink).toHaveClass('pointer-events-none');
     expect(screen.getByRole('link', { name: '6' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '10' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: '2' })).not.toBeInTheDocument();
@@ -84,6 +86,8 @@ describe('AdminPagination', () => {
     const nextLink = screen.getByRole('link', { name: /next/i });
 
     expect(nextLink).toHaveAttribute('aria-disabled', 'true');
+    expect(nextLink).toHaveAttribute('tabindex', '-1');
+    expect(nextLink).toHaveAttribute('aria-label', 'Next');
 
     fireEvent.click(nextLink);
     fireEvent.click(screen.getByRole('link', { name: '9' }));

--- a/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
@@ -11,6 +11,8 @@ describe('AdminPagination', () => {
         onPageChange={jest.fn()}
         prevLabel='Previous'
         nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
         hideWhenSinglePage
       />,
     );
@@ -30,6 +32,8 @@ describe('AdminPagination', () => {
         onPageChange={onPageChange}
         prevLabel='Previous'
         nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
       />,
     );
 
@@ -38,7 +42,7 @@ describe('AdminPagination', () => {
 
     expect(previousLink).toHaveAttribute('aria-disabled', 'true');
     expect(previousLink).toHaveAttribute('tabindex', '-1');
-    expect(previousLink).toHaveAttribute('aria-label', 'Previous');
+    expect(previousLink).toHaveAttribute('aria-label', 'Go to previous page');
 
     fireEvent.click(previousLink);
     fireEvent.click(nextLink);
@@ -55,6 +59,8 @@ describe('AdminPagination', () => {
         onPageChange={jest.fn()}
         prevLabel='Previous'
         nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
       />,
     );
 
@@ -80,6 +86,8 @@ describe('AdminPagination', () => {
         onPageChange={onPageChange}
         prevLabel='Previous'
         nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
       />,
     );
 
@@ -87,7 +95,7 @@ describe('AdminPagination', () => {
 
     expect(nextLink).toHaveAttribute('aria-disabled', 'true');
     expect(nextLink).toHaveAttribute('tabindex', '-1');
-    expect(nextLink).toHaveAttribute('aria-label', 'Next');
+    expect(nextLink).toHaveAttribute('aria-label', 'Go to next page');
 
     fireEvent.click(nextLink);
     fireEvent.click(screen.getByRole('link', { name: '9' }));
@@ -106,6 +114,8 @@ describe('AdminPagination', () => {
         onPageChange={onPageChange}
         prevLabel='Previous'
         nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
       />,
     );
 

--- a/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.test.tsx
@@ -108,9 +108,7 @@ describe('AdminPagination', () => {
     expect(screen.getAllByRole('link', { name: '1' })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: '2' })).toHaveLength(1);
     expect(
-      screen.queryByText((_, element) =>
-        element?.textContent === 'More pages',
-      ),
+      screen.queryByText((_, element) => element?.textContent === 'More pages'),
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('link', { name: '1' }));

--- a/src/cook-web/src/app/admin/components/AdminPagination.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import type { MouseEvent } from 'react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+
+type AdminPaginationProps = {
+  pageIndex: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+  prevLabel: string;
+  nextLabel: string;
+  className?: string;
+  hideWhenSinglePage?: boolean;
+};
+
+const MAX_VISIBLE_PAGES = 5;
+const DISABLED_LINK_CLASS_NAME = 'pointer-events-none opacity-50';
+
+const buildPageItems = (
+  pageIndex: number,
+  pageCount: number,
+): Array<number | 'start-ellipsis' | 'end-ellipsis'> => {
+  if (pageCount <= MAX_VISIBLE_PAGES + 2) {
+    return Array.from({ length: pageCount }, (_, index) => index + 1);
+  }
+
+  const items: Array<number | 'start-ellipsis' | 'end-ellipsis'> = [1];
+
+  if (pageIndex > 3) {
+    items.push('start-ellipsis');
+  }
+
+  let rangeStart = Math.max(2, pageIndex - 1);
+  let rangeEnd = Math.min(pageCount - 1, pageIndex + 1);
+
+  if (pageIndex <= 3) {
+    rangeStart = 2;
+    rangeEnd = Math.min(4, pageCount - 1);
+  }
+
+  if (pageIndex >= pageCount - 2) {
+    rangeStart = Math.max(2, pageCount - 3);
+    rangeEnd = pageCount - 1;
+  }
+
+  for (let page = rangeStart; page <= rangeEnd; page += 1) {
+    items.push(page);
+  }
+
+  if (pageIndex < pageCount - 2) {
+    items.push('end-ellipsis');
+  }
+
+  items.push(pageCount);
+
+  return items;
+};
+
+export function AdminPagination({
+  pageIndex,
+  pageCount,
+  onPageChange,
+  prevLabel,
+  nextLabel,
+  className,
+  hideWhenSinglePage = false,
+}: AdminPaginationProps) {
+  const normalizedPageCount = Math.max(pageCount, 1);
+  const normalizedPageIndex = Math.min(
+    Math.max(pageIndex, 1),
+    normalizedPageCount,
+  );
+
+  if (hideWhenSinglePage && normalizedPageCount <= 1) {
+    return null;
+  }
+
+  const handlePageClick =
+    (targetPage: number) => (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      if (
+        targetPage < 1 ||
+        targetPage > normalizedPageCount ||
+        targetPage === normalizedPageIndex
+      ) {
+        return;
+      }
+      onPageChange(targetPage);
+    };
+
+  return (
+    <Pagination className={className}>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            href='#'
+            onClick={handlePageClick(normalizedPageIndex - 1)}
+            aria-disabled={normalizedPageIndex <= 1}
+            className={
+              normalizedPageIndex <= 1 ? DISABLED_LINK_CLASS_NAME : undefined
+            }
+          >
+            {prevLabel}
+          </PaginationPrevious>
+        </PaginationItem>
+
+        {buildPageItems(normalizedPageIndex, normalizedPageCount).map(item => {
+          if (item === 'start-ellipsis' || item === 'end-ellipsis') {
+            return (
+              <PaginationItem key={item}>
+                <PaginationEllipsis />
+              </PaginationItem>
+            );
+          }
+
+          return (
+            <PaginationItem key={item}>
+              <PaginationLink
+                href='#'
+                isActive={normalizedPageIndex === item}
+                onClick={handlePageClick(item)}
+              >
+                {item}
+              </PaginationLink>
+            </PaginationItem>
+          );
+        })}
+
+        <PaginationItem>
+          <PaginationNext
+            href='#'
+            onClick={handlePageClick(normalizedPageIndex + 1)}
+            aria-disabled={normalizedPageIndex >= normalizedPageCount}
+            className={
+              normalizedPageIndex >= normalizedPageCount
+                ? DISABLED_LINK_CLASS_NAME
+                : undefined
+            }
+          >
+            {nextLabel}
+          </PaginationNext>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/src/cook-web/src/app/admin/components/AdminPagination.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.tsx
@@ -132,7 +132,9 @@ export function AdminPagination({
                 onClick={handlePageClick(item)}
                 tabIndex={normalizedPageIndex === item ? -1 : undefined}
                 className={
-                  normalizedPageIndex === item ? ACTIVE_LINK_CLASS_NAME : undefined
+                  normalizedPageIndex === item
+                    ? ACTIVE_LINK_CLASS_NAME
+                    : undefined
                 }
               >
                 {item}
@@ -147,7 +149,9 @@ export function AdminPagination({
             onClick={handlePageClick(normalizedPageIndex + 1)}
             aria-disabled={normalizedPageIndex >= normalizedPageCount}
             aria-label={nextLabel}
-            tabIndex={normalizedPageIndex >= normalizedPageCount ? -1 : undefined}
+            tabIndex={
+              normalizedPageIndex >= normalizedPageCount ? -1 : undefined
+            }
             className={
               normalizedPageIndex >= normalizedPageCount
                 ? DISABLED_LINK_CLASS_NAME

--- a/src/cook-web/src/app/admin/components/AdminPagination.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.tsx
@@ -17,6 +17,8 @@ type AdminPaginationProps = {
   onPageChange: (page: number) => void;
   prevLabel: string;
   nextLabel: string;
+  prevAriaLabel?: string;
+  nextAriaLabel?: string;
   className?: string;
   hideWhenSinglePage?: boolean;
 };
@@ -71,6 +73,8 @@ export function AdminPagination({
   onPageChange,
   prevLabel,
   nextLabel,
+  prevAriaLabel = 'Go to previous page',
+  nextAriaLabel = 'Go to next page',
   className,
   hideWhenSinglePage = false,
 }: AdminPaginationProps) {
@@ -105,7 +109,7 @@ export function AdminPagination({
             href='#'
             onClick={handlePageClick(normalizedPageIndex - 1)}
             aria-disabled={normalizedPageIndex <= 1}
-            aria-label={prevLabel}
+            aria-label={prevAriaLabel}
             tabIndex={normalizedPageIndex <= 1 ? -1 : undefined}
             className={
               normalizedPageIndex <= 1 ? DISABLED_LINK_CLASS_NAME : undefined
@@ -148,7 +152,7 @@ export function AdminPagination({
             href='#'
             onClick={handlePageClick(normalizedPageIndex + 1)}
             aria-disabled={normalizedPageIndex >= normalizedPageCount}
-            aria-label={nextLabel}
+            aria-label={nextAriaLabel}
             tabIndex={
               normalizedPageIndex >= normalizedPageCount ? -1 : undefined
             }

--- a/src/cook-web/src/app/admin/components/AdminPagination.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.tsx
@@ -23,6 +23,7 @@ type AdminPaginationProps = {
 
 const MAX_VISIBLE_PAGES = 5;
 const DISABLED_LINK_CLASS_NAME = 'pointer-events-none opacity-50';
+const ACTIVE_LINK_CLASS_NAME = 'pointer-events-none';
 
 const buildPageItems = (
   pageIndex: number,
@@ -104,6 +105,8 @@ export function AdminPagination({
             href='#'
             onClick={handlePageClick(normalizedPageIndex - 1)}
             aria-disabled={normalizedPageIndex <= 1}
+            aria-label={prevLabel}
+            tabIndex={normalizedPageIndex <= 1 ? -1 : undefined}
             className={
               normalizedPageIndex <= 1 ? DISABLED_LINK_CLASS_NAME : undefined
             }
@@ -127,6 +130,10 @@ export function AdminPagination({
                 href='#'
                 isActive={normalizedPageIndex === item}
                 onClick={handlePageClick(item)}
+                tabIndex={normalizedPageIndex === item ? -1 : undefined}
+                className={
+                  normalizedPageIndex === item ? ACTIVE_LINK_CLASS_NAME : undefined
+                }
               >
                 {item}
               </PaginationLink>
@@ -139,6 +146,8 @@ export function AdminPagination({
             href='#'
             onClick={handlePageClick(normalizedPageIndex + 1)}
             aria-disabled={normalizedPageIndex >= normalizedPageCount}
+            aria-label={nextLabel}
+            tabIndex={normalizedPageIndex >= normalizedPageCount ? -1 : undefined}
             className={
               normalizedPageIndex >= normalizedPageCount
                 ? DISABLED_LINK_CLASS_NAME

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -16,6 +17,7 @@ const mockGetAdminOperationCourseChapterDetail = jest.fn();
 const mockCopyText = jest.fn();
 const mockToastShow = jest.fn();
 const mockToastFail = jest.fn();
+const translationCache = new Map<string, { t: (key: string) => string }>();
 const mockEnvState = {
   currencySymbol: '¥',
   loginMethodsEnabled: ['phone'],
@@ -83,9 +85,13 @@ jest.mock('@/hooks/useToast', () => ({
 jest.mock('react-i18next', () => ({
   useTranslation: (namespace?: string | string[]) => {
     const ns = Array.isArray(namespace) ? namespace[0] : namespace;
-    return {
-      t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
-    };
+    const cacheKey = ns || 'translation';
+    if (!translationCache.has(cacheKey)) {
+      translationCache.set(cacheKey, {
+        t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
+      });
+    }
+    return translationCache.get(cacheKey)!;
   },
 }));
 
@@ -159,6 +165,16 @@ jest.mock('@/components/ui/Select', () => {
     },
   };
 });
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
 
 describe('AdminOperationCourseDetailPage', () => {
   beforeEach(() => {
@@ -319,8 +335,9 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
     expect(screen.getAllByText('3').length).toBeGreaterThan(0);
     expect(screen.getAllByText('2').length).toBeGreaterThan(0);
-    const bobRow = screen.getByText('Bob').closest('tr');
+    const bobRow = screen.getAllByText('13900001234').at(-1)?.closest('tr');
     expect(bobRow).not.toBeNull();
+    expect(within(bobRow as HTMLElement).getByText('Bob')).toBeInTheDocument();
     expect(within(bobRow as HTMLElement).getByText('88')).toBeInTheDocument();
     expect(
       screen.getAllByText('module.operationsCourse.detail.userRole.student')
@@ -337,6 +354,17 @@ describe('AdminOperationCourseDetailPage', () => {
   });
 
   test('opens chapter content dialog and requests chapter detail', async () => {
+    const chapterDetailRequest = createDeferred<{
+      outline_item_bid: string;
+      title: string;
+      content: string;
+      llm_system_prompt: string;
+      llm_system_prompt_source: 'chapter';
+    }>();
+    mockGetAdminOperationCourseChapterDetail.mockReturnValueOnce(
+      chapterDetailRequest.promise,
+    );
+
     render(<AdminOperationCourseDetailPage />);
 
     await screen.findByText('Course One');
@@ -359,17 +387,38 @@ describe('AdminOperationCourseDetailPage', () => {
       shifu_bid: 'course-1',
       outline_item_bid: 'lesson-1',
     });
-    expect(await screen.findByText('lesson content')).toBeInTheDocument();
 
-    const copyButton = screen.getByRole('button', {
+    const initialCopyButton = screen.getByRole('button', {
       name: 'module.operationsCourse.detail.contentDetailDialog.copy',
+    });
+    expect(initialCopyButton).toBeDisabled();
+
+    await act(async () => {
+      chapterDetailRequest.resolve({
+        outline_item_bid: 'lesson-1',
+        title: 'Lesson 1',
+        content: 'lesson content',
+        llm_system_prompt: 'lesson system prompt',
+        llm_system_prompt_source: 'chapter',
+      });
+      await chapterDetailRequest.promise;
     });
 
     await waitFor(() => {
-      expect(copyButton).not.toBeDisabled();
+      expect(screen.getByText('lesson content')).toBeInTheDocument();
+      expect(screen.getByText('lesson system prompt')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: 'module.operationsCourse.detail.contentDetailDialog.copy',
+        }),
+      ).not.toBeDisabled();
     });
 
-    fireEvent.click(copyButton);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsCourse.detail.contentDetailDialog.copy',
+      }),
+    );
 
     await waitFor(() => {
       expect(mockCopyText).toHaveBeenCalledWith(
@@ -381,10 +430,11 @@ describe('AdminOperationCourseDetailPage', () => {
           'lesson system prompt',
         ].join('\n'),
       );
+      expect(mockToastShow).toHaveBeenCalledWith(
+        'module.operationsCourse.detail.contentDetailDialog.copySuccess',
+      );
     });
-    expect(mockToastShow).toHaveBeenCalledWith(
-      'module.operationsCourse.detail.contentDetailDialog.copySuccess',
-    );
+    expect(mockToastFail).not.toHaveBeenCalled();
   });
 
   test('redirects non-operators back to admin', async () => {
@@ -593,6 +643,71 @@ describe('AdminOperationCourseDetailPage', () => {
         page_size: 20,
         keyword: '',
         user_role: 'operator',
+        learning_status: 'all',
+        payment_status: 'all',
+      });
+    });
+  });
+
+  test('requests the selected page when course user pagination changes', async () => {
+    mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          user_role: 'student',
+          learned_lesson_count: 1,
+          total_lesson_count: 3,
+          learning_status: 'learning',
+          is_paid: true,
+          total_paid_amount: '88',
+          last_learning_at: '2026-04-08 11:30:00',
+          joined_at: '2026-04-07 09:00:00',
+          last_login_at: '2026-04-08 12:00:00',
+        },
+      ],
+      page: 1,
+      page_count: 2,
+      page_size: 20,
+      total: 21,
+    });
+    mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
+      items: [],
+      page: 2,
+      page_count: 2,
+      page_size: 20,
+      total: 21,
+    });
+
+    render(<AdminOperationCourseDetailPage />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseUsers).toHaveBeenCalledWith({
+        shifu_bid: 'course-1',
+        page: 1,
+        page_size: 20,
+        keyword: '',
+        user_role: 'all',
+        learning_status: 'all',
+        payment_status: 'all',
+      });
+    });
+
+    fireEvent.click(
+      await screen.findByRole('link', {
+        name: '2',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseUsers).toHaveBeenLastCalledWith({
+        shifu_bid: 'course-1',
+        page: 2,
+        page_size: 20,
+        keyword: '',
+        user_role: 'all',
         learning_status: 'all',
         payment_status: 'all',
       });

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -17,7 +17,7 @@ const mockGetAdminOperationCourseChapterDetail = jest.fn();
 const mockCopyText = jest.fn();
 const mockToastShow = jest.fn();
 const mockToastFail = jest.fn();
-const translationCache = new Map<string, { t: (key: string) => string }>();
+const mockTranslationCache = new Map<string, { t: (key: string) => string }>();
 const mockEnvState = {
   currencySymbol: '¥',
   loginMethodsEnabled: ['phone'],
@@ -86,12 +86,12 @@ jest.mock('react-i18next', () => ({
   useTranslation: (namespace?: string | string[]) => {
     const ns = Array.isArray(namespace) ? namespace[0] : namespace;
     const cacheKey = ns || 'translation';
-    if (!translationCache.has(cacheKey)) {
-      translationCache.set(cacheKey, {
+    if (!mockTranslationCache.has(cacheKey)) {
+      mockTranslationCache.set(cacheKey, {
         t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
       });
     }
-    return translationCache.get(cacheKey)!;
+    return mockTranslationCache.get(cacheKey)!;
   },
 }));
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -2309,7 +2309,6 @@ export default function AdminOperationCourseDetailPage() {
                       prevLabel={t('module.order.paginationPrev', 'Previous')}
                       nextLabel={t('module.order.paginationNext', 'Next')}
                       className='mx-0 w-auto justify-end'
-                      hideWhenSinglePage
                     />
                   </div>
                 ) : null}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
+import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -36,15 +37,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from '@/components/ui/pagination';
 import {
   Tooltip,
   TooltipContent,
@@ -337,117 +329,6 @@ const createCourseUserFilters = (): CourseUserFilters => ({
   learningStatus: FILTER_ALL_OPTION,
   paymentStatus: FILTER_ALL_OPTION,
 });
-
-const renderPaginationItems = (
-  pageIndex: number,
-  pageCount: number,
-  onPageChange: (page: number) => void,
-) => {
-  if (pageCount <= 1) {
-    return [];
-  }
-
-  const items: JSX.Element[] = [];
-  const maxVisiblePages = 5;
-
-  if (pageCount <= maxVisiblePages + 2) {
-    for (let index = 1; index <= pageCount; index += 1) {
-      items.push(
-        <PaginationItem key={index}>
-          <PaginationLink
-            href='#'
-            isActive={pageIndex === index}
-            onClick={event => {
-              event.preventDefault();
-              onPageChange(index);
-            }}
-          >
-            {index}
-          </PaginationLink>
-        </PaginationItem>,
-      );
-    }
-    return items;
-  }
-
-  items.push(
-    <PaginationItem key={1}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === 1}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(1);
-        }}
-      >
-        {1}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  if (pageIndex > 3) {
-    items.push(
-      <PaginationItem key='start-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  let rangeStart = Math.max(2, pageIndex - 1);
-  let rangeEnd = Math.min(pageCount - 1, pageIndex + 1);
-
-  if (pageIndex <= 3) {
-    rangeStart = 2;
-    rangeEnd = 4;
-  }
-
-  if (pageIndex >= pageCount - 2) {
-    rangeStart = pageCount - 3;
-    rangeEnd = pageCount - 1;
-  }
-
-  for (let index = rangeStart; index <= rangeEnd; index += 1) {
-    items.push(
-      <PaginationItem key={index}>
-        <PaginationLink
-          href='#'
-          isActive={pageIndex === index}
-          onClick={event => {
-            event.preventDefault();
-            onPageChange(index);
-          }}
-        >
-          {index}
-        </PaginationLink>
-      </PaginationItem>,
-    );
-  }
-
-  if (pageIndex < pageCount - 2) {
-    items.push(
-      <PaginationItem key='end-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  items.push(
-    <PaginationItem key={pageCount}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === pageCount}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(pageCount);
-        }}
-      >
-        {pageCount}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  return items;
-};
 
 function ClearableTextInput({
   value,
@@ -2421,61 +2302,15 @@ export default function AdminOperationCourseDetailPage() {
 
                 {courseUserPageCount > 1 ? (
                   <div className='mb-4 mt-4 flex justify-end'>
-                    <Pagination className='mx-0 w-auto justify-end'>
-                      <PaginationContent>
-                        <PaginationItem>
-                          <PaginationPrevious
-                            href='#'
-                            onClick={event => {
-                              event.preventDefault();
-                              if (currentCourseUserPage > 1) {
-                                handleCourseUserPageChange(
-                                  currentCourseUserPage - 1,
-                                );
-                              }
-                            }}
-                            aria-disabled={currentCourseUserPage <= 1}
-                            className={
-                              currentCourseUserPage <= 1
-                                ? 'pointer-events-none opacity-50'
-                                : ''
-                            }
-                          >
-                            {t('module.order.paginationPrev', 'Previous')}
-                          </PaginationPrevious>
-                        </PaginationItem>
-
-                        {renderPaginationItems(
-                          currentCourseUserPage,
-                          courseUserPageCount,
-                          handleCourseUserPageChange,
-                        )}
-
-                        <PaginationItem>
-                          <PaginationNext
-                            href='#'
-                            onClick={event => {
-                              event.preventDefault();
-                              if (currentCourseUserPage < courseUserPageCount) {
-                                handleCourseUserPageChange(
-                                  currentCourseUserPage + 1,
-                                );
-                              }
-                            }}
-                            aria-disabled={
-                              currentCourseUserPage >= courseUserPageCount
-                            }
-                            className={
-                              currentCourseUserPage >= courseUserPageCount
-                                ? 'pointer-events-none opacity-50'
-                                : ''
-                            }
-                          >
-                            {t('module.order.paginationNext', 'Next')}
-                          </PaginationNext>
-                        </PaginationItem>
-                      </PaginationContent>
-                    </Pagination>
+                    <AdminPagination
+                      pageIndex={currentCourseUserPage}
+                      pageCount={courseUserPageCount}
+                      onPageChange={handleCourseUserPageChange}
+                      prevLabel={t('module.order.paginationPrev', 'Previous')}
+                      nextLabel={t('module.order.paginationNext', 'Next')}
+                      className='mx-0 w-auto justify-end'
+                      hideWhenSinglePage
+                    />
                   </div>
                 ) : null}
               </CardContent>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -2308,6 +2308,14 @@ export default function AdminOperationCourseDetailPage() {
                       onPageChange={handleCourseUserPageChange}
                       prevLabel={t('module.order.paginationPrev', 'Previous')}
                       nextLabel={t('module.order.paginationNext', 'Next')}
+                      prevAriaLabel={t(
+                        'module.order.paginationPrevAriaLabel',
+                        'Go to previous page',
+                      )}
+                      nextAriaLabel={t(
+                        'module.order.paginationNextAriaLabel',
+                        'Go to next page',
+                      )}
                       className='mx-0 w-auto justify-end'
                     />
                   </div>

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -1569,6 +1569,14 @@ const OperationsPage = () => {
             onPageChange={handlePageChange}
             prevLabel={t('module.order.paginationPrev', 'Previous')}
             nextLabel={t('module.order.paginationNext', 'Next')}
+            prevAriaLabel={t(
+              'module.order.paginationPrevAriaLabel',
+              'Go to previous page',
+            )}
+            nextAriaLabel={t(
+              'module.order.paginationNextAriaLabel',
+              'Go to next page',
+            )}
             className='justify-end w-auto mx-0'
           />
         </div>

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -41,15 +42,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from '@/components/ui/pagination';
 import {
   Table,
   TableBody,
@@ -196,112 +188,6 @@ const loadStoredColumnWidthOverrides = (): Partial<ColumnWidthState> => {
   } catch {
     return {};
   }
-};
-
-const renderPagination = (
-  pageIndex: number,
-  pageCount: number,
-  onPageChange: (page: number) => void,
-) => {
-  const items: React.ReactElement[] = [];
-  const maxVisiblePages = 5;
-
-  if (pageCount <= maxVisiblePages + 2) {
-    for (let index = 1; index <= pageCount; index += 1) {
-      items.push(
-        <PaginationItem key={index}>
-          <PaginationLink
-            href='#'
-            isActive={pageIndex === index}
-            onClick={event => {
-              event.preventDefault();
-              onPageChange(index);
-            }}
-          >
-            {index}
-          </PaginationLink>
-        </PaginationItem>,
-      );
-    }
-    return items;
-  }
-
-  items.push(
-    <PaginationItem key={1}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === 1}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(1);
-        }}
-      >
-        {1}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  if (pageIndex > 3) {
-    items.push(
-      <PaginationItem key='start-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  let rangeStart = Math.max(2, pageIndex - 1);
-  let rangeEnd = Math.min(pageCount - 1, pageIndex + 1);
-
-  if (pageIndex <= 3) {
-    rangeStart = 2;
-    rangeEnd = 4;
-  }
-  if (pageIndex >= pageCount - 2) {
-    rangeEnd = pageCount - 1;
-    rangeStart = pageCount - 3;
-  }
-
-  for (let index = rangeStart; index <= rangeEnd; index += 1) {
-    items.push(
-      <PaginationItem key={index}>
-        <PaginationLink
-          href='#'
-          isActive={pageIndex === index}
-          onClick={event => {
-            event.preventDefault();
-            onPageChange(index);
-          }}
-        >
-          {index}
-        </PaginationLink>
-      </PaginationItem>,
-    );
-  }
-
-  if (pageIndex < pageCount - 2) {
-    items.push(
-      <PaginationItem key='end-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  items.push(
-    <PaginationItem key={pageCount}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === pageCount}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(pageCount);
-        }}
-      >
-        {pageCount}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  return items;
 };
 
 const renderTooltipText = (text?: string, className?: string) => {
@@ -1677,49 +1563,14 @@ const OperationsPage = () => {
         </AlertDialog>
 
         <div className='mt-4 mb-4 flex justify-end'>
-          <Pagination className='justify-end w-auto mx-0'>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious
-                  href='#'
-                  onClick={event => {
-                    event.preventDefault();
-                    if (pageIndex > 1) {
-                      handlePageChange(pageIndex - 1);
-                    }
-                  }}
-                  aria-disabled={pageIndex <= 1}
-                  className={
-                    pageIndex <= 1 ? 'pointer-events-none opacity-50' : ''
-                  }
-                >
-                  {t('module.order.paginationPrev', 'Previous')}
-                </PaginationPrevious>
-              </PaginationItem>
-
-              {renderPagination(pageIndex, pageCount, handlePageChange)}
-
-              <PaginationItem>
-                <PaginationNext
-                  href='#'
-                  onClick={event => {
-                    event.preventDefault();
-                    if (pageIndex < pageCount) {
-                      handlePageChange(pageIndex + 1);
-                    }
-                  }}
-                  aria-disabled={pageIndex >= pageCount}
-                  className={
-                    pageIndex >= pageCount
-                      ? 'pointer-events-none opacity-50'
-                      : ''
-                  }
-                >
-                  {t('module.order.paginationNext', 'Next')}
-                </PaginationNext>
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
+          <AdminPagination
+            pageIndex={pageIndex}
+            pageCount={pageCount}
+            onPageChange={handlePageChange}
+            prevLabel={t('module.order.paginationPrev', 'Previous')}
+            nextLabel={t('module.order.paginationNext', 'Next')}
+            className='justify-end w-auto mx-0'
+          />
         </div>
       </div>
     </div>

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -554,4 +554,67 @@ describe('AdminOperationUsersPage', () => {
       await screen.findByText('module.user.defaultUserName'),
     ).toBeInTheDocument();
   });
+
+  test('requests the selected page when the user list pagination changes', async () => {
+    mockGetAdminOperationUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'user-1',
+          mobile: '13812345678',
+          email: 'user-1@example.com',
+          nickname: 'Nick',
+          user_status: 'paid',
+          user_role: 'operator',
+          user_roles: ['operator'],
+          login_methods: ['phone'],
+          registration_source: 'google',
+          language: 'zh-CN',
+          learning_courses: [],
+          created_courses: [],
+          total_paid_amount: '88.50',
+          last_login_at: '2026-04-15 09:00:00',
+          last_learning_at: '2026-04-15 10:00:00',
+          created_at: '2026-04-14 10:00:00',
+          updated_at: '2026-04-14 11:00:00',
+        },
+      ],
+      page: 1,
+      page_count: 2,
+      page_size: 20,
+      total: 21,
+    });
+    mockGetAdminOperationUsers.mockResolvedValueOnce({
+      items: [],
+      page: 2,
+      page_count: 2,
+      page_size: 20,
+      total: 21,
+    });
+
+    render(<AdminOperationUsersPage />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page_index: 1,
+          page_size: 20,
+        }),
+      );
+    });
+
+    fireEvent.click(
+      await screen.findByRole('link', {
+        name: '2',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page_index: 2,
+          page_size: 20,
+        }),
+      );
+    });
+  });
 });

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1188,7 +1188,6 @@ export default function AdminOperationUsersPage() {
               prevLabel={t('module.order.paginationPrev', 'Previous')}
               nextLabel={t('module.order.paginationNext', 'Next')}
               className='justify-end w-auto mx-0'
-              hideWhenSinglePage
             />
           </div>
         ) : null}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1187,6 +1187,14 @@ export default function AdminOperationUsersPage() {
               onPageChange={handlePageChange}
               prevLabel={t('module.order.paginationPrev', 'Previous')}
               nextLabel={t('module.order.paginationNext', 'Next')}
+              prevAriaLabel={t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              )}
+              nextAriaLabel={t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              )}
               className='justify-end w-auto mx-0'
             />
           </div>

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Button } from '@/components/ui/Button';
@@ -17,15 +18,6 @@ import {
   DialogTitle,
 } from '@/components/ui/Dialog';
 import { Input } from '@/components/ui/Input';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from '@/components/ui/pagination';
 import {
   Select,
   SelectContent,
@@ -144,112 +136,6 @@ const createDefaultFilters = (): UserFilters => ({
   start_time: '',
   end_time: '',
 });
-
-const renderPagination = (
-  pageIndex: number,
-  pageCount: number,
-  onPageChange: (page: number) => void,
-) => {
-  const items: React.ReactElement[] = [];
-  const maxVisiblePages = 5;
-
-  if (pageCount <= maxVisiblePages + 2) {
-    for (let index = 1; index <= pageCount; index += 1) {
-      items.push(
-        <PaginationItem key={index}>
-          <PaginationLink
-            href='#'
-            isActive={pageIndex === index}
-            onClick={event => {
-              event.preventDefault();
-              onPageChange(index);
-            }}
-          >
-            {index}
-          </PaginationLink>
-        </PaginationItem>,
-      );
-    }
-    return items;
-  }
-
-  items.push(
-    <PaginationItem key={1}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === 1}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(1);
-        }}
-      >
-        {1}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  if (pageIndex > 3) {
-    items.push(
-      <PaginationItem key='start-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  let rangeStart = Math.max(2, pageIndex - 1);
-  let rangeEnd = Math.min(pageCount - 1, pageIndex + 1);
-
-  if (pageIndex <= 3) {
-    rangeStart = 2;
-    rangeEnd = Math.min(4, pageCount - 1);
-  }
-  if (pageIndex >= pageCount - 2) {
-    rangeStart = Math.max(2, pageCount - 3);
-    rangeEnd = pageCount - 1;
-  }
-
-  for (let index = rangeStart; index <= rangeEnd; index += 1) {
-    items.push(
-      <PaginationItem key={index}>
-        <PaginationLink
-          href='#'
-          isActive={pageIndex === index}
-          onClick={event => {
-            event.preventDefault();
-            onPageChange(index);
-          }}
-        >
-          {index}
-        </PaginationLink>
-      </PaginationItem>,
-    );
-  }
-
-  if (pageIndex < pageCount - 2) {
-    items.push(
-      <PaginationItem key='end-ellipsis'>
-        <PaginationEllipsis />
-      </PaginationItem>,
-    );
-  }
-
-  items.push(
-    <PaginationItem key={pageCount}>
-      <PaginationLink
-        href='#'
-        isActive={pageIndex === pageCount}
-        onClick={event => {
-          event.preventDefault();
-          onPageChange(pageCount);
-        }}
-      >
-        {pageCount}
-      </PaginationLink>
-    </PaginationItem>,
-  );
-
-  return items;
-};
 
 const OverflowTooltipText = ({
   text,
@@ -1295,47 +1181,15 @@ export default function AdminOperationUsersPage() {
 
         {pageCount > 1 ? (
           <div className='mt-4 mb-4 flex justify-end'>
-            <Pagination className='justify-end w-auto mx-0'>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    href='#'
-                    onClick={event => {
-                      event.preventDefault();
-                      if (pageIndex > 1) {
-                        handlePageChange(pageIndex - 1);
-                      }
-                    }}
-                    aria-disabled={pageIndex <= 1}
-                    className={
-                      pageIndex <= 1 ? 'pointer-events-none opacity-50' : ''
-                    }
-                  >
-                    {t('module.order.paginationPrev', 'Previous')}
-                  </PaginationPrevious>
-                </PaginationItem>
-                {renderPagination(pageIndex, pageCount, handlePageChange)}
-                <PaginationItem>
-                  <PaginationNext
-                    href='#'
-                    onClick={event => {
-                      event.preventDefault();
-                      if (pageIndex < pageCount) {
-                        handlePageChange(pageIndex + 1);
-                      }
-                    }}
-                    aria-disabled={pageIndex >= pageCount}
-                    className={
-                      pageIndex >= pageCount
-                        ? 'pointer-events-none opacity-50'
-                        : ''
-                    }
-                  >
-                    {t('module.order.paginationNext', 'Next')}
-                  </PaginationNext>
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
+            <AdminPagination
+              pageIndex={pageIndex}
+              pageCount={pageCount}
+              onPageChange={handlePageChange}
+              prevLabel={t('module.order.paginationPrev', 'Previous')}
+              nextLabel={t('module.order.paginationNext', 'Next')}
+              className='justify-end w-auto mx-0'
+              hideWhenSinglePage
+            />
           </div>
         ) : null}
 

--- a/src/cook-web/src/app/admin/orders/page.tsx
+++ b/src/cook-web/src/app/admin/orders/page.tsx
@@ -9,6 +9,8 @@ import React, {
 } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import api from '@/api';
+import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '@/store';
 import { ErrorWithCode } from '@/lib/request';
@@ -45,15 +47,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from '@/components/ui/pagination';
 import OrderDetailSheet from '@/components/order/OrderDetailSheet';
 import ImportActivationDialog from '@/components/order/ImportActivationDialog';
 import { cn } from '@/lib/utils';
@@ -63,7 +56,6 @@ import type { OrderSummary } from '@/components/order/order-types';
 import type { Shifu } from '@/types/shifu';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
-import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 
 type OrderListResponse = {
   items: OrderSummary[];
@@ -824,106 +816,6 @@ const OrdersPage = () => {
     return 'secondary';
   };
 
-  const renderPaginationItems = () => {
-    const items: React.ReactElement[] = [];
-    const maxVisiblePages = 5;
-
-    if (pageCount <= maxVisiblePages + 2) {
-      for (let i = 1; i <= pageCount; i++) {
-        items.push(
-          <PaginationItem key={i}>
-            <PaginationLink
-              href='#'
-              isActive={pageIndex === i}
-              onClick={e => {
-                e.preventDefault();
-                handlePageChange(i);
-              }}
-            >
-              {i}
-            </PaginationLink>
-          </PaginationItem>,
-        );
-      }
-    } else {
-      items.push(
-        <PaginationItem key={1}>
-          <PaginationLink
-            href='#'
-            isActive={pageIndex === 1}
-            onClick={e => {
-              e.preventDefault();
-              handlePageChange(1);
-            }}
-          >
-            {1}
-          </PaginationLink>
-        </PaginationItem>,
-      );
-
-      if (pageIndex > 3) {
-        items.push(
-          <PaginationItem key='start-ellipsis'>
-            <PaginationEllipsis />
-          </PaginationItem>,
-        );
-      }
-
-      let rangeStart = Math.max(2, pageIndex - 1);
-      let rangeEnd = Math.min(pageCount - 1, pageIndex + 1);
-
-      if (pageIndex <= 3) {
-        rangeStart = 2;
-        rangeEnd = 4;
-      }
-      if (pageIndex >= pageCount - 2) {
-        rangeEnd = pageCount - 1;
-        rangeStart = pageCount - 3;
-      }
-
-      for (let i = rangeStart; i <= rangeEnd; i++) {
-        items.push(
-          <PaginationItem key={i}>
-            <PaginationLink
-              href='#'
-              isActive={pageIndex === i}
-              onClick={e => {
-                e.preventDefault();
-                handlePageChange(i);
-              }}
-            >
-              {i}
-            </PaginationLink>
-          </PaginationItem>,
-        );
-      }
-
-      if (pageIndex < pageCount - 2) {
-        items.push(
-          <PaginationItem key='end-ellipsis'>
-            <PaginationEllipsis />
-          </PaginationItem>,
-        );
-      }
-
-      items.push(
-        <PaginationItem key={pageCount}>
-          <PaginationLink
-            href='#'
-            isActive={pageIndex === pageCount}
-            onClick={e => {
-              e.preventDefault();
-              handlePageChange(pageCount);
-            }}
-          >
-            {pageCount}
-          </PaginationLink>
-        </PaginationItem>,
-      );
-    }
-    return items;
-  };
-
   const filterItems = [
     {
       key: 'user_bid',
@@ -1417,45 +1309,14 @@ const OrdersPage = () => {
         </div>
 
         <div className='mt-4 mb-4 flex justify-end'>
-          <Pagination className='justify-end w-auto mx-0'>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious
-                  href='#'
-                  onClick={e => {
-                    e.preventDefault();
-                    if (pageIndex > 1) handlePageChange(pageIndex - 1);
-                  }}
-                  aria-disabled={pageIndex <= 1}
-                  className={
-                    pageIndex <= 1 ? 'pointer-events-none opacity-50' : ''
-                  }
-                >
-                  {t('module.order.paginationPrev', 'Previous')}
-                </PaginationPrevious>
-              </PaginationItem>
-
-              {renderPaginationItems()}
-
-              <PaginationItem>
-                <PaginationNext
-                  href='#'
-                  onClick={e => {
-                    e.preventDefault();
-                    if (pageIndex < pageCount) handlePageChange(pageIndex + 1);
-                  }}
-                  aria-disabled={pageIndex >= pageCount}
-                  className={
-                    pageIndex >= pageCount
-                      ? 'pointer-events-none opacity-50'
-                      : ''
-                  }
-                >
-                  {t('module.order.paginationNext', 'Next')}
-                </PaginationNext>
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
+          <AdminPagination
+            pageIndex={pageIndex}
+            pageCount={pageCount}
+            onPageChange={handlePageChange}
+            prevLabel={t('module.order.paginationPrev', 'Previous')}
+            nextLabel={t('module.order.paginationNext', 'Next')}
+            className='justify-end w-auto mx-0'
+          />
         </div>
       </div>
 

--- a/src/cook-web/src/app/admin/orders/page.tsx
+++ b/src/cook-web/src/app/admin/orders/page.tsx
@@ -1315,6 +1315,14 @@ const OrdersPage = () => {
             onPageChange={handlePageChange}
             prevLabel={t('module.order.paginationPrev', 'Previous')}
             nextLabel={t('module.order.paginationNext', 'Next')}
+            prevAriaLabel={t(
+              'module.order.paginationPrevAriaLabel',
+              'Go to previous page',
+            )}
+            nextAriaLabel={t(
+              'module.order.paginationNextAriaLabel',
+              'Go to next page',
+            )}
             className='justify-end w-auto mx-0'
           />
         </div>

--- a/src/i18n/en-US/modules/order.json
+++ b/src/i18n/en-US/modules/order.json
@@ -98,7 +98,9 @@
     "title": "Import Activation"
   },
   "paginationNext": "Next",
+  "paginationNextAriaLabel": "Go to next page",
   "paginationPrev": "Previous",
+  "paginationPrevAriaLabel": "Go to previous page",
   "paymentChannel": {
     "manual": "Manual",
     "open_api": "Open API",

--- a/src/i18n/zh-CN/modules/order.json
+++ b/src/i18n/zh-CN/modules/order.json
@@ -98,7 +98,9 @@
     "title": "导入开通"
   },
   "paginationNext": "下一页",
+  "paginationNextAriaLabel": "前往下一页",
   "paginationPrev": "上一页",
+  "paginationPrevAriaLabel": "前往上一页",
   "paymentChannel": {
     "manual": "人工",
     "open_api": "Open API",


### PR DESCRIPTION
## Summary
- add a shared `AdminPagination` component for admin list pages
- migrate orders and operations admin pages to the shared pagination renderer
- add focused pagination tests for shared behavior and connected admin pages

## Testing
- `pre-commit run -a`
- `cd src/cook-web && npm run test -- src/app/admin/components/AdminPagination.test.tsx src/app/admin/orders/page.test.tsx src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.test.tsx --runTestsByPath 'src/app/admin/operations/[shifu_bid]/page.test.tsx'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared admin pagination component with previous/next controls and dynamic page navigation.

* **Refactor**
  * Replaced duplicated inline pagination UI across multiple admin list pages with the shared component.

* **Tests**
  * Added comprehensive tests for the shared pagination and updated page tests to verify pagination-driven requests and interactions.

* **Documentation**
  * Added docs describing the shared pagination effort, target pages, constraints, and rollout plan.

* **Accessibility**
  * Added accessible ARIA labels for pagination previous/next controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->