### PR TITLE
fix: align operator promotion legacy compatibility

### DIFF
--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -9,7 +9,7 @@ from flaskr.service.promo.consts import (
     COUPON_TYPE_FIXED,
     COUPON_TYPE_PERCENT,
 )
-from flaskr.service.promo.funcs import (
+from flaskr.service.promo.api import (
     build_coupon_enabled_expression,
     is_coupon_enabled_for_runtime,
 )

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -4,11 +4,14 @@ from flaskr.service.order.models import Order
 from flaskr.service.order.funs import success_buy_record, query_buy_record
 from flaskr.service.promo.consts import (
     COUPON_APPLY_TYPE_SPECIFIC,
-    COUPON_BATCH_STATUS_ACTIVE,
     COUPON_STATUS_USED,
     COUPON_STATUS_ACTIVE,
     COUPON_TYPE_FIXED,
     COUPON_TYPE_PERCENT,
+)
+from flaskr.service.promo.funcs import (
+    build_coupon_enabled_expression,
+    is_coupon_enabled_for_runtime,
 )
 from flaskr.service.common import raise_error
 from flaskr.util import generate_id
@@ -43,7 +46,7 @@ def _coupon_matches_course(coupon: Coupon, shifu_bid: str) -> bool:
     """Check whether coupon is applicable to the given course."""
     if (
         not coupon
-        or int(getattr(coupon, "status", 0) or 0) != COUPON_BATCH_STATUS_ACTIVE
+        or not is_coupon_enabled_for_runtime(coupon)
         or int(getattr(coupon, "deleted", 0) or 0) != 0
     ):
         return False
@@ -181,7 +184,7 @@ def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
             Coupon.query.filter(
                 Coupon.code == coupon_code,
                 Coupon.deleted == 0,
-                Coupon.status == COUPON_BATCH_STATUS_ACTIVE,
+                build_coupon_enabled_expression(Coupon),
                 Coupon.usage_type != COUPON_APPLY_TYPE_SPECIFIC,
             )
             .order_by(Coupon.id.desc())

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -1549,7 +1549,7 @@ def _validate_campaign_overlap(
         PromoCampaign.deleted == 0,
         PromoCampaign.apply_type == PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
         PromoCampaign.shifu_bid == shifu_bid,
-        PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+        build_campaign_enabled_expression(PromoCampaign),
         PromoCampaign.start_at <= end_at,
         PromoCampaign.end_at >= start_at,
     )
@@ -1666,7 +1666,7 @@ def update_operator_promotion_campaign(
         ):
             raise_param_error("apply_type")
         if (
-            int(campaign.status or 0) == PROMO_CAMPAIGN_STATUS_ACTIVE
+            is_campaign_enabled_for_runtime(campaign)
             and apply_type == PROMO_CAMPAIGN_JOIN_TYPE_AUTO
         ):
             _validate_campaign_overlap(

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -9,7 +9,7 @@ import math
 from typing import Dict, Optional
 
 from flask import Flask, current_app
-from sqlalchemy import and_, case, func, or_
+from sqlalchemy import and_, case, func, not_, or_
 
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
@@ -50,7 +50,13 @@ from flaskr.service.promo.consts import (
     PROMO_CAMPAIGN_STATUS_ACTIVE,
     PROMO_CAMPAIGN_STATUS_INACTIVE,
 )
-from flaskr.service.promo.funcs import _calculate_discount_amount
+from flaskr.service.promo.funcs import (
+    _calculate_discount_amount,
+    build_campaign_enabled_expression,
+    build_coupon_enabled_expression,
+    is_campaign_enabled_for_runtime,
+    is_coupon_enabled_for_runtime,
+)
 from flaskr.service.promo.models import (
     Coupon,
     CouponUsage,
@@ -324,22 +330,23 @@ def _build_coupon_status_filter(status: str):
     if not normalized:
         return None
     now = _now_local_naive()
+    enabled_filter = build_coupon_enabled_expression(Coupon)
     if normalized == "inactive":
-        return Coupon.status != COUPON_BATCH_STATUS_ACTIVE
+        return not_(enabled_filter)
     if normalized == "not_started":
         return and_(
-            Coupon.status == COUPON_BATCH_STATUS_ACTIVE,
+            enabled_filter,
             Coupon.start > now,
         )
     if normalized == "active":
         return and_(
-            Coupon.status == COUPON_BATCH_STATUS_ACTIVE,
+            enabled_filter,
             Coupon.start <= now,
             Coupon.end >= now,
         )
     if normalized == "expired":
         return and_(
-            Coupon.status == COUPON_BATCH_STATUS_ACTIVE,
+            enabled_filter,
             Coupon.end < now,
         )
     return None
@@ -350,26 +357,26 @@ def _build_campaign_status_filter(status: str):
     if not normalized:
         return None
     now = _now_local_naive()
+    enabled_filter = build_campaign_enabled_expression(PromoCampaign)
     if normalized == "inactive":
-        return PromoCampaign.status != PROMO_CAMPAIGN_STATUS_ACTIVE
+        return not_(enabled_filter)
     if normalized == "not_started":
         return and_(
-            PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+            enabled_filter,
             PromoCampaign.start_at > now,
         )
     if normalized == "active":
         return and_(
-            PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+            enabled_filter,
             PromoCampaign.start_at <= now,
             PromoCampaign.end_at >= now,
         )
     if normalized == "ended":
         return and_(
-            PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+            enabled_filter,
             PromoCampaign.end_at < now,
         )
     return None
-
 
 def _generate_random_coupon_code(length: int = 12) -> str:
     charset = string.ascii_uppercase + string.digits
@@ -521,7 +528,7 @@ def _resolve_batch_coupon_code(
 
 def _compute_coupon_status(coupon: Coupon) -> str:
     now = _now_local_naive()
-    if int(coupon.status or 0) != COUPON_BATCH_STATUS_ACTIVE:
+    if not is_coupon_enabled_for_runtime(coupon):
         return "inactive"
     if coupon.start and coupon.start > now:
         return "not_started"
@@ -532,7 +539,7 @@ def _compute_coupon_status(coupon: Coupon) -> str:
 
 def _compute_campaign_status(campaign: PromoCampaign) -> str:
     now = _now_local_naive()
-    if int(campaign.status or 0) != PROMO_CAMPAIGN_STATUS_ACTIVE:
+    if not is_campaign_enabled_for_runtime(campaign):
         return "inactive"
     if campaign.start_at and campaign.start_at > now:
         return "not_started"
@@ -708,6 +715,8 @@ def list_operator_promotion_coupons(
         Coupon.status.label("status"),
         Coupon.start.label("start"),
         Coupon.end.label("end"),
+        Coupon.created_user_bid.label("created_user_bid"),
+        Coupon.updated_user_bid.label("updated_user_bid"),
     ).subquery()
     latest_usage = (
         db.session.query(CouponUsage.updated_at)
@@ -722,6 +731,7 @@ def list_operator_promotion_coupons(
         .first()
     )
     now = _now_local_naive()
+    active_coupon_expression = build_coupon_enabled_expression(filtered_subquery.c)
     summary_row = db.session.query(
         func.count(filtered_subquery.c.coupon_bid).label("total"),
         func.coalesce(
@@ -729,7 +739,7 @@ def list_operator_promotion_coupons(
                 case(
                     (
                         and_(
-                            filtered_subquery.c.status == COUPON_BATCH_STATUS_ACTIVE,
+                            active_coupon_expression,
                             filtered_subquery.c.start <= now,
                             filtered_subquery.c.end >= now,
                         ),
@@ -1415,12 +1425,15 @@ def list_operator_promotion_campaigns(
         PromoCampaign.status.label("status"),
         PromoCampaign.start_at.label("start_at"),
         PromoCampaign.end_at.label("end_at"),
+        PromoCampaign.created_user_bid.label("created_user_bid"),
+        PromoCampaign.updated_user_bid.label("updated_user_bid"),
     ).subquery()
     now = _now_local_naive()
+    active_campaign_expression = build_campaign_enabled_expression(filtered_subquery.c)
     active_campaign_case = case(
         (
             and_(
-                filtered_subquery.c.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+                active_campaign_expression,
                 filtered_subquery.c.start_at <= now,
                 filtered_subquery.c.end_at >= now,
             ),

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -378,6 +378,7 @@ def _build_campaign_status_filter(status: str):
         )
     return None
 
+
 def _generate_random_coupon_code(length: int = 12) -> str:
     charset = string.ascii_uppercase + string.digits
     return "".join(secrets.choice(charset) for _ in range(length))

--- a/src/api/flaskr/service/promo/api.py
+++ b/src/api/flaskr/service/promo/api.py
@@ -15,6 +15,12 @@ from flaskr.service.promo.admin import (
     update_operator_promotion_coupon,
     update_operator_promotion_coupon_status,
 )
+from flaskr.service.promo.funcs import (
+    build_campaign_enabled_expression,
+    build_coupon_enabled_expression,
+    is_campaign_enabled_for_runtime,
+    is_coupon_enabled_for_runtime,
+)
 
 __all__ = [
     "create_operator_promotion_campaign",
@@ -26,6 +32,10 @@ __all__ = [
     "list_operator_promotion_coupon_codes",
     "list_operator_promotion_coupon_usages",
     "list_operator_promotion_coupons",
+    "build_campaign_enabled_expression",
+    "build_coupon_enabled_expression",
+    "is_campaign_enabled_for_runtime",
+    "is_coupon_enabled_for_runtime",
     "update_operator_promotion_campaign",
     "update_operator_promotion_campaign_status",
     "update_operator_promotion_coupon",

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -2,10 +2,12 @@
 Promo functions
 """
 
+from contextlib import nullcontext
 from datetime import datetime
 import decimal
 
 import pytz
+from sqlalchemy import and_, or_
 from sqlalchemy.sql import func
 
 from .models import (
@@ -15,16 +17,68 @@ from .models import (
 )
 from ...dao import db
 from .consts import (
+    COUPON_BATCH_STATUS_ACTIVE,
+    COUPON_BATCH_STATUS_INACTIVE,
     COUPON_STATUS_ACTIVE,
     COUPON_STATUS_USED,
     PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
     PROMO_CAMPAIGN_APPLICATION_STATUS_VOIDED,
     PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
     PROMO_CAMPAIGN_STATUS_ACTIVE,
+    PROMO_CAMPAIGN_STATUS_INACTIVE,
 )
-from flask import Flask
+from flask import Flask, has_app_context
 from ...util import generate_id
 from .consts import COUPON_TYPE_FIXED, COUPON_TYPE_PERCENT
+
+
+def _is_legacy_operator_promotion(record: object) -> bool:
+    return (
+        not str(getattr(record, "created_user_bid", "") or "").strip()
+        and not str(getattr(record, "updated_user_bid", "") or "").strip()
+    )
+
+
+def is_coupon_enabled_for_runtime(coupon) -> bool:
+    status = int(getattr(coupon, "status", 0) or 0)
+    return status == COUPON_BATCH_STATUS_ACTIVE or (
+        status == COUPON_BATCH_STATUS_INACTIVE
+        and _is_legacy_operator_promotion(coupon)
+    )
+
+
+def is_campaign_enabled_for_runtime(campaign) -> bool:
+    status = int(getattr(campaign, "status", 0) or 0)
+    return status == PROMO_CAMPAIGN_STATUS_ACTIVE or (
+        status == PROMO_CAMPAIGN_STATUS_INACTIVE
+        and _is_legacy_operator_promotion(campaign)
+    )
+
+
+def build_coupon_enabled_expression(model_or_columns):
+    return or_(
+        model_or_columns.status == COUPON_BATCH_STATUS_ACTIVE,
+        and_(
+            model_or_columns.status == COUPON_BATCH_STATUS_INACTIVE,
+            func.coalesce(model_or_columns.created_user_bid, "") == "",
+            func.coalesce(model_or_columns.updated_user_bid, "") == "",
+        ),
+    )
+
+
+def build_campaign_enabled_expression(model_or_columns):
+    return or_(
+        model_or_columns.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+        and_(
+            model_or_columns.status == PROMO_CAMPAIGN_STATUS_INACTIVE,
+            func.coalesce(model_or_columns.created_user_bid, "") == "",
+            func.coalesce(model_or_columns.updated_user_bid, "") == "",
+        ),
+    )
+
+
+def _app_context_scope(app: Flask):
+    return nullcontext() if has_app_context() else app.app_context()
 
 
 def timeout_coupon_code_rollback(app: Flask, user_bid, order_bid):
@@ -90,12 +144,12 @@ def apply_promo_campaigns(
     payable_price: decimal.Decimal,
 ) -> list[PromoRedemption]:
     """Apply eligible promo campaigns to an order and create application records."""
-    with app.app_context():
+    with _app_context_scope(app):
         now = datetime.now(pytz.timezone("Asia/Shanghai"))
 
         campaigns: list[PromoCampaign] = PromoCampaign.query.filter(
             PromoCampaign.shifu_bid == shifu_bid,
-            PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+            build_campaign_enabled_expression(PromoCampaign),
             PromoCampaign.start_at <= now,
             PromoCampaign.end_at >= now,
             PromoCampaign.apply_type == PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
@@ -105,7 +159,7 @@ def apply_promo_campaigns(
         if promo_bid:
             manual_campaign = PromoCampaign.query.filter(
                 PromoCampaign.promo_bid == promo_bid,
-                PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+                build_campaign_enabled_expression(PromoCampaign),
                 PromoCampaign.start_at <= now,
                 PromoCampaign.end_at >= now,
                 PromoCampaign.shifu_bid == shifu_bid,
@@ -175,7 +229,7 @@ def query_promo_campaign_applications(
     app: Flask, order_bid: str, recalc_discount: bool
 ) -> list[PromoRedemption]:
     """Query promo campaign applications tied to an order."""
-    with app.app_context():
+    with _app_context_scope(app):
         records: list[PromoRedemption] = PromoRedemption.query.filter(
             PromoRedemption.order_bid == order_bid,
             PromoRedemption.deleted == 0,
@@ -189,7 +243,7 @@ def query_promo_campaign_applications(
         campaign_bids = [record.promo_bid for record in records]
         campaigns = PromoCampaign.query.filter(
             PromoCampaign.promo_bid.in_(campaign_bids),
-            PromoCampaign.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
+            build_campaign_enabled_expression(PromoCampaign),
             PromoCampaign.start_at <= now,
             PromoCampaign.end_at >= now,
             PromoCampaign.deleted == 0,

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -54,13 +54,21 @@ def is_campaign_enabled_for_runtime(campaign) -> bool:
     )
 
 
+def _blank_legacy_bid_expression(column):
+    normalized = func.coalesce(column, "")
+    normalized = func.replace(normalized, "\t", "")
+    normalized = func.replace(normalized, "\n", "")
+    normalized = func.replace(normalized, "\r", "")
+    return func.trim(normalized) == ""
+
+
 def build_coupon_enabled_expression(model_or_columns):
     return or_(
         model_or_columns.status == COUPON_BATCH_STATUS_ACTIVE,
         and_(
             model_or_columns.status == COUPON_BATCH_STATUS_INACTIVE,
-            func.coalesce(model_or_columns.created_user_bid, "") == "",
-            func.coalesce(model_or_columns.updated_user_bid, "") == "",
+            _blank_legacy_bid_expression(model_or_columns.created_user_bid),
+            _blank_legacy_bid_expression(model_or_columns.updated_user_bid),
         ),
     )
 
@@ -70,8 +78,8 @@ def build_campaign_enabled_expression(model_or_columns):
         model_or_columns.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
         and_(
             model_or_columns.status == PROMO_CAMPAIGN_STATUS_INACTIVE,
-            func.coalesce(model_or_columns.created_user_bid, "") == "",
-            func.coalesce(model_or_columns.updated_user_bid, "") == "",
+            _blank_legacy_bid_expression(model_or_columns.created_user_bid),
+            _blank_legacy_bid_expression(model_or_columns.updated_user_bid),
         ),
     )
 

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -7,8 +7,7 @@ from datetime import datetime
 import decimal
 
 import pytz
-from sqlalchemy import and_, or_
-from sqlalchemy.sql import func
+from sqlalchemy import and_, func, or_
 
 from .models import (
     CouponUsage as CouponUsageModel,
@@ -34,8 +33,8 @@ from .consts import COUPON_TYPE_FIXED, COUPON_TYPE_PERCENT
 
 def _is_legacy_operator_promotion(record: object) -> bool:
     return (
-        not str(getattr(record, "created_user_bid", "") or "").strip()
-        and not str(getattr(record, "updated_user_bid", "") or "").strip()
+        not (record.created_user_bid or "").strip()
+        and not (record.updated_user_bid or "").strip()
     )
 
 

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -42,8 +42,7 @@ def _is_legacy_operator_promotion(record: object) -> bool:
 def is_coupon_enabled_for_runtime(coupon) -> bool:
     status = int(getattr(coupon, "status", 0) or 0)
     return status == COUPON_BATCH_STATUS_ACTIVE or (
-        status == COUPON_BATCH_STATUS_INACTIVE
-        and _is_legacy_operator_promotion(coupon)
+        status == COUPON_BATCH_STATUS_INACTIVE and _is_legacy_operator_promotion(coupon)
     )
 
 

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -1139,6 +1139,244 @@ def test_admin_promotions_campaign_route_rejects_overlap(app, test_client, monke
 
     assert second_response.status_code == 200
     assert second_payload["code"] != 0
+
+
+def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
+    app, test_client, monkeypatch
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user("operator-1", "operator@example.com", "Operator", is_operator=True)
+        _seed_course("legacy-course-1", "Legacy Coupon Course")
+        now = datetime.now()
+        db.session.add_all(
+            [
+                Coupon(
+                    coupon_bid="legacy-coupon-active",
+                    name="Legacy Active Coupon",
+                    code="LEGACYACTIVE",
+                    discount_type=COUPON_TYPE_FIXED,
+                    usage_type=801,
+                    value=Decimal("10"),
+                    start=now - timedelta(days=1),
+                    end=now + timedelta(days=1),
+                    filter='{"course_id":"legacy-course-1"}',
+                    total_count=20,
+                    used_count=3,
+                    status=0,
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                Coupon(
+                    coupon_bid="legacy-coupon-future",
+                    name="Legacy Future Coupon",
+                    code="LEGACYFUTURE",
+                    discount_type=COUPON_TYPE_FIXED,
+                    usage_type=801,
+                    value=Decimal("10"),
+                    start=now + timedelta(days=1),
+                    end=now + timedelta(days=2),
+                    filter='{"course_id":"legacy-course-1"}',
+                    total_count=20,
+                    used_count=0,
+                    status=0,
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                Coupon(
+                    coupon_bid="legacy-coupon-expired",
+                    name="Legacy Expired Coupon",
+                    code="LEGACYEXPIRED",
+                    discount_type=COUPON_TYPE_FIXED,
+                    usage_type=801,
+                    value=Decimal("10"),
+                    start=now - timedelta(days=3),
+                    end=now - timedelta(days=1),
+                    filter='{"course_id":"legacy-course-1"}',
+                    total_count=20,
+                    used_count=0,
+                    status=0,
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                Coupon(
+                    coupon_bid="operator-inactive-coupon",
+                    name="Operator Inactive Coupon",
+                    code="OPINACTIVE",
+                    discount_type=COUPON_TYPE_FIXED,
+                    usage_type=801,
+                    value=Decimal("10"),
+                    start=now - timedelta(days=1),
+                    end=now + timedelta(days=1),
+                    filter='{"course_id":"legacy-course-1"}',
+                    total_count=20,
+                    used_count=0,
+                    status=0,
+                    created_user_bid="operator-1",
+                    updated_user_bid="operator-1",
+                ),
+            ]
+        )
+        db.session.commit()
+
+    list_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/coupons",
+        query_string={"page_index": 1, "page_size": 20},
+        headers={"Token": "test-token"},
+    )
+    list_payload = list_response.get_json(force=True)
+
+    assert list_payload["code"] == 0
+    assert list_payload["data"]["summary"]["active"] == 1
+    status_map = {
+        item["name"]: item["computed_status"] for item in list_payload["data"]["items"]
+    }
+    assert status_map["Legacy Active Coupon"] == "active"
+    assert status_map["Legacy Future Coupon"] == "not_started"
+    assert status_map["Legacy Expired Coupon"] == "expired"
+    assert status_map["Operator Inactive Coupon"] == "inactive"
+
+    active_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/coupons",
+        query_string={"page_index": 1, "page_size": 20, "status": "active"},
+        headers={"Token": "test-token"},
+    )
+    active_payload = active_response.get_json(force=True)
+
+    assert active_payload["code"] == 0
+    assert active_payload["data"]["total"] == 1
+    assert active_payload["data"]["items"][0]["name"] == "Legacy Active Coupon"
+
+    inactive_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/coupons",
+        query_string={"page_index": 1, "page_size": 20, "status": "inactive"},
+        headers={"Token": "test-token"},
+    )
+    inactive_payload = inactive_response.get_json(force=True)
+
+    assert inactive_payload["code"] == 0
+    assert inactive_payload["data"]["total"] == 1
+    assert inactive_payload["data"]["items"][0]["name"] == "Operator Inactive Coupon"
+
+
+def test_admin_promotions_campaign_list_compatibly_displays_legacy_status_rows(
+    app, test_client, monkeypatch
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user("operator-1", "operator@example.com", "Operator", is_operator=True)
+        _seed_course("legacy-course-2", "Legacy Campaign Course")
+        now = datetime.now()
+        db.session.add_all(
+            [
+                PromoCampaign(
+                    promo_bid="legacy-campaign-active",
+                    shifu_bid="legacy-course-2",
+                    name="Legacy Active Campaign",
+                    description="Legacy active",
+                    apply_type=PROMO_CAMPAIGN_JOIN_TYPE_EVENT,
+                    status=0,
+                    start_at=now - timedelta(days=1),
+                    end_at=now + timedelta(days=1),
+                    discount_type=COUPON_TYPE_FIXED,
+                    value=Decimal("20"),
+                    channel="app",
+                    filter="{}",
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                PromoCampaign(
+                    promo_bid="legacy-campaign-future",
+                    shifu_bid="legacy-course-2",
+                    name="Legacy Future Campaign",
+                    description="Legacy future",
+                    apply_type=PROMO_CAMPAIGN_JOIN_TYPE_EVENT,
+                    status=0,
+                    start_at=now + timedelta(days=1),
+                    end_at=now + timedelta(days=2),
+                    discount_type=COUPON_TYPE_FIXED,
+                    value=Decimal("20"),
+                    channel="app",
+                    filter="{}",
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                PromoCampaign(
+                    promo_bid="legacy-campaign-ended",
+                    shifu_bid="legacy-course-2",
+                    name="Legacy Ended Campaign",
+                    description="Legacy ended",
+                    apply_type=PROMO_CAMPAIGN_JOIN_TYPE_EVENT,
+                    status=0,
+                    start_at=now - timedelta(days=3),
+                    end_at=now - timedelta(days=1),
+                    discount_type=COUPON_TYPE_FIXED,
+                    value=Decimal("20"),
+                    channel="app",
+                    filter="{}",
+                    created_user_bid="",
+                    updated_user_bid="",
+                ),
+                PromoCampaign(
+                    promo_bid="operator-inactive-campaign",
+                    shifu_bid="legacy-course-2",
+                    name="Operator Inactive Campaign",
+                    description="Operator inactive",
+                    apply_type=PROMO_CAMPAIGN_JOIN_TYPE_EVENT,
+                    status=0,
+                    start_at=now - timedelta(days=1),
+                    end_at=now + timedelta(days=1),
+                    discount_type=COUPON_TYPE_FIXED,
+                    value=Decimal("20"),
+                    channel="app",
+                    filter="{}",
+                    created_user_bid="operator-1",
+                    updated_user_bid="operator-1",
+                ),
+            ]
+        )
+        db.session.commit()
+
+    list_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/campaigns",
+        query_string={"page_index": 1, "page_size": 20},
+        headers={"Token": "test-token"},
+    )
+    list_payload = list_response.get_json(force=True)
+
+    assert list_payload["code"] == 0
+    assert list_payload["data"]["summary"]["active"] == 1
+    status_map = {
+        item["name"]: item["computed_status"] for item in list_payload["data"]["items"]
+    }
+    assert status_map["Legacy Active Campaign"] == "active"
+    assert status_map["Legacy Future Campaign"] == "not_started"
+    assert status_map["Legacy Ended Campaign"] == "ended"
+    assert status_map["Operator Inactive Campaign"] == "inactive"
+
+    active_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/campaigns",
+        query_string={"page_index": 1, "page_size": 20, "status": "active"},
+        headers={"Token": "test-token"},
+    )
+    active_payload = active_response.get_json(force=True)
+
+    assert active_payload["code"] == 0
+    assert active_payload["data"]["total"] == 1
+    assert active_payload["data"]["items"][0]["name"] == "Legacy Active Campaign"
+
+    inactive_response = test_client.get(
+        "/api/shifu/admin/operations/promotions/campaigns",
+        query_string={"page_index": 1, "page_size": 20, "status": "inactive"},
+        headers={"Token": "test-token"},
+    )
+    inactive_payload = inactive_response.get_json(force=True)
+
+    assert inactive_payload["code"] == 0
+    assert inactive_payload["data"]["total"] == 1
+    assert inactive_payload["data"]["items"][0]["name"] == "Operator Inactive Campaign"
 
 
 def test_admin_promotions_coupon_update_rejects_locked_fields(

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -1141,6 +1141,54 @@ def test_admin_promotions_campaign_route_rejects_overlap(app, test_client, monke
     assert second_payload["code"] != 0
 
 
+def test_admin_promotions_campaign_route_rejects_overlap_with_legacy_enabled_campaign(
+    app, test_client, monkeypatch
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user("operator-1", "operator@example.com", "Operator", is_operator=True)
+        _seed_course("course-legacy-overlap", "Legacy Overlap Course")
+        db.session.add(
+            PromoCampaign(
+                promo_bid="legacy-overlap-campaign",
+                shifu_bid="course-legacy-overlap",
+                name="Legacy Auto Campaign",
+                description="Legacy overlap campaign",
+                apply_type=PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
+                status=0,
+                start_at=datetime.strptime("2026-04-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
+                end_at=datetime.strptime("2026-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
+                discount_type=COUPON_TYPE_FIXED,
+                value=Decimal("10"),
+                channel="app",
+                filter="{}",
+                created_user_bid="",
+                updated_user_bid="",
+            )
+        )
+        db.session.commit()
+
+    overlap_response = test_client.post(
+        "/api/shifu/admin/operations/promotions/campaigns",
+        json={
+            "name": "Window Two",
+            "apply_type": PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
+            "shifu_bid": "course-legacy-overlap",
+            "discount_type": COUPON_TYPE_FIXED,
+            "value": "5",
+            "start_at": "2026-05-01 10:00:00",
+            "end_at": "2026-05-20 10:00:00",
+            "enabled": True,
+        },
+        headers={"Token": "test-token"},
+    )
+    overlap_payload = overlap_response.get_json(force=True)
+
+    assert overlap_response.status_code == 200
+    assert overlap_payload["code"] != 0
+
+
 def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
     app, test_client, monkeypatch
 ):
@@ -1165,8 +1213,8 @@ def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
                     total_count=20,
                     used_count=3,
                     status=0,
-                    created_user_bid="",
-                    updated_user_bid="",
+                    created_user_bid=" ",
+                    updated_user_bid="\t",
                 ),
                 Coupon(
                     coupon_bid="legacy-coupon-future",
@@ -1284,8 +1332,8 @@ def test_admin_promotions_campaign_list_compatibly_displays_legacy_status_rows(
                     value=Decimal("20"),
                     channel="app",
                     filter="{}",
-                    created_user_bid="",
-                    updated_user_bid="",
+                    created_user_bid=" ",
+                    updated_user_bid="\t",
                 ),
                 PromoCampaign(
                     promo_bid="legacy-campaign-future",

--- a/src/api/tests/test_discount.py
+++ b/src/api/tests/test_discount.py
@@ -19,6 +19,8 @@ def _make_coupon(course_id: str | None = None) -> Coupon:
     coupon.coupon_bid = "coupon-1"
     coupon.code = "CODE"
     coupon.status = COUPON_BATCH_STATUS_ACTIVE
+    coupon.created_user_bid = "operator-1"
+    coupon.updated_user_bid = "operator-1"
     return coupon
 
 
@@ -51,6 +53,15 @@ def test_coupon_matches_course_returns_false_for_inactive_coupon():
     coupon.status = 0
 
     assert _coupon_matches_course(coupon, "course-1") is False
+
+
+def test_coupon_matches_course_returns_true_for_legacy_inactive_coupon():
+    coupon = _make_coupon("course-1")
+    coupon.status = 0
+    coupon.created_user_bid = ""
+    coupon.updated_user_bid = ""
+
+    assert _coupon_matches_course(coupon, "course-1") is True
 
 
 def test_coupon_matches_course_returns_false_for_deleted_coupon():

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -139,3 +139,58 @@ def test_use_specific_all_courses_coupon_keeps_unbound_usage_course(app, monkeyp
         assert usage.shifu_bid == ""
         assert updated_coupon is not None
         assert updated_coupon.used_count == 1
+
+
+def test_use_coupon_code_accepts_legacy_coupon_status(app, monkeypatch):
+    order_bid = "order-fix-discount-legacy"
+    course_bid = "course-fix-discount-legacy"
+    user_bid = "user-fix-discount-legacy"
+    coupon_bid = "coupon-fix-discount-legacy"
+    coupon_code = "CODE-FIX-LEGACY"
+
+    with app.app_context():
+        order = Order(
+            order_bid=order_bid,
+            shifu_bid=course_bid,
+            user_bid=user_bid,
+            payable_price=Decimal("100.00"),
+            paid_price=Decimal("100.00"),
+        )
+        db.session.add(order)
+
+        now = datetime.now()
+        coupon = Coupon(
+            coupon_bid=coupon_bid,
+            code=coupon_code,
+            discount_type=COUPON_TYPE_FIXED,
+            value=Decimal("10.00"),
+            start=now - timedelta(days=1),
+            end=now + timedelta(days=1),
+            channel="legacy",
+            filter="",
+            total_count=5,
+            used_count=0,
+            status=0,
+            created_user_bid="",
+            updated_user_bid="",
+        )
+        db.session.add(coupon)
+        db.session.commit()
+
+    monkeypatch.setattr(
+        "flaskr.service.order.coupon_funcs.send_feishu_coupon_code",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = use_coupon_code(app, user_bid, coupon_code, order_bid)
+    assert result.order_id == order_bid
+
+    with app.app_context():
+        refreshed = Order.query.filter(Order.order_bid == order_bid).first()
+        usage = CouponUsage.query.filter(CouponUsage.order_bid == order_bid).first()
+        updated_coupon = Coupon.query.filter(Coupon.coupon_bid == coupon_bid).first()
+        assert refreshed is not None
+        assert str(refreshed.paid_price) == "90.00"
+        assert usage is not None
+        assert updated_coupon is not None
+        assert updated_coupon.used_count == 1

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -7,6 +7,7 @@ from flaskr.service.order.funs import init_buy_record
 from flaskr.service.order.consts import ORDER_STATUS_INIT
 from flaskr.service.order.models import Order
 from flaskr.service.promo.consts import (
+    PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
     COUPON_STATUS_USED,
     COUPON_TYPE_FIXED,
     PROMO_CAMPAIGN_APPLICATION_STATUS_VOIDED,
@@ -174,6 +175,95 @@ def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch):
         db.session.delete(campaign)
         db.session.delete(order)
         db.session.commit()
+
+
+def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
+    from flaskr.service.order import funs as order_funs
+
+    monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
+    monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        order_funs,
+        "get_shifu_info",
+        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("500.00")),
+    )
+
+    now = datetime.now()
+
+    with app.app_context():
+        campaign = PromoCampaign(
+            promo_bid="promo-legacy-runtime-1",
+            shifu_bid="course-legacy-runtime-1",
+            name="Legacy Spring Promo",
+            apply_type=PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
+            status=0,
+            start_at=now - timedelta(days=1),
+            end_at=now + timedelta(days=1),
+            discount_type=COUPON_TYPE_FIXED,
+            value=Decimal("120.00"),
+            channel="legacy",
+            filter="{}",
+            created_user_bid="",
+            updated_user_bid="",
+        )
+        db.session.add(campaign)
+        db.session.commit()
+
+        result = init_buy_record(app, "user-legacy-runtime-1", "course-legacy-runtime-1")
+
+        assert Decimal(result.discount) == Decimal("120.00")
+        assert Decimal(result.value_to_pay) == Decimal("380.00")
+
+        redemptions = PromoRedemption.query.filter(
+            PromoRedemption.order_bid == result.order_id
+        ).all()
+        assert len(redemptions) == 1
+        assert redemptions[0].promo_bid == "promo-legacy-runtime-1"
+
+
+def test_query_promo_campaign_applications_keeps_legacy_campaign_when_recalculating(app):
+    from flaskr.service.promo.funcs import query_promo_campaign_applications
+
+    now = datetime.now()
+
+    with app.app_context():
+        campaign = PromoCampaign(
+            promo_bid="promo-legacy-runtime-2",
+            shifu_bid="course-legacy-runtime-2",
+            name="Legacy Refresh Promo",
+            apply_type=PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
+            status=0,
+            start_at=now - timedelta(days=1),
+            end_at=now + timedelta(days=1),
+            discount_type=COUPON_TYPE_FIXED,
+            value=Decimal("80.00"),
+            channel="legacy",
+            filter="{}",
+            created_user_bid="",
+            updated_user_bid="",
+        )
+        redemption = PromoRedemption(
+            redemption_bid="redeem-legacy-runtime-2",
+            promo_bid="promo-legacy-runtime-2",
+            order_bid="order-legacy-runtime-2",
+            user_bid="user-legacy-runtime-2",
+            shifu_bid="course-legacy-runtime-2",
+            promo_name="Legacy Refresh Promo",
+            discount_type=COUPON_TYPE_FIXED,
+            value=Decimal("80.00"),
+            discount_amount=Decimal("80.00"),
+            status=PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
+        )
+        db.session.add(campaign)
+        db.session.add(redemption)
+        db.session.commit()
+
+    result = query_promo_campaign_applications(
+        app, "order-legacy-runtime-2", recalc_discount=True
+    )
+
+    assert len(result) == 1
+    assert result[0].promo_bid == "promo-legacy-runtime-2"
 
 
 def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch):

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -209,7 +209,9 @@ def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
         db.session.add(campaign)
         db.session.commit()
 
-        result = init_buy_record(app, "user-legacy-runtime-1", "course-legacy-runtime-1")
+        result = init_buy_record(
+            app, "user-legacy-runtime-1", "course-legacy-runtime-1"
+        )
 
         assert Decimal(result.discount) == Decimal("120.00")
         assert Decimal(result.value_to_pay) == Decimal("380.00")
@@ -221,7 +223,9 @@ def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
         assert redemptions[0].promo_bid == "promo-legacy-runtime-1"
 
 
-def test_query_promo_campaign_applications_keeps_legacy_campaign_when_recalculating(app):
+def test_query_promo_campaign_applications_keeps_legacy_campaign_when_recalculating(
+    app,
+):
     from flaskr.service.promo.funcs import query_promo_campaign_applications
 
     now = datetime.now()

--- a/src/cook-web/src/components/ui/Dialog.tsx
+++ b/src/cook-web/src/components/ui/Dialog.tsx
@@ -17,7 +17,7 @@ const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
 const DIALOG_OVERLAY_LAYER_CLASS = 'z-[100]';
-const DIALOG_CONTENT_LAYER_CLASS = 'z-[101]';
+export const DIALOG_CONTENT_LAYER_CLASS = 'z-[101]';
 
 type DialogPortalContainer = React.ComponentPropsWithoutRef<
   typeof DialogPrimitive.Portal

--- a/src/cook-web/src/components/ui/Select.test.tsx
+++ b/src/cook-web/src/components/ui/Select.test.tsx
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DIALOG_CONTENT_LAYER_CLASS,
   DialogTitle,
 } from '@/components/ui/Dialog';
 
@@ -57,10 +58,19 @@ describe('Select layering', () => {
     expect(selectContentElement?.className).toContain(
       SELECT_CONTENT_LAYER_CLASS,
     );
-    expect(selectContentElement?.className).not.toContain('z-50');
-    expect(selectContentElement?.className).not.toContain('z-[101]');
-    expect(selectContentElement?.className).not.toContain(
-      ALERT_DIALOG_CONTENT_LAYER_CLASS,
+    expect(extractZIndex(SELECT_CONTENT_LAYER_CLASS)).toBeGreaterThan(
+      extractZIndex(DIALOG_CONTENT_LAYER_CLASS),
+    );
+    expect(extractZIndex(SELECT_CONTENT_LAYER_CLASS)).toBeGreaterThan(
+      extractZIndex(ALERT_DIALOG_CONTENT_LAYER_CLASS),
     );
   });
 });
+
+function extractZIndex(layerClass: string): number {
+  const match = layerClass.match(/z-\[(\d+)\]/);
+  if (!match) {
+    throw new Error(`Unexpected z-index layer class: ${layerClass}`);
+  }
+  return Number(match[1]);
+}

--- a/src/cook-web/src/components/ui/Select.test.tsx
+++ b/src/cook-web/src/components/ui/Select.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SELECT_CONTENT_LAYER_CLASS,
+} from '@/components/ui/Select';
+import { ALERT_DIALOG_CONTENT_LAYER_CLASS } from '@/components/ui/AlertDialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+
+const SELECT_ITEM_TEXT = 'Automatic';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('Select layering', () => {
+  it('keeps select content above dialog and alert dialog layers', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <DialogTitle>Select Layering</DialogTitle>
+          <DialogDescription>Select layering description</DialogDescription>
+          <Select open={true} value='2101' onValueChange={() => undefined}>
+            <SelectTrigger>
+              <SelectValue placeholder='Select grant type' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='2101'>{SELECT_ITEM_TEXT}</SelectItem>
+            </SelectContent>
+          </Select>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const selectContentElement = Array.from(document.body.querySelectorAll('*'))
+      .find(element =>
+        String(element.className).includes(SELECT_CONTENT_LAYER_CLASS),
+      );
+
+    expect(selectContentElement).toBeTruthy();
+    expect(selectContentElement?.className).toContain(SELECT_CONTENT_LAYER_CLASS);
+    expect(selectContentElement?.className).not.toContain('z-50');
+    expect(selectContentElement?.className).not.toContain('z-[101]');
+    expect(selectContentElement?.className).not.toContain(
+      ALERT_DIALOG_CONTENT_LAYER_CLASS,
+    );
+  });
+});

--- a/src/cook-web/src/components/ui/Select.test.tsx
+++ b/src/cook-web/src/components/ui/Select.test.tsx
@@ -31,7 +31,11 @@ describe('Select layering', () => {
         <DialogContent>
           <DialogTitle>Select Layering</DialogTitle>
           <DialogDescription>Select layering description</DialogDescription>
-          <Select open={true} value='2101' onValueChange={() => undefined}>
+          <Select
+            open={true}
+            value='2101'
+            onValueChange={() => undefined}
+          >
             <SelectTrigger>
               <SelectValue placeholder='Select grant type' />
             </SelectTrigger>
@@ -43,13 +47,16 @@ describe('Select layering', () => {
       </Dialog>,
     );
 
-    const selectContentElement = Array.from(document.body.querySelectorAll('*'))
-      .find(element =>
-        String(element.className).includes(SELECT_CONTENT_LAYER_CLASS),
-      );
+    const selectContentElement = Array.from(
+      document.body.querySelectorAll('*'),
+    ).find(element =>
+      String(element.className).includes(SELECT_CONTENT_LAYER_CLASS),
+    );
 
     expect(selectContentElement).toBeTruthy();
-    expect(selectContentElement?.className).toContain(SELECT_CONTENT_LAYER_CLASS);
+    expect(selectContentElement?.className).toContain(
+      SELECT_CONTENT_LAYER_CLASS,
+    );
     expect(selectContentElement?.className).not.toContain('z-50');
     expect(selectContentElement?.className).not.toContain('z-[101]');
     expect(selectContentElement?.className).not.toContain(

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -6,6 +6,8 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+const SELECT_CONTENT_LAYER_CLASS = 'z-[112]';
+
 const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
@@ -65,7 +67,8 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-56 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        'relative max-h-56 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+        SELECT_CONTENT_LAYER_CLASS,
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -147,4 +150,5 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
+  SELECT_CONTENT_LAYER_CLASS,
 };

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+// Keep Select content above dialog (`101`) and alert dialog (`111`) layers.
 const SELECT_CONTENT_LAYER_CLASS = 'z-[112]';
 
 const Select = SelectPrimitive.Root;


### PR DESCRIPTION
# Summary

This PR fixes two operator promotion regressions around legacy data and create dialogs.

- raise the shared `Select` popup layer so promotion and coupon selects remain clickable inside dialogs
- align operator campaign and coupon status presentation for legacy records migrated from the old admin
- reuse the same legacy-enabled status rules in runtime promotion and coupon application flows so checkout behavior matches operator-facing status
- avoid nested promo app contexts during order pricing refresh so matched campaign records stay attached to the active session
- add regression coverage for operator promotion status filters, legacy coupon redemption, legacy campaign application, order refresh, and select layering

Validation:
- `cd src/api && .venv/bin/pytest -q tests/service/promo/test_admin_promotions.py tests/test_discount.py tests/test_fix_discount.py tests/test_order.py tests/test_query_order.py tests/service/order/test_legacy_purchase_flow.py`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm test -- --runInBand src/components/ui/Select.test.tsx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promo coupons and campaigns now respect legacy/operator-edge records when determining active/inactive status, improving eligibility and admin listing accuracy.

* **Bug Fixes**
  * Fixed select component stacking so dropdowns render above dialogs.
  * Admin promo lists now show correct computed statuses and filters for legacy and time-windowed promotions.

* **Tests**
  * Added coverage for legacy promo/coupon behaviors and select layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->