### PR TITLE
Add billing CLI backfill for missing creator trials

### DIFF
--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -75,6 +75,7 @@ from .subscriptions import (
     repair_subscription_cycle_mismatches,
     repair_topup_grant_expiries,
 )
+from .trials import backfill_missing_creator_trial_credits
 from .wallets import rebuild_credit_wallet_snapshots
 
 _PRODUCT_TYPE_LABELS = {
@@ -283,6 +284,40 @@ def register_billing_commands(console) -> None:
             product_code=product_code,
             effective_to=effective_to,
             note=note,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="backfill-trial-plans")
+    @click.option("--creator-bid", default="", help="Grant one creator only.")
+    @click.option(
+        "--limit",
+        type=click.IntRange(min=1),
+        default=None,
+        help="Maximum creator rows to scan when used with --all.",
+    )
+    @click.option(
+        "--all",
+        "process_all",
+        is_flag=True,
+        help="Scan creator users and grant the missing public trial plan.",
+    )
+    @with_appcontext
+    def backfill_trial_plans_command(
+        creator_bid: str,
+        limit: int | None,
+        process_all: bool,
+    ) -> None:
+        """Grant the configured public trial plan to creators who still miss it."""
+
+        if not str(creator_bid or "").strip() and not process_all:
+            raise click.ClickException(
+                "Pass --creator-bid or --all for trial plan backfill."
+            )
+
+        payload = backfill_missing_creator_trial_credits(
+            current_app,
+            creator_bid=creator_bid,
+            limit=limit if process_all else None,
         )
         _echo_payload(payload)
 

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -12,6 +12,7 @@ from flask import Flask
 from sqlalchemy.exc import IntegrityError
 
 from flaskr.dao import db
+from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.repository import get_user_entity_by_bid
 
 from .consts import (
@@ -441,6 +442,207 @@ def _bootstrap_trial_subscription(
         raise RuntimeError("trial_order_credit_grant_failed")
 
 
+def _resolve_trial_bootstrap_status(
+    creator_bid: str,
+    *,
+    creator: UserEntity | None = None,
+    product_ref: BillingProduct | dict[str, Any] | None = None,
+) -> tuple[str, BillingProduct | dict[str, Any] | None]:
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    if not normalized_creator_bid:
+        return "invalid_creator_bid", None
+    if not _is_billing_enabled():
+        return "billing_disabled", None
+
+    resolved_creator = creator or get_user_entity_by_bid(normalized_creator_bid)
+    if resolved_creator is None:
+        return "creator_not_found", None
+    if not bool(resolved_creator.is_creator):
+        return "not_creator", None
+
+    resolved_product_ref = product_ref or _resolve_trial_product_reference()
+    if resolved_product_ref is None:
+        return "trial_product_missing", None
+    if not _trial_product_public_enabled(resolved_product_ref):
+        return "trial_product_not_public", resolved_product_ref
+
+    if _load_active_creator_subscription(normalized_creator_bid) is not None:
+        return "active_subscription_exists", resolved_product_ref
+    if _load_trial_subscription(normalized_creator_bid) is not None:
+        return "trial_subscription_exists", resolved_product_ref
+    if _load_trial_order(normalized_creator_bid) is not None:
+        return "trial_order_exists", resolved_product_ref
+    if _load_legacy_trial_entry(normalized_creator_bid) is not None:
+        return "legacy_trial_exists", resolved_product_ref
+
+    return "grantable", resolved_product_ref
+
+
+def _backfill_missing_creator_trial_credits(
+    app: Flask,
+    *,
+    creator_bid: str = "",
+    limit: int | None = None,
+) -> dict[str, Any]:
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
+
+    with app.app_context():
+        if not _is_billing_enabled():
+            return {
+                "status": "noop",
+                "reason": "billing_disabled",
+                "creator_bid": normalized_creator_bid or None,
+                "limit": normalized_limit,
+                "creator_count": 0,
+                "granted_count": 0,
+                "skipped_count": 0,
+                "records": [],
+            }
+
+        product_ref = _resolve_trial_product_reference()
+        if product_ref is None:
+            return {
+                "status": "noop",
+                "reason": "trial_product_missing",
+                "creator_bid": normalized_creator_bid or None,
+                "limit": normalized_limit,
+                "creator_count": 0,
+                "granted_count": 0,
+                "skipped_count": 0,
+                "records": [],
+            }
+        if not _trial_product_public_enabled(product_ref):
+            return {
+                "status": "noop",
+                "reason": "trial_product_not_public",
+                "creator_bid": normalized_creator_bid or None,
+                "limit": normalized_limit,
+                "creator_count": 0,
+                "granted_count": 0,
+                "skipped_count": 0,
+                "records": [],
+            }
+
+        creators: list[UserEntity] = []
+        if normalized_creator_bid:
+            creator = get_user_entity_by_bid(normalized_creator_bid)
+            if creator is None:
+                return {
+                    "status": "completed",
+                    "reason": None,
+                    "creator_bid": normalized_creator_bid,
+                    "limit": normalized_limit,
+                    "trial_product_bid": str(
+                        _trial_product_field(
+                            product_ref,
+                            "product_bid",
+                            BILLING_TRIAL_PRODUCT_BID,
+                        )
+                    ),
+                    "trial_product_code": str(
+                        _trial_product_field(
+                            product_ref,
+                            "product_code",
+                            BILLING_TRIAL_PRODUCT_CODE,
+                        )
+                    ),
+                    "creator_count": 1,
+                    "granted_count": 0,
+                    "skipped_count": 1,
+                    "records": [
+                        {
+                            "creator_bid": normalized_creator_bid,
+                            "status": "skipped",
+                            "reason": "creator_not_found",
+                        }
+                    ],
+                }
+            creators = [creator]
+        else:
+            creator_query = UserEntity.query.filter(
+                UserEntity.deleted == 0,
+                UserEntity.is_creator == 1,
+            ).order_by(UserEntity.id.asc())
+            if normalized_limit is not None:
+                creator_query = creator_query.limit(normalized_limit)
+            creators = creator_query.all()
+
+        records: list[dict[str, Any]] = []
+        granted_count = 0
+        skipped_count = 0
+        trial_product_bid = str(
+            _trial_product_field(product_ref, "product_bid", BILLING_TRIAL_PRODUCT_BID)
+        )
+        trial_product_code = str(
+            _trial_product_field(
+                product_ref,
+                "product_code",
+                BILLING_TRIAL_PRODUCT_CODE,
+            )
+        )
+
+        for creator in creators:
+            current_creator_bid = _normalize_bid(getattr(creator, "user_bid", ""))
+            status, resolved_product_ref = _resolve_trial_bootstrap_status(
+                current_creator_bid,
+                creator=creator,
+                product_ref=product_ref,
+            )
+            if status != "grantable" or resolved_product_ref is None:
+                records.append(
+                    {
+                        "creator_bid": current_creator_bid or None,
+                        "status": "skipped",
+                        "reason": status,
+                    }
+                )
+                skipped_count += 1
+                continue
+
+            try:
+                _bootstrap_trial_subscription(
+                    app,
+                    creator_bid=current_creator_bid,
+                    product_ref=resolved_product_ref,
+                    trigger="cli_backfill_missing_creator_trial",
+                )
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                records.append(
+                    {
+                        "creator_bid": current_creator_bid,
+                        "status": "skipped",
+                        "reason": "integrity_conflict",
+                    }
+                )
+                skipped_count += 1
+                continue
+
+            records.append(
+                {
+                    "creator_bid": current_creator_bid,
+                    "status": "granted",
+                    "reason": None,
+                }
+            )
+            granted_count += 1
+
+        return {
+            "status": "completed",
+            "reason": None,
+            "creator_bid": normalized_creator_bid or None,
+            "limit": normalized_limit,
+            "trial_product_bid": trial_product_bid,
+            "trial_product_code": trial_product_code,
+            "creator_count": len(creators) if not normalized_creator_bid else 1,
+            "granted_count": granted_count,
+            "skipped_count": skipped_count,
+            "records": records,
+        }
+
+
 def _resolve_new_creator_trial_offer(
     app: Flask,
     creator_bid: str,
@@ -605,25 +807,10 @@ def _bootstrap_new_creator_trial_credits(app: Flask, creator_bid: str) -> None:
     normalized_creator_bid = _normalize_bid(creator_bid)
     if not normalized_creator_bid:
         return
-    if not _is_billing_enabled():
-        return
 
     with app.app_context():
-        creator = get_user_entity_by_bid(normalized_creator_bid)
-        if creator is None or not bool(creator.is_creator):
-            return
-
-        product_ref = _resolve_trial_product_reference()
-        if not product_ref or not _trial_product_public_enabled(product_ref):
-            return
-
-        if _load_active_creator_subscription(normalized_creator_bid) is not None:
-            return
-        if _load_trial_subscription(normalized_creator_bid) is not None:
-            return
-        if _load_trial_order(normalized_creator_bid) is not None:
-            return
-        if _load_legacy_trial_entry(normalized_creator_bid) is not None:
+        status, product_ref = _resolve_trial_bootstrap_status(normalized_creator_bid)
+        if status != "grantable" or product_ref is None:
             return
 
         try:
@@ -644,3 +831,4 @@ def _bootstrap_new_creator_trial_credits(app: Flask, creator_bid: str) -> None:
 resolve_new_creator_trial_offer = _resolve_new_creator_trial_offer
 bootstrap_new_creator_trial_credits = _bootstrap_new_creator_trial_credits
 acknowledge_trial_welcome_dialog = _acknowledge_trial_welcome_dialog
+backfill_missing_creator_trial_credits = _backfill_missing_creator_trial_credits

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -14,7 +14,9 @@ from flaskr.service.billing.consts import (
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_SUBSCRIPTION_STATUS_DRAFT,
     BILL_SYS_CONFIG_SEEDS,
+    BILLING_TRIAL_PRODUCT_BID,
     CREDIT_USAGE_RATE_SEEDS,
 )
 from flaskr.service.billing.cli import register_billing_commands
@@ -166,6 +168,48 @@ def test_billing_backfill_settlement_cli_prints_helper_payload(
     assert payload["processed_count"] == 2
     assert payload["kwargs"]["usage_id_start"] == 10
     assert payload["kwargs"]["usage_id_end"] == 12
+
+
+def test_billing_backfill_trial_plans_cli_requires_explicit_scope(
+    billing_cli_runner,
+) -> None:
+    result = billing_cli_runner.invoke(
+        args=["console", "billing", "backfill-trial-plans"]
+    )
+
+    assert result.exit_code != 0
+    assert "Pass --creator-bid or --all for trial plan backfill." in result.output
+
+
+def test_billing_backfill_trial_plans_cli_prints_helper_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.backfill_missing_creator_trial_credits",
+        lambda app, **kwargs: {
+            "status": "completed",
+            "granted_count": 2,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "backfill-trial-plans",
+            "--all",
+            "--limit",
+            "3",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "completed"
+    assert payload["granted_count"] == 2
+    assert payload["kwargs"]["limit"] == 3
 
 
 def test_billing_rebuild_wallets_cli_prints_helper_payload(
@@ -515,6 +559,129 @@ def test_billing_grant_plan_cli_grants_manual_plan_by_phone_identify(
         assert subscription.current_period_end_at > subscription.current_period_start_at
         assert len(pending_events) == 1
         assert pending_events[0].event_type == BILLING_RENEWAL_EVENT_TYPE_EXPIRE
+
+
+def test_billing_backfill_trial_plans_cli_grants_missing_trials_for_creators(
+    billing_cli_db_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+    monkeypatch.setattr(
+        "flaskr.service.billing.trials._is_billing_enabled",
+        lambda: True,
+    )
+
+    with billing_cli_db_app.app_context():
+        dao.db.session.add_all(
+            build_bill_products(
+                product_bids=[
+                    "bill-product-plan-trial",
+                    "bill-product-plan-monthly",
+                ]
+            )
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-trial-missing",
+            identify="creator-cli-trial-missing@example.com",
+            email="creator-cli-trial-missing@example.com",
+            is_creator=True,
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-trial-existing",
+            identify="creator-cli-trial-existing@example.com",
+            email="creator-cli-trial-existing@example.com",
+            is_creator=True,
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-trial-paid",
+            identify="creator-cli-trial-paid@example.com",
+            email="creator-cli-trial-paid@example.com",
+            is_creator=True,
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-non-creator",
+            identify="creator-cli-non-creator@example.com",
+            email="creator-cli-non-creator@example.com",
+            is_creator=False,
+        )
+        dao.db.session.add(
+            BillingSubscription(
+                subscription_bid="sub-cli-trial-existing",
+                creator_bid="creator-cli-trial-existing",
+                product_bid=BILLING_TRIAL_PRODUCT_BID,
+                status=BILLING_SUBSCRIPTION_STATUS_DRAFT,
+                billing_provider="manual",
+                provider_subscription_id="",
+                provider_customer_id="",
+                current_period_start_at=datetime.now() - timedelta(days=1),
+                current_period_end_at=datetime.now() + timedelta(days=14),
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={"trial_bootstrap": True},
+            )
+        )
+        dao.db.session.add(
+            BillingSubscription(
+                subscription_bid="sub-cli-trial-paid",
+                creator_bid="creator-cli-trial-paid",
+                product_bid="bill-product-plan-monthly",
+                status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                billing_provider="stripe",
+                provider_subscription_id="sub_provider_cli_trial_paid",
+                provider_customer_id="cus_provider_cli_trial_paid",
+                current_period_start_at=datetime.now() - timedelta(days=1),
+                current_period_end_at=datetime.now() + timedelta(days=30),
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={},
+            )
+        )
+        dao.db.session.commit()
+
+    result = runner.invoke(args=["console", "billing", "backfill-trial-plans", "--all"])
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "completed"
+    assert payload["creator_count"] == 3
+    assert payload["granted_count"] == 1
+    assert payload["skipped_count"] == 2
+
+    records_by_bid = {item["creator_bid"]: item for item in payload["records"]}
+    assert records_by_bid["creator-cli-trial-missing"]["status"] == "granted"
+    assert records_by_bid["creator-cli-trial-existing"]["reason"] == (
+        "trial_subscription_exists"
+    )
+    assert records_by_bid["creator-cli-trial-paid"]["reason"] == (
+        "active_subscription_exists"
+    )
+
+    with billing_cli_db_app.app_context():
+        granted_subscription = BillingSubscription.query.filter_by(
+            creator_bid="creator-cli-trial-missing"
+        ).one()
+        granted_order = BillingOrder.query.filter_by(
+            creator_bid="creator-cli-trial-missing"
+        ).one()
+        granted_wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-cli-trial-missing"
+        ).one()
+
+        assert granted_subscription.product_bid == BILLING_TRIAL_PRODUCT_BID
+        assert granted_subscription.billing_provider == "manual"
+        assert granted_order.product_bid == BILLING_TRIAL_PRODUCT_BID
+        assert granted_order.payment_provider == "manual"
+        assert granted_wallet.available_credits == Decimal("100.0000000000")
+        assert (
+            BillingSubscription.query.filter_by(
+                creator_bid="creator-cli-non-creator"
+            ).count()
+            == 0
+        )
 
 
 def test_billing_grant_plan_cli_accepts_explicit_effective_to(


### PR DESCRIPTION
## Summary
- add a billing CLI command to backfill the public trial plan for creators who are still missing it
- skip creators who already have an active subscription, an existing trial record, or a legacy trial credit record
- add billing CLI coverage for the new command and the creator trial backfill flow

## Testing
- /Users/geyunfei/dev/yfge/ai-shifu/src/api/.venv/bin/pytest src/api/tests/service/billing/test_billing_cli.py src/api/tests/service/billing/test_billing_trial_credits.py -q
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `backfill-trial-plans` CLI command to retrospectively grant trial subscriptions to creators, with options to target specific creators or process all eligible creators.

* **Tests**
  * Added comprehensive test coverage for the new CLI command and backfill operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->