### PR TITLE
fix: prevent import activation confirm dialog from hiding behind modal

### DIFF
--- a/src/cook-web/src/components/ui/AlertDialog.test.tsx
+++ b/src/cook-web/src/components/ui/AlertDialog.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from '@/components/ui/AlertDialog';
+
+const ALERT_DIALOG_TITLE = 'Confirm import';
+const ALERT_DIALOG_DESCRIPTION = 'Confirmation dialog description';
+const ALERT_DIALOG_CONTENT = 'Alert content';
+
+describe('AlertDialog layering', () => {
+  it('keeps confirmation dialogs above base dialog layers', () => {
+    render(
+      <AlertDialog open={true}>
+        <AlertDialogContent>
+          <AlertDialogTitle>{ALERT_DIALOG_TITLE}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {ALERT_DIALOG_DESCRIPTION}
+          </AlertDialogDescription>
+          <div>{ALERT_DIALOG_CONTENT}</div>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    const openElements = Array.from(
+      document.body.querySelectorAll('[data-state="open"]'),
+    );
+    const overlayElement = openElements.find(element =>
+      element.className.includes('z-[110]'),
+    );
+
+    expect(overlayElement).toBeTruthy();
+    expect(screen.getByRole('alertdialog')).toHaveClass('z-[111]');
+  });
+});

--- a/src/cook-web/src/components/ui/AlertDialog.test.tsx
+++ b/src/cook-web/src/components/ui/AlertDialog.test.tsx
@@ -5,6 +5,8 @@ import {
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogTitle,
+  ALERT_DIALOG_CONTENT_LAYER_CLASS,
+  ALERT_DIALOG_OVERLAY_LAYER_CLASS,
 } from '@/components/ui/AlertDialog';
 
 const ALERT_DIALOG_TITLE = 'Confirm import';
@@ -29,10 +31,31 @@ describe('AlertDialog layering', () => {
       document.body.querySelectorAll('[data-state="open"]'),
     );
     const overlayElement = openElements.find(element =>
-      element.className.includes('z-[110]'),
+      element.className.includes(ALERT_DIALOG_OVERLAY_LAYER_CLASS),
     );
 
     expect(overlayElement).toBeTruthy();
-    expect(screen.getByRole('alertdialog')).toHaveClass('z-[111]');
+    expect(screen.getByRole('alertdialog')).toHaveClass(
+      ALERT_DIALOG_CONTENT_LAYER_CLASS,
+    );
+  });
+
+  it('keeps the internal content layer when callers pass a lower z-index', () => {
+    render(
+      <AlertDialog open={true}>
+        <AlertDialogContent className='z-[51]'>
+          <AlertDialogTitle>{ALERT_DIALOG_TITLE}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {ALERT_DIALOG_DESCRIPTION}
+          </AlertDialogDescription>
+          <div>{ALERT_DIALOG_CONTENT}</div>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    const dialog = screen.getByRole('alertdialog');
+
+    expect(dialog).toHaveClass(ALERT_DIALOG_CONTENT_LAYER_CLASS);
+    expect(dialog).not.toHaveClass('z-[51]');
   });
 });

--- a/src/cook-web/src/components/ui/AlertDialog.tsx
+++ b/src/cook-web/src/components/ui/AlertDialog.tsx
@@ -12,8 +12,8 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
-const ALERT_DIALOG_OVERLAY_LAYER_CLASS = 'z-[110]';
-const ALERT_DIALOG_CONTENT_LAYER_CLASS = 'z-[111]';
+export const ALERT_DIALOG_OVERLAY_LAYER_CLASS = 'z-[110]';
+export const ALERT_DIALOG_CONTENT_LAYER_CLASS = 'z-[111]';
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -22,8 +22,8 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     className={cn(
       'fixed inset-0 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      ALERT_DIALOG_OVERLAY_LAYER_CLASS,
       className,
+      ALERT_DIALOG_OVERLAY_LAYER_CLASS,
     )}
     {...props}
     ref={ref}
@@ -41,8 +41,8 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         'fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-        ALERT_DIALOG_CONTENT_LAYER_CLASS,
         className,
+        ALERT_DIALOG_CONTENT_LAYER_CLASS,
       )}
       {...props}
     />

--- a/src/cook-web/src/components/ui/AlertDialog.tsx
+++ b/src/cook-web/src/components/ui/AlertDialog.tsx
@@ -12,13 +12,17 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
+const ALERT_DIALOG_OVERLAY_LAYER_CLASS = 'z-[110]';
+const ALERT_DIALOG_CONTENT_LAYER_CLASS = 'z-[111]';
+
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      ALERT_DIALOG_OVERLAY_LAYER_CLASS,
       className,
     )}
     {...props}
@@ -36,7 +40,8 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        ALERT_DIALOG_CONTENT_LAYER_CLASS,
         className,
       )}
       {...props}


### PR DESCRIPTION
Summary
- raise alert dialog overlay/content layers above the base dialog so nested confirmation dialogs stay visible
- add a focused alert dialog layering test to prevent regressions in import activation and similar nested modal flows

Testing
- cd src/cook-web && npm run test -- --runTestsByPath src/components/ui/AlertDialog.test.tsx src/components/ui/Dialog.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/components/ui/AlertDialog.test.tsx --file src/components/ui/AlertDialog.tsx
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage validating AlertDialog z-index stacking behavior and visual layering.

* **Bug Fixes**
  * Improved AlertDialog visual stacking by updating z-index values for overlay and content elements, ensuring confirmation dialogs appear above base dialog layers with proper hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->