### PR TITLE
fix: support DeepSeek model listing

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -367,12 +367,28 @@ def _load_gemini_models(
     return models
 
 
+def _load_deepseek_models(
+    config: ProviderConfig, params: Dict[str, str], base_url: Optional[str]
+) -> List[Union[str, Tuple[str, str]]]:
+    api_key = params.get("api_key", "")
+    try:
+        return _fetch_provider_models(api_key, base_url)
+    except Exception as exc:
+        _log_warning(f"load {config.key} models error: {exc}")
+        return list(DEEPSEEK_FALLBACK_MODELS)
+
+
 QWEN_PREFIX = "qwen/"
 ERNIE_V2_PREFIX = "ernie/"
 GLM_PREFIX = "glm/"
 SILICON_PREFIX = "silicon/"
 GEMINI_PREFIX = ""
-DEEPSEEK_EXTRA_MODELS = ["deepseek-chat"]
+DEEPSEEK_FALLBACK_MODELS = [
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "deepseek-chat",
+    "deepseek-reasoner",
+]
 
 
 def _reload_openai_params(model_id: str, temperature: float) -> Dict[str, Any]:
@@ -480,9 +496,9 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         api_key_env="DEEPSEEK_API_KEY",
         base_url_env="DEEPSEEK_API_URL",
         default_base_url="https://api.deepseek.com",
-        extra_models=DEEPSEEK_EXTRA_MODELS,
         config_hint="DEEPSEEK_API_KEY,DEEPSEEK_API_URL",
         custom_llm_provider="openai",
+        model_loader=_load_deepseek_models,
     ),
     ProviderConfig(
         key="gemini",

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -113,6 +113,76 @@ class FakeResponse:
         self.usage = usage
 
 
+class FakeModelsResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_deepseek_model_loader_lists_models(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return FakeModelsResponse(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "deepseek-v4-flash", "object": "model"},
+                    {"id": "deepseek-v4-pro", "object": "model"},
+                ],
+            }
+        )
+
+    monkeypatch.setattr(llm.requests, "get", fake_get)
+    config = llm.ProviderConfig(
+        key="deepseek",
+        api_key_env="DEEPSEEK_API_KEY",
+        base_url_env="DEEPSEEK_API_URL",
+        default_base_url="https://api.deepseek.com",
+    )
+
+    models = llm._load_deepseek_models(
+        config,
+        {"api_key": "test-key", "api_base": "https://api.deepseek.com"},
+        "https://api.deepseek.com",
+    )
+
+    assert models == ["deepseek-v4-flash", "deepseek-v4-pro"]
+    assert captured["url"] == "https://api.deepseek.com/models"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["timeout"] == 20
+
+
+def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
+    def fake_get(*args, **kwargs):
+        _ = args, kwargs
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr(llm.requests, "get", fake_get)
+    config = llm.ProviderConfig(
+        key="deepseek",
+        api_key_env="DEEPSEEK_API_KEY",
+        base_url_env="DEEPSEEK_API_URL",
+        default_base_url="https://api.deepseek.com",
+    )
+
+    models = llm._load_deepseek_models(
+        config,
+        {"api_key": "test-key", "api_base": "https://api.deepseek.com"},
+        "https://api.deepseek.com",
+    )
+
+    assert models == llm.DEEPSEEK_FALLBACK_MODELS
+
+
 def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
 


### PR DESCRIPTION
## Summary
- add a DeepSeek-specific model loader that calls the provider /models endpoint
- fall back to known DeepSeek models when model listing fails
- cover list-models success and fallback behavior in LLM tests

## Tests
- cd src/api && pytest -q tests/test_llm.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DeepSeek models are now dynamically discovered and loaded based on your API configuration, providing access to the latest available models.
  * Added automatic fallback mechanism to ensure model availability even if API communication fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->