### PR TITLE
feat: notify billing paid orders in Feishu

### DIFF
--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -58,11 +58,8 @@ from .dtos import (
     BillingRefundResultDTO,
 )
 from .models import BillingOrder, BillingProduct, BillingSubscription
-from .paid_side_effects import (
-    dispatch_billing_paid_order_side_effects as _dispatch_billing_paid_order_side_effects,
-    stage_billing_paid_order_side_effects as _stage_billing_paid_order_side_effects,
-)
 from .provider_state import (
+    BillingOrderProviderUpdateResult,
     apply_billing_order_provider_update as _apply_billing_order_provider_update,
     apply_billing_subscription_provider_update as _apply_billing_subscription_provider_update,
     apply_subscription_checkout_success as _apply_subscription_checkout_success,
@@ -529,24 +526,19 @@ def sync_billing_order(
         )
         if order is None:
             raise_error("server.order.orderNotFound")
-        previous_status = int(order.status or 0)
 
         if order.payment_provider == "stripe":
-            _sync_stripe_order(app, order, session_id=session_id)
+            order_update = _sync_stripe_order(app, order, session_id=session_id)
         elif order.payment_provider == "pingxx":
-            _sync_pingxx_order(app, order)
+            order_update = _sync_pingxx_order(app, order)
         else:
             raise_error("server.pay.payChannelNotSupport")
 
-        paid_order_side_effects = _stage_billing_paid_order_side_effects(
-            app,
-            order,
-            previous_status=previous_status,
-        )
+        order_update.stage_after_state_changes(app, order)
 
         db.session.add(order)
         db.session.commit()
-        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
+        order_update.dispatch_after_commit(app)
 
         if order.status == BILLING_ORDER_STATUS_PAID:
             return BillingOrderSyncResultDTO(
@@ -1098,18 +1090,17 @@ def _sync_stripe_order(
     order: BillingOrder,
     *,
     session_id: str,
-) -> None:
+) -> BillingOrderProviderUpdateResult:
     reference_type = _resolve_billing_order_provider_reference_type(order)
     if reference_type == "subscription":
         resolved_subscription_id = session_id or order.provider_reference_id
         if not resolved_subscription_id:
             raise_error("server.order.orderNotFound")
-        _sync_stripe_subscription_order(
+        return _sync_stripe_subscription_order(
             app,
             order,
             subscription_id=resolved_subscription_id,
         )
-        return
 
     provider = get_payment_provider("stripe")
     resolved_session_id = session_id or order.provider_reference_id
@@ -1133,7 +1124,7 @@ def _sync_stripe_order(
         failure_code = "expired"
         failure_message = "Stripe checkout session expired"
 
-    _apply_billing_order_provider_update(
+    order_update = _apply_billing_order_provider_update(
         order,
         provider="stripe",
         event_type="manual_sync",
@@ -1174,6 +1165,7 @@ def _sync_stripe_order(
                 event_type="manual_sync",
                 source="sync",
             )
+    return order_update
 
 
 def _resolve_billing_order_provider_reference_type(order: BillingOrder) -> str:
@@ -1200,7 +1192,7 @@ def _sync_stripe_subscription_order(
     order: BillingOrder,
     *,
     subscription_id: str,
-) -> None:
+) -> BillingOrderProviderUpdateResult:
     provider = get_payment_provider("stripe")
     sync_result = provider.sync_reference(
         provider_reference=subscription_id,
@@ -1217,7 +1209,7 @@ def _sync_stripe_subscription_order(
         failure_code = str(subscription_payload.get("status") or "subscription_sync")
         failure_message = "Stripe subscription sync indicates renewal is not paid yet"
 
-    _apply_billing_order_provider_update(
+    order_update = _apply_billing_order_provider_update(
         order,
         provider="stripe",
         event_type="manual_sync",
@@ -1245,9 +1237,13 @@ def _sync_stripe_subscription_order(
                 data_object=subscription_payload,
                 source="sync",
             )
+    return order_update
 
 
-def _sync_pingxx_order(app: Flask, order: BillingOrder) -> None:
+def _sync_pingxx_order(
+    app: Flask,
+    order: BillingOrder,
+) -> BillingOrderProviderUpdateResult:
     provider = get_payment_provider("pingxx")
     if not order.provider_reference_id:
         raise_error("server.order.orderNotFound")
@@ -1262,7 +1258,7 @@ def _sync_pingxx_order(app: Flask, order: BillingOrder) -> None:
     if charge.get("paid") or charge.get("time_paid"):
         target_status = BILLING_ORDER_STATUS_PAID
 
-    _apply_billing_order_provider_update(
+    order_update = _apply_billing_order_provider_update(
         order,
         provider="pingxx",
         event_type="manual_sync",
@@ -1288,6 +1284,7 @@ def _sync_pingxx_order(app: Flask, order: BillingOrder) -> None:
         client_ip=str(charge.get("client_ip") or ""),
         extra=charge.get("extra"),
     )
+    return order_update
 
 
 def _load_billing_order_for_stripe_event(

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -58,11 +58,9 @@ from .dtos import (
     BillingRefundResultDTO,
 )
 from .models import BillingOrder, BillingProduct, BillingSubscription
-from .notifications import (
-    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
-    enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
-    stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
-    stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
+from .paid_side_effects import (
+    dispatch_billing_paid_order_side_effects as _dispatch_billing_paid_order_side_effects,
+    stage_billing_paid_order_side_effects as _stage_billing_paid_order_side_effects,
 )
 from .provider_state import (
     apply_billing_order_provider_update as _apply_billing_order_provider_update,
@@ -80,7 +78,6 @@ from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
 from .primitives import to_decimal as _to_decimal
 from .subscriptions import (
-    grant_paid_order_credits as _grant_paid_order_credits,
     load_billing_product_by_bid as _load_billing_product_by_bid,
     load_effective_topup_subscription as _load_effective_topup_subscription,
     load_subscription_by_bid as _load_subscription_by_bid,
@@ -541,35 +538,15 @@ def sync_billing_order(
         else:
             raise_error("server.pay.payChannelNotSupport")
 
-        should_deliver_billing_paid_feishu = False
-        should_enqueue_subscription_purchase_sms = False
-        if order.status == BILLING_ORDER_STATUS_PAID:
-            _grant_paid_order_credits(app, order)
-            should_enqueue_subscription_purchase_sms = (
-                _stage_subscription_purchase_sms_for_paid_order(
-                    order,
-                    previous_status=previous_status,
-                )
-            )
-            should_deliver_billing_paid_feishu = (
-                _stage_billing_paid_feishu_for_paid_order(
-                    order,
-                    previous_status=previous_status,
-                )
-            )
+        paid_order_side_effects = _stage_billing_paid_order_side_effects(
+            app,
+            order,
+            previous_status=previous_status,
+        )
 
         db.session.add(order)
         db.session.commit()
-        if should_enqueue_subscription_purchase_sms:
-            _enqueue_subscription_purchase_sms(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
-        if should_deliver_billing_paid_feishu:
-            _deliver_billing_paid_feishu(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
+        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
 
         if order.status == BILLING_ORDER_STATUS_PAID:
             return BillingOrderSyncResultDTO(

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -59,7 +59,9 @@ from .dtos import (
 )
 from .models import BillingOrder, BillingProduct, BillingSubscription
 from .notifications import (
+    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
     enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
+    stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
     stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
 )
 from .provider_state import (
@@ -539,6 +541,7 @@ def sync_billing_order(
         else:
             raise_error("server.pay.payChannelNotSupport")
 
+        should_deliver_billing_paid_feishu = False
         should_enqueue_subscription_purchase_sms = False
         if order.status == BILLING_ORDER_STATUS_PAID:
             _grant_paid_order_credits(app, order)
@@ -548,11 +551,22 @@ def sync_billing_order(
                     previous_status=previous_status,
                 )
             )
+            should_deliver_billing_paid_feishu = (
+                _stage_billing_paid_feishu_for_paid_order(
+                    order,
+                    previous_status=previous_status,
+                )
+            )
 
         db.session.add(order)
         db.session.commit()
         if should_enqueue_subscription_purchase_sms:
             _enqueue_subscription_purchase_sms(
+                app,
+                bill_order_bid=order.bill_order_bid,
+            )
+        if should_deliver_billing_paid_feishu:
+            _deliver_billing_paid_feishu(
                 app,
                 bill_order_bid=order.bill_order_bid,
             )

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -35,6 +35,7 @@ from .queries import (
 )
 
 TASK_NAME = "billing.send_subscription_purchase_sms"
+BILLING_PAID_FEISHU_TASK_NAME = "billing.send_billing_paid_feishu"
 _NOTIFICATIONS_KEY = "notifications"
 _SUBSCRIPTION_PURCHASE_SMS_KEY = "subscription_purchase_sms"
 _BILLING_PAID_FEISHU_KEY = "billing_paid_feishu"
@@ -391,6 +392,7 @@ def _build_feishu_result(
     creator_bid: str | None = None,
     message: str | None = None,
     notification_status: str | None = None,
+    enqueued: bool | None = None,
 ) -> dict[str, Any]:
     payload = {
         "status": status,
@@ -398,10 +400,65 @@ def _build_feishu_result(
         "creator_bid": creator_bid,
         "notification_status": notification_status,
         "notification": _BILLING_PAID_FEISHU_KEY,
+        "task_name": BILLING_PAID_FEISHU_TASK_NAME,
     }
     if message is not None:
         payload["message"] = message
+    if enqueued is not None:
+        payload["enqueued"] = enqueued
     return payload
+
+
+def enqueue_billing_paid_feishu(
+    app: Flask,
+    *,
+    bill_order_bid: str,
+) -> dict[str, Any]:
+    """Enqueue the billing paid Feishu worker after commit."""
+
+    normalized_bill_order_bid = _normalize_bid(bill_order_bid)
+    if not normalized_bill_order_bid:
+        return _build_feishu_result(
+            "invalid_bill_order_bid",
+            enqueued=False,
+        )
+
+    try:
+        from flaskr.common.celery_app import get_celery_app
+
+        celery_app = get_celery_app(flask_app=app)
+        task = celery_app.tasks.get(BILLING_PAID_FEISHU_TASK_NAME)
+        if task is None:
+            app.logger.warning(
+                "%s is unavailable for bill_order_bid=%s",
+                BILLING_PAID_FEISHU_TASK_NAME,
+                normalized_bill_order_bid,
+            )
+            return _build_feishu_result(
+                "task_unavailable",
+                bill_order_bid=normalized_bill_order_bid,
+                enqueued=False,
+            )
+        task.apply_async(kwargs={"bill_order_bid": normalized_bill_order_bid})
+        return _build_feishu_result(
+            "enqueued",
+            bill_order_bid=normalized_bill_order_bid,
+            enqueued=True,
+        )
+    except Exception as exc:
+        app.logger.error(
+            "Failed to enqueue %s for bill_order_bid=%s: %s",
+            BILLING_PAID_FEISHU_TASK_NAME,
+            normalized_bill_order_bid,
+            exc,
+            exc_info=True,
+        )
+        return _build_feishu_result(
+            "enqueue_failed",
+            bill_order_bid=normalized_bill_order_bid,
+            message=str(exc),
+            enqueued=False,
+        )
 
 
 def _load_notification_product(order: BillingOrder) -> BillingProduct | None:
@@ -578,7 +635,7 @@ def deliver_billing_paid_feishu(
             _BILLING_PAID_FEISHU_KEY,
         )
         notification_status = _normalize_bid(payload.get("status"))
-        if notification_status != "pending":
+        if notification_status not in _PROCESSABLE_STATUSES:
             return _build_feishu_result(
                 "noop",
                 bill_order_bid=order.bill_order_bid,

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -1,17 +1,22 @@
-"""Billing subscription purchase SMS orchestration helpers."""
+"""Billing purchase notification orchestration helpers."""
 
 from __future__ import annotations
 
 from copy import deepcopy
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from flask import Flask
 
+from flaskr.api.doc.feishu import send_notify
 from flaskr.api.sms.aliyun import send_sms_ali
 from flaskr.dao import db
 from flaskr.i18n import _ as translate
 from flaskr.i18n import get_current_language, set_language
+from flaskr.service.user.consts import USER_STATE_PAID, USER_STATE_REGISTERED
+from flaskr.service.user.models import UserConversion
+from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.repository import load_user_aggregate
 from flaskr.util.timezone import format_with_app_timezone
 
@@ -20,6 +25,7 @@ from .consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
+    BILLING_ORDER_TYPE_TOPUP,
 )
 from .models import BillingOrder, BillingProduct
 from .primitives import normalize_bid as _normalize_bid
@@ -31,11 +37,30 @@ from .queries import (
 TASK_NAME = "billing.send_subscription_purchase_sms"
 _NOTIFICATIONS_KEY = "notifications"
 _SUBSCRIPTION_PURCHASE_SMS_KEY = "subscription_purchase_sms"
+_BILLING_PAID_FEISHU_KEY = "billing_paid_feishu"
 _PROCESSABLE_STATUSES = {"pending", "failed_provider"}
 _SUPPORTED_ORDER_TYPES = {
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+}
+_SUPPORTED_FEISHU_ORDER_TYPES = {
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_ORDER_TYPE_TOPUP,
+}
+_FEISHU_CHANNEL_LABELS = {
+    "pingxx": "用户购买 (Pingxx)",
+    "stripe": "用户购买 (Stripe)",
+    "manual": "手动导入",
+    "open_api": "Open API",
+}
+_FEISHU_ORDER_TYPE_LABELS = {
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START: "订阅开通",
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE: "订阅升级",
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL: "订阅续费",
+    BILLING_ORDER_TYPE_TOPUP: "积分包",
 }
 
 
@@ -80,28 +105,47 @@ def _read_order_metadata(order: BillingOrder) -> dict[str, Any]:
     return {}
 
 
-def _read_notification_payload(order: BillingOrder) -> dict[str, Any]:
+def _read_notification_payload_by_key(
+    order: BillingOrder,
+    notification_key: str,
+) -> dict[str, Any]:
     metadata = _read_order_metadata(order)
     notifications = metadata.get(_NOTIFICATIONS_KEY)
     if not isinstance(notifications, dict):
         return {}
-    payload = notifications.get(_SUBSCRIPTION_PURCHASE_SMS_KEY)
+    payload = notifications.get(notification_key)
     if not isinstance(payload, dict):
         return {}
     return dict(payload)
 
 
-def _write_notification_payload(
+def _write_notification_payload_by_key(
     order: BillingOrder,
+    notification_key: str,
     payload: dict[str, Any],
 ) -> None:
     metadata = _read_order_metadata(order)
     notifications = metadata.get(_NOTIFICATIONS_KEY)
     if not isinstance(notifications, dict):
         notifications = {}
-    notifications[_SUBSCRIPTION_PURCHASE_SMS_KEY] = dict(payload)
+    notifications[notification_key] = dict(payload)
     metadata[_NOTIFICATIONS_KEY] = notifications
     order.metadata_json = metadata
+
+
+def _read_notification_payload(order: BillingOrder) -> dict[str, Any]:
+    return _read_notification_payload_by_key(order, _SUBSCRIPTION_PURCHASE_SMS_KEY)
+
+
+def _write_notification_payload(
+    order: BillingOrder,
+    payload: dict[str, Any],
+) -> None:
+    _write_notification_payload_by_key(
+        order,
+        _SUBSCRIPTION_PURCHASE_SMS_KEY,
+        payload,
+    )
 
 
 def stage_subscription_purchase_sms_for_paid_order(
@@ -128,6 +172,43 @@ def stage_subscription_purchase_sms_for_paid_order(
     payload["requested_at"] = now
     payload["updated_at"] = now
     _write_notification_payload(order, payload)
+    return True
+
+
+def _supports_billing_paid_feishu(order: BillingOrder | None) -> bool:
+    if order is None:
+        return False
+    if int(order.order_type or 0) not in _SUPPORTED_FEISHU_ORDER_TYPES:
+        return False
+    if int(order.status or 0) != BILLING_ORDER_STATUS_PAID:
+        return False
+    paid_amount = int(order.paid_amount or 0)
+    payable_amount = int(order.payable_amount or 0)
+    return max(paid_amount, payable_amount) > 0
+
+
+def stage_billing_paid_feishu_for_paid_order(
+    order: BillingOrder,
+    *,
+    previous_status: int | None,
+) -> bool:
+    """Mark one newly paid billing order as pending Feishu delivery."""
+
+    if not _supports_billing_paid_feishu(order):
+        return False
+    if int(previous_status or 0) == BILLING_ORDER_STATUS_PAID:
+        return False
+
+    payload = _read_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY)
+    current_status = _normalize_bid(payload.get("status"))
+    if current_status:
+        return False
+
+    now = datetime.now().isoformat()
+    payload["status"] = "pending"
+    payload["requested_at"] = now
+    payload["updated_at"] = now
+    _write_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY, payload)
     return True
 
 
@@ -303,6 +384,152 @@ def _resolve_notification_date_text(
     )
 
 
+def _build_feishu_result(
+    status: str,
+    *,
+    bill_order_bid: str | None = None,
+    creator_bid: str | None = None,
+    message: str | None = None,
+    notification_status: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "bill_order_bid": bill_order_bid,
+        "creator_bid": creator_bid,
+        "notification_status": notification_status,
+        "notification": _BILLING_PAID_FEISHU_KEY,
+    }
+    if message is not None:
+        payload["message"] = message
+    return payload
+
+
+def _load_notification_product(order: BillingOrder) -> BillingProduct | None:
+    return (
+        BillingProduct.query.filter(
+            BillingProduct.deleted == 0,
+            BillingProduct.product_bid == order.product_bid,
+        )
+        .order_by(BillingProduct.id.desc())
+        .first()
+    )
+
+
+def _format_minor_currency_amount(currency: str | None, amount: Any) -> str:
+    try:
+        major_amount = Decimal(str(amount or 0)) / Decimal("100")
+    except (InvalidOperation, TypeError, ValueError):
+        major_amount = Decimal("0")
+    return f"{_normalize_bid(currency) or 'CNY'} {major_amount:.2f}"
+
+
+def _format_credit_amount(amount: Any) -> str:
+    try:
+        credit_amount = Decimal(str(amount or 0))
+    except (InvalidOperation, TypeError, ValueError):
+        credit_amount = Decimal("0")
+    if credit_amount == credit_amount.to_integral_value():
+        return str(int(credit_amount))
+    return format(credit_amount.normalize(), "f").rstrip("0").rstrip(".")
+
+
+def _resolve_feishu_channel_label(order: BillingOrder) -> str:
+    provider = _normalize_bid(order.payment_provider)
+    if provider in _FEISHU_CHANNEL_LABELS:
+        return _FEISHU_CHANNEL_LABELS[provider]
+    channel = _normalize_bid(order.channel)
+    return channel or "未知"
+
+
+def _resolve_user_conversion_source(user_bid: str) -> str:
+    user_convertion = UserConversion.query.filter(
+        UserConversion.user_id == user_bid
+    ).first()
+    if user_convertion:
+        return _normalize_bid(user_convertion.conversion_source)
+    return ""
+
+
+def _append_user_count_lines(msgs: list[str]) -> None:
+    user_count = UserEntity.query.filter(
+        UserEntity.state == USER_STATE_PAID,
+        UserEntity.deleted == 0,
+    ).count()
+    msgs.append("总付费用户数：{}".format(user_count))
+    user_reg_count = UserEntity.query.filter(
+        UserEntity.state >= USER_STATE_REGISTERED,
+        UserEntity.deleted == 0,
+    ).count()
+    msgs.append("总注册用户数：{}".format(user_reg_count))
+    user_total_count = UserEntity.query.filter(UserEntity.deleted == 0).count()
+    msgs.append("总访客数：{}".format(user_total_count))
+
+
+def _build_billing_paid_feishu_message(
+    app: Flask,
+    order: BillingOrder,
+    *,
+    aggregate: Any,
+    product: BillingProduct | None,
+    product_name: str,
+) -> tuple[str, list[str]]:
+    order_type = int(order.order_type or 0)
+    is_topup = order_type == BILLING_ORDER_TYPE_TOPUP
+    title = "购买积分包通知" if is_topup else "购买订阅套餐通知"
+    product_label = "积分包名称" if is_topup else "套餐名称"
+    order_type_label = _FEISHU_ORDER_TYPE_LABELS.get(order_type, "订单")
+    amount_text = _format_minor_currency_amount(
+        order.currency,
+        order.paid_amount or order.payable_amount,
+    )
+
+    msgs = [
+        "手机号：{}".format(getattr(aggregate, "mobile", "")),
+        "昵称：{}".format(getattr(aggregate, "name", "")),
+        "{}：{}".format(product_label, product_name),
+        "实付金额：{}".format(amount_text),
+        "订单来源：{}".format(_resolve_feishu_channel_label(order)),
+        "渠道：{}".format(_resolve_user_conversion_source(order.creator_bid)),
+        "{}-{}-{}".format(order_type_label, product_name, amount_text),
+    ]
+    if product is not None:
+        msgs.append("积分数量：{}".format(_format_credit_amount(product.credit_amount)))
+    paid_at_text = format_with_app_timezone(
+        app,
+        order.paid_at,
+        "%Y-%m-%d %H:%M:%S",
+    )
+    if paid_at_text:
+        msgs.append("支付时间：{}".format(paid_at_text))
+    msgs.append("订单号：{}".format(order.bill_order_bid))
+    _append_user_count_lines(msgs)
+    return title, msgs
+
+
+def _finalize_billing_paid_feishu_notification(
+    order: BillingOrder,
+    *,
+    status: str,
+    now: datetime,
+    error_code: str = "",
+    error_message: str = "",
+) -> None:
+    payload = _read_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY)
+    payload["status"] = status
+    payload["updated_at"] = now.isoformat()
+    payload["processed_at"] = now.isoformat()
+    if status == "sent":
+        payload["sent_at"] = now.isoformat()
+        payload.pop("error_code", None)
+        payload.pop("error_message", None)
+    else:
+        if error_code:
+            payload["error_code"] = error_code
+        if error_message:
+            payload["error_message"] = error_message
+    _write_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY, payload)
+
+
 def _finalize_notification(
     order: BillingOrder,
     *,
@@ -325,6 +552,156 @@ def _finalize_notification(
         if error_message:
             payload["error_message"] = error_message
     _write_notification_payload(order, payload)
+
+
+def deliver_billing_paid_feishu(
+    app: Flask,
+    *,
+    bill_order_bid: str,
+) -> dict[str, Any]:
+    """Send one billing paid Feishu notification if the order is pending."""
+
+    normalized_bill_order_bid = _normalize_bid(bill_order_bid)
+    if not normalized_bill_order_bid:
+        return _build_feishu_result("invalid_bill_order_bid")
+
+    with app.app_context():
+        order = _resolve_notification_order(normalized_bill_order_bid)
+        if order is None:
+            return _build_feishu_result(
+                "not_found",
+                bill_order_bid=normalized_bill_order_bid,
+            )
+
+        payload = _read_notification_payload_by_key(
+            order,
+            _BILLING_PAID_FEISHU_KEY,
+        )
+        notification_status = _normalize_bid(payload.get("status"))
+        if notification_status != "pending":
+            return _build_feishu_result(
+                "noop",
+                bill_order_bid=order.bill_order_bid,
+                creator_bid=order.creator_bid,
+                notification_status=notification_status or None,
+            )
+
+        if not _supports_billing_paid_feishu(order):
+            now = datetime.now()
+            _finalize_billing_paid_feishu_notification(
+                order,
+                status="skipped_unsupported",
+                now=now,
+                error_code="unsupported_order",
+                error_message="Billing order is not a paid subscription or topup.",
+            )
+            db.session.add(order)
+            db.session.commit()
+            return _build_feishu_result(
+                "skipped_unsupported",
+                bill_order_bid=order.bill_order_bid,
+                creator_bid=order.creator_bid,
+                notification_status="skipped_unsupported",
+            )
+
+        aggregate = load_user_aggregate(order.creator_bid)
+        if not aggregate:
+            app.logger.warning(
+                "billing paid feishu notify skipped: user aggregate missing for %s",
+                order.creator_bid,
+            )
+            now = datetime.now()
+            _finalize_billing_paid_feishu_notification(
+                order,
+                status="skipped_missing_user",
+                now=now,
+                error_code="missing_user",
+                error_message="Creator aggregate is missing.",
+            )
+            db.session.add(order)
+            db.session.commit()
+            return _build_feishu_result(
+                "skipped_missing_user",
+                bill_order_bid=order.bill_order_bid,
+                creator_bid=order.creator_bid,
+                notification_status="skipped_missing_user",
+            )
+
+        product = _load_notification_product(order)
+        product_name = _resolve_notification_product_name(order, language="zh-CN")
+        title, msgs = _build_billing_paid_feishu_message(
+            app,
+            order,
+            aggregate=aggregate,
+            product=product,
+            product_name=product_name,
+        )
+        now = datetime.now()
+        payload["status"] = "processing"
+        payload["attempted_at"] = now.isoformat()
+        payload["updated_at"] = now.isoformat()
+        _write_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY, payload)
+        db.session.add(order)
+        db.session.commit()
+
+    response = None
+    provider_error_message = ""
+    try:
+        with app.app_context():
+            response = send_notify(app, title, msgs)
+    except Exception as exc:
+        provider_error_message = str(exc)
+        app.logger.error(
+            "Billing paid Feishu provider failed for bill_order_bid=%s: %s",
+            normalized_bill_order_bid,
+            exc,
+            exc_info=True,
+        )
+
+    with app.app_context():
+        order = _resolve_notification_order(normalized_bill_order_bid)
+        if order is None:
+            return _build_feishu_result(
+                "not_found",
+                bill_order_bid=normalized_bill_order_bid,
+            )
+
+        now = datetime.now()
+        if response is not None:
+            _finalize_billing_paid_feishu_notification(
+                order,
+                status="sent",
+                now=now,
+            )
+            db.session.add(order)
+            db.session.commit()
+            return _build_feishu_result(
+                "sent",
+                bill_order_bid=order.bill_order_bid,
+                creator_bid=order.creator_bid,
+                notification_status="sent",
+            )
+
+        error_message = (
+            provider_error_message
+            or "Feishu notification provider returned no response."
+        )
+        _finalize_billing_paid_feishu_notification(
+            order,
+            status="failed_provider",
+            now=now,
+            error_code="provider_failed",
+            error_message=error_message,
+        )
+        db.session.add(order)
+        db.session.commit()
+        return _build_feishu_result(
+            "failed_provider",
+            bill_order_bid=order.bill_order_bid,
+            creator_bid=order.creator_bid,
+            message=error_message,
+            notification_status="failed_provider",
+        )
 
 
 def deliver_subscription_purchase_sms(

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -14,9 +14,7 @@ from flaskr.api.sms.aliyun import send_sms_ali
 from flaskr.dao import db
 from flaskr.i18n import _ as translate
 from flaskr.i18n import get_current_language, set_language
-from flaskr.service.user.consts import USER_STATE_PAID, USER_STATE_REGISTERED
 from flaskr.service.user.models import UserConversion
-from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.repository import load_user_aggregate
 from flaskr.util.timezone import format_with_app_timezone
 
@@ -26,8 +24,12 @@ from .consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
+    BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
+    BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
+    BILLING_SUBSCRIPTION_STATUS_PAUSED,
 )
-from .models import BillingOrder, BillingProduct
+from .models import BillingOrder, BillingProduct, BillingSubscription
 from .primitives import normalize_bid as _normalize_bid
 from .queries import (
     extract_resolved_order_cycle_end_at as _extract_resolved_order_cycle_end_at,
@@ -62,6 +64,12 @@ _FEISHU_ORDER_TYPE_LABELS = {
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE: "订阅升级",
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL: "订阅续费",
     BILLING_ORDER_TYPE_TOPUP: "积分包",
+}
+_COUNTED_SUBSCRIPTION_STATUSES = {
+    BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
+    BILLING_SUBSCRIPTION_STATUS_PAUSED,
+    BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
 }
 
 
@@ -507,19 +515,25 @@ def _resolve_user_conversion_source(user_bid: str) -> str:
     return ""
 
 
-def _append_user_count_lines(msgs: list[str]) -> None:
-    user_count = UserEntity.query.filter(
-        UserEntity.state == USER_STATE_PAID,
-        UserEntity.deleted == 0,
-    ).count()
-    msgs.append("总付费用户数：{}".format(user_count))
-    user_reg_count = UserEntity.query.filter(
-        UserEntity.state >= USER_STATE_REGISTERED,
-        UserEntity.deleted == 0,
-    ).count()
-    msgs.append("总注册用户数：{}".format(user_reg_count))
-    user_total_count = UserEntity.query.filter(UserEntity.deleted == 0).count()
-    msgs.append("总访客数：{}".format(user_total_count))
+def _append_subscription_user_count_line(msgs: list[str]) -> None:
+    now = datetime.now()
+    subscription_user_count = (
+        BillingSubscription.query.with_entities(BillingSubscription.creator_bid)
+        .filter(
+            BillingSubscription.deleted == 0,
+            BillingSubscription.creator_bid != "",
+            BillingSubscription.status.in_(_COUNTED_SUBSCRIPTION_STATUSES),
+            (
+                BillingSubscription.current_period_start_at.is_(None)
+                | (BillingSubscription.current_period_start_at <= now)
+            ),
+            BillingSubscription.current_period_end_at.isnot(None),
+            BillingSubscription.current_period_end_at > now,
+        )
+        .distinct()
+        .count()
+    )
+    msgs.append("订阅用户数：{}".format(subscription_user_count))
 
 
 def _build_billing_paid_feishu_message(
@@ -559,7 +573,7 @@ def _build_billing_paid_feishu_message(
     if paid_at_text:
         msgs.append("支付时间：{}".format(paid_at_text))
     msgs.append("订单号：{}".format(order.bill_order_bid))
-    _append_user_count_lines(msgs)
+    _append_subscription_user_count_line(msgs)
     return title, msgs
 
 

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -24,6 +24,7 @@ from .consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
+    BILLING_PRODUCT_TYPE_PLAN,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
     BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
@@ -519,10 +520,17 @@ def _append_subscription_user_count_line(msgs: list[str]) -> None:
     now = datetime.now()
     subscription_user_count = (
         BillingSubscription.query.with_entities(BillingSubscription.creator_bid)
+        .join(
+            BillingProduct,
+            (BillingProduct.product_bid == BillingSubscription.product_bid)
+            & (BillingProduct.deleted == 0),
+        )
         .filter(
             BillingSubscription.deleted == 0,
             BillingSubscription.creator_bid != "",
             BillingSubscription.status.in_(_COUNTED_SUBSCRIPTION_STATUSES),
+            BillingProduct.product_type == BILLING_PRODUCT_TYPE_PLAN,
+            BillingProduct.price_amount > 0,
             (
                 BillingSubscription.current_period_start_at.is_(None)
                 | (BillingSubscription.current_period_start_at <= now)

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -21,7 +21,7 @@ from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
 class BillingPaidOrderSideEffects:
     bill_order_bid: str = ""
     should_enqueue_subscription_purchase_sms: bool = False
-    should_deliver_billing_paid_feishu: bool = False
+    should_enqueue_billing_paid_feishu: bool = False
 
 
 def stage_billing_paid_order_side_effects(
@@ -42,14 +42,14 @@ def stage_billing_paid_order_side_effects(
             previous_status=previous_status,
         )
     )
-    should_deliver_billing_paid_feishu = _stage_billing_paid_feishu_for_paid_order(
+    should_enqueue_billing_paid_feishu = _stage_billing_paid_feishu_for_paid_order(
         order,
         previous_status=previous_status,
     )
     return BillingPaidOrderSideEffects(
         bill_order_bid=order.bill_order_bid,
         should_enqueue_subscription_purchase_sms=should_enqueue_subscription_purchase_sms,
-        should_deliver_billing_paid_feishu=should_deliver_billing_paid_feishu,
+        should_enqueue_billing_paid_feishu=should_enqueue_billing_paid_feishu,
     )
 
 
@@ -66,7 +66,7 @@ def dispatch_billing_paid_order_side_effects(
             app,
             bill_order_bid=side_effects.bill_order_bid,
         )
-    if side_effects.should_deliver_billing_paid_feishu:
+    if side_effects.should_enqueue_billing_paid_feishu:
         _enqueue_billing_paid_feishu(
             app,
             bill_order_bid=side_effects.bill_order_bid,

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -1,0 +1,73 @@
+"""Shared post-paid side-effect orchestration for billing orders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from flask import Flask
+
+from .consts import BILLING_ORDER_STATUS_PAID
+from .models import BillingOrder
+from .notifications import (
+    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
+    enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
+    stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
+    stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
+)
+from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
+
+
+@dataclass(slots=True, frozen=True)
+class BillingPaidOrderSideEffects:
+    bill_order_bid: str = ""
+    should_enqueue_subscription_purchase_sms: bool = False
+    should_deliver_billing_paid_feishu: bool = False
+
+
+def stage_billing_paid_order_side_effects(
+    app: Flask,
+    order: BillingOrder | None,
+    *,
+    previous_status: int | None,
+) -> BillingPaidOrderSideEffects:
+    """Stage idempotent side effects for one paid billing order."""
+
+    if order is None or order.status != BILLING_ORDER_STATUS_PAID:
+        return BillingPaidOrderSideEffects()
+
+    _grant_paid_order_credits(app, order)
+    should_enqueue_subscription_purchase_sms = (
+        _stage_subscription_purchase_sms_for_paid_order(
+            order,
+            previous_status=previous_status,
+        )
+    )
+    should_deliver_billing_paid_feishu = _stage_billing_paid_feishu_for_paid_order(
+        order,
+        previous_status=previous_status,
+    )
+    return BillingPaidOrderSideEffects(
+        bill_order_bid=order.bill_order_bid,
+        should_enqueue_subscription_purchase_sms=should_enqueue_subscription_purchase_sms,
+        should_deliver_billing_paid_feishu=should_deliver_billing_paid_feishu,
+    )
+
+
+def dispatch_billing_paid_order_side_effects(
+    app: Flask,
+    side_effects: BillingPaidOrderSideEffects,
+) -> None:
+    """Dispatch post-commit side effects for one paid billing order."""
+
+    if not side_effects.bill_order_bid:
+        return
+    if side_effects.should_enqueue_subscription_purchase_sms:
+        _enqueue_subscription_purchase_sms(
+            app,
+            bill_order_bid=side_effects.bill_order_bid,
+        )
+    if side_effects.should_deliver_billing_paid_feishu:
+        _deliver_billing_paid_feishu(
+            app,
+            bill_order_bid=side_effects.bill_order_bid,
+        )

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -9,7 +9,7 @@ from flask import Flask
 from .consts import BILLING_ORDER_STATUS_PAID
 from .models import BillingOrder
 from .notifications import (
-    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
+    enqueue_billing_paid_feishu as _enqueue_billing_paid_feishu,
     enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
     stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
     stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
@@ -67,7 +67,7 @@ def dispatch_billing_paid_order_side_effects(
             bill_order_bid=side_effects.bill_order_bid,
         )
     if side_effects.should_deliver_billing_paid_feishu:
-        _deliver_billing_paid_feishu(
+        _enqueue_billing_paid_feishu(
             app,
             bill_order_bid=side_effects.bill_order_bid,
         )

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -23,6 +24,11 @@ from .consts import (
     BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
 )
 from .models import BillingOrder, BillingSubscription
+from .paid_side_effects import (
+    BillingPaidOrderSideEffects,
+    dispatch_billing_paid_order_side_effects as _dispatch_billing_paid_order_side_effects,
+    stage_billing_paid_order_side_effects as _stage_billing_paid_order_side_effects,
+)
 from .queries import (
     extract_order_metadata_datetime as _extract_order_metadata_datetime,
     load_latest_subscription_renewal_order as _load_latest_subscription_renewal_order,
@@ -66,6 +72,35 @@ _STRIPE_SUBSCRIPTION_STATUS_MAP = {
 }
 
 
+@dataclass(slots=True)
+class BillingOrderProviderUpdateResult:
+    applied: bool = False
+    previous_status: int | None = None
+    paid_order_side_effects: BillingPaidOrderSideEffects = field(
+        default_factory=BillingPaidOrderSideEffects
+    )
+
+    def __bool__(self) -> bool:
+        return self.applied
+
+    def stage_after_state_changes(
+        self,
+        app: Flask,
+        order: BillingOrder | None,
+    ) -> None:
+        self.paid_order_side_effects = _stage_billing_paid_order_side_effects(
+            app,
+            order,
+            previous_status=self.previous_status,
+        )
+
+    def dispatch_after_commit(self, app: Flask) -> None:
+        _dispatch_billing_paid_order_side_effects(
+            app,
+            self.paid_order_side_effects,
+        )
+
+
 def _apply_billing_order_provider_update(
     order: BillingOrder,
     *,
@@ -77,7 +112,10 @@ def _apply_billing_order_provider_update(
     target_status: int | None,
     failure_code: str = "",
     failure_message: str = "",
-) -> bool:
+) -> BillingOrderProviderUpdateResult:
+    result = BillingOrderProviderUpdateResult(
+        previous_status=int(order.status or 0),
+    )
     event_time = _extract_provider_event_time(payload)
     if provider_reference_id:
         order.provider_reference_id = provider_reference_id
@@ -95,35 +133,36 @@ def _apply_billing_order_provider_update(
         target_status=target_status,
         source=source,
     ):
-        return False
+        return result
 
     now = event_time or datetime.now()
     order.status = int(target_status or order.status or 0)
     order.updated_at = datetime.now()
+    result.applied = True
     if target_status == BILLING_ORDER_STATUS_PENDING:
-        return True
+        return result
     if target_status == BILLING_ORDER_STATUS_PAID:
         order.paid_amount = int(order.payable_amount or 0)
         order.paid_at = order.paid_at or now
         order.failed_at = None
         order.failure_code = ""
         order.failure_message = ""
-        return True
+        return result
     if target_status == BILLING_ORDER_STATUS_FAILED:
         order.failed_at = order.failed_at or now
         order.failure_code = failure_code or order.failure_code
         order.failure_message = failure_message or order.failure_message
-        return True
+        return result
     if target_status == BILLING_ORDER_STATUS_REFUNDED:
         order.refunded_at = order.refunded_at or now
-        return True
+        return result
     if target_status in {
         BILLING_ORDER_STATUS_CANCELED,
         BILLING_ORDER_STATUS_TIMEOUT,
     }:
         order.failed_at = order.failed_at or now
-        return True
-    return True
+        return result
+    return result
 
 
 def _can_transition_billing_order_status(

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -23,7 +23,9 @@ from .daily_aggregates import (
 from .domains import verify_domain_binding
 from .models import BillingRenewalEvent, BillingSubscription, CreditWallet
 from .notifications import (
+    BILLING_PAID_FEISHU_TASK_NAME as _BILLING_PAID_FEISHU_TASK_NAME,
     TASK_NAME as _SUBSCRIPTION_PURCHASE_SMS_TASK_NAME,
+    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
     deliver_subscription_purchase_sms as _deliver_subscription_purchase_sms,
 )
 from .primitives import coerce_bool as _coerce_bool
@@ -47,6 +49,10 @@ except ImportError:  # pragma: no cover - local fallback for non-Celery test env
 
 class SubscriptionPurchaseSmsRetryableError(RuntimeError):
     """Raised when the SMS worker should use Celery autoretry."""
+
+
+class BillingPaidFeishuRetryableError(RuntimeError):
+    """Raised when the billing paid Feishu worker should use Celery autoretry."""
 
 
 def _create_task_app():
@@ -399,6 +405,36 @@ def send_subscription_purchase_sms_task(
     payload["task_name"] = _SUBSCRIPTION_PURCHASE_SMS_TASK_NAME
     if payload.get("status") == "failed_provider":
         raise SubscriptionPurchaseSmsRetryableError(
+            json.dumps(
+                payload,
+                sort_keys=True,
+                default=str,
+            )
+        )
+    return payload
+
+
+@shared_task(
+    name=_BILLING_PAID_FEISHU_TASK_NAME,
+    autoretry_for=(BillingPaidFeishuRetryableError,),
+    retry_kwargs={"max_retries": 3},
+    retry_backoff=True,
+)
+def send_billing_paid_feishu_task(
+    *,
+    bill_order_bid: str = "",
+) -> dict[str, Any]:
+    """Deliver one pending billing paid Feishu notification."""
+
+    app = _create_task_app()
+    payload = _deliver_billing_paid_feishu(
+        app,
+        bill_order_bid=_normalize_bid(bill_order_bid),
+    )
+    payload = _serialize_task_payload(payload)
+    payload["task_name"] = _BILLING_PAID_FEISHU_TASK_NAME
+    if payload.get("status") == "failed_provider":
+        raise BillingPaidFeishuRetryableError(
             json.dumps(
                 payload,
                 sort_keys=True,

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -26,11 +26,8 @@ from .consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_REFUNDED,
 )
-from .paid_side_effects import (
-    dispatch_billing_paid_order_side_effects as _dispatch_billing_paid_order_side_effects,
-    stage_billing_paid_order_side_effects as _stage_billing_paid_order_side_effects,
-)
 from .provider_state import (
+    BillingOrderProviderUpdateResult,
     apply_billing_order_provider_update as _apply_billing_order_provider_update,
     apply_billing_subscription_provider_update as _apply_billing_subscription_provider_update,
     apply_subscription_checkout_failure as _apply_subscription_checkout_failure,
@@ -148,7 +145,6 @@ def apply_billing_stripe_notification(
             order = _load_latest_billing_order_by_subscription(
                 subscription.subscription_bid
             )
-        order_previous_status = int(order.status or 0) if order is not None else None
 
         if order is None and subscription is None:
             app.logger.warning(
@@ -164,6 +160,7 @@ def apply_billing_stripe_notification(
             )
 
         response_status = "acknowledged"
+        order_update = BillingOrderProviderUpdateResult()
         if order is not None:
             target_status = _map_stripe_order_status(event_type)
             if target_status is None and event_type in _STRIPE_SUBSCRIPTION_EVENT_TYPES:
@@ -171,7 +168,7 @@ def apply_billing_stripe_notification(
                     order,
                     data_object,
                 )
-            applied = _apply_billing_order_provider_update(
+            order_update = _apply_billing_order_provider_update(
                 order,
                 provider="stripe",
                 event_type=event_type,
@@ -223,11 +220,11 @@ def apply_billing_stripe_notification(
             if target_status == BILLING_ORDER_STATUS_PAID:
                 response_status = "paid"
             elif target_status == BILLING_ORDER_STATUS_FAILED:
-                response_status = "failed" if applied else "acknowledged"
+                response_status = "failed" if order_update else "acknowledged"
             elif target_status == BILLING_ORDER_STATUS_REFUNDED:
-                response_status = "refunded" if applied else "acknowledged"
+                response_status = "refunded" if order_update else "acknowledged"
             elif target_status == BILLING_ORDER_STATUS_CANCELED:
-                response_status = "canceled" if applied else "acknowledged"
+                response_status = "canceled" if order_update else "acknowledged"
 
         if subscription is not None:
             if event_type in _STRIPE_SUBSCRIPTION_EVENT_TYPES:
@@ -259,14 +256,10 @@ def apply_billing_stripe_notification(
                     payload=event,
                 )
 
-        paid_order_side_effects = _stage_billing_paid_order_side_effects(
-            app,
-            order,
-            previous_status=order_previous_status,
-        )
+        order_update.stage_after_state_changes(app, order)
 
         db.session.commit()
-        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
+        order_update.dispatch_after_commit(app)
         return BillingWebhookResult(
             status=response_status,
             event_type=event_type,
@@ -305,9 +298,8 @@ def handle_billing_pingxx_webhook(
         target_status = None
         if event_type == "charge.succeeded":
             target_status = BILLING_ORDER_STATUS_PAID
-        order_previous_status = int(order.status or 0)
 
-        _apply_billing_order_provider_update(
+        order_update = _apply_billing_order_provider_update(
             order,
             provider="pingxx",
             event_type=event_type,
@@ -333,13 +325,9 @@ def handle_billing_pingxx_webhook(
             client_ip=str(charge.get("client_ip") or ""),
             extra=charge.get("extra"),
         )
-        paid_order_side_effects = _stage_billing_paid_order_side_effects(
-            app,
-            order,
-            previous_status=order_previous_status,
-        )
+        order_update.stage_after_state_changes(app, order)
         db.session.commit()
-        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
+        order_update.dispatch_after_commit(app)
         return BillingWebhookResult(
             status="paid"
             if target_status == BILLING_ORDER_STATUS_PAID

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -27,7 +27,9 @@ from .consts import (
     BILLING_ORDER_STATUS_REFUNDED,
 )
 from .notifications import (
+    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
     enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
+    stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
     stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
 )
 from .provider_state import (
@@ -260,6 +262,7 @@ def apply_billing_stripe_notification(
                     payload=event,
                 )
 
+        should_deliver_billing_paid_feishu = False
         should_enqueue_subscription_purchase_sms = False
         if order is not None and order.status == BILLING_ORDER_STATUS_PAID:
             _grant_paid_order_credits(app, order)
@@ -269,10 +272,21 @@ def apply_billing_stripe_notification(
                     previous_status=order_previous_status,
                 )
             )
+            should_deliver_billing_paid_feishu = (
+                _stage_billing_paid_feishu_for_paid_order(
+                    order,
+                    previous_status=order_previous_status,
+                )
+            )
 
         db.session.commit()
         if should_enqueue_subscription_purchase_sms:
             _enqueue_subscription_purchase_sms(
+                app,
+                bill_order_bid=order.bill_order_bid,
+            )
+        if should_deliver_billing_paid_feishu:
+            _deliver_billing_paid_feishu(
                 app,
                 bill_order_bid=order.bill_order_bid,
             )
@@ -342,6 +356,7 @@ def handle_billing_pingxx_webhook(
             client_ip=str(charge.get("client_ip") or ""),
             extra=charge.get("extra"),
         )
+        should_deliver_billing_paid_feishu = False
         should_enqueue_subscription_purchase_sms = False
         if order.status == BILLING_ORDER_STATUS_PAID:
             _grant_paid_order_credits(app, order)
@@ -351,9 +366,20 @@ def handle_billing_pingxx_webhook(
                     previous_status=order_previous_status,
                 )
             )
+            should_deliver_billing_paid_feishu = (
+                _stage_billing_paid_feishu_for_paid_order(
+                    order,
+                    previous_status=order_previous_status,
+                )
+            )
         db.session.commit()
         if should_enqueue_subscription_purchase_sms:
             _enqueue_subscription_purchase_sms(
+                app,
+                bill_order_bid=order.bill_order_bid,
+            )
+        if should_deliver_billing_paid_feishu:
+            _deliver_billing_paid_feishu(
                 app,
                 bill_order_bid=order.bill_order_bid,
             )

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -26,11 +26,9 @@ from .consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_REFUNDED,
 )
-from .notifications import (
-    deliver_billing_paid_feishu as _deliver_billing_paid_feishu,
-    enqueue_subscription_purchase_sms as _enqueue_subscription_purchase_sms,
-    stage_billing_paid_feishu_for_paid_order as _stage_billing_paid_feishu_for_paid_order,
-    stage_subscription_purchase_sms_for_paid_order as _stage_subscription_purchase_sms_for_paid_order,
+from .paid_side_effects import (
+    dispatch_billing_paid_order_side_effects as _dispatch_billing_paid_order_side_effects,
+    stage_billing_paid_order_side_effects as _stage_billing_paid_order_side_effects,
 )
 from .provider_state import (
     apply_billing_order_provider_update as _apply_billing_order_provider_update,
@@ -48,7 +46,6 @@ from .queries import (
     load_latest_billing_order_by_subscription as _load_latest_billing_order_by_subscription,
 )
 from .primitives import normalize_bid as _normalize_bid
-from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
 
 _STRIPE_SUBSCRIPTION_EVENT_TYPES = {
     "customer.subscription.created",
@@ -262,34 +259,14 @@ def apply_billing_stripe_notification(
                     payload=event,
                 )
 
-        should_deliver_billing_paid_feishu = False
-        should_enqueue_subscription_purchase_sms = False
-        if order is not None and order.status == BILLING_ORDER_STATUS_PAID:
-            _grant_paid_order_credits(app, order)
-            should_enqueue_subscription_purchase_sms = (
-                _stage_subscription_purchase_sms_for_paid_order(
-                    order,
-                    previous_status=order_previous_status,
-                )
-            )
-            should_deliver_billing_paid_feishu = (
-                _stage_billing_paid_feishu_for_paid_order(
-                    order,
-                    previous_status=order_previous_status,
-                )
-            )
+        paid_order_side_effects = _stage_billing_paid_order_side_effects(
+            app,
+            order,
+            previous_status=order_previous_status,
+        )
 
         db.session.commit()
-        if should_enqueue_subscription_purchase_sms:
-            _enqueue_subscription_purchase_sms(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
-        if should_deliver_billing_paid_feishu:
-            _deliver_billing_paid_feishu(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
+        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
         return BillingWebhookResult(
             status=response_status,
             event_type=event_type,
@@ -356,33 +333,13 @@ def handle_billing_pingxx_webhook(
             client_ip=str(charge.get("client_ip") or ""),
             extra=charge.get("extra"),
         )
-        should_deliver_billing_paid_feishu = False
-        should_enqueue_subscription_purchase_sms = False
-        if order.status == BILLING_ORDER_STATUS_PAID:
-            _grant_paid_order_credits(app, order)
-            should_enqueue_subscription_purchase_sms = (
-                _stage_subscription_purchase_sms_for_paid_order(
-                    order,
-                    previous_status=order_previous_status,
-                )
-            )
-            should_deliver_billing_paid_feishu = (
-                _stage_billing_paid_feishu_for_paid_order(
-                    order,
-                    previous_status=order_previous_status,
-                )
-            )
+        paid_order_side_effects = _stage_billing_paid_order_side_effects(
+            app,
+            order,
+            previous_status=order_previous_status,
+        )
         db.session.commit()
-        if should_enqueue_subscription_purchase_sms:
-            _enqueue_subscription_purchase_sms(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
-        if should_deliver_billing_paid_feishu:
-            _deliver_billing_paid_feishu(
-                app,
-                bill_order_bid=order.bill_order_bid,
-            )
+        _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
         return BillingWebhookResult(
             status="paid"
             if target_status == BILLING_ORDER_STATUS_PAID

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -386,7 +386,7 @@ def test_stripe_subscription_webhook_enqueues_subscription_purchase_sms_once(
         assert notification_payload["status"] == "pending"
 
 
-def test_sync_billing_order_sends_subscription_paid_feishu_once(
+def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
     billing_subscription_sms_app,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -484,7 +484,7 @@ def test_sync_billing_order_sends_subscription_paid_feishu_once(
         assert notification["requested_at"] is not None
 
 
-def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
+def test_pingxx_topup_webhook_enqueues_billing_paid_feishu_once(
     billing_subscription_sms_app,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -548,7 +548,7 @@ def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
         assert notification["status"] == "pending"
 
 
-def test_sync_billing_topup_sends_billing_paid_feishu_once(
+def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
     billing_subscription_sms_app,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -17,6 +17,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_TRIAL_PRODUCT_BID,
 )
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.models import BillingOrder, BillingSubscription
@@ -665,6 +666,15 @@ def test_send_billing_paid_feishu_task_marks_sent(
         dao.db.session.add(
             _create_subscription(
                 subscription_bid="sub-feishu-task-sent-1",
+                current_period_start_at=paid_at,
+                current_period_end_at=now + timedelta(days=30),
+            )
+        )
+        dao.db.session.add(
+            _create_subscription(
+                subscription_bid="sub-feishu-task-free-1",
+                creator_bid="creator-free-trial",
+                product_bid=BILLING_TRIAL_PRODUCT_BID,
                 current_period_start_at=paid_at,
                 current_period_end_at=now + timedelta(days=30),
             )

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -535,6 +535,93 @@ def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
         assert notification["status"] == "sent"
 
 
+def test_sync_billing_topup_sends_billing_paid_feishu_once(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app)
+    captured: list[dict[str, object]] = []
+
+    class FakePingxxProvider:
+        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            assert provider_reference == "ch_billing_feishu_topup_sync_1"
+            assert reference_type == "charge"
+            return PaymentNotificationResult(
+                order_bid="",
+                status="manual_sync",
+                provider_payload={
+                    "charge": {
+                        "id": provider_reference,
+                        "order_no": "billing-topup-sync-feishu-1",
+                        "paid": True,
+                        "time_paid": 1712577600,
+                        "channel": "alipay_qr",
+                    }
+                },
+                charge_id=provider_reference,
+            )
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.checkout.get_payment_provider",
+        lambda channel: FakePingxxProvider(),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: (
+            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        ),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            UserConversion(
+                user_id="creator-1",
+                conversion_id="conversion-topup-sync-feishu-1",
+                conversion_source="sync-campaign",
+                conversion_status=1,
+            )
+        )
+        dao.db.session.add(
+            _create_pending_topup_order(
+                bill_order_bid="billing-topup-sync-feishu-1",
+                charge_id="ch_billing_feishu_topup_sync_1",
+            )
+        )
+        dao.db.session.commit()
+
+    first_payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-topup-sync-feishu-1",
+        {},
+    )
+    second_payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-topup-sync-feishu-1",
+        {},
+    )
+
+    assert first_payload.status == "paid"
+    assert second_payload.status == "paid"
+    assert len(captured) == 1
+    assert captured[0]["title"] == "购买积分包通知"
+    assert "手机号：13800000000" in captured[0]["msgs"]
+    assert "积分包名称：20 积分包" in captured[0]["msgs"]
+    assert "实付金额：CNY 50.00" in captured[0]["msgs"]
+    assert "订单来源：用户购买 (Pingxx)" in captured[0]["msgs"]
+    assert "渠道：sync-campaign" in captured[0]["msgs"]
+    assert "积分包-20 积分包-CNY 50.00" in captured[0]["msgs"]
+
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-topup-sync-feishu-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "sent"
+
+
 def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
     billing_subscription_sms_app,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -248,7 +248,7 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
         lambda channel: FakeStripeProvider(),
     )
     monkeypatch.setattr(
-        "flaskr.service.billing.checkout._enqueue_subscription_purchase_sms",
+        "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
         lambda app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
@@ -304,7 +304,7 @@ def test_stripe_subscription_webhook_enqueues_subscription_purchase_sms_once(
     enqueued: list[str] = []
 
     monkeypatch.setattr(
-        "flaskr.service.billing.webhooks._enqueue_subscription_purchase_sms",
+        "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
         lambda app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
@@ -400,7 +400,7 @@ def test_sync_billing_order_sends_subscription_paid_feishu_once(
         lambda channel: FakeStripeProvider(),
     )
     monkeypatch.setattr(
-        "flaskr.service.billing.checkout._enqueue_subscription_purchase_sms",
+        "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
         lambda app, *, bill_order_bid: {"status": "enqueued"},
     )
     monkeypatch.setattr(

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -638,7 +638,8 @@ def test_send_billing_paid_feishu_task_marks_sent(
 ) -> None:
     app = billing_subscription_sms_app
     _seed_creator(app)
-    paid_at = datetime(2026, 4, 20, 0, 0, 0)
+    now = datetime.now()
+    paid_at = now - timedelta(days=1)
     captured: list[dict[str, object]] = []
 
     monkeypatch.setattr(
@@ -659,6 +660,13 @@ def test_send_billing_paid_feishu_task_marks_sent(
                 conversion_id="conversion-feishu-task-1",
                 conversion_source="task-campaign",
                 conversion_status=1,
+            )
+        )
+        dao.db.session.add(
+            _create_subscription(
+                subscription_bid="sub-feishu-task-sent-1",
+                current_period_start_at=paid_at,
+                current_period_end_at=now + timedelta(days=30),
             )
         )
         dao.db.session.add(
@@ -684,6 +692,11 @@ def test_send_billing_paid_feishu_task_marks_sent(
     assert "订单来源：用户购买 (Stripe)" in captured[0]["msgs"]
     assert "渠道：task-campaign" in captured[0]["msgs"]
     assert "订阅开通-轻量版-CNY 9.90" in captured[0]["msgs"]
+    assert "订阅用户数：1" in captured[0]["msgs"]
+    assert not any(
+        str(line).startswith(("总付费用户数：", "总注册用户数：", "总访客数："))
+        for line in captured[0]["msgs"]
+    )
 
     with app.app_context():
         order = BillingOrder.query.filter_by(

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -21,12 +21,15 @@ from flaskr.service.billing.consts import (
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.models import BillingOrder, BillingSubscription
 from flaskr.service.billing.notifications import (
+    BILLING_PAID_FEISHU_TASK_NAME,
     TASK_NAME as SUBSCRIPTION_SMS_TASK_NAME,
     deliver_subscription_purchase_sms,
     requeue_subscription_purchase_sms,
 )
 from flaskr.service.billing.tasks import (
+    BillingPaidFeishuRetryableError,
     SubscriptionPurchaseSmsRetryableError,
+    send_billing_paid_feishu_task,
     send_subscription_purchase_sms_task,
 )
 from flaskr.service.billing.webhooks import apply_billing_stripe_notification
@@ -109,6 +112,23 @@ def _notification_payload(
             }
         }
     }
+
+
+def _billing_paid_feishu_payload(
+    status: str = "pending",
+) -> dict[str, dict[str, dict[str, str]]]:
+    return {
+        "notifications": {
+            "billing_paid_feishu": {
+                "status": status,
+                "requested_at": "2026-04-20T00:00:00",
+            }
+        }
+    }
+
+
+def _raise_if_send_notify_called(*args, **kwargs):
+    raise AssertionError("billing paid Feishu delivery should run in a Celery task")
 
 
 def _create_subscription(
@@ -374,7 +394,7 @@ def test_sync_billing_order_sends_subscription_paid_feishu_once(
     _seed_creator(app)
     cycle_start_at = datetime(2026, 7, 1, 0, 0, 0)
     cycle_end_at = datetime(2026, 8, 1, 0, 0, 0)
-    captured: list[dict[str, object]] = []
+    enqueued: list[str] = []
 
     class FakeStripeProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
@@ -404,10 +424,14 @@ def test_sync_billing_order_sends_subscription_paid_feishu_once(
         lambda app, *, bill_order_bid: {"status": "enqueued"},
     )
     monkeypatch.setattr(
-        "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: (
-            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
+        lambda app, *, bill_order_bid: (
+            enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        _raise_if_send_notify_called,
     )
 
     with app.app_context():
@@ -449,23 +473,15 @@ def test_sync_billing_order_sends_subscription_paid_feishu_once(
 
     assert first_payload.status == "paid"
     assert second_payload.status == "paid"
-    assert len(captured) == 1
-    assert captured[0]["title"] == "购买订阅套餐通知"
-    assert "手机号：13800000000" in captured[0]["msgs"]
-    assert "昵称：Creator" in captured[0]["msgs"]
-    assert "套餐名称：轻量版" in captured[0]["msgs"]
-    assert "实付金额：CNY 9.90" in captured[0]["msgs"]
-    assert "订单来源：用户购买 (Stripe)" in captured[0]["msgs"]
-    assert "渠道：ads" in captured[0]["msgs"]
-    assert "订阅续费-轻量版-CNY 9.90" in captured[0]["msgs"]
+    assert enqueued == ["billing-sync-feishu-1"]
 
     with app.app_context():
         order = BillingOrder.query.filter_by(
             bill_order_bid="billing-sync-feishu-1"
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
-        assert notification["status"] == "sent"
-        assert notification["sent_at"] is not None
+        assert notification["status"] == "pending"
+        assert notification["requested_at"] is not None
 
 
 def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
@@ -474,13 +490,17 @@ def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
 ) -> None:
     app = billing_subscription_sms_app
     _seed_creator(app)
-    captured: list[dict[str, object]] = []
+    enqueued: list[str] = []
 
     monkeypatch.setattr(
-        "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: (
-            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
+        lambda app, *, bill_order_bid: (
+            enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        _raise_if_send_notify_called,
     )
 
     with app.app_context():
@@ -518,21 +538,14 @@ def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
     assert second_status == 200
     assert first_payload["status"] == "paid"
     assert second_payload["status"] == "paid"
-    assert len(captured) == 1
-    assert captured[0]["title"] == "购买积分包通知"
-    assert "手机号：13800000000" in captured[0]["msgs"]
-    assert "积分包名称：20 积分包" in captured[0]["msgs"]
-    assert "实付金额：CNY 50.00" in captured[0]["msgs"]
-    assert "订单来源：用户购买 (Pingxx)" in captured[0]["msgs"]
-    assert "渠道：campaign" in captured[0]["msgs"]
-    assert "积分包-20 积分包-CNY 50.00" in captured[0]["msgs"]
+    assert enqueued == ["billing-topup-feishu-1"]
 
     with app.app_context():
         order = BillingOrder.query.filter_by(
             bill_order_bid="billing-topup-feishu-1"
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
-        assert notification["status"] == "sent"
+        assert notification["status"] == "pending"
 
 
 def test_sync_billing_topup_sends_billing_paid_feishu_once(
@@ -541,7 +554,7 @@ def test_sync_billing_topup_sends_billing_paid_feishu_once(
 ) -> None:
     app = billing_subscription_sms_app
     _seed_creator(app)
-    captured: list[dict[str, object]] = []
+    enqueued: list[str] = []
 
     class FakePingxxProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
@@ -567,10 +580,14 @@ def test_sync_billing_topup_sends_billing_paid_feishu_once(
         lambda channel: FakePingxxProvider(),
     )
     monkeypatch.setattr(
-        "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: (
-            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
+        lambda app, *, bill_order_bid: (
+            enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        _raise_if_send_notify_called,
     )
 
     with app.app_context():
@@ -605,21 +622,164 @@ def test_sync_billing_topup_sends_billing_paid_feishu_once(
 
     assert first_payload.status == "paid"
     assert second_payload.status == "paid"
-    assert len(captured) == 1
-    assert captured[0]["title"] == "购买积分包通知"
-    assert "手机号：13800000000" in captured[0]["msgs"]
-    assert "积分包名称：20 积分包" in captured[0]["msgs"]
-    assert "实付金额：CNY 50.00" in captured[0]["msgs"]
-    assert "订单来源：用户购买 (Pingxx)" in captured[0]["msgs"]
-    assert "渠道：sync-campaign" in captured[0]["msgs"]
-    assert "积分包-20 积分包-CNY 50.00" in captured[0]["msgs"]
+    assert enqueued == ["billing-topup-sync-feishu-1"]
 
     with app.app_context():
         order = BillingOrder.query.filter_by(
             bill_order_bid="billing-topup-sync-feishu-1"
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "pending"
+
+
+def test_send_billing_paid_feishu_task_marks_sent(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app)
+    paid_at = datetime(2026, 4, 20, 0, 0, 0)
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.tasks._create_task_app",
+        lambda: app,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: (
+            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        ),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            UserConversion(
+                user_id="creator-1",
+                conversion_id="conversion-feishu-task-1",
+                conversion_source="task-campaign",
+                conversion_status=1,
+            )
+        )
+        dao.db.session.add(
+            _create_paid_start_order(
+                bill_order_bid="billing-feishu-task-sent-1",
+                subscription_bid="sub-feishu-task-sent-1",
+                paid_at=paid_at,
+                metadata_json=_billing_paid_feishu_payload(),
+            )
+        )
+        dao.db.session.commit()
+
+    payload = send_billing_paid_feishu_task(bill_order_bid="billing-feishu-task-sent-1")
+
+    assert payload["status"] == "sent"
+    assert payload["task_name"] == BILLING_PAID_FEISHU_TASK_NAME
+    assert len(captured) == 1
+    assert captured[0]["title"] == "购买订阅套餐通知"
+    assert "手机号：13800000000" in captured[0]["msgs"]
+    assert "昵称：Creator" in captured[0]["msgs"]
+    assert "套餐名称：轻量版" in captured[0]["msgs"]
+    assert "实付金额：CNY 9.90" in captured[0]["msgs"]
+    assert "订单来源：用户购买 (Stripe)" in captured[0]["msgs"]
+    assert "渠道：task-campaign" in captured[0]["msgs"]
+    assert "订阅开通-轻量版-CNY 9.90" in captured[0]["msgs"]
+
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-feishu-task-sent-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
         assert notification["status"] == "sent"
+        assert notification["sent_at"] is not None
+
+
+def test_send_billing_paid_feishu_task_raises_retryable_error_on_provider_failure(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app, creator_bid="creator-feishu-failure")
+    paid_at = datetime(2026, 4, 20, 0, 0, 0)
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.tasks._create_task_app",
+        lambda: app,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: None,
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            _create_paid_start_order(
+                bill_order_bid="billing-feishu-task-failure-1",
+                subscription_bid="sub-feishu-task-failure-1",
+                creator_bid="creator-feishu-failure",
+                paid_at=paid_at,
+                metadata_json=_billing_paid_feishu_payload(),
+            )
+        )
+        dao.db.session.commit()
+
+    with pytest.raises(BillingPaidFeishuRetryableError):
+        send_billing_paid_feishu_task(bill_order_bid="billing-feishu-task-failure-1")
+
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-feishu-task-failure-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "failed_provider"
+        assert notification["error_code"] == "provider_failed"
+
+
+def test_send_billing_paid_feishu_task_retries_failed_provider_notification(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app, creator_bid="creator-feishu-retry")
+    paid_at = datetime(2026, 4, 20, 0, 0, 0)
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.tasks._create_task_app",
+        lambda: app,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: (
+            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        ),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            _create_paid_start_order(
+                bill_order_bid="billing-feishu-task-retry-1",
+                subscription_bid="sub-feishu-task-retry-1",
+                creator_bid="creator-feishu-retry",
+                paid_at=paid_at,
+                metadata_json=_billing_paid_feishu_payload(status="failed_provider"),
+            )
+        )
+        dao.db.session.commit()
+
+    payload = send_billing_paid_feishu_task(
+        bill_order_bid="billing-feishu-task-retry-1"
+    )
+
+    assert payload["status"] == "sent"
+    assert len(captured) == 1
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-feishu-task-retry-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "sent"
+        assert notification["sent_at"] is not None
 
 
 def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -15,6 +15,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PENDING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
 )
 from flaskr.service.billing.checkout import sync_billing_order
@@ -29,8 +30,10 @@ from flaskr.service.billing.tasks import (
     send_subscription_purchase_sms_task,
 )
 from flaskr.service.billing.webhooks import apply_billing_stripe_notification
+from flaskr.service.billing.webhooks import handle_billing_pingxx_webhook
 from flaskr.service.order.payment_providers.base import PaymentNotificationResult
 from flaskr.service.user.consts import USER_STATE_REGISTERED
+from flaskr.service.user.models import UserConversion
 from flaskr.service.user.repository import create_user_entity, upsert_credential
 from tests.common.fixtures.bill_products import build_bill_products
 
@@ -189,6 +192,29 @@ def _create_paid_start_order(
     )
 
 
+def _create_pending_topup_order(
+    *,
+    bill_order_bid: str,
+    creator_bid: str = "creator-1",
+    charge_id: str = "ch_billing_feishu_topup_1",
+) -> BillingOrder:
+    return BillingOrder(
+        bill_order_bid=bill_order_bid,
+        creator_bid=creator_bid,
+        order_type=BILLING_ORDER_TYPE_TOPUP,
+        product_bid="bill-product-topup-small",
+        subscription_bid="",
+        currency="CNY",
+        payable_amount=5000,
+        paid_amount=0,
+        payment_provider="pingxx",
+        channel="alipay_qr",
+        provider_reference_id=charge_id,
+        status=BILLING_ORDER_STATUS_PENDING,
+        metadata_json={},
+    )
+
+
 def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
     billing_subscription_sms_app,
     monkeypatch: pytest.MonkeyPatch,
@@ -338,6 +364,175 @@ def test_stripe_subscription_webhook_enqueues_subscription_purchase_sms_once(
             "subscription_purchase_sms"
         ]
         assert notification_payload["status"] == "pending"
+
+
+def test_sync_billing_order_sends_subscription_paid_feishu_once(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app)
+    cycle_start_at = datetime(2026, 7, 1, 0, 0, 0)
+    cycle_end_at = datetime(2026, 8, 1, 0, 0, 0)
+    captured: list[dict[str, object]] = []
+
+    class FakeStripeProvider:
+        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            assert reference_type == "subscription"
+            return PaymentNotificationResult(
+                order_bid="",
+                status="manual_sync",
+                provider_payload={
+                    "subscription": {
+                        "id": provider_reference,
+                        "customer": "cus_sync_feishu_1",
+                        "status": "active",
+                        "current_period_start": int(cycle_start_at.timestamp()),
+                        "current_period_end": int(cycle_end_at.timestamp()),
+                        "cancel_at_period_end": False,
+                    }
+                },
+                charge_id=None,
+            )
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.checkout.get_payment_provider",
+        lambda channel: FakeStripeProvider(),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.checkout._enqueue_subscription_purchase_sms",
+        lambda app, *, bill_order_bid: {"status": "enqueued"},
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: (
+            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        ),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            UserConversion(
+                user_id="creator-1",
+                conversion_id="conversion-sync-feishu-1",
+                conversion_source="ads",
+                conversion_status=1,
+            )
+        )
+        subscription = _create_subscription(
+            subscription_bid="sub-sync-feishu-1",
+            current_period_start_at=cycle_start_at - timedelta(days=30),
+            current_period_end_at=cycle_start_at,
+        )
+        order = _create_renewal_order(
+            bill_order_bid="billing-sync-feishu-1",
+            subscription_bid=subscription.subscription_bid,
+            cycle_start_at=cycle_start_at,
+            cycle_end_at=cycle_end_at,
+        )
+        dao.db.session.add(subscription)
+        dao.db.session.add(order)
+        dao.db.session.commit()
+
+    first_payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-sync-feishu-1",
+        {},
+    )
+    second_payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-sync-feishu-1",
+        {},
+    )
+
+    assert first_payload.status == "paid"
+    assert second_payload.status == "paid"
+    assert len(captured) == 1
+    assert captured[0]["title"] == "购买订阅套餐通知"
+    assert "手机号：13800000000" in captured[0]["msgs"]
+    assert "昵称：Creator" in captured[0]["msgs"]
+    assert "套餐名称：轻量版" in captured[0]["msgs"]
+    assert "实付金额：CNY 9.90" in captured[0]["msgs"]
+    assert "订单来源：用户购买 (Stripe)" in captured[0]["msgs"]
+    assert "渠道：ads" in captured[0]["msgs"]
+    assert "订阅续费-轻量版-CNY 9.90" in captured[0]["msgs"]
+
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-sync-feishu-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "sent"
+        assert notification["sent_at"] is not None
+
+
+def test_pingxx_topup_webhook_sends_billing_paid_feishu_once(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app)
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.notifications.send_notify",
+        lambda app, title, msgs: (
+            captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
+        ),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            UserConversion(
+                user_id="creator-1",
+                conversion_id="conversion-topup-feishu-1",
+                conversion_source="campaign",
+                conversion_status=1,
+            )
+        )
+        dao.db.session.add(
+            _create_pending_topup_order(
+                bill_order_bid="billing-topup-feishu-1",
+                charge_id="ch_billing_feishu_topup_1",
+            )
+        )
+        dao.db.session.commit()
+
+    body = {
+        "type": "charge.succeeded",
+        "data": {
+            "object": {
+                "id": "ch_billing_feishu_topup_1",
+                "order_no": "billing-topup-feishu-1",
+                "paid": True,
+                "time_paid": 1712577600,
+            }
+        },
+    }
+    first_payload, first_status = handle_billing_pingxx_webhook(app, body)
+    second_payload, second_status = handle_billing_pingxx_webhook(app, body)
+
+    assert first_status == 200
+    assert second_status == 200
+    assert first_payload["status"] == "paid"
+    assert second_payload["status"] == "paid"
+    assert len(captured) == 1
+    assert captured[0]["title"] == "购买积分包通知"
+    assert "手机号：13800000000" in captured[0]["msgs"]
+    assert "积分包名称：20 积分包" in captured[0]["msgs"]
+    assert "实付金额：CNY 50.00" in captured[0]["msgs"]
+    assert "订单来源：用户购买 (Pingxx)" in captured[0]["msgs"]
+    assert "渠道：campaign" in captured[0]["msgs"]
+    assert "积分包-20 积分包-CNY 50.00" in captured[0]["msgs"]
+
+    with app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-topup-feishu-1"
+        ).one()
+        notification = order.metadata_json["notifications"]["billing_paid_feishu"]
+        assert notification["status"] == "sent"
 
 
 def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(


### PR DESCRIPTION
## Summary
- send Feishu notifications for newly paid billing subscription and topup orders
- persist billing_paid_feishu notification state in order metadata for idempotency
- cover subscription sync and Pingxx topup webhook notification paths

## Tests
- pre-commit run -a
- cd src/api && pytest tests/service/billing/test_billing_subscription_sms.py tests/service/billing/test_billing_callbacks.py tests/service/order/test_stripe_webhook.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Feishu “billing paid” notifications so users receive billing confirmation via Feishu.

* **Improvements**
  * More reliable, idempotent billing notifications (SMS and Feishu) with background delivery and retry behavior.
  * Paid-order side effects (credits and notification enqueueing) are now consistently staged and applied to ensure correct, exactly-once processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->