### PR TITLE
revert: "fix(run): stream visual elements without listen mode"

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2417,7 +2417,7 @@ class RunScriptContextV2:
                 usage_scene,
             ),
             use_learner_language=self._shifu_info.use_learner_language,
-            visual_mode=True,
+            visual_mode=self._listen,
         )
         block_list = mdflow_context.get_all_blocks()
         user_profile = get_user_profiles(

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -109,7 +109,6 @@ from flaskr.service.learn.context_v2 import (
     RUNLLMProvider,
     RunScriptContextV2,
     RunScriptPreviewContextV2,
-    _iter_llm_result_content_parts,
 )
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.learn_dtos import (
@@ -965,22 +964,6 @@ class StreamTtsTeardownTests(unittest.TestCase):
         self.assertEqual(flush_calls, [])
         self.assertEqual(processor.finalize_calls, 0)
         self.assertEqual(ctx._element_index_cursor, 1)
-
-
-class LLMResultContentPartsTests(unittest.TestCase):
-    def test_formatted_elements_are_preserved_without_raw_splitting(self):
-        result = types.SimpleNamespace(
-            content="",
-            formatted_elements=[
-                types.SimpleNamespace(content="<svg", type="svg", number=7),
-                types.SimpleNamespace(content="</svg>", type="svg", number=7),
-            ],
-        )
-
-        self.assertEqual(
-            list(_iter_llm_result_content_parts(result)),
-            [("<svg", "svg", 7), ("</svg>", "svg", 7)],
-        )
 
 
 class MdflowContextCompatibilityTests(unittest.TestCase):

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1215,7 +1215,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
         ctx._input_type = "normal"
         ctx._input = None
         ctx._last_position = -1
-        ctx._listen = False
+        ctx._listen = True
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
@@ -1253,8 +1253,6 @@ def test_listen_run_persists_content_block_before_element_rows(app):
             def __init__(self, content):
                 self.content = content
 
-        visual_mode_calls = []
-
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs):
                 self.blocks = [
@@ -1265,8 +1263,8 @@ def test_listen_run_persists_content_block_before_element_rows(app):
                     )
                 ]
 
-            def set_visual_mode(self, visual_mode):
-                visual_mode_calls.append(visual_mode)
+            def set_visual_mode(self, *_args, **_kwargs):
+                pass
 
             def set_output_language(self, *_args, **_kwargs):
                 return self
@@ -1329,8 +1327,6 @@ def test_listen_run_persists_content_block_before_element_rows(app):
         )
 
     assert [item.type for item in streamed] == ["element", "done"]
-    assert visual_mode_calls
-    assert all(visual_mode is True for visual_mode in visual_mode_calls)
     assert rows
     assert {row.progress_record_bid for row in rows} == {progress_bid}
     assert {row.content_text for row in rows} == {"Persisted content block"}


### PR DESCRIPTION
Reverts ai-shifu/ai-shifu#1604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified visual mode handling so that visual rendering behavior is now conditional and dynamically linked to listen mode instead of being universally enabled.

* **Tests**
  * Simplified test utilities and updated test setup configurations to properly validate behavior in listen mode scenarios, with improvements to internal test double implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->