### PR TITLE
Fix billing SMS Aliyun response validation

### DIFF
--- a/src/api/flaskr/api/sms/aliyun.py
+++ b/src/api/flaskr/api/sms/aliyun.py
@@ -8,6 +8,14 @@ from alibabacloud_tea_util.client import Client as UtilClient
 from flask import Flask
 
 
+def _body_value(
+    response: dysmsapi_20170525_models.SendSmsResponse | None,
+    field_name: str,
+) -> str:
+    body = getattr(response, "body", None)
+    return str(getattr(body, field_name, "") or "").strip()
+
+
 def send_sms_ali(
     app: Flask,
     mobile: str,
@@ -52,11 +60,26 @@ def send_sms_ali(
     runtime = util_models.RuntimeOptions()
     try:
         res = client.send_sms_with_options(send_sms_request, runtime)
+        response_code = _body_value(res, "code")
+        if response_code != "OK":
+            app.logger.error(
+                "Aliyun SMS send failed for mobile=%s template_code=%s code=%s "
+                "message=%s request_id=%s biz_id=%s",
+                mobile,
+                resolved_template_code,
+                response_code or "<empty>",
+                _body_value(res, "message") or "<empty>",
+                _body_value(res, "request_id") or "<empty>",
+                _body_value(res, "biz_id") or "<empty>",
+            )
+            return None
         return res
     except Exception as error:
-        app.logger.error(error.message)
-        app.logger.error(error.data.get("Recommend"))
-        UtilClient.assert_as_string(error.message)
+        error_message = getattr(error, "message", str(error))
+        error_data = getattr(error, "data", {}) or {}
+        app.logger.error(error_message)
+        app.logger.error(error_data.get("Recommend"))
+        UtilClient.assert_as_string(error_message)
     return None
 
 

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -297,7 +297,7 @@ def _resolve_notification_date_text(
         format_with_app_timezone(
             app,
             expiry_at,
-            "%Y-%m-%d %H:%M %Z",
+            "%Y-%m-%d %H:%M:%S",
         )
         or ""
     )

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -15,7 +15,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch):
         def send_sms_with_options(self, request, runtime):
             captured["request"] = request
             captured["runtime"] = runtime
-            return SimpleNamespace(ok=True)
+            return SimpleNamespace(body=SimpleNamespace(code="OK"))
 
     monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
 
@@ -34,7 +34,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch):
     )
 
     assert result is not None
-    assert result.ok is True
+    assert result.body.code == "OK"
 
     request = captured["request"]
     assert request.sign_name == "TestSign"
@@ -58,7 +58,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch):
         def send_sms_with_options(self, request, runtime):
             captured["request"] = request
             captured["runtime"] = runtime
-            return SimpleNamespace(ok=True)
+            return SimpleNamespace(body=SimpleNamespace(code="OK"))
 
     monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
 
@@ -73,7 +73,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch):
     result = sms_aliyun.send_sms_code_ali(app, "13800000000", "123456")
 
     assert result is not None
-    assert result.ok is True
+    assert result.body.code == "OK"
 
     request = captured["request"]
     assert request.sign_name == "TestSign"
@@ -140,3 +140,40 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
 
     assert result is None
     assert captured["assert_message"] == "boom"
+
+
+def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(monkeypatch):
+    from flaskr.api.sms import aliyun as sms_aliyun
+
+    class FakeClient:
+        def __init__(self, _config):
+            pass
+
+        def send_sms_with_options(self, request, runtime):
+            del request, runtime
+            return SimpleNamespace(
+                body=SimpleNamespace(
+                    code="isv.TEMPLATE_PARAMS_ILLEGAL",
+                    message="bad template params",
+                    request_id="req-1",
+                    biz_id=None,
+                )
+            )
+
+    monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
+
+    app = Flask("contract-sms-provider-failure")
+    app.config.update(
+        ALIBABA_CLOUD_SMS_ACCESS_KEY_ID="key",
+        ALIBABA_CLOUD_SMS_ACCESS_KEY_SECRET="secret",
+        ALIBABA_CLOUD_SMS_SIGN_NAME="TestSign",
+    )
+
+    result = sms_aliyun.send_sms_ali(
+        app,
+        "13800000000",
+        template_code="TPL-SUB-001",
+        template_params={"product": "轻量版", "date": "2026-05-01 00:00:00"},
+    )
+
+    assert result is None

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -394,7 +394,7 @@ def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
     assert captured[0]["template_code"] == "TPL-SUB-001"
     assert captured[0]["mobile"] == "13800000000"
     assert captured[0]["template_params"]["product"] == "轻量版"
-    assert captured[0]["template_params"]["date"] == "2026-05-20 00:00 UTC"
+    assert captured[0]["template_params"]["date"] == "2026-05-20 00:00:00"
 
     with app.app_context():
         order = BillingOrder.query.filter_by(bill_order_bid="billing-task-sent-1").one()


### PR DESCRIPTION
## Summary
- format billing subscription SMS expiry timestamps without a timezone suffix so the Aliyun template accepts the Tue Apr 21 01:30:16 CST 2026 field
- treat non-OK Aliyun SMS responses as failures instead of marking them as sent
- add regression coverage for the Aliyun wrapper and billing subscription SMS payload date format

## Testing
- pytest -q src/api/tests/contract/test_sms_contract.py src/api/tests/service/billing/test_billing_subscription_sms.py
- pytest -q src/api/tests/service/billing/test_billing_cli.py
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * SMS delivery now properly validates provider responses and correctly identifies when delivery fails instead of incorrectly reporting success.
  * Improved error handling for SMS delivery exceptions with enhanced diagnostic logging.

* **Tests**
  * Added test coverage for SMS provider failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->