### PR TITLE
fix: drain run tts finalization asynchronously

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -113,6 +113,7 @@ from flaskr.service.learn.lesson_feedback import build_lesson_feedback_interacti
 from flaskr.service.learn.exceptions import PaidException
 from flaskr.service.learn.listen_element_queries import _load_latest_active_element_row
 from flaskr.service.learn.preview_elements import PreviewElementRunAdapter
+from flaskr.service.learn.stream_tts_finalize import StreamTTSFinalizeDrainer
 from flaskr.i18n import _, get_current_language, set_language
 from flaskr.service.user.exceptions import UserNotLoginException
 from flaskr.common.shifu_context import (
@@ -3034,8 +3035,10 @@ class RunScriptContextV2:
                 tts_enabled = bool(self._should_stream_tts())
                 current_tts_stream_key: tuple[str, int] | None = None
                 next_tts_position = 0
-                # Finalize prior text TTS after visual chunks keep flowing.
-                pending_tts_processors = []
+                tts_finalize_drainer = StreamTTSFinalizeDrainer(
+                    self,
+                    log_prefix="Finalize streaming TTS failed",
+                )
 
                 # Direct synchronous stream processing (markdown-flow 0.2.27+)
                 app.logger.info(f"process_stream: {run_script_info.block_position}")
@@ -3075,8 +3078,7 @@ class RunScriptContextV2:
                         tts_processor, \
                         tts_enabled, \
                         current_tts_stream_key, \
-                        next_tts_position, \
-                        pending_tts_processors
+                        next_tts_position
                     next_key = _normalize_tts_stream_key(
                         stream_element_type=stream_element_type,
                         stream_element_number=stream_element_number,
@@ -3084,7 +3086,7 @@ class RunScriptContextV2:
                     if current_tts_stream_key == next_key:
                         return
                     if tts_processor:
-                        pending_tts_processors.append(tts_processor)
+                        tts_finalize_drainer.submit(tts_processor)
                         tts_processor = None
                         current_tts_stream_key = None
                     if not tts_enabled or next_key is None:
@@ -3125,9 +3127,11 @@ class RunScriptContextV2:
                         stream_element_number=stream_element_number,
                     )
                     if not tts_processor or current_tts_stream_key is None:
+                        yield from _drain_tts_ready_events()
                         return
                     try:
                         yield from tts_processor.process_chunk(chunk_content)
+                        yield from _drain_tts_ready_events()
                     except Exception as exc:
                         app.logger.warning(
                             "Streaming TTS failed; disable for this block: %s",
@@ -3138,38 +3142,38 @@ class RunScriptContextV2:
                         current_tts_stream_key = None
                         tts_enabled = False
 
-                def _drain_tts_ready_events():
-                    nonlocal tts_processor, current_tts_stream_key, tts_enabled
-                    processors = [
-                        *pending_tts_processors,
-                        *([tts_processor] if tts_processor else []),
-                    ]
-                    if not processors:
-                        return
-                    for processor in processors:
-                        try:
-                            yield from processor.drain_ready_segments()
-                        except Exception as exc:
-                            app.logger.warning(
-                                "Idle streaming TTS drain failed; disable for this block: %s",
-                                exc,
-                                exc_info=True,
-                            )
-                            if processor is tts_processor:
-                                tts_processor = None
-                                current_tts_stream_key = None
-                                tts_enabled = False
-                            elif processor in pending_tts_processors:
-                                pending_tts_processors.remove(processor)
+                def _disable_current_tts_processor() -> None:
+                    nonlocal tts_processor, current_tts_stream_key
+                    tts_processor = None
+                    current_tts_stream_key = None
 
-                def _finalize_pending_tts_processors():
-                    nonlocal pending_tts_processors
-                    while pending_tts_processors:
-                        pending_tts_processor = pending_tts_processors.pop(0)
-                        yield from self._finalize_stream_tts_processor(
-                            pending_tts_processor,
-                            log_prefix="Finalize streaming TTS failed",
-                        )
+                def _disable_all_tts() -> None:
+                    nonlocal tts_enabled
+                    _disable_current_tts_processor()
+                    tts_enabled = False
+
+                def _handle_current_tts_drain_error(exc: Exception) -> None:
+                    app.logger.warning(
+                        "Idle streaming TTS drain failed; disable for this block: %s",
+                        exc,
+                        exc_info=True,
+                    )
+                    _disable_all_tts()
+
+                def _drain_current_tts_ready_events():
+                    if not tts_processor:
+                        return
+                    if not hasattr(tts_processor, "drain_ready_segments"):
+                        return
+                    try:
+                        yield from tts_processor.drain_ready_segments()
+                    except Exception as exc:
+                        _handle_current_tts_drain_error(exc)
+
+                def _drain_tts_ready_events():
+                    yield from tts_finalize_drainer.drain()
+                    yield from _drain_current_tts_ready_events()
+                    yield from tts_finalize_drainer.drain()
 
                 stream_exc: BaseException | None = None
                 try:
@@ -3227,9 +3231,12 @@ class RunScriptContextV2:
                     raise
                 finally:
                     if not isinstance(stream_exc, GeneratorExit):
-                        yield from _finalize_pending_tts_processors()
+                        yield from tts_finalize_drainer.drain(wait=True)
+                    else:
+                        tts_finalize_drainer.close()
                     yield from self._teardown_stream_tts_state(
                         tts_processor=tts_processor,
+                        flush_content_cache=_drain_current_tts_ready_events,
                         log_prefix="Finalize streaming TTS failed",
                         skip_emit=isinstance(stream_exc, GeneratorExit),
                     )

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any, Generator
+
+from flaskr.common.shifu_context import (
+    apply_shifu_context_snapshot,
+    get_shifu_context_snapshot,
+)
+from flaskr.i18n import get_current_language, set_language
+from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
+
+
+class _StreamTTSFinalizeJob:
+    def __init__(
+        self,
+        *,
+        event_queue: queue.Queue,
+        thread: threading.Thread,
+    ):
+        self.event_queue = event_queue
+        self.thread = thread
+        self.done = False
+
+
+class StreamTTSFinalizeDrainer:
+    """Finalize switched-out text TTS without blocking mdflow visual chunks."""
+
+    def __init__(self, run_context: Any, *, log_prefix: str):
+        self._run_context = run_context
+        self._app = run_context.app
+        self._log_prefix = log_prefix
+        self._jobs: list[_StreamTTSFinalizeJob] = []
+
+    def submit(self, processor) -> None:
+        if not processor:
+            return
+
+        event_queue: queue.Queue = queue.Queue()
+        parent_language = get_current_language()
+        parent_shifu_context = get_shifu_context_snapshot()
+
+        def _produce() -> None:
+            with self._app.app_context():
+                set_language(parent_language)
+                apply_shifu_context_snapshot(parent_shifu_context)
+                try:
+                    # The background worker owns a thread-local DB session. Audio
+                    # records are sidecar artifacts, while RUN element events are
+                    # still yielded by the main generator from this queue.
+                    for event in processor.finalize(commit=True):
+                        event_queue.put(("event", event))
+                except Exception as exc:
+                    event_queue.put(("error", exc))
+                finally:
+                    event_queue.put(
+                        (
+                            "done",
+                            int(getattr(processor, "next_element_index", 0) or 0),
+                        )
+                    )
+
+        thread = threading.Thread(
+            target=_produce,
+            name="stream_tts_finalize",
+            daemon=True,
+        )
+        self._jobs.append(_StreamTTSFinalizeJob(event_queue=event_queue, thread=thread))
+        thread.start()
+
+    def drain(self, *, wait: bool = False) -> Generator[RunMarkdownFlowDTO, None, None]:
+        while self._jobs:
+            for job in list(self._jobs):
+                yield from self._drain_job(job, wait=wait)
+                if job.done:
+                    job.thread.join(timeout=0)
+            self._jobs = [job for job in self._jobs if not job.done]
+            if not wait:
+                break
+
+    def close(self) -> None:
+        for job in list(self._jobs):
+            job.thread.join(timeout=0.1)
+
+    def _drain_job(
+        self,
+        job: _StreamTTSFinalizeJob,
+        *,
+        wait: bool,
+    ) -> Generator[RunMarkdownFlowDTO, None, None]:
+        waited_once = False
+        while True:
+            try:
+                if wait and not waited_once and not job.done:
+                    kind, payload = job.event_queue.get(timeout=0.05)
+                    waited_once = True
+                else:
+                    kind, payload = job.event_queue.get_nowait()
+            except queue.Empty:
+                break
+
+            if kind == "event":
+                yield payload
+                continue
+            if kind == "error":
+                self._app.logger.warning(
+                    "%s: %s",
+                    self._log_prefix,
+                    payload,
+                    exc_info=(
+                        type(payload),
+                        payload,
+                        getattr(payload, "__traceback__", None),
+                    ),
+                )
+                continue
+            if kind == "done":
+                job.done = True
+                self._run_context._element_index_cursor = max(
+                    int(getattr(self._run_context, "_element_index_cursor", 0) or 0),
+                    int(payload or 0),
+                )

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1,4 +1,5 @@
 import json
+import time
 import types
 
 import pytest
@@ -1358,6 +1359,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
     outline_bid = "outline-listen-run-visual-before-tts"
     progress_bid = "progress-listen-run-visual-before-tts"
     audio_url = "https://example.com/intro-after-visual.mp3"
+    later_audio_url = "https://example.com/later-after-visual.mp3"
 
     with app.app_context():
         LearnGeneratedElement.query.delete()
@@ -1472,8 +1474,12 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                     yield DummyLLMResult(
                         [DummyFormattedElement("<div>Visual start\n", "html", 1)]
                     )
+                    time.sleep(0.08)
                     yield DummyLLMResult(
                         [DummyFormattedElement("Visual end</div>\n", "html", 1)]
+                    )
+                    yield DummyLLMResult(
+                        [DummyFormattedElement("Later narration.\n", "text", 2)]
                     )
 
                 return _gen()
@@ -1497,14 +1503,23 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                 if False:
                     yield chunk_content
 
+            def drain_ready_segments(self):
+                if False:
+                    yield None
+
             def finalize(self, *, commit=True):
+                if self.stream_element_number == 0:
+                    time.sleep(0.02)
+                resolved_audio_url = (
+                    audio_url if self.stream_element_number == 0 else later_audio_url
+                )
                 yield RunMarkdownFlowDTO(
                     outline_bid=outline_bid,
                     generated_block_bid=self.generated_block_bid,
                     type=GeneratedType.AUDIO_COMPLETE,
                     content=AudioCompleteDTO(
-                        audio_url=audio_url,
-                        audio_bid="intro-after-visual-audio",
+                        audio_url=resolved_audio_url,
+                        audio_bid=f"audio-{self.stream_element_number}",
                         duration_ms=240,
                         position=self.position,
                         stream_element_number=self.stream_element_number,
@@ -1552,6 +1567,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                 "flaskr.service.learn.context_v2.get_profile_item_definition_list",
                 lambda *args, **kwargs: [],
             )
+            monkeypatch.setitem(app.config, "STREAM_TTS_IDLE_DRAIN_INTERVAL", 0.005)
             streamed = list(adapter.process(ctx.run_inner(app)))
 
         indexed_elements = [
@@ -1569,11 +1585,19 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
             for index, element in indexed_elements
             if element.element_type == ElementType.HTML and not element.is_final
         ]
+        last_html_index = max(html_indexes)
         text_audio_index, text_audio_patch = next(
             (index, element)
             for index, element in indexed_elements
             if element.element_type == ElementType.TEXT
             and element.audio_url == audio_url
+        )
+        later_text_index, _later_text_element = next(
+            (index, element)
+            for index, element in indexed_elements
+            if element.element_type == ElementType.TEXT
+            and element.content_text == "Later narration.\n"
+            and not element.audio_url
         )
 
         rows = (
@@ -1590,7 +1614,8 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
         )
 
         assert html_index < text_audio_index
-        assert max(html_indexes) < text_audio_index
+        assert text_audio_index < last_html_index
+        assert text_audio_index < later_text_index
         assert html_element.audio_url == ""
         assert html_element.audio_segments == []
         assert text_audio_patch.content_text == "Intro narration.\n"
@@ -1603,8 +1628,16 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
     first_audio_patch_seq = min(
         row.run_event_seq for row in rows if row.audio_url and row.is_final == 1
     )
+    later_text_seq = min(
+        row.run_event_seq
+        for row in rows
+        if row.element_type == ElementType.TEXT.value
+        and row.content_text == "Later narration.\n"
+        and row.is_final == 0
+    )
     assert min(html_seqs) < first_audio_patch_seq
-    assert max(html_seqs) < first_audio_patch_seq
+    assert first_audio_patch_seq < max(html_seqs)
+    assert first_audio_patch_seq < later_text_seq
 
 
 def test_listen_run_persists_exception_gate_block_before_element_rows(app):


### PR DESCRIPTION
## Summary
- Extract switched-out RUN text TTS finalization into a focused drainer helper.
- Start old text TTS finalization in the background after visual/content chunks are emitted.
- Drain ready audio patches during subsequent chunks and final teardown so audio is not structurally delayed to the end of RUN.

## Tests
- python -m py_compile flaskr/service/learn/context_v2.py flaskr/service/learn/listen_element_run_stream.py flaskr/service/learn/stream_tts_finalize.py tests/service/learn/test_listen_elements.py
- pytest tests/service/learn/test_listen_elements.py -k "audio or listen_run" -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved audio processing stability and reliability during streaming content delivery
  * Enhanced error handling and recovery for audio operations
  * Better synchronization between audio playback and visual content in streaming scenarios
  * More robust handling of concurrent audio processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->