### PR TITLE
fix(learn): enable visual mode for runtime streams

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2417,7 +2417,7 @@ class RunScriptContextV2:
                 usage_scene,
             ),
             use_learner_language=self._shifu_info.use_learner_language,
-            visual_mode=self._listen,
+            visual_mode=True,
         )
         block_list = mdflow_context.get_all_blocks()
         user_profile = get_user_profiles(


### PR DESCRIPTION
## Summary
- Always enable MarkdownFlow visual mode for learn runtime streams so all elements stream in read mode as well as listen mode.

## Verification
- git diff --check -- src/api/flaskr/service/learn/context_v2.py
- ./.venv/bin/python -m py_compile flaskr/service/learn/context_v2.py
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MarkdownFlow rendering to ensure visual mode is consistently applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->