### PR TITLE
feat(cook-web): show mobile unsupported dialog on admin and shifu pages

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -18,6 +18,7 @@
 - 账务/积分页面如果同一类时间展示同时出现在卡片、表格或 tooltip 中，优先抽到 `src/lib/billing.ts` 的共享格式化方法；涉及中英文文案时，同步更新 `zh-CN/en-US`、`i18n-keys.d.ts` 和对应组件测试，避免只改页面不改类型与回归用例。
 - 钱包余额、可用积分、侧边会员卡余额这类“积分余额”展示统一只保留整数部分且不加千分位分隔；套餐赠送额度、购买额度、消耗量等非余额数字继续使用通用积分格式化方法，避免把两类数字口径混用。
 - 当产品要求把套餐赠送积分数、免费体验积分和积分充值包额度也统一成整数展示时，优先复用 `src/lib/billing.ts` 的共享积分数量格式化方法，确保套餐卡、免费卡、充值卡和对应测试口径一致。
+- 对于明确暂不支持移动端的页面，优先复用共享的国际化弹窗组件统一提示，避免在多个页面分别写一套移动端拦截文案和状态逻辑。
 - For system interaction buttons such as `_sys_pay`, prefer ai-shifu-side render overrides to keep repeatable CTAs clickable without patching `markdown-flow-ui`.
 - When adapting cook-web payloads into `markdown-flow-ui` slide elements, normalize optional API fields into the stricter slide contract first instead of passing broader API types through render layers.
 - When listen-mode misses trailing interaction cards, check whether `outline_item_update: completed` arrived before the final `element` events; completion must not cause post-completion interaction markers to be dropped.

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -446,9 +446,6 @@ describe('AdminLayout', () => {
     expect(
       screen.getByText('module.billing.sidebar.monthlyBalanceTitle'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText('module.billing.sidebar.monthlyTitle'),
-    ).toBeInTheDocument();
     expect(screen.getByText('12500')).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
@@ -483,9 +480,6 @@ describe('AdminLayout', () => {
 
     expect(
       screen.getByText('module.billing.sidebar.nonMemberBalanceTitle'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('module.billing.sidebar.nonMemberTitle'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('admin-billing-sidebar-card')).toHaveAttribute(
       'data-href',

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -34,6 +34,7 @@ import Loading from '@/components/loading';
 import { useTranslation } from 'react-i18next';
 import { ErrorWithCode } from '@/lib/request';
 import ErrorDisplay from '@/components/ErrorDisplay';
+import MobileUnsupportedDialog from '@/components/MobileUnsupportedDialog';
 import { useUserStore } from '@/store';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import { canManageArchive as canManageArchiveForShifu } from '@/lib/shifu-permissions';
@@ -452,6 +453,7 @@ const ScriptManagementPage = () => {
 
   return (
     <>
+      <MobileUnsupportedDialog />
       <AlertDialog
         open={archiveDialogOpen}
         onOpenChange={open => {

--- a/src/cook-web/src/app/shifu/[id]/page.tsx
+++ b/src/cook-web/src/app/shifu/[id]/page.tsx
@@ -3,6 +3,7 @@ import { use } from 'react';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import Loading from '@/components/loading';
+import MobileUnsupportedDialog from '@/components/MobileUnsupportedDialog';
 import { getLessonIdFromQuery } from '@/c-utils/urlUtils';
 
 const ShifuRoot = dynamic(() => import('@/components/shifu-root'), {
@@ -22,11 +23,14 @@ export default function Page({ params }: { params: Promise<ShifuPageParams> }) {
   const initialLessonId = getLessonIdFromQuery(searchParams);
 
   return (
-    <div className='h-screen w-full'>
-      <ShifuRoot
-        id={id}
-        initialLessonId={initialLessonId}
-      />
-    </div>
+    <>
+      <MobileUnsupportedDialog />
+      <div className='h-screen w-full'>
+        <ShifuRoot
+          id={id}
+          initialLessonId={initialLessonId}
+        />
+      </div>
+    </>
   );
 }

--- a/src/cook-web/src/components/MobileUnsupportedDialog.test.tsx
+++ b/src/cook-web/src/components/MobileUnsupportedDialog.test.tsx
@@ -12,9 +12,8 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('@/c-store/useUiLayoutStore', () => ({
   __esModule: true,
-  useUiLayoutStore: (
-    selector: (state: { inMobile: boolean }) => boolean,
-  ) => mockUseUiLayoutStore(selector),
+  useUiLayoutStore: (selector: (state: { inMobile: boolean }) => boolean) =>
+    mockUseUiLayoutStore(selector),
 }));
 
 describe('MobileUnsupportedDialog', () => {

--- a/src/cook-web/src/components/MobileUnsupportedDialog.test.tsx
+++ b/src/cook-web/src/components/MobileUnsupportedDialog.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import MobileUnsupportedDialog from './MobileUnsupportedDialog';
+
+const mockUseUiLayoutStore = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/c-store/useUiLayoutStore', () => ({
+  __esModule: true,
+  useUiLayoutStore: (
+    selector: (state: { inMobile: boolean }) => boolean,
+  ) => mockUseUiLayoutStore(selector),
+}));
+
+describe('MobileUnsupportedDialog', () => {
+  beforeEach(() => {
+    mockUseUiLayoutStore.mockReset();
+  });
+
+  test('renders nothing on desktop', () => {
+    mockUseUiLayoutStore.mockImplementation(selector =>
+      selector({ inMobile: false }),
+    );
+
+    render(<MobileUnsupportedDialog />);
+
+    expect(
+      screen.queryByText('common.core.mobileUnsupportedTitle'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows the dialog on mobile and closes after confirmation', () => {
+    mockUseUiLayoutStore.mockImplementation(selector =>
+      selector({ inMobile: true }),
+    );
+
+    render(<MobileUnsupportedDialog />);
+
+    expect(
+      screen.getByText('common.core.mobileUnsupportedTitle'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('common.core.mobileUnsupportedDescription'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('common.core.ok'));
+
+    expect(
+      screen.queryByText('common.core.mobileUnsupportedTitle'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/components/MobileUnsupportedDialog.tsx
+++ b/src/cook-web/src/components/MobileUnsupportedDialog.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useUiLayoutStore } from '@/c-store/useUiLayoutStore';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/AlertDialog';
+
+export default function MobileUnsupportedDialog() {
+  const { t } = useTranslation();
+  const inMobile = useUiLayoutStore(state => state.inMobile);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(inMobile);
+  }, [inMobile]);
+
+  if (!inMobile) {
+    return null;
+  }
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <AlertDialogContent className='w-[calc(100vw-32px)] max-w-md sm:max-w-md'>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t('common.core.mobileUnsupportedTitle')}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('common.core.mobileUnsupportedDescription')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={() => setOpen(false)}>
+            {t('common.core.ok')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -23,6 +23,8 @@ export type I18nKey =
   | 'common.core.expand'
   | 'common.core.follow'
   | 'common.core.logout'
+  | 'common.core.mobileUnsupportedDescription'
+  | 'common.core.mobileUnsupportedTitle'
   | 'common.core.more'
   | 'common.core.networkError'
   | 'common.core.noMoreShifus'

--- a/src/i18n/en-US/common/core.json
+++ b/src/i18n/en-US/common/core.json
@@ -23,6 +23,8 @@
   "expand": "Expand",
   "follow": "Follow",
   "logout": "Logout",
+  "mobileUnsupportedDescription": "Please use a desktop device to view this page.",
+  "mobileUnsupportedTitle": "This page is not supported on mobile devices",
   "more": "More",
   "networkError": "Network error, please try again later",
   "noMoreShifus": "No more Courses",

--- a/src/i18n/zh-CN/common/core.json
+++ b/src/i18n/zh-CN/common/core.json
@@ -23,6 +23,8 @@
   "expand": "展开",
   "follow": "关注",
   "logout": "退出",
+  "mobileUnsupportedDescription": "请前往 PC 端查看。",
+  "mobileUnsupportedTitle": "本页面暂不支持移动端",
   "more": "更多",
   "networkError": "网络错误,请稍后重试",
   "noMoreShifus": "没有更多课程了",


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
