### PR TITLE
fix: avoid false draft conflict on lesson switch

### DIFF
--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -394,6 +394,34 @@ describe('ShifuEdit draft conflict checks', () => {
     expect(baseActions.setBaseRevision).toHaveBeenCalledWith(3);
   });
 
+  test('does not open conflict dialog before base revision is initialized', async () => {
+    setLessonNode();
+    mockShifuState.baseRevision = null;
+    baseActions.hasUnsavedMdflow.mockReturnValue(true);
+    baseActions.loadMdflow.mockResolvedValue(false);
+    mockLoadDraftMeta.mockResolvedValue({
+      revision: 3,
+      updated_user: { user_bid: 'user-1', phone: '13900139000' },
+    });
+
+    render(<ScriptEditor id='shifu-1' />);
+
+    await waitFor(() => {
+      expect(baseActions.loadMdflow).toHaveBeenCalledWith(
+        'lesson-1',
+        'shifu-1',
+        expect.any(Object),
+      );
+    });
+
+    expect(baseActions.setDraftConflict).not.toHaveBeenCalledWith(true);
+    expect(baseActions.setAutosavePaused).not.toHaveBeenCalledWith(true);
+    expect(
+      screen.queryByTestId('draft-conflict-dialog'),
+    ).not.toBeInTheDocument();
+    expect(baseActions.setBaseRevision).toHaveBeenCalledWith(3);
+  });
+
   test('keeps local editor typing from being echoed back as controlled content', async () => {
     setLessonNode();
     mockShifuState.mdflow = 'initial content';

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -366,6 +366,34 @@ describe('ShifuEdit draft conflict checks', () => {
     expect(baseActions.setAutosavePaused).toHaveBeenCalledWith(true);
   });
 
+  test('does not open conflict dialog on lesson switch when remote revision is not newer', async () => {
+    setLessonNode();
+    mockShifuState.baseRevision = 10;
+    baseActions.hasUnsavedMdflow.mockReturnValue(true);
+    baseActions.loadMdflow.mockResolvedValue(false);
+    mockLoadDraftMeta.mockResolvedValue({
+      revision: 3,
+      updated_user: { user_bid: 'user-1', phone: '13900139000' },
+    });
+
+    render(<ScriptEditor id='shifu-1' />);
+
+    await waitFor(() => {
+      expect(baseActions.loadMdflow).toHaveBeenCalledWith(
+        'lesson-1',
+        'shifu-1',
+        expect.any(Object),
+      );
+    });
+
+    expect(baseActions.setDraftConflict).not.toHaveBeenCalledWith(true);
+    expect(baseActions.setAutosavePaused).not.toHaveBeenCalledWith(true);
+    expect(
+      screen.queryByTestId('draft-conflict-dialog'),
+    ).not.toBeInTheDocument();
+    expect(baseActions.setBaseRevision).toHaveBeenCalledWith(3);
+  });
+
   test('keeps local editor typing from being echoed back as controlled content', async () => {
     setLessonNode();
     mockShifuState.mdflow = 'initial content';

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -390,6 +390,17 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
         const latestMeta =
           (await actionsRef.current.loadDraftMeta(shifuBid, outlineBid)) ??
           meta;
+        const latestRevision =
+          latestMeta && typeof latestMeta.revision === 'number'
+            ? latestMeta.revision
+            : typeof meta?.revision === 'number'
+              ? meta.revision
+              : null;
+        const currentBaseRevision = baseRevisionRef.current;
+        const remoteRevisionIsNewer =
+          latestRevision != null &&
+          (typeof currentBaseRevision !== 'number' ||
+            latestRevision > currentBaseRevision);
         if (
           currentShifuBidRef.current !== shifuBid ||
           currentLessonBidRef.current !== outlineBid
@@ -399,9 +410,17 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
         if (!didApplyRemote) {
           if (
             !options?.forceApply &&
+            remoteRevisionIsNewer &&
             actionsRef.current.hasUnsavedMdflow(outlineBid)
           ) {
             markDraftConflict(latestMeta ?? meta, mode);
+            return;
+          }
+          if (latestRevision != null) {
+            actionsRef.current.setBaseRevision(latestRevision);
+            if (latestMeta) {
+              actionsRef.current.setLatestDraftMeta(latestMeta);
+            }
           }
           return;
         }

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -397,10 +397,11 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
               ? meta.revision
               : null;
         const currentBaseRevision = baseRevisionRef.current;
+        const hasKnownBaseRevision = typeof currentBaseRevision === 'number';
         const remoteRevisionIsNewer =
           latestRevision != null &&
-          (typeof currentBaseRevision !== 'number' ||
-            latestRevision > currentBaseRevision);
+          hasKnownBaseRevision &&
+          latestRevision > currentBaseRevision;
         if (
           currentShifuBidRef.current !== shifuBid ||
           currentLessonBidRef.current !== outlineBid

--- a/src/cook-web/src/store/useShifu.tsx
+++ b/src/cook-web/src/store/useShifu.tsx
@@ -248,7 +248,10 @@ export const ShifuProvider = ({
       const cached = mdflowCacheRef.current[cacheKey];
       currentMdflow.current = cached;
       setMdflow(cached);
+      return;
     }
+    currentMdflow.current = '';
+    setMdflow('');
   };
   // Debounced autosave for mdflow; kept stable via ref
   const debouncedAutoSaveRef = useRef(

--- a/src/cook-web/src/store/useShifu.tsx
+++ b/src/cook-web/src/store/useShifu.tsx
@@ -250,8 +250,10 @@ export const ShifuProvider = ({
       setMdflow(cached);
       return;
     }
-    currentMdflow.current = '';
-    setMdflow('');
+    if (currentMdflow.current !== '') {
+      currentMdflow.current = '';
+      setMdflow('');
+    }
   };
   // Debounced autosave for mdflow; kept stable via ref
   const debouncedAutoSaveRef = useRef(


### PR DESCRIPTION
## Summary
- avoid carrying the previous lesson editor buffer into a newly selected lesson with no local cache
- only surface the draft conflict dialog during lesson sync when the remote revision is actually newer than the local base revision
- add a regression test covering lesson switches where the remote revision is not newer


## Testing
- cd src/cook-web && npm test -- --runInBand src/components/shifu-edit/ShifuEdit.test.tsx
- cd src/cook-web && npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved draft conflict detection to only trigger when remote revisions are newer than local versions, reducing false conflict warnings
  * Enhanced cleanup of stale content during synchronization operations

* **Tests**
  * Added test coverage for remote revision comparison scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->