### PR TITLE
fix(cook-web): preserve paired subtitle closers when trimming trailing punctuation

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -23,6 +23,7 @@
 - When adapting cook-web payloads into `markdown-flow-ui` slide elements, normalize optional API fields into the stricter slide contract first instead of passing broader API types through render layers.
 - When listen-mode misses trailing interaction cards, check whether `outline_item_update: completed` arrived before the final `element` events; completion must not cause post-completion interaction markers to be dropped.
 - 当新增共享 loading 动画时，优先放在 `src/components/loading/` 并以命名导出追加能力，不要直接替换已有默认 loading；动画节奏、尺寸和间距用可配置 props 暴露，保证旧调用方零破坏。
+- 听课模式字幕尾部清洗只移除不允许的结束标点，遇到右引号、右括号这类成对符号的结尾符必须保留；即使这些结尾符后面还跟着句号、逗号等待过滤标点，也要按从右向左的顺序先保留结尾符、再剥离无效标点，并补齐 `。”`、`），`、`？”。` 一类回归测试。
 
 ## Skills Index
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -164,6 +164,26 @@ describe('listenModeUtils', () => {
                 start_ms: 4000,
                 end_ms: 5000,
               },
+              {
+                text: '句号后跟双引号。”',
+                start_ms: 5000,
+                end_ms: 6000,
+              },
+              {
+                text: '右括号后跟句号）。',
+                start_ms: 6000,
+                end_ms: 7000,
+              },
+              {
+                text: '问号双引号后再跟句号？”。',
+                start_ms: 7000,
+                end_ms: 8000,
+              },
+              {
+                text: '双引号后跟逗号”，',
+                start_ms: 8000,
+                end_ms: 9000,
+              },
             ],
           },
         },
@@ -199,6 +219,30 @@ describe('listenModeUtils', () => {
         text: '双引号保留”',
         start_ms: 4000,
         end_ms: 5000,
+        segment_index: 0,
+      },
+      {
+        text: '句号后跟双引号”',
+        start_ms: 5000,
+        end_ms: 6000,
+        segment_index: 0,
+      },
+      {
+        text: '右括号后跟句号）',
+        start_ms: 6000,
+        end_ms: 7000,
+        segment_index: 0,
+      },
+      {
+        text: '问号双引号后再跟句号？”',
+        start_ms: 7000,
+        end_ms: 8000,
+        segment_index: 0,
+      },
+      {
+        text: '双引号后跟逗号”',
+        start_ms: 8000,
+        end_ms: 9000,
         segment_index: 0,
       },
     ]);

--- a/src/cook-web/src/c-utils/subtitleUtils.ts
+++ b/src/cook-web/src/c-utils/subtitleUtils.ts
@@ -28,6 +28,7 @@ const isAllowedSubtitleEnding = (text: string) =>
   ALLOWED_SUBTITLE_ENDING_PATTERN.test(text);
 
 const isPunctuationChar = (char: string) => PUNCTUATION_CHAR_PATTERN.test(char);
+const isWhitespaceChar = (char: string) => /\s/u.test(char);
 
 export const stripDisallowedSubtitleTrailingPunctuation = (text: string) => {
   const trimmedText = text.trimEnd();
@@ -39,32 +40,33 @@ export const stripDisallowedSubtitleTrailingPunctuation = (text: string) => {
   let suffix = '';
   let cursor = trimmedText.length;
 
-  // Preserve trailing paired closers such as quotes or brackets.
+  // Walk backwards so paired closers stay preserved even if removable
+  // punctuation appears after them, such as `。”` or `），`.
   while (cursor > 0) {
     const currentChar = trimmedText[cursor - 1];
+    const currentContent = trimmedText.slice(0, cursor);
 
-    if (!isTrailingSubtitlePairCloser(currentChar)) {
+    if (isTrailingSubtitlePairCloser(currentChar)) {
+      suffix = `${currentChar}${suffix}`;
+      cursor -= 1;
+      continue;
+    }
+
+    if (isAllowedSubtitleEnding(currentContent)) {
       break;
     }
 
-    suffix = `${currentChar}${suffix}`;
-    cursor -= 1;
-  }
-
-  let content = trimmedText.slice(0, cursor);
-
-  while (content) {
-    if (isAllowedSubtitleEnding(content)) {
-      break;
-    }
-
-    const currentChar = content[content.length - 1];
     if (!isPunctuationChar(currentChar)) {
       break;
     }
 
-    content = content.slice(0, -1).trimEnd();
+    cursor -= 1;
+
+    while (cursor > 0 && isWhitespaceChar(trimmedText[cursor - 1])) {
+      cursor -= 1;
+    }
   }
 
+  const content = trimmedText.slice(0, cursor).trimEnd();
   return `${content}${suffix}`;
 };


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
