### PR TITLE
fix(cook-web): tone-driven button styling in billing plan comparison

### DIFF
--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.module.scss
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.module.scss
@@ -180,15 +180,10 @@ $color-on-accent: #fff;
   color: $color-accent;
 }
 
-.featuredColumn .columnAction:not(:disabled) {
-  background: $color-accent;
-  color: $color-on-accent;
-}
-
-.featuredColumn .columnAction:disabled {
-  background: $color-accent;
-  color: $color-on-accent;
-  opacity: 0.6;
+// "Current plan" indicator masquerading as a button: stays solid even when
+// disabled so it reads as a status, not a faded CTA.
+.columnActionCurrent:disabled {
+  opacity: 1;
 }
 
 // ============================================================================

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.module.scss
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.module.scss
@@ -180,12 +180,6 @@ $color-on-accent: #fff;
   color: $color-accent;
 }
 
-// "Current plan" indicator masquerading as a button: stays solid even when
-// disabled so it reads as a status, not a faded CTA.
-.columnActionCurrent:disabled {
-  opacity: 1;
-}
-
 // ============================================================================
 // Body rows (scenario, data, features)
 // ============================================================================

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
@@ -394,8 +394,7 @@ export function BillingPlanComparisonTable({
                   <Button
                     className={cn(
                       styles.columnAction,
-                      col.action.tone === 'current' &&
-                        'disabled:opacity-100',
+                      col.action.tone === 'current' && 'disabled:opacity-100',
                     )}
                     data-testid={col.action.testId}
                     disabled={col.action.disabled || col.action.loading}

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
@@ -78,13 +78,22 @@ function resolveCheckoutProvider(
   return null;
 }
 
+type ActionTone = 'primary' | 'current' | 'muted';
+
 type ColumnAction = {
   label: string;
   loading: boolean;
   disabled: boolean;
+  tone: ActionTone;
   tooltip?: string;
   onClick?: () => void;
   testId: string;
+};
+
+const TONE_VARIANT: Record<ActionTone, 'default' | 'secondary'> = {
+  primary: 'default',
+  current: 'default',
+  muted: 'secondary',
 };
 
 type ColumnDescriptor = {
@@ -231,6 +240,8 @@ export function BillingPlanComparisonTable({
         ),
         loading: false,
         disabled: true,
+        tone:
+          !hasActiveSubscription || isTrialCurrentPlan ? 'current' : 'muted',
         tooltip: !hasActiveSubscription
           ? t('module.billing.package.actions.nonMemberTooltip')
           : undefined,
@@ -288,6 +299,11 @@ export function BillingPlanComparisonTable({
               : t('module.billing.package.actions.subscribeNow'),
         loading: checkoutKey !== null && checkoutLoadingKey === checkoutKey,
         disabled: !provider || isCurrentPlan || isDowngradeLocked,
+        tone: isCurrentPlan
+          ? 'current'
+          : isDowngradeLocked
+            ? 'muted'
+            : 'primary',
         tooltip: isDowngradeLocked
           ? t('module.billing.package.actions.upgradeOnlyTooltip')
           : undefined,
@@ -354,12 +370,16 @@ export function BillingPlanComparisonTable({
                           tabIndex={0}
                         >
                           <Button
-                            className={styles.columnAction}
+                            className={cn(
+                              styles.columnAction,
+                              col.action.tone === 'current' &&
+                                styles.columnActionCurrent,
+                            )}
                             data-testid={col.action.testId}
                             disabled={col.action.disabled || col.action.loading}
                             onClick={col.action.onClick}
                             type='button'
-                            variant='secondary'
+                            variant={TONE_VARIANT[col.action.tone]}
                           >
                             {col.action.loading
                               ? processingLabel
@@ -372,12 +392,16 @@ export function BillingPlanComparisonTable({
                   </TooltipProvider>
                 ) : (
                   <Button
-                    className={styles.columnAction}
+                    className={cn(
+                      styles.columnAction,
+                      col.action.tone === 'current' &&
+                        styles.columnActionCurrent,
+                    )}
                     data-testid={col.action.testId}
                     disabled={col.action.disabled || col.action.loading}
                     onClick={col.action.onClick}
                     type='button'
-                    variant='secondary'
+                    variant={TONE_VARIANT[col.action.tone]}
                   >
                     {col.action.loading ? processingLabel : col.action.label}
                   </Button>

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
@@ -333,80 +333,70 @@ export function BillingPlanComparisonTable({
         </colgroup>
         <thead>
           <tr>
-            {columns.map(col => (
-              <th
-                key={col.key}
-                className={cn(
-                  styles.columnHead,
-                  col.featured && styles.featuredColumn,
-                )}
-                data-testid={col.testId}
-                data-featured={col.featured ? 'true' : 'false'}
-              >
-                <div className={styles.columnTitleRow}>
-                  <span className={styles.columnTitle}>{col.title}</span>
-                  {col.badgeLabel ? (
-                    <span className={styles.columnBadge}>
-                      <Star className={styles.columnBadgeIcon} />
-                      {col.badgeLabel}
-                    </span>
-                  ) : null}
-                </div>
-                <div className={styles.columnPrice}>
-                  {col.periodLabel
-                    ? `${col.priceLabel} / ${col.periodLabel}`
-                    : col.priceLabel}
-                </div>
-                <div className={styles.columnCreditAmount}>
-                  {col.creditAmount}
-                </div>
-                {col.action.tooltip ? (
-                  <TooltipProvider delayDuration={0}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          className={styles.columnActionWrap}
-                          data-testid={`${col.action.testId}-trigger`}
-                          tabIndex={0}
-                        >
-                          <Button
-                            className={cn(
-                              styles.columnAction,
-                              col.action.tone === 'current' &&
-                                'disabled:opacity-100',
-                            )}
-                            data-testid={col.action.testId}
-                            disabled={col.action.disabled || col.action.loading}
-                            onClick={col.action.onClick}
-                            type='button'
-                            variant={TONE_VARIANT[col.action.tone]}
+            {columns.map(col => {
+              const actionButton = (
+                <Button
+                  className={cn(
+                    styles.columnAction,
+                    col.action.tone === 'current' && 'disabled:opacity-100',
+                  )}
+                  data-testid={col.action.testId}
+                  disabled={col.action.disabled || col.action.loading}
+                  onClick={col.action.onClick}
+                  type='button'
+                  variant={TONE_VARIANT[col.action.tone]}
+                >
+                  {col.action.loading ? processingLabel : col.action.label}
+                </Button>
+              );
+              return (
+                <th
+                  key={col.key}
+                  className={cn(
+                    styles.columnHead,
+                    col.featured && styles.featuredColumn,
+                  )}
+                  data-testid={col.testId}
+                  data-featured={col.featured ? 'true' : 'false'}
+                >
+                  <div className={styles.columnTitleRow}>
+                    <span className={styles.columnTitle}>{col.title}</span>
+                    {col.badgeLabel ? (
+                      <span className={styles.columnBadge}>
+                        <Star className={styles.columnBadgeIcon} />
+                        {col.badgeLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className={styles.columnPrice}>
+                    {col.periodLabel
+                      ? `${col.priceLabel} / ${col.periodLabel}`
+                      : col.priceLabel}
+                  </div>
+                  <div className={styles.columnCreditAmount}>
+                    {col.creditAmount}
+                  </div>
+                  {col.action.tooltip ? (
+                    <TooltipProvider delayDuration={0}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            className={styles.columnActionWrap}
+                            data-testid={`${col.action.testId}-trigger`}
+                            tabIndex={0}
                           >
-                            {col.action.loading
-                              ? processingLabel
-                              : col.action.label}
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>{col.action.tooltip}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
-                  <Button
-                    className={cn(
-                      styles.columnAction,
-                      col.action.tone === 'current' && 'disabled:opacity-100',
-                    )}
-                    data-testid={col.action.testId}
-                    disabled={col.action.disabled || col.action.loading}
-                    onClick={col.action.onClick}
-                    type='button'
-                    variant={TONE_VARIANT[col.action.tone]}
-                  >
-                    {col.action.loading ? processingLabel : col.action.label}
-                  </Button>
-                )}
-              </th>
-            ))}
+                            {actionButton}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{col.action.tooltip}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    actionButton
+                  )}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
@@ -373,7 +373,7 @@ export function BillingPlanComparisonTable({
                             className={cn(
                               styles.columnAction,
                               col.action.tone === 'current' &&
-                                styles.columnActionCurrent,
+                                'disabled:opacity-100',
                             )}
                             data-testid={col.action.testId}
                             disabled={col.action.disabled || col.action.loading}
@@ -395,7 +395,7 @@ export function BillingPlanComparisonTable({
                     className={cn(
                       styles.columnAction,
                       col.action.tone === 'current' &&
-                        styles.columnActionCurrent,
+                        'disabled:opacity-100',
                     )}
                     data-testid={col.action.testId}
                     disabled={col.action.disabled || col.action.loading}


### PR DESCRIPTION
## Summary

- Replace the single hardcoded `variant='secondary'` on `BillingPlanComparisonTable` action buttons with a tone-driven mapping (`primary` / `current` / `muted`) so the button color matches what the action actually means.
- Solid primary blue for both actionable CTAs (`Subscribe Now` / `Upgrade Now`) and the current-plan indicator (`Current Plan` / `Currently Using`); secondary gray for genuinely unavailable actions (`Downgrade not supported`, `Free Trial` once the user already has a paid plan).
- Drop the `.featuredColumn .columnAction` SCSS overrides that were stacking on top of `disabled:opacity-50` and double-fading the current-plan button. Add a small `.columnActionCurrent` modifier that keeps the disabled "current plan" button at full opacity so it reads as a status, not a faded CTA.

## Why

Before this change every column rendered the action as gray secondary, which made the "Upgrade Now" CTAs look disabled. Meanwhile a featured-column SCSS rule faded the current-plan button to opacity 0.6 on top of the base `disabled:opacity-50`, so the current plan was visually indistinguishable from a locked button. With the new tone mapping the visual hierarchy lines up with the action intent.

## Test plan

- [ ] `cd src/cook-web && npm run lint` is clean for the billing component
- [ ] Open the Billing → Plans tab in the local dev stack and confirm:
  - [ ] Non-current paid columns show solid primary-blue "Upgrade Now" / "Subscribe Now" buttons
  - [ ] The current-plan column shows a solid primary-blue "Current Plan" button (not faded)
  - [ ] A locked downgrade column shows a gray secondary "Downgrade not supported" button with the existing tooltip
  - [ ] When no checkout provider is available, paid columns show a faded primary-blue button (still distinguishable from "downgrade locked" which stays gray)
  - [ ] When the trial column renders for a paid user, "Free Trial" shows as gray secondary; for a non-subscriber it shows as solid primary "Currently Using"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed forced accent/opacity overrides for featured-column action buttons, improving visual consistency.
* **Improvements**
  * Action buttons in the billing plan comparison table now determine visual tone and variant dynamically based on plan/subscription state.
  * "Current" actions retain full opacity so active-plan actions display more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->