### PR TITLE
Fix manual grant upgrades for active trial subscriptions

### DIFF
--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -34,6 +34,7 @@ from .consts import (
     BILLING_MODE_RECURRING,
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_PRODUCT_STATUS_ACTIVE,
     BILLING_PRODUCT_STATUS_INACTIVE,
     BILLING_PRODUCT_TYPE_CUSTOM,
@@ -731,6 +732,7 @@ def grant_billing_plan_by_identify(
             aggregate.user_bid,
             as_of=datetime.now(),
         )
+        order_type = BILLING_ORDER_TYPE_SUBSCRIPTION_START
         if existing_subscription is not None:
             if (
                 str(existing_subscription.product_bid or "").strip()
@@ -754,10 +756,27 @@ def grant_billing_plan_by_identify(
                     "email": aggregate.email,
                     "mobile": aggregate.mobile,
                 }
-            raise click.ClickException(
-                "User already has an active subscription. "
-                "Cancel or let the current cycle expire before using manual grant."
+            current_product = _load_plan_product_by_bid(
+                existing_subscription.product_bid
             )
+            if (
+                str(existing_subscription.billing_provider or "").strip().lower()
+                != "manual"
+            ):
+                raise click.ClickException(
+                    "User already has an active provider-managed subscription. "
+                    "Use the normal checkout upgrade flow or wait for the current cycle to expire."
+                )
+            if current_product is None:
+                raise click.ClickException(
+                    "Active billing plan not found for the current subscription."
+                )
+            if int(product.sort_order or 0) <= int(current_product.sort_order or 0):
+                raise click.ClickException(
+                    "The current manual subscription is still active. "
+                    "Manual grant only supports upgrades to a higher-tier plan."
+                )
+            order_type = BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE
 
         granted_at = datetime.now()
         cycle_end_at = (
@@ -790,34 +809,47 @@ def grant_billing_plan_by_identify(
         }
         if normalized_effective_to:
             order_metadata["effective_to"] = cycle_end_at.isoformat()
+            order_metadata["applied_cycle_end_at"] = cycle_end_at.isoformat()
         if normalized_note:
             order_metadata["note"] = normalized_note
 
-        subscription = BillingSubscription(
-            subscription_bid=generate_id(current_app),
-            creator_bid=aggregate.user_bid,
-            product_bid=product.product_bid,
-            status=BILLING_SUBSCRIPTION_STATUS_DRAFT,
-            billing_provider="manual",
-            provider_subscription_id="",
-            provider_customer_id="",
-            billing_anchor_at=granted_at,
-            current_period_start_at=granted_at,
-            current_period_end_at=cycle_end_at,
-            grace_period_end_at=None,
-            cancel_at_period_end=0,
-            next_product_bid="",
-            last_renewed_at=None,
-            last_failed_at=None,
-            metadata_json=subscription_metadata,
-        )
+        if existing_subscription is None:
+            subscription = BillingSubscription(
+                subscription_bid=generate_id(current_app),
+                creator_bid=aggregate.user_bid,
+                product_bid=product.product_bid,
+                status=BILLING_SUBSCRIPTION_STATUS_DRAFT,
+                billing_provider="manual",
+                provider_subscription_id="",
+                provider_customer_id="",
+                billing_anchor_at=granted_at,
+                current_period_start_at=granted_at,
+                current_period_end_at=cycle_end_at,
+                grace_period_end_at=None,
+                cancel_at_period_end=0,
+                next_product_bid="",
+                last_renewed_at=None,
+                last_failed_at=None,
+                metadata_json=subscription_metadata,
+            )
+        else:
+            subscription = existing_subscription
+            subscription.metadata_json = {
+                **(
+                    subscription.metadata_json
+                    if isinstance(subscription.metadata_json, dict)
+                    else {}
+                ),
+                **subscription_metadata,
+            }
+            subscription.updated_at = granted_at
         db.session.add(subscription)
         db.session.flush()
 
         order = BillingOrder(
             bill_order_bid=generate_id(current_app),
             creator_bid=aggregate.user_bid,
-            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+            order_type=order_type,
             product_bid=product.product_bid,
             subscription_bid=subscription.subscription_bid,
             currency=product.currency,
@@ -956,6 +988,22 @@ def _load_active_plan_product(
         return None
 
     return query.order_by(BillingProduct.id.desc()).first()
+
+
+def _load_plan_product_by_bid(product_bid: str) -> BillingProduct | None:
+    normalized_product_bid = str(product_bid or "").strip()
+    if not normalized_product_bid:
+        return None
+
+    return (
+        BillingProduct.query.filter(
+            BillingProduct.deleted == 0,
+            BillingProduct.product_bid == normalized_product_bid,
+            BillingProduct.product_type == BILLING_PRODUCT_TYPE_PLAN,
+        )
+        .order_by(BillingProduct.id.desc())
+        .first()
+    )
 
 
 def _parse_effective_to_option(raw_value: str) -> datetime:

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -1210,11 +1210,10 @@ def _resolve_credit_bucket_effective_to(
             effective_from=effective_from,
         )
 
-    if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
-        metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
-        renewal_cycle_end_at = _extract_resolved_order_cycle_end_at(metadata)
-        if renewal_cycle_end_at is not None:
-            return renewal_cycle_end_at
+    metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
+    resolved_cycle_end_at = _extract_resolved_order_cycle_end_at(metadata)
+    if resolved_cycle_end_at is not None:
+        return resolved_cycle_end_at
 
     if (
         order.subscription_bid

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -11,6 +11,7 @@ import flaskr.dao as dao
 from flaskr.service.billing import notifications as billing_notifications
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -590,6 +591,116 @@ def test_billing_grant_plan_cli_accepts_explicit_effective_to(
         )
 
 
+def test_billing_grant_plan_cli_upgrades_active_manual_subscription(
+    billing_cli_db_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+    expected_effective_to = "2030-05-01T12:30:00"
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",
+        lambda app, *, bill_order_bid: {
+            "status": "enqueued",
+            "bill_order_bid": bill_order_bid,
+            "enqueued": True,
+        },
+    )
+
+    with billing_cli_db_app.app_context():
+        dao.db.session.add_all(
+            build_bill_products(
+                product_bids=[
+                    "bill-product-plan-trial",
+                    "bill-product-plan-yearly-premium",
+                ]
+            )
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-trial-upgrade",
+            identify="creator-cli-trial-upgrade@example.com",
+            email="creator-cli-trial-upgrade@example.com",
+            is_creator=True,
+        )
+        dao.db.session.add(
+            BillingSubscription(
+                subscription_bid="sub-cli-trial-upgrade",
+                creator_bid="creator-cli-trial-upgrade",
+                product_bid="bill-product-plan-trial",
+                status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                billing_provider="manual",
+                provider_subscription_id="",
+                provider_customer_id="",
+                current_period_start_at=datetime.now() - timedelta(days=1),
+                current_period_end_at=datetime.now() + timedelta(days=14),
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={"trial_bootstrap": True},
+            )
+        )
+        dao.db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "grant-plan",
+            "--identify",
+            "creator-cli-trial-upgrade@example.com",
+            "--product-code",
+            "creator-plan-yearly-premium",
+            "--effective-to",
+            expected_effective_to,
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "granted"
+    assert payload["current_period_end_at"] == expected_effective_to
+
+    with billing_cli_db_app.app_context():
+        order = BillingOrder.query.filter_by(
+            creator_bid="creator-cli-trial-upgrade"
+        ).one()
+        subscription = BillingSubscription.query.filter_by(
+            creator_bid="creator-cli-trial-upgrade"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-cli-trial-upgrade"
+        ).one()
+        expire_event = BillingRenewalEvent.query.filter_by(
+            subscription_bid=subscription.subscription_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+        ).one()
+
+        assert (
+            BillingSubscription.query.filter_by(
+                creator_bid="creator-cli-trial-upgrade"
+            ).count()
+            == 1
+        )
+        assert order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE
+        assert order.subscription_bid == "sub-cli-trial-upgrade"
+        assert order.metadata_json["effective_to"] == expected_effective_to
+        assert order.metadata_json["applied_cycle_end_at"] == expected_effective_to
+        assert subscription.subscription_bid == "sub-cli-trial-upgrade"
+        assert subscription.product_bid == "bill-product-plan-yearly-premium"
+        assert subscription.billing_provider == "manual"
+        assert subscription.current_period_end_at == datetime.fromisoformat(
+            expected_effective_to
+        )
+        assert wallet.available_credits == Decimal("22000.0000000000")
+        assert billing_notifications._resolve_notification_date_text(
+            billing_cli_db_app,
+            order,
+        ).startswith("2030-05-01 12:30")
+        assert expire_event.scheduled_at == datetime.fromisoformat(
+            expected_effective_to
+        )
+
+
 def test_billing_grant_plan_cli_returns_noop_for_same_active_plan_without_sms(
     billing_cli_db_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
@@ -654,7 +765,7 @@ def test_billing_grant_plan_cli_returns_noop_for_same_active_plan_without_sms(
         assert BillingOrder.query.filter_by(creator_bid="creator-cli-noop").count() == 0
 
 
-def test_billing_grant_plan_cli_rejects_when_active_subscription_exists(
+def test_billing_grant_plan_cli_rejects_when_provider_managed_subscription_exists(
     billing_cli_db_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -715,7 +826,7 @@ def test_billing_grant_plan_cli_rejects_when_active_subscription_exists(
     )
 
     assert result.exit_code != 0
-    assert "already has an active subscription" in result.output
+    assert "active provider-managed subscription" in result.output
 
     with billing_cli_db_app.app_context():
         assert (


### PR DESCRIPTION
## Summary
- allow `billing grant-plan` to upgrade active manual subscriptions instead of rejecting all active subscriptions
- keep provider-managed active subscriptions blocked so CLI manual grant does not bypass checkout semantics
- preserve explicit `--effective-to` for manual upgrade orders and cover the path with billing CLI tests

## Testing
- cd src/api && pytest -q tests/service/billing/test_billing_cli.py
- cd src/api && pytest -q tests/service/billing/test_billing_subscription_sms.py
- pre-commit run -a