### PR TITLE
fix: avoid extra subscription row for manual credit grants

### DIFF
--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -324,7 +324,9 @@ describe('BillingCreditDetailsPanel', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      within(subscriptionRow as HTMLElement).queryByText('2026年05月06日 07:59'),
+      within(subscriptionRow as HTMLElement).queryByText(
+        '2026年05月06日 07:59',
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   useBillingOverview,
@@ -39,7 +39,20 @@ describe('BillingCreditDetailsPanel', () => {
           lifetime_granted_credits: 2000,
           lifetime_consumed_credits: 890,
         },
-        subscription: null,
+        subscription: {
+          subscription_bid: 'sub-1',
+          product_bid: 'product-plan-paid',
+          product_code: 'creator-plan-pro',
+          status: 'active',
+          billing_provider: 'stripe',
+          current_period_start_at: '2026-04-01T00:00:00',
+          current_period_end_at: '2026-10-12T23:59:00',
+          grace_period_end_at: null,
+          cancel_at_period_end: false,
+          next_product_bid: null,
+          last_renewed_at: null,
+          last_failed_at: null,
+        },
         billing_alerts: [],
         trial_offer: {
           enabled: true,
@@ -70,8 +83,8 @@ describe('BillingCreditDetailsPanel', () => {
           {
             wallet_bucket_bid: 'bucket-sub-1',
             category: 'subscription',
-            source_type: 'gift',
-            source_bid: 'gift-1',
+            source_type: 'manual',
+            source_bid: 'manual-1',
             available_credits: 10,
             effective_from: '2026-04-01T00:00:00',
             effective_to: '2026-08-12T23:59:00',
@@ -107,7 +120,7 @@ describe('BillingCreditDetailsPanel', () => {
     });
   });
 
-  test('renders total credits and splits category rows by expiry window', async () => {
+  test('renders subscription credits in one row and prefers the active subscription expiry', async () => {
     const user = userEvent.setup();
     const onUpgrade = jest.fn();
     render(<BillingCreditDetailsPanel onUpgrade={onUpgrade} />);
@@ -115,17 +128,15 @@ describe('BillingCreditDetailsPanel', () => {
     expect(
       screen.getByText('module.billing.details.title'),
     ).toBeInTheDocument();
-    expect(screen.getByText('1110')).toBeInTheDocument();
+    expect(screen.getByText('1,110.00')).toBeInTheDocument();
     expect(
       screen.getAllByText('module.billing.ledger.category.subscription'),
-    ).toHaveLength(2);
+    ).toHaveLength(1);
     expect(
       screen.getByText('module.billing.ledger.category.topup'),
     ).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
-    expect(screen.getByText('90')).toBeInTheDocument();
-    expect(screen.getByText('1000')).toBeInTheDocument();
-    expect(screen.getByText('2026年08月12日 23:59')).toBeInTheDocument();
+    expect(screen.getByText('100.00')).toBeInTheDocument();
+    expect(screen.getByText('1,000.00')).toBeInTheDocument();
     expect(screen.getByText('2026年10月12日 23:59')).toBeInTheDocument();
     expect(screen.getByText('2026年10月20日 23:59')).toBeInTheDocument();
 
@@ -136,6 +147,102 @@ describe('BillingCreditDetailsPanel', () => {
     );
 
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to the earliest manual grant expiry when no active subscription remains', () => {
+    mockUseBillingOverview.mockReturnValue({
+      data: {
+        creator_bid: 'creator-1',
+        wallet: {
+          available_credits: 120,
+          reserved_credits: 0,
+          lifetime_granted_credits: 2000,
+          lifetime_consumed_credits: 1880,
+        },
+        subscription: {
+          subscription_bid: 'sub-expired',
+          product_bid: 'product-plan-trial',
+          product_code: 'creator-plan-trial',
+          status: 'expired',
+          billing_provider: 'stripe',
+          current_period_start_at: '2026-04-01T00:00:00',
+          current_period_end_at: '2026-04-16T23:59:00',
+          grace_period_end_at: null,
+          cancel_at_period_end: false,
+          next_product_bid: null,
+          last_renewed_at: null,
+          last_failed_at: null,
+        },
+        billing_alerts: [],
+        trial_offer: {
+          enabled: true,
+          status: 'ineligible',
+          product_bid: 'bill-product-plan-trial',
+          product_code: 'creator-plan-trial',
+          display_name: 'module.billing.package.free.title',
+          description: 'module.billing.package.free.description',
+          currency: 'CNY',
+          price_amount: 0,
+          credit_amount: 100,
+          valid_days: 15,
+          highlights: [],
+          starts_on_first_grant: true,
+          granted_at: null,
+          expires_at: null,
+        },
+      },
+      error: undefined,
+      isLoading: false,
+    });
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: {
+        items: [
+          {
+            wallet_bucket_bid: 'bucket-manual-1',
+            category: 'subscription',
+            source_type: 'manual',
+            source_bid: 'manual-1',
+            available_credits: 20,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-05-06T07:59:00',
+            priority: 20,
+            status: 'active',
+          },
+          {
+            wallet_bucket_bid: 'bucket-manual-2',
+            category: 'subscription',
+            source_type: 'manual',
+            source_bid: 'manual-2',
+            available_credits: 100,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-05-23T10:00:00',
+            priority: 20,
+            status: 'active',
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    const subscriptionLabel = screen.getByText(
+      'module.billing.ledger.category.subscription',
+    );
+    const subscriptionRow = subscriptionLabel.closest('.grid');
+
+    expect(subscriptionRow).not.toBeNull();
+    expect(
+      screen.getByText('module.billing.ledger.category.topup'),
+    ).toBeInTheDocument();
+    expect(subscriptionLabel).toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).getByText('120.00'),
+    ).toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).getByText('2026年05月06日 07:59'),
+    ).toBeInTheDocument();
   });
 
   test('shows a tooltip for topup availability when the topup bucket has no expiry', async () => {

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -245,6 +245,89 @@ describe('BillingCreditDetailsPanel', () => {
     ).toBeInTheDocument();
   });
 
+  test('does not fall back to manual grant expiry while an active subscription still exists', () => {
+    mockUseBillingOverview.mockReturnValue({
+      data: {
+        creator_bid: 'creator-1',
+        wallet: {
+          available_credits: 35,
+          reserved_credits: 0,
+          lifetime_granted_credits: 2000,
+          lifetime_consumed_credits: 1965,
+        },
+        subscription: {
+          subscription_bid: 'sub-active-no-expiry',
+          product_bid: 'product-plan-paid',
+          product_code: 'creator-plan-pro',
+          status: 'active',
+          billing_provider: 'stripe',
+          current_period_start_at: '2026-04-01T00:00:00',
+          current_period_end_at: null,
+          grace_period_end_at: null,
+          cancel_at_period_end: false,
+          next_product_bid: null,
+          last_renewed_at: null,
+          last_failed_at: null,
+        },
+        billing_alerts: [],
+        trial_offer: {
+          enabled: true,
+          status: 'ineligible',
+          product_bid: 'bill-product-plan-trial',
+          product_code: 'creator-plan-trial',
+          display_name: 'module.billing.package.free.title',
+          description: 'module.billing.package.free.description',
+          currency: 'CNY',
+          price_amount: 0,
+          credit_amount: 100,
+          valid_days: 15,
+          highlights: [],
+          starts_on_first_grant: true,
+          granted_at: null,
+          expires_at: null,
+        },
+      },
+      error: undefined,
+      isLoading: false,
+    });
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: {
+        items: [
+          {
+            wallet_bucket_bid: 'bucket-manual-active-subscription',
+            category: 'subscription',
+            source_type: 'manual',
+            source_bid: 'manual-1',
+            available_credits: 35,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-05-06T07:59:00',
+            priority: 20,
+            status: 'active',
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    const subscriptionLabel = screen.getByText(
+      'module.billing.ledger.category.subscription',
+    );
+    const subscriptionRow = subscriptionLabel.closest('.grid');
+
+    expect(subscriptionRow).not.toBeNull();
+    expect(
+      within(subscriptionRow as HTMLElement).getByText(
+        'module.billing.ledger.neverExpires',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).queryByText('2026年05月06日 07:59'),
+    ).not.toBeInTheDocument();
+  });
+
   test('shows a tooltip for topup availability when the topup bucket has no expiry', async () => {
     const user = userEvent.setup();
 

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -83,7 +83,8 @@ function buildCategorySummary(
             (total, bucket) => total + Number(bucket.available_credits || 0),
             0,
           ),
-          effectiveTo: activeSubscriptionEffectiveTo || manualGrantExpiry || null,
+          effectiveTo:
+            activeSubscriptionEffectiveTo || manualGrantExpiry || null,
         },
       ];
     }

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -45,7 +45,12 @@ const CATEGORY_ORDER: BillingBucketCategory[] = ['subscription', 'topup'];
 
 function buildCategorySummary(
   buckets: BillingWalletBucket[],
+  options: {
+    activeSubscriptionEffectiveTo: string | null;
+  },
 ): CategorySummaryRow[] {
+  const { activeSubscriptionEffectiveTo } = options;
+
   return CATEGORY_ORDER.flatMap(category => {
     const activeBuckets = buckets.filter(
       bucket => bucket.category === category && bucket.status === 'active',
@@ -57,6 +62,28 @@ function buildCategorySummary(
           category,
           availableCredits: 0,
           effectiveTo: null,
+        },
+      ];
+    }
+
+    if (category === 'subscription') {
+      const manualGrantExpiry = activeBuckets
+        .filter(
+          bucket =>
+            bucket.source_type === 'manual' &&
+            Boolean(bucket.effective_to?.trim()),
+        )
+        .map(bucket => bucket.effective_to as string)
+        .sort((left, right) => left.localeCompare(right))[0];
+
+      return [
+        {
+          category,
+          availableCredits: activeBuckets.reduce(
+            (total, bucket) => total + Number(bucket.available_credits || 0),
+            0,
+          ),
+          effectiveTo: activeSubscriptionEffectiveTo || manualGrantExpiry || null,
         },
       ];
     }
@@ -149,10 +176,21 @@ export function BillingCreditDetailsPanel({
     error: bucketsError,
     isLoading: bucketsLoading,
   } = useBillingWalletBuckets();
+  const hasActiveSubscription = Boolean(
+    overview?.subscription &&
+    !['canceled', 'expired', 'draft'].includes(overview.subscription.status),
+  );
+  const activeSubscriptionEffectiveTo =
+    hasActiveSubscription && overview?.subscription?.current_period_end_at
+      ? String(overview.subscription.current_period_end_at)
+      : null;
 
   const summaryRows = useMemo(
-    () => buildCategorySummary(bucketList?.items || []),
-    [bucketList?.items],
+    () =>
+      buildCategorySummary(bucketList?.items || [], {
+        activeSubscriptionEffectiveTo,
+      }),
+    [activeSubscriptionEffectiveTo, bucketList?.items],
   );
 
   const totalCreditsLabel = formatBillingCredits(

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -46,10 +46,11 @@ const CATEGORY_ORDER: BillingBucketCategory[] = ['subscription', 'topup'];
 function buildCategorySummary(
   buckets: BillingWalletBucket[],
   options: {
+    hasActiveSubscription: boolean;
     activeSubscriptionEffectiveTo: string | null;
   },
 ): CategorySummaryRow[] {
-  const { activeSubscriptionEffectiveTo } = options;
+  const { activeSubscriptionEffectiveTo, hasActiveSubscription } = options;
 
   return CATEGORY_ORDER.flatMap(category => {
     const activeBuckets = buckets.filter(
@@ -61,7 +62,10 @@ function buildCategorySummary(
         {
           category,
           availableCredits: 0,
-          effectiveTo: null,
+          effectiveTo:
+            category === 'subscription' && hasActiveSubscription
+              ? activeSubscriptionEffectiveTo
+              : null,
         },
       ];
     }
@@ -83,8 +87,9 @@ function buildCategorySummary(
             (total, bucket) => total + Number(bucket.available_credits || 0),
             0,
           ),
-          effectiveTo:
-            activeSubscriptionEffectiveTo || manualGrantExpiry || null,
+          effectiveTo: hasActiveSubscription
+            ? activeSubscriptionEffectiveTo
+            : manualGrantExpiry || null,
         },
       ];
     }
@@ -189,9 +194,10 @@ export function BillingCreditDetailsPanel({
   const summaryRows = useMemo(
     () =>
       buildCategorySummary(bucketList?.items || [], {
+        hasActiveSubscription,
         activeSubscriptionEffectiveTo,
       }),
-    [activeSubscriptionEffectiveTo, bucketList?.items],
+    [activeSubscriptionEffectiveTo, bucketList?.items, hasActiveSubscription],
   );
 
   const totalCreditsLabel = formatBillingCredits(

--- a/src/i18n/en-US/common/core.json
+++ b/src/i18n/en-US/common/core.json
@@ -23,7 +23,7 @@
   "expand": "Expand",
   "follow": "Follow",
   "logout": "Logout",
-  "mobileUnsupportedDescription": "Please use a desktop device to view this page.",
+  "mobileUnsupportedDescription": "Please use a desktop device to view this page",
   "mobileUnsupportedTitle": "This page is not supported on mobile devices",
   "more": "More",
   "networkError": "Network error, please try again later",

--- a/src/i18n/zh-CN/common/core.json
+++ b/src/i18n/zh-CN/common/core.json
@@ -23,7 +23,7 @@
   "expand": "展开",
   "follow": "关注",
   "logout": "退出",
-  "mobileUnsupportedDescription": "请前往 PC 端查看。",
+  "mobileUnsupportedDescription": "请前往 PC 端查看",
   "mobileUnsupportedTitle": "本页面暂不支持移动端",
   "more": "更多",
   "networkError": "网络错误,请稍后重试",


### PR DESCRIPTION
# Summary

- merge manual grant credit buckets into a single `subscription` summary row on the billing credit details page
- prefer the active subscription expiry for the merged subscription row, and fall back to the earliest manual grant expiry only when no active subscription remains
- add focused tests covering the active-subscription and fallback-expiry scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Subscription credits are now consolidated into a single ledger row with aggregated totals instead of being split across multiple entries
  * Subscription expiry dates are correctly displayed
  * Improved fallback behavior for expired subscription scenarios

* **Tests**
  * Added test coverage for expired subscription scenarios
  * Updated tests to verify consolidated credit display and expiry date handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->