### PR TITLE
fix(cook-web): preserve mobile follow-up button after finalize updates

### DIFF
--- a/src/cook-web/skills/chat-actionbar-ask-placement/SKILL.md
+++ b/src/cook-web/skills/chat-actionbar-ask-placement/SKILL.md
@@ -19,6 +19,8 @@ description: 当调整聊天操作栏、追问入口和 AskBlock 锚点时使用
 - 当需求要求“按接口顺序直接展示内容与追问”时，不要额外引入 `readyElementBids`、`onTypeFinished` 等前端渲染门禁。
 - SSE 流里 `ELEMENT/CONTENT` 阶段只更新当前元素本体，不要提前插入 `LIKE_STATUS`；追问入口统一在 `TEXT_END` 后补齐，避免按钮先于流式正文出现。
 - 若后端未必为每个 `element` 都补 `TEXT_END`，前端可在“下一个 `element` 开始”或“当前流关闭”时，把上一个活动 `element` 视为隐式完成并补齐追问入口。
+- 移动端阅读模式的正文追问按钮时序必须完全复用 `useChatLogicHook` 的 finalize 结果；渲染层只消费已有 `content/LIKE_STATUS/ASK` 状态，不能再按相邻元素关系提前补按钮。
+- 移动端正文一旦在 finalize 后补上 `custom-button-after-content`，同一 `element_bid` 后续再收到 `ELEMENT/CONTENT` 覆盖时也必须继承该按钮，不能用新的原始正文把它抹掉，否则会出现“按钮闪一下又消失”。
 - 交互块触发 `onSend` 且需要截断后续内容时，必须保留该交互块关联的辅助行（`LIKE_STATUS` / `ASK`），避免进入思考中后追问入口消失。
 - 后台调试/预览链路中收到 `interaction` 时，也要为该 `interaction` 本身补齐 `LIKE_STATUS`，否则追问按钮不会渲染。
 - 重生成判定不能直接依赖“列表最后一项”；应忽略 `LIKE_STATUS`/`ASK` 等辅助行，按“最后可操作元素”判断，避免点击末尾交互块误弹重生成确认框。

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -40,8 +40,6 @@ import {
 } from '@/c-utils/audio-utils';
 import { ELEMENT_TYPE } from '@/c-api/studyV2';
 import {
-  resolvePreviousActionableItem,
-  shouldShowMobileAskButtonForReadContent,
   syncCustomButtonAfterContent,
 } from './chatUiUtils';
 import {
@@ -81,12 +79,10 @@ const buildReadModeItemsWithAskState = ({
   items,
   askListByAnchorElementBid,
   mobileStyle,
-  askButtonMarkup,
 }: {
   items: ChatContentItem[];
   askListByAnchorElementBid: Record<string, AskMessage[]>;
   mobileStyle: boolean;
-  askButtonMarkup: string;
 }) => {
   const existingAskAnchorSet = new Set<string>();
   const likeStatusAnchorSet = new Set<string>();
@@ -107,24 +103,7 @@ const buildReadModeItemsWithAskState = ({
   const insertedAskAnchorSet = new Set<string>();
   const nextItems: ChatContentItem[] = [];
 
-  items.forEach((item, index) => {
-    const previousActionableItem = resolvePreviousActionableItem(items, index);
-    const shouldShowMobileAskButton = shouldShowMobileAskButtonForReadContent({
-      item,
-      previousActionableItem,
-    });
-    const nextItem =
-      mobileStyle && item.type === ChatContentItemType.CONTENT
-        ? ({
-            ...item,
-            content: syncCustomButtonAfterContent({
-              content: item.content,
-              buttonMarkup: askButtonMarkup,
-              shouldShowButton: shouldShowMobileAskButton,
-            }),
-          } satisfies ChatContentItem)
-        : item;
-
+  items.forEach(item => {
     if (item.type === ChatContentItemType.ASK) {
       const anchorElementBid = item.parent_element_bid || '';
       const storedAskList = anchorElementBid
@@ -147,12 +126,12 @@ const buildReadModeItemsWithAskState = ({
       return;
     }
 
-    nextItems.push(nextItem);
+    nextItems.push(item);
 
     const anchorElementBid =
-      nextItem.type === ChatContentItemType.LIKE_STATUS
-        ? nextItem.parent_element_bid || ''
-        : nextItem.element_bid || '';
+      item.type === ChatContentItemType.LIKE_STATUS
+        ? item.parent_element_bid || ''
+        : item.element_bid || '';
 
     if (
       !anchorElementBid ||
@@ -169,10 +148,10 @@ const buildReadModeItemsWithAskState = ({
     }
 
     const shouldInsertAfterCurrent =
-      nextItem.type === ChatContentItemType.LIKE_STATUS ||
+      item.type === ChatContentItemType.LIKE_STATUS ||
       (!likeStatusAnchorSet.has(anchorElementBid) &&
-        (nextItem.type === ChatContentItemType.CONTENT ||
-          nextItem.type === ChatContentItemType.INTERACTION));
+        (item.type === ChatContentItemType.CONTENT ||
+          item.type === ChatContentItemType.INTERACTION));
 
     if (!shouldInsertAfterCurrent) {
       return;
@@ -521,9 +500,8 @@ export const NewChatComponents = ({
         items,
         askListByAnchorElementBid: scopedAskListByAnchorElementBid,
         mobileStyle,
-        askButtonMarkup,
       }),
-    [askButtonMarkup, items, mobileStyle, scopedAskListByAnchorElementBid],
+    [items, mobileStyle, scopedAskListByAnchorElementBid],
   );
 
   useEffect(() => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -39,9 +39,7 @@ import {
   hasAudioContentInTrack,
 } from '@/c-utils/audio-utils';
 import { ELEMENT_TYPE } from '@/c-api/studyV2';
-import {
-  syncCustomButtonAfterContent,
-} from './chatUiUtils';
+import { syncCustomButtonAfterContent } from './chatUiUtils';
 import {
   Dialog,
   DialogContent,

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiUtils.test.ts
@@ -1,7 +1,7 @@
 import {
   appendCustomButtonAfterContent,
-  resolvePreviousActionableItem,
-  shouldShowMobileAskButtonForReadContent,
+  hasCustomButtonAfterContent,
+  inheritCustomButtonAfterContent,
   syncCustomButtonAfterContent,
 } from './chatUiUtils';
 
@@ -36,64 +36,30 @@ describe('chatUiUtils', () => {
     ).toBe('Lesson summary');
   });
 
-  it('hides the mobile follow-up button for loading placeholders', () => {
-    expect(
-      shouldShowMobileAskButtonForReadContent({
-        item: {
-          element_bid: 'loading',
-          type: 'content',
-        },
-      }),
-    ).toBe(false);
+  it('detects the follow-up button markup in content', () => {
+    const contentWithButton = appendCustomButtonAfterContent(
+      'Lesson summary',
+      buttonMarkup,
+    );
+
+    expect(hasCustomButtonAfterContent(contentWithButton)).toBe(true);
+    expect(hasCustomButtonAfterContent('Lesson summary')).toBe(false);
   });
 
-  it('hides the mobile follow-up button for content after an interaction', () => {
-    const items = [
-      {
-        element_bid: 'interaction-1',
-        type: 'interaction',
-      },
-      {
-        parent_element_bid: 'interaction-1',
-        type: 'likeStatus',
-      },
-      {
-        element_bid: 'content-1',
-        type: 'content',
-      },
-    ];
-    const previousActionableItem = resolvePreviousActionableItem(items, 2);
+  it('inherits the follow-up button from previous finalized content', () => {
+    const previousContent = appendCustomButtonAfterContent(
+      'Lesson summary',
+      buttonMarkup,
+    );
 
     expect(
-      shouldShowMobileAskButtonForReadContent({
-        item: items[2],
-        previousActionableItem,
+      inheritCustomButtonAfterContent({
+        nextContent: 'Updated lesson summary',
+        previousContent,
+        buttonMarkup,
       }),
-    ).toBe(false);
-  });
-
-  it('keeps the mobile follow-up button for regular read-mode content', () => {
-    const items = [
-      {
-        element_bid: 'content-0',
-        type: 'content',
-      },
-      {
-        parent_element_bid: 'content-0',
-        type: 'likeStatus',
-      },
-      {
-        element_bid: 'content-1',
-        type: 'content',
-      },
-    ];
-    const previousActionableItem = resolvePreviousActionableItem(items, 2);
-
-    expect(
-      shouldShowMobileAskButtonForReadContent({
-        item: items[2],
-        previousActionableItem,
-      }),
-    ).toBe(true);
+    ).toBe(
+      appendCustomButtonAfterContent('Updated lesson summary', buttonMarkup),
+    );
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiUtils.ts
@@ -11,8 +11,6 @@ type LegacyBlockCompatItem = {
   type?: string;
 };
 
-type ReadModeAskButtonCandidate = LegacyBlockCompatItem;
-
 export const appendCustomButtonAfterContent = (
   content: string | undefined,
   buttonMarkup: string,
@@ -36,13 +34,19 @@ export const appendCustomButtonAfterContent = (
   return baseContent + needsLineBreak + buttonMarkup;
 };
 
+export const hasCustomButtonAfterContent = (
+  content?: string | null,
+): boolean => {
+  return Boolean(content?.includes(CUSTOM_BUTTON_AFTER_CONTENT_TAG));
+};
+
 export const stripCustomButtonAfterContent = (
   content?: string | null,
 ): string | null | undefined => {
   if (!content) {
     return content;
   }
-  if (!content.includes(CUSTOM_BUTTON_AFTER_CONTENT_TAG)) {
+  if (!hasCustomButtonAfterContent(content)) {
     return content;
   }
   // Remove ask button markup from listen mode content.
@@ -65,6 +69,24 @@ export const syncCustomButtonAfterContent = ({
   }
 
   return stripCustomButtonAfterContent(baseContent) ?? '';
+};
+
+export const inheritCustomButtonAfterContent = ({
+  nextContent,
+  previousContent,
+  buttonMarkup,
+}: {
+  nextContent?: string | null;
+  previousContent?: string | null;
+  buttonMarkup: string;
+}): string => {
+  const resolvedNextContent = nextContent ?? '';
+
+  if (!hasCustomButtonAfterContent(previousContent)) {
+    return resolvedNextContent;
+  }
+
+  return appendCustomButtonAfterContent(resolvedNextContent, buttonMarkup);
 };
 
 export const normalizeLegacyBlockCompatItem = <T extends LegacyBlockCompatItem>(
@@ -103,50 +125,3 @@ export const normalizeLegacyBlockCompatItem = <T extends LegacyBlockCompatItem>(
 export const normalizeLegacyBlockCompatList = <T extends LegacyBlockCompatItem>(
   items: T[],
 ): T[] => items.map(normalizeLegacyBlockCompatItem);
-
-export const resolvePreviousActionableItem = <
-  T extends ReadModeAskButtonCandidate,
->(
-  items: T[],
-  currentIndex: number,
-): T | undefined => {
-  for (let index = currentIndex - 1; index >= 0; index -= 1) {
-    const candidate = items[index];
-
-    if (!candidate) {
-      continue;
-    }
-
-    if (candidate.element_bid === 'loading') {
-      continue;
-    }
-
-    if (candidate.type === 'ask' || candidate.type === 'likeStatus') {
-      continue;
-    }
-
-    return candidate;
-  }
-
-  return undefined;
-};
-
-export const shouldShowMobileAskButtonForReadContent = <
-  T extends ReadModeAskButtonCandidate,
->({
-  item,
-  previousActionableItem,
-}: {
-  item: T;
-  previousActionableItem?: T;
-}): boolean => {
-  if (item.type !== 'content') {
-    return false;
-  }
-
-  if (!item.element_bid || item.element_bid === 'loading') {
-    return false;
-  }
-
-  return previousActionableItem?.type !== 'interaction';
-};

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -237,6 +237,20 @@ describe('useChatLogicHook stream cleanup', () => {
     </AppContext.Provider>
   );
 
+  const mobileWrapper = ({ children }: { children: React.ReactNode }) => (
+    <AppContext.Provider
+      value={{
+        isLoggedIn: false,
+        mobileStyle: true,
+        userInfo: null,
+        theme: 'light',
+        frameLayout: 0,
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+
   const buildBaseParams = () => ({
     shifuBid: 'shifu-1',
     outlineBid: 'lesson-1',
@@ -662,20 +676,6 @@ describe('useChatLogicHook stream cleanup', () => {
       records: [],
     });
 
-    const mobileWrapper = ({ children }: { children: React.ReactNode }) => (
-      <AppContext.Provider
-        value={{
-          isLoggedIn: false,
-          mobileStyle: true,
-          userInfo: null,
-          theme: 'light',
-          frameLayout: 0,
-        }}
-      >
-        {children}
-      </AppContext.Provider>
-    );
-
     const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
       wrapper: mobileWrapper,
     });
@@ -689,6 +689,217 @@ describe('useChatLogicHook stream cleanup', () => {
     );
     expect(askBlock).toBeDefined();
     expect(askBlock?.isAskExpanded).toBe(false);
+  });
+
+  it('finalizes previous mobile content when a new element arrives', async () => {
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper: mobileWrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-html-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-html-1',
+          generated_block_bid: 'content-html-1',
+          element_type: 'html',
+          content: '<p>HTML block</p>',
+          like_status: 'none',
+        },
+      });
+    });
+
+    expect(
+      result.current.items.find(item => item.element_bid === 'content-html-1')
+        ?.content,
+    ).not.toContain('<custom-button-after-content>');
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-2',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-text-2',
+          generated_block_bid: 'content-text-2',
+          element_type: 'text',
+          content: 'Text block',
+          like_status: 'none',
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(item => item.element_bid === 'content-html-1')
+          ?.content,
+      ).toContain('<custom-button-after-content>'),
+    );
+    expect(
+      result.current.items.find(
+        item =>
+          item.type === ChatContentItemType.LIKE_STATUS &&
+          item.parent_element_bid === 'content-html-1',
+      ),
+    ).toBeDefined();
+    expect(
+      result.current.items.find(item => item.element_bid === 'content-text-2')
+        ?.content,
+    ).not.toContain('<custom-button-after-content>');
+  });
+
+  it('adds the mobile follow-up button only after text end for the current element', async () => {
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper: mobileWrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-text-1',
+          generated_block_bid: 'content-text-1',
+          element_type: 'text',
+          content: 'First line',
+          like_status: 'none',
+        },
+      });
+    });
+
+    expect(
+      result.current.items.find(item => item.element_bid === 'content-text-1')
+        ?.content,
+    ).not.toContain('<custom-button-after-content>');
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-1',
+        type: SSE_OUTPUT_TYPE.TEXT_END,
+        content: '',
+        is_terminal: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(item => item.element_bid === 'content-text-1')
+          ?.content,
+      ).toContain('<custom-button-after-content>'),
+    );
+    expect(
+      result.current.items.find(
+        item =>
+          item.type === ChatContentItemType.LIKE_STATUS &&
+          item.parent_element_bid === 'content-text-1',
+      ),
+    ).toBeDefined();
+  });
+
+  it('keeps the mobile follow-up button after finalized content receives more stream text', async () => {
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper: mobileWrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-text-1',
+          generated_block_bid: 'content-text-1',
+          element_type: 'text',
+          content: 'First line',
+          like_status: 'none',
+        },
+      });
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-1',
+        type: SSE_OUTPUT_TYPE.TEXT_END,
+        content: '',
+        is_terminal: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(item => item.element_bid === 'content-text-1')
+          ?.content,
+      ).toContain('<custom-button-after-content>'),
+    );
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-text-1',
+        type: SSE_OUTPUT_TYPE.CONTENT,
+        content: ' and second line',
+      });
+    });
+
+    expect(
+      result.current.items.find(item => item.element_bid === 'content-text-1')
+        ?.content,
+    ).toContain('<custom-button-after-content>');
+  });
+
+  it('keeps the mobile follow-up button after finalized content receives another element update', async () => {
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper: mobileWrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-html-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-html-1',
+          generated_block_bid: 'content-html-1',
+          element_type: 'html',
+          content: '<p>HTML block</p>',
+          like_status: 'none',
+        },
+      });
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-html-1',
+        type: SSE_OUTPUT_TYPE.TEXT_END,
+        content: '',
+        is_terminal: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(item => item.element_bid === 'content-html-1')
+          ?.content,
+      ).toContain('<custom-button-after-content>'),
+    );
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-html-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-html-1',
+          generated_block_bid: 'content-html-1',
+          element_type: 'html',
+          content: '<p>Updated HTML block</p>',
+          like_status: 'none',
+        },
+      });
+    });
+
+    expect(
+      result.current.items.find(item => item.element_bid === 'content-html-1')
+        ?.content,
+    ).toContain('<custom-button-after-content>');
   });
 
   it('keeps ask block position by history sequence order instead of anchor position', async () => {
@@ -777,6 +988,12 @@ describe('useChatLogicHook stream cleanup', () => {
           content: 'Hello',
           like_status: 'none',
         },
+      });
+      await activeRun?.onMessage({
+        generated_block_bid: 'content-1',
+        type: SSE_OUTPUT_TYPE.TEXT_END,
+        content: '',
+        is_terminal: false,
       });
     });
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -67,6 +67,8 @@ import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
 import { AppContext } from '../AppContext';
 import {
   appendCustomButtonAfterContent,
+  hasCustomButtonAfterContent,
+  inheritCustomButtonAfterContent,
   normalizeLegacyBlockCompatList,
 } from './chatUiUtils';
 
@@ -479,7 +481,7 @@ function useChatLogicHook({
         mobileStyle &&
         !isListenMode &&
         targetItem.type === ChatContentItemType.CONTENT &&
-        !targetItem.content?.includes(`<custom-button-after-content>`)
+        !hasCustomButtonAfterContent(targetItem.content)
       ) {
         nextItems[targetIndex] = {
           ...targetItem,
@@ -745,13 +747,18 @@ function useChatLogicHook({
       const isInteractionElement =
         record.element_type === ELEMENT_TYPE.INTERACTION;
       const rawContent = record.content ?? '';
-      const content =
+      const contentWithAskButton =
         options?.appendAskButton &&
         mobileStyle &&
         !isListenMode &&
         !isInteractionElement
           ? appendCustomButtonAfterContent(rawContent, getAskButtonMarkup())
           : rawContent;
+      const content = inheritCustomButtonAfterContent({
+        nextContent: contentWithAskButton,
+        previousContent: options?.previousItem?.content,
+        buttonMarkup: getAskButtonMarkup(),
+      });
 
       return {
         ...options?.previousItem,
@@ -765,7 +772,7 @@ function useChatLogicHook({
           options?.previousItem?.user_input ??
           '',
         readonly: options?.previousItem?.readonly ?? false,
-        isHistory: options?.isHistory,
+        isHistory: options?.isHistory ?? options?.previousItem?.isHistory,
         type: isInteractionElement
           ? ChatContentItemType.INTERACTION
           : ChatContentItemType.CONTENT,
@@ -1412,7 +1419,11 @@ function useChatLogicHook({
                       hasItem = true;
                       return {
                         ...item,
-                        content: displayText,
+                        content: inheritCustomButtonAfterContent({
+                          nextContent: displayText,
+                          previousContent: item.content,
+                          buttonMarkup: getAskButtonMarkup(),
+                        }),
                         customRenderBar: () => null,
                         listenSlides:
                           item.listenSlides ??


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed follow-up buttons briefly disappearing and reappearing in mobile read mode when chat content updates
  * Improved button persistence stability across content refreshes and interactions

* **Refactor**
  * Simplified internal logic for managing follow-up button state and visibility in chat read mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->