### PR TITLE
fix(cook-web): sanitize trailing punctuation in slide subtitle cues

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "^0.1.113",
+        "markdown-flow-ui": "^0.1.114",
         "next": "15.5.7",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -12842,9 +12842,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.1.113",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.113.tgz",
-      "integrity": "sha512-yeYBuGav+6TBQrPF/dR3hjM2w0UKmKXIvPv7RYVtdi7IvYAILr5wsc4x7eJbBYvx1VObTzJsP62dM65+AJEPgw==",
+      "version": "0.1.114",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.114.tgz",
+      "integrity": "sha512-dS9U/P4EzSSr9z//BfrTp11KCcVIQ3c5QAEJwX+Pe17GChR7XNsbHZeh1MGH54ZTe4aj33Fg9GXLYrfQqEt4vA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -66,7 +66,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "^0.1.113",
+    "markdown-flow-ui": "^0.1.114",
     "next": "15.5.7",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",

--- a/src/cook-web/skills/listen-mode-audio-streaming/SKILL.md
+++ b/src/cook-web/skills/listen-mode-audio-streaming/SKILL.md
@@ -29,6 +29,7 @@ description: 当处理听课模式的流式音频、buffering、TTS 请求门禁
 14. 听课模式 `run` 的 `audio_segment` 若已生成当前累计字幕 cue，必须同步透传到对应 element patch 的 `payload.audio.subtitle_cues`，不要等到 `audio_complete` 才返回字幕。
 15. 课程设置里的 `tts_enabled` 虽然沿用后端字段名，但前端产品语义视为“听课模式开关”；改动作者端文案或 learner 端默认模式时，必须同时检查设置页文案、课程信息映射和 `/c/...` 布局层默认 `learningMode` 是否一致。
 16. 从阅读模式切到听课模式前，如果 `record` 历史接口映射出来的首个 `text` 内容块没有 `audio_url/audioUrl`，必须拦截进入听课模式并提示用户先重修；判断范围只能看 `isHistory === true` 的历史内容，不能把后续 SSE 流里的新内容也算进去。
+17. 听课模式把后端 `subtitle_cues[].text` 透传给 `markdown-flow-ui/slide` 前，要先过滤尾部终止标点：默认删除句号、逗号、冒号、分号等收尾符号，但保留问号、叹号、省略号，以及成对标点的后半个（如 `”`、`）`、`》`）。
 
 ## 备注
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -132,4 +132,75 @@ describe('listenModeUtils', () => {
       },
     ]);
   });
+
+  it('strips disallowed trailing punctuation from subtitle cues', () => {
+    const subtitleCues = resolveListenSlideSubtitleCues(
+      createContentItem({
+        payload: {
+          audio: {
+            subtitle_cues: [
+              {
+                text: '句号结尾。',
+                start_ms: 0,
+                end_ms: 1000,
+              },
+              {
+                text: '冒号结尾：',
+                start_ms: 1000,
+                end_ms: 2000,
+              },
+              {
+                text: '问号保留？”',
+                start_ms: 2000,
+                end_ms: 3000,
+              },
+              {
+                text: '省略号保留……',
+                start_ms: 3000,
+                end_ms: 4000,
+              },
+              {
+                text: '双引号保留”',
+                start_ms: 4000,
+                end_ms: 5000,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(subtitleCues).toEqual([
+      {
+        text: '句号结尾',
+        start_ms: 0,
+        end_ms: 1000,
+        segment_index: 0,
+      },
+      {
+        text: '冒号结尾',
+        start_ms: 1000,
+        end_ms: 2000,
+        segment_index: 0,
+      },
+      {
+        text: '问号保留？”',
+        start_ms: 2000,
+        end_ms: 3000,
+        segment_index: 0,
+      },
+      {
+        text: '省略号保留……',
+        start_ms: 3000,
+        end_ms: 4000,
+        segment_index: 0,
+      },
+      {
+        text: '双引号保留”',
+        start_ms: 4000,
+        end_ms: 5000,
+        segment_index: 0,
+      },
+    ]);
+  });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -3,6 +3,7 @@ import type {
   StudyRecordAudioPayload,
   StudyRecordPayload,
 } from '@/c-api/studyV2';
+import { stripDisallowedSubtitleTrailingPunctuation } from '@/c-utils/subtitleUtils';
 import type { ElementSubtitleCue } from 'markdown-flow-ui/slide';
 import {
   getAudioSegmentDataListFromTracks,
@@ -73,7 +74,10 @@ export const resolveListenSlideSubtitleCues = (
       }
 
       const rawCue = cue as Record<string, unknown>;
-      const text = typeof rawCue.text === 'string' ? rawCue.text : undefined;
+      const text =
+        typeof rawCue.text === 'string'
+          ? stripDisallowedSubtitleTrailingPunctuation(rawCue.text)
+          : undefined;
       const startMs = normalizeSubtitleCueNumber(rawCue.start_ms);
       const endMs = normalizeSubtitleCueNumber(rawCue.end_ms);
 

--- a/src/cook-web/src/c-utils/subtitleUtils.ts
+++ b/src/cook-web/src/c-utils/subtitleUtils.ts
@@ -1,0 +1,70 @@
+const TRAILING_SUBTITLE_PAIR_CLOSERS = new Set([
+  '"',
+  "'",
+  '”',
+  '’',
+  '）',
+  ')',
+  ']',
+  '】',
+  '}',
+  '》',
+  '〉',
+  '」',
+  '』',
+  '〕',
+  '〗',
+  '〙',
+  '〛',
+]);
+
+const ALLOWED_SUBTITLE_ENDING_PATTERN = /(?:[?!？！]+|\.{3,}|…+|⋯+)$/u;
+const PUNCTUATION_CHAR_PATTERN = /\p{P}/u;
+
+const isTrailingSubtitlePairCloser = (char: string) =>
+  TRAILING_SUBTITLE_PAIR_CLOSERS.has(char);
+
+const isAllowedSubtitleEnding = (text: string) =>
+  ALLOWED_SUBTITLE_ENDING_PATTERN.test(text);
+
+const isPunctuationChar = (char: string) => PUNCTUATION_CHAR_PATTERN.test(char);
+
+export const stripDisallowedSubtitleTrailingPunctuation = (text: string) => {
+  const trimmedText = text.trimEnd();
+
+  if (!trimmedText) {
+    return trimmedText;
+  }
+
+  let suffix = '';
+  let cursor = trimmedText.length;
+
+  // Preserve trailing paired closers such as quotes or brackets.
+  while (cursor > 0) {
+    const currentChar = trimmedText[cursor - 1];
+
+    if (!isTrailingSubtitlePairCloser(currentChar)) {
+      break;
+    }
+
+    suffix = `${currentChar}${suffix}`;
+    cursor -= 1;
+  }
+
+  let content = trimmedText.slice(0, cursor);
+
+  while (content) {
+    if (isAllowedSubtitleEnding(content)) {
+      break;
+    }
+
+    const currentChar = content[content.length - 1];
+    if (!isPunctuationChar(currentChar)) {
+      break;
+    }
+
+    content = content.slice(0, -1).trimEnd();
+  }
+
+  return `${content}${suffix}`;
+};


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
