### PR TITLE
Add MiniMax RUN WebSocket TTS RPM queue

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -852,6 +852,16 @@ MINIMAX_GROUP_ID=""
 # Type: int
 MINIMAX_TTS_BITRATE="128000"
 
+# Maximum seconds a MiniMax TTS request waits in the RPM queue
+# (Optional - default: 10)
+# Type: int
+MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS="10"
+
+# MiniMax TTS RPM queue limit; 0 disables queue gating
+# (Optional - default: 0)
+# Type: int
+MINIMAX_TTS_RPM_LIMIT="0"
+
 # TTS audio sample rate (8000-44100)
 # (Optional - default: 24000)
 # Type: int

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -5,6 +5,7 @@ This module provides TTS synthesis using Minimax's Text-to-Speech API (t2a_v2).
 """
 
 import logging
+import json
 import requests
 from typing import Optional, Dict, Any, List
 
@@ -18,12 +19,19 @@ from flaskr.api.tts.base import (
     ProviderConfig,
     ParamRange,
 )
+from flaskr.service.tts.rpm_gate import acquire_tts_rpm_slot
+
+try:
+    import websocket
+except ImportError:  # pragma: no cover - dependency is present in runtime images
+    websocket = None
 
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
 # Minimax TTS API endpoint
 MINIMAX_TTS_API_URL = "https://api.minimax.chat/v1/t2a_v2"
+MINIMAX_TTS_WS_URL = "wss://api.minimaxi.com/ws/v1/t2a_v2"
 
 # Allowed emotion values for Minimax TTS
 MINIMAX_ALLOWED_EMOTIONS = [
@@ -41,6 +49,10 @@ MINIMAX_ALLOWED_EMOTIONS = [
 
 # Minimax TTS models
 MINIMAX_MODELS = [
+    {"value": "speech-2.8-turbo", "label": "Speech-2.8-Turbo"},
+    {"value": "speech-2.8-hd", "label": "Speech-2.8-HD"},
+    {"value": "speech-2.6-turbo", "label": "Speech-2.6-Turbo"},
+    {"value": "speech-2.6-hd", "label": "Speech-2.6-HD"},
     {"value": "speech-01-turbo", "label": "Speech-01-Turbo"},
     {"value": "speech-01-hd", "label": "Speech-01-HD"},
     {"value": "speech-02-turbo", "label": "Speech-02-Turbo"},
@@ -76,6 +88,266 @@ MINIMAX_EMOTIONS = [
     {"value": "surprised", "label": "惊讶"},
     {"value": "calm", "label": "平静"},
 ]
+
+
+def _resolve_minimax_model(model: Optional[str]) -> str:
+    valid_models = {m["value"] for m in MINIMAX_MODELS}
+    requested_model = (model or "").strip()
+    if requested_model and requested_model not in valid_models:
+        logger.warning(
+            "Ignoring invalid Minimax TTS model: %s (falling back to default)",
+            requested_model,
+        )
+        requested_model = ""
+    return requested_model or "speech-01-turbo"
+
+
+def _build_minimax_voice_setting(
+    voice_settings: VoiceSettings,
+    *,
+    model: str,
+    websocket_mode: bool = False,
+) -> Dict[str, Any]:
+    voice_setting_dict: Dict[str, Any] = {
+        "voice_id": voice_settings.voice_id,
+        "speed": voice_settings.speed,
+        "vol": voice_settings.volume,
+    }
+    if voice_settings.pitch is not None:
+        voice_setting_dict["pitch"] = int(voice_settings.pitch)
+
+    emotion = (voice_settings.emotion or "").strip()
+    if not emotion or emotion == "neutral" or emotion not in MINIMAX_ALLOWED_EMOTIONS:
+        return voice_setting_dict
+
+    if websocket_mode:
+        if model.startswith("speech-2.8") and emotion == "whisper":
+            return voice_setting_dict
+        voice_setting_dict["emotion"] = emotion
+        return voice_setting_dict
+
+    if model.startswith("speech-01"):
+        voice_setting_dict["emotion"] = emotion
+    return voice_setting_dict
+
+
+def _coerce_int_config(name: str, default: int) -> int:
+    try:
+        return int(get_config(name) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float_config(name: str, default: float) -> float:
+    try:
+        return float(get_config(name) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+class MinimaxWebSocketTTSSession:
+    """A single MiniMax WebSocket TTS task session."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        voice_settings: VoiceSettings,
+        audio_settings: AudioSettings,
+        rpm_limit: int,
+        queue_max_wait_seconds: float,
+        connect_timeout_seconds: float = 10.0,
+        receive_timeout_seconds: float = 60.0,
+    ):
+        if websocket is None:
+            raise ValueError("websocket-client is required for MiniMax WebSocket TTS")
+        if not api_key:
+            raise ValueError("MINIMAX_API_KEY is not configured")
+
+        self._api_key = api_key
+        self._model = _resolve_minimax_model(model)
+        self._voice_settings = voice_settings
+        self._audio_settings = audio_settings
+        self._rpm_limit = int(rpm_limit or 0)
+        self._queue_max_wait_seconds = float(queue_max_wait_seconds or 0)
+        self._connect_timeout_seconds = float(connect_timeout_seconds or 10.0)
+        self._receive_timeout_seconds = float(receive_timeout_seconds or 60.0)
+        self._ws = None
+        self._started = False
+
+    def open(self) -> None:
+        """Open the socket and send `task_start` after acquiring the RPM gate."""
+        if self._started and self._ws is not None:
+            return
+
+        headers = [
+            "Content-Type: application/json",
+            f"Authorization: Bearer {self._api_key}",
+        ]
+        self._ws = websocket.create_connection(
+            MINIMAX_TTS_WS_URL,
+            header=headers,
+            timeout=self._connect_timeout_seconds,
+        )
+        self._ws.settimeout(self._receive_timeout_seconds)
+
+        connected = self._recv_json()
+        self._ensure_event(connected, "connected_success")
+
+        self._acquire_gate()
+        self._send_json(
+            {
+                "event": "task_start",
+                "model": self._model,
+                "voice_setting": _build_minimax_voice_setting(
+                    self._voice_settings,
+                    model=self._model,
+                    websocket_mode=True,
+                ),
+                "audio_setting": self._audio_settings.to_dict(),
+            }
+        )
+        started = self._recv_json()
+        self._ensure_event(started, "task_started")
+        self._started = True
+
+    def synthesize_segment(self, text: str) -> TTSResult:
+        """Send one `task_continue` and collect all returned audio chunks."""
+        if not text or not text.strip():
+            raise ValueError("Text cannot be empty")
+        if not self._started or self._ws is None:
+            self.open()
+
+        self._acquire_gate()
+        self._send_json({"event": "task_continue", "text": text})
+
+        audio_chunks: list[bytes] = []
+        extra_info: Dict[str, Any] = {}
+        while True:
+            message = self._recv_json()
+            event = message.get("event")
+            if event and event != "task_continued":
+                raise ValueError(f"Unexpected MiniMax WebSocket event: {event}")
+
+            data = message.get("data") or {}
+            audio_hex = data.get("audio")
+            if audio_hex:
+                audio_chunks.append(bytes.fromhex(audio_hex))
+            if message.get("extra_info"):
+                extra_info = message.get("extra_info") or {}
+            if message.get("is_final"):
+                break
+
+        audio_data = b"".join(audio_chunks)
+        if not audio_data:
+            raise ValueError("No audio data in MiniMax WebSocket response")
+
+        duration_ms = int(extra_info.get("audio_length") or 0)
+        sample_rate = int(
+            extra_info.get("audio_sample_rate")
+            or self._audio_settings.sample_rate
+            or 24000
+        )
+        audio_format = str(
+            extra_info.get("audio_format") or self._audio_settings.format or "mp3"
+        )
+        word_count = int(extra_info.get("usage_characters") or 0)
+
+        logger.info(
+            "MiniMax WebSocket TTS segment completed: duration=%sms, size=%s bytes, usage_characters=%s",
+            duration_ms,
+            len(audio_data),
+            word_count,
+        )
+        return TTSResult(
+            audio_data=audio_data,
+            duration_ms=duration_ms,
+            sample_rate=sample_rate,
+            format=audio_format,
+            word_count=word_count,
+        )
+
+    def close(self) -> None:
+        """Finish the MiniMax task and close the socket."""
+        ws = self._ws
+        self._ws = None
+        self._started = False
+        if ws is None:
+            return
+        try:
+            ws.settimeout(10)
+            ws.send(json.dumps({"event": "task_finish"}, ensure_ascii=False))
+            message = self._recv_json_from(ws)
+            if message.get("event"):
+                self._ensure_event(message, "task_finished")
+        except Exception:
+            logger.debug(
+                "MiniMax WebSocket task_finish failed during close", exc_info=True
+            )
+        finally:
+            try:
+                ws.close()
+            except Exception:
+                logger.debug("MiniMax WebSocket close failed", exc_info=True)
+
+    def _acquire_gate(self) -> None:
+        acquire_tts_rpm_slot(
+            provider="minimax",
+            api_key=self._api_key,
+            rpm_limit=self._rpm_limit,
+            max_wait_seconds=self._queue_max_wait_seconds,
+        )
+
+    def _send_json(self, payload: Dict[str, Any]) -> None:
+        if self._ws is None:
+            raise ValueError("MiniMax WebSocket is not connected")
+        self._ws.send(json.dumps(payload, ensure_ascii=False))
+
+    def _recv_json(self) -> Dict[str, Any]:
+        if self._ws is None:
+            raise ValueError("MiniMax WebSocket is not connected")
+        return self._recv_json_from(self._ws)
+
+    def _recv_json_from(self, ws) -> Dict[str, Any]:
+        raw = ws.recv()
+        if not raw:
+            raise ValueError("Empty MiniMax WebSocket response")
+        try:
+            message = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid MiniMax WebSocket JSON response") from exc
+
+        if message.get("event") == "task_failed":
+            raise ValueError(
+                _format_minimax_error(message, "MiniMax WebSocket task failed")
+            )
+        _ensure_minimax_base_resp(message, "MiniMax WebSocket error")
+        return message
+
+    @staticmethod
+    def _ensure_event(message: Dict[str, Any], expected_event: str) -> None:
+        actual_event = message.get("event")
+        if actual_event != expected_event:
+            raise ValueError(
+                f"Unexpected MiniMax WebSocket event: expected={expected_event}, actual={actual_event}"
+            )
+
+
+def _ensure_minimax_base_resp(message: Dict[str, Any], prefix: str) -> None:
+    base_resp = message.get("base_resp") or {}
+    status_code = int(base_resp.get("status_code") or 0)
+    if status_code != 0:
+        raise ValueError(_format_minimax_error(message, prefix))
+
+
+def _format_minimax_error(message: Dict[str, Any], prefix: str) -> str:
+    base_resp = message.get("base_resp") or {}
+    status_code = base_resp.get("status_code", "unknown")
+    status_msg = base_resp.get("status_msg", "Unknown error")
+    trace_id = message.get("trace_id") or ""
+    trace_suffix = f", trace_id={trace_id}" if trace_id else ""
+    return f"{prefix}: {status_code} - {status_msg}{trace_suffix}"
 
 
 class MinimaxTTSProvider(BaseTTSProvider):
@@ -210,16 +482,7 @@ class MinimaxTTSProvider(BaseTTSProvider):
         """
         api_key = get_config("MINIMAX_API_KEY")
         group_id = get_config("MINIMAX_GROUP_ID")
-        valid_models = {m["value"] for m in MINIMAX_MODELS}
-        requested_model = (model or "").strip()
-        if requested_model and requested_model not in valid_models:
-            logger.warning(
-                "Ignoring invalid Minimax TTS model: %s (falling back to default)",
-                requested_model,
-            )
-            requested_model = ""
-
-        tts_model = requested_model or "speech-01-turbo"
+        tts_model = _resolve_minimax_model(model)
 
         if not api_key:
             raise ValueError("MINIMAX_API_KEY is not configured")
@@ -236,22 +499,11 @@ class MinimaxTTSProvider(BaseTTSProvider):
             url = f"{url}?GroupId={group_id}"
 
         # Build voice setting dict for Minimax API
-        voice_setting_dict = {
-            "voice_id": voice_settings.voice_id,
-            "speed": voice_settings.speed,
-            "vol": voice_settings.volume,
-        }
-        if voice_settings.pitch is not None:
-            voice_setting_dict["pitch"] = int(voice_settings.pitch)
-        emotion = (voice_settings.emotion or "").strip()
-        emotion_supported_by_model = tts_model.startswith("speech-01")
-        if (
-            emotion_supported_by_model
-            and emotion
-            and emotion != "neutral"
-            and emotion in MINIMAX_ALLOWED_EMOTIONS
-        ):
-            voice_setting_dict["emotion"] = emotion
+        voice_setting_dict = _build_minimax_voice_setting(
+            voice_settings,
+            model=tts_model,
+            websocket_mode=False,
+        )
 
         # Build request payload
         payload = {
@@ -288,6 +540,28 @@ class MinimaxTTSProvider(BaseTTSProvider):
             raise ValueError(f"Minimax TTS API error: {status_code} - {status_msg}")
 
         return result
+
+    def create_websocket_session(
+        self,
+        *,
+        voice_settings: Optional[VoiceSettings] = None,
+        audio_settings: Optional[AudioSettings] = None,
+        model: Optional[str] = None,
+    ) -> MinimaxWebSocketTTSSession:
+        """Create one WebSocket TTS task session for RUN streaming."""
+        api_key = get_config("MINIMAX_API_KEY")
+        if not api_key:
+            raise ValueError("MINIMAX_API_KEY is not configured")
+        return MinimaxWebSocketTTSSession(
+            api_key=api_key,
+            model=_resolve_minimax_model(model),
+            voice_settings=voice_settings or self.get_default_voice_settings(),
+            audio_settings=audio_settings or self.get_default_audio_settings(),
+            rpm_limit=_coerce_int_config("MINIMAX_TTS_RPM_LIMIT", 0),
+            queue_max_wait_seconds=_coerce_float_config(
+                "MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS", 10.0
+            ),
+        )
 
     def get_provider_config(self) -> ProviderConfig:
         """Get Minimax provider configuration for frontend."""

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1133,6 +1133,20 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         description="TTS audio bitrate (32000-256000)",
         group="tts",
     ),
+    "MINIMAX_TTS_RPM_LIMIT": EnvVar(
+        name="MINIMAX_TTS_RPM_LIMIT",
+        default=0,
+        type=int,
+        description="MiniMax TTS RPM queue limit; 0 disables queue gating",
+        group="tts",
+    ),
+    "MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS": EnvVar(
+        name="MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS",
+        default=10,
+        type=int,
+        description="Maximum seconds a MiniMax TTS request waits in the RPM queue",
+        group="tts",
+    ),
     # Volcengine TTS Configuration (shared by WebSocket + HTTP providers)
     "VOLCENGINE_TTS_APP_KEY": EnvVar(
         name="VOLCENGINE_TTS_APP_KEY",

--- a/src/api/flaskr/service/tts/minimax_run_tts.py
+++ b/src/api/flaskr/service/tts/minimax_run_tts.py
@@ -1,0 +1,125 @@
+"""MiniMax RUN-level WebSocket TTS orchestration."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Optional
+
+from flaskr.api.tts import AudioSettings, TTSResult, VoiceSettings
+from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
+from flaskr.common.config import get_config
+from flaskr.common.log import AppLoggerProxy
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+
+
+logger = AppLoggerProxy(logging.getLogger(__name__))
+
+
+class MinimaxRunTTSDisabled(RuntimeError):
+    """Raised after the MiniMax RUN WebSocket TTS path has been disabled."""
+
+
+class MinimaxRunTTSManager:
+    """Serializes all MiniMax WebSocket TTS sends for one RUN."""
+
+    def __init__(
+        self,
+        *,
+        voice_settings: VoiceSettings,
+        audio_settings: AudioSettings,
+        model: str = "",
+        session_factory: Optional[Callable[[], object]] = None,
+    ):
+        self._voice_settings = voice_settings
+        self._audio_settings = audio_settings
+        self._model = model or ""
+        self._session_factory = session_factory
+        self._session = None
+        self._disabled = False
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def is_disabled(self) -> bool:
+        with self._lock:
+            return self._disabled or self._closed
+
+    def synthesize(self, text: str) -> TTSResult:
+        """Synthesize one sentence/segment over the RUN WebSocket session."""
+        with self._lock:
+            if self._disabled or self._closed:
+                raise MinimaxRunTTSDisabled("MiniMax RUN TTS is disabled")
+
+            try:
+                return self._synthesize_locked(text)
+            except TTSRpmQueueTimeout:
+                self._disable_locked()
+                raise
+            except Exception as first_error:
+                logger.warning(
+                    "MiniMax WebSocket TTS segment failed; reconnecting once: %s",
+                    first_error,
+                )
+                self._close_session_locked()
+
+            try:
+                return self._synthesize_locked(text)
+            except TTSRpmQueueTimeout:
+                self._disable_locked()
+                raise
+            except Exception as second_error:
+                self._disable_locked()
+                raise MinimaxRunTTSDisabled(
+                    f"MiniMax RUN TTS failed after reconnect: {second_error}"
+                ) from second_error
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            self._close_session_locked()
+
+    def _synthesize_locked(self, text: str) -> TTSResult:
+        session = self._ensure_session_locked()
+        return session.synthesize_segment(text)
+
+    def _ensure_session_locked(self):
+        if self._session is not None:
+            return self._session
+        session = self._create_session()
+        session.open()
+        self._session = session
+        return session
+
+    def _create_session(self):
+        if self._session_factory is not None:
+            return self._session_factory()
+        return MinimaxTTSProvider().create_websocket_session(
+            voice_settings=self._voice_settings,
+            audio_settings=self._audio_settings,
+            model=self._model,
+        )
+
+    def _disable_locked(self) -> None:
+        self._disabled = True
+        self._close_session_locked()
+
+    def _close_session_locked(self) -> None:
+        session = self._session
+        self._session = None
+        if session is None:
+            return
+        try:
+            session.close()
+        except Exception:
+            logger.debug("Failed to close MiniMax RUN TTS session", exc_info=True)
+
+
+def should_use_minimax_run_websocket(tts_provider: str) -> bool:
+    """Return whether the RUN streaming path should use MiniMax WebSocket TTS."""
+    normalized = (tts_provider or "").strip().lower()
+    if normalized == "default":
+        normalized = ""
+    if normalized and normalized != "minimax":
+        return False
+    return bool(get_config("MINIMAX_API_KEY"))

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -1,0 +1,198 @@
+"""Shared RPM queue gate for TTS provider calls."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from flaskr.common.log import AppLoggerProxy
+
+
+logger = AppLoggerProxy(logging.getLogger(__name__))
+
+_LOCAL_STATE: dict[str, float] = {}
+_LOCAL_LOCK = threading.RLock()
+_FALLBACK_WARNING_LOCK = threading.Lock()
+_FALLBACK_WARNING_KEYS: set[str] = set()
+
+
+class TTSRpmQueueTimeout(TimeoutError):
+    """Raised when a TTS request cannot enter the RPM queue fast enough."""
+
+
+@dataclass(frozen=True)
+class TTSRpmGateResult:
+    """Queue wait metadata returned after a successful gate acquisition."""
+
+    waited_seconds: float
+    scheduled_at: float
+
+
+def acquire_tts_rpm_slot(
+    *,
+    provider: str,
+    api_key: str,
+    rpm_limit: int | float,
+    max_wait_seconds: int | float,
+    now_fn: Callable[[], float] = time.time,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> TTSRpmGateResult:
+    """Reserve one smoothed RPM slot for a provider/API-key pair.
+
+    The Redis path coordinates all workers. When Redis is not configured or is
+    unreachable, the local process path still protects a single worker so the
+    request can continue with reduced coordination guarantees.
+    """
+
+    limit = float(rpm_limit or 0)
+    if limit <= 0:
+        now = now_fn()
+        return TTSRpmGateResult(waited_seconds=0.0, scheduled_at=now)
+
+    wait_cap = max(float(max_wait_seconds or 0), 0.0)
+    interval = 60.0 / limit
+    scope_key = _scope_key(provider=provider, api_key=api_key)
+    start = now_fn()
+    deadline = start + wait_cap
+
+    try:
+        result = _acquire_redis_slot(
+            scope_key=scope_key,
+            interval=interval,
+            deadline=deadline,
+            max_wait_seconds=wait_cap,
+            now_fn=now_fn,
+        )
+    except TTSRpmQueueTimeout:
+        raise
+    except Exception as exc:
+        _warn_redis_fallback_once(provider=provider, scope_key=scope_key, exc=exc)
+        result = _acquire_local_slot(
+            scope_key=scope_key,
+            interval=interval,
+            deadline=deadline,
+            now_fn=now_fn,
+        )
+
+    sleep_seconds = max(result.scheduled_at - now_fn(), 0.0)
+    if sleep_seconds > 0:
+        sleep_fn(sleep_seconds)
+
+    return TTSRpmGateResult(
+        waited_seconds=max(result.scheduled_at - start, 0.0),
+        scheduled_at=result.scheduled_at,
+    )
+
+
+def _acquire_redis_slot(
+    *,
+    scope_key: str,
+    interval: float,
+    deadline: float,
+    max_wait_seconds: float,
+    now_fn: Callable[[], float],
+) -> TTSRpmGateResult:
+    redis_client = _get_redis_client()
+    next_key = f"tts:rpm_gate:{scope_key}:next_available_at"
+    lock_key = f"tts:rpm_gate:{scope_key}:lock"
+    lock_timeout = max(math.ceil(max_wait_seconds + 5), 5)
+    lock = redis_client.lock(
+        lock_key,
+        timeout=lock_timeout,
+        blocking_timeout=max_wait_seconds,
+    )
+    acquired = lock.acquire(blocking=True, blocking_timeout=max_wait_seconds)
+    if not acquired:
+        raise TTSRpmQueueTimeout(
+            f"TTS RPM queue lock timed out after {max_wait_seconds:.2f}s"
+        )
+
+    try:
+        now = now_fn()
+        raw_next = redis_client.get(next_key)
+        next_available_at = _parse_timestamp(raw_next, default=now)
+        scheduled_at = max(now, next_available_at)
+        if scheduled_at > deadline:
+            raise TTSRpmQueueTimeout(
+                f"TTS RPM queue wait exceeded {max_wait_seconds:.2f}s"
+            )
+
+        ttl_seconds = max(math.ceil(interval * 4 + max_wait_seconds + 60), 120)
+        redis_client.set(next_key, f"{scheduled_at + interval:.6f}", ex=ttl_seconds)
+        return TTSRpmGateResult(
+            waited_seconds=max(scheduled_at - now, 0.0),
+            scheduled_at=scheduled_at,
+        )
+    finally:
+        try:
+            lock.release()
+        except Exception:
+            logger.debug("Failed to release TTS RPM Redis lock", exc_info=True)
+
+
+def _acquire_local_slot(
+    *,
+    scope_key: str,
+    interval: float,
+    deadline: float,
+    now_fn: Callable[[], float],
+) -> TTSRpmGateResult:
+    with _LOCAL_LOCK:
+        now = now_fn()
+        scheduled_at = max(now, _LOCAL_STATE.get(scope_key, now))
+        if scheduled_at > deadline:
+            raise TTSRpmQueueTimeout("TTS RPM local queue wait exceeded limit")
+
+        _LOCAL_STATE[scope_key] = scheduled_at + interval
+        return TTSRpmGateResult(
+            waited_seconds=max(scheduled_at - now, 0.0),
+            scheduled_at=scheduled_at,
+        )
+
+
+def _get_redis_client():
+    from flaskr.dao import redis_client
+
+    if redis_client is None:
+        raise RuntimeError("Redis is not configured")
+    return redis_client
+
+
+def _scope_key(*, provider: str, api_key: str) -> str:
+    normalized_provider = (provider or "default").strip().lower() or "default"
+    key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:24]
+    return f"{normalized_provider}:{key_hash}"
+
+
+def _parse_timestamp(
+    raw: Optional[bytes | str | float | int], *, default: float
+) -> float:
+    if raw is None:
+        return default
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="ignore")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+def _warn_redis_fallback_once(*, provider: str, scope_key: str, exc: Exception) -> None:
+    with _FALLBACK_WARNING_LOCK:
+        if scope_key in _FALLBACK_WARNING_KEYS:
+            return
+        _FALLBACK_WARNING_KEYS.add(scope_key)
+
+    logger.warning(
+        "Redis unavailable for TTS RPM gate; using process-local queue for provider=%s: %s",
+        (provider or "default").strip().lower() or "default",
+        exc,
+    )

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -60,6 +60,12 @@ from flaskr.service.tts.pipeline import (
     build_av_segmentation_contract,
     _find_next_av_boundary,
 )
+from flaskr.service.tts.minimax_run_tts import (
+    MinimaxRunTTSDisabled,
+    MinimaxRunTTSManager,
+    should_use_minimax_run_websocket,
+)
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
 
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
@@ -141,6 +147,7 @@ class StreamingTTSProcessor:
         stream_element_type: str | None = None,
         av_contract: Optional[Dict[str, Any]] = None,
         usage_scene: int = BILL_USAGE_SCENE_PROD,
+        minimax_run_manager: Optional[MinimaxRunTTSManager] = None,
     ):
         self.app = app
         self.generated_block_bid = generated_block_bid
@@ -170,6 +177,8 @@ class StreamingTTSProcessor:
         if emotion:
             self.voice_settings.emotion = emotion
         self.audio_settings = get_default_audio_settings(tts_provider)
+        self._minimax_run_manager = minimax_run_manager
+        self._owns_minimax_run_manager = False
 
         # State
         self._buffer = ""
@@ -205,6 +214,15 @@ class StreamingTTSProcessor:
             logger.warning(
                 f"TTS is not configured for provider '{tts_provider or '(unset)'}', streaming TTS disabled"
             )
+        elif self._minimax_run_manager is None and should_use_minimax_run_websocket(
+            tts_provider
+        ):
+            self._minimax_run_manager = MinimaxRunTTSManager(
+                voice_settings=self.voice_settings,
+                audio_settings=self.audio_settings,
+                model=self.tts_model,
+            )
+            self._owns_minimax_run_manager = True
 
     def process_chunk(self, chunk: str) -> Generator[RunMarkdownFlowDTO, None, None]:
         """
@@ -311,6 +329,14 @@ class StreamingTTSProcessor:
 
     def _submit_tts_task(self, text: str):
         """Submit a TTS synthesis task to the background thread pool."""
+        if (
+            self._minimax_run_manager is not None
+            and self._minimax_run_manager.is_disabled
+        ):
+            self._enabled = False
+            logger.warning("MiniMax RUN TTS disabled; skipping new TTS segment")
+            return
+
         with self._lock:
             segment_index = self._segment_index
             self._segment_index += 1
@@ -387,13 +413,16 @@ class StreamingTTSProcessor:
         with self.app.app_context():
             try:
                 segment_start = time.monotonic()
-                result = synthesize_text(
-                    text=segment.text,
-                    voice_settings=voice_settings,
-                    audio_settings=audio_settings,
-                    model=tts_model,
-                    provider_name=tts_provider,
-                )
+                if self._minimax_run_manager is not None:
+                    result = self._minimax_run_manager.synthesize(segment.text)
+                else:
+                    result = synthesize_text(
+                        text=segment.text,
+                        voice_settings=voice_settings,
+                        audio_settings=audio_settings,
+                        model=tts_model,
+                        provider_name=tts_provider,
+                    )
                 segment.audio_data = result.audio_data
                 segment.duration_ms = result.duration_ms
                 segment.word_count = int(result.word_count or 0)
@@ -427,6 +456,24 @@ class StreamingTTSProcessor:
                     f"TTS segment {segment.index} synthesized: "
                     f"text_len={len(segment.text)}, duration={segment.duration_ms}ms"
                 )
+            except TTSRpmQueueTimeout as e:
+                self._enabled = False
+                logger.warning(
+                    "TTS segment %s skipped after RPM queue timeout: %s",
+                    segment.index,
+                    e,
+                )
+                segment.error = str(e)
+                segment.is_ready = True
+            except MinimaxRunTTSDisabled as e:
+                self._enabled = False
+                logger.warning(
+                    "TTS segment %s skipped because MiniMax RUN TTS is disabled: %s",
+                    segment.index,
+                    e,
+                )
+                segment.error = str(e)
+                segment.is_ready = True
             except Exception as e:
                 logger.error(f"TTS segment {segment.index} failed: {e}")
                 segment.error = str(e)
@@ -507,6 +554,14 @@ class StreamingTTSProcessor:
                     time.sleep(0.1)  # 100ms delay between segment yields
                 segments_yielded += 1
 
+    def _close_owned_minimax_run_manager(self) -> None:
+        if not self._owns_minimax_run_manager or self._minimax_run_manager is None:
+            return
+        try:
+            self._minimax_run_manager.close()
+        finally:
+            self._owns_minimax_run_manager = False
+
     def finalize(
         self, *, commit: bool = True
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
@@ -530,12 +585,16 @@ class StreamingTTSProcessor:
             f"pending_futures={len(self._pending_futures)}, "
             f"all_audio_data={len(self._all_audio_data)}"
         )
-        if not self._enabled:
+        has_existing_work = bool(
+            self._pending_futures or self._completed_segments or self._all_audio_data
+        )
+        if not self._enabled and not has_existing_work:
             logger.debug("TTS finalize: TTS not enabled, returning early")
+            self._close_owned_minimax_run_manager()
             return
 
         # Submit any remaining buffer content in segments to avoid burst
-        if self._buffer:
+        if self._enabled and self._buffer:
             raw_remaining = self._buffer[self._raw_offset :]
             remaining_text = preprocess_for_tts(raw_remaining).strip()
             # Use segmented submission to maintain consistent pacing
@@ -567,6 +626,7 @@ class StreamingTTSProcessor:
                 f"next_yield_index={self._next_yield_index}, "
                 f"completed_segments keys={list(self._completed_segments.keys())}"
             )
+            self._close_owned_minimax_run_manager()
             return
 
         # Sort by index and concatenate
@@ -684,6 +744,8 @@ class StreamingTTSProcessor:
         except Exception as e:
             logger.error(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
 
+        self._close_owned_minimax_run_manager()
+
 
 class AVStreamingTTSProcessor:
     """
@@ -746,6 +808,22 @@ class AVStreamingTTSProcessor:
             None
             # 'fence' | 'svg' | 'iframe' | 'video' | 'html_table' | 'md_table' | 'sandbox' | 'md_img'
         )
+        self._minimax_run_manager: Optional[MinimaxRunTTSManager] = None
+        if should_use_minimax_run_websocket(tts_provider):
+            voice_settings = get_default_voice_settings(tts_provider)
+            if voice_id:
+                voice_settings.voice_id = voice_id
+            if speed is not None:
+                voice_settings.speed = float(speed)
+            if pitch is not None:
+                voice_settings.pitch = int(pitch)
+            if emotion:
+                voice_settings.emotion = emotion
+            self._minimax_run_manager = MinimaxRunTTSManager(
+                voice_settings=voice_settings,
+                audio_settings=get_default_audio_settings(tts_provider),
+                model=tts_model,
+            )
 
     def _update_av_contract(self):
         try:
@@ -775,6 +853,7 @@ class AVStreamingTTSProcessor:
             tts_model=self.tts_model,
             av_contract=self._av_contract,
             usage_scene=self.usage_scene,
+            minimax_run_manager=self._minimax_run_manager,
         )
         self._current_segment_has_speakable_text = False
         return self._current_processor
@@ -897,17 +976,21 @@ class AVStreamingTTSProcessor:
     def finalize(
         self, *, commit: bool = True
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
-        # Ignore any trailing non-speakable content if we are mid-boundary.
-        if self._skip_mode:
-            self._raw_buffer = ""
-            self._skip_mode = None
+        try:
+            # Ignore any trailing non-speakable content if we are mid-boundary.
+            if self._skip_mode:
+                self._raw_buffer = ""
+                self._skip_mode = None
 
-        if self._raw_buffer:
-            processor = self._ensure_processor()
-            yield from self._process_processor_chunk(processor, self._raw_buffer)
-            self._raw_buffer = ""
+            if self._raw_buffer:
+                processor = self._ensure_processor()
+                yield from self._process_processor_chunk(processor, self._raw_buffer)
+                self._raw_buffer = ""
 
-        yield from self._finalize_current(commit=commit)
+            yield from self._finalize_current(commit=commit)
 
-        # Refresh cursor from the full contract so next block can continue element index.
-        self._refresh_next_element_index_from_contract()
+            # Refresh cursor from the full contract so next block can continue element index.
+            self._refresh_next_element_index_from_contract()
+        finally:
+            if self._minimax_run_manager is not None:
+                self._minimax_run_manager.close()

--- a/src/api/tests/service/tts/test_minimax_run_tts_manager.py
+++ b/src/api/tests/service/tts/test_minimax_run_tts_manager.py
@@ -1,0 +1,79 @@
+import pytest
+
+from flaskr.api.tts import AudioSettings, TTSResult, VoiceSettings
+from flaskr.service.tts.minimax_run_tts import (
+    MinimaxRunTTSDisabled,
+    MinimaxRunTTSManager,
+)
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+
+
+class _FakeSession:
+    def __init__(self, *, fail_once=False, queue_timeout=False):
+        self.fail_once = fail_once
+        self.queue_timeout = queue_timeout
+        self.open_count = 0
+        self.close_count = 0
+        self.texts = []
+
+    def open(self):
+        self.open_count += 1
+
+    def synthesize_segment(self, text):
+        self.texts.append(text)
+        if self.queue_timeout:
+            raise TTSRpmQueueTimeout("queue timeout")
+        if self.fail_once:
+            self.fail_once = False
+            raise RuntimeError("network down")
+        return TTSResult(
+            audio_data=f"audio:{text}".encode("utf-8"),
+            duration_ms=100,
+            sample_rate=24000,
+            format="mp3",
+            word_count=len(text),
+        )
+
+    def close(self):
+        self.close_count += 1
+
+
+def _manager(session_factory):
+    return MinimaxRunTTSManager(
+        voice_settings=VoiceSettings(voice_id="voice-a"),
+        audio_settings=AudioSettings(format="mp3"),
+        model="speech-2.8-turbo",
+        session_factory=session_factory,
+    )
+
+
+def test_minimax_run_tts_manager_reconnects_once_and_resends_current_text():
+    sessions = [_FakeSession(fail_once=True), _FakeSession()]
+    created = []
+
+    def session_factory():
+        session = sessions.pop(0)
+        created.append(session)
+        return session
+
+    manager = _manager(session_factory)
+
+    result = manager.synthesize("hello")
+
+    assert result.audio_data == b"audio:hello"
+    assert sessions == []
+    assert [session.texts for session in created] == [["hello"], ["hello"]]
+    assert created[0].close_count == 1
+
+
+def test_minimax_run_tts_manager_disables_run_after_queue_timeout():
+    session = _FakeSession(queue_timeout=True)
+    manager = _manager(lambda: session)
+
+    with pytest.raises(TTSRpmQueueTimeout):
+        manager.synthesize("hello")
+
+    assert manager.is_disabled is True
+    with pytest.raises(MinimaxRunTTSDisabled):
+        manager.synthesize("later")
+    assert session.texts == ["hello"]

--- a/src/api/tests/service/tts/test_minimax_websocket_session.py
+++ b/src/api/tests/service/tts/test_minimax_websocket_session.py
@@ -1,0 +1,189 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from flaskr.api.tts import AudioSettings, VoiceSettings
+import flaskr.api.tts.minimax_provider as minimax_provider
+from flaskr.api.tts.minimax_provider import MinimaxWebSocketTTSSession
+
+
+class _FakeWebSocket:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.sent = []
+        self.closed = False
+        self.timeouts = []
+
+    def settimeout(self, timeout):
+        self.timeouts.append(timeout)
+
+    def recv(self):
+        if not self.responses:
+            raise RuntimeError("no response queued")
+        return json.dumps(self.responses.pop(0))
+
+    def send(self, payload):
+        self.sent.append(json.loads(payload))
+
+    def close(self):
+        self.closed = True
+
+
+def _session(monkeypatch, responses, gate_calls):
+    fake_ws = _FakeWebSocket(responses)
+    monkeypatch.setattr(
+        minimax_provider,
+        "websocket",
+        SimpleNamespace(create_connection=lambda *args, **kwargs: fake_ws),
+    )
+    monkeypatch.setattr(
+        minimax_provider,
+        "acquire_tts_rpm_slot",
+        lambda **kwargs: gate_calls.append(kwargs),
+    )
+    session = MinimaxWebSocketTTSSession(
+        api_key="api-key",
+        model="speech-2.8-turbo",
+        voice_settings=VoiceSettings(
+            voice_id="voice-a",
+            speed=1.2,
+            pitch=1,
+            emotion="happy",
+            volume=0.9,
+        ),
+        audio_settings=AudioSettings(
+            format="mp3",
+            sample_rate=32000,
+            bitrate=128000,
+            channel=1,
+        ),
+        rpm_limit=120,
+        queue_max_wait_seconds=10,
+    )
+    return session, fake_ws
+
+
+def test_minimax_websocket_session_gates_task_start_and_continue(monkeypatch):
+    gate_calls = []
+    session, fake_ws = _session(
+        monkeypatch,
+        responses=[
+            {
+                "event": "connected_success",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+            {
+                "event": "task_started",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+            {
+                "event": "task_continued",
+                "data": {"audio": "61"},
+                "is_final": False,
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+            {
+                "event": "task_continued",
+                "data": {"audio": "62"},
+                "is_final": True,
+                "extra_info": {
+                    "audio_length": 240,
+                    "audio_sample_rate": 32000,
+                    "audio_format": "mp3",
+                    "usage_characters": 2,
+                },
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+            {
+                "event": "task_continued",
+                "data": {"audio": "63"},
+                "is_final": True,
+                "extra_info": {
+                    "audio_length": 120,
+                    "audio_sample_rate": 32000,
+                    "audio_format": "mp3",
+                    "usage_characters": 1,
+                },
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+            {
+                "event": "task_finished",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            },
+        ],
+        gate_calls=gate_calls,
+    )
+
+    session.open()
+    result = session.synthesize_segment("hi")
+    next_result = session.synthesize_segment("!")
+    session.close()
+
+    assert [payload["event"] for payload in fake_ws.sent] == [
+        "task_start",
+        "task_continue",
+        "task_continue",
+        "task_finish",
+    ]
+    assert fake_ws.sent[0]["voice_setting"]["emotion"] == "happy"
+    assert fake_ws.sent[1]["text"] == "hi"
+    assert fake_ws.sent[2]["text"] == "!"
+    assert len(gate_calls) == 3
+    assert all(call["provider"] == "minimax" for call in gate_calls)
+    assert result.audio_data == b"ab"
+    assert result.duration_ms == 240
+    assert result.sample_rate == 32000
+    assert result.word_count == 2
+    assert next_result.audio_data == b"c"
+    assert fake_ws.closed is True
+
+
+def test_minimax_websocket_session_allows_null_data_before_final_audio(monkeypatch):
+    gate_calls = []
+    session, _fake_ws = _session(
+        monkeypatch,
+        responses=[
+            {"event": "connected_success", "base_resp": {"status_code": 0}},
+            {"event": "task_started", "base_resp": {"status_code": 0}},
+            {
+                "event": "task_continued",
+                "data": None,
+                "is_final": False,
+                "base_resp": {"status_code": 0},
+            },
+            {
+                "event": "task_continued",
+                "data": {"audio": "6869"},
+                "is_final": True,
+                "extra_info": {"audio_length": 100},
+                "base_resp": {"status_code": 0},
+            },
+        ],
+        gate_calls=gate_calls,
+    )
+
+    result = session.synthesize_segment("hi")
+
+    assert len(gate_calls) == 2
+    assert result.audio_data == b"hi"
+    assert result.duration_ms == 100
+
+
+def test_minimax_websocket_session_raises_on_task_failed(monkeypatch):
+    gate_calls = []
+    session, _fake_ws = _session(
+        monkeypatch,
+        responses=[
+            {"event": "connected_success", "base_resp": {"status_code": 0}},
+            {"event": "task_started", "base_resp": {"status_code": 0}},
+            {
+                "event": "task_failed",
+                "base_resp": {"status_code": 1004, "status_msg": "auth failed"},
+            },
+        ],
+        gate_calls=gate_calls,
+    )
+
+    with pytest.raises(ValueError, match="task failed"):
+        session.synthesize_segment("hi")

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -54,6 +54,10 @@ class TestStreamingTtsSubtitles:
             lambda _provider: True,
         )
         monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.should_use_minimax_run_websocket",
+            lambda _provider: False,
+        )
+        monkeypatch.setattr(
             "flaskr.service.tts.streaming_tts.synthesize_text",
             lambda **kwargs: SimpleNamespace(
                 audio_data=f"audio:{kwargs['text']}".encode("utf-8"),

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -1,0 +1,162 @@
+import pytest
+
+from flaskr.service.tts import rpm_gate
+
+
+class _FakeRedisLock:
+    def __init__(self):
+        self.released = False
+
+    def acquire(self, blocking=True, blocking_timeout=None):
+        _ = blocking, blocking_timeout
+        return True
+
+    def release(self):
+        self.released = True
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.values = {}
+        self.locks = []
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def set(self, key, value, ex=None):
+        _ = ex
+        self.values[key] = str(value).encode("utf-8")
+        return True
+
+    def lock(self, key, timeout=None, blocking_timeout=None):
+        _ = key, timeout, blocking_timeout
+        lock = _FakeRedisLock()
+        self.locks.append(lock)
+        return lock
+
+
+def _clock(start=1000.0):
+    now = {"value": float(start)}
+
+    def now_fn():
+        return now["value"]
+
+    def sleep_fn(seconds):
+        now["value"] += seconds
+
+    return now_fn, sleep_fn
+
+
+@pytest.fixture(autouse=True)
+def _reset_gate_state():
+    rpm_gate._LOCAL_STATE.clear()
+    rpm_gate._FALLBACK_WARNING_KEYS.clear()
+    yield
+    rpm_gate._LOCAL_STATE.clear()
+    rpm_gate._FALLBACK_WARNING_KEYS.clear()
+
+
+def test_rpm_gate_smooths_same_provider_and_api_key(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
+    now_fn, sleep_fn = _clock()
+
+    first = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+    second = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert first.waited_seconds == 0
+    assert second.waited_seconds == pytest.approx(1.0)
+
+
+def test_rpm_gate_uses_independent_queues_for_different_api_keys(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
+    now_fn, sleep_fn = _clock()
+
+    first = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+    second = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-b",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert first.waited_seconds == 0
+    assert second.waited_seconds == 0
+
+
+def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
+    now_fn, sleep_fn = _clock()
+
+    rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=6,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    with pytest.raises(rpm_gate.TTSRpmQueueTimeout):
+        rpm_gate.acquire_tts_rpm_slot(
+            provider="minimax",
+            api_key="api-key-a",
+            rpm_limit=6,
+            max_wait_seconds=5,
+            now_fn=now_fn,
+            sleep_fn=sleep_fn,
+        )
+
+
+def test_rpm_gate_falls_back_to_process_local_when_redis_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        rpm_gate,
+        "_get_redis_client",
+        lambda: (_ for _ in ()).throw(RuntimeError("redis down")),
+    )
+    now_fn, sleep_fn = _clock()
+
+    first = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+    second = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert first.waited_seconds == 0
+    assert second.waited_seconds == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- Add a shared provider/API-key scoped TTS RPM gate with Redis coordination and process-local fallback.
- Add MiniMax WebSocket TTS session support for RUN streaming, gating `task_start` and each `task_continue`.
- Wire MiniMax RUN streaming through a shared run manager that serializes sends, reconnects once on WebSocket failure, and disables later TTS after queue timeout.
- Register `MINIMAX_TTS_RPM_LIMIT` and `MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS`, and regenerate the full env example.

## Tests
- `cd src/api && ruff check flaskr/service/tts/rpm_gate.py flaskr/service/tts/minimax_run_tts.py flaskr/api/tts/minimax_provider.py flaskr/service/tts/streaming_tts.py tests/service/tts/test_tts_rpm_gate.py tests/service/tts/test_minimax_websocket_session.py tests/service/tts/test_minimax_run_tts_manager.py tests/service/tts/test_streaming_tts_subtitles.py`
- `cd src/api && python -m py_compile flaskr/service/tts/rpm_gate.py flaskr/service/tts/minimax_run_tts.py flaskr/api/tts/minimax_provider.py flaskr/service/tts/streaming_tts.py`
- `cd src/api && SKIP_APP_FIXTURE=1 pytest tests/service/tts/ -q`
- `cd src/api && SKIP_APP_FIXTURE=1 pytest tests/service/learn/test_generated_block_tts_av_mode.py tests/service/shifu/test_tts_preview_helper.py -q`

## Notes
- `cd src/api && pytest tests/service/tts/ -q` is currently blocked in this local environment by LiteLLM importing `openai.types.responses` from an installed OpenAI package that does not provide that module.
