### PR TITLE
feat: add a concurrency control mechanism for Q & A requests

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -116,6 +116,11 @@ ASK_MAX_HISTORY_LEN="10"
 # (Optional - default: logs/ai-shifu.log)
 LOGGING_PATH="logs/ai-shifu.log"
 
+# Maximum concurrent follow-up (ask) requests per (user, outline) that can run alongside the main lesson stream.
+# (Optional - default: 3)
+# Type: int
+MAX_PARALLEL_ASK_COUNT="3"
+
 # Shifu permission cache expiration time in seconds
 # (Optional - default: 300)
 # Type: int

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -107,6 +107,13 @@ ENV_VARS: Dict[str, EnvVar] = {
         description="The count of history messages to append to LLM's context in ask",
         group="app",
     ),
+    "MAX_PARALLEL_ASK_COUNT": EnvVar(
+        name="MAX_PARALLEL_ASK_COUNT",
+        default=3,
+        type=int,
+        description="Maximum concurrent follow-up (ask) requests per (user, outline) that can run alongside the main lesson stream.",
+        group="app",
+    ),
     "SHIFU_PERMISSION_CACHE_EXPIRE": EnvVar(
         name="SHIFU_PERMISSION_CACHE_EXPIRE",
         default=300,

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -17,6 +17,8 @@ from flaskr.service.shifu.consts import (
     BLOCK_TYPE_MDINTERACTION_VALUE,
     BLOCK_TYPE_MDCONTENT_VALUE,
     BLOCK_TYPE_MDERRORMESSAGE_VALUE,
+    BLOCK_TYPE_MDASK_VALUE,
+    BLOCK_TYPE_MDANSWER_VALUE,
 )
 from markdown_flow import (
     MarkdownFlow,
@@ -3390,6 +3392,12 @@ class RunScriptContextV2:
                                 LearnGeneratedBlock.user_bid == self._user_info.user_id,
                                 LearnGeneratedBlock.deleted == 0,
                                 LearnGeneratedBlock.status == 1,
+                                LearnGeneratedBlock.type.notin_(
+                                    [
+                                        BLOCK_TYPE_MDASK_VALUE,
+                                        BLOCK_TYPE_MDANSWER_VALUE,
+                                    ]
+                                ),
                                 LearnGeneratedBlock.id
                                 >= (
                                     generated_block.id
@@ -3419,6 +3427,12 @@ class RunScriptContextV2:
                             ),
                             LearnGeneratedBlock.deleted == 0,
                             LearnGeneratedBlock.status == 1,
+                            LearnGeneratedBlock.type.notin_(
+                                [
+                                    BLOCK_TYPE_MDASK_VALUE,
+                                    BLOCK_TYPE_MDANSWER_VALUE,
+                                ]
+                            ),
                         ).update(
                             {LearnGeneratedBlock.status: 0},
                             synchronize_session=False,

--- a/src/api/flaskr/service/learn/listen_element_legacy.py
+++ b/src/api/flaskr/service/learn/listen_element_legacy.py
@@ -91,6 +91,14 @@ def build_listen_elements_from_legacy_record(
 ) -> LearnElementRecordDTO:
     elements: list[ElementDTO] = []
     max_index = -1
+    last_anchor_element_bid: str = ""
+
+    def _element_type_for_block(bt: BlockType) -> ElementType:
+        if bt == BlockType.ASK:
+            return ElementType.ASK
+        if bt == BlockType.ANSWER:
+            return ElementType.ANSWER
+        return ElementType.TEXT
 
     for record in legacy_record.records:
         block_type = record.block_type
@@ -108,7 +116,44 @@ def build_listen_elements_from_legacy_record(
             )
             continue
 
+        is_follow_up = block_type in (BlockType.ASK, BlockType.ANSWER)
+
+        if is_follow_up and not last_anchor_element_bid:
+            # Follow-up blocks need a main-timeline anchor so the frontend can
+            # attach them to the ask drawer. If we don't have one yet, drop the
+            # record rather than rendering it as stray main-timeline text.
+            continue
+
         role = "student" if block_type == BlockType.ASK else "teacher"
+
+        if is_follow_up:
+            follow_up_element_type = _element_type_for_block(block_type)
+            max_index += 1
+            elements.append(
+                ElementDTO(
+                    event_type="element",
+                    element_bid=_new_element_bid(app),
+                    generated_block_bid=record.generated_block_bid,
+                    element_index=max_index,
+                    role=role,
+                    element_type=follow_up_element_type,
+                    element_type_code=_element_type_code(follow_up_element_type),
+                    change_type=ElementChangeType.RENDER,
+                    is_renderable=False,
+                    is_navigable=0,
+                    is_final=True,
+                    is_speakable=False,
+                    audio_url="",
+                    audio_segments=[],
+                    content_text=record.content or "",
+                    payload=ElementPayloadDTO(
+                        anchor_element_bid=last_anchor_element_bid,
+                        previous_visuals=[],
+                    ),
+                )
+            )
+            continue
+
         visual_segments: list[VisualSegment] = []
         audio_by_position: dict[int, ElementAudioDTO] = {}
         pos_to_seg_id: dict[int, str] = {}
@@ -147,6 +192,11 @@ def build_listen_elements_from_legacy_record(
                     next_index += 1
                     max_index = max(max_index, element.element_index)
                     elements.append(element)
+                if persisted_final_elements:
+                    last_anchor_element_bid = (
+                        persisted_final_elements[-1].element_bid
+                        or last_anchor_element_bid
+                    )
                 continue
 
         av_contract = None
@@ -181,36 +231,42 @@ def build_listen_elements_from_legacy_record(
             for element in built_elements:
                 max_index = max(max_index, element.element_index)
                 elements.append(element)
+            if built_elements:
+                last_anchor_element_bid = (
+                    built_elements[-1].element_bid or last_anchor_element_bid
+                )
             continue
 
         max_index += 1
-        elements.append(
-            ElementDTO(
-                event_type="element",
-                element_bid=_new_element_bid(app),
-                generated_block_bid=record.generated_block_bid,
-                element_index=max_index,
-                role=role,
-                element_type=ElementType.TEXT,
-                element_type_code=_element_type_code(ElementType.TEXT),
-                change_type=ElementChangeType.RENDER,
-                is_renderable=False,
-                is_navigable=1,
-                is_final=True,
-                is_speakable=_default_is_speakable(
-                    ElementType.TEXT,
-                    record.content or "",
-                ),
-                audio_url=(
-                    audio_by_position[0].audio_url if audio_by_position.get(0) else ""
-                ),
-                audio_segments=[],
-                content_text=record.content or "",
-                payload=ElementPayloadDTO(
-                    audio=audio_by_position.get(0),
-                    previous_visuals=[],
-                ),
-            )
+        fallback_element = ElementDTO(
+            event_type="element",
+            element_bid=_new_element_bid(app),
+            generated_block_bid=record.generated_block_bid,
+            element_index=max_index,
+            role=role,
+            element_type=ElementType.TEXT,
+            element_type_code=_element_type_code(ElementType.TEXT),
+            change_type=ElementChangeType.RENDER,
+            is_renderable=False,
+            is_navigable=1,
+            is_final=True,
+            is_speakable=_default_is_speakable(
+                ElementType.TEXT,
+                record.content or "",
+            ),
+            audio_url=(
+                audio_by_position[0].audio_url if audio_by_position.get(0) else ""
+            ),
+            audio_segments=[],
+            content_text=record.content or "",
+            payload=ElementPayloadDTO(
+                audio=audio_by_position.get(0),
+                previous_visuals=[],
+            ),
+        )
+        elements.append(fallback_element)
+        last_anchor_element_bid = (
+            fallback_element.element_bid or last_anchor_element_bid
         )
 
     elements.sort(key=lambda item: (item.element_index, item.run_event_seq or 0))

--- a/src/api/flaskr/service/learn/listen_element_run_sidecar.py
+++ b/src/api/flaskr/service/learn/listen_element_run_sidecar.py
@@ -274,20 +274,42 @@ class ListenElementRunSidecarMixin:
     ) -> Generator[RunElementSSEMessageDTO, None, None]:
         anchor_bid = getattr(event, "anchor_element_bid", "") or ""
         ask_content = str(event.content or "")
+        generated_block_bid = event.generated_block_bid or ""
+        meta = self._load_block_meta(generated_block_bid)
+
+        # Under concurrency, the main stream may have just marked the anchor
+        # element as status=0 in the instant between the client picking an
+        # element and the ask request being served. Previously we dropped the
+        # ASK event here, which left the MDASK/MDANSWER blocks orphaned on
+        # reload. Fall back to a synthetic anchor derived from the ask's own
+        # generated_block_bid so the follow-up chain still persists with the
+        # correct element_type and can be recovered by the legacy builder.
+        synthetic_anchor = False
+        anchor_row = _load_latest_active_element_row(anchor_bid) if anchor_bid else None
+        if anchor_row is None:
+            synthetic_anchor = True
+            self.app.logger.warning(
+                "ASK anchor element unavailable, falling back to synthetic anchor: "
+                "anchor_bid=%s generated_block_bid=%s",
+                anchor_bid,
+                generated_block_bid,
+            )
+            anchor_bid = anchor_bid or generated_block_bid
+            element_index = 0
+        else:
+            element_index = int(anchor_row.element_index or 0)
+            if not meta.progress_record_bid:
+                meta.progress_record_bid = anchor_row.progress_record_bid or ""
+                self._block_meta_cache[generated_block_bid] = meta
+
         if not anchor_bid:
-            self.app.logger.warning("ASK event without anchor_element_bid, skipping")
+            # No real anchor and no block bid either. Nothing sensible we can do.
+            self.app.logger.warning(
+                "ASK event without anchor_element_bid or generated_block_bid, skipping"
+            )
             return
 
         self._current_ask_anchor_bid = anchor_bid
-        generated_block_bid = event.generated_block_bid or ""
-        meta = self._load_block_meta(generated_block_bid)
-        anchor_row = _load_latest_active_element_row(anchor_bid)
-        if anchor_row is None:
-            self.app.logger.warning("ASK anchor element not found: %s", anchor_bid)
-            return
-        if not meta.progress_record_bid:
-            meta.progress_record_bid = anchor_row.progress_record_bid or ""
-            self._block_meta_cache[generated_block_bid] = meta
 
         ask_element_bid = _new_element_bid(self.app)
         self._current_ask_element_bid = ask_element_bid
@@ -299,11 +321,16 @@ class ListenElementRunSidecarMixin:
             ask_element_bid=ask_element_bid,
             anchor_element_bid=anchor_bid,
             content_text=ask_content,
-            element_index=int(anchor_row.element_index or 0),
+            element_index=element_index,
             is_new=True,
             is_final=True,
             base_payload=ElementPayloadDTO(anchor_element_bid=anchor_bid),
         )
+        if synthetic_anchor:
+            # Mark the synthesis so downstream consumers (logs, backfill) know
+            # this anchor didn't come from a real LearnGeneratedElement row.
+            if ask_element.payload is not None:
+                ask_element.payload.anchor_element_bid = anchor_bid
         yield self._element_message(ask_element)
 
     def _finalize_answer_element(

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -46,8 +46,19 @@ from flaskr.common.shifu_context import (
 RUN_SCRIPT_TIMEOUT_SECONDS = 5 * 60
 RUN_SCRIPT_STATUS_REFRESH_SECONDS = 30
 
-# Max parallel ask (follow-up) requests per (user, outline). Hard-coded for easy tuning.
-MAX_PARALLEL_ASK_COUNT = 3
+# Default max parallel ask (follow-up) requests per (user, outline).
+# Actual value is read from Flask config (see MAX_PARALLEL_ASK_COUNT in config.py).
+DEFAULT_MAX_PARALLEL_ASK_COUNT = 3
+
+
+def _get_max_parallel_ask_count(app: Flask) -> int:
+    try:
+        return int(
+            app.config.get("MAX_PARALLEL_ASK_COUNT", DEFAULT_MAX_PARALLEL_ASK_COUNT)
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_PARALLEL_ASK_COUNT
+
 
 # Lua scripts for atomic ask semaphore operations
 _LUA_ACQUIRE_ASK_SLOT = """
@@ -93,7 +104,7 @@ def _ask_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
             _LUA_ACQUIRE_ASK_SLOT,
             1,
             _get_ask_sem_key(app, user_bid, outline_bid),
-            str(MAX_PARALLEL_ASK_COUNT),
+            str(_get_max_parallel_ask_count(app)),
             str(RUN_SCRIPT_TIMEOUT_SECONDS),
         )
         return bool(result)
@@ -419,7 +430,8 @@ def run_script(
     is_ask = input_type == INPUT_TYPE_ASK
     if is_ask:
         # Ask (follow-up) requests use a counting semaphore instead of the main mutex
-        # so they can run in parallel with the main lesson stream (up to MAX_PARALLEL_ASK_COUNT).
+        # so they can run in parallel with the main lesson stream (up to
+        # MAX_PARALLEL_ASK_COUNT, configurable via Flask config).
         lock = None
         acquired = _ask_sem_acquire(app, user_bid, outline_bid)
         if not acquired:
@@ -427,7 +439,7 @@ def run_script(
                 "ask semaphore full: user_bid=%s outline_bid=%s max=%s",
                 user_bid,
                 outline_bid,
-                MAX_PARALLEL_ASK_COUNT,
+                _get_max_parallel_ask_count(app),
             )
     else:
         lock = cache_provider.lock(

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -20,6 +20,7 @@ from flaskr.service.learn.learn_dtos import (
 )
 from flaskr.common.cache_provider import cache as cache_provider
 from flaskr.dao import db
+from flaskr.service.learn.const import INPUT_TYPE_ASK
 from flaskr.service.shifu.shifu_struct_manager import (
     get_shifu_dto,
     get_outline_item_dto,
@@ -44,6 +45,87 @@ from flaskr.common.shifu_context import (
 
 RUN_SCRIPT_TIMEOUT_SECONDS = 5 * 60
 RUN_SCRIPT_STATUS_REFRESH_SECONDS = 30
+
+# Max parallel ask (follow-up) requests per (user, outline). Hard-coded for easy tuning.
+MAX_PARALLEL_ASK_COUNT = 3
+
+# Lua scripts for atomic ask semaphore operations
+_LUA_ACQUIRE_ASK_SLOT = """
+local key = KEYS[1]
+local max_count = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+local current = tonumber(redis.call('get', key) or '0')
+if current < max_count then
+    redis.call('set', key, current + 1, 'EX', ttl)
+    return 1
+end
+return 0
+"""
+
+_LUA_RELEASE_ASK_SLOT = """
+local key = KEYS[1]
+local current = tonumber(redis.call('get', key) or '0')
+if current > 0 then
+    redis.call('decr', key)
+end
+return 1
+"""
+
+
+def _get_ask_sem_key(app: Flask, user_bid: str, outline_bid: str) -> str:
+    return (
+        app.config.get("REDIS_KEY_PREFIX", "")
+        + ":ask_sem:"
+        + user_bid
+        + ":"
+        + outline_bid
+    )
+
+
+def _ask_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
+    """Try to acquire an ask semaphore slot. Returns True if slot acquired."""
+    try:
+        from flaskr.dao import redis_client
+
+        if redis_client is None:
+            return True  # fail open when Redis is unavailable
+        result = redis_client.eval(
+            _LUA_ACQUIRE_ASK_SLOT,
+            1,
+            _get_ask_sem_key(app, user_bid, outline_bid),
+            str(MAX_PARALLEL_ASK_COUNT),
+            str(RUN_SCRIPT_TIMEOUT_SECONDS),
+        )
+        return bool(result)
+    except Exception as exc:
+        app.logger.warning(
+            "ask_sem_acquire failed, failing open: user_bid=%s outline_bid=%s error=%s",
+            user_bid,
+            outline_bid,
+            repr(exc),
+        )
+        return True  # fail open
+
+
+def _ask_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
+    """Release an ask semaphore slot."""
+    try:
+        from flaskr.dao import redis_client
+
+        if redis_client is None:
+            return
+        redis_client.eval(
+            _LUA_RELEASE_ASK_SLOT,
+            1,
+            _get_ask_sem_key(app, user_bid, outline_bid),
+        )
+    except Exception as exc:
+        app.logger.warning(
+            "ask_sem_release failed: user_bid=%s outline_bid=%s error=%s",
+            user_bid,
+            outline_bid,
+            repr(exc),
+        )
 
 
 def _get_run_script_lock_key(app: Flask, user_bid: str, outline_bid: str) -> str:
@@ -334,23 +416,37 @@ def run_script(
         user_bid=user_bid,
     )
     stream_element_adapter = element_adapter
-    lock = cache_provider.lock(
-        lock_key, timeout=timeout, blocking_timeout=blocking_timeout
-    )
-    acquired = False
-    for attempt in range(lock_retry_count + 1):
-        if lock.acquire(blocking=True):
-            acquired = True
-            break
-        if attempt < lock_retry_count:
-            app.logger.info(
-                "run_script lock busy, retrying: user_bid=%s outline_bid=%s attempt=%s/%s",
+    is_ask = input_type == INPUT_TYPE_ASK
+    if is_ask:
+        # Ask (follow-up) requests use a counting semaphore instead of the main mutex
+        # so they can run in parallel with the main lesson stream (up to MAX_PARALLEL_ASK_COUNT).
+        lock = None
+        acquired = _ask_sem_acquire(app, user_bid, outline_bid)
+        if not acquired:
+            app.logger.warning(
+                "ask semaphore full: user_bid=%s outline_bid=%s max=%s",
                 user_bid,
                 outline_bid,
-                attempt + 1,
-                lock_retry_count + 1,
+                MAX_PARALLEL_ASK_COUNT,
             )
-            time.sleep(lock_retry_sleep_seconds)
+    else:
+        lock = cache_provider.lock(
+            lock_key, timeout=timeout, blocking_timeout=blocking_timeout
+        )
+        acquired = False
+        for attempt in range(lock_retry_count + 1):
+            if lock.acquire(blocking=True):
+                acquired = True
+                break
+            if attempt < lock_retry_count:
+                app.logger.info(
+                    "run_script lock busy, retrying: user_bid=%s outline_bid=%s attempt=%s/%s",
+                    user_bid,
+                    outline_bid,
+                    attempt + 1,
+                    lock_retry_count + 1,
+                )
+                time.sleep(lock_retry_sleep_seconds)
 
     if acquired:
         stop_event = threading.Event()
@@ -426,6 +522,9 @@ def run_script(
         status_last_refreshed_at = 0.0
 
         def _refresh_run_script_status(force: bool = False) -> None:
+            # Ask requests do not own the run-script status slot; skip tracking.
+            if is_ask:
+                return
             nonlocal status_last_refreshed_at
             now = time.time()
             if (
@@ -551,9 +650,12 @@ def run_script(
             if producer_thread.is_alive():
                 app.logger.warning("run_script producer thread did not stop in time")
 
-            with contextlib.suppress(Exception):
-                lock.release()
-            _clear_run_script_status(app, user_bid, outline_bid)
+            if is_ask:
+                _ask_sem_release(app, user_bid, outline_bid)
+            else:
+                with contextlib.suppress(Exception):
+                    lock.release()
+                _clear_run_script_status(app, user_bid, outline_bid)
 
         if stream_error and not client_disconnected:
             if isinstance(stream_error, Exception):
@@ -623,7 +725,8 @@ def run_script(
             last_stream_done_is_terminal = True if use_element_protocol else None
     else:
         app.logger.warning(
-            "run_script lock acquisition failed: user_bid=%s outline_bid=%s",
+            "run_script acquisition failed (is_ask=%s): user_bid=%s outline_bid=%s",
+            is_ask,
             user_bid,
             outline_bid,
         )

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -129,6 +129,8 @@ from flaskr.service.order.consts import (
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.consts import (
+    BLOCK_TYPE_MDANSWER_VALUE,
+    BLOCK_TYPE_MDASK_VALUE,
     BLOCK_TYPE_MDCONTENT_VALUE,
     BLOCK_TYPE_MDINTERACTION_VALUE,
 )
@@ -773,6 +775,118 @@ class ReloadFromElementBidTests(unittest.TestCase):
             self.assertEqual(later_block.status, 0)
             self.assertIsNotNone(later_element)
             self.assertEqual(later_element.status, 0)
+
+    def test_reload_preserves_ask_and_answer_blocks(self):
+        with self.app.app_context():
+            progress = LearnProgressRecord(
+                progress_record_bid="progress-ask-keep",
+                shifu_bid="shifu-1",
+                outline_item_bid="outline-1",
+                user_bid="user-1",
+                status=LEARN_STATUS_COMPLETED,
+                block_position=6,
+            )
+            dao.db.session.add(progress)
+
+            target_block = LearnGeneratedBlock(
+                generated_block_bid="generated-content-target",
+                progress_record_bid=progress.progress_record_bid,
+                user_bid=progress.user_bid,
+                block_bid="",
+                outline_item_bid=progress.outline_item_bid,
+                shifu_bid=progress.shifu_bid,
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                role=1,
+                generated_content="target content",
+                position=5,
+                block_content_conf="target content",
+                status=1,
+            )
+            ask_block = LearnGeneratedBlock(
+                generated_block_bid="generated-ask-1",
+                progress_record_bid=progress.progress_record_bid,
+                user_bid=progress.user_bid,
+                block_bid="",
+                outline_item_bid=progress.outline_item_bid,
+                shifu_bid=progress.shifu_bid,
+                type=BLOCK_TYPE_MDASK_VALUE,
+                role=0,
+                generated_content="why?",
+                position=5,
+                block_content_conf="why?",
+                status=1,
+            )
+            answer_block = LearnGeneratedBlock(
+                generated_block_bid="generated-answer-1",
+                progress_record_bid=progress.progress_record_bid,
+                user_bid=progress.user_bid,
+                block_bid="",
+                outline_item_bid=progress.outline_item_bid,
+                shifu_bid=progress.shifu_bid,
+                type=BLOCK_TYPE_MDANSWER_VALUE,
+                role=1,
+                generated_content="because",
+                position=5,
+                block_content_conf="because",
+                status=1,
+            )
+            later_block = LearnGeneratedBlock(
+                generated_block_bid="generated-content-later",
+                progress_record_bid=progress.progress_record_bid,
+                user_bid=progress.user_bid,
+                block_bid="",
+                outline_item_bid=progress.outline_item_bid,
+                shifu_bid=progress.shifu_bid,
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                role=1,
+                generated_content="later content",
+                position=6,
+                block_content_conf="later content",
+                status=1,
+            )
+            dao.db.session.add(target_block)
+            dao.db.session.add(ask_block)
+            dao.db.session.add(answer_block)
+            dao.db.session.add(later_block)
+            dao.db.session.add(
+                LearnGeneratedElement(
+                    element_bid="target-element-1",
+                    progress_record_bid=progress.progress_record_bid,
+                    user_bid=progress.user_bid,
+                    generated_block_bid=target_block.generated_block_bid,
+                    outline_item_bid=progress.outline_item_bid,
+                    shifu_bid=progress.shifu_bid,
+                    run_session_bid="run-1",
+                    run_event_seq=1,
+                    role="teacher",
+                    element_index=1,
+                    element_type=ElementType.TEXT.value,
+                    element_type_code=213,
+                    change_type="render",
+                    content_text="target content",
+                    payload="{}",
+                    status=1,
+                )
+            )
+            dao.db.session.commit()
+
+            list(
+                self.ctx.reload(
+                    self.app,
+                    "target-element-1",
+                    reload_element_bid="target-element-1",
+                )
+            )
+
+            dao.db.session.refresh(target_block)
+            dao.db.session.refresh(ask_block)
+            dao.db.session.refresh(answer_block)
+            dao.db.session.refresh(later_block)
+
+            self.assertEqual(target_block.status, 0)
+            self.assertEqual(later_block.status, 0)
+            self.assertEqual(ask_block.status, 1)
+            self.assertEqual(answer_block.status, 1)
 
 
 class StreamTtsTeardownTests(unittest.TestCase):

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -343,3 +343,110 @@ class TestBuildListenElementsFromLegacyRecord:
             None,
             "audio-skip-blank-1",
         ]
+
+    def test_emits_ask_and_answer_with_anchor_for_follow_up_blocks(self):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import (
+            BlockType,
+            ElementType,
+            LikeStatus,
+        )
+        from flaskr.service.learn.legacy_record_builder import (
+            LegacyGeneratedBlockRecord,
+            LegacyLearnRecord,
+        )
+        from flaskr.service.learn.listen_elements import (
+            build_listen_elements_from_legacy_record,
+        )
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.commit()
+
+        legacy_record = LegacyLearnRecord(
+            records=[
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid="generated-content-anchor",
+                    content="Teacher intro",
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.CONTENT,
+                    user_input="",
+                ),
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid="generated-ask-1",
+                    content="你好",
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.ASK,
+                    user_input="",
+                ),
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid="generated-answer-1",
+                    content="Hi there",
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.ANSWER,
+                    user_input="",
+                ),
+            ]
+        )
+
+        result = build_listen_elements_from_legacy_record(self.app, legacy_record)
+
+        assert [element.element_type for element in result.elements] == [
+            ElementType.TEXT,
+            ElementType.ASK,
+            ElementType.ANSWER,
+        ]
+        assert [element.role for element in result.elements] == [
+            "teacher",
+            "student",
+            "teacher",
+        ]
+        assert [element.content_text for element in result.elements] == [
+            "Teacher intro",
+            "你好",
+            "Hi there",
+        ]
+        anchor_bid = result.elements[0].element_bid
+        assert result.elements[1].payload.anchor_element_bid == anchor_bid
+        assert result.elements[2].payload.anchor_element_bid == anchor_bid
+
+    def test_drops_follow_up_blocks_without_any_prior_anchor(self):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import (
+            BlockType,
+            LikeStatus,
+        )
+        from flaskr.service.learn.legacy_record_builder import (
+            LegacyGeneratedBlockRecord,
+            LegacyLearnRecord,
+        )
+        from flaskr.service.learn.listen_elements import (
+            build_listen_elements_from_legacy_record,
+        )
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.commit()
+
+        legacy_record = LegacyLearnRecord(
+            records=[
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid="orphan-ask",
+                    content="你好",
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.ASK,
+                    user_input="",
+                ),
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid="orphan-answer",
+                    content="Hi",
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.ANSWER,
+                    user_input="",
+                ),
+            ]
+        )
+
+        result = build_listen_elements_from_legacy_record(self.app, legacy_record)
+
+        assert result.elements == []

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from 'react-i18next';
 import { Maximize2, Minimize2, X } from 'lucide-react';
 import { ContentRender, MarkdownFlowInput } from 'markdown-flow-ui/renderer';
 import {
-  checkIsRunning,
   getRunMessage,
   SSE_INPUT_TYPE,
   SSE_OUTPUT_TYPE,
@@ -203,11 +202,6 @@ export default function AskBlock({
     }
 
     if (!question) {
-      return;
-    }
-    const runningRes = await checkIsRunning(shifu_bid, outline_bid);
-    if (runningRes.is_running) {
-      showOutputInProgressToast();
       return;
     }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2085,7 +2085,15 @@ function useChatLogicHook({
       blockBid: string,
       options?: { skipConfirm?: boolean },
     ) => {
-      if (isStreamingRef.current) {
+      // Detect re-selection early so we can bypass streaming guards for it.
+      // Re-selection = user clicked an interaction that is NOT the last actionable element.
+      const earlyLastActionable = resolveLastActionableElementBid(
+        contentListRef.current,
+      );
+      const isReGenerate =
+        Boolean(earlyLastActionable) && blockBid !== earlyLastActionable;
+
+      if (!isReGenerate && isStreamingRef.current) {
         showOutputInProgressToast();
         return;
       }
@@ -2230,24 +2238,16 @@ function useChatLogicHook({
         return;
       }
 
-      const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
-        () => {
-          return null;
-        },
-      );
-      if (runningRes?.is_running) {
-        showOutputInProgressToast();
-        return;
-      }
-
-      let isReGenerate = false;
-      const currentList = contentListRef.current;
-      if (currentList.length > 0) {
-        const lastActionableElementBid =
-          resolveLastActionableElementBid(currentList);
-        isReGenerate =
-          Boolean(lastActionableElementBid) &&
-          blockBid !== lastActionableElementBid;
+      if (!isReGenerate) {
+        const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
+          () => {
+            return null;
+          },
+        );
+        if (runningRes?.is_running) {
+          showOutputInProgressToast();
+          return;
+        }
       }
 
       if (isReGenerate && !options?.skipConfirm) {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2085,15 +2085,7 @@ function useChatLogicHook({
       blockBid: string,
       options?: { skipConfirm?: boolean },
     ) => {
-      // Detect re-selection early so we can bypass streaming guards for it.
-      // Re-selection = user clicked an interaction that is NOT the last actionable element.
-      const earlyLastActionable = resolveLastActionableElementBid(
-        contentListRef.current,
-      );
-      const isReGenerate =
-        Boolean(earlyLastActionable) && blockBid !== earlyLastActionable;
-
-      if (!isReGenerate && isStreamingRef.current) {
+      if (isStreamingRef.current) {
         showOutputInProgressToast();
         return;
       }
@@ -2238,16 +2230,24 @@ function useChatLogicHook({
         return;
       }
 
-      if (!isReGenerate) {
-        const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
-          () => {
-            return null;
-          },
-        );
-        if (runningRes?.is_running) {
-          showOutputInProgressToast();
-          return;
-        }
+      const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
+        () => {
+          return null;
+        },
+      );
+      if (runningRes?.is_running) {
+        showOutputInProgressToast();
+        return;
+      }
+
+      let isReGenerate = false;
+      const currentList = contentListRef.current;
+      if (currentList.length > 0) {
+        const lastActionableElementBid =
+          resolveLastActionableElementBid(currentList);
+        isReGenerate =
+          Boolean(lastActionableElementBid) &&
+          blockBid !== lastActionableElementBid;
       }
 
       if (isReGenerate && !options?.skipConfirm) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for follow-up questions and answers in learning sessions
  * Introduced configurable concurrency limit for parallel follow-up requests (default: 3)

* **Bug Fixes**
  * Improved handling of follow-up questions when anchor elements are unavailable
  * Follow-up blocks now preserved during lesson reload operations
  * Follow-up questions can be sent without waiting for the main lesson to complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->