### PR TITLE
refactor: share admin table behaviors across admin pages

### DIFF
--- a/docs/shared-admin-table-component.md
+++ b/docs/shared-admin-table-component.md
@@ -1,0 +1,336 @@
+# Shared Admin Table Component
+
+## Context
+
+The admin operations and order pages already share a large amount of table
+behavior, but the shared logic still lives inside individual pages today.
+
+Current repetition exists across:
+
+- `src/cook-web/src/app/admin/operations/page.tsx`
+- `src/cook-web/src/app/admin/orders/page.tsx`
+- `src/cook-web/src/app/admin/operations/users/page.tsx`
+- `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
+- `src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx`
+
+The repeated patterns include:
+
+- loading / empty / table / footer shell structure
+- resizable columns with width persistence in `localStorage`
+- sticky right-side action columns
+- repeated tooltip-based truncated text rendering
+- repeated pagination placement and composition
+
+Two prerequisite frontend refactors already exist as open PRs and should stay
+independent:
+
+- PR `#1542`: shared admin pagination component
+- PR `#1545`: shared admin tooltip text component
+
+This design assumes those two PRs merge into `main` first, and then this branch
+builds the shared admin table layer on top of them.
+
+## Goals
+
+- Introduce a shared admin table layer for operations and order pages.
+- Reduce repeated table shell and column-resize logic across admin pages.
+- Preserve current UX for resizable columns and sticky action columns.
+- Keep pagination and tooltip text reusable as independent components.
+- Make the first migration small enough to validate safely on two pages before
+  wider rollout.
+
+## Non-Goals
+
+- Do not replace `src/cook-web/src/components/ui/Table.tsx` with an admin-only
+  implementation.
+- Do not merge pagination, tooltip text, and admin table shell into one
+  monolithic component.
+- Do not abstract page-specific filters, data fetching, dialogs, or row-level
+  business actions in the first version.
+- Do not force every admin table to support pagination or tooltip text.
+
+## Existing Layering
+
+The current and target layering should remain:
+
+1. Base UI table primitives
+   - `src/cook-web/src/components/ui/Table.tsx`
+2. Independent admin utilities
+   - `src/cook-web/src/app/admin/components/AdminPagination.tsx`
+   - `src/cook-web/src/app/admin/components/AdminTooltipText.tsx`
+3. New admin table capability layer
+   - `AdminTableShell`
+   - `useAdminResizableColumns`
+   - sticky column style helpers
+4. Page-specific business rendering
+   - column definitions
+   - row content
+   - filters
+   - dialogs
+   - actions
+
+## Proposed Shared Admin Table Layer
+
+### 1. `AdminTableShell`
+
+Suggested path:
+
+- `src/cook-web/src/app/admin/components/AdminTableShell.tsx`
+
+Responsibilities:
+
+- render the common table container shell
+- render loading state
+- render empty state
+- render the provided table markup
+- render an optional footer slot
+- optionally wrap the subtree with `TooltipProvider`
+
+Suggested props:
+
+- `loading`
+- `isEmpty`
+- `emptyContent`
+- `emptyColSpan`
+- `table`
+- `footer`
+- `withTooltipProvider`
+- `containerClassName`
+- `tableWrapperClassName`
+
+Important boundary:
+
+- `AdminTableShell` does not own pagination logic
+- `AdminTableShell` does not own tooltip text logic
+- `AdminTableShell` does not own column definitions or row rendering
+
+It only provides the stable outer structure.
+
+### 2. `useAdminResizableColumns`
+
+Suggested path:
+
+- `src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts`
+
+Responsibilities:
+
+- initialize column widths from defaults
+- enforce min / max width limits
+- track drag-resize interaction
+- persist manual widths to `localStorage`
+- restore widths after reload
+- expose width styles for headers and cells
+- expose resize handle rendering or props
+
+Suggested API shape:
+
+```ts
+const { columnWidths, getColumnStyle, getResizeHandleProps } =
+  useAdminResizableColumns({
+    storageKey: 'adminOrdersColumnWidths',
+    defaultWidths,
+    minWidth: 80,
+    maxWidth: 360,
+  });
+```
+
+Design requirements:
+
+- match the current user-facing resize behavior as closely as possible
+- keep the API generic enough for orders, operations, and course detail tables
+- avoid coupling to a specific page data type
+
+### 3. Sticky Right Column Helpers
+
+Suggested path:
+
+- `src/cook-web/src/app/admin/components/adminTableStyles.ts`
+  or a similarly named local helper file
+
+Responsibilities:
+
+- centralize shared sticky-right header styles
+- centralize shared sticky-right cell styles
+- preserve shadow, separator, and z-index behavior
+
+Important boundary:
+
+- keep this lightweight in v1
+- do not introduce a heavyweight dedicated sticky-column component unless the
+  first migration proves that helper functions or class constants are
+  insufficient
+
+## Why Pagination And Tooltip Stay Independent
+
+### Pagination
+
+Pagination should stay independent because:
+
+- not every admin table paginates
+- pagination is not inherently table-specific
+- some dialog tables or summary tables are intentionally unpaginated
+
+The table shell should expose a footer slot, and pages should pass
+`AdminPagination` only when needed.
+
+### Tooltip Text
+
+Tooltip text should stay independent because:
+
+- not every cell needs truncation help
+- some cells render badges, buttons, or multi-line custom content
+- the tooltip component is already a useful independent primitive outside the
+  future table shell
+
+Pages should continue to opt into `AdminTooltipText` at the cell level.
+
+## Recommended Composition Pattern
+
+After the prerequisite PRs merge, target page composition should resemble:
+
+```tsx
+<AdminTableShell
+  loading={loading}
+  isEmpty={items.length === 0}
+  emptyContent={emptyText}
+  emptyColSpan={columnCount}
+  table={
+    <Table>
+      {/* header + body defined by the page */}
+    </Table>
+  }
+  footer={
+    pageCount > 1 ? (
+      <AdminPagination
+        pageIndex={pageIndex}
+        pageCount={pageCount}
+        onPageChange={handlePageChange}
+      />
+    ) : null
+  }
+  withTooltipProvider
+/>
+```
+
+Cell content remains page-owned:
+
+```tsx
+<AdminTooltipText text={value} />
+```
+
+## Rollout Plan
+
+### Phase 0: Wait For Prerequisites
+
+Before implementation on this branch:
+
+- PR `#1542` must merge to `main`
+- PR `#1545` must merge to `main`
+
+Then:
+
+- update local `main`
+- rebase or recreate `refactor/shared-table-component` from the latest `main`
+
+### Phase 1: Build Shared Capabilities
+
+Create:
+
+- `AdminTableShell`
+- `useAdminResizableColumns`
+- sticky-right style helpers
+
+At this phase, do not migrate every page yet.
+
+### Phase 2: First Migration Targets
+
+Migrate first:
+
+- `src/cook-web/src/app/admin/operations/page.tsx`
+- `src/cook-web/src/app/admin/orders/page.tsx`
+
+Reasons:
+
+- both are standard list pages
+- both use pagination
+- both use resizable columns
+- both use sticky right-side action columns
+- both are the cleanest validation targets for the new shared layer
+
+### Phase 3: Secondary Migration
+
+Migrate next:
+
+- `src/cook-web/src/app/admin/operations/users/page.tsx`
+
+This page is more complex but still follows the same list-page structure.
+
+### Phase 4: Complex Page Migration
+
+Migrate last:
+
+- `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
+
+Reasons:
+
+- it contains multiple tables
+- it mixes detail-page concerns with table concerns
+- it is the highest-risk page for over-abstraction
+
+## Validation Plan
+
+For each migrated page:
+
+- run focused page tests first
+- then run broader frontend validation
+
+Required checks after meaningful implementation work:
+
+- `cd src/cook-web && npm run lint`
+- `pre-commit run -a`
+
+Likely focused tests during rollout:
+
+- `src/app/admin/operations/page.test.tsx`
+- `src/app/admin/orders/page.test.tsx`
+- `src/app/admin/operations/users/page.test.tsx`
+- `src/app/admin/operations/[shifu_bid]/page.test.tsx`
+
+## Risks And Guardrails
+
+### Risk: Over-abstracting Page Logic
+
+Guardrail:
+
+- keep filters, requests, dialogs, and row actions inside each page
+
+### Risk: Regressing Resize UX
+
+Guardrail:
+
+- match the current pointer interaction and persisted-width behavior closely
+- migrate only two pages first before expanding scope
+
+### Risk: Sticky Column Visual Regressions
+
+Guardrail:
+
+- centralize only the shared sticky-right styles first
+- keep page-specific action content unchanged
+
+### Risk: Waiting On Open PRs
+
+Guardrail:
+
+- do not begin the shared table implementation until PR `#1542` and PR `#1545`
+  are both merged into `main`
+
+## Expected Outcome
+
+After this work:
+
+- admin list pages should share one table shell pattern
+- resizable column behavior should be maintained through one shared hook
+- sticky right-side action column styling should stop being copy-pasted
+- pagination and tooltip text remain independent and reusable
+- future operations-style list pages should be cheaper to add and maintain

--- a/docs/shared-admin-table-component.md
+++ b/docs/shared-admin-table-component.md
@@ -21,14 +21,13 @@ The repeated patterns include:
 - repeated tooltip-based truncated text rendering
 - repeated pagination placement and composition
 
-Two prerequisite frontend refactors already exist as open PRs and should stay
-independent:
+Two prerequisite frontend refactors were delivered independently first:
 
 - PR `#1542`: shared admin pagination component
 - PR `#1545`: shared admin tooltip text component
 
-This design assumes those two PRs merge into `main` first, and then this branch
-builds the shared admin table layer on top of them.
+This shared table work builds on top of those merged utilities and reuses them
+as runtime dependencies in the migrated admin pages.
 
 ## Goals
 
@@ -220,31 +219,29 @@ Cell content remains page-owned:
 
 ## Rollout Plan
 
-### Phase 0: Wait For Prerequisites
+### Phase 0: Prerequisites Landed
 
-Before implementation on this branch:
+This rollout started after the shared admin pagination and shared admin tooltip
+refactors landed in `main`.
 
-- PR `#1542` must merge to `main`
-- PR `#1545` must merge to `main`
-
-Then:
+Branch preparation for this implementation:
 
 - update local `main`
 - rebase or recreate `refactor/shared-table-component` from the latest `main`
 
 ### Phase 1: Build Shared Capabilities
 
-Create:
+Implemented in this PR:
 
 - `AdminTableShell`
 - `useAdminResizableColumns`
 - sticky-right style helpers
 
-At this phase, do not migrate every page yet.
+These shared capabilities are now used by the migrated admin pages below.
 
 ### Phase 2: First Migration Targets
 
-Migrate first:
+Migrated first in this rollout:
 
 - `src/cook-web/src/app/admin/operations/page.tsx`
 - `src/cook-web/src/app/admin/orders/page.tsx`
@@ -259,7 +256,7 @@ Reasons:
 
 ### Phase 3: Secondary Migration
 
-Migrate next:
+Migrated next:
 
 - `src/cook-web/src/app/admin/operations/users/page.tsx`
 
@@ -267,11 +264,11 @@ This page is more complex but still follows the same list-page structure.
 
 ### Phase 4: Complex Page Migration
 
-Migrate last:
+Migrated last:
 
 - `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
 
-Reasons:
+Reasons this page was left for the final migration step:
 
 - it contains multiple tables
 - it mixes detail-page concerns with table concerns
@@ -284,10 +281,22 @@ For each migrated page:
 - run focused page tests first
 - then run broader frontend validation
 
-Required checks after meaningful implementation work:
+Required checks after meaningful frontend implementation work:
 
+- `cd src/cook-web && npm run type-check`
 - `cd src/cook-web && npm run lint`
 - `pre-commit run -a`
+
+For `src/cook-web/**/*.{js,ts,tsx,jsx}` changes, the frontend baseline remains:
+
+- `cd src/cook-web && npm run type-check && npm run lint`
+
+Current note for this branch:
+
+- `npm run type-check` still reports known unrelated failures outside this PR
+  under `src/cook-web/src/__tests__/...`,
+  `src/cook-web/src/app/c/[[...id]]/...`, and
+  `src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx`
 
 Likely focused tests during rollout:
 

--- a/src/cook-web/src/app/admin/components/AdminTableShell.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.tsx
@@ -46,20 +46,16 @@ export default function AdminTableShell({
   footerClassName,
 }: AdminTableShellProps) {
   const emptyRow =
-    isEmpty && emptyContent && emptyColSpan
-      ? (
-          <TableEmpty colSpan={emptyColSpan}>
-            {emptyContent}
-          </TableEmpty>
-        )
-      : null;
+    isEmpty && emptyContent && emptyColSpan ? (
+      <TableEmpty colSpan={emptyColSpan}>{emptyContent}</TableEmpty>
+    ) : null;
 
   const tableContent = renderTableContent(table, emptyRow);
-  const wrappedTableContent = withTooltipProvider
-    ? (
-        <TooltipProvider delayDuration={150}>{tableContent}</TooltipProvider>
-      )
-    : tableContent;
+  const wrappedTableContent = withTooltipProvider ? (
+    <TooltipProvider delayDuration={150}>{tableContent}</TooltipProvider>
+  ) : (
+    tableContent
+  );
 
   return (
     <div className={cn('flex min-h-0 flex-col', containerClassName)}>

--- a/src/cook-web/src/app/admin/components/AdminTableShell.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Loading from '@/components/loading';
+import { TableEmpty } from '@/components/ui/Table';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type AdminTableRenderer = (emptyRow: ReactNode | null) => ReactNode;
+
+type AdminTableShellProps = {
+  loading: boolean;
+  isEmpty: boolean;
+  emptyContent?: ReactNode;
+  emptyColSpan?: number;
+  table: ReactNode | AdminTableRenderer;
+  footer?: ReactNode;
+  withTooltipProvider?: boolean;
+  containerClassName?: string;
+  tableWrapperClassName?: string;
+  loadingClassName?: string;
+  footerClassName?: string;
+};
+
+const renderTableContent = (
+  table: ReactNode | AdminTableRenderer,
+  emptyRow: ReactNode | null,
+) => {
+  if (typeof table === 'function') {
+    return (table as AdminTableRenderer)(emptyRow);
+  }
+  return table;
+};
+
+export default function AdminTableShell({
+  loading,
+  isEmpty,
+  emptyContent,
+  emptyColSpan,
+  table,
+  footer,
+  withTooltipProvider = false,
+  containerClassName,
+  tableWrapperClassName,
+  loadingClassName,
+  footerClassName,
+}: AdminTableShellProps) {
+  const emptyRow =
+    isEmpty && emptyContent && emptyColSpan
+      ? (
+          <TableEmpty colSpan={emptyColSpan}>
+            {emptyContent}
+          </TableEmpty>
+        )
+      : null;
+
+  const tableContent = renderTableContent(table, emptyRow);
+  const wrappedTableContent = withTooltipProvider
+    ? (
+        <TooltipProvider delayDuration={150}>{tableContent}</TooltipProvider>
+      )
+    : tableContent;
+
+  return (
+    <div className={cn('flex min-h-0 flex-col', containerClassName)}>
+      <div
+        className={cn(
+          'rounded-xl border border-border bg-white shadow-sm',
+          tableWrapperClassName,
+        )}
+      >
+        {loading ? (
+          <div
+            className={cn(
+              'flex h-40 items-center justify-center',
+              loadingClassName,
+            )}
+          >
+            <Loading />
+          </div>
+        ) : (
+          wrappedTableContent
+        )}
+      </div>
+      {loading || !footer ? null : (
+        <div className={cn('mt-4 flex justify-end', footerClassName)}>
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/cook-web/src/app/admin/components/adminTableStyles.ts
+++ b/src/cook-web/src/app/admin/components/adminTableStyles.ts
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils';
+
+export const ADMIN_TABLE_HEADER_CELL_CLASS =
+  'relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted';
+
+export const ADMIN_TABLE_HEADER_CELL_CENTER_CLASS = cn(
+  ADMIN_TABLE_HEADER_CELL_CLASS,
+  'text-center',
+);
+
+export const ADMIN_TABLE_HEADER_LAST_CELL_CLASS =
+  'relative sticky top-0 z-30 bg-muted';
+
+export const ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS = cn(
+  ADMIN_TABLE_HEADER_LAST_CELL_CLASS,
+  'text-center',
+);
+
+export const ADMIN_TABLE_RESIZE_HANDLE_CLASS =
+  'absolute top-0 right-0 h-full w-2 cursor-col-resize select-none';
+
+const ADMIN_TABLE_STICKY_RIGHT_SHADOW_CLASS =
+  'shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-border before:content-[""]';
+
+export const getAdminStickyRightHeaderClass = (className?: string) =>
+  cn(
+    'sticky right-0 top-0 z-40 bg-muted',
+    ADMIN_TABLE_STICKY_RIGHT_SHADOW_CLASS,
+    className,
+  );
+
+export const getAdminStickyRightCellClass = (className?: string) =>
+  cn(
+    'sticky right-0 z-10 bg-white',
+    ADMIN_TABLE_STICKY_RIGHT_SHADOW_CLASS,
+    className,
+  );

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.test.tsx
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.test.tsx
@@ -43,12 +43,14 @@ describe('useAdminResizableColumns', () => {
       } as any);
     });
 
-    const moveListener = getListenerCalls(addEventListenerSpy, 'mousemove')[0]?.[1] as
-      | ((event: MouseEvent) => void)
-      | undefined;
-    const upListener = getListenerCalls(addEventListenerSpy, 'mouseup')[0]?.[1] as
-      | (() => void)
-      | undefined;
+    const moveListener = getListenerCalls(
+      addEventListenerSpy,
+      'mousemove',
+    )[0]?.[1] as ((event: MouseEvent) => void) | undefined;
+    const upListener = getListenerCalls(
+      addEventListenerSpy,
+      'mouseup',
+    )[0]?.[1] as (() => void) | undefined;
 
     expect(moveListener).toBeDefined();
     expect(upListener).toBeDefined();

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.test.tsx
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAdminResizableColumns } from './useAdminResizableColumns';
+
+const DEFAULT_WIDTHS = {
+  title: 120,
+  amount: 160,
+} as const;
+
+const SINGLE_COLUMN_WIDTHS = {
+  title: 120,
+} as const;
+
+const getListenerCalls = (
+  spy: jest.SpyInstance,
+  eventName: string,
+): unknown[][] => spy.mock.calls.filter(([type]) => type === eventName);
+
+describe('useAdminResizableColumns', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  test('only attaches window listeners while a resize is active', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    const { result } = renderHook(() =>
+      useAdminResizableColumns({
+        storageKey: 'admin-table-widths',
+        defaultWidths: DEFAULT_WIDTHS,
+      }),
+    );
+
+    expect(getListenerCalls(addEventListenerSpy, 'mousemove')).toHaveLength(0);
+    expect(getListenerCalls(addEventListenerSpy, 'mouseup')).toHaveLength(0);
+
+    act(() => {
+      result.current.getResizeHandleProps('title').onMouseDown({
+        preventDefault: jest.fn(),
+        clientX: 100,
+      } as any);
+    });
+
+    const moveListener = getListenerCalls(addEventListenerSpy, 'mousemove')[0]?.[1] as
+      | ((event: MouseEvent) => void)
+      | undefined;
+    const upListener = getListenerCalls(addEventListenerSpy, 'mouseup')[0]?.[1] as
+      | (() => void)
+      | undefined;
+
+    expect(moveListener).toBeDefined();
+    expect(upListener).toBeDefined();
+
+    act(() => {
+      moveListener?.({ clientX: 145 } as MouseEvent);
+    });
+
+    expect(result.current.columnWidths.title).toBe(165);
+
+    act(() => {
+      upListener?.();
+    });
+
+    expect(setItemSpy).toHaveBeenCalledWith(
+      'admin-table-widths',
+      JSON.stringify({ title: 165 }),
+    );
+    expect(getListenerCalls(removeEventListenerSpy, 'mousemove')).toHaveLength(
+      1,
+    );
+    expect(getListenerCalls(removeEventListenerSpy, 'mouseup')).toHaveLength(1);
+  });
+
+  test('cleans up active resize listeners on unmount', () => {
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { result, unmount } = renderHook(() =>
+      useAdminResizableColumns({
+        storageKey: 'admin-table-widths',
+        defaultWidths: SINGLE_COLUMN_WIDTHS,
+      }),
+    );
+
+    act(() => {
+      result.current.getResizeHandleProps('title').onMouseDown({
+        preventDefault: jest.fn(),
+        clientX: 100,
+      } as any);
+    });
+
+    unmount();
+
+    expect(getListenerCalls(removeEventListenerSpy, 'mousemove')).toHaveLength(
+      1,
+    );
+    expect(getListenerCalls(removeEventListenerSpy, 'mouseup')).toHaveLength(1);
+  });
+});

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
@@ -87,9 +87,11 @@ export function useAdminResizableColumns<Key extends string>({
   }, [clampWidth, columnKeys, storageKey]);
 
   const [hasLoadedStoredWidths, setHasLoadedStoredWidths] = useState(false);
-  const storedManualWidthsRef = useRef<Partial<ColumnWidthState<Key>>>({});
-
   const columnResizeRef = useRef<ColumnResizeState<Key> | null>(null);
+  const mouseMoveListenerRef = useRef<((event: MouseEvent) => void) | null>(
+    null,
+  );
+  const mouseUpListenerRef = useRef<(() => void) | null>(null);
   const manualResizeRef = useRef<Record<Key, boolean>>(
     columnKeys.reduce(
       (acc, key) => ({
@@ -133,7 +135,6 @@ export function useAdminResizableColumns<Key extends string>({
 
   useEffect(() => {
     const storedManualWidths = loadStoredManualWidths();
-    storedManualWidthsRef.current = storedManualWidths;
     manualResizeRef.current = columnKeys.reduce(
       (acc, key) => ({
         ...acc,
@@ -174,53 +175,78 @@ export function useAdminResizableColumns<Key extends string>({
     }
   }, [columnKeys, hasLoadedStoredWidths, storageKey]);
 
+  const removeWindowListeners = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (mouseMoveListenerRef.current) {
+      window.removeEventListener('mousemove', mouseMoveListenerRef.current);
+      mouseMoveListenerRef.current = null;
+    }
+
+    if (mouseUpListenerRef.current) {
+      window.removeEventListener('mouseup', mouseUpListenerRef.current);
+      mouseUpListenerRef.current = null;
+    }
+  }, []);
+
   const startColumnResize = useCallback(
     (key: Key, clientX: number) => {
+      removeWindowListeners();
       columnResizeRef.current = {
         key,
         startX: clientX,
-        startWidth: columnWidths[key],
+        startWidth: columnWidthsRef.current[key],
       };
       manualResizeRef.current[key] = true;
-    },
-    [columnWidths],
-  );
 
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const info = columnResizeRef.current;
-      if (!info) {
+      if (typeof window === 'undefined') {
         return;
       }
 
-      const nextWidth = clampWidth(
-        info.startWidth + event.clientX - info.startX,
-      );
-      setColumnWidthsState(prev => {
-        if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
-          return prev;
+      const handleMouseMove = (event: MouseEvent) => {
+        const info = columnResizeRef.current;
+        if (!info) {
+          return;
         }
-        const next = { ...prev, [info.key]: nextWidth };
-        columnWidthsRef.current = next;
-        return next;
-      });
-    };
 
-    const handleMouseUp = () => {
-      if (columnResizeRef.current) {
-        persistManualWidths();
-      }
-      columnResizeRef.current = null;
-    };
+        const nextWidth = clampWidth(
+          info.startWidth + event.clientX - info.startX,
+        );
+        setColumnWidthsState(prev => {
+          if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
+            return prev;
+          }
+          const next = { ...prev, [info.key]: nextWidth };
+          columnWidthsRef.current = next;
+          return next;
+        });
+      };
 
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
+      const handleMouseUp = () => {
+        if (columnResizeRef.current) {
+          persistManualWidths();
+        }
+        columnResizeRef.current = null;
+        removeWindowListeners();
+      };
 
+      mouseMoveListenerRef.current = handleMouseMove;
+      mouseUpListenerRef.current = handleMouseUp;
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [clampWidth, persistManualWidths, removeWindowListeners],
+  );
+
+  useEffect(() => {
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
+      columnResizeRef.current = null;
+      removeWindowListeners();
     };
-  }, [clampWidth, persistManualWidths]);
+  }, [removeWindowListeners]);
 
   const getColumnStyle = useCallback(
     (key: Key) => {

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
@@ -108,6 +108,7 @@ export function useAdminResizableColumns<Key extends string>({
   const [columnWidths, setColumnWidthsState] = useState<ColumnWidthState<Key>>(
     () => createColumnWidthState(storedManualWidthsRef.current || {}),
   );
+  const columnWidthsRef = useRef(columnWidths);
 
   const setColumnWidths = useCallback(
     (
@@ -121,11 +122,46 @@ export function useAdminResizableColumns<Key extends string>({
         const changed = columnKeys.some(
           key => Math.abs(next[key] - prev[key]) > 0.5,
         );
-        return changed ? next : prev;
+        if (!changed) {
+          return prev;
+        }
+        columnWidthsRef.current = next;
+        return next;
       });
     },
     [columnKeys, createColumnWidthState],
   );
+
+  useEffect(() => {
+    columnWidthsRef.current = columnWidths;
+  }, [columnWidths]);
+
+  const persistManualWidths = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const manualOverrides = columnKeys.reduce<Partial<ColumnWidthState<Key>>>(
+        (acc, key) => {
+          if (manualResizeRef.current[key]) {
+            acc[key] = columnWidthsRef.current[key];
+          }
+          return acc;
+        },
+        {},
+      );
+
+      if (Object.keys(manualOverrides).length === 0) {
+        window.localStorage.removeItem(storageKey);
+        return;
+      }
+
+      window.localStorage.setItem(storageKey, JSON.stringify(manualOverrides));
+    } catch {
+      // Ignore storage errors.
+    }
+  }, [columnKeys, storageKey]);
 
   const startColumnResize = useCallback(
     (key: Key, clientX: number) => {
@@ -153,11 +189,16 @@ export function useAdminResizableColumns<Key extends string>({
         if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
           return prev;
         }
-        return { ...prev, [info.key]: nextWidth };
+        const next = { ...prev, [info.key]: nextWidth };
+        columnWidthsRef.current = next;
+        return next;
       });
     };
 
     const handleMouseUp = () => {
+      if (columnResizeRef.current) {
+        persistManualWidths();
+      }
       columnResizeRef.current = null;
     };
 
@@ -168,34 +209,7 @@ export function useAdminResizableColumns<Key extends string>({
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [clampWidth]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    try {
-      const manualOverrides = columnKeys.reduce<Partial<ColumnWidthState<Key>>>(
-        (acc, key) => {
-          if (manualResizeRef.current[key]) {
-            acc[key] = columnWidths[key];
-          }
-          return acc;
-        },
-        {},
-      );
-
-      if (Object.keys(manualOverrides).length === 0) {
-        window.localStorage.removeItem(storageKey);
-        return;
-      }
-
-      window.localStorage.setItem(storageKey, JSON.stringify(manualOverrides));
-    } catch {
-      // Ignore storage errors.
-    }
-  }, [columnKeys, columnWidths, storageKey]);
+  }, [clampWidth, persistManualWidths]);
 
   const getColumnStyle = useCallback(
     (key: Key) => {

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
@@ -1,0 +1,232 @@
+'use client';
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type ColumnWidthState<Key extends string> = Record<Key, number>;
+
+type ColumnResizeState<Key extends string> = {
+  key: Key;
+  startX: number;
+  startWidth: number;
+};
+
+type UseAdminResizableColumnsOptions<Key extends string> = {
+  storageKey: string;
+  defaultWidths: ColumnWidthState<Key>;
+  minWidth?: number;
+  maxWidth?: number;
+};
+
+const hasOwn = <Key extends string>(
+  value: Partial<Record<Key, number>>,
+  key: Key,
+): boolean => Object.prototype.hasOwnProperty.call(value, key);
+
+export function useAdminResizableColumns<Key extends string>({
+  storageKey,
+  defaultWidths,
+  minWidth = 80,
+  maxWidth = 360,
+}: UseAdminResizableColumnsOptions<Key>) {
+  const columnKeys = useMemo(
+    () => Object.keys(defaultWidths) as Key[],
+    [defaultWidths],
+  );
+
+  const clampWidth = useCallback(
+    (value: number) => Math.min(maxWidth, Math.max(minWidth, value)),
+    [maxWidth, minWidth],
+  );
+
+  const createColumnWidthState = useCallback(
+    (overrides?: Partial<ColumnWidthState<Key>>) => {
+      const widths = {} as ColumnWidthState<Key>;
+
+      columnKeys.forEach(key => {
+        const nextValue = overrides?.[key];
+        const fallback = defaultWidths[key];
+        widths[key] =
+          typeof nextValue === 'number' && Number.isFinite(nextValue)
+            ? clampWidth(nextValue)
+            : clampWidth(fallback);
+      });
+
+      return widths;
+    },
+    [clampWidth, columnKeys, defaultWidths],
+  );
+
+  const loadStoredManualWidths = useCallback((): Partial<ColumnWidthState<Key>> => {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+
+    try {
+      const serialized = window.localStorage.getItem(storageKey);
+      if (!serialized) {
+        return {};
+      }
+
+      const parsed = JSON.parse(serialized) as Partial<ColumnWidthState<Key>>;
+      const overrides: Partial<ColumnWidthState<Key>> = {};
+
+      columnKeys.forEach(key => {
+        const nextValue = parsed?.[key];
+        if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
+          overrides[key] = clampWidth(nextValue);
+        }
+      });
+
+      return overrides;
+    } catch {
+      return {};
+    }
+  }, [clampWidth, columnKeys, storageKey]);
+
+  const storedManualWidthsRef = useRef<Partial<ColumnWidthState<Key>> | null>(
+    null,
+  );
+
+  if (storedManualWidthsRef.current === null) {
+    storedManualWidthsRef.current = loadStoredManualWidths();
+  }
+
+  const columnResizeRef = useRef<ColumnResizeState<Key> | null>(null);
+  const manualResizeRef = useRef<Record<Key, boolean>>(
+    columnKeys.reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: hasOwn(storedManualWidthsRef.current || {}, key),
+      }),
+      {} as Record<Key, boolean>,
+    ),
+  );
+
+  const [columnWidths, setColumnWidthsState] = useState<ColumnWidthState<Key>>(
+    () => createColumnWidthState(storedManualWidthsRef.current || {}),
+  );
+
+  const setColumnWidths = useCallback(
+    (
+      value:
+        | ColumnWidthState<Key>
+        | ((prev: ColumnWidthState<Key>) => ColumnWidthState<Key>),
+    ) => {
+      setColumnWidthsState(prev => {
+        const resolved = typeof value === 'function' ? value(prev) : value;
+        const next = createColumnWidthState(resolved);
+        const changed = columnKeys.some(
+          key => Math.abs(next[key] - prev[key]) > 0.5,
+        );
+        return changed ? next : prev;
+      });
+    },
+    [columnKeys, createColumnWidthState],
+  );
+
+  const startColumnResize = useCallback(
+    (key: Key, clientX: number) => {
+      columnResizeRef.current = {
+        key,
+        startX: clientX,
+        startWidth: columnWidths[key],
+      };
+      manualResizeRef.current[key] = true;
+    },
+    [columnWidths],
+  );
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      const info = columnResizeRef.current;
+      if (!info) {
+        return;
+      }
+
+      const nextWidth = clampWidth(info.startWidth + event.clientX - info.startX);
+      setColumnWidthsState(prev => {
+        if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
+          return prev;
+        }
+        return { ...prev, [info.key]: nextWidth };
+      });
+    };
+
+    const handleMouseUp = () => {
+      columnResizeRef.current = null;
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [clampWidth]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const manualOverrides = columnKeys.reduce<Partial<ColumnWidthState<Key>>>(
+        (acc, key) => {
+          if (manualResizeRef.current[key]) {
+            acc[key] = columnWidths[key];
+          }
+          return acc;
+        },
+        {},
+      );
+
+      if (Object.keys(manualOverrides).length === 0) {
+        window.localStorage.removeItem(storageKey);
+        return;
+      }
+
+      window.localStorage.setItem(storageKey, JSON.stringify(manualOverrides));
+    } catch {
+      // Ignore storage errors.
+    }
+  }, [columnKeys, columnWidths, storageKey]);
+
+  const getColumnStyle = useCallback(
+    (key: Key) => {
+      const width = columnWidths[key];
+      return {
+        width,
+        minWidth: width,
+        maxWidth: width,
+      };
+    },
+    [columnWidths],
+  );
+
+  const getResizeHandleProps = useCallback(
+    (key: Key) => ({
+      onMouseDown: (event: ReactMouseEvent<HTMLElement>) => {
+        event.preventDefault();
+        startColumnResize(key, event.clientX);
+      },
+      'aria-hidden': 'true' as const,
+    }),
+    [startColumnResize],
+  );
+
+  const isManualColumn = useCallback(
+    (key: Key) => manualResizeRef.current[key],
+    [],
+  );
+
+  return {
+    columnWidths,
+    setColumnWidths,
+    getColumnStyle,
+    getResizeHandleProps,
+    isManualColumn,
+    clampWidth,
+  };
+}

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
@@ -86,27 +86,22 @@ export function useAdminResizableColumns<Key extends string>({
     }
   }, [clampWidth, columnKeys, storageKey]);
 
-  const storedManualWidthsRef = useRef<Partial<ColumnWidthState<Key>> | null>(
-    null,
-  );
-
-  if (storedManualWidthsRef.current === null) {
-    storedManualWidthsRef.current = loadStoredManualWidths();
-  }
+  const [hasLoadedStoredWidths, setHasLoadedStoredWidths] = useState(false);
+  const storedManualWidthsRef = useRef<Partial<ColumnWidthState<Key>>>({});
 
   const columnResizeRef = useRef<ColumnResizeState<Key> | null>(null);
   const manualResizeRef = useRef<Record<Key, boolean>>(
     columnKeys.reduce(
       (acc, key) => ({
         ...acc,
-        [key]: hasOwn(storedManualWidthsRef.current || {}, key),
+        [key]: false,
       }),
       {} as Record<Key, boolean>,
     ),
   );
 
   const [columnWidths, setColumnWidthsState] = useState<ColumnWidthState<Key>>(
-    () => createColumnWidthState(storedManualWidthsRef.current || {}),
+    () => createColumnWidthState(),
   );
   const columnWidthsRef = useRef(columnWidths);
 
@@ -136,8 +131,24 @@ export function useAdminResizableColumns<Key extends string>({
     columnWidthsRef.current = columnWidths;
   }, [columnWidths]);
 
+  useEffect(() => {
+    const storedManualWidths = loadStoredManualWidths();
+    storedManualWidthsRef.current = storedManualWidths;
+    manualResizeRef.current = columnKeys.reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: hasOwn(storedManualWidths, key),
+      }),
+      {} as Record<Key, boolean>,
+    );
+    const nextColumnWidths = createColumnWidthState(storedManualWidths);
+    columnWidthsRef.current = nextColumnWidths;
+    setColumnWidthsState(nextColumnWidths);
+    setHasLoadedStoredWidths(true);
+  }, [columnKeys, createColumnWidthState, loadStoredManualWidths]);
+
   const persistManualWidths = useCallback(() => {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || !hasLoadedStoredWidths) {
       return;
     }
 
@@ -161,7 +172,7 @@ export function useAdminResizableColumns<Key extends string>({
     } catch {
       // Ignore storage errors.
     }
-  }, [columnKeys, storageKey]);
+  }, [columnKeys, hasLoadedStoredWidths, storageKey]);
 
   const startColumnResize = useCallback(
     (key: Key, clientX: number) => {

--- a/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminResizableColumns.ts
@@ -57,7 +57,9 @@ export function useAdminResizableColumns<Key extends string>({
     [clampWidth, columnKeys, defaultWidths],
   );
 
-  const loadStoredManualWidths = useCallback((): Partial<ColumnWidthState<Key>> => {
+  const loadStoredManualWidths = useCallback((): Partial<
+    ColumnWidthState<Key>
+  > => {
     if (typeof window === 'undefined') {
       return {};
     }
@@ -144,7 +146,9 @@ export function useAdminResizableColumns<Key extends string>({
         return;
       }
 
-      const nextWidth = clampWidth(info.startWidth + event.clientX - info.startX);
+      const nextWidth = clampWidth(
+        info.startWidth + event.clientX - info.startX,
+      );
       setColumnWidthsState(prev => {
         if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
           return prev;

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -6,9 +6,18 @@ import { useParams, useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import AdminTableShell from '@/app/admin/components/AdminTableShell';
+import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
+import {
+  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+  ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+  ADMIN_TABLE_RESIZE_HANDLE_CLASS,
+  getAdminStickyRightCellClass,
+  getAdminStickyRightHeaderClass,
+} from '@/app/admin/components/adminTableStyles';
+import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
-import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Badge } from '@/components/ui/Badge';
@@ -25,7 +34,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableEmpty,
   TableHead,
   TableHeader,
   TableRow,
@@ -38,10 +46,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import { fail, show } from '@/hooks/useToast';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
+import { cn } from '@/lib/utils';
 import type {
   AdminOperationCourseChapterDetailResponse,
   AdminOperationCourseDetailChapter,
@@ -92,8 +100,6 @@ const CHAPTER_COLUMN_DEFAULT_WIDTHS = {
 } as const;
 
 type ChapterColumnKey = keyof typeof CHAPTER_COLUMN_DEFAULT_WIDTHS;
-type ChapterColumnWidthState = Record<ChapterColumnKey, number>;
-
 const CHAPTER_COLUMN_KEYS = Object.keys(
   CHAPTER_COLUMN_DEFAULT_WIDTHS,
 ) as ChapterColumnKey[];
@@ -116,8 +122,6 @@ const USER_COLUMN_DEFAULT_WIDTHS = {
 } as const;
 
 type UserColumnKey = keyof typeof USER_COLUMN_DEFAULT_WIDTHS;
-type UserColumnWidthState = Record<UserColumnKey, number>;
-
 const USER_COLUMN_KEYS = Object.keys(
   USER_COLUMN_DEFAULT_WIDTHS,
 ) as UserColumnKey[];
@@ -130,152 +134,6 @@ const EMPTY_COURSE_USERS_RESPONSE: AdminOperationCourseUsersResponse = {
   page_count: 0,
   page_size: USER_PAGE_SIZE,
   total: 0,
-};
-
-const clampChapterWidth = (value: number): number =>
-  Math.min(CHAPTER_COLUMN_MAX_WIDTH, Math.max(CHAPTER_COLUMN_MIN_WIDTH, value));
-
-const clampUserWidth = (value: number): number =>
-  Math.min(USER_COLUMN_MAX_WIDTH, Math.max(USER_COLUMN_MIN_WIDTH, value));
-
-const createChapterColumnWidthState = (
-  overrides?: Partial<ChapterColumnWidthState>,
-): ChapterColumnWidthState => {
-  const widths: ChapterColumnWidthState = { ...CHAPTER_COLUMN_DEFAULT_WIDTHS };
-  CHAPTER_COLUMN_KEYS.forEach(key => {
-    const nextValue = overrides?.[key];
-    if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-      widths[key] = clampChapterWidth(nextValue);
-    } else {
-      widths[key] = clampChapterWidth(widths[key]);
-    }
-  });
-  return widths;
-};
-
-const loadStoredChapterColumnWidthOverrides =
-  (): Partial<ChapterColumnWidthState> => {
-    if (typeof window === 'undefined') {
-      return {};
-    }
-    try {
-      const serialized = window.localStorage.getItem(
-        CHAPTER_COLUMN_WIDTH_STORAGE_KEY,
-      );
-      if (!serialized) {
-        return {};
-      }
-      const parsed = JSON.parse(serialized) as Partial<ChapterColumnWidthState>;
-      const overrides: Partial<ChapterColumnWidthState> = {};
-      CHAPTER_COLUMN_KEYS.forEach(key => {
-        const nextValue = parsed?.[key];
-        if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-          overrides[key] = clampChapterWidth(nextValue);
-        }
-      });
-      return overrides;
-    } catch {
-      return {};
-    }
-  };
-
-const persistManualChapterColumnWidths = (
-  chapterColumnWidths: ChapterColumnWidthState,
-  manualResizeMap: Record<ChapterColumnKey, boolean>,
-): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    const manualOverrides = CHAPTER_COLUMN_KEYS.reduce<
-      Partial<ChapterColumnWidthState>
-    >((acc, key) => {
-      if (manualResizeMap[key]) {
-        acc[key] = chapterColumnWidths[key];
-      }
-      return acc;
-    }, {});
-    if (Object.keys(manualOverrides).length === 0) {
-      window.localStorage.removeItem(CHAPTER_COLUMN_WIDTH_STORAGE_KEY);
-      return;
-    }
-    window.localStorage.setItem(
-      CHAPTER_COLUMN_WIDTH_STORAGE_KEY,
-      JSON.stringify(manualOverrides),
-    );
-  } catch {
-    // Ignore storage errors.
-  }
-};
-
-const createUserColumnWidthState = (
-  overrides?: Partial<UserColumnWidthState>,
-): UserColumnWidthState => {
-  const widths: UserColumnWidthState = { ...USER_COLUMN_DEFAULT_WIDTHS };
-  USER_COLUMN_KEYS.forEach(key => {
-    const nextValue = overrides?.[key];
-    if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-      widths[key] = clampUserWidth(nextValue);
-    } else {
-      widths[key] = clampUserWidth(widths[key]);
-    }
-  });
-  return widths;
-};
-
-const loadStoredUserColumnWidthOverrides =
-  (): Partial<UserColumnWidthState> => {
-    if (typeof window === 'undefined') {
-      return {};
-    }
-    try {
-      const serialized = window.localStorage.getItem(
-        USER_COLUMN_WIDTH_STORAGE_KEY,
-      );
-      if (!serialized) {
-        return {};
-      }
-      const parsed = JSON.parse(serialized) as Partial<UserColumnWidthState>;
-      const overrides: Partial<UserColumnWidthState> = {};
-      USER_COLUMN_KEYS.forEach(key => {
-        const nextValue = parsed?.[key];
-        if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-          overrides[key] = clampUserWidth(nextValue);
-        }
-      });
-      return overrides;
-    } catch {
-      return {};
-    }
-  };
-
-const persistManualUserColumnWidths = (
-  userColumnWidths: UserColumnWidthState,
-  manualResizeMap: Record<UserColumnKey, boolean>,
-): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  try {
-    const manualOverrides = USER_COLUMN_KEYS.reduce<
-      Partial<UserColumnWidthState>
-    >((acc, key) => {
-      if (manualResizeMap[key]) {
-        acc[key] = userColumnWidths[key];
-      }
-      return acc;
-    }, {});
-    if (Object.keys(manualOverrides).length === 0) {
-      window.localStorage.removeItem(USER_COLUMN_WIDTH_STORAGE_KEY);
-      return;
-    }
-    window.localStorage.setItem(
-      USER_COLUMN_WIDTH_STORAGE_KEY,
-      JSON.stringify(manualOverrides),
-    );
-  } catch {
-    // Ignore storage errors.
-  }
 };
 
 const EMPTY_DETAIL: AdminOperationCourseDetailResponse = {
@@ -465,12 +323,6 @@ export default function AdminOperationCourseDetailPage() {
   const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
   const defaultLoginMethod = useEnvStore(state => state.defaultLoginMethod);
   const currencySymbol = useEnvStore(state => state.currencySymbol || '');
-  const storedChapterManualWidthsRef = useRef<Partial<ChapterColumnWidthState>>(
-    loadStoredChapterColumnWidthOverrides(),
-  );
-  const storedUserManualWidthsRef = useRef<Partial<UserColumnWidthState>>(
-    loadStoredUserColumnWidthOverrides(),
-  );
 
   const [detail, setDetail] =
     useState<AdminOperationCourseDetailResponse>(EMPTY_DETAIL);
@@ -481,14 +333,6 @@ export default function AdminOperationCourseDetailPage() {
   const [selectedChapterDetail, setSelectedChapterDetail] =
     useState<AdminOperationCourseChapterDetailResponse>(EMPTY_CHAPTER_DETAIL);
   const [chapterDetailLoading, setChapterDetailLoading] = useState(false);
-  const [chapterColumnWidths, setChapterColumnWidths] =
-    useState<ChapterColumnWidthState>(() =>
-      createChapterColumnWidthState(storedChapterManualWidthsRef.current),
-    );
-  const [userColumnWidths, setUserColumnWidths] =
-    useState<UserColumnWidthState>(() =>
-      createUserColumnWidthState(storedUserManualWidthsRef.current),
-    );
   const [courseUserFiltersDraft, setCourseUserFiltersDraft] =
     useState<CourseUserFilters>(createCourseUserFilters);
   const [courseUserFilters, setCourseUserFilters] = useState<CourseUserFilters>(
@@ -501,37 +345,31 @@ export default function AdminOperationCourseDetailPage() {
     null,
   );
   const [courseUserPage, setCourseUserPage] = useState(1);
-  const chapterColumnWidthsRef = useRef(chapterColumnWidths);
-  const userColumnWidthsRef = useRef(userColumnWidths);
   const courseUsersRequestIdRef = useRef(0);
-  const chapterColumnResizeRef = useRef<{
-    key: ChapterColumnKey;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-  const userColumnResizeRef = useRef<{
-    key: UserColumnKey;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-  const manualChapterResizeRef = useRef<Record<ChapterColumnKey, boolean>>(
-    CHAPTER_COLUMN_KEYS.reduce(
-      (acc, key) => ({
-        ...acc,
-        [key]: typeof storedChapterManualWidthsRef.current[key] === 'number',
-      }),
-      {} as Record<ChapterColumnKey, boolean>,
-    ),
-  );
-  const manualUserResizeRef = useRef<Record<UserColumnKey, boolean>>(
-    USER_COLUMN_KEYS.reduce(
-      (acc, key) => ({
-        ...acc,
-        [key]: typeof storedUserManualWidthsRef.current[key] === 'number',
-      }),
-      {} as Record<UserColumnKey, boolean>,
-    ),
-  );
+  const {
+    setColumnWidths: setChapterColumnWidths,
+    getColumnStyle: getChapterColumnStyle,
+    getResizeHandleProps: getChapterResizeHandleProps,
+    isManualColumn: isManualChapterColumn,
+    clampWidth: clampChapterWidth,
+  } = useAdminResizableColumns<ChapterColumnKey>({
+    storageKey: CHAPTER_COLUMN_WIDTH_STORAGE_KEY,
+    defaultWidths: CHAPTER_COLUMN_DEFAULT_WIDTHS,
+    minWidth: CHAPTER_COLUMN_MIN_WIDTH,
+    maxWidth: CHAPTER_COLUMN_MAX_WIDTH,
+  });
+  const {
+    setColumnWidths: setUserColumnWidths,
+    getColumnStyle: getUserColumnStyle,
+    getResizeHandleProps: getUserResizeHandleProps,
+    isManualColumn: isManualUserColumn,
+    clampWidth: clampUserWidth,
+  } = useAdminResizableColumns<UserColumnKey>({
+    storageKey: USER_COLUMN_WIDTH_STORAGE_KEY,
+    defaultWidths: USER_COLUMN_DEFAULT_WIDTHS,
+    minWidth: USER_COLUMN_MIN_WIDTH,
+    maxWidth: USER_COLUMN_MAX_WIDTH,
+  });
 
   const shifuBid = Array.isArray(params?.shifu_bid)
     ? params.shifu_bid[0] || ''
@@ -653,14 +491,6 @@ export default function AdminOperationCourseDetailPage() {
     }
     fetchCourseUsers(courseUserPage, courseUserFilters);
   }, [courseUserFilters, courseUserPage, fetchCourseUsers, isReady]);
-
-  useEffect(() => {
-    chapterColumnWidthsRef.current = chapterColumnWidths;
-  }, [chapterColumnWidths]);
-
-  useEffect(() => {
-    userColumnWidthsRef.current = userColumnWidths;
-  }, [userColumnWidths]);
 
   const formatUnknownEnumLabel = useCallback(
     (labelKey: string, rawValue?: string) => {
@@ -1083,108 +913,6 @@ export default function AdminOperationCourseDetailPage() {
     };
   }, [selectedChapter?.outline_item_bid, shifuBid, t]);
 
-  const startChapterColumnResize = useCallback(
-    (key: ChapterColumnKey, clientX: number) => {
-      chapterColumnResizeRef.current = {
-        key,
-        startX: clientX,
-        startWidth: chapterColumnWidths[key],
-      };
-      manualChapterResizeRef.current[key] = true;
-    },
-    [chapterColumnWidths],
-  );
-
-  const startUserColumnResize = useCallback(
-    (key: UserColumnKey, clientX: number) => {
-      userColumnResizeRef.current = {
-        key,
-        startX: clientX,
-        startWidth: userColumnWidths[key],
-      };
-      manualUserResizeRef.current[key] = true;
-    },
-    [userColumnWidths],
-  );
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const chapterInfo = chapterColumnResizeRef.current;
-      if (chapterInfo) {
-        const delta = event.clientX - chapterInfo.startX;
-        const nextWidth = clampChapterWidth(chapterInfo.startWidth + delta);
-        setChapterColumnWidths(prev => {
-          if (Math.abs(prev[chapterInfo.key] - nextWidth) < 0.5) {
-            return prev;
-          }
-          return { ...prev, [chapterInfo.key]: nextWidth };
-        });
-      }
-
-      const userInfo = userColumnResizeRef.current;
-      if (!userInfo) {
-        return;
-      }
-      const delta = event.clientX - userInfo.startX;
-      const nextWidth = clampUserWidth(userInfo.startWidth + delta);
-      setUserColumnWidths(prev => {
-        if (Math.abs(prev[userInfo.key] - nextWidth) < 0.5) {
-          return prev;
-        }
-        return { ...prev, [userInfo.key]: nextWidth };
-      });
-    };
-
-    const handleMouseUp = () => {
-      if (chapterColumnResizeRef.current) {
-        persistManualChapterColumnWidths(
-          chapterColumnWidthsRef.current,
-          manualChapterResizeRef.current,
-        );
-      }
-      chapterColumnResizeRef.current = null;
-
-      if (userColumnResizeRef.current) {
-        persistManualUserColumnWidths(
-          userColumnWidthsRef.current,
-          manualUserResizeRef.current,
-        );
-      }
-      userColumnResizeRef.current = null;
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
-
-  const getChapterColumnStyle = useCallback(
-    (key: ChapterColumnKey) => {
-      const width = chapterColumnWidths[key];
-      return {
-        width,
-        minWidth: width,
-        maxWidth: width,
-      };
-    },
-    [chapterColumnWidths],
-  );
-
-  const getUserColumnStyle = useCallback(
-    (key: UserColumnKey) => {
-      const width = userColumnWidths[key];
-      return {
-        width,
-        minWidth: width,
-        maxWidth: width,
-      };
-    },
-    [userColumnWidths],
-  );
-
   const estimateChapterColumnWidth = useCallback(
     (text: string, multiplier = 7) => {
       if (!text) {
@@ -1211,14 +939,11 @@ export default function AdminOperationCourseDetailPage() {
         setChapterColumnWidths(prev => {
           const next = { ...prev };
           CHAPTER_COLUMN_KEYS.forEach(key => {
-            if (!manualChapterResizeRef.current[key]) {
+            if (!isManualChapterColumn(key)) {
               next[key] = CHAPTER_COLUMN_DEFAULT_WIDTHS[key];
             }
           });
-          const changed = CHAPTER_COLUMN_KEYS.some(
-            key => Math.abs(next[key] - prev[key]) > 0.5,
-          );
-          return changed ? next : prev;
+          return next;
         });
         return;
       }
@@ -1296,36 +1021,25 @@ export default function AdminOperationCourseDetailPage() {
       setChapterColumnWidths(prev => {
         const next = { ...prev };
         CHAPTER_COLUMN_KEYS.forEach(key => {
-          if (!manualChapterResizeRef.current[key]) {
+          if (!isManualChapterColumn(key)) {
             next[key] = clampChapterWidth(
               nextWidths[key] ?? CHAPTER_COLUMN_DEFAULT_WIDTHS[key],
             );
           }
         });
-        const changed = CHAPTER_COLUMN_KEYS.some(
-          key => Math.abs(next[key] - prev[key]) > 0.5,
-        );
-        return changed ? next : prev;
+        return next;
       });
     },
     [
+      clampChapterWidth,
       estimateChapterColumnWidth,
+      isManualChapterColumn,
       resolveContentStatusLabel,
       resolveLearningPermissionLabel,
       resolveModifierDisplay,
+      setChapterColumnWidths,
       tOperations,
     ],
-  );
-
-  const renderChapterResizeHandle = (key: ChapterColumnKey) => (
-    <span
-      className='absolute right-0 top-0 h-full w-2 cursor-col-resize select-none'
-      onMouseDown={event => {
-        event.preventDefault();
-        startChapterColumnResize(key, event.clientX);
-      }}
-      aria-hidden='true'
-    />
   );
 
   const autoAdjustUserColumns = useCallback(
@@ -1334,14 +1048,11 @@ export default function AdminOperationCourseDetailPage() {
         setUserColumnWidths(prev => {
           const next = { ...prev };
           USER_COLUMN_KEYS.forEach(key => {
-            if (!manualUserResizeRef.current[key]) {
+            if (!isManualUserColumn(key)) {
               next[key] = USER_COLUMN_DEFAULT_WIDTHS[key];
             }
           });
-          const changed = USER_COLUMN_KEYS.some(
-            key => Math.abs(next[key] - prev[key]) > 0.5,
-          );
-          return changed ? next : prev;
+          return next;
         });
         return;
       }
@@ -1417,38 +1128,41 @@ export default function AdminOperationCourseDetailPage() {
       setUserColumnWidths(prev => {
         const next = { ...prev };
         USER_COLUMN_KEYS.forEach(key => {
-          if (!manualUserResizeRef.current[key]) {
+          if (!isManualUserColumn(key)) {
             next[key] = clampUserWidth(
               nextWidths[key] ?? USER_COLUMN_DEFAULT_WIDTHS[key],
             );
           }
         });
-        const changed = USER_COLUMN_KEYS.some(
-          key => Math.abs(next[key] - prev[key]) > 0.5,
-        );
-        return changed ? next : prev;
+        return next;
       });
     },
     [
+      clampUserWidth,
       defaultUserName,
       emptyValue,
       estimateUserColumnWidth,
+      isManualUserColumn,
       resolveCourseUserAccount,
       resolveCourseUserLearningStatusLabel,
       resolveCourseUserPaidAmountDisplay,
       resolveCourseUserRoleLabel,
+      setUserColumnWidths,
       tOperations,
     ],
   );
 
+  const renderChapterResizeHandle = (key: ChapterColumnKey) => (
+    <span
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getChapterResizeHandleProps(key)}
+    />
+  );
+
   const renderUserResizeHandle = (key: UserColumnKey) => (
     <span
-      className='absolute right-0 top-0 h-full w-2 cursor-col-resize select-none'
-      onMouseDown={event => {
-        event.preventDefault();
-        startUserColumnResize(key, event.clientX);
-      }}
-      aria-hidden='true'
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getUserResizeHandleProps(key)}
     />
   );
 
@@ -1610,34 +1324,52 @@ export default function AdminOperationCourseDetailPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent className='pt-0'>
-                <div className='overflow-auto rounded-xl border border-border bg-white shadow-sm'>
-                  <TooltipProvider delayDuration={150}>
+                <AdminTableShell
+                  loading={false}
+                  isEmpty={chapterRows.length === 0}
+                  emptyContent={tOperations('detail.chaptersTable.empty')}
+                  emptyColSpan={11}
+                  withTooltipProvider
+                  tableWrapperClassName='overflow-auto'
+                  table={emptyRow => (
                     <Table className='table-auto'>
                       <TableHeader>
                         <TableRow>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('position')}
                           >
                             {tOperations('detail.chaptersTable.position')}
                             {renderChapterResizeHandle('position')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('name')}
                           >
                             {tOperations('detail.chaptersTable.name')}
                             {renderChapterResizeHandle('name')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('chapterId')}
                           >
                             {tOperations('detail.chaptersTable.chapterId')}
                             {renderChapterResizeHandle('chapterId')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('learningPermission')}
                           >
                             {tOperations(
@@ -1646,49 +1378,70 @@ export default function AdminOperationCourseDetailPage() {
                             {renderChapterResizeHandle('learningPermission')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('visibility')}
                           >
                             {tOperations('detail.chaptersTable.visibility')}
                             {renderChapterResizeHandle('visibility')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('contentStatus')}
                           >
                             {tOperations('detail.chaptersTable.contentStatus')}
                             {renderChapterResizeHandle('contentStatus')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('contentDetail')}
                           >
                             {tOperations('detail.chaptersTable.contentDetail')}
                             {renderChapterResizeHandle('contentDetail')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('modifier')}
                           >
                             {tOperations('detail.chaptersTable.modifier')}
                             {renderChapterResizeHandle('modifier')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('updatedAt')}
                           >
                             {tOperations('detail.chaptersTable.updatedAt')}
                             {renderChapterResizeHandle('updatedAt')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap border-l-2 border-l-border/80 border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap border-l-2 border-l-border/80 bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('followUpCount')}
                           >
                             {tOperations('detail.chaptersTable.followUpCount')}
                             {renderChapterResizeHandle('followUpCount')}
                           </TableHead>
                           <TableHead
-                            className='relative h-10 whitespace-nowrap bg-muted/80 text-center text-xs font-medium text-muted-foreground'
+                            className={cn(
+                              ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+                              'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                            )}
                             style={getChapterColumnStyle('ratingCount')}
                           >
                             {tOperations('detail.chaptersTable.ratingCount')}
@@ -1697,151 +1450,142 @@ export default function AdminOperationCourseDetailPage() {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {chapterRows.length === 0 ? (
-                          <TableEmpty colSpan={11}>
-                            {tOperations('detail.chaptersTable.empty')}
-                          </TableEmpty>
-                        ) : (
-                          chapterRows.map(chapter => {
-                            const {
-                              primary: modifierPrimary,
-                              secondary: modifierSecondary,
-                            } = resolveModifierDisplay(chapter);
+                        {emptyRow}
+                        {chapterRows.map(chapter => {
+                          const {
+                            primary: modifierPrimary,
+                            secondary: modifierSecondary,
+                          } = resolveModifierDisplay(chapter);
 
-                            return (
-                              <TableRow key={chapter.outline_item_bid}>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/80 last:border-r-0'
-                                  style={getChapterColumnStyle('position')}
+                          return (
+                            <TableRow key={chapter.outline_item_bid}>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/80 last:border-r-0'
+                                style={getChapterColumnStyle('position')}
+                              >
+                                {chapter.position || emptyValue}
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 border-r border-border last:border-r-0'
+                                style={getChapterColumnStyle('name')}
+                              >
+                                <div
+                                  className='flex min-w-0 items-center justify-center gap-2'
+                                  style={{
+                                    paddingLeft: `${chapter.depth * 20}px`,
+                                  }}
                                 >
-                                  {chapter.position || emptyValue}
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 border-r border-border last:border-r-0'
-                                  style={getChapterColumnStyle('name')}
-                                >
-                                  <div
-                                    className='flex min-w-0 items-center justify-center gap-2'
-                                    style={{
-                                      paddingLeft: `${chapter.depth * 20}px`,
-                                    }}
+                                  <Badge
+                                    variant='outline'
+                                    className='shrink-0 rounded-full border-border/60 bg-background px-1.5 py-0 text-[10px] font-medium text-muted-foreground'
                                   >
-                                    <Badge
-                                      variant='outline'
-                                      className='shrink-0 rounded-full border-border/60 bg-background px-1.5 py-0 text-[10px] font-medium text-muted-foreground'
-                                    >
-                                      {resolveChapterTypeLabel(
-                                        chapter.node_type,
-                                      )}
-                                    </Badge>
-                                    <AdminTooltipText
-                                      text={chapter.title || emptyValue}
-                                      emptyValue={emptyValue}
-                                      className='text-center text-sm font-medium text-foreground'
-                                    />
-                                  </div>
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle('chapterId')}
-                                >
+                                    {resolveChapterTypeLabel(chapter.node_type)}
+                                  </Badge>
                                   <AdminTooltipText
-                                    text={
-                                      chapter.outline_item_bid || emptyValue
-                                    }
+                                    text={chapter.title || emptyValue}
                                     emptyValue={emptyValue}
-                                    className='mx-auto block max-w-[240px] font-mono text-[11px] text-muted-foreground/65'
+                                    className='text-center text-sm font-medium text-foreground'
                                   />
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle(
-                                    'learningPermission',
+                                </div>
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle('chapterId')}
+                              >
+                                <AdminTooltipText
+                                  text={chapter.outline_item_bid || emptyValue}
+                                  emptyValue={emptyValue}
+                                  className='mx-auto block max-w-[240px] font-mono text-[11px] text-muted-foreground/65'
+                                />
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle(
+                                  'learningPermission',
+                                )}
+                              >
+                                {resolveLearningPermissionLabel(
+                                  chapter.learning_permission,
+                                )}
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle('visibility')}
+                              >
+                                {chapter.is_visible
+                                  ? tOperations('detail.visibility.visible')
+                                  : tOperations('detail.visibility.hidden')}
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle('contentStatus')}
+                              >
+                                {resolveContentStatusLabel(
+                                  chapter.content_status,
+                                )}
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center last:border-r-0'
+                                style={getChapterColumnStyle('contentDetail')}
+                              >
+                                <button
+                                  type='button'
+                                  className='text-sm text-primary transition-colors hover:text-primary/80'
+                                  onClick={() => setSelectedChapter(chapter)}
+                                >
+                                  {tOperations(
+                                    'detail.chaptersTable.detailAction',
                                   )}
-                                >
-                                  {resolveLearningPermissionLabel(
-                                    chapter.learning_permission,
-                                  )}
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle('visibility')}
-                                >
-                                  {chapter.is_visible
-                                    ? tOperations('detail.visibility.visible')
-                                    : tOperations('detail.visibility.hidden')}
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle('contentStatus')}
-                                >
-                                  {resolveContentStatusLabel(
-                                    chapter.content_status,
-                                  )}
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center last:border-r-0'
-                                  style={getChapterColumnStyle('contentDetail')}
-                                >
-                                  <button
-                                    type='button'
-                                    className='text-sm text-primary transition-colors hover:text-primary/80'
-                                    onClick={() => setSelectedChapter(chapter)}
-                                  >
-                                    {tOperations(
-                                      'detail.chaptersTable.detailAction',
-                                    )}
-                                  </button>
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 border-r border-border text-center last:border-r-0'
-                                  style={getChapterColumnStyle('modifier')}
-                                >
-                                  <div className='flex flex-col gap-0.5 leading-tight'>
-                                    <AdminTooltipText
-                                      text={modifierPrimary}
-                                      emptyValue={emptyValue}
-                                      className='text-sm text-foreground'
-                                    />
-                                    {modifierSecondary ? (
-                                      <AdminTooltipText
-                                        text={modifierSecondary}
-                                        emptyValue={emptyValue}
-                                        className='text-xs text-muted-foreground'
-                                      />
-                                    ) : null}
-                                  </div>
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle('updatedAt')}
-                                >
+                                </button>
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 border-r border-border text-center last:border-r-0'
+                                style={getChapterColumnStyle('modifier')}
+                              >
+                                <div className='flex flex-col gap-0.5 leading-tight'>
                                   <AdminTooltipText
-                                    text={chapter.updated_at || emptyValue}
+                                    text={modifierPrimary}
                                     emptyValue={emptyValue}
-                                    className='mx-auto block max-w-full'
+                                    className='text-sm text-foreground'
                                   />
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap border-l-2 border-l-border/80 border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
-                                  style={getChapterColumnStyle('followUpCount')}
-                                >
-                                  {formatCount(chapter.follow_up_count)}
-                                </TableCell>
-                                <TableCell
-                                  className='py-2.5 whitespace-nowrap text-center text-sm text-muted-foreground/75'
-                                  style={getChapterColumnStyle('ratingCount')}
-                                >
-                                  {formatCount(chapter.rating_count)}
-                                </TableCell>
-                              </TableRow>
-                            );
-                          })
-                        )}
+                                  {modifierSecondary ? (
+                                    <AdminTooltipText
+                                      text={modifierSecondary}
+                                      emptyValue={emptyValue}
+                                      className='text-xs text-muted-foreground'
+                                    />
+                                  ) : null}
+                                </div>
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle('updatedAt')}
+                              >
+                                <AdminTooltipText
+                                  text={chapter.updated_at || emptyValue}
+                                  emptyValue={emptyValue}
+                                  className='mx-auto block max-w-full'
+                                />
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap border-l-2 border-l-border/80 border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
+                                style={getChapterColumnStyle('followUpCount')}
+                              >
+                                {formatCount(chapter.follow_up_count)}
+                              </TableCell>
+                              <TableCell
+                                className='py-2.5 whitespace-nowrap text-center text-sm text-muted-foreground/75'
+                                style={getChapterColumnStyle('ratingCount')}
+                              >
+                                {formatCount(chapter.rating_count)}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
                       </TableBody>
                     </Table>
-                  </TooltipProvider>
-                </div>
+                  )}
+                />
               </CardContent>
             </Card>
 
@@ -2006,124 +1750,186 @@ export default function AdminOperationCourseDetailPage() {
                   </div>
                 </form>
 
-                <div className='overflow-auto rounded-xl border border-border bg-white shadow-sm'>
-                  {courseUsersLoading ? (
-                    <div className='flex min-h-[240px] items-center justify-center'>
-                      <Loading />
-                    </div>
-                  ) : courseUsersError ? (
-                    <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
-                      <div className='space-y-2'>
-                        <div className='text-sm font-medium text-destructive'>
-                          {courseUsersError.message}
-                        </div>
-                        {typeof courseUsersError.code === 'number' ? (
-                          <div className='text-xs text-muted-foreground'>
-                            {courseUsersError.code}
+                <AdminTableShell
+                  loading={courseUsersLoading}
+                  isEmpty={!courseUsersError && courseUserRows.length === 0}
+                  emptyContent={tOperations('detail.usersTable.empty')}
+                  emptyColSpan={12}
+                  withTooltipProvider={!courseUsersError}
+                  tableWrapperClassName='overflow-auto'
+                  loadingClassName='min-h-[240px]'
+                  footer={
+                    courseUserPageCount > 1 ? (
+                      <AdminPagination
+                        pageIndex={currentCourseUserPage}
+                        pageCount={courseUserPageCount}
+                        onPageChange={handleCourseUserPageChange}
+                        prevLabel={t('module.order.paginationPrev', 'Previous')}
+                        nextLabel={t('module.order.paginationNext', 'Next')}
+                        prevAriaLabel={t(
+                          'module.order.paginationPrevAriaLabel',
+                          'Go to previous page',
+                        )}
+                        nextAriaLabel={t(
+                          'module.order.paginationNextAriaLabel',
+                          'Go to next page',
+                        )}
+                        className='mx-0 w-auto justify-end'
+                      />
+                    ) : null
+                  }
+                  table={
+                    courseUsersError ? (
+                      <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
+                        <div className='space-y-2'>
+                          <div className='text-sm font-medium text-destructive'>
+                            {courseUsersError.message}
                           </div>
-                        ) : null}
+                          {typeof courseUsersError.code === 'number' ? (
+                            <div className='text-xs text-muted-foreground'>
+                              {courseUsersError.code}
+                            </div>
+                          ) : null}
+                        </div>
                       </div>
-                    </div>
-                  ) : (
-                    <TooltipProvider delayDuration={150}>
-                      <Table className='table-auto'>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('userId')}
-                            >
-                              {tOperations('detail.usersTable.userId')}
-                              {renderUserResizeHandle('userId')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('account')}
-                            >
-                              {courseUserAccountLabel}
-                              {renderUserResizeHandle('account')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('nickname')}
-                            >
-                              {tOperations('detail.usersTable.nickname')}
-                              {renderUserResizeHandle('nickname')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('userRole')}
-                            >
-                              {tOperations('detail.usersTable.userRole')}
-                              {renderUserResizeHandle('userRole')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('learningProgress')}
-                            >
-                              {tOperations(
-                                'detail.usersTable.learningProgress',
-                              )}
-                              {renderUserResizeHandle('learningProgress')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('learningStatus')}
-                            >
-                              {tOperations('detail.usersTable.learningStatus')}
-                              {renderUserResizeHandle('learningStatus')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('isPaid')}
-                            >
-                              {tOperations('detail.usersTable.isPaid')}
-                              {renderUserResizeHandle('isPaid')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('totalPaidAmount')}
-                            >
-                              {tOperations('detail.usersTable.totalPaidAmount')}
-                              {renderUserResizeHandle('totalPaidAmount')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('lastLearnedAt')}
-                            >
-                              {tOperations('detail.usersTable.lastLearnedAt')}
-                              {renderUserResizeHandle('lastLearnedAt')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('joinedAt')}
-                            >
-                              {tOperations('detail.usersTable.joinedAt')}
-                              {renderUserResizeHandle('joinedAt')}
-                            </TableHead>
-                            <TableHead
-                              className='relative h-10 whitespace-nowrap border-r border-border bg-muted/80 text-center text-xs font-medium text-muted-foreground last:border-r-0'
-                              style={getUserColumnStyle('lastLoginAt')}
-                            >
-                              {tOperations('detail.usersTable.lastLoginAt')}
-                              {renderUserResizeHandle('lastLoginAt')}
-                            </TableHead>
-                            <TableHead
-                              className='sticky right-0 z-10 h-10 whitespace-nowrap bg-muted text-center text-xs font-medium text-muted-foreground shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-border before:content-[""]'
-                              style={getUserColumnStyle('action')}
-                            >
-                              {tOperations('detail.usersTable.action')}
-                              {renderUserResizeHandle('action')}
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {courseUserRows.length === 0 ? (
-                            <TableEmpty colSpan={12}>
-                              {tOperations('detail.usersTable.empty')}
-                            </TableEmpty>
-                          ) : (
-                            courseUserRows.map(row => (
+                    ) : (
+                      emptyRow => (
+                        <Table className='table-auto'>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('userId')}
+                              >
+                                {tOperations('detail.usersTable.userId')}
+                                {renderUserResizeHandle('userId')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('account')}
+                              >
+                                {courseUserAccountLabel}
+                                {renderUserResizeHandle('account')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('nickname')}
+                              >
+                                {tOperations('detail.usersTable.nickname')}
+                                {renderUserResizeHandle('nickname')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('userRole')}
+                              >
+                                {tOperations('detail.usersTable.userRole')}
+                                {renderUserResizeHandle('userRole')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('learningProgress')}
+                              >
+                                {tOperations(
+                                  'detail.usersTable.learningProgress',
+                                )}
+                                {renderUserResizeHandle('learningProgress')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('learningStatus')}
+                              >
+                                {tOperations(
+                                  'detail.usersTable.learningStatus',
+                                )}
+                                {renderUserResizeHandle('learningStatus')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('isPaid')}
+                              >
+                                {tOperations('detail.usersTable.isPaid')}
+                                {renderUserResizeHandle('isPaid')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('totalPaidAmount')}
+                              >
+                                {tOperations(
+                                  'detail.usersTable.totalPaidAmount',
+                                )}
+                                {renderUserResizeHandle('totalPaidAmount')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('lastLearnedAt')}
+                              >
+                                {tOperations('detail.usersTable.lastLearnedAt')}
+                                {renderUserResizeHandle('lastLearnedAt')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('joinedAt')}
+                              >
+                                {tOperations('detail.usersTable.joinedAt')}
+                                {renderUserResizeHandle('joinedAt')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                                  'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                                )}
+                                style={getUserColumnStyle('lastLoginAt')}
+                              >
+                                {tOperations('detail.usersTable.lastLoginAt')}
+                                {renderUserResizeHandle('lastLoginAt')}
+                              </TableHead>
+                              <TableHead
+                                className={cn(
+                                  getAdminStickyRightHeaderClass(
+                                    'h-10 whitespace-nowrap text-center text-xs',
+                                  ),
+                                  'bg-muted/80',
+                                )}
+                                style={getUserColumnStyle('action')}
+                              >
+                                {tOperations('detail.usersTable.action')}
+                                {renderUserResizeHandle('action')}
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {emptyRow}
+                            {courseUserRows.map(row => (
                               <TableRow key={row.user_bid}>
                                 <TableCell
                                   className='py-2.5 border-r border-border text-center text-xs text-muted-foreground/65 last:border-r-0'
@@ -2237,40 +2043,21 @@ export default function AdminOperationCourseDetailPage() {
                                   />
                                 </TableCell>
                                 <TableCell
-                                  className='sticky right-0 z-[1] bg-white py-2.5 text-center text-sm text-muted-foreground/80 shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:absolute before:inset-y-0 before:left-0 before:w-px before:bg-border before:content-[""]'
+                                  className={getAdminStickyRightCellClass(
+                                    'py-2.5 text-center text-sm text-muted-foreground/80',
+                                  )}
                                   style={getUserColumnStyle('action')}
                                 >
                                   {emptyValue}
                                 </TableCell>
                               </TableRow>
-                            ))
-                          )}
-                        </TableBody>
-                      </Table>
-                    </TooltipProvider>
-                  )}
-                </div>
-
-                {courseUserPageCount > 1 ? (
-                  <div className='mb-4 mt-4 flex justify-end'>
-                    <AdminPagination
-                      pageIndex={currentCourseUserPage}
-                      pageCount={courseUserPageCount}
-                      onPageChange={handleCourseUserPageChange}
-                      prevLabel={t('module.order.paginationPrev', 'Previous')}
-                      nextLabel={t('module.order.paginationNext', 'Next')}
-                      prevAriaLabel={t(
-                        'module.order.paginationPrevAriaLabel',
-                        'Go to previous page',
-                      )}
-                      nextAriaLabel={t(
-                        'module.order.paginationNextAriaLabel',
-                        'Go to next page',
-                      )}
-                      className='mx-0 w-auto justify-end'
-                    />
-                  </div>
-                ) : null}
+                            ))}
+                          </TableBody>
+                        </Table>
+                      )
+                    )
+                  }
+                />
               </CardContent>
             </Card>
           </div>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -1918,7 +1918,6 @@ export default function AdminOperationCourseDetailPage() {
                                   getAdminStickyRightHeaderClass(
                                     'h-10 whitespace-nowrap text-center text-xs',
                                   ),
-                                  'bg-muted/80',
                                 )}
                                 style={getUserColumnStyle('action')}
                               >

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -12,8 +12,16 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import {
+  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+  ADMIN_TABLE_RESIZE_HANDLE_CLASS,
+  getAdminStickyRightCellClass,
+  getAdminStickyRightHeaderClass,
+} from '@/app/admin/components/adminTableStyles';
+import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -47,12 +55,10 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableEmpty,
   TableHead,
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -105,7 +111,6 @@ const DEFAULT_COLUMN_WIDTHS = {
   action: 115,
 } as const;
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
-type ColumnWidthState = Record<ColumnKey, number>;
 const COLUMN_KEYS = Object.keys(DEFAULT_COLUMN_WIDTHS) as ColumnKey[];
 const SINGLE_SELECT_ITEM_CLASS =
   'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
@@ -124,9 +129,6 @@ const createDefaultFilters = (): CourseFilters => ({
   updated_start_time: '',
   updated_end_time: '',
 });
-
-const clampWidth = (value: number): number =>
-  Math.min(COLUMN_MAX_WIDTH, Math.max(COLUMN_MIN_WIDTH, value));
 
 const normalizeTransferIdentifier = (
   contactType: TransferContactType,
@@ -147,44 +149,6 @@ const isValidTransferIdentifier = (
     return isValidEmail(value);
   }
   return TRANSFER_PHONE_PATTERN.test(value);
-};
-
-const createColumnWidthState = (
-  overrides?: Partial<ColumnWidthState>,
-): ColumnWidthState => {
-  const widths: ColumnWidthState = { ...DEFAULT_COLUMN_WIDTHS };
-  COLUMN_KEYS.forEach(key => {
-    const nextValue = overrides?.[key];
-    if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-      widths[key] = clampWidth(nextValue);
-    } else {
-      widths[key] = clampWidth(widths[key]);
-    }
-  });
-  return widths;
-};
-
-const loadStoredColumnWidthOverrides = (): Partial<ColumnWidthState> => {
-  if (typeof window === 'undefined') {
-    return {};
-  }
-  try {
-    const serialized = window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY);
-    if (!serialized) {
-      return {};
-    }
-    const parsed = JSON.parse(serialized) as Partial<ColumnWidthState>;
-    const overrides: Partial<ColumnWidthState> = {};
-    COLUMN_KEYS.forEach(key => {
-      const nextValue = parsed?.[key];
-      if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-        overrides[key] = clampWidth(nextValue);
-      }
-    });
-    return overrides;
-  } catch {
-    return {};
-  }
 };
 
 const renderTooltipText = (text?: string, className?: string) => {
@@ -345,9 +309,6 @@ const OperationsPage = () => {
     () => t('module.chat.lessonFeedbackClearInput'),
     [t],
   );
-  const storedManualWidthsRef = useRef<Partial<ColumnWidthState>>(
-    loadStoredColumnWidthOverrides(),
-  );
   const statusOptions = useMemo(
     () => [
       {
@@ -369,9 +330,6 @@ const OperationsPage = () => {
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const [expanded, setExpanded] = useState(false);
-  const [columnWidths, setColumnWidths] = useState<ColumnWidthState>(() =>
-    createColumnWidthState(storedManualWidthsRef.current),
-  );
   const [transferDialogOpen, setTransferDialogOpen] = useState(false);
   const [transferTargetCourse, setTransferTargetCourse] =
     useState<AdminOperationCourseItem | null>(null);
@@ -381,26 +339,24 @@ const OperationsPage = () => {
   const [transferLoading, setTransferLoading] = useState(false);
   const [transferError, setTransferError] = useState('');
   const [transferConfirmOpen, setTransferConfirmOpen] = useState(false);
-  const columnResizeRef = useRef<{
-    key: ColumnKey;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-  const manualResizeRef = useRef<Record<ColumnKey, boolean>>(
-    COLUMN_KEYS.reduce(
-      (acc, key) => ({
-        ...acc,
-        [key]: typeof storedManualWidthsRef.current[key] === 'number',
-      }),
-      {} as Record<ColumnKey, boolean>,
-    ),
-  );
   const requestedPageRef = useRef(1);
   const requestIdRef = useRef(0);
   const fetchCoursesRef = useRef<
     | ((targetPage: number, nextFilters?: CourseFilters) => Promise<void>)
     | undefined
   >(undefined);
+  const {
+    setColumnWidths,
+    getColumnStyle,
+    getResizeHandleProps,
+    isManualColumn,
+    clampWidth,
+  } = useAdminResizableColumns<ColumnKey>({
+    storageKey: COLUMN_WIDTH_STORAGE_KEY,
+    defaultWidths: DEFAULT_COLUMN_WIDTHS,
+    minWidth: COLUMN_MIN_WIDTH,
+    maxWidth: COLUMN_MAX_WIDTH,
+  });
 
   const formatMoney = useCallback(
     (value?: string) =>
@@ -409,36 +365,6 @@ const OperationsPage = () => {
   );
   const defaultUserName = useMemo(() => t('module.user.defaultUserName'), [t]);
   const displayStatusValue = filters.course_status || ALL_OPTION_VALUE;
-
-  useEffect(() => {
-    const hasManualResize = Object.values(manualResizeRef.current).some(
-      Boolean,
-    );
-    if (!hasManualResize || typeof window === 'undefined') {
-      return;
-    }
-    try {
-      const manualOverrides = COLUMN_KEYS.reduce<Partial<ColumnWidthState>>(
-        (acc, key) => {
-          if (manualResizeRef.current[key]) {
-            acc[key] = columnWidths[key];
-          }
-          return acc;
-        },
-        {},
-      );
-      if (Object.keys(manualOverrides).length === 0) {
-        window.localStorage.removeItem(COLUMN_WIDTH_STORAGE_KEY);
-        return;
-      }
-      window.localStorage.setItem(
-        COLUMN_WIDTH_STORAGE_KEY,
-        JSON.stringify(manualOverrides),
-      );
-    } catch {
-      // Ignore storage errors.
-    }
-  }, [columnWidths]);
 
   const fetchCourses = useCallback(
     async (targetPage: number, nextFilters?: CourseFilters) => {
@@ -725,59 +651,6 @@ const OperationsPage = () => {
     transferTargetCourse,
   ]);
 
-  const startColumnResize = useCallback(
-    (key: ColumnKey, clientX: number) => {
-      columnResizeRef.current = {
-        key,
-        startX: clientX,
-        startWidth: columnWidths[key],
-      };
-      manualResizeRef.current[key] = true;
-    },
-    [columnWidths],
-  );
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const info = columnResizeRef.current;
-      if (!info) {
-        return;
-      }
-      const delta = event.clientX - info.startX;
-      const desiredWidth = info.startWidth + delta;
-      const nextWidth = clampWidth(desiredWidth);
-      setColumnWidths(prev => {
-        if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
-          return prev;
-        }
-        return { ...prev, [info.key]: nextWidth };
-      });
-    };
-
-    const handleMouseUp = () => {
-      columnResizeRef.current = null;
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
-
-  const getColumnStyle = useCallback(
-    (key: ColumnKey) => {
-      const width = columnWidths[key];
-      return {
-        width,
-        minWidth: width,
-        maxWidth: width,
-      };
-    },
-    [columnWidths],
-  );
-
   const estimateWidth = (text: string, multiplier = 7) => {
     if (!text) {
       return COLUMN_MIN_WIDTH;
@@ -908,7 +781,7 @@ const OperationsPage = () => {
         setColumnWidths(prev => {
           const next = { ...prev };
           COLUMN_KEYS.forEach(key => {
-            if (!manualResizeRef.current[key]) {
+            if (!isManualColumn(key)) {
               next[key] = DEFAULT_COLUMN_WIDTHS[key];
             }
           });
@@ -980,7 +853,7 @@ const OperationsPage = () => {
       setColumnWidths(prev => {
         const updated = { ...prev };
         COLUMN_KEYS.forEach(key => {
-          if (manualResizeRef.current[key]) {
+          if (isManualColumn(key)) {
             return;
           }
           const fallback = DEFAULT_COLUMN_WIDTHS[key];
@@ -996,17 +869,21 @@ const OperationsPage = () => {
         return updated;
       });
     },
-    [formatMoney, resolveActorDisplay, resolveCourseStatusLabel, t],
+    [
+      clampWidth,
+      formatMoney,
+      isManualColumn,
+      resolveActorDisplay,
+      resolveCourseStatusLabel,
+      setColumnWidths,
+      t,
+    ],
   );
 
   const renderResizeHandle = (key: ColumnKey) => (
     <span
-      className='absolute top-0 right-0 h-full w-2 cursor-col-resize select-none'
-      onMouseDown={event => {
-        event.preventDefault();
-        startColumnResize(key, event.clientX);
-      }}
-      aria-hidden='true'
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getResizeHandleProps(key)}
     />
   );
 
@@ -1147,220 +1024,229 @@ const OperationsPage = () => {
           </div>
         </div>
 
-        <div className='max-h-[calc(100vh-18rem)] overflow-auto rounded-xl border border-border bg-white shadow-sm'>
-          {loading ? (
-            <div className='flex items-center justify-center h-40'>
-              <Loading />
-            </div>
-          ) : (
-            <TooltipProvider delayDuration={150}>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('courseId')}
-                    >
-                      {tOperations('table.courseId')}
-                      {renderResizeHandle('courseId')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('courseName')}
-                    >
-                      {tOperations('table.courseName')}
-                      {renderResizeHandle('courseName')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('price')}
-                    >
-                      {tOperations('table.price')}
-                      {renderResizeHandle('price')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('status')}
-                    >
-                      {tOperations('table.status')}
-                      {renderResizeHandle('status')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('creator')}
-                    >
-                      {tOperations('table.creator')}
-                      {renderResizeHandle('creator')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('modifier')}
-                    >
-                      {tOperations('table.modifier')}
-                      {renderResizeHandle('modifier')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('createdAt')}
-                    >
-                      {tOperations('table.createdAt')}
-                      {renderResizeHandle('createdAt')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
-                      style={getColumnStyle('updatedAt')}
-                    >
-                      {tOperations('table.updatedAt')}
-                      {renderResizeHandle('updatedAt')}
-                    </TableHead>
-                    <TableHead
-                      className='sticky right-0 top-0 z-40 bg-muted text-center shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:content-[""] before:absolute before:left-0 before:inset-y-0 before:w-px before:bg-border'
-                      style={getColumnStyle('action')}
-                    >
-                      {tOperations('table.action')}
-                      {renderResizeHandle('action')}
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {courses.length === 0 && (
-                    <TableEmpty colSpan={9}>
-                      {tOperations('emptyList')}
-                    </TableEmpty>
-                  )}
-                  {courses.map(course => {
-                    const creatorDisplay = resolveActorDisplay(
-                      course,
-                      'creator',
-                    );
-                    const updaterDisplay = resolveActorDisplay(
-                      course,
-                      'updater',
-                    );
+        <AdminTableShell
+          loading={loading}
+          isEmpty={courses.length === 0}
+          emptyContent={tOperations('emptyList')}
+          emptyColSpan={9}
+          withTooltipProvider
+          tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
+          table={emptyRow => (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('courseId')}
+                  >
+                    {tOperations('table.courseId')}
+                    {renderResizeHandle('courseId')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('courseName')}
+                  >
+                    {tOperations('table.courseName')}
+                    {renderResizeHandle('courseName')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('price')}
+                  >
+                    {tOperations('table.price')}
+                    {renderResizeHandle('price')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('status')}
+                  >
+                    {tOperations('table.status')}
+                    {renderResizeHandle('status')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('creator')}
+                  >
+                    {tOperations('table.creator')}
+                    {renderResizeHandle('creator')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('modifier')}
+                  >
+                    {tOperations('table.modifier')}
+                    {renderResizeHandle('modifier')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('createdAt')}
+                  >
+                    {tOperations('table.createdAt')}
+                    {renderResizeHandle('createdAt')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('updatedAt')}
+                  >
+                    {tOperations('table.updatedAt')}
+                    {renderResizeHandle('updatedAt')}
+                  </TableHead>
+                  <TableHead
+                    className={getAdminStickyRightHeaderClass('text-center')}
+                    style={getColumnStyle('action')}
+                  >
+                    {tOperations('table.action')}
+                    {renderResizeHandle('action')}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {emptyRow}
+                {courses.map(course => {
+                  const creatorDisplay = resolveActorDisplay(course, 'creator');
+                  const updaterDisplay = resolveActorDisplay(course, 'updater');
 
-                    return (
-                      <TableRow key={course.shifu_bid}>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('courseId')}
-                        >
-                          {renderTooltipText(course.shifu_bid)}
-                        </TableCell>
-                        <TableCell
-                          className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
-                          style={getColumnStyle('courseName')}
-                        >
-                          <button
-                            type='button'
-                            className='block max-w-full text-left text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
-                            onClick={() => handleDetailClick(course)}
-                          >
-                            {renderTooltipText(
-                              course.course_name,
-                              'truncate text-left',
-                            )}
-                          </button>
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('price')}
+                  return (
+                    <TableRow key={course.shifu_bid}>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('courseId')}
+                      >
+                        {renderTooltipText(course.shifu_bid)}
+                      </TableCell>
+                      <TableCell
+                        className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
+                        style={getColumnStyle('courseName')}
+                      >
+                        <button
+                          type='button'
+                          className='block max-w-full text-left text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
+                          onClick={() => handleDetailClick(course)}
                         >
                           {renderTooltipText(
-                            formatMoney(course.price),
-                            'text-foreground',
+                            course.course_name,
+                            'truncate text-left',
                           )}
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('status')}
-                        >
+                        </button>
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('price')}
+                      >
+                        {renderTooltipText(
+                          formatMoney(course.price),
+                          'text-foreground',
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('status')}
+                      >
+                        {renderTooltipText(
+                          resolveCourseStatusLabel(course.course_status),
+                          'text-foreground',
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('creator')}
+                      >
+                        <div className='flex flex-col gap-0.5 leading-tight'>
                           {renderTooltipText(
-                            resolveCourseStatusLabel(course.course_status),
-                            'text-foreground',
+                            creatorDisplay.primary,
+                            'text-foreground whitespace-nowrap',
                           )}
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('creator')}
-                        >
-                          <div className='flex flex-col gap-0.5 leading-tight'>
-                            {renderTooltipText(
-                              creatorDisplay.primary,
-                              'text-foreground whitespace-nowrap',
-                            )}
-                            {creatorDisplay.secondary
-                              ? renderTooltipText(
-                                  creatorDisplay.secondary,
-                                  'text-xs text-muted-foreground',
-                                )
-                              : null}
-                          </div>
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('modifier')}
-                        >
-                          <div className='flex flex-col gap-0.5 leading-tight'>
-                            {renderTooltipText(
-                              updaterDisplay.primary,
-                              'text-foreground whitespace-nowrap',
-                            )}
-                            {updaterDisplay.secondary
-                              ? renderTooltipText(
-                                  updaterDisplay.secondary,
-                                  'text-xs text-muted-foreground',
-                                )
-                              : null}
-                          </div>
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('createdAt')}
-                        >
-                          {renderTooltipText(course.created_at)}
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                          style={getColumnStyle('updatedAt')}
-                        >
-                          {renderTooltipText(course.updated_at)}
-                        </TableCell>
-                        <TableCell
-                          className='sticky right-0 z-10 bg-white shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:content-[""] before:absolute before:left-0 before:inset-y-0 before:w-px before:bg-border whitespace-nowrap text-center'
-                          style={getColumnStyle('action')}
-                        >
-                          <div className='flex justify-center'>
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <button
-                                  type='button'
-                                  className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
-                                >
-                                  {t('common.core.more')}
-                                  <ChevronDown className='h-3.5 w-3.5' />
-                                </button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align='center'>
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    handleTransferCreatorClick(course)
-                                  }
-                                >
-                                  {tOperations('actions.transferCreator')}
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </TooltipProvider>
+                          {creatorDisplay.secondary
+                            ? renderTooltipText(
+                                creatorDisplay.secondary,
+                                'text-xs text-muted-foreground',
+                              )
+                            : null}
+                        </div>
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('modifier')}
+                      >
+                        <div className='flex flex-col gap-0.5 leading-tight'>
+                          {renderTooltipText(
+                            updaterDisplay.primary,
+                            'text-foreground whitespace-nowrap',
+                          )}
+                          {updaterDisplay.secondary
+                            ? renderTooltipText(
+                                updaterDisplay.secondary,
+                                'text-xs text-muted-foreground',
+                              )
+                            : null}
+                        </div>
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('createdAt')}
+                      >
+                        {renderTooltipText(course.created_at)}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        style={getColumnStyle('updatedAt')}
+                      >
+                        {renderTooltipText(course.updated_at)}
+                      </TableCell>
+                      <TableCell
+                        className={getAdminStickyRightCellClass(
+                          'whitespace-nowrap text-center',
+                        )}
+                        style={getColumnStyle('action')}
+                      >
+                        <div className='flex justify-center'>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                type='button'
+                                className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
+                              >
+                                {t('common.core.more')}
+                                <ChevronDown className='h-3.5 w-3.5' />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align='center'>
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  handleTransferCreatorClick(course)
+                                }
+                              >
+                                {tOperations('actions.transferCreator')}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
           )}
-        </div>
-
+          footer={
+            <AdminPagination
+              pageIndex={pageIndex}
+              pageCount={pageCount}
+              onPageChange={handlePageChange}
+              prevLabel={t('module.order.paginationPrev', 'Previous')}
+              nextLabel={t('module.order.paginationNext', 'Next')}
+              prevAriaLabel={t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              )}
+              nextAriaLabel={t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              )}
+              className='justify-end w-auto mx-0'
+            />
+          }
+        />
         <Dialog
           open={transferDialogOpen}
           onOpenChange={handleTransferDialogOpenChange}
@@ -1499,25 +1385,6 @@ const OperationsPage = () => {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
-
-        <div className='mt-4 mb-4 flex justify-end'>
-          <AdminPagination
-            pageIndex={pageIndex}
-            pageCount={pageCount}
-            onPageChange={handlePageChange}
-            prevLabel={t('module.order.paginationPrev', 'Previous')}
-            nextLabel={t('module.order.paginationNext', 'Next')}
-            prevAriaLabel={t(
-              'module.order.paginationPrevAriaLabel',
-              'Go to previous page',
-            )}
-            nextAriaLabel={t(
-              'module.order.paginationNextAriaLabel',
-              'Go to next page',
-            )}
-            className='justify-end w-auto mx-0'
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -6,8 +6,15 @@ import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import {
+  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+  ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+  ADMIN_TABLE_RESIZE_HANDLE_CLASS,
+} from '@/app/admin/components/adminTableStyles';
+import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Button } from '@/components/ui/Button';
@@ -86,49 +93,6 @@ const DEFAULT_COLUMN_WIDTHS = {
   updatedAt: 180,
 } as const;
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
-type ColumnWidthState = Record<ColumnKey, number>;
-const COLUMN_KEYS = Object.keys(DEFAULT_COLUMN_WIDTHS) as ColumnKey[];
-const clampWidth = (value: number): number =>
-  Math.min(COLUMN_MAX_WIDTH, Math.max(COLUMN_MIN_WIDTH, value));
-
-const createColumnWidthState = (
-  overrides?: Partial<ColumnWidthState>,
-): ColumnWidthState => {
-  const widths: ColumnWidthState = { ...DEFAULT_COLUMN_WIDTHS };
-  COLUMN_KEYS.forEach(key => {
-    const nextValue = overrides?.[key];
-    if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-      widths[key] = clampWidth(nextValue);
-    } else {
-      widths[key] = clampWidth(widths[key]);
-    }
-  });
-  return widths;
-};
-
-const loadStoredColumnWidthOverrides = (): Partial<ColumnWidthState> => {
-  if (typeof window === 'undefined') {
-    return {};
-  }
-  try {
-    const serialized = window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY);
-    if (!serialized) {
-      return {};
-    }
-    const parsed = JSON.parse(serialized) as Partial<ColumnWidthState>;
-    const overrides: Partial<ColumnWidthState> = {};
-    COLUMN_KEYS.forEach(key => {
-      const nextValue = parsed?.[key];
-      if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-        overrides[key] = clampWidth(nextValue);
-      }
-    });
-    return overrides;
-  } catch {
-    return {};
-  }
-};
-
 const createDefaultFilters = (): UserFilters => ({
   user_bid: '',
   identifier: '',
@@ -138,6 +102,16 @@ const createDefaultFilters = (): UserFilters => ({
   start_time: '',
   end_time: '',
 });
+
+const renderTooltipText = (text?: string, className?: string) => {
+  return (
+    <AdminTooltipText
+      text={text}
+      emptyValue={EMPTY_STATE_LABEL}
+      className={className}
+    />
+  );
+};
 
 type ClearableTextInputProps = {
   value: string;
@@ -207,7 +181,7 @@ const CourseListPreview = ({
   return (
     <button
       type='button'
-      aria-label={ariaLabel}
+      aria-label={`${ariaLabel} (${courses.length})`}
       className='py-1 text-center text-sm font-semibold text-primary transition-colors hover:text-primary/80'
       onClick={onView}
     >
@@ -299,12 +273,6 @@ export default function AdminOperationUsersPage() {
   const [courseDialog, setCourseDialog] = useState<CourseDialogState | null>(
     null,
   );
-  const storedManualWidthsRef = useRef<Partial<ColumnWidthState>>(
-    loadStoredColumnWidthOverrides(),
-  );
-  const [columnWidths, setColumnWidths] = useState<ColumnWidthState>(() =>
-    createColumnWidthState(storedManualWidthsRef.current),
-  );
   const [draftFilters, setDraftFilters] = useState<UserFilters>(() =>
     createDefaultFilters(),
   );
@@ -313,11 +281,13 @@ export default function AdminOperationUsersPage() {
   );
   const requestIdRef = useRef(0);
   const lastRequestedPageRef = useRef(1);
-  const columnResizeRef = useRef<{
-    key: ColumnKey;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
+  const { getColumnStyle, getResizeHandleProps } =
+    useAdminResizableColumns<ColumnKey>({
+      storageKey: COLUMN_WIDTH_STORAGE_KEY,
+      defaultWidths: DEFAULT_COLUMN_WIDTHS,
+      minWidth: COLUMN_MIN_WIDTH,
+      maxWidth: COLUMN_MAX_WIDTH,
+    });
 
   const resolveStatusLabel = useCallback(
     (status: string) => {
@@ -458,80 +428,10 @@ export default function AdminOperationUsersPage() {
     void fetchUsers(nextPage, appliedFilters);
   };
 
-  React.useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    try {
-      window.localStorage.setItem(
-        COLUMN_WIDTH_STORAGE_KEY,
-        JSON.stringify(columnWidths),
-      );
-    } catch {
-      // Ignore persistence failures so table interactions do not crash the page.
-    }
-  }, [columnWidths]);
-
-  const startColumnResize = useCallback(
-    (key: ColumnKey, clientX: number) => {
-      columnResizeRef.current = {
-        key,
-        startX: clientX,
-        startWidth: columnWidths[key],
-      };
-    },
-    [columnWidths],
-  );
-
-  React.useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const info = columnResizeRef.current;
-      if (!info) {
-        return;
-      }
-      const delta = event.clientX - info.startX;
-      const desiredWidth = info.startWidth + delta;
-      const nextWidth = clampWidth(desiredWidth);
-      setColumnWidths(prev => {
-        if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
-          return prev;
-        }
-        return { ...prev, [info.key]: nextWidth };
-      });
-    };
-
-    const handleMouseUp = () => {
-      columnResizeRef.current = null;
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
-
-  const getColumnStyle = useCallback(
-    (key: ColumnKey) => {
-      const width = columnWidths[key];
-      return {
-        width,
-        minWidth: width,
-        maxWidth: width,
-      };
-    },
-    [columnWidths],
-  );
-
   const renderResizeHandle = (key: ColumnKey) => (
     <span
-      className='absolute top-0 right-0 h-full w-2 cursor-col-resize select-none'
-      onMouseDown={event => {
-        event.preventDefault();
-        startColumnResize(key, event.clientX);
-      }}
-      aria-hidden='true'
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getResizeHandleProps(key)}
     />
   );
 
@@ -852,108 +752,109 @@ export default function AdminOperationUsersPage() {
             </div>
           </div>
 
-          <div className='max-h-[calc(100vh-18rem)] overflow-auto rounded-xl border border-border bg-white shadow-sm'>
-            {loading ? (
-              <div className='flex items-center justify-center h-40'>
-                <Loading />
-              </div>
-            ) : (
+          <AdminTableShell
+            loading={loading}
+            isEmpty={users.length === 0}
+            emptyContent={tOperationsUsers('emptyList')}
+            emptyColSpan={14}
+            tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
+            table={emptyRow => (
               <Table>
                 <TableHeader>
                   <TableRow>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('userId')}
                     >
                       {tOperationsUsers('table.userId')}
                       {renderResizeHandle('userId')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('mobile')}
                     >
                       {contactColumnLabel}
                       {renderResizeHandle('mobile')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('nickname')}
                     >
                       {tOperationsUsers('table.nickname')}
                       {renderResizeHandle('nickname')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('status')}
                     >
                       {tOperationsUsers('table.status')}
                       {renderResizeHandle('status')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('role')}
                     >
                       {tOperationsUsers('table.role')}
                       {renderResizeHandle('role')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('loginMethods')}
                     >
                       {tOperationsUsers('table.loginMethods')}
                       {renderResizeHandle('loginMethods')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('registrationSource')}
                     >
                       {tOperationsUsers('table.registrationSource')}
                       {renderResizeHandle('registrationSource')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('learningCourses')}
                     >
                       {tOperationsUsers('table.learningCourses')}
                       {renderResizeHandle('learningCourses')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('createdCourses')}
                     >
                       {tOperationsUsers('table.createdCourses')}
                       {renderResizeHandle('createdCourses')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('totalPaidAmount')}
                     >
                       {tOperationsUsers('table.totalPaidAmount')}
                       {renderResizeHandle('totalPaidAmount')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('lastLoginAt')}
                     >
                       {tOperationsUsers('table.lastLoginAt')}
                       {renderResizeHandle('lastLoginAt')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('lastLearningAt')}
                     >
                       {tOperationsUsers('table.lastLearningAt')}
                       {renderResizeHandle('lastLearningAt')}
                     </TableHead>
                     <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                       style={getColumnStyle('createdAt')}
                     >
                       {tOperationsUsers('table.createdAt')}
                       {renderResizeHandle('createdAt')}
                     </TableHead>
                     <TableHead
-                      className='relative sticky top-0 z-30 bg-muted text-center'
+                      className={ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS}
                       style={getColumnStyle('updatedAt')}
                     >
                       {tOperationsUsers('table.updatedAt')}
@@ -962,11 +863,7 @@ export default function AdminOperationUsersPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {users.length === 0 ? (
-                    <TableEmpty colSpan={14}>
-                      {tOperationsUsers('emptyList')}
-                    </TableEmpty>
-                  ) : null}
+                  {emptyRow}
                   {users.map(user => {
                     const primaryContact =
                       contactType === 'email'
@@ -980,175 +877,142 @@ export default function AdminOperationUsersPage() {
                           .map(resolveLoginMethodLabel)
                           .join(' / ')
                       : EMPTY_STATE_LABEL;
+                    const registrationSource = resolveRegistrationSourceLabel(
+                      user.registration_source,
+                    );
                     return (
                       <TableRow key={user.user_bid}>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('userId')}
                         >
                           {userDetailUrl ? (
                             <Link
                               href={userDetailUrl}
-                              className='inline-block max-w-full text-primary transition-colors hover:text-primary/80 hover:underline'
+                              className='text-primary transition-colors hover:text-primary/80'
                             >
-                              <AdminTooltipText
-                                text={user.user_bid}
-                                emptyValue={EMPTY_STATE_LABEL}
-                              />
+                              {renderTooltipText(user.user_bid)}
                             </Link>
                           ) : (
-                            <AdminTooltipText
-                              text={user.user_bid}
-                              emptyValue={EMPTY_STATE_LABEL}
-                            />
+                            renderTooltipText(user.user_bid)
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('mobile')}
                         >
                           {userDetailUrl && primaryContact ? (
                             <Link
                               href={userDetailUrl}
-                              className='inline-block max-w-full text-primary transition-colors hover:text-primary/80 hover:underline'
+                              className='text-primary transition-colors hover:text-primary/80'
                             >
-                              <AdminTooltipText
-                                text={primaryContact}
-                                emptyValue={EMPTY_STATE_LABEL}
-                              />
+                              {renderTooltipText(primaryContact)}
                             </Link>
                           ) : (
-                            <AdminTooltipText
-                              text={primaryContact}
-                              emptyValue={EMPTY_STATE_LABEL}
-                            />
+                            renderTooltipText(
+                              primaryContact || EMPTY_STATE_LABEL,
+                            )
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('nickname')}
                         >
-                          <AdminTooltipText
-                            text={user.nickname || defaultUserName}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(user.nickname || defaultUserName)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('status')}
                         >
-                          <AdminTooltipText
-                            text={resolveStatusLabel(user.user_status)}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(
+                            resolveStatusLabel(user.user_status),
+                          )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('role')}
                         >
-                          <AdminTooltipText
-                            text={resolveRoleLabel(user.user_role)}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(resolveRoleLabel(user.user_role))}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('loginMethods')}
                         >
-                          <AdminTooltipText
-                            text={loginMethods}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(loginMethods)}
+                        </TableCell>
+                        <TableCell
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          style={getColumnStyle('registrationSource')}
+                        >
+                          {renderTooltipText(registrationSource)}
                         </TableCell>
                         <TableCell
                           className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
-                          style={getColumnStyle('registrationSource')}
-                        >
-                          <AdminTooltipText
-                            text={resolveRegistrationSourceLabel(
-                              user.registration_source,
-                            )}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='border-r border-border last:border-r-0 align-top text-center'
                           style={getColumnStyle('learningCourses')}
                         >
                           <CourseListPreview
-                            courses={user.learning_courses || []}
-                            emptyLabel={tOperationsUsers('courseSummary.empty')}
-                            ariaLabel={`${tOperationsUsers('table.learningCourses')} (${(user.learning_courses || []).length})`}
+                            courses={user.learning_courses}
+                            emptyLabel={EMPTY_STATE_LABEL}
+                            ariaLabel={tOperationsUsers(
+                              'table.learningCourses',
+                            )}
                             onView={() =>
                               setCourseDialog({
                                 user,
-                                courses: user.learning_courses || [],
+                                courses: user.learning_courses,
                                 type: 'learning',
                               })
                             }
                           />
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 align-top text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('createdCourses')}
                         >
                           <CourseListPreview
-                            courses={user.created_courses || []}
-                            emptyLabel={tOperationsUsers('courseSummary.empty')}
-                            ariaLabel={`${tOperationsUsers('table.createdCourses')} (${(user.created_courses || []).length})`}
+                            courses={user.created_courses}
+                            emptyLabel={EMPTY_STATE_LABEL}
+                            ariaLabel={tOperationsUsers('table.createdCourses')}
                             onView={() =>
                               setCourseDialog({
                                 user,
-                                courses: user.created_courses || [],
+                                courses: user.created_courses,
                                 type: 'created',
                               })
                             }
                           />
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('totalPaidAmount')}
                         >
-                          <AdminTooltipText
-                            text={`${currencySymbol}${user.total_paid_amount || '0'}`}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(
+                            `${currencySymbol}${user.total_paid_amount || '0'}`,
+                          )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('lastLoginAt')}
                         >
-                          <AdminTooltipText
-                            text={user.last_login_at}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(user.last_login_at)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('lastLearningAt')}
                         >
-                          <AdminTooltipText
-                            text={user.last_learning_at}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(user.last_learning_at)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('createdAt')}
                         >
-                          <AdminTooltipText
-                            text={user.created_at}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(user.created_at)}
                         </TableCell>
                         <TableCell
-                          className='whitespace-nowrap overflow-hidden text-ellipsis text-center'
+                          className='whitespace-nowrap overflow-hidden text-ellipsis'
                           style={getColumnStyle('updatedAt')}
                         >
-                          <AdminTooltipText
-                            text={user.updated_at}
-                            emptyValue={EMPTY_STATE_LABEL}
-                          />
+                          {renderTooltipText(user.updated_at)}
                         </TableCell>
                       </TableRow>
                     );
@@ -1156,10 +1020,7 @@ export default function AdminOperationUsersPage() {
                 </TableBody>
               </Table>
             )}
-          </div>
-
-          {pageCount > 1 ? (
-            <div className='mt-4 mb-4 flex justify-end'>
+            footer={
               <AdminPagination
                 pageIndex={pageIndex}
                 pageCount={pageCount}
@@ -1176,9 +1037,8 @@ export default function AdminOperationUsersPage() {
                 )}
                 className='justify-end w-auto mx-0'
               />
-            </div>
-          ) : null}
-
+            }
+          />
           <Dialog
             open={Boolean(courseDialog)}
             onOpenChange={open => {

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -883,13 +883,13 @@ export default function AdminOperationUsersPage() {
                     return (
                       <TableRow key={user.user_bid}>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('userId')}
                         >
                           {userDetailUrl ? (
                             <Link
                               href={userDetailUrl}
-                              className='text-primary transition-colors hover:text-primary/80'
+                              className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(user.user_bid)}
                             </Link>
@@ -898,13 +898,13 @@ export default function AdminOperationUsersPage() {
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('mobile')}
                         >
                           {userDetailUrl && primaryContact ? (
                             <Link
                               href={userDetailUrl}
-                              className='text-primary transition-colors hover:text-primary/80'
+                              className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(primaryContact)}
                             </Link>
@@ -915,13 +915,13 @@ export default function AdminOperationUsersPage() {
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('nickname')}
                         >
                           {renderTooltipText(user.nickname || defaultUserName)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('status')}
                         >
                           {renderTooltipText(
@@ -929,19 +929,19 @@ export default function AdminOperationUsersPage() {
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('role')}
                         >
                           {renderTooltipText(resolveRoleLabel(user.user_role))}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('loginMethods')}
                         >
                           {renderTooltipText(loginMethods)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('registrationSource')}
                         >
                           {renderTooltipText(registrationSource)}
@@ -983,7 +983,7 @@ export default function AdminOperationUsersPage() {
                           />
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('totalPaidAmount')}
                         >
                           {renderTooltipText(
@@ -991,25 +991,25 @@ export default function AdminOperationUsersPage() {
                           )}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('lastLoginAt')}
                         >
                           {renderTooltipText(user.last_login_at)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('lastLearningAt')}
                         >
                           {renderTooltipText(user.last_learning_at)}
                         </TableCell>
                         <TableCell
-                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(user.created_at)}
                         </TableCell>
                         <TableCell
-                          className='whitespace-nowrap overflow-hidden text-ellipsis'
+                          className='whitespace-nowrap overflow-hidden text-ellipsis text-center'
                           style={getColumnStyle('updatedAt')}
                         >
                           {renderTooltipText(user.updated_at)}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1021,22 +1021,24 @@ export default function AdminOperationUsersPage() {
               </Table>
             )}
             footer={
-              <AdminPagination
-                pageIndex={pageIndex}
-                pageCount={pageCount}
-                onPageChange={handlePageChange}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='justify-end w-auto mx-0'
-              />
+              pageCount > 1 ? (
+                <AdminPagination
+                  pageIndex={pageIndex}
+                  pageCount={pageCount}
+                  onPageChange={handlePageChange}
+                  prevLabel={t('module.order.paginationPrev', 'Previous')}
+                  nextLabel={t('module.order.paginationNext', 'Next')}
+                  prevAriaLabel={t(
+                    'module.order.paginationPrevAriaLabel',
+                    'Go to previous page',
+                  )}
+                  nextAriaLabel={t(
+                    'module.order.paginationNextAriaLabel',
+                    'Go to next page',
+                  )}
+                  className='justify-end w-auto mx-0'
+                />
+              ) : null
             }
           />
           <Dialog

--- a/src/cook-web/src/app/admin/orders/page.tsx
+++ b/src/cook-web/src/app/admin/orders/page.tsx
@@ -10,7 +10,16 @@ import React, {
 import { useRouter, useSearchParams } from 'next/navigation';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import {
+  ADMIN_TABLE_HEADER_CELL_CLASS,
+  ADMIN_TABLE_HEADER_LAST_CELL_CLASS,
+  ADMIN_TABLE_RESIZE_HANDLE_CLASS,
+  getAdminStickyRightCellClass,
+  getAdminStickyRightHeaderClass,
+} from '@/app/admin/components/adminTableStyles';
+import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '@/store';
 import { ErrorWithCode } from '@/lib/request';
@@ -35,13 +44,11 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableEmpty,
   TableHead,
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
 import { Badge } from '@/components/ui/Badge';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import OrderDetailSheet from '@/components/order/OrderDetailSheet';
 import ImportActivationDialog from '@/components/order/ImportActivationDialog';
 import { cn } from '@/lib/utils';
@@ -98,42 +105,8 @@ type SearchParamsLike = Pick<
   'get' | 'has' | 'toString'
 > | null;
 
-const clampWidth = (value: number): number =>
-  Math.min(COLUMN_MAX_WIDTH, Math.max(COLUMN_MIN_WIDTH, value));
-
 const SINGLE_SELECT_ITEM_CLASS =
   'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
-
-const createColumnWidthState = (
-  overrides?: Partial<ColumnWidthState>,
-): ColumnWidthState => {
-  const widths = { ...DEFAULT_COLUMN_WIDTHS };
-  COLUMN_KEYS.forEach(key => {
-    const nextValue = overrides?.[key];
-    if (typeof nextValue === 'number' && Number.isFinite(nextValue)) {
-      widths[key] = clampWidth(nextValue);
-    } else {
-      widths[key] = clampWidth(widths[key]);
-    }
-  });
-  return widths;
-};
-
-const loadStoredColumnWidths = (): ColumnWidthState => {
-  if (typeof window === 'undefined') {
-    return createColumnWidthState();
-  }
-  try {
-    const serialized = window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY);
-    if (!serialized) {
-      return createColumnWidthState();
-    }
-    const parsed = JSON.parse(serialized) as Partial<ColumnWidthState>;
-    return createColumnWidthState(parsed);
-  } catch {
-    return createColumnWidthState();
-  }
-};
 
 const createDefaultFilters = (): OrderFilters => ({
   order_bid: '',
@@ -231,52 +204,18 @@ const OrdersPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const [columnWidths, setColumnWidths] = useState<ColumnWidthState>(() =>
-    loadStoredColumnWidths(),
-  );
-  const columnResizeRef = useRef<{
-    key: ColumnKey;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-  const manualResizeRef = useRef<Record<ColumnKey, boolean>>(
-    COLUMN_KEYS.reduce(
-      (acc, key) => ({ ...acc, [key]: false }),
-      {} as Record<ColumnKey, boolean>,
-    ),
-  );
-  const initializedManualRef = useRef(false);
-
-  useEffect(() => {
-    if (initializedManualRef.current) {
-      return;
-    }
-    initializedManualRef.current = true;
-    COLUMN_KEYS.forEach(key => {
-      const storedWidth = columnWidths[key];
-      const defaultWidth = DEFAULT_COLUMN_WIDTHS[key];
-      if (Math.abs(storedWidth - defaultWidth) > 0.5) {
-        manualResizeRef.current[key] = true;
-      }
-    });
-  }, [columnWidths]);
-
-  useEffect(() => {
-    const hasManualResize = Object.values(manualResizeRef.current).some(
-      Boolean,
-    );
-    if (!hasManualResize || typeof window === 'undefined') {
-      return;
-    }
-    try {
-      window.localStorage.setItem(
-        COLUMN_WIDTH_STORAGE_KEY,
-        JSON.stringify(columnWidths),
-      );
-    } catch {
-      // Ignore storage errors (e.g. private mode, quota issues).
-    }
-  }, [columnWidths]);
+  const {
+    setColumnWidths,
+    getColumnStyle,
+    getResizeHandleProps,
+    isManualColumn,
+    clampWidth,
+  } = useAdminResizableColumns<ColumnKey>({
+    storageKey: COLUMN_WIDTH_STORAGE_KEY,
+    defaultWidths: DEFAULT_COLUMN_WIDTHS,
+    minWidth: COLUMN_MIN_WIDTH,
+    maxWidth: COLUMN_MAX_WIDTH,
+  });
 
   const ALL_OPTION_VALUE = '__all__';
 
@@ -441,62 +380,6 @@ const OrdersPage = () => {
     [router, searchParamsString],
   );
 
-  const startColumnResize = useCallback(
-    (key: ColumnKey, clientX: number) => {
-      columnResizeRef.current = {
-        key,
-        startX: clientX,
-        startWidth: columnWidths[key],
-      };
-      manualResizeRef.current[key] = true;
-    },
-    [columnWidths],
-  );
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      const info = columnResizeRef.current;
-      if (!info) {
-        return;
-      }
-      const delta = event.clientX - info.startX;
-      const desiredWidth = info.startWidth + delta;
-      const nextWidth = Math.min(
-        COLUMN_MAX_WIDTH,
-        Math.max(COLUMN_MIN_WIDTH, desiredWidth),
-      );
-      setColumnWidths(prev => {
-        if (Math.abs(prev[info.key] - nextWidth) < 0.5) {
-          return prev;
-        }
-        return { ...prev, [info.key]: nextWidth };
-      });
-    };
-
-    const handleMouseUp = () => {
-      columnResizeRef.current = null;
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, []);
-
-  const getColumnStyle = useCallback(
-    (key: ColumnKey) => {
-      const width = columnWidths[key];
-      return {
-        width,
-        minWidth: width,
-        maxWidth: width,
-      };
-    },
-    [columnWidths],
-  );
-
   const estimateWidth = (text: string, multiplier = 7) => {
     if (!text) {
       return COLUMN_MIN_WIDTH;
@@ -511,7 +394,7 @@ const OrdersPage = () => {
         setColumnWidths(prev => {
           const next = { ...prev };
           COLUMN_KEYS.forEach(key => {
-            if (!manualResizeRef.current[key]) {
+            if (!isManualColumn(key)) {
               next[key] = DEFAULT_COLUMN_WIDTHS[key];
             }
           });
@@ -573,20 +456,25 @@ const OrdersPage = () => {
       setColumnWidths(prev => {
         const updated = { ...prev };
         COLUMN_KEYS.forEach(key => {
-          if (manualResizeRef.current[key]) {
+          if (isManualColumn(key)) {
             return;
           }
           const fallback = DEFAULT_COLUMN_WIDTHS[key];
           const calculated = nextWidths[key] ?? fallback;
-          updated[key] = Math.min(
-            COLUMN_MAX_WIDTH,
-            Math.max(COLUMN_MIN_WIDTH, calculated),
-          );
+          updated[key] = clampWidth(calculated);
         });
         return updated;
       });
     },
-    [defaultUserName, formatMoney, isEmailMode, t],
+    [
+      clampWidth,
+      defaultUserName,
+      formatMoney,
+      isEmailMode,
+      isManualColumn,
+      setColumnWidths,
+      t,
+    ],
   );
 
   const resolveStatusLabel = useCallback(
@@ -603,12 +491,8 @@ const OrdersPage = () => {
 
   const renderResizeHandle = (key: ColumnKey) => (
     <span
-      className='absolute top-0 right-0 h-full w-2 cursor-col-resize select-none'
-      onMouseDown={event => {
-        event.preventDefault();
-        startColumnResize(key, event.clientX);
-      }}
-      aria-hidden='true'
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getResizeHandleProps(key)}
     />
   );
 
@@ -1112,225 +996,221 @@ const OrdersPage = () => {
           )}
         </div>
 
-        <div className='flex-1 overflow-auto rounded-xl border border-border bg-white shadow-sm'>
-          {loading ? (
-            <div className='flex items-center justify-center h-40'>
-              <Loading />
-            </div>
-          ) : (
-            <TooltipProvider delayDuration={150}>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
+        <AdminTableShell
+          loading={loading}
+          isEmpty={orders.length === 0}
+          emptyContent={t('module.order.emptyList')}
+          emptyColSpan={8}
+          withTooltipProvider
+          containerClassName='flex-1'
+          tableWrapperClassName='flex-1 overflow-auto'
+          table={emptyRow => (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('orderId')}
+                  >
+                    {t('module.order.table.orderId')}
+                    {renderResizeHandle('orderId')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('shifu')}
+                  >
+                    {t('module.order.table.shifu')}
+                    {renderResizeHandle('shifu')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('user')}
+                  >
+                    {t('module.order.table.user')}
+                    {renderResizeHandle('user')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('amount')}
+                  >
+                    {t('module.order.table.amount')}
+                    {renderResizeHandle('amount')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('status')}
+                  >
+                    {t('module.order.table.status')}
+                    {renderResizeHandle('status')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CLASS}
+                    style={getColumnStyle('payment')}
+                  >
+                    {t('module.order.table.payment')}
+                    {renderResizeHandle('payment')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_LAST_CELL_CLASS}
+                    style={getColumnStyle('createdAt')}
+                  >
+                    {t('module.order.table.createdAt')}
+                    {renderResizeHandle('createdAt')}
+                  </TableHead>
+                  <TableHead
+                    className={getAdminStickyRightHeaderClass()}
+                    style={getColumnStyle('action')}
+                  >
+                    {t('module.order.table.action')}
+                    {renderResizeHandle('action')}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {emptyRow}
+                {orders.map(order => (
+                  <TableRow key={order.order_bid}>
+                    <TableCell
+                      className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                       style={getColumnStyle('orderId')}
                     >
-                      {t('module.order.table.orderId')}
-                      {renderResizeHandle('orderId')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
+                      {renderTooltipText(order.order_bid)}
+                    </TableCell>
+                    <TableCell
+                      className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
                       style={getColumnStyle('shifu')}
                     >
-                      {t('module.order.table.shifu')}
-                      {renderResizeHandle('shifu')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
+                      {renderTooltipText(
+                        order.shifu_name || order.shifu_bid,
+                        'text-foreground',
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                       style={getColumnStyle('user')}
                     >
-                      {t('module.order.table.user')}
-                      {renderResizeHandle('user')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
+                      {renderTooltipText(
+                        (isEmailMode ? order.user_email : order.user_mobile) ||
+                          order.user_bid,
+                        'text-foreground whitespace-nowrap',
+                      )}
+                      <br />
+                      {renderTooltipText(
+                        order.user_nickname || defaultUserName,
+                        'text-xs text-muted-foreground mt-1',
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
                       style={getColumnStyle('amount')}
                     >
-                      {t('module.order.table.amount')}
-                      {renderResizeHandle('amount')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
-                      style={getColumnStyle('status')}
-                    >
-                      {t('module.order.table.status')}
-                      {renderResizeHandle('status')}
-                    </TableHead>
-                    <TableHead
-                      className='relative border-r border-border last:border-r-0 sticky top-0 z-30 bg-muted'
-                      style={getColumnStyle('payment')}
-                    >
-                      {t('module.order.table.payment')}
-                      {renderResizeHandle('payment')}
-                    </TableHead>
-                    <TableHead
-                      className='relative sticky top-0 z-30 bg-muted'
-                      style={getColumnStyle('createdAt')}
-                    >
-                      {t('module.order.table.createdAt')}
-                      {renderResizeHandle('createdAt')}
-                    </TableHead>
-                    <TableHead
-                      className='sticky right-0 top-0 z-40 bg-muted shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:content-[""] before:absolute before:left-0 before:inset-y-0 before:w-px before:bg-border'
-                      style={getColumnStyle('action')}
-                    >
-                      {t('module.order.table.action')}
-                      {renderResizeHandle('action')}
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {orders.length === 0 && (
-                    <TableEmpty colSpan={8}>
-                      {t('module.order.emptyList')}
-                    </TableEmpty>
-                  )}
-                  {orders.map(order => (
-                    <TableRow key={order.order_bid}>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('orderId')}
-                      >
-                        {renderTooltipText(order.order_bid)}
-                      </TableCell>
-                      <TableCell
-                        className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
-                        style={getColumnStyle('shifu')}
-                      >
+                      <div className='flex flex-col gap-1'>
                         {renderTooltipText(
-                          order.shifu_name || order.shifu_bid,
+                          formatMoney(order.paid_price),
                           'text-foreground',
                         )}
-                      </TableCell>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('user')}
-                      >
-                        {renderTooltipText(
-                          (isEmailMode
-                            ? order.user_email
-                            : order.user_mobile) || order.user_bid,
-                          'text-foreground whitespace-nowrap',
-                        )}
-                        <br />
-                        {renderTooltipText(
-                          order.user_nickname || defaultUserName,
-                          'text-xs text-muted-foreground mt-1',
-                        )}
-                      </TableCell>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('amount')}
-                      >
-                        <div className='flex flex-col gap-1'>
-                          {renderTooltipText(
-                            formatMoney(order.paid_price),
-                            'text-foreground',
-                          )}
-                          {order.discount_amount &&
-                            order.discount_amount !== '0' && (
-                              <span className='text-xs text-muted-foreground'>
-                                <span className="after:content-[':'] after:mr-1">
-                                  {t('module.order.fields.discount')}
-                                </span>
-                                {formatMoney(order.discount_amount)}
-                              </span>
-                            )}
-                          {order.coupon_codes?.length > 0 && (
-                            <span
-                              className='text-xs text-muted-foreground'
-                              title={order.coupon_codes.join(', ')}
-                            >
+                        {order.discount_amount &&
+                          order.discount_amount !== '0' && (
+                            <span className='text-xs text-muted-foreground'>
                               <span className="after:content-[':'] after:mr-1">
-                                {t('module.order.sections.coupons')}
+                                {t('module.order.fields.discount')}
                               </span>
-                              {order.coupon_codes.length}
+                              {formatMoney(order.discount_amount)}
                             </span>
                           )}
-                        </div>
-                      </TableCell>
-                      <TableCell
-                        className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
-                        style={getColumnStyle('status')}
+                        {order.coupon_codes?.length > 0 && (
+                          <span
+                            className='text-xs text-muted-foreground'
+                            title={order.coupon_codes.join(', ')}
+                          >
+                            <span className="after:content-[':'] after:mr-1">
+                              {t('module.order.sections.coupons')}
+                            </span>
+                            {order.coupon_codes.length}
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell
+                      className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
+                      style={getColumnStyle('status')}
+                    >
+                      <Badge variant={resolveStatusVariant(order.status)}>
+                        {resolveStatusLabel(order)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell
+                      className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                      style={getColumnStyle('payment')}
+                    >
+                      <div className='text-sm text-foreground'>
+                        {renderTooltipText(
+                          t(order.payment_channel_key),
+                          'text-sm',
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell
+                      className='whitespace-nowrap overflow-hidden text-ellipsis'
+                      style={getColumnStyle('createdAt')}
+                    >
+                      {renderTooltipText(order.created_at)}
+                    </TableCell>
+                    <TableCell
+                      className={getAdminStickyRightCellClass(
+                        'whitespace-nowrap overflow-hidden text-ellipsis',
+                      )}
+                      style={getColumnStyle('action')}
+                    >
+                      <Button
+                        size='sm'
+                        variant='outline'
+                        onClick={() => handleViewDetail(order)}
                       >
-                        <Badge variant={resolveStatusVariant(order.status)}>
-                          {resolveStatusLabel(order)}
-                        </Badge>
-                      </TableCell>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('payment')}
-                      >
-                        <div className='text-sm text-foreground'>
-                          {renderTooltipText(
-                            t(order.payment_channel_key),
-                            'text-sm',
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell
-                        className='whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('createdAt')}
-                      >
-                        {renderTooltipText(order.created_at)}
-                      </TableCell>
-                      <TableCell
-                        className='sticky right-0 z-10 bg-white shadow-[-4px_0_4px_rgba(0,0,0,0.02)] before:content-[""] before:absolute before:left-0 before:inset-y-0 before:w-px before:bg-border whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('action')}
-                      >
-                        <Button
-                          size='sm'
-                          variant='outline'
-                          onClick={() => handleViewDetail(order)}
-                        >
-                          {t('module.order.table.view')}
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TooltipProvider>
+                        {t('module.order.table.view')}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           )}
-        </div>
-
-        <div className='mt-4 mb-4 flex justify-end'>
-          <AdminPagination
-            pageIndex={pageIndex}
-            pageCount={pageCount}
-            onPageChange={handlePageChange}
-            prevLabel={t('module.order.paginationPrev', 'Previous')}
-            nextLabel={t('module.order.paginationNext', 'Next')}
-            prevAriaLabel={t(
-              'module.order.paginationPrevAriaLabel',
-              'Go to previous page',
-            )}
-            nextAriaLabel={t(
-              'module.order.paginationNextAriaLabel',
-              'Go to next page',
-            )}
-            className='justify-end w-auto mx-0'
-          />
-        </div>
-      </div>
-
-      <OrderDetailSheet
-        open={detailOpen}
-        orderBid={selectedOrder?.order_bid}
-        onOpenChange={open => {
-          setDetailOpen(open);
-          if (!open) {
-            setSelectedOrder(null);
+          footer={
+            <AdminPagination
+              pageIndex={pageIndex}
+              pageCount={pageCount}
+              onPageChange={handlePageChange}
+              prevLabel={t('module.order.paginationPrev', 'Previous')}
+              nextLabel={t('module.order.paginationNext', 'Next')}
+              prevAriaLabel={t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              )}
+              nextAriaLabel={t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              )}
+              className='justify-end w-auto mx-0'
+            />
           }
-        }}
-      />
+        />
+        <OrderDetailSheet
+          open={detailOpen}
+          orderBid={selectedOrder?.order_bid}
+          onOpenChange={open => {
+            setDetailOpen(open);
+            if (!open) {
+              setSelectedOrder(null);
+            }
+          }}
+        />
 
-      <ImportActivationDialog
-        open={importOpen}
-        onOpenChange={setImportOpen}
-        onSuccess={() => fetchOrders(1)}
-      />
+        <ImportActivationDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          onSuccess={() => fetchOrders(1)}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a shared admin table layer with `AdminTableShell`, `useAdminResizableColumns`, and sticky column style helpers
- migrate the admin operations list, orders list, operations users list, and operations course detail pages to the shared table behaviors
- preserve loading, empty state, pagination footer, sticky action columns, and resizable column persistence across the migrated pages
- keep the users page behavior aligned after migration by restoring detail links and course-count button labels

## Testing
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/page.test.tsx src/app/admin/orders/page.test.tsx src/app/admin/operations/users/page.test.tsx 'src/app/admin/operations/[shifu_bid]/page.test.tsx' --runInBand`
- `cd src/cook-web && npm run lint`
- `pre-commit run -a`

## Notes
- `cd src/cook-web && npm run type-check` still fails on existing unrelated issues under `src/cook-web/src/__tests__/...`, `src/cook-web/src/app/c/[[...id]]/...`, and `src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified admin table shell for consistent loading, empty state, and footer rendering across admin operations and orders pages.
  * Implemented shared column resizing functionality with persistent width preferences across admin tables.

* **Documentation**
  * Added comprehensive documentation outlining the admin table architecture and layering approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->