### PR TITLE
fix: disable DeepSeek thinking mode

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -460,6 +460,13 @@ def _reload_qwen_params(model_id: str, temperature: float) -> Dict[str, Any]:
     }
 
 
+def _reload_deepseek_params(model_id: str, temperature: float) -> Dict[str, Any]:
+    return {
+        "temperature": temperature,
+        "extra_body": {"thinking": {"type": "disabled"}},
+    }
+
+
 LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
     ProviderConfig(
         key="openai",
@@ -499,6 +506,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         config_hint="DEEPSEEK_API_KEY,DEEPSEEK_API_URL",
         custom_llm_provider="openai",
         model_loader=_load_deepseek_models,
+        reload_params=_reload_deepseek_params,
     ),
     ProviderConfig(
         key="gemini",

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -183,6 +183,50 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
     assert models == llm.DEEPSEEK_FALLBACK_MODELS
 
 
+def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
+    captured_kwargs = {}
+
+    def fake_completion(*args, **kwargs):
+        captured_kwargs["kwargs"] = kwargs
+        return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
+
+    monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    provider_state = llm.ProviderState(
+        enabled=True,
+        params={"api_key": "test-key", "api_base": "https://api.deepseek.com"},
+        models=["deepseek-v4-pro"],
+        prefix="",
+        wildcard_prefixes=(),
+        reload_params=llm._reload_deepseek_params,
+    )
+    monkeypatch.setattr(llm, "PROVIDER_STATES", {"deepseek": provider_state})
+    monkeypatch.setattr(
+        llm,
+        "MODEL_ALIAS_MAP",
+        {"deepseek-v4-pro": ("deepseek", "deepseek-v4-pro")},
+    )
+    monkeypatch.setattr(
+        llm,
+        "PROVIDER_CONFIG_HINTS",
+        {"deepseek": "DEEPSEEK_API_KEY,DEEPSEEK_API_URL"},
+    )
+
+    list(
+        llm.chat_llm(
+            app=app,
+            user_id="user-1",
+            span=DummySpan(),
+            model="deepseek-v4-pro",
+            messages=[{"role": "user", "content": "hello"}],
+            temperature="0.7",
+            generation_name="deepseek-test",
+        )
+    )
+
+    assert captured_kwargs["kwargs"]["temperature"] == 0.7
+    assert captured_kwargs["kwargs"]["extra_body"] == {"thinking": {"type": "disabled"}}
+
+
 def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
 


### PR DESCRIPTION
## Summary
- pass DeepSeek's OpenAI-compatible thinking disable flag through LiteLLM extra_body
- keep temperature behavior unchanged for DeepSeek requests
- add LLM test coverage for the DeepSeek request parameters

## Tests
- cd src/api && pytest -q tests/test_llm.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DeepSeek models now support configurable temperature parameters during inference
  * Ability to disable thinking mode for DeepSeek model inference
  * Enhanced parameter configuration for DeepSeek provider integration

* **Tests**
  * Added tests to verify temperature parameter forwarding for DeepSeek models
  * Added tests to validate thinking mode disable configuration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->