### PR TITLE
refactor: add stable promo api entrypoint for architecture checks

### DIFF
--- a/src/api/flaskr/service/order/api.py
+++ b/src/api/flaskr/service/order/api.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from flaskr.service.order.admin import (
+    ORDER_STATUS_KEY_MAP,
+    _format_decimal,
+    _load_shifu_map,
+    _load_user_map,
     get_operator_order_detail,
     list_operator_orders,
 )
 
 __all__ = [
+    "ORDER_STATUS_KEY_MAP",
+    "_format_decimal",
+    "_load_shifu_map",
+    "_load_user_map",
     "get_operator_order_detail",
     "list_operator_orders",
 ]

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -13,7 +13,7 @@ from sqlalchemy import and_, case, func, or_
 
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
-from flaskr.service.order.admin import (
+from flaskr.service.order.api import (
     ORDER_STATUS_KEY_MAP,
     _format_decimal,
     _load_shifu_map,

--- a/src/api/flaskr/service/promo/api.py
+++ b/src/api/flaskr/service/promo/api.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from flaskr.service.promo.admin import (
+    create_operator_promotion_campaign,
+    create_operator_promotion_coupon,
+    get_operator_promotion_campaign_detail,
+    get_operator_promotion_coupon_detail,
+    list_operator_promotion_campaign_redemptions,
+    list_operator_promotion_campaigns,
+    list_operator_promotion_coupon_codes,
+    list_operator_promotion_coupon_usages,
+    list_operator_promotion_coupons,
+    update_operator_promotion_campaign,
+    update_operator_promotion_campaign_status,
+    update_operator_promotion_coupon,
+    update_operator_promotion_coupon_status,
+)
+
+__all__ = [
+    "create_operator_promotion_campaign",
+    "create_operator_promotion_coupon",
+    "get_operator_promotion_campaign_detail",
+    "get_operator_promotion_coupon_detail",
+    "list_operator_promotion_campaign_redemptions",
+    "list_operator_promotion_campaigns",
+    "list_operator_promotion_coupon_codes",
+    "list_operator_promotion_coupon_usages",
+    "list_operator_promotion_coupons",
+    "update_operator_promotion_campaign",
+    "update_operator_promotion_campaign_status",
+    "update_operator_promotion_coupon",
+    "update_operator_promotion_coupon_status",
+]

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -120,7 +120,7 @@ from flaskr.service.order.api import (
     get_operator_order_detail,
     list_operator_orders,
 )
-from flaskr.service.promo.admin import (
+from flaskr.service.promo.api import (
     create_operator_promotion_campaign,
     create_operator_promotion_coupon,
     get_operator_promotion_campaign_detail,


### PR DESCRIPTION
# Summary

Add a stable `promo.api` service entrypoint so operator promotion routes and helpers can depend on allowed backend service APIs without introducing new architecture-boundary violations.

- add `src/api/flaskr/service/promo/api.py` as the stable promo service facade
- switch `shifu.route` to import operator promotion handlers from `promo.api`
- switch `promo.admin` to reuse the stable `order.api` entrypoint instead of importing `order.admin` directly

## Verification

- `python scripts/check_architecture_boundaries.py`
- `pre-commit run --files src/api/flaskr/service/promo/api.py src/api/flaskr/service/promo/admin.py src/api/flaskr/service/shifu/route.py`
