### PR TITLE
fix: fall back when TTS segment mp3 decode fails

### DIFF
--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -68,6 +68,7 @@ def concat_audio_mp3(
 
     # Initialize combined audio
     combined = None
+    failed_segments: list[int] = []
 
     for i, segment_data in enumerate(segments):
         try:
@@ -91,12 +92,20 @@ def concat_audio_mp3(
                     combined = combined.append(segment)
 
         except Exception as e:
-            logger.error(f"Error processing audio segment {i}: {e}")
-            # Try to continue with remaining segments
-            continue
+            failed_segments.append(i)
+            logger.warning(
+                "Error processing audio segment %s (%s bytes): %s",
+                i,
+                len(segment_data or b""),
+                e,
+            )
 
     if combined is None:
         raise ValueError("Failed to concatenate audio segments")
+
+    if failed_segments:
+        failed_segment_list = ", ".join(str(index) for index in failed_segments)
+        raise ValueError(f"Failed to decode audio segments: {failed_segment_list}")
 
     # Export to bytes
     output_io = io.BytesIO()

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -1,5 +1,7 @@
 import io
 
+import pytest
+
 from flaskr.service.tts import audio_utils
 
 
@@ -38,6 +40,15 @@ class _FakeAudioSegment:
         return _FakeSegment(duration)
 
 
+class _PartiallyBrokenAudioSegment:
+    @staticmethod
+    def from_mp3(segment_io: io.BytesIO):
+        payload = segment_io.getvalue()
+        if payload == b"BAD":
+            raise ValueError("Decoding failed")
+        return _FakeSegment(int(payload.decode("utf-8")))
+
+
 def test_concat_audio_mp3_does_not_crossfade_by_default(monkeypatch):
     _FakeSegment.append_crossfades.clear()
     monkeypatch.setattr(audio_utils, "AudioSegment", _FakeAudioSegment, raising=False)
@@ -58,3 +69,26 @@ def test_concat_audio_mp3_caps_explicit_crossfade_for_short_segments(monkeypatch
 
     assert _FakeSegment.append_crossfades == [2, 50]
     assert output == b"duration=130"
+
+
+def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    with pytest.raises(ValueError, match="Failed to decode audio segments: 1"):
+        audio_utils.concat_audio_mp3([b"100", b"BAD", b"80"])
+
+
+def test_concat_audio_best_effort_falls_back_to_byte_join_on_partial_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    output = audio_utils.concat_audio_best_effort([b"100", b"BAD", b"80"])
+
+    assert output == b"100BAD80"


### PR DESCRIPTION
## Summary
- raise out of `concat_audio_mp3` when any segment fails to decode instead of silently dropping the bad segment
- let `concat_audio_best_effort` fall back to raw byte-join for partially corrupt MP3 segment sets
- add focused coverage for partial decode failures and fallback behavior

## Testing
- pre-commit run -a
- cd src/api && pytest tests/service/tts/test_audio_utils.py -q