### PR TITLE
fix: align course user payment metrics

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -317,6 +317,14 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
+def _build_course_order_amount_expr():
+    return case(
+        (Order.paid_price > 0, Order.paid_price),
+        (Order.payable_price > 0, Order.payable_price),
+        else_=0,
+    )
+
+
 def _find_matching_creator_bids(keyword: str) -> Optional[Set[str]]:
     normalized = _normalize_identifier(keyword)
     if not normalized:
@@ -1819,10 +1827,11 @@ def _load_course_user_paid_amount_map(
     if not normalized_user_bids:
         return {}
 
+    counted_order_amount_expr = _build_course_order_amount_expr()
     rows = (
         db.session.query(
             Order.user_bid,
-            db.func.coalesce(db.func.sum(Order.paid_price), 0).label(
+            db.func.coalesce(db.func.sum(counted_order_amount_expr), 0).label(
                 "total_paid_amount"
             ),
         )
@@ -2024,11 +2033,7 @@ def get_operator_course_detail(
             .scalar()
             or 0
         )
-        order_amount_expr = case(
-            (Order.paid_price > 0, Order.paid_price),
-            (Order.payable_price > 0, Order.payable_price),
-            else_=0,
-        )
+        order_amount_expr = _build_course_order_amount_expr()
         order_summary = (
             db.session.query(
                 db.func.count(Order.id).label("order_count"),

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -539,10 +539,11 @@ def _load_operator_user_total_paid_amount_map(
     if not normalized_user_bids:
         return {}
 
+    counted_order_amount_expr = _build_course_order_amount_expr()
     rows = (
         db.session.query(
             Order.user_bid,
-            db.func.coalesce(db.func.sum(Order.paid_price), 0).label(
+            db.func.coalesce(db.func.sum(counted_order_amount_expr), 0).label(
                 "total_paid_amount"
             ),
         )

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -194,15 +194,17 @@ def _seed_paid_order(
     shifu_bid: str,
     user_bid: str,
     paid_price: str,
+    payable_price: str | None = None,
     created_at: datetime,
 ) -> None:
+    resolved_payable_price = payable_price if payable_price is not None else paid_price
     db.session.add(
         Order(
             order_bid=f"order-{user_bid}-{shifu_bid}",
             shifu_bid=shifu_bid,
             user_bid=user_bid,
             paid_price=Decimal(paid_price),
-            payable_price=Decimal(paid_price),
+            payable_price=Decimal(resolved_payable_price),
             status=ORDER_STATUS_SUCCESS,
             created_at=created_at,
             updated_at=created_at,
@@ -1331,6 +1333,79 @@ def test_admin_operation_course_users_route_applies_filters(
     item = payload["data"]["items"][0]
     assert item["user_bid"] == "student-1"
     assert item["total_paid_amount"] == "299"
+
+
+def test_admin_operation_course_users_route_marks_redeem_orders_as_paid(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+    updated_at = datetime(2026, 4, 3, 15, 30, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(app, user_bid="redeem-user", phone="13900001235")
+        _seed_user(app, user_bid="zero-user", phone="13900001236")
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            title="Lesson 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=updated_at,
+        )
+        _seed_paid_order(
+            shifu_bid="course-detail",
+            user_bid="redeem-user",
+            paid_price="0.00",
+            payable_price="199.00",
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+        )
+        _seed_paid_order(
+            shifu_bid="course-detail",
+            user_bid="zero-user",
+            paid_price="0.00",
+            payable_price="0.00",
+            created_at=datetime(2026, 4, 5, 10, 0, 0),
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/users?page=1&page_size=20",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+
+    items_by_user_bid = {item["user_bid"]: item for item in payload["data"]["items"]}
+    assert items_by_user_bid["redeem-user"]["is_paid"] is True
+    assert items_by_user_bid["redeem-user"]["total_paid_amount"] == "199"
+    assert items_by_user_bid["zero-user"]["is_paid"] is False
+    assert items_by_user_bid["zero-user"]["total_paid_amount"] == "0"
+
+    paid_only_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/users?page=1&page_size=20"
+        "&payment_status=paid",
+        headers={"Token": "test-token"},
+    )
+    paid_only_payload = paid_only_response.get_json(force=True)
+
+    assert paid_only_response.status_code == 200
+    assert paid_only_payload["code"] == 0
+    assert paid_only_payload["data"]["total"] == 1
+    assert paid_only_payload["data"]["items"][0]["user_bid"] == "redeem-user"
 
 
 def test_admin_operation_course_detail_metrics_include_full_coupon_redemptions(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -172,12 +172,16 @@ def _seed_success_order(
     shifu_bid: str,
     user_bid: str,
     created_at: datetime,
+    paid_price: str = "0.00",
+    payable_price: str = "0.00",
 ):
     order = Order(
         order_bid=order_bid,
         shifu_bid=shifu_bid,
         user_bid=user_bid,
         status=ORDER_STATUS_SUCCESS,
+        paid_price=Decimal(paid_price),
+        payable_price=Decimal(payable_price),
     )
     order.created_at = created_at
     order.updated_at = created_at
@@ -615,10 +619,9 @@ def test_get_operator_user_detail_returns_registration_login_payment_and_learnin
             shifu_bid="course-rich-1",
             user_bid="user-profile-rich",
             created_at=datetime(2026, 4, 10, 9, 0, 0),
+            paid_price="88.50",
+            payable_price="88.50",
         )
-        paid_order = Order.query.filter(Order.order_bid == "order-rich-1").first()
-        paid_order.paid_price = Decimal("88.50")
-        db.session.commit()
         _seed_learn_progress(
             shifu_bid="course-rich-1",
             outline_item_bid="lesson-rich-1",
@@ -633,6 +636,60 @@ def test_get_operator_user_detail_returns_registration_login_payment_and_learnin
     assert item.last_login_at == "2026-04-10 08:00:00"
     assert item.total_paid_amount == "88.50"
     assert item.last_learning_at == "2026-04-11 10:00:00"
+
+
+def test_list_operator_users_counts_redeem_orders_in_total_paid_amount(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="user-redeem",
+            identify="redeem@example.com",
+            nickname="Redeem User",
+            state=USER_STATE_PAID,
+            created_at=datetime(2026, 4, 9, 9, 0, 0),
+            updated_at=datetime(2026, 4, 9, 10, 0, 0),
+            providers=[("email", "redeem@example.com")],
+        )
+        _seed_success_order(
+            order_bid="order-redeem-1",
+            shifu_bid="course-redeem-1",
+            user_bid="user-redeem",
+            created_at=datetime(2026, 4, 10, 9, 0, 0),
+            paid_price="0.00",
+            payable_price="66.00",
+        )
+
+        result = list_operator_users(app, 1, 20, {"identifier": "redeem@"})
+
+    assert result.total == 1
+    assert result.data[0].user_bid == "user-redeem"
+    assert result.data[0].total_paid_amount == "66"
+
+
+def test_get_operator_user_detail_counts_redeem_orders_in_total_paid_amount(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="user-profile-redeem",
+            identify="profile-redeem@example.com",
+            nickname="Profile Redeem User",
+            state=USER_STATE_PAID,
+            created_at=datetime(2026, 4, 9, 9, 0, 0),
+            updated_at=datetime(2026, 4, 9, 10, 0, 0),
+            providers=[("email", "profile-redeem@example.com")],
+        )
+        _seed_success_order(
+            order_bid="order-profile-redeem-1",
+            shifu_bid="course-redeem-1",
+            user_bid="user-profile-redeem",
+            created_at=datetime(2026, 4, 10, 9, 0, 0),
+            paid_price="0.00",
+            payable_price="66.00",
+        )
+
+        item = get_operator_user_detail(app, "user-profile-redeem")
+
+    assert item.total_paid_amount == "66"
 
 
 def test_get_operator_user_detail_returns_learning_progress_for_learning_courses(app):


### PR DESCRIPTION
## Why
- the course detail header already counts redeem and external orders in `order_amount` by falling back to `payable_price` when `paid_price` is zero
- the course user list still summed only `paid_price`, so redeem users appeared as unpaid and the paid filter undercounted badly
- this made the course header metrics and user table payment filters diverge for the same course

## What changed
- extract a shared course order amount expression for the course detail payment metrics
- reuse the same expression when aggregating course user `total_paid_amount`
- keep zero-value activation orders excluded from paid users while still allowing redeem/external orders with revenue contribution to count as paid
- add regression coverage for redeem orders, zero-value orders, and `payment_status=paid` filtering

## Validation
- `pre-commit run --files src/api/flaskr/service/shifu/admin.py src/api/tests/service/shifu/test_admin_course_detail.py`
- `cd src/api && pytest tests/service/shifu/test_admin_course_detail.py -q` in a local Python 3.11 venv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment amount and status calculations for course orders to accurately reflect payments across various transaction scenarios, including refunds and alternative payment methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->