### PR TITLE
Handle learn SSE generator closes

### DIFF
--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -65,6 +65,10 @@ def _to_sse_data_line(message) -> str:
     return "data: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
 
 
+def _is_generator_close_error(exc: RuntimeError) -> bool:
+    return str(exc) == "generator ignored GeneratorExit"
+
+
 def _stream_sse_response(
     app: Flask,
     *,
@@ -108,6 +112,12 @@ def _stream_passthrough_response(
             yield from message_iter_factory()
         except GeneratorExit:
             app.logger.info(close_log)
+            raise
+        except RuntimeError as exc:
+            if _is_generator_close_error(exc):
+                app.logger.info(close_log)
+                return
+            app.logger.error(error_log, exc_info=True)
             raise
         except Exception:
             app.logger.error(error_log, exc_info=True)

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -603,7 +603,7 @@ def run_script(
                             app.logger.info(
                                 "Client disconnected from SSE stream during heartbeat"
                             )
-                            break
+                            return
                         except (ConnectionError, BrokenPipeError, OSError) as exc:
                             client_disconnected = True
                             stop_event.set()
@@ -641,7 +641,7 @@ def run_script(
                         app.logger.info(
                             "Client disconnected from SSE stream (GeneratorExit)"
                         )
-                        break
+                        return
                     except (ConnectionError, BrokenPipeError, OSError) as exc:
                         client_disconnected = True
                         stop_event.set()
@@ -709,7 +709,7 @@ def run_script(
                             False if use_element_protocol else None
                         )
 
-            if not (
+            if not client_disconnected and not (
                 use_element_protocol
                 and last_stream_type == GeneratedType.DONE.value
                 and last_stream_done_is_terminal is True

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -840,3 +840,37 @@ def test_get_run_status_reports_true_while_stream_is_open(monkeypatch):
         assert status_during.running_time == 0
         assert status_after.is_running is False
         assert status_after.running_time == 0
+
+
+def test_run_script_close_during_data_yield_does_not_raise_runtime_error(monkeypatch):
+    app = _make_test_app()
+    _patch_fake_element_adapter(monkeypatch)
+    with app.app_context():
+        lock = FakeLock([True])
+        cache = FakeCacheProvider(lock)
+        monkeypatch.setattr(runscript_v2, "cache_provider", cache)
+
+        def fake_run_script_inner(**_kwargs):
+            yield RunMarkdownFlowDTO(
+                outline_bid="outline-1",
+                generated_block_bid="generated-1",
+                type=GeneratedType.CONTENT,
+                content="hello",
+            )
+
+        monkeypatch.setattr(runscript_v2, "run_script_inner", fake_run_script_inner)
+
+        stream = runscript_v2.run_script(
+            app=app,
+            shifu_bid="shifu-1",
+            outline_bid="outline-1",
+            user_bid="user-1",
+            input={"input": ["x"]},
+            input_type="normal",
+        )
+
+        first_chunk = next(stream)
+        stream.close()
+
+        assert first_chunk.startswith("data: ")
+        assert lock.release_calls == 1


### PR DESCRIPTION
## Summary
- stop emitting terminal SSE events after learn stream GeneratorExit
- treat Python's generator close RuntimeError as client-close in passthrough streams
- add regression coverage for closing run_script mid-stream

## Tests
- cd src/api && ./.venv/bin/pytest tests/service/learn/test_runscript_v2_lock.py tests/service/learn/test_runtime_tts_admission.py -q
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client disconnections during streaming operations to prevent runtime errors and ensure proper cleanup.
  * Enhanced error logging to distinguish between intentional stream closures and unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->