### PR TITLE
fix(billing): unify plan features and update descriptions

### DIFF
--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -164,6 +164,12 @@ def collect_frontend_keys() -> Set[str]:
             for pattern in patterns:
                 for match in pattern.findall(text):
                     used.add(match)
+            # Catch translation keys referenced as bare string literals
+            # (e.g. in arrays or maps) that are later passed to t().
+            for match in STRING_LITERAL.findall(text):
+                candidate = match[1:-1]
+                if candidate.startswith("module.") or candidate.startswith("server."):
+                    used.add(candidate)
     return used
 
 

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -17,6 +17,9 @@ COOK_WEB_DIR = ROOT / "src" / "cook-web" / "src"
 WEB_DIR = ROOT / "src" / "web" / "src"
 
 STRING_LITERAL = re.compile(r"['\"][^'\"]+['\"]")
+TRANSLATION_KEY_LITERAL = re.compile(
+    r"^(?:module|server)\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+$"
+)
 
 BACKEND_PATTERNS = [
     re.compile(r"_\(\s*['\"]([A-Za-z0-9_.-]+)['\"]"),
@@ -160,6 +163,12 @@ def collect_frontend_keys() -> Set[str]:
         for file_path in root.rglob("*"):
             if file_path.suffix not in extensions:
                 continue
+            if (
+                ".test." in file_path.name
+                or ".spec." in file_path.name
+                or "__tests__" in file_path.parts
+            ):
+                continue
             text = file_path.read_text(encoding="utf-8", errors="ignore")
             for pattern in patterns:
                 for match in pattern.findall(text):
@@ -168,7 +177,7 @@ def collect_frontend_keys() -> Set[str]:
             # (e.g. in arrays or maps) that are later passed to t().
             for match in STRING_LITERAL.findall(text):
                 candidate = match[1:-1]
-                if candidate.startswith("module.") or candidate.startswith("server."):
+                if TRANSLATION_KEY_LITERAL.fullmatch(candidate):
                     used.add(candidate)
     return used
 

--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -13,6 +13,7 @@
 - 当 `listen=true` 先以听课模式初始化、后续又因为旧课兼容或能力检查回退到阅读模式时，要基于当前模式重新同步移动端正文里的追问按钮，不要只依赖首轮数据装配结果。
 - Streaming chat must use `element_bid` as the stable render key, with compatibility fields backfilled in the shared normalization entry point.
 - When the same logic is reused by more than two files, extract it into shared `utils/constants/hooks` instead of duplicating it.
+- 做 i18n key usage 排查时，不要把 `*.test.*`、`*.spec.*`、`__tests__` 里的断言文案、namespace 字符串或拼接后的展示文本当成真实翻译 key；优先统计生产代码里的 `t()`、`i18n.t()`、`Trans` 和符合完整 key 结构的常量。
 - For system interaction buttons such as `_sys_pay`, prefer ai-shifu-side render overrides to keep repeatable CTAs clickable without patching `markdown-flow-ui`.
 - When adapting cook-web payloads into `markdown-flow-ui` slide elements, normalize optional API fields into the stricter slide contract first instead of passing broader API types through render layers.
 - When listen-mode misses trailing interaction cards, check whether `outline_item_update: completed` arrived before the final `element` events; completion must not cause post-completion interaction markers to be dropped.

--- a/src/cook-web/src/components/billing/BillingOverviewCards.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewCards.tsx
@@ -24,46 +24,35 @@ type PlanFeatureData = {
   items: string[];
 };
 
-const DEFAULT_FREE_FEATURE_KEYS: string[] = [
-  'module.billing.package.features.free.publish',
-  'module.billing.package.features.free.preview',
+const COMMON_FEATURE_KEYS: string[] = [
+  'module.billing.package.features.common.unlimitedCourses',
+  'module.billing.package.features.common.createDebugPublish',
+  'module.billing.package.features.common.allLearning',
+  'module.billing.package.features.common.aiNarration',
+  'module.billing.package.features.common.orderAndData',
 ];
 
+const DEFAULT_FREE_FEATURE_KEYS: string[] = COMMON_FEATURE_KEYS;
+
 const PLAN_FEATURE_INCLUDE_LABELS: Record<string, string> = {
-  'creator-plan-yearly-lite':
-    'module.billing.package.features.advanced.includesLabel',
   'creator-plan-yearly': 'module.billing.package.features.pro.includesLabel',
   'creator-plan-yearly-premium':
     'module.billing.package.features.premium.includesLabel',
 };
 
 const PLAN_FEATURE_FALLBACK_KEYS: Record<string, string[]> = {
-  'creator-plan-monthly': [
-    'module.billing.package.features.monthly.publish',
-    'module.billing.package.features.monthly.preview',
-    'module.billing.package.features.monthly.support',
-  ],
-  'creator-plan-monthly-pro': [
-    'module.billing.package.features.monthly.publish',
-    'module.billing.package.features.monthly.preview',
-    'module.billing.package.features.monthly.support',
-  ],
+  'creator-plan-monthly': COMMON_FEATURE_KEYS,
+  'creator-plan-monthly-pro': COMMON_FEATURE_KEYS,
   'creator-plan-yearly-lite': [
-    'module.billing.package.features.yearly.lite.ops',
-    'module.billing.package.features.yearly.lite.publish',
+    ...COMMON_FEATURE_KEYS,
+    'module.billing.package.features.common.higherConcurrency',
   ],
   'creator-plan-yearly': [
     'module.billing.package.features.yearly.pro.branding',
     'module.billing.package.features.yearly.pro.domain',
-    'module.billing.package.features.yearly.pro.priority',
-    'module.billing.package.features.yearly.pro.analytics',
-    'module.billing.package.features.yearly.pro.support',
   ],
   'creator-plan-yearly-premium': [
-    'module.billing.package.features.yearly.premium.branding',
-    'module.billing.package.features.yearly.premium.domain',
     'module.billing.package.features.yearly.premium.priority',
-    'module.billing.package.features.yearly.premium.analytics',
     'module.billing.package.features.yearly.premium.support',
   ],
 };
@@ -90,18 +79,18 @@ const PLAN_SCALE_KEYS: Record<string, { students: string }> = {
 };
 
 export function getPlanFeatureData(product: BillingPlan): PlanFeatureData {
+  if (PLAN_FEATURE_FALLBACK_KEYS[product.product_code]) {
+    return {
+      includesLabel: PLAN_FEATURE_INCLUDE_LABELS[product.product_code],
+      items: PLAN_FEATURE_FALLBACK_KEYS[product.product_code],
+    };
+  }
+
   const productHighlights = product.highlights?.filter(item => Boolean(item));
   if (productHighlights && productHighlights.length > 0) {
     return {
       includesLabel: PLAN_FEATURE_INCLUDE_LABELS[product.product_code],
       items: productHighlights,
-    };
-  }
-
-  if (PLAN_FEATURE_FALLBACK_KEYS[product.product_code]) {
-    return {
-      includesLabel: PLAN_FEATURE_INCLUDE_LABELS[product.product_code],
-      items: PLAN_FEATURE_FALLBACK_KEYS[product.product_code],
     };
   }
 
@@ -126,13 +115,9 @@ export function getPlanFeatureData(product: BillingPlan): PlanFeatureData {
   };
 }
 
-export function getFreeFeatureData(highlights?: string[]): PlanFeatureData {
-  const featureItems = highlights?.filter(item => Boolean(item));
+export function getFreeFeatureData(_highlights?: string[]): PlanFeatureData {
   return {
-    items:
-      featureItems && featureItems.length > 0
-        ? featureItems
-        : DEFAULT_FREE_FEATURE_KEYS,
+    items: DEFAULT_FREE_FEATURE_KEYS,
   };
 }
 

--- a/src/cook-web/src/components/billing/BillingOverviewShowcase.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewShowcase.tsx
@@ -128,23 +128,7 @@ export function BillingOverviewShowcase({
     t('module.billing.package.free.description'),
   );
 
-  let freePriceMetaLabel = '';
-  if (trialOffer) {
-    if (
-      trialOffer.status === 'granted' &&
-      trialOffer.granted_at &&
-      trialOffer.expires_at
-    ) {
-      freePriceMetaLabel = t('module.billing.package.free.priceNoteGranted', {
-        grantedAt: formatBillingDate(trialOffer.granted_at, i18n.language),
-        expiresAt: formatBillingDate(trialOffer.expires_at, i18n.language),
-      });
-    } else {
-      freePriceMetaLabel = t('module.billing.package.free.priceNote', {
-        days: trialOffer.valid_days,
-      });
-    }
-  }
+  const freePriceMetaLabel = '';
 
   return (
     <>

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -280,23 +280,23 @@
     },
     "plans": {
       "creatorMonthly": {
-        "description": "Best for low-cost trial teaching and validating your course with learner feedback.",
+        "description": "Best for course iteration and maintenance outside delivery periods.",
         "title": "Lite"
       },
       "creatorMonthlyPro": {
-        "description": "Best for steady course delivery and ongoing support for small cohorts.",
+        "description": "Best for serving a small number of learners.",
         "title": "Basic"
       },
       "creatorYearly": {
-        "description": "Best for stable annual operations and standard course delivery.",
+        "description": "Best for large organizations.",
         "title": "Pro"
       },
       "creatorYearlyLite": {
-        "description": "Best for branded delivery with support for custom branding and a custom domain.",
+        "description": "Best for small and medium organizations.",
         "title": "Advanced"
       },
       "creatorYearlyPremium": {
-        "description": "Best for large-scale operations with support for high-concurrency course delivery.",
+        "description": "Best for extra-large organizations.",
         "title": "Premium"
       }
     },
@@ -523,6 +523,14 @@
         "publish": "Short-term publishing and onboarding coverage",
         "support": "Daily plan operational support"
       },
+      "common": {
+        "aiNarration": "AI narration and audio lessons",
+        "allLearning": "All learning features",
+        "createDebugPublish": "Create, debug, and publish courses",
+        "higherConcurrency": "Higher concurrency support",
+        "orderAndData": "Order and learning data queries",
+        "unlimitedCourses": "Unlimited courses"
+      },
       "free": {
         "preview": "Learner delivery and account import",
         "publish": "Course creation and content storage"
@@ -554,7 +562,7 @@
           "branding": "Custom branding",
           "domain": "Custom domain",
           "priority": "Dedicated technical support",
-          "support": "1 live course-building session included"
+          "support": "One exclusive course-building training session"
         },
         "pro": {
           "analytics": "Priority technical support",
@@ -568,7 +576,7 @@
     "featuresTitle": "Included benefits:",
     "free": {
       "creditSummary": "{credits} bonus credits",
-      "description": "Best for a first look — quickly run through courses and learner delivery.",
+      "description": "Best for a first look — run through the full teaching and research workflow.",
       "priceNote": "/ valid within {days} days of registration",
       "priceNoteGranted": "/ activated on {grantedAt}, valid until {expiresAt}",
       "priceValue": "¥0",

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -518,11 +518,6 @@
         "taskPriority": "Priority task processing",
         "techBasic": "Basic technical support"
       },
-      "daily": {
-        "preview": "Fast-turn daily access for short validation cycles",
-        "publish": "Short-term publishing and onboarding coverage",
-        "support": "Daily plan operational support"
-      },
       "common": {
         "aiNarration": "AI narration and audio lessons",
         "allLearning": "All learning features",
@@ -530,6 +525,11 @@
         "higherConcurrency": "Higher concurrency support",
         "orderAndData": "Order and learning data queries",
         "unlimitedCourses": "Unlimited courses"
+      },
+      "daily": {
+        "preview": "Fast-turn daily access for short validation cycles",
+        "publish": "Short-term publishing and onboarding coverage",
+        "support": "Daily plan operational support"
       },
       "free": {
         "preview": "Learner delivery and account import",

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -544,7 +544,7 @@
         "concurrencyQuota": "Higher concurrency quota",
         "dedicatedSupport": "Dedicated technical support",
         "includesLabel": "Everything in Pro, and:",
-        "onboarding": "1 live course-building session included"
+        "onboarding": "One exclusive course-building training session"
       },
       "pro": {
         "branding": "Custom branding",

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -280,23 +280,23 @@
     },
     "plans": {
       "creatorMonthly": {
-        "description": "适合低成本试教，验证课程与学员反馈",
+        "description": "适合在交付期之外做课程迭代和维护",
         "title": "轻量版"
       },
       "creatorMonthlyPro": {
-        "description": "适合稳定开课，持续服务小班学员",
+        "description": "适合服务少量学员",
         "title": "基础版"
       },
       "creatorYearly": {
-        "description": "适合年度稳定运营，覆盖常规课程交付",
+        "description": "适合大型机构",
         "title": "高阶版"
       },
       "creatorYearlyLite": {
-        "description": "适合品牌化交付，支持品牌标识与独立域名",
+        "description": "适合中小型机构",
         "title": "进阶版"
       },
       "creatorYearlyPremium": {
-        "description": "适合大规模运营，支持高并发课程交付",
+        "description": "适合超大型机构",
         "title": "旗舰版"
       }
     },
@@ -523,6 +523,14 @@
         "publish": "支持短期发布与快速上手",
         "support": "日订阅运营支持"
       },
+      "common": {
+        "aiNarration": "AI 讲解与听课语音",
+        "allLearning": "全部学习功能",
+        "createDebugPublish": "创建、调试和发布课程",
+        "higherConcurrency": "更高并发支持",
+        "orderAndData": "订单和学习数据查询",
+        "unlimitedCourses": "不限课程数"
+      },
       "free": {
         "preview": "学员交付与学习账号导入",
         "publish": "课程创建与内容存储"
@@ -536,7 +544,7 @@
         "concurrencyQuota": "更高并发任务配额",
         "dedicatedSupport": "专属技术支持",
         "includesLabel": "享有高阶版全部权益，以及：",
-        "onboarding": "含 1 次线上做课培训"
+        "onboarding": "一次专属课程制作培训"
       },
       "pro": {
         "branding": "自定义品牌标识",
@@ -554,7 +562,7 @@
           "branding": "自定义品牌标识",
           "domain": "自定义域名",
           "priority": "专属技术支持",
-          "support": "含 1 次线上做课培训"
+          "support": "一次专属课程制作培训"
         },
         "pro": {
           "analytics": "技术优先支持",
@@ -568,7 +576,7 @@
     "featuresTitle": "享有权益：",
     "free": {
       "creditSummary": "赠送积分数 {credits}",
-      "description": "适合首次体验，快速跑通建课与交付",
+      "description": "适合首次体验，跑通教研教学全流程",
       "priceNote": "/ 新注册 {days} 日内有效",
       "priceNoteGranted": "/ 已于 {grantedAt} 激活，有效至 {expiresAt}",
       "priceValue": "¥0",

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -518,11 +518,6 @@
         "taskPriority": "任务优先处理",
         "techBasic": "技术基础支持"
       },
-      "daily": {
-        "preview": "适合短周期验证与快速体验",
-        "publish": "支持短期发布与快速上手",
-        "support": "日订阅运营支持"
-      },
       "common": {
         "aiNarration": "AI 讲解与听课语音",
         "allLearning": "全部学习功能",
@@ -530,6 +525,11 @@
         "higherConcurrency": "更高并发支持",
         "orderAndData": "订单和学习数据查询",
         "unlimitedCourses": "不限课程数"
+      },
+      "daily": {
+        "preview": "适合短周期验证与快速体验",
+        "publish": "支持短期发布与快速上手",
+        "support": "日订阅运营支持"
       },
       "free": {
         "preview": "学员交付与学习账号导入",


### PR DESCRIPTION
## Summary
- Standardize all plan cards (体验版/轻量版/基础版/进阶版) to show unified feature list: unlimited courses, create/debug/publish, all learning features, AI narration, order & data queries
- Update plan descriptions to match latest product copy (体验版→教研教学全流程, 轻量版→课程迭代维护, 基础版→少量学员, 进阶版→中小型机构, 高阶版→大型机构, 旗舰版→超大型机构)
- Simplify yearly plan features: 进阶版 adds higher concurrency, 高阶版 adds custom branding & domain, 旗舰版 adds dedicated support & training
- Remove trial activation date label from free plan card

## Test plan
- [ ] Verify monthly plan cards (体验版/轻量版/基础版) show 5 unified features
- [ ] Verify yearly plan cards show correct tiered features with includesLabel
- [ ] Verify plan descriptions match product spec
- [ ] Verify free plan card no longer shows activation date line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated billing plan descriptions and feature messaging to better reflect organization size and use cases across all plan tiers.
  * Added consolidated feature labels for advanced plan capabilities (AI narration, course creation, higher concurrency, data queries, unlimited courses).
  * Removed expiration and validity date messaging from free plan pricing display.
  * Updated plan descriptions and feature labels in both English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->