### PR TITLE
fix: handle string datetimes in operator promotion campaigns

### DIFF
--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -183,7 +183,7 @@ def _resolve_update_datetime(
     return _parse_datetime(value, field_name, is_end=is_end)
 
 
-def _format_promotion_admin_datetime(value: Optional[datetime]) -> str:
+def _format_promotion_admin_datetime(value: datetime | str | None) -> str:
     if not value:
         return ""
 
@@ -192,24 +192,24 @@ def _format_promotion_admin_datetime(value: Optional[datetime]) -> str:
         if not normalized:
             return ""
         parsed_value = None
-        for candidate in (
-            normalized.replace("Z", "+00:00"),
-            normalized.replace(" ", "T"),
-        ):
-            try:
-                parsed_value = datetime.fromisoformat(candidate)
-                break
-            except ValueError:
-                continue
+        candidate = normalized.replace("Z", "+00:00").replace(" ", "T")
+        try:
+            parsed_value = datetime.fromisoformat(candidate)
+        except ValueError:
+            parsed_value = None
         if parsed_value is None:
-            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
                 try:
                     parsed_value = datetime.strptime(normalized, fmt)
                     break
                 except ValueError:
                     continue
         if parsed_value is None:
-            raise_param_error("promotion_datetime")
+            current_app.logger.warning(
+                "Failed to parse promotion admin datetime string: %s",
+                normalized,
+            )
+            return ""
         value = parsed_value
 
     app = current_app._get_current_object()

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -187,6 +187,31 @@ def _format_promotion_admin_datetime(value: Optional[datetime]) -> str:
     if not value:
         return ""
 
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return ""
+        parsed_value = None
+        for candidate in (
+            normalized.replace("Z", "+00:00"),
+            normalized.replace(" ", "T"),
+        ):
+            try:
+                parsed_value = datetime.fromisoformat(candidate)
+                break
+            except ValueError:
+                continue
+        if parsed_value is None:
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+                try:
+                    parsed_value = datetime.strptime(normalized, fmt)
+                    break
+                except ValueError:
+                    continue
+        if parsed_value is None:
+            raise_param_error("promotion_datetime")
+        value = parsed_value
+
     app = current_app._get_current_object()
     source_tz = get_app_timezone(app, PROMOTION_ADMIN_SOURCE_TIMEZONE)
     target_tz = get_app_timezone(app, "UTC")

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -1580,6 +1581,15 @@ def test_format_promotion_admin_datetime_accepts_string_value(app):
             _format_promotion_admin_datetime("2026-04-28 14:38:41")
             == "2026-04-28T06:38:41Z"
         )
+
+
+def test_format_promotion_admin_datetime_returns_empty_for_invalid_string(app):
+    with app.app_context():
+        warning = Mock()
+        app.logger.warning = warning
+
+        assert _format_promotion_admin_datetime("not-a-datetime") == ""
+        warning.assert_called_once()
 
 
 def test_admin_promotions_campaign_update_rejects_apply_type_change_after_redemption(

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -9,6 +9,7 @@ import pytest
 from flaskr.dao import db
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
+from flaskr.service.promo.admin import _format_promotion_admin_datetime
 from flaskr.service.promo.consts import (
     COUPON_APPLY_TYPE_SPECIFIC,
     COUPON_STATUS_USED,
@@ -1570,6 +1571,14 @@ def test_admin_promotions_campaign_update_ignores_null_end_time(
         )
         assert campaign.end_at == datetime.strptime(
             "2099-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"
+        )
+
+
+def test_format_promotion_admin_datetime_accepts_string_value(app):
+    with app.app_context():
+        assert (
+            _format_promotion_admin_datetime("2026-04-28 14:38:41")
+            == "2026-04-28T06:38:41Z"
         )
 
 


### PR DESCRIPTION
# Summary

Handle string-valued promotion campaign datetimes in the operator promotions admin flow so the campaigns tab can render safely for historical or backfilled records.

- accept string datetime values in `_format_promotion_admin_datetime` before timezone conversion
- keep existing datetime behavior unchanged for normal ORM-loaded rows
- add focused regression coverage for string datetime formatting

## Verification

- `python -m py_compile src/api/flaskr/service/promo/admin.py src/api/tests/service/promo/test_admin_promotions.py`
- `cd src/api && pytest -q tests/service/promo/test_admin_promotions.py` *(blocked locally: missing `opentelemetry` dependency in the current environment)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced promotional datetime handling to support string inputs alongside datetime objects, with improved parsing for multiple formats and more robust error handling.

* **Tests**
  * Added unit test for promotional datetime formatting verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->