### PR TITLE
feat: enhance operator course management table

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1374,6 +1374,8 @@ def _build_course_summary(
         course_name=course.title or "",
         course_status=course_status,
         price=_format_decimal(course.price),
+        course_model=str(course.llm or "").strip(),
+        course_prompt=str(course.llm_system_prompt or "").strip(),
         creator_user_bid=course.created_user_bid or "",
         creator_mobile=creator.get("mobile", ""),
         creator_email=creator.get("email", ""),

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -84,6 +84,7 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseFollowUpSummaryDTO,
     AdminOperationCourseFollowUpTimelineItemDTO,
     AdminOperationCourseDetailMetricsDTO,
+    AdminOperationCoursePromptDTO,
     AdminOperationCourseUserDTO,
     AdminOperationUserCreditGrantResultDTO,
     AdminOperationUserCreditGrantRequestDTO,
@@ -1369,13 +1370,14 @@ def _build_course_summary(
     ).strip()
     updater = user_map.get(updater_user_bid, {})
     updated_at = resolved_activity.get("updated_at") or course.updated_at
+    course_prompt = str(course.llm_system_prompt or "").strip()
     return AdminOperationCourseSummaryDTO(
         shifu_bid=course.shifu_bid or "",
         course_name=course.title or "",
         course_status=course_status,
         price=_format_decimal(course.price),
         course_model=str(course.llm or "").strip(),
-        course_prompt=str(course.llm_system_prompt or "").strip(),
+        has_course_prompt=bool(course_prompt),
         creator_user_bid=course.created_user_bid or "",
         creator_mobile=creator.get("mobile", ""),
         creator_email=creator.get("email", ""),
@@ -3030,6 +3032,26 @@ def get_operator_course_detail(
                 follow_up_count_map=follow_up_count_map,
                 rating_count_map=rating_count_map,
             ),
+        )
+
+
+def get_operator_course_prompt(
+    app: Flask,
+    *,
+    shifu_bid: str,
+) -> AdminOperationCoursePromptDTO:
+    with app.app_context():
+        normalized_shifu_bid = str(shifu_bid or "").strip()
+        if not normalized_shifu_bid:
+            raise_param_error("shifu_bid is required")
+
+        detail_source = _load_operator_course_detail_source(normalized_shifu_bid)
+        if detail_source is None:
+            raise_error("server.shifu.shifuNotFound")
+
+        course = detail_source["course"]
+        return AdminOperationCoursePromptDTO(
+            course_prompt=str(getattr(course, "llm_system_prompt", "") or "").strip()
         )
 
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1365,9 +1365,7 @@ def _load_latest_shifus(
 
 
 def _attach_course_prompt_flags(model, rows) -> None:
-    course_ids = [
-        getattr(row, "id", None) for row in rows if getattr(row, "id", None)
-    ]
+    course_ids = [getattr(row, "id", None) for row in rows if getattr(row, "id", None)]
     if not course_ids:
         return
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
 from flask import Flask, current_app
 from sqlalchemy import and_, case, or_
+from sqlalchemy.orm import defer
 
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_config
@@ -1330,6 +1331,7 @@ def _load_latest_shifus(
     updated_start_time: Optional[datetime],
     updated_end_time: Optional[datetime],
 ):
+    is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -1339,6 +1341,8 @@ def _load_latest_shifus(
     latest_rows = db.session.query(model).filter(
         model.id.in_(db.session.query(latest_subquery.c.max_id))
     )
+    if is_mapped_model:
+        latest_rows = latest_rows.options(defer(model.llm_system_prompt))
     if course_name:
         latest_rows = latest_rows.filter(model.title.ilike(f"%{course_name}%"))
     if creator_bids is not None:
@@ -1354,7 +1358,46 @@ def _load_latest_shifus(
     if updated_end_time:
         latest_rows = latest_rows.filter(model.updated_at <= updated_end_time)
 
-    return latest_rows.order_by(model.updated_at.desc(), model.id.desc()).all()
+    rows = latest_rows.order_by(model.updated_at.desc(), model.id.desc()).all()
+    if is_mapped_model:
+        _attach_course_prompt_flags(model, rows)
+    return rows
+
+
+def _attach_course_prompt_flags(model, rows) -> None:
+    course_ids = [
+        getattr(row, "id", None) for row in rows if getattr(row, "id", None)
+    ]
+    if not course_ids:
+        return
+
+    has_course_prompt_rows = (
+        db.session.query(
+            model.id,
+            case(
+                (
+                    db.func.length(
+                        db.func.trim(db.func.coalesce(model.llm_system_prompt, ""))
+                    )
+                    > 0,
+                    True,
+                ),
+                else_=False,
+            ).label("has_course_prompt"),
+        )
+        .filter(model.id.in_(course_ids))
+        .all()
+    )
+    has_course_prompt_map = {
+        row_id: bool(has_course_prompt)
+        for row_id, has_course_prompt in has_course_prompt_rows
+    }
+    for row in rows:
+        setattr(
+            row,
+            "has_course_prompt",
+            bool(has_course_prompt_map.get(getattr(row, "id", None), False)),
+        )
 
 
 def _build_course_summary(
@@ -1370,14 +1413,18 @@ def _build_course_summary(
     ).strip()
     updater = user_map.get(updater_user_bid, {})
     updated_at = resolved_activity.get("updated_at") or course.updated_at
-    course_prompt = str(course.llm_system_prompt or "").strip()
+    has_course_prompt = getattr(course, "has_course_prompt", None)
+    if has_course_prompt is None:
+        has_course_prompt = bool(
+            str(getattr(course, "llm_system_prompt", "") or "").strip()
+        )
     return AdminOperationCourseSummaryDTO(
         shifu_bid=course.shifu_bid or "",
         course_name=course.title or "",
         course_status=course_status,
         price=_format_decimal(course.price),
         course_model=str(course.llm or "").strip(),
-        has_course_prompt=bool(course_prompt),
+        has_course_prompt=bool(has_course_prompt),
         creator_user_bid=course.created_user_bid or "",
         creator_mobile=creator.get("mobile", ""),
         creator_email=creator.get("email", ""),

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -17,6 +17,10 @@ class AdminOperationCourseSummaryDTO(BaseModel):
     course_name: str = Field(..., description="Course name", required=False)
     course_status: str = Field(..., description="Course status", required=False)
     price: str = Field(..., description="Course price", required=False)
+    course_model: str = Field(..., description="Course model", required=False)
+    course_prompt: str = Field(
+        ..., description="Course-level system prompt", required=False
+    )
     creator_user_bid: str = Field(
         ..., description="Creator user business identifier", required=False
     )
@@ -38,6 +42,8 @@ class AdminOperationCourseSummaryDTO(BaseModel):
         course_name: str,
         course_status: str,
         price: str,
+        course_model: str,
+        course_prompt: str,
         creator_user_bid: str,
         creator_mobile: str,
         creator_email: str,
@@ -54,6 +60,8 @@ class AdminOperationCourseSummaryDTO(BaseModel):
             course_name=course_name,
             course_status=course_status,
             price=price,
+            course_model=course_model,
+            course_prompt=course_prompt,
             creator_user_bid=creator_user_bid,
             creator_mobile=creator_mobile,
             creator_email=creator_email,
@@ -72,6 +80,8 @@ class AdminOperationCourseSummaryDTO(BaseModel):
             "course_name": self.course_name,
             "course_status": self.course_status,
             "price": self.price,
+            "course_model": self.course_model,
+            "course_prompt": self.course_prompt,
             "creator_user_bid": self.creator_user_bid,
             "creator_mobile": self.creator_mobile,
             "creator_email": self.creator_email,

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -18,8 +18,10 @@ class AdminOperationCourseSummaryDTO(BaseModel):
     course_status: str = Field(..., description="Course status", required=False)
     price: str = Field(..., description="Course price", required=False)
     course_model: str = Field(..., description="Course model", required=False)
-    course_prompt: str = Field(
-        ..., description="Course-level system prompt", required=False
+    has_course_prompt: bool = Field(
+        ...,
+        description="Whether the course has a course-level system prompt",
+        required=False,
     )
     creator_user_bid: str = Field(
         ..., description="Creator user business identifier", required=False
@@ -43,7 +45,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
         course_status: str,
         price: str,
         course_model: str,
-        course_prompt: str,
+        has_course_prompt: bool,
         creator_user_bid: str,
         creator_mobile: str,
         creator_email: str,
@@ -61,7 +63,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
             course_status=course_status,
             price=price,
             course_model=course_model,
-            course_prompt=course_prompt,
+            has_course_prompt=has_course_prompt,
             creator_user_bid=creator_user_bid,
             creator_mobile=creator_mobile,
             creator_email=creator_email,
@@ -81,7 +83,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
             "course_status": self.course_status,
             "price": self.price,
             "course_model": self.course_model,
-            "course_prompt": self.course_prompt,
+            "has_course_prompt": self.has_course_prompt,
             "creator_user_bid": self.creator_user_bid,
             "creator_mobile": self.creator_mobile,
             "creator_email": self.creator_email,
@@ -475,6 +477,18 @@ class AdminOperationCourseUserDTO(BaseModel):
     )
     last_login_at: str = Field(
         default="", description="Latest login timestamp", required=False
+    )
+
+    def __json__(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
+@register_schema_to_swagger
+class AdminOperationCoursePromptDTO(BaseModel):
+    """Operator-facing course prompt payload."""
+
+    course_prompt: str = Field(
+        ..., description="Course-level system prompt", required=False
     )
 
     def __json__(self) -> dict[str, Any]:

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -106,6 +106,7 @@ from flaskr.service.shifu.admin import (
     OPERATOR_ORDER_LIST_MAX_PAGE_SIZE,
     get_operator_course_follow_up_detail,
     get_operator_course_follow_ups,
+    get_operator_course_prompt,
     get_operator_user_detail,
     get_operator_user_credits,
     grant_operator_user_credits,
@@ -1162,6 +1163,17 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 operator_user_bid=str(getattr(request.user, "user_id", "") or ""),
                 payload=payload,
             )
+        )
+
+    @app.route(
+        path_prefix + "/admin/operations/courses/<shifu_bid>/prompt",
+        methods=["GET"],
+    )
+    def admin_operation_course_prompt(shifu_bid: str):
+        """Get operator course prompt."""
+        _require_operator()
+        return make_common_response(
+            get_operator_course_prompt(app, shifu_bid=shifu_bid)
         )
 
     @app.route(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1033,7 +1033,10 @@ def test_admin_operation_course_prompt_route_returns_course_prompt(
             creator_user_bid="creator-1",
             created_at=updated_at,
             updated_at=updated_at,
-            llm_system_prompt="course system prompt",
+        )
+        DraftShifu.query.filter(DraftShifu.shifu_bid == "course-detail").update(
+            {DraftShifu.llm_system_prompt: "course system prompt"},
+            synchronize_session=False,
         )
         db.session.commit()
 

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -996,6 +996,7 @@ def test_admin_operation_course_detail_route_sorts_numeric_positions_and_surface
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/shifu/admin/operations/courses/course-detail/prompt",
         "/api/shifu/admin/operations/courses/course-detail/detail",
         "/api/shifu/admin/operations/courses/course-detail/chapters/lesson-1/detail",
         "/api/shifu/admin/operations/courses/course-detail/users?page=1&page_size=20",
@@ -1015,6 +1016,38 @@ def test_admin_operation_course_detail_routes_require_operator(
 
     assert response.status_code == 200
     assert payload["code"] == 401
+
+
+def test_admin_operation_course_prompt_route_returns_course_prompt(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    updated_at = datetime(2026, 4, 3, 15, 30, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=updated_at,
+            updated_at=updated_at,
+            llm_system_prompt="course system prompt",
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/prompt",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"] == {
+        "course_prompt": "course system prompt",
+    }
 
 
 def test_admin_operation_course_chapter_detail_route_returns_prompt_content(

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -117,7 +117,7 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     assert item.course_status == "published"
     assert item.price == "199"
     assert item.course_model == "gpt-4.1-mini"
-    assert item.course_prompt == "You are a patient course assistant."
+    assert item.has_course_prompt is True
     assert item.creator_mobile == "15811112222"
     assert item.creator_email == "creator@example.com"
     assert item.creator_nickname == "Creator Mars"

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -30,10 +30,14 @@ class DummyCourse:
         updated_user_bid: str,
         created_at: datetime,
         updated_at: datetime,
+        llm: str = "",
+        llm_system_prompt: str = "",
     ):
         self.shifu_bid = shifu_bid
         self.title = title
         self.price = price
+        self.llm = llm
+        self.llm_system_prompt = llm_system_prompt
         self.created_user_bid = created_user_bid
         self.updated_user_bid = updated_user_bid
         self.created_at = created_at
@@ -52,6 +56,8 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
         updated_user_bid="editor-1",
         created_at=datetime(2025, 4, 1, 10, 0, 0),
         updated_at=datetime(2025, 4, 3, 10, 0, 0),
+        llm="gpt-4.1-mini",
+        llm_system_prompt="You are a patient course assistant.",
     )
     published_course = DummyCourse(
         shifu_bid="course-1",
@@ -110,6 +116,8 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     assert item.course_name == "Draft Course"
     assert item.course_status == "published"
     assert item.price == "199"
+    assert item.course_model == "gpt-4.1-mini"
+    assert item.course_prompt == "You are a patient course assistant."
     assert item.creator_mobile == "15811112222"
     assert item.creator_email == "creator@example.com"
     assert item.creator_nickname == "Creator Mars"

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -38,6 +38,7 @@ class DummyCourse:
         self.price = price
         self.llm = llm
         self.llm_system_prompt = llm_system_prompt
+        self.has_course_prompt = bool(str(llm_system_prompt or "").strip())
         self.created_user_bid = created_user_bid
         self.updated_user_bid = updated_user_bid
         self.created_at = created_at

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -137,6 +137,8 @@ const api = {
   grantAdminOperationUserCredits:
     'POST /shifu/admin/operations/users/{user_bid}/credits/grant',
   getAdminOperationCourses: 'GET /shifu/admin/operations/courses',
+  getAdminOperationCoursePrompt:
+    'GET /shifu/admin/operations/courses/{shifu_bid}/prompt',
   getAdminOperationCourseDetail:
     'GET /shifu/admin/operations/courses/{shifu_bid}/detail',
   getAdminOperationCourseUsers:

--- a/src/cook-web/src/app/admin/operations/operation-course-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-course-types.ts
@@ -5,6 +5,8 @@ export type AdminOperationCourseItem = {
   course_name: string;
   course_status: string;
   price: string;
+  course_model: string;
+  course_prompt: string;
   creator_user_bid: string;
   creator_mobile: string;
   creator_email: string;

--- a/src/cook-web/src/app/admin/operations/operation-course-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-course-types.ts
@@ -6,7 +6,7 @@ export type AdminOperationCourseItem = {
   course_status: string;
   price: string;
   course_model: string;
-  course_prompt: string;
+  has_course_prompt: boolean;
   creator_user_bid: string;
   creator_mobile: string;
   creator_email: string;
@@ -25,6 +25,10 @@ export type AdminOperationCourseListResponse = {
   page_count: number;
   page_size: number;
   total: number;
+};
+
+export type AdminOperationCoursePromptResponse = {
+  course_prompt: string;
 };
 
 export type AdminOperationCourseDetailBasicInfo = {

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -631,50 +631,50 @@ describe('OperationsPage', () => {
       .mockReturnValue(0);
 
     try {
-    await renderAndWaitForLoadedPage();
+      await renderAndWaitForLoadedPage();
 
-    const firstRow = screen.getByText('Course 1').closest('tr');
-    expect(firstRow).not.toBeNull();
+      const firstRow = screen.getByText('Course 1').closest('tr');
+      expect(firstRow).not.toBeNull();
 
-    fireEvent.click(
-      within(firstRow as HTMLElement).getByRole('button', {
-        name: 'module.operationsCourse.table.detailAction',
-      }),
-    );
+      fireEvent.click(
+        within(firstRow as HTMLElement).getByRole('button', {
+          name: 'module.operationsCourse.table.detailAction',
+        }),
+      );
 
-    await waitFor(() => {
-      expect(mockGetAdminOperationCoursePrompt).toHaveBeenCalledWith({
-        shifu_bid: 'course-1',
+      await waitFor(() => {
+        expect(mockGetAdminOperationCoursePrompt).toHaveBeenCalledWith({
+          shifu_bid: 'course-1',
+        });
       });
-    });
 
-    expect(
-      screen.getByText('module.operationsCourse.coursePromptDialog.title'),
-    ).toBeInTheDocument();
-    expect(await screen.findByText(LONG_COURSE_PROMPT)).toBeInTheDocument();
-    const promptDialog = screen.getByRole('dialog');
+      expect(
+        screen.getByText('module.operationsCourse.coursePromptDialog.title'),
+      ).toBeInTheDocument();
+      expect(await screen.findByText(LONG_COURSE_PROMPT)).toBeInTheDocument();
+      const promptDialog = screen.getByRole('dialog');
 
-    fireEvent.click(
-      within(promptDialog).getByRole('button', {
-        name: 'module.operationsCourse.coursePromptDialog.copy',
-      }),
-    );
+      fireEvent.click(
+        within(promptDialog).getByRole('button', {
+          name: 'module.operationsCourse.coursePromptDialog.copy',
+        }),
+      );
 
-    await waitFor(() => {
-      expect(mockCopyText).toHaveBeenCalledWith(LONG_COURSE_PROMPT);
-    });
+      await waitFor(() => {
+        expect(mockCopyText).toHaveBeenCalledWith(LONG_COURSE_PROMPT);
+      });
 
-    fireEvent.click(
-      await within(promptDialog).findByRole('button', {
-        name: 'common.core.expand',
-      }),
-    );
+      fireEvent.click(
+        await within(promptDialog).findByRole('button', {
+          name: 'common.core.expand',
+        }),
+      );
 
-    expect(
-      within(promptDialog).getByRole('button', {
-        name: 'common.core.collapse',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        within(promptDialog).getByRole('button', {
+          name: 'common.core.collapse',
+        }),
+      ).toBeInTheDocument();
     } finally {
       scrollHeightSpy.mockRestore();
       clientHeightSpy.mockRestore();

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -18,6 +18,8 @@ const originalLocation = window.location;
 const originalFetch = global.fetch;
 const originalWindow = global.window;
 const RETRY_LABEL = 'retry';
+const LONG_COURSE_PROMPT =
+  'You are a patient course assistant. Help learners build understanding step by step, summarize key ideas clearly, and always connect each answer back to the course context.';
 
 const mockUserState: {
   isInitialized: boolean;
@@ -410,6 +412,8 @@ describe('OperationsPage', () => {
           course_name: 'Course 1',
           course_status: 'published',
           price: '99',
+          course_model: 'gpt-4.1-mini',
+          course_prompt: LONG_COURSE_PROMPT,
           creator_user_bid: 'creator-1',
           creator_mobile: '15811112222',
           creator_email: 'creator@example.com',
@@ -426,6 +430,8 @@ describe('OperationsPage', () => {
           course_name: 'Custom System Course',
           course_status: 'unpublished',
           price: '0',
+          course_model: '',
+          course_prompt: '',
           creator_user_bid: 'system',
           creator_mobile: '',
           creator_email: '',
@@ -473,6 +479,12 @@ describe('OperationsPage', () => {
     );
 
     expect(screen.getByText('Course 1')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4.1-mini')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'module.operationsCourse.table.detailAction',
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByText('creator@example.com')).toBeInTheDocument();
     expect(screen.getByText('Creator Mars')).toBeInTheDocument();
     expect(screen.getByText('editor@example.com')).toBeInTheDocument();
@@ -589,6 +601,37 @@ describe('OperationsPage', () => {
     expect(
       screen.queryByText('module.operationsCourse.transferCreatorDialog.title'),
     ).not.toBeInTheDocument();
+  });
+
+  test('opens course prompt detail dialog and toggles expand state', async () => {
+    await renderAndWaitForLoadedPage();
+
+    const firstRow = screen.getByText('Course 1').closest('tr');
+    expect(firstRow).not.toBeNull();
+
+    fireEvent.click(
+      within(firstRow as HTMLElement).getByRole('button', {
+        name: 'module.operationsCourse.table.detailAction',
+      }),
+    );
+
+    expect(
+      screen.getByText('module.operationsCourse.coursePromptDialog.title'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(LONG_COURSE_PROMPT)).toBeInTheDocument();
+    const promptDialog = screen.getByRole('dialog');
+
+    fireEvent.click(
+      within(promptDialog).getByRole('button', {
+        name: 'common.core.expand',
+      }),
+    );
+
+    expect(
+      within(promptDialog).getByRole('button', {
+        name: 'common.core.collapse',
+      }),
+    ).toBeInTheDocument();
   });
 
   test('clears search input with the right-side clear action', async () => {
@@ -719,6 +762,8 @@ describe('OperationsPage', () => {
           course_name: 'Course 1',
           course_status: 'published',
           price: '99',
+          course_model: 'gpt-4.1-mini',
+          course_prompt: LONG_COURSE_PROMPT,
           creator_user_bid: 'creator-1',
           creator_mobile: '15811112222',
           creator_email: 'creator@example.com',
@@ -828,6 +873,8 @@ describe('OperationsPage', () => {
           course_name: 'Course Second',
           course_status: 'published',
           price: '29',
+          course_model: 'gpt-4.1',
+          course_prompt: 'Second search prompt',
           creator_user_bid: 'creator-2',
           creator_mobile: '15899990000',
           creator_email: 'second@example.com',
@@ -855,6 +902,8 @@ describe('OperationsPage', () => {
           course_name: 'Course First',
           course_status: 'published',
           price: '19',
+          course_model: 'gpt-4.1',
+          course_prompt: 'First search prompt',
           creator_user_bid: 'creator-1',
           creator_mobile: '15888880000',
           creator_email: 'first@example.com',

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -14,6 +14,7 @@ const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockToast = jest.fn();
 const mockErrorDisplay = jest.fn();
+const mockCopyText = jest.fn();
 const originalLocation = window.location;
 const originalFetch = global.fetch;
 const originalWindow = global.window;
@@ -44,6 +45,7 @@ jest.mock('@/api', () => ({
   __esModule: true,
   default: {
     getAdminOperationCourses: jest.fn(),
+    getAdminOperationCoursePrompt: jest.fn(),
     transferAdminOperationCourseCreator: jest.fn(),
   },
 }));
@@ -92,6 +94,10 @@ jest.mock('@/hooks/useToast', () => ({
   useToast: () => ({
     toast: mockToast,
   }),
+}));
+
+jest.mock('@/c-utils/textutils', () => ({
+  copyText: (...args: unknown[]) => mockCopyText(...args),
 }));
 
 jest.mock('@/components/ErrorDisplay', () => ({
@@ -342,6 +348,8 @@ jest.mock('@/components/ui/DropdownMenu', () => {
 });
 
 const mockGetAdminOperationCourses = api.getAdminOperationCourses as jest.Mock;
+const mockGetAdminOperationCoursePrompt =
+  api.getAdminOperationCoursePrompt as jest.Mock;
 const mockTransferAdminOperationCourseCreator =
   api.transferAdminOperationCourseCreator as jest.Mock;
 
@@ -392,7 +400,9 @@ describe('OperationsPage', () => {
     mockPush.mockReset();
     mockToast.mockReset();
     mockErrorDisplay.mockReset();
+    mockCopyText.mockReset();
     mockGetAdminOperationCourses.mockReset();
+    mockGetAdminOperationCoursePrompt.mockReset();
     mockTransferAdminOperationCourseCreator.mockReset();
     mockUserState.isInitialized = true;
     mockUserState.isGuest = false;
@@ -413,7 +423,7 @@ describe('OperationsPage', () => {
           course_status: 'published',
           price: '99',
           course_model: 'gpt-4.1-mini',
-          course_prompt: LONG_COURSE_PROMPT,
+          has_course_prompt: true,
           creator_user_bid: 'creator-1',
           creator_mobile: '15811112222',
           creator_email: 'creator@example.com',
@@ -431,7 +441,7 @@ describe('OperationsPage', () => {
           course_status: 'unpublished',
           price: '0',
           course_model: '',
-          course_prompt: '',
+          has_course_prompt: false,
           creator_user_bid: 'system',
           creator_mobile: '',
           creator_email: '',
@@ -448,6 +458,9 @@ describe('OperationsPage', () => {
       page_count: 1,
       page_size: 20,
       total: 2,
+    });
+    mockGetAdminOperationCoursePrompt.mockResolvedValue({
+      course_prompt: LONG_COURSE_PROMPT,
     });
     mockTransferAdminOperationCourseCreator.mockResolvedValue({});
   });
@@ -604,6 +617,20 @@ describe('OperationsPage', () => {
   });
 
   test('opens course prompt detail dialog and toggles expand state', async () => {
+    const scrollHeightSpy = jest
+      .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+      .mockReturnValue(160);
+    const clientHeightSpy = jest
+      .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+      .mockReturnValue(72);
+    const scrollWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockReturnValue(0);
+    const clientWidthSpy = jest
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(0);
+
+    try {
     await renderAndWaitForLoadedPage();
 
     const firstRow = screen.getByText('Course 1').closest('tr');
@@ -615,14 +642,30 @@ describe('OperationsPage', () => {
       }),
     );
 
+    await waitFor(() => {
+      expect(mockGetAdminOperationCoursePrompt).toHaveBeenCalledWith({
+        shifu_bid: 'course-1',
+      });
+    });
+
     expect(
       screen.getByText('module.operationsCourse.coursePromptDialog.title'),
     ).toBeInTheDocument();
-    expect(screen.getByText(LONG_COURSE_PROMPT)).toBeInTheDocument();
+    expect(await screen.findByText(LONG_COURSE_PROMPT)).toBeInTheDocument();
     const promptDialog = screen.getByRole('dialog');
 
     fireEvent.click(
       within(promptDialog).getByRole('button', {
+        name: 'module.operationsCourse.coursePromptDialog.copy',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith(LONG_COURSE_PROMPT);
+    });
+
+    fireEvent.click(
+      await within(promptDialog).findByRole('button', {
         name: 'common.core.expand',
       }),
     );
@@ -632,6 +675,12 @@ describe('OperationsPage', () => {
         name: 'common.core.collapse',
       }),
     ).toBeInTheDocument();
+    } finally {
+      scrollHeightSpy.mockRestore();
+      clientHeightSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+      clientWidthSpy.mockRestore();
+    }
   });
 
   test('clears search input with the right-side clear action', async () => {
@@ -763,7 +812,7 @@ describe('OperationsPage', () => {
           course_status: 'published',
           price: '99',
           course_model: 'gpt-4.1-mini',
-          course_prompt: LONG_COURSE_PROMPT,
+          has_course_prompt: true,
           creator_user_bid: 'creator-1',
           creator_mobile: '15811112222',
           creator_email: 'creator@example.com',
@@ -822,14 +871,14 @@ describe('OperationsPage', () => {
 
   test('ignores stale responses when a newer search finishes later', async () => {
     const firstSearch = createDeferred<{
-      items: Array<Record<string, string>>;
+      items: Array<Record<string, string | boolean>>;
       page: number;
       page_count: number;
       page_size: number;
       total: number;
     }>();
     const secondSearch = createDeferred<{
-      items: Array<Record<string, string>>;
+      items: Array<Record<string, string | boolean>>;
       page: number;
       page_count: number;
       page_size: number;
@@ -874,7 +923,7 @@ describe('OperationsPage', () => {
           course_status: 'published',
           price: '29',
           course_model: 'gpt-4.1',
-          course_prompt: 'Second search prompt',
+          has_course_prompt: true,
           creator_user_bid: 'creator-2',
           creator_mobile: '15899990000',
           creator_email: 'second@example.com',
@@ -903,7 +952,7 @@ describe('OperationsPage', () => {
           course_status: 'published',
           price: '19',
           course_model: 'gpt-4.1',
-          course_prompt: 'First search prompt',
+          has_course_prompt: true,
           creator_user_bid: 'creator-1',
           creator_mobile: '15888880000',
           creator_email: 'first@example.com',

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -1382,7 +1382,9 @@ const OperationsPage = () => {
           <DialogContent className='w-[min(88vw,760px)] max-w-[760px] p-0'>
             <DialogHeader className='border-b border-border px-6 py-4 pr-12'>
               <div className='flex items-center justify-between gap-4'>
-                <DialogTitle>{tOperations('coursePromptDialog.title')}</DialogTitle>
+                <DialogTitle>
+                  {tOperations('coursePromptDialog.title')}
+                </DialogTitle>
                 <Button
                   type='button'
                   variant='outline'

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -6,10 +6,11 @@ import React, {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
 } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronUp, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Copy, X } from 'lucide-react';
 import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
@@ -69,6 +70,7 @@ import {
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { useToast } from '@/hooks/useToast';
+import { copyText } from '@/c-utils/textutils';
 import { ErrorWithCode } from '@/lib/request';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { cn } from '@/lib/utils';
@@ -102,13 +104,15 @@ const COLUMN_MAX_WIDTH = 360;
 const COLUMN_WIDTH_STORAGE_KEY = 'adminOperationsColumnWidths';
 const DEFAULT_COLUMN_WIDTHS = {
   courseId: 260,
-  courseName: 180,
-  price: 90,
+  courseName: 220,
   status: 110,
+  price: 90,
+  model: 170,
+  coursePrompt: 120,
   creator: 170,
   modifier: 170,
-  createdAt: 170,
   updatedAt: 170,
+  createdAt: 170,
   action: 115,
 } as const;
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
@@ -117,6 +121,14 @@ const SINGLE_SELECT_ITEM_CLASS =
   'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
 const TRANSFER_PHONE_PATTERN = /^\d{11}$/;
 const EMPTY_STATE_LABEL = '--';
+const TABLE_INLINE_ACTION_BUTTON_CLASS =
+  'inline-flex h-8 items-center justify-center rounded-md px-2.5 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2';
+const COLLAPSED_TEXT_STYLE: CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 6,
+  overflow: 'hidden',
+};
 
 type TransferContactType = 'email' | 'phone';
 
@@ -219,15 +231,23 @@ const ClearableTextInput = ({
  * t('module.operationsCourse.filters.endTime')
  * t('module.operationsCourse.statusLabels.published')
  * t('module.operationsCourse.statusLabels.unpublished')
- * t('module.operationsCourse.table.courseId')
  * t('module.operationsCourse.table.courseName')
- * t('module.operationsCourse.table.price')
+ * t('module.operationsCourse.table.courseId')
  * t('module.operationsCourse.table.status')
+ * t('module.operationsCourse.table.price')
+ * t('module.operationsCourse.table.model')
+ * t('module.operationsCourse.table.coursePrompt')
+ * t('module.operationsCourse.table.detailAction')
  * t('module.operationsCourse.table.creator')
  * t('module.operationsCourse.table.modifier')
- * t('module.operationsCourse.table.createdAt')
  * t('module.operationsCourse.table.updatedAt')
+ * t('module.operationsCourse.table.createdAt')
  * t('module.operationsCourse.table.action')
+ * t('module.operationsCourse.coursePromptDialog.title')
+ * t('module.operationsCourse.coursePromptDialog.copy')
+ * t('module.operationsCourse.coursePromptDialog.copySuccess')
+ * t('module.operationsCourse.coursePromptDialog.copyFailed')
+ * t('module.operationsCourse.coursePromptDialog.empty')
  * t('module.operationsCourse.transferCreatorDialog.title')
  * t('module.operationsCourse.transferCreatorDialog.description')
  * t('module.operationsCourse.transferCreatorDialog.currentCreator')
@@ -331,6 +351,9 @@ const OperationsPage = () => {
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const [expanded, setExpanded] = useState(false);
+  const [coursePromptExpanded, setCoursePromptExpanded] = useState(false);
+  const [promptDetailCourse, setPromptDetailCourse] =
+    useState<AdminOperationCourseItem | null>(null);
   const [transferDialogOpen, setTransferDialogOpen] = useState(false);
   const [transferTargetCourse, setTransferTargetCourse] =
     useState<AdminOperationCourseItem | null>(null);
@@ -366,6 +389,26 @@ const OperationsPage = () => {
   );
   const defaultUserName = useMemo(() => t('module.user.defaultUserName'), [t]);
   const displayStatusValue = filters.course_status || ALL_OPTION_VALUE;
+  const promptDetailText = promptDetailCourse?.course_prompt?.trim() || '';
+  const canTogglePromptDetail = promptDetailText.length > 80;
+
+  const handleCopyCoursePrompt = useCallback(async () => {
+    if (!promptDetailText) {
+      return;
+    }
+
+    try {
+      await copyText(promptDetailText);
+      toast({
+        title: tOperations('coursePromptDialog.copySuccess'),
+      });
+    } catch {
+      toast({
+        title: tOperations('coursePromptDialog.copyFailed'),
+        variant: 'destructive',
+      });
+    }
+  }, [promptDetailText, tOperations, toast]);
 
   const fetchCourses = useCallback(
     async (targetPage: number, nextFilters?: CourseFilters) => {
@@ -454,6 +497,24 @@ const OperationsPage = () => {
     }
     router.push(detailUrl);
   };
+
+  const handlePromptDetailOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setPromptDetailCourse(null);
+      setCoursePromptExpanded(false);
+    }
+  }, []);
+
+  const handlePromptDetailClick = useCallback(
+    (course: AdminOperationCourseItem) => {
+      if (!course.course_prompt?.trim()) {
+        return;
+      }
+      setPromptDetailCourse(course);
+      setCoursePromptExpanded(false);
+    },
+    [],
+  );
 
   const handleTransferDialogOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -802,10 +863,16 @@ const OperationsPage = () => {
         ColumnKey,
         (course: AdminOperationCourseItem) => string[]
       > = {
-        courseId: course => [course.shifu_bid],
         courseName: course => [course.course_name],
-        price: course => [formatMoney(course.price)],
+        courseId: course => [course.shifu_bid],
         status: course => [resolveCourseStatusLabel(course.course_status)],
+        price: course => [formatMoney(course.price)],
+        model: course => [course.course_model],
+        coursePrompt: course => [
+          course.course_prompt?.trim()
+            ? tOperations('table.detailAction')
+            : EMPTY_STATE_LABEL,
+        ],
         creator: course => [
           resolveActorDisplay(course, 'creator').primary,
           resolveActorDisplay(course, 'creator').secondary,
@@ -814,8 +881,8 @@ const OperationsPage = () => {
           resolveActorDisplay(course, 'updater').primary,
           resolveActorDisplay(course, 'updater').secondary,
         ],
-        createdAt: course => [course.created_at],
         updatedAt: course => [course.updated_at],
+        createdAt: course => [course.created_at],
         action: () => [t('common.core.more')],
       };
 
@@ -826,14 +893,16 @@ const OperationsPage = () => {
             return;
           }
           const multiplierMap: Partial<Record<ColumnKey, number>> = {
-            courseId: 5,
             courseName: 4.5,
-            price: 4,
+            courseId: 5,
             status: 5,
+            price: 4,
+            model: 4.2,
+            coursePrompt: 5.5,
             creator: 4.6,
             modifier: 4.6,
-            createdAt: 4.8,
             updatedAt: 4.8,
+            createdAt: 4.8,
             action: 4.2,
           };
           const multiplier = multiplierMap[key] ?? 7;
@@ -878,6 +947,7 @@ const OperationsPage = () => {
       resolveCourseStatusLabel,
       setColumnWidths,
       t,
+      tOperations,
     ],
   );
 
@@ -1038,7 +1108,7 @@ const OperationsPage = () => {
           loading={loading}
           isEmpty={courses.length === 0}
           emptyContent={tOperations('emptyList')}
-          emptyColSpan={9}
+          emptyColSpan={11}
           withTooltipProvider
           tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
           table={emptyRow => (
@@ -1061,6 +1131,13 @@ const OperationsPage = () => {
                   </TableHead>
                   <TableHead
                     className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('status')}
+                  >
+                    {tOperations('table.status')}
+                    {renderResizeHandle('status')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                     style={getColumnStyle('price')}
                   >
                     {tOperations('table.price')}
@@ -1068,10 +1145,17 @@ const OperationsPage = () => {
                   </TableHead>
                   <TableHead
                     className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
-                    style={getColumnStyle('status')}
+                    style={getColumnStyle('model')}
                   >
-                    {tOperations('table.status')}
-                    {renderResizeHandle('status')}
+                    {tOperations('table.model')}
+                    {renderResizeHandle('model')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('coursePrompt')}
+                  >
+                    {tOperations('table.coursePrompt')}
+                    {renderResizeHandle('coursePrompt')}
                   </TableHead>
                   <TableHead
                     className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
@@ -1089,17 +1173,17 @@ const OperationsPage = () => {
                   </TableHead>
                   <TableHead
                     className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
-                    style={getColumnStyle('createdAt')}
-                  >
-                    {tOperations('table.createdAt')}
-                    {renderResizeHandle('createdAt')}
-                  </TableHead>
-                  <TableHead
-                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
                     style={getColumnStyle('updatedAt')}
                   >
                     {tOperations('table.updatedAt')}
                     {renderResizeHandle('updatedAt')}
+                  </TableHead>
+                  <TableHead
+                    className={ADMIN_TABLE_HEADER_CELL_CENTER_CLASS}
+                    style={getColumnStyle('createdAt')}
+                  >
+                    {tOperations('table.createdAt')}
+                    {renderResizeHandle('createdAt')}
                   </TableHead>
                   <TableHead
                     className={getAdminStickyRightHeaderClass('text-center')}
@@ -1119,92 +1203,119 @@ const OperationsPage = () => {
                   return (
                     <TableRow key={course.shifu_bid}>
                       <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('courseId')}
                       >
-                        {renderTooltipText(course.shifu_bid)}
+                        {renderTooltipText(course.shifu_bid, 'mx-auto block')}
                       </TableCell>
                       <TableCell
-                        className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-ellipsis'
+                        className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('courseName')}
                       >
                         <button
                           type='button'
-                          className='block max-w-full text-left text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
+                          className='mx-auto block max-w-full text-center text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
                           onClick={() => handleDetailClick(course)}
                         >
                           {renderTooltipText(
                             course.course_name,
-                            'truncate text-left',
+                            'truncate text-center',
                           )}
                         </button>
                       </TableCell>
                       <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('price')}
-                      >
-                        {renderTooltipText(
-                          formatMoney(course.price),
-                          'text-foreground',
-                        )}
-                      </TableCell>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('status')}
                       >
                         {renderTooltipText(
                           resolveCourseStatusLabel(course.course_status),
-                          'text-foreground',
+                          'mx-auto block text-foreground',
                         )}
                       </TableCell>
                       <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
+                        style={getColumnStyle('price')}
+                      >
+                        {renderTooltipText(
+                          formatMoney(course.price),
+                          'mx-auto block text-foreground',
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
+                        style={getColumnStyle('model')}
+                      >
+                        {renderTooltipText(
+                          course.course_model,
+                          'mx-auto block text-foreground',
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
+                        style={getColumnStyle('coursePrompt')}
+                      >
+                        {course.course_prompt?.trim() ? (
+                          <button
+                            type='button'
+                            className='text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
+                            onClick={() => handlePromptDetailClick(course)}
+                          >
+                            {tOperations('table.detailAction')}
+                          </button>
+                        ) : (
+                          renderTooltipText(undefined, 'text-foreground')
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('creator')}
                       >
-                        <div className='flex flex-col gap-0.5 leading-tight'>
+                        <div className='flex flex-col items-center gap-0.5 leading-tight'>
                           {renderTooltipText(
                             creatorDisplay.primary,
-                            'text-foreground whitespace-nowrap',
+                            'mx-auto block text-foreground whitespace-nowrap text-center',
                           )}
                           {creatorDisplay.secondary
                             ? renderTooltipText(
                                 creatorDisplay.secondary,
-                                'text-xs text-muted-foreground',
+                                'mx-auto block text-xs text-muted-foreground text-center',
                               )
                             : null}
                         </div>
                       </TableCell>
                       <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('modifier')}
                       >
-                        <div className='flex flex-col gap-0.5 leading-tight'>
+                        <div className='flex flex-col items-center gap-0.5 leading-tight'>
                           {renderTooltipText(
                             updaterDisplay.primary,
-                            'text-foreground whitespace-nowrap',
+                            'mx-auto block text-foreground whitespace-nowrap text-center',
                           )}
                           {updaterDisplay.secondary
                             ? renderTooltipText(
                                 updaterDisplay.secondary,
-                                'text-xs text-muted-foreground',
+                                'mx-auto block text-xs text-muted-foreground text-center',
                               )
                             : null}
                         </div>
                       </TableCell>
                       <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
-                        style={getColumnStyle('createdAt')}
-                      >
-                        {renderTooltipText(
-                          formatAdminUtcDateTime(course.created_at),
-                        )}
-                      </TableCell>
-                      <TableCell
-                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-ellipsis'
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('updatedAt')}
                       >
                         {renderTooltipText(
                           formatAdminUtcDateTime(course.updated_at),
+                          'mx-auto block',
+                        )}
+                      </TableCell>
+                      <TableCell
+                        className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
+                        style={getColumnStyle('createdAt')}
+                      >
+                        {renderTooltipText(
+                          formatAdminUtcDateTime(course.created_at),
+                          'mx-auto block',
                         )}
                       </TableCell>
                       <TableCell
@@ -1218,7 +1329,10 @@ const OperationsPage = () => {
                             <DropdownMenuTrigger asChild>
                               <button
                                 type='button'
-                                className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
+                                className={cn(
+                                  TABLE_INLINE_ACTION_BUTTON_CLASS,
+                                  'gap-1',
+                                )}
                               >
                                 {t('common.core.more')}
                                 <ChevronDown className='h-3.5 w-3.5' />
@@ -1261,6 +1375,61 @@ const OperationsPage = () => {
             />
           }
         />
+        <Dialog
+          open={Boolean(promptDetailCourse)}
+          onOpenChange={handlePromptDetailOpenChange}
+        >
+          <DialogContent className='w-[min(88vw,760px)] max-w-[760px] p-0'>
+            <DialogHeader className='border-b border-border px-6 py-4 pr-12'>
+              <div className='flex items-center justify-between gap-4'>
+                <DialogTitle>{tOperations('coursePromptDialog.title')}</DialogTitle>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  className='gap-2'
+                  onClick={handleCopyCoursePrompt}
+                  disabled={!promptDetailText}
+                >
+                  <Copy className='h-4 w-4' />
+                  {tOperations('coursePromptDialog.copy')}
+                </Button>
+              </div>
+            </DialogHeader>
+            <div className='min-h-[240px] max-h-[460px] overflow-auto px-6 py-5'>
+              <section>
+                <div className='rounded-lg border border-border bg-muted/20 p-4'>
+                  <div
+                    className='break-words whitespace-pre-wrap text-sm leading-6 text-foreground'
+                    style={
+                      coursePromptExpanded || !canTogglePromptDetail
+                        ? undefined
+                        : COLLAPSED_TEXT_STYLE
+                    }
+                  >
+                    {promptDetailText ||
+                      tOperations('coursePromptDialog.empty')}
+                  </div>
+                  {canTogglePromptDetail ? (
+                    <div className='mt-3 flex justify-end'>
+                      <button
+                        type='button'
+                        className='text-sm font-medium text-primary transition-colors hover:text-primary/80'
+                        onClick={() =>
+                          setCoursePromptExpanded(previous => !previous)
+                        }
+                      >
+                        {coursePromptExpanded
+                          ? t('common.core.collapse')
+                          : t('common.core.expand')}
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+            </div>
+          </DialogContent>
+        </Dialog>
         <Dialog
           open={transferDialogOpen}
           onOpenChange={handleTransferDialogOpenChange}

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -79,6 +79,7 @@ import { buildAdminOperationsCourseDetailUrl } from './operation-course-routes';
 import type {
   AdminOperationCourseItem,
   AdminOperationCourseListResponse,
+  AdminOperationCoursePromptResponse,
 } from './operation-course-types';
 import useOperatorGuard from './useOperatorGuard';
 
@@ -354,6 +355,10 @@ const OperationsPage = () => {
   const [coursePromptExpanded, setCoursePromptExpanded] = useState(false);
   const [promptDetailCourse, setPromptDetailCourse] =
     useState<AdminOperationCourseItem | null>(null);
+  const [promptDetailText, setPromptDetailText] = useState('');
+  const [promptDetailLoading, setPromptDetailLoading] = useState(false);
+  const [promptDetailError, setPromptDetailError] = useState('');
+  const [canTogglePromptDetail, setCanTogglePromptDetail] = useState(false);
   const [transferDialogOpen, setTransferDialogOpen] = useState(false);
   const [transferTargetCourse, setTransferTargetCourse] =
     useState<AdminOperationCourseItem | null>(null);
@@ -365,6 +370,8 @@ const OperationsPage = () => {
   const [transferConfirmOpen, setTransferConfirmOpen] = useState(false);
   const requestedPageRef = useRef(1);
   const requestIdRef = useRef(0);
+  const promptRequestIdRef = useRef(0);
+  const promptDetailContentRef = useRef<HTMLDivElement | null>(null);
   const fetchCoursesRef = useRef<
     | ((targetPage: number, nextFilters?: CourseFilters) => Promise<void>)
     | undefined
@@ -389,11 +396,42 @@ const OperationsPage = () => {
   );
   const defaultUserName = useMemo(() => t('module.user.defaultUserName'), [t]);
   const displayStatusValue = filters.course_status || ALL_OPTION_VALUE;
-  const promptDetailText = promptDetailCourse?.course_prompt?.trim() || '';
-  const canTogglePromptDetail = promptDetailText.length > 80;
+  const hasPromptDetailText = promptDetailText.trim().length > 0;
+
+  useEffect(() => {
+    if (promptDetailLoading || promptDetailError || !hasPromptDetailText) {
+      setCanTogglePromptDetail(false);
+      return;
+    }
+    if (coursePromptExpanded) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      const container = promptDetailContentRef.current;
+      if (!container) {
+        setCanTogglePromptDetail(false);
+        return;
+      }
+      setCanTogglePromptDetail(
+        container.scrollHeight > container.clientHeight ||
+          container.scrollWidth > container.clientWidth,
+      );
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [
+    coursePromptExpanded,
+    hasPromptDetailText,
+    promptDetailError,
+    promptDetailLoading,
+    promptDetailText,
+  ]);
 
   const handleCopyCoursePrompt = useCallback(async () => {
-    if (!promptDetailText) {
+    if (!hasPromptDetailText || promptDetailLoading || promptDetailError) {
       return;
     }
 
@@ -408,7 +446,14 @@ const OperationsPage = () => {
         variant: 'destructive',
       });
     }
-  }, [promptDetailText, tOperations, toast]);
+  }, [
+    hasPromptDetailText,
+    promptDetailError,
+    promptDetailLoading,
+    promptDetailText,
+    tOperations,
+    toast,
+  ]);
 
   const fetchCourses = useCallback(
     async (targetPage: number, nextFilters?: CourseFilters) => {
@@ -500,20 +545,54 @@ const OperationsPage = () => {
 
   const handlePromptDetailOpenChange = useCallback((nextOpen: boolean) => {
     if (!nextOpen) {
+      promptRequestIdRef.current += 1;
       setPromptDetailCourse(null);
       setCoursePromptExpanded(false);
+      setPromptDetailText('');
+      setPromptDetailLoading(false);
+      setPromptDetailError('');
+      setCanTogglePromptDetail(false);
     }
   }, []);
 
   const handlePromptDetailClick = useCallback(
-    (course: AdminOperationCourseItem) => {
-      if (!course.course_prompt?.trim()) {
+    async (course: AdminOperationCourseItem) => {
+      if (!course.has_course_prompt) {
         return;
       }
+
+      const requestId = promptRequestIdRef.current + 1;
+      promptRequestIdRef.current = requestId;
       setPromptDetailCourse(course);
       setCoursePromptExpanded(false);
+      setPromptDetailText('');
+      setPromptDetailError('');
+      setPromptDetailLoading(true);
+
+      try {
+        const response = (await api.getAdminOperationCoursePrompt({
+          shifu_bid: course.shifu_bid,
+        })) as AdminOperationCoursePromptResponse;
+        if (requestId !== promptRequestIdRef.current) {
+          return;
+        }
+        setPromptDetailText(response.course_prompt ?? '');
+      } catch (err) {
+        if (requestId !== promptRequestIdRef.current) {
+          return;
+        }
+        if (err instanceof Error) {
+          setPromptDetailError(err.message);
+        } else {
+          setPromptDetailError(t('common.core.unknownError'));
+        }
+      } finally {
+        if (requestId === promptRequestIdRef.current) {
+          setPromptDetailLoading(false);
+        }
+      }
     },
-    [],
+    [t],
   );
 
   const handleTransferDialogOpenChange = useCallback(
@@ -869,7 +948,7 @@ const OperationsPage = () => {
         price: course => [formatMoney(course.price)],
         model: course => [course.course_model],
         coursePrompt: course => [
-          course.course_prompt?.trim()
+          course.has_course_prompt
             ? tOperations('table.detailAction')
             : EMPTY_STATE_LABEL,
         ],
@@ -1254,7 +1333,7 @@ const OperationsPage = () => {
                         className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('coursePrompt')}
                       >
-                        {course.course_prompt?.trim() ? (
+                        {course.has_course_prompt ? (
                           <button
                             type='button'
                             className='text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
@@ -1391,7 +1470,11 @@ const OperationsPage = () => {
                   size='sm'
                   className='gap-2'
                   onClick={handleCopyCoursePrompt}
-                  disabled={!promptDetailText}
+                  disabled={
+                    !hasPromptDetailText ||
+                    promptDetailLoading ||
+                    Boolean(promptDetailError)
+                  }
                 >
                   <Copy className='h-4 w-4' />
                   {tOperations('coursePromptDialog.copy')}
@@ -1401,31 +1484,60 @@ const OperationsPage = () => {
             <div className='min-h-[240px] max-h-[460px] overflow-auto px-6 py-5'>
               <section>
                 <div className='rounded-lg border border-border bg-muted/20 p-4'>
-                  <div
-                    className='break-words whitespace-pre-wrap text-sm leading-6 text-foreground'
-                    style={
-                      coursePromptExpanded || !canTogglePromptDetail
-                        ? undefined
-                        : COLLAPSED_TEXT_STYLE
-                    }
-                  >
-                    {promptDetailText ||
-                      tOperations('coursePromptDialog.empty')}
-                  </div>
-                  {canTogglePromptDetail ? (
-                    <div className='mt-3 flex justify-end'>
+                  {promptDetailLoading ? (
+                    <div className='flex min-h-[180px] items-center justify-center'>
+                      <Loading />
+                    </div>
+                  ) : null}
+                  {!promptDetailLoading && promptDetailError ? (
+                    <div className='flex min-h-[180px] flex-col items-center justify-center gap-3 text-center'>
+                      <p className='text-sm leading-6 text-destructive'>
+                        {promptDetailError}
+                      </p>
                       <button
                         type='button'
                         className='text-sm font-medium text-primary transition-colors hover:text-primary/80'
-                        onClick={() =>
-                          setCoursePromptExpanded(previous => !previous)
-                        }
+                        onClick={() => {
+                          if (promptDetailCourse) {
+                            void handlePromptDetailClick(promptDetailCourse);
+                          }
+                        }}
                       >
-                        {coursePromptExpanded
-                          ? t('common.core.collapse')
-                          : t('common.core.expand')}
+                        {t('common.core.retry')}
                       </button>
                     </div>
+                  ) : null}
+                  {!promptDetailLoading && !promptDetailError ? (
+                    <>
+                      <div
+                        ref={promptDetailContentRef}
+                        className='break-words whitespace-pre-wrap text-sm leading-6 text-foreground'
+                        style={
+                          coursePromptExpanded || !canTogglePromptDetail
+                            ? undefined
+                            : COLLAPSED_TEXT_STYLE
+                        }
+                      >
+                        {hasPromptDetailText
+                          ? promptDetailText
+                          : tOperations('coursePromptDialog.empty')}
+                      </div>
+                      {canTogglePromptDetail ? (
+                        <div className='mt-3 flex justify-end'>
+                          <button
+                            type='button'
+                            className='text-sm font-medium text-primary transition-colors hover:text-primary/80'
+                            onClick={() =>
+                              setCoursePromptExpanded(previous => !previous)
+                            }
+                          >
+                            {coursePromptExpanded
+                              ? t('common.core.collapse')
+                              : t('common.core.expand')}
+                          </button>
+                        </div>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
               </section>

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -3,6 +3,13 @@
   "actions": {
     "transferCreator": "Transfer creator"
   },
+  "coursePromptDialog": {
+    "copy": "Copy",
+    "copyFailed": "Failed to copy course prompt",
+    "copySuccess": "Course prompt copied",
+    "empty": "No course prompt",
+    "title": "Course Prompt"
+  },
   "detail": {
     "back": "Back to list",
     "basicInfo": "Basic Info",
@@ -214,8 +221,11 @@
     "action": "Action",
     "courseId": "Course ID",
     "courseName": "Course Name",
+    "coursePrompt": "Course Prompt",
     "createdAt": "Created At",
     "creator": "Creator",
+    "detailAction": "Detail",
+    "model": "Model",
     "modifier": "Modifier",
     "price": "Price",
     "status": "Status",

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -3,6 +3,13 @@
   "actions": {
     "transferCreator": "转移创作者"
   },
+  "coursePromptDialog": {
+    "copy": "复制",
+    "copyFailed": "复制课程提示词失败",
+    "copySuccess": "已复制课程提示词",
+    "empty": "暂无课程提示词",
+    "title": "课程提示词"
+  },
   "detail": {
     "back": "返回课程列表",
     "basicInfo": "基础信息",
@@ -214,8 +221,11 @@
     "action": "操作",
     "courseId": "课程ID",
     "courseName": "课程名",
+    "coursePrompt": "课程提示词",
     "createdAt": "创建时间",
     "creator": "创建者",
+    "detailAction": "详情",
+    "model": "模型",
     "modifier": "修改者",
     "price": "价格",
     "status": "状态",


### PR DESCRIPTION
## Summary
- add model and course prompt fields to the operator course list response and table
- show course prompts through a dedicated detail dialog with copy and expand/collapse support instead of inline table text
- reorder and center-align course table columns to better match operator browsing habits
- fetch full course prompts on demand and avoid loading prompt text in operator list queries
- fix operator course prompt test seeding for backend CI

## Testing
- python -m py_compile src/api/flaskr/service/shifu/admin.py src/api/flaskr/service/shifu/admin_dtos.py src/api/flaskr/service/shifu/route.py src/api/tests/service/shifu/test_admin_courses.py src/api/tests/service/shifu/test_admin_course_detail.py
- cd src/cook-web && npm test -- --runInBand src/app/admin/operations/page.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/app/admin/operations/page.tsx --file src/app/admin/operations/page.test.tsx
