### PR TITLE
fix: broaden operations course revenue metrics

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -25,11 +25,6 @@ from flaskr.service.common.dtos import PageNationDTO
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
-from flaskr.service.promo.consts import (
-    COUPON_STATUS_USED,
-    PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
-)
-from flaskr.service.promo.models import CouponUsage, PromoRedemption
 from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseChapterDetailDTO,
     AdminOperationCourseDetailBasicInfoDTO,
@@ -2029,31 +2024,9 @@ def get_operator_course_detail(
             .scalar()
             or 0
         )
-        redeemed_discount_order_bids = (
-            db.session.query(CouponUsage.order_bid.label("order_bid"))
-            .filter(
-                CouponUsage.shifu_bid == normalized_shifu_bid,
-                CouponUsage.deleted == 0,
-                CouponUsage.status == COUPON_STATUS_USED,
-            )
-            .union(
-                db.session.query(PromoRedemption.order_bid.label("order_bid")).filter(
-                    PromoRedemption.shifu_bid == normalized_shifu_bid,
-                    PromoRedemption.deleted == 0,
-                    PromoRedemption.status == PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
-                )
-            )
-            .subquery()
-        )
         order_amount_expr = case(
             (Order.paid_price > 0, Order.paid_price),
-            (
-                and_(
-                    redeemed_discount_order_bids.c.order_bid.isnot(None),
-                    Order.payable_price > 0,
-                ),
-                Order.payable_price,
-            ),
+            (Order.payable_price > 0, Order.payable_price),
             else_=0,
         )
         order_summary = (
@@ -2062,10 +2035,6 @@ def get_operator_course_detail(
                 db.func.coalesce(db.func.sum(order_amount_expr), 0).label(
                     "order_amount"
                 ),
-            )
-            .outerjoin(
-                redeemed_discount_order_bids,
-                redeemed_discount_order_bids.c.order_bid == Order.order_bid,
             )
             .filter(
                 Order.shifu_bid == normalized_shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -204,7 +204,7 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     order_count: int = Field(..., description="Successful order count", required=False)
     order_amount: str = Field(
         ...,
-        description="Collected amount for successful orders using paid price when present, otherwise payable price",
+        description="Collected amount for successful orders using paid price when paid_price > 0, otherwise payable price when payable_price > 0",
         required=False,
     )
     follow_up_count: int = Field(

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -204,7 +204,7 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     order_count: int = Field(..., description="Successful order count", required=False)
     order_amount: str = Field(
         ...,
-        description="Collected amount including full coupon and promo redemptions",
+        description="Collected amount for successful orders using paid price when present, otherwise payable price",
         required=False,
     )
     follow_up_count: int = Field(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1478,6 +1478,163 @@ def test_admin_operation_course_detail_metrics_include_full_promo_redemptions(
     assert payload["data"]["metrics"]["order_amount"] == "154"
 
 
+def test_admin_operation_course_detail_metrics_prefer_paid_price_and_fallback_to_payable_price(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.admin.get_course_visit_count_30d",
+        lambda _app, _shifu_bid: 0,
+    )
+    created_at = datetime(2026, 4, 3, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        db.session.add_all(
+            [
+                Order(
+                    order_bid="order-direct-paid",
+                    shifu_bid="course-detail",
+                    user_bid="user-direct-paid",
+                    payable_price=Decimal("88.00"),
+                    paid_price=Decimal("88.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-partial-discount",
+                    shifu_bid="course-detail",
+                    user_bid="user-partial-discount",
+                    payable_price=Decimal("49.00"),
+                    paid_price=Decimal("19.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-external-paid",
+                    shifu_bid="course-detail",
+                    user_bid="user-external-paid",
+                    payable_price=Decimal("66.00"),
+                    paid_price=Decimal("0.00"),
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+            ]
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/detail",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["metrics"]["order_count"] == 3
+    assert payload["data"]["metrics"]["order_amount"] == "173"
+
+
+def test_admin_operation_course_detail_metrics_include_successful_orders_across_channels(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.admin.get_course_visit_count_30d",
+        lambda _app, _shifu_bid: 0,
+    )
+    created_at = datetime(2026, 4, 4, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        db.session.add_all(
+            [
+                Order(
+                    order_bid="order-manual-paid",
+                    shifu_bid="course-detail",
+                    user_bid="user-manual-paid",
+                    payable_price=Decimal("88.00"),
+                    paid_price=Decimal("88.00"),
+                    payment_channel="manual",
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-manual-external-redeem",
+                    shifu_bid="course-detail",
+                    user_bid="user-manual-redeem",
+                    payable_price=Decimal("66.00"),
+                    paid_price=Decimal("0.00"),
+                    payment_channel="manual",
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-openapi-external-redeem",
+                    shifu_bid="course-detail",
+                    user_bid="user-openapi-redeem",
+                    payable_price=Decimal("99.00"),
+                    paid_price=Decimal("0.00"),
+                    payment_channel="open_api",
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+                Order(
+                    order_bid="order-activation-zero",
+                    shifu_bid="course-detail",
+                    user_bid="user-activation-zero",
+                    payable_price=Decimal("0.00"),
+                    paid_price=Decimal("0.00"),
+                    payment_channel="manual",
+                    status=ORDER_STATUS_SUCCESS,
+                    deleted=0,
+                    created_at=created_at,
+                    updated_at=created_at,
+                ),
+            ]
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/detail",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["metrics"]["order_count"] == 4
+    assert payload["data"]["metrics"]["order_amount"] == "253"
+
+
 @pytest.mark.parametrize(
     ("query_string", "expected_param"),
     [


### PR DESCRIPTION
## Summary

## What
- broaden operations course detail revenue aggregation to use `paid_price` first and fall back to `payable_price` for successful orders
- remove the coupon/promo-only gating so externally redeemed revenue is included in the course income view
- add focused backend tests for cross-channel successful orders and zero-value activation orders

## Why
The goal of this metric is to understand course revenue more accurately, not only revenue settled directly inside the platform.

Coupon or promo redemption can still represent real course revenue when users purchased redemption rights through an external channel and then redeemed on the platform. Restricting the fallback to coupon/promo linkage undercounts this type of income, and it also misses other successful external-channel orders where `paid_price` is zero but `payable_price` still records the revenue amount.

With this change, the metric behaves as:
- use `paid_price` when it is present
- otherwise use `payable_price` for successful orders
- keep zero-value activation / authorization orders counted in order volume but excluded from revenue

## Tests
- `cd src/api && LOGGING_PATH=logs/local-debug.log ./.venv/bin/pytest -q tests/service/shifu/test_admin_course_detail.py`
- `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Order amount calculation simplified. System now uses paid price when available; otherwise, falls back to payable price for metrics reporting.
  * Updated order metrics documentation to reflect current calculation methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->