### PR TITLE
chore: update admin skill course link

### DIFF
--- a/src/cook-web/src/__tests__/url-utils.test.ts
+++ b/src/cook-web/src/__tests__/url-utils.test.ts
@@ -133,7 +133,7 @@ describe('domain aware urls', () => {
     });
 
     expect(getCourseCreatorUrl()).toBe(
-      'https://app.ai-shifu.com/educators.html#course-creator-skill',
+      'https://ai-shifu.com/educators.html#course-creator-skill',
     );
   });
 

--- a/src/cook-web/src/__tests__/url-utils.test.ts
+++ b/src/cook-web/src/__tests__/url-utils.test.ts
@@ -1,8 +1,12 @@
 import {
   buildLoginRedirectPath,
   buildUrlWithLessonId,
+  getCourseCreatorUrl,
+  getPaymentAgreementUrl,
   replaceCurrentUrlWithLessonId,
 } from '../c-utils/urlUtils';
+
+const originalLocation = window.location;
 
 describe('buildLoginRedirectPath', () => {
   it('removes WeChat OAuth params but keeps other query params', () => {
@@ -41,9 +45,27 @@ describe('buildUrlWithLessonId', () => {
 });
 
 describe('replaceCurrentUrlWithLessonId', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
   it('replaces the browser url with the resolved lessonid', () => {
-    window.history.replaceState({}, '', '/shifu/course-1?listen=1');
-    const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: 'http://localhost/shifu/course-1?listen=1',
+        pathname: '/shifu/course-1',
+        search: '?listen=1',
+        hash: '',
+      },
+    });
+    const replaceStateSpy = jest
+      .spyOn(window.history, 'replaceState')
+      .mockImplementation(() => undefined);
 
     replaceCurrentUrlWithLessonId('lesson-3');
 
@@ -57,17 +79,75 @@ describe('replaceCurrentUrlWithLessonId', () => {
   });
 
   it('skips history updates when lessonid is already in sync', () => {
-    window.history.replaceState(
-      {},
-      '',
-      '/shifu/course-1?listen=1&lessonid=lesson-3',
-    );
-    const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: 'http://localhost/shifu/course-1?listen=1&lessonid=lesson-3',
+        pathname: '/shifu/course-1',
+        search: '?listen=1&lessonid=lesson-3',
+        hash: '',
+      },
+    });
+    const replaceStateSpy = jest
+      .spyOn(window.history, 'replaceState')
+      .mockImplementation(() => undefined);
 
     replaceCurrentUrlWithLessonId('lesson-3');
 
     expect(replaceStateSpy).not.toHaveBeenCalled();
 
     replaceStateSpy.mockRestore();
+  });
+});
+
+describe('domain aware urls', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('returns the cn course creator deep link on ai-shifu.cn hosts', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hostname: 'app.ai-shifu.cn',
+      },
+    });
+
+    expect(getCourseCreatorUrl()).toBe(
+      'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848',
+    );
+  });
+
+  it('keeps the existing educators page url on ai-shifu.com hosts', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hostname: 'app.ai-shifu.com',
+      },
+    });
+
+    expect(getCourseCreatorUrl()).toBe(
+      'https://app.ai-shifu.com/educators.html#course-creator-skill',
+    );
+  });
+
+  it('resolves payment agreement urls from the detected host domain', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hostname: 'app.ai-shifu.com',
+      },
+    });
+
+    expect(getPaymentAgreementUrl()).toBe(
+      'https://ai-shifu.com/payment-agreement.html',
+    );
   });
 });

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -38,7 +38,6 @@ import MobileUnsupportedDialog from '@/components/MobileUnsupportedDialog';
 import { useUserStore } from '@/store';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import { canManageArchive as canManageArchiveForShifu } from '@/lib/shifu-permissions';
-import { getHostDomain } from '@/c-utils/urlUtils';
 interface ShifuCardProps {
   id: string;
   image: string | undefined;
@@ -156,7 +155,8 @@ const ScriptManagementPage = () => {
   const isInitialized = useUserStore(state => state.isInitialized);
   const isGuest = useUserStore(state => state.isGuest);
   const currentUserId = useUserStore(state => state.userInfo?.user_id || '');
-  const [courseCreatorUrl, setCourseCreatorUrl] = useState<string | null>(null);
+  const courseCreatorUrl =
+    'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848';
   const [adminReady, setAdminReady] = useState(false);
   const [activeTab, setActiveTab] = useState<'all' | 'archived'>('all');
   const [shifus, setShifus] = useState<Shifu[]>([]);
@@ -182,15 +182,6 @@ const ScriptManagementPage = () => {
   useEffect(() => {
     activeTabRef.current = activeTab;
   }, [activeTab]);
-
-  useEffect(() => {
-    const domain = getHostDomain();
-    if (domain) {
-      setCourseCreatorUrl(
-        `https://${domain}/educators.html#course-creator-skill`,
-      );
-    }
-  }, []);
 
   const setHasMoreState = useCallback((value: boolean) => {
     hasMoreRef.current = value;

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -37,6 +37,7 @@ import ErrorDisplay from '@/components/ErrorDisplay';
 import MobileUnsupportedDialog from '@/components/MobileUnsupportedDialog';
 import { useUserStore } from '@/store';
 import { useTracking } from '@/c-common/hooks/useTracking';
+import { getCourseCreatorUrl } from '@/c-utils/urlUtils';
 import { canManageArchive as canManageArchiveForShifu } from '@/lib/shifu-permissions';
 interface ShifuCardProps {
   id: string;
@@ -155,8 +156,7 @@ const ScriptManagementPage = () => {
   const isInitialized = useUserStore(state => state.isInitialized);
   const isGuest = useUserStore(state => state.isGuest);
   const currentUserId = useUserStore(state => state.userInfo?.user_id || '');
-  const courseCreatorUrl =
-    'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848';
+  const [courseCreatorUrl, setCourseCreatorUrl] = useState<string | null>(null);
   const [adminReady, setAdminReady] = useState(false);
   const [activeTab, setActiveTab] = useState<'all' | 'archived'>('all');
   const [shifus, setShifus] = useState<Shifu[]>([]);
@@ -182,6 +182,10 @@ const ScriptManagementPage = () => {
   useEffect(() => {
     activeTabRef.current = activeTab;
   }, [activeTab]);
+
+  useEffect(() => {
+    setCourseCreatorUrl(getCourseCreatorUrl());
+  }, []);
 
   const setHasMoreState = useCallback((value: boolean) => {
     hasMoreRef.current = value;

--- a/src/cook-web/src/c-utils/urlUtils.ts
+++ b/src/cook-web/src/c-utils/urlUtils.ts
@@ -133,3 +133,14 @@ export const getPaymentAgreementUrl = (): string | null => {
   const domain = getHostDomain();
   return domain ? `https://${domain}/payment-agreement.html` : null;
 };
+
+const COURSE_CREATOR_URLS: Record<'ai-shifu.cn' | 'ai-shifu.com', string> = {
+  'ai-shifu.cn':
+    'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848',
+  'ai-shifu.com': 'https://app.ai-shifu.com/educators.html#course-creator-skill',
+};
+
+export const getCourseCreatorUrl = (): string | null => {
+  const domain = getHostDomain();
+  return domain ? COURSE_CREATOR_URLS[domain] : null;
+};

--- a/src/cook-web/src/c-utils/urlUtils.ts
+++ b/src/cook-web/src/c-utils/urlUtils.ts
@@ -137,7 +137,8 @@ export const getPaymentAgreementUrl = (): string | null => {
 const COURSE_CREATOR_URLS: Record<'ai-shifu.cn' | 'ai-shifu.com', string> = {
   'ai-shifu.cn':
     'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848',
-  'ai-shifu.com': 'https://app.ai-shifu.com/educators.html#course-creator-skill',
+  'ai-shifu.com':
+    'https://app.ai-shifu.com/educators.html#course-creator-skill',
 };
 
 export const getCourseCreatorUrl = (): string | null => {

--- a/src/cook-web/src/c-utils/urlUtils.ts
+++ b/src/cook-web/src/c-utils/urlUtils.ts
@@ -137,8 +137,7 @@ export const getPaymentAgreementUrl = (): string | null => {
 const COURSE_CREATOR_URLS: Record<'ai-shifu.cn' | 'ai-shifu.com', string> = {
   'ai-shifu.cn':
     'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848',
-  'ai-shifu.com':
-    'https://app.ai-shifu.com/educators.html#course-creator-skill',
+  'ai-shifu.com': 'https://ai-shifu.com/educators.html#course-creator-skill',
 };
 
 export const getCourseCreatorUrl = (): string | null => {


### PR DESCRIPTION
## Summary
- Update the admin skill-install entry to point to the new OpenClaw course link provided by product
- Remove the old domain-derived educators page URL logic

## Verify
- cd src/cook-web && npx eslint src/app/admin/page.tsx