### PR TITLE
fix: stabilize learner lesson navigation state

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -19,7 +19,7 @@ interface ChatUiProps {
   chapterId: string;
   lessonId?: string;
   lessonUpdate: (val: any) => void;
-  onGoChapter: (id: any) => Promise<void>;
+  onGoChapter: (id: any) => void;
   onPurchased: () => void;
   lessonTitle?: string;
   lessonStatus?: string;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -60,7 +60,7 @@ import { stopActiveLessonStream } from '@/app/c/[[...id]]/events';
 interface NewChatComponentsProps {
   className?: string;
   lessonUpdate: (val: any) => void;
-  onGoChapter: (id: any) => Promise<void>;
+  onGoChapter: (id: any) => void;
   chapterId: string;
   lessonId?: string;
   lessonTitle?: string;

--- a/src/cook-web/src/app/c/[[...id]]/lessonNavigation.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/lessonNavigation.test.ts
@@ -1,0 +1,100 @@
+import {
+  applyLessonSelection,
+  resolveRequestedLessonId,
+} from './lessonNavigation';
+
+describe('applyLessonSelection', () => {
+  it('updates local lesson selection immediately in the same chapter', () => {
+    const updateSelectedLesson = jest.fn();
+    const updateLessonId = jest.fn();
+    const updateChapterId = jest.fn();
+    const syncLessonUrl = jest.fn();
+
+    const result = applyLessonSelection({
+      lessonId: 'lesson-2',
+      currentChapterId: 'chapter-1',
+      getChapterByLesson: () => ({ id: 'chapter-1' }),
+      updateSelectedLesson,
+      updateLessonId,
+      updateChapterId,
+      syncLessonUrl,
+    });
+
+    expect(result).toEqual({
+      chapterId: 'chapter-1',
+      lessonId: 'lesson-2',
+    });
+    expect(updateSelectedLesson).toHaveBeenCalledWith('lesson-2', false);
+    expect(updateLessonId).toHaveBeenCalledWith('lesson-2');
+    expect(syncLessonUrl).toHaveBeenCalledWith('lesson-2');
+    expect(updateChapterId).not.toHaveBeenCalled();
+  });
+
+  it('syncs chapter state when the lesson belongs to another chapter', () => {
+    const updateSelectedLesson = jest.fn();
+    const updateLessonId = jest.fn();
+    const updateChapterId = jest.fn();
+    const syncLessonUrl = jest.fn();
+
+    const result = applyLessonSelection({
+      lessonId: 'lesson-3',
+      currentChapterId: 'chapter-1',
+      forceExpand: true,
+      getChapterByLesson: () => ({ id: 'chapter-2' }),
+      updateSelectedLesson,
+      updateLessonId,
+      updateChapterId,
+      syncLessonUrl,
+    });
+
+    expect(result).toEqual({
+      chapterId: 'chapter-2',
+      lessonId: 'lesson-3',
+    });
+    expect(updateSelectedLesson).toHaveBeenCalledWith('lesson-3', true);
+    expect(updateLessonId).toHaveBeenCalledWith('lesson-3');
+    expect(syncLessonUrl).toHaveBeenCalledWith('lesson-3');
+    expect(updateChapterId).toHaveBeenCalledWith('chapter-2');
+  });
+
+  it('does nothing when the lesson does not map to a chapter', () => {
+    const updateSelectedLesson = jest.fn();
+    const updateLessonId = jest.fn();
+    const updateChapterId = jest.fn();
+    const syncLessonUrl = jest.fn();
+
+    const result = applyLessonSelection({
+      lessonId: 'lesson-missing',
+      currentChapterId: 'chapter-1',
+      getChapterByLesson: () => null,
+      updateSelectedLesson,
+      updateLessonId,
+      updateChapterId,
+      syncLessonUrl,
+    });
+
+    expect(result).toBeNull();
+    expect(updateSelectedLesson).not.toHaveBeenCalled();
+    expect(updateLessonId).not.toHaveBeenCalled();
+    expect(updateChapterId).not.toHaveBeenCalled();
+    expect(syncLessonUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveRequestedLessonId', () => {
+  it('prefers selected lesson over store and url values', () => {
+    expect(
+      resolveRequestedLessonId('lesson-selected', 'lesson-store', 'lesson-url'),
+    ).toBe('lesson-selected');
+  });
+
+  it('falls back to store lesson before url lesson', () => {
+    expect(resolveRequestedLessonId('', 'lesson-store', 'lesson-url')).toBe(
+      'lesson-store',
+    );
+  });
+
+  it('uses url lesson when local state is still empty after refresh', () => {
+    expect(resolveRequestedLessonId('', '', 'lesson-url')).toBe('lesson-url');
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/lessonNavigation.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/lessonNavigation.test.ts
@@ -88,13 +88,15 @@ describe('resolveRequestedLessonId', () => {
     ).toBe('lesson-selected');
   });
 
-  it('falls back to store lesson before url lesson', () => {
+  it('falls back to url lesson before store lesson', () => {
     expect(resolveRequestedLessonId('', 'lesson-store', 'lesson-url')).toBe(
-      'lesson-store',
+      'lesson-url',
     );
   });
 
-  it('uses url lesson when local state is still empty after refresh', () => {
-    expect(resolveRequestedLessonId('', '', 'lesson-url')).toBe('lesson-url');
+  it('uses store lesson only when selected and url lessons are both empty', () => {
+    expect(resolveRequestedLessonId('', 'lesson-store', '')).toBe(
+      'lesson-store',
+    );
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/lessonNavigation.ts
+++ b/src/cook-web/src/app/c/[[...id]]/lessonNavigation.ts
@@ -7,7 +7,7 @@ export function resolveRequestedLessonId(
   lessonId?: string | null,
   urlLessonId?: string | null,
 ): string {
-  return selectedLessonId || lessonId || urlLessonId || '';
+  return selectedLessonId || urlLessonId || lessonId || '';
 }
 
 type ApplyLessonSelectionParams = {

--- a/src/cook-web/src/app/c/[[...id]]/lessonNavigation.ts
+++ b/src/cook-web/src/app/c/[[...id]]/lessonNavigation.ts
@@ -1,0 +1,56 @@
+type LessonChapter = {
+  id: string;
+};
+
+export function resolveRequestedLessonId(
+  selectedLessonId?: string | null,
+  lessonId?: string | null,
+  urlLessonId?: string | null,
+): string {
+  return selectedLessonId || lessonId || urlLessonId || '';
+}
+
+type ApplyLessonSelectionParams = {
+  lessonId: string;
+  currentChapterId?: string;
+  forceExpand?: boolean;
+  getChapterByLesson: (lessonId: string) => LessonChapter | null;
+  updateSelectedLesson: (lessonId: string, forceExpand?: boolean) => void;
+  updateLessonId: (lessonId: string) => void;
+  updateChapterId: (chapterId: string) => void;
+  syncLessonUrl: (lessonId: string) => void;
+};
+
+type AppliedLessonSelection = {
+  chapterId: string;
+  lessonId: string;
+};
+
+export function applyLessonSelection({
+  lessonId,
+  currentChapterId = '',
+  forceExpand = false,
+  getChapterByLesson,
+  updateSelectedLesson,
+  updateLessonId,
+  updateChapterId,
+  syncLessonUrl,
+}: ApplyLessonSelectionParams): AppliedLessonSelection | null {
+  const chapter = getChapterByLesson(lessonId);
+  if (!chapter?.id) {
+    return null;
+  }
+
+  updateSelectedLesson(lessonId, forceExpand);
+  updateLessonId(lessonId);
+  syncLessonUrl(lessonId);
+
+  if (chapter.id !== currentChapterId) {
+    updateChapterId(chapter.id);
+  }
+
+  return {
+    chapterId: chapter.id,
+    lessonId,
+  };
+}

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -494,7 +494,7 @@ export default function ChatPage() {
   );
 
   const onGoChapter = useCallback(
-    async id => {
+    id => {
       applyLessonSelection({
         lessonId: id,
         currentChapterId: chapterId,

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -28,6 +28,10 @@ import { useUserStore } from '@/store';
 import { useDisclosure } from '@/c-common/hooks/useDisclosure';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import { useLessonTree } from './hooks/useLessonTree';
+import {
+  applyLessonSelection,
+  resolveRequestedLessonId,
+} from './lessonNavigation';
 import { updateWxcode } from '@/c-api/user';
 import { shifu } from '@/c-service/Shifu';
 import {
@@ -386,9 +390,15 @@ export default function ChatPage() {
     }
   }, [selectedLessonId, updateLessonId]);
 
+  const requestedLessonId = resolveRequestedLessonId(
+    selectedLessonId,
+    lessonId,
+    urlLessonId,
+  );
+
   const loadData = useCallback(async () => {
-    await loadTree(chapterId, urlLessonId || lessonId);
-  }, [chapterId, lessonId, loadTree, urlLessonId]);
+    await loadTree(chapterId, requestedLessonId);
+  }, [chapterId, loadTree, requestedLessonId]);
 
   const [loadedChapterId, setLoadedChapterId] = useState<string | null>(null);
 
@@ -445,22 +455,27 @@ export default function ChatPage() {
   }, [resolvedLessonId, tree]);
 
   const onLessonSelect = ({ id }) => {
-    const chapter = getChapterByLesson(id);
-    if (!chapter) {
+    const selection = applyLessonSelection({
+      lessonId: id,
+      currentChapterId: chapterId,
+      getChapterByLesson,
+      updateSelectedLesson,
+      updateLessonId,
+      updateChapterId,
+      syncLessonUrl,
+    });
+
+    if (!selection) {
       return;
     }
-    updateLessonId(id);
-    syncLessonUrl(id);
-    if (chapter.id !== chapterId) {
-      updateChapterId(chapter.id);
-    }
+
     if (lessonId === id) {
       return;
     }
     events.dispatchEvent(
       new CustomEvent(EVENT_NAMES.GO_TO_NAVIGATION_NODE, {
         detail: {
-          chapterId: chapter.id,
+          chapterId: selection.chapterId,
           lessonId: id,
         },
       }),
@@ -478,11 +493,28 @@ export default function ChatPage() {
     [updateLesson],
   );
 
-  const onGoChapter = async id => {
-    // updateChapterId(id);
-    updateLessonId(id);
-    syncLessonUrl(id);
-  };
+  const onGoChapter = useCallback(
+    async id => {
+      applyLessonSelection({
+        lessonId: id,
+        currentChapterId: chapterId,
+        forceExpand: true,
+        getChapterByLesson,
+        updateSelectedLesson,
+        updateLessonId,
+        updateChapterId,
+        syncLessonUrl,
+      });
+    },
+    [
+      chapterId,
+      getChapterByLesson,
+      syncLessonUrl,
+      updateChapterId,
+      updateLessonId,
+      updateSelectedLesson,
+    ],
+  );
 
   const onChapterUpdate = useCallback(
     ({ id, status, status_value }) => {


### PR DESCRIPTION
# Summary
- stabilize learner lesson selection after refresh by prioritizing the in-memory selected lesson over stale `lessonid` query params when reloading the lesson tree
- update both catalog clicks and the in-chat next-lesson action to apply lesson, chapter, and URL state through a shared navigation helper so the left-side highlight and content stay in sync
- add focused tests for lesson navigation state resolution and keep existing lesson URL utility coverage passing

## Verification
- `cd src/cook-web && npm test -- --runInBand --runTestsByPath 'src/app/c/[[...id]]/lessonNavigation.test.ts' 'src/__tests__/url-utils.test.ts'`
- `cd src/cook-web && npm run type-check`
- `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of lesson selection and chapter navigation
  * Enhanced URL synchronization when switching between lessons

* **Tests**
  * Added comprehensive test suite validating lesson navigation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->