### PR TITLE
Dedup persisted follow-up answer elements

### DIFF
--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -49,6 +49,25 @@ class ListenElementRunPersistenceMixin:
             return False
         return bool(element.is_new)
 
+    def _remember_latest_element_snapshot(
+        self, base_element_bid: str, element: ElementDTO
+    ) -> None:
+        if not base_element_bid:
+            return
+        snapshots = getattr(self, "_latest_element_snapshots", None)
+        if snapshots is None:
+            snapshots = {}
+            self._latest_element_snapshots = snapshots
+        snapshots[base_element_bid] = element.model_copy(deep=True)
+
+    def _forget_latest_element_snapshot(self, base_element_bid: str) -> None:
+        if not base_element_bid:
+            return
+        snapshots = getattr(self, "_latest_element_snapshots", None)
+        if snapshots is None:
+            return
+        snapshots.pop(base_element_bid, None)
+
     def _load_block_meta(self, generated_block_bid: str) -> BlockMeta:
         if generated_block_bid in self._block_meta_cache:
             return self._block_meta_cache[generated_block_bid]
@@ -223,6 +242,20 @@ class ListenElementRunPersistenceMixin:
             content=element,
         )
 
+    def _stream_only_element_message(
+        self, element: ElementDTO
+    ) -> RunElementSSEMessageDTO:
+        base_element_bid = self._prepare_runtime_element(element)
+        self._remember_latest_element_snapshot(base_element_bid, element)
+        return RunElementSSEMessageDTO(
+            type="element",
+            event_type="element",
+            generated_block_bid=element.generated_block_bid or None,
+            run_session_bid=self.run_session_bid,
+            run_event_seq=element.run_event_seq,
+            content=element,
+        )
+
     def _prepare_runtime_element(self, element: ElementDTO) -> str:
         seq = self._next_seq()
         if element.element_type in {ElementType.ASK, ElementType.ANSWER}:
@@ -277,6 +310,7 @@ class ListenElementRunPersistenceMixin:
             payload=element.payload,
             run_event_seq=element.run_event_seq,
         )
+        self._remember_latest_element_snapshot(base_element_bid, element)
 
     def _build_non_element_message(
         self,
@@ -419,6 +453,11 @@ class ListenElementRunPersistenceMixin:
         )
 
     def _load_latest_element_snapshot(self, element_bid: str) -> ElementDTO | None:
+        in_memory_snapshot = getattr(self, "_latest_element_snapshots", {}).get(
+            element_bid
+        )
+        if in_memory_snapshot is not None:
+            return in_memory_snapshot.model_copy(deep=True)
         row = (
             LearnGeneratedElement.query.filter(
                 LearnGeneratedElement.run_session_bid == self.run_session_bid,

--- a/src/api/flaskr/service/learn/listen_element_run_stream.py
+++ b/src/api/flaskr/service/learn/listen_element_run_stream.py
@@ -144,6 +144,7 @@ class ListenElementRunStreamMixin:
             generated_block_bid=state.generated_block_bid,
             element_bids=[state.fallback_element_bid],
         )
+        self._forget_latest_element_snapshot(state.fallback_element_bid)
         if not emit_notification:
             return
         meta = self._load_block_meta(state.generated_block_bid)
@@ -394,6 +395,8 @@ class ListenElementRunStreamMixin:
             generated_block_bid=state.generated_block_bid,
             element_bids=target_bids,
         )
+        for target_bid in target_bids:
+            self._forget_latest_element_snapshot(target_bid)
         if not emit_notification:
             return
         meta = self._load_block_meta(state.generated_block_bid)
@@ -447,7 +450,7 @@ class ListenElementRunStreamMixin:
                 is_final=False,
             )
             if answer_element is not None:
-                yield self._element_message(answer_element)
+                yield self._stream_only_element_message(answer_element)
             return
 
         formatted_parts = self._formatted_parts_from_event(event)

--- a/src/api/flaskr/service/learn/listen_elements.py
+++ b/src/api/flaskr/service/learn/listen_elements.py
@@ -79,6 +79,7 @@ class ListenElementRunAdapter(
         self._current_answer_element_bid: str | None = None
         self._ask_element_bid_by_block_bid: dict[str, str] = {}
         self._answer_element_bid_by_block_bid: dict[str, str] = {}
+        self._latest_element_snapshots: dict[str, object] = {}
 
     def process(
         self, events: Iterable[RunMarkdownFlowDTO]

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -1976,6 +1976,121 @@ class TestHandleAskAdapter:
             assert payload["ask_element_bid"] == ask_row.element_bid
             assert "asks" not in payload
 
+    def test_process_streams_multi_chunk_follow_up_answer_but_persists_only_final_row(
+        self, adapter_app
+    ):
+        from flaskr.service.learn.listen_element_payloads import _serialize_payload
+        from flaskr.service.learn.listen_elements import ListenElementRunAdapter
+        from flaskr.service.learn.learn_dtos import (
+            ElementPayloadDTO,
+            ElementType,
+            GeneratedType,
+            RunMarkdownFlowDTO,
+        )
+        from flaskr.service.learn.models import LearnGeneratedElement
+        from flaskr.dao import db
+
+        with adapter_app.app_context():
+            adapter = ListenElementRunAdapter(
+                adapter_app, shifu_bid="s1", outline_bid="o1", user_bid="u1"
+            )
+
+            anchor = LearnGeneratedElement(
+                element_bid="anchor_elem_multi_chunk",
+                progress_record_bid="pr1",
+                user_bid="u1",
+                generated_block_bid="gb1",
+                outline_item_bid="o1",
+                shifu_bid="s1",
+                run_session_bid="rs1",
+                run_event_seq=1,
+                event_type="element",
+                role="teacher",
+                element_index=0,
+                element_type="text",
+                element_type_code=0,
+                change_type="render",
+                is_final=1,
+                content_text="anchor content",
+                payload=_serialize_payload(ElementPayloadDTO()),
+                deleted=0,
+                status=1,
+            )
+            db.session.add(anchor)
+            db.session.flush()
+
+            events = [
+                RunMarkdownFlowDTO(
+                    outline_bid="o1",
+                    generated_block_bid="ask_gb_multi_chunk",
+                    type=GeneratedType.ASK,
+                    content="question",
+                    anchor_element_bid="anchor_elem_multi_chunk",
+                ),
+                RunMarkdownFlowDTO(
+                    outline_bid="o1",
+                    generated_block_bid="ask_gb_multi_chunk",
+                    type=GeneratedType.CONTENT,
+                    content="hello",
+                ),
+                RunMarkdownFlowDTO(
+                    outline_bid="o1",
+                    generated_block_bid="ask_gb_multi_chunk",
+                    type=GeneratedType.CONTENT,
+                    content=" world",
+                ),
+                RunMarkdownFlowDTO(
+                    outline_bid="o1",
+                    generated_block_bid="ask_gb_multi_chunk",
+                    type=GeneratedType.BREAK,
+                    content="",
+                ),
+            ]
+
+            streamed = list(adapter.process(events))
+            answer_messages = [
+                message.content
+                for message in streamed
+                if message.type == "element"
+                and message.content.element_type == ElementType.ANSWER
+            ]
+
+            assert len(answer_messages) == 3
+            assert answer_messages[0].content_text == "hello"
+            assert answer_messages[0].is_final is False
+            assert answer_messages[1].content_text == "hello world"
+            assert answer_messages[1].is_final is False
+            assert answer_messages[2].content_text == "hello world"
+            assert answer_messages[2].is_final is True
+
+            logical_answer_bid = (
+                answer_messages[0].target_element_bid or answer_messages[0].element_bid
+            )
+            assert logical_answer_bid
+            assert (
+                answer_messages[1].target_element_bid or answer_messages[1].element_bid
+            ) == logical_answer_bid
+            assert (
+                answer_messages[2].target_element_bid or answer_messages[2].element_bid
+            ) == logical_answer_bid
+
+            answer_rows = (
+                LearnGeneratedElement.query.filter(
+                    LearnGeneratedElement.generated_block_bid == "ask_gb_multi_chunk",
+                    LearnGeneratedElement.element_type == "answer",
+                    LearnGeneratedElement.run_session_bid == adapter.run_session_bid,
+                )
+                .order_by(
+                    LearnGeneratedElement.run_event_seq.asc(),
+                    LearnGeneratedElement.id.asc(),
+                )
+                .all()
+            )
+            assert len(answer_rows) == 1
+            assert answer_rows[0].status == 1
+            assert answer_rows[0].content_text == "hello world"
+            assert answer_rows[0].target_element_bid == logical_answer_bid
+
     def test_process_creates_answer_element_for_patched_anchor_bid(self, adapter_app):
         from flaskr.service.learn.listen_element_payloads import _serialize_payload
         from flaskr.service.learn.listen_elements import ListenElementRunAdapter


### PR DESCRIPTION
## Summary
- stop persisting intermediate follow-up answer element patches while keeping the existing SSE element stream
- keep latest follow-up answer snapshots in memory so final persisted rows reuse the same logical element identity
- add a regression test covering multi-chunk follow-up answers with a single final stored answer row

## Testing
- pre-commit run -a
- cd src/api && pytest tests/service/learn/test_element_protocol.py -q -k "standalone_answer_element or multi_chunk_follow_up_answer or patched_anchor_bid or answer_audio_events_do_not_attach_audio or handle_input_ask_provider_stream_returns_answer_element or handle_input_ask_provider_only_error_returns_answer_element"
- python -m py_compile src/api/flaskr/service/learn/listen_elements.py src/api/flaskr/service/learn/listen_element_run_persistence.py src/api/flaskr/service/learn/listen_element_run_stream.py src/api/tests/service/learn/test_element_protocol.py

## Notes
- a full run of tests/service/learn/test_element_protocol.py is not clean in the current environment because of pre-existing litellm/openai import issues and an unrelated TestVisualKindMapping failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented real-time streaming of intermediate content updates to users while only persisting the final version to the database, improving responsiveness for multi-chunk content delivery.

* **Tests**
  * Added test coverage for multi-chunk answer content, verifying correct streaming behavior and database persistence of final content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->