### PR TITLE
fix: harden runtime billing config fallback

### DIFF
--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -11,7 +11,10 @@ from flaskr.service.billing.primitives import (
     get_billing_credit_precision,
     is_billing_enabled,
 )
-from flaskr.service.billing.runtime_config import build_runtime_billing_context
+from flaskr.service.billing.runtime_config import (
+    build_default_runtime_billing_context,
+    build_runtime_billing_context,
+)
 from flaskr.service.config.funcs import get_config
 
 from .common import bypass_token_validation, make_common_response
@@ -64,6 +67,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
     @with_shifu_context()
     def get_runtime_config():
         creator_bid = str(get_shifu_creator_bid() or "").strip()
+        request_host = _extract_request_host()
         legal_urls = RuntimeLegalUrlsDTO(
             agreement=RuntimeLocalizedUrlDTO(
                 **{
@@ -78,11 +82,27 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                 }
             ),
         )
-        runtime_billing = build_runtime_billing_context(
-            app,
-            creator_bid=creator_bid,
-            request_host=_extract_request_host(),
-        )
+        billing_enabled = is_billing_enabled()
+        if billing_enabled:
+            try:
+                runtime_billing = build_runtime_billing_context(
+                    app,
+                    creator_bid=creator_bid,
+                    request_host=request_host,
+                )
+            except Exception:
+                app.logger.exception(
+                    "Failed to build billing runtime config; using default payload"
+                )
+                runtime_billing = build_default_runtime_billing_context(
+                    creator_bid=creator_bid,
+                    request_host=request_host,
+                )
+        else:
+            runtime_billing = build_default_runtime_billing_context(
+                creator_bid=creator_bid,
+                request_host=request_host,
+            )
         branding = runtime_billing.branding
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
@@ -94,7 +114,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             defaultLlmModel=get_config("DEFAULT_LLM_MODEL", ""),
             wechatAppId=get_config("WECHAT_APP_ID", ""),
             enableWechatCode=bool(get_config("WECHAT_APP_ID", "")),
-            billingEnabled=is_billing_enabled(),
+            billingEnabled=billing_enabled,
             billingCreditPrecision=get_billing_credit_precision(),
             stripePublishableKey=get_config("STRIPE_PUBLISHABLE_KEY", ""),
             stripeEnabled=_to_bool(get_config("STRIPE_ENABLED", False), False),

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -82,6 +82,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                 }
             ),
         )
+        runtime_billing = None
         billing_enabled = is_billing_enabled()
         if billing_enabled:
             try:
@@ -91,14 +92,17 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                     request_host=request_host,
                 )
             except Exception:
+                # Runtime config is a shared bootstrap dependency. Fall back
+                # to a stable empty billing payload instead of failing the
+                # whole endpoint when billing data is unavailable.
                 app.logger.exception(
-                    "Failed to build billing runtime config; using default payload"
+                    "Failed to build billing runtime config; using default payload "
+                    "creator_bid=%s request_host=%s",
+                    creator_bid or "-",
+                    request_host or "-",
                 )
-                runtime_billing = build_default_runtime_billing_context(
-                    creator_bid=creator_bid,
-                    request_host=request_host,
-                )
-        else:
+
+        if runtime_billing is None:
             runtime_billing = build_default_runtime_billing_context(
                 creator_bid=creator_bid,
                 request_host=request_host,

--- a/src/api/flaskr/service/billing/runtime_config.py
+++ b/src/api/flaskr/service/billing/runtime_config.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from flask import Flask
 
+from .consts import (
+    BILLING_ENTITLEMENT_ANALYTICS_TIER_BASIC,
+    BILLING_ENTITLEMENT_ANALYTICS_TIER_LABELS,
+    BILLING_ENTITLEMENT_PRIORITY_CLASS_LABELS,
+    BILLING_ENTITLEMENT_PRIORITY_CLASS_STANDARD,
+    BILLING_ENTITLEMENT_SUPPORT_TIER_LABELS,
+    BILLING_ENTITLEMENT_SUPPORT_TIER_SELF_SERVE,
+)
 from .dtos import (
     RuntimeBillingBrandingDTO,
     RuntimeBillingContextDTO,
@@ -57,9 +65,18 @@ def build_default_runtime_billing_context(
         entitlements=RuntimeBillingEntitlementsDTO(
             branding_enabled=False,
             custom_domain_enabled=False,
-            priority_class="standard",
-            analytics_tier="basic",
-            support_tier="self_serve",
+            priority_class=BILLING_ENTITLEMENT_PRIORITY_CLASS_LABELS.get(
+                BILLING_ENTITLEMENT_PRIORITY_CLASS_STANDARD,
+                "standard",
+            ),
+            analytics_tier=BILLING_ENTITLEMENT_ANALYTICS_TIER_LABELS.get(
+                BILLING_ENTITLEMENT_ANALYTICS_TIER_BASIC,
+                "basic",
+            ),
+            support_tier=BILLING_ENTITLEMENT_SUPPORT_TIER_LABELS.get(
+                BILLING_ENTITLEMENT_SUPPORT_TIER_SELF_SERVE,
+                "self_serve",
+            ),
         ),
         branding=RuntimeBillingBrandingDTO(
             logo_wide_url=None,

--- a/src/api/flaskr/service/billing/runtime_config.py
+++ b/src/api/flaskr/service/billing/runtime_config.py
@@ -7,13 +7,15 @@ from flask import Flask
 from .dtos import (
     RuntimeBillingBrandingDTO,
     RuntimeBillingContextDTO,
+    RuntimeBillingDomainDTO,
     RuntimeBillingEntitlementsDTO,
 )
-from .domains import resolve_runtime_domain_result
+from .domains import normalize_domain_host, resolve_runtime_domain_result
 from .entitlements import (
     resolve_creator_entitlement_state,
     serialize_creator_entitlements,
 )
+from .primitives import normalize_bid
 
 
 def build_runtime_billing_context(
@@ -39,6 +41,41 @@ def build_runtime_billing_context(
         entitlements=entitlements,
         branding=branding,
         domain=domain,
+    )
+
+
+def build_default_runtime_billing_context(
+    *,
+    creator_bid: str = "",
+    request_host: str = "",
+) -> RuntimeBillingContextDTO:
+    """Build an empty billing payload without touching billing tables."""
+
+    normalized_creator_bid = normalize_bid(creator_bid) or None
+    normalized_host = normalize_domain_host(request_host, strict=False) or None
+    return RuntimeBillingContextDTO(
+        entitlements=RuntimeBillingEntitlementsDTO(
+            branding_enabled=False,
+            custom_domain_enabled=False,
+            priority_class="standard",
+            analytics_tier="basic",
+            support_tier="self_serve",
+        ),
+        branding=RuntimeBillingBrandingDTO(
+            logo_wide_url=None,
+            logo_square_url=None,
+            favicon_url=None,
+            home_url=None,
+        ),
+        domain=RuntimeBillingDomainDTO(
+            request_host=normalized_host,
+            matched=False,
+            is_custom_domain=False,
+            creator_bid=normalized_creator_bid,
+            domain_binding_bid=None,
+            host=None,
+            binding_status=None,
+        ),
     )
 
 

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -344,11 +344,6 @@ def test_runtime_config_reports_disabled_billing_flag(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
-        config_route,
-        "get_config",
-        lambda key, default="": False if key == "BILL_ENABLED" else default,
-    )
-    monkeypatch.setattr(
         "flaskr.service.billing.primitives.get_config",
         lambda key, default="": False if key == "BILL_ENABLED" else default,
     )

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -295,7 +295,19 @@ def test_runtime_billing_builder_and_route_config_use_dto_outputs(
     }
 
 
-def test_default_runtime_billing_context_is_database_free() -> None:
+def test_default_runtime_billing_context_is_database_free(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.runtime_config.resolve_creator_entitlement_state",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("entitlement resolver must not run in default builder")
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.runtime_config.resolve_runtime_domain_result",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("domain resolver must not run in default builder")
+        ),
+    )
     payload = build_default_runtime_billing_context(
         creator_bid="creator-1",
         request_host="creator.example.com",

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -15,7 +15,10 @@ from flaskr.service.billing.consts import (
 )
 from flaskr.service.billing.dtos import RuntimeBillingContextDTO, RuntimeConfigDTO
 from flaskr.service.billing.models import BillingDomainBinding, BillingEntitlement
-from flaskr.service.billing.runtime_config import build_runtime_billing_context
+from flaskr.service.billing.runtime_config import (
+    build_default_runtime_billing_context,
+    build_runtime_billing_context,
+)
 
 
 @pytest.fixture
@@ -292,6 +295,38 @@ def test_runtime_billing_builder_and_route_config_use_dto_outputs(
     }
 
 
+def test_default_runtime_billing_context_is_database_free() -> None:
+    payload = build_default_runtime_billing_context(
+        creator_bid="creator-1",
+        request_host="creator.example.com",
+    ).__json__()
+
+    assert payload == {
+        "entitlements": {
+            "branding_enabled": False,
+            "custom_domain_enabled": False,
+            "priority_class": "standard",
+            "analytics_tier": "basic",
+            "support_tier": "self_serve",
+        },
+        "branding": {
+            "logo_wide_url": None,
+            "logo_square_url": None,
+            "favicon_url": None,
+            "home_url": None,
+        },
+        "domain": {
+            "request_host": "creator.example.com",
+            "matched": False,
+            "is_custom_domain": False,
+            "creator_bid": "creator-1",
+            "domain_binding_bid": None,
+            "host": None,
+            "binding_status": None,
+        },
+    }
+
+
 def test_runtime_config_reports_disabled_billing_flag(
     runtime_config_client,
     monkeypatch,
@@ -309,8 +344,70 @@ def test_runtime_config_reports_disabled_billing_flag(
         "flaskr.service.billing.primitives.get_common_config",
         lambda key, default=None: False if key == "BILL_ENABLED" else default,
     )
+    monkeypatch.setattr(
+        config_route,
+        "build_runtime_billing_context",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("billing builder should not run when disabled")
+        ),
+    )
 
     response = runtime_config_client.get("/api/runtime-config")
     payload = response.get_json(force=True)["data"]
 
     assert payload["billingEnabled"] is False
+    assert payload["entitlements"] == {
+        "branding_enabled": False,
+        "custom_domain_enabled": False,
+        "priority_class": "standard",
+        "analytics_tier": "basic",
+        "support_tier": "self_serve",
+    }
+    assert payload["domain"] == {
+        "request_host": None,
+        "matched": False,
+        "is_custom_domain": False,
+        "creator_bid": None,
+        "domain_binding_bid": None,
+        "host": None,
+        "binding_status": None,
+    }
+
+
+def test_runtime_config_falls_back_when_billing_context_build_fails(
+    runtime_config_client,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        config_route,
+        "build_runtime_billing_context",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    response = runtime_config_client.get(
+        "/api/runtime-config?shifu_bid=shifu-1",
+        headers={"Host": "creator.example.com"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["billingEnabled"] is True
+    assert payload["logoWideUrl"] == "https://cdn.example.com/global-wide.png"
+    assert payload["logoSquareUrl"] == "https://cdn.example.com/global-square.png"
+    assert payload["faviconUrl"] == "https://cdn.example.com/global-favicon.ico"
+    assert payload["homeUrl"] == "/"
+    assert payload["entitlements"] == {
+        "branding_enabled": False,
+        "custom_domain_enabled": False,
+        "priority_class": "standard",
+        "analytics_tier": "basic",
+        "support_tier": "self_serve",
+    }
+    assert payload["domain"] == {
+        "request_host": "creator.example.com",
+        "matched": False,
+        "is_custom_domain": False,
+        "creator_bid": "creator-1",
+        "domain_binding_bid": None,
+        "host": None,
+        "binding_status": None,
+    }


### PR DESCRIPTION
Summary
- harden `/api/runtime-config` so billing failures no longer break the whole runtime payload
- short-circuit billing context building when `BILL_ENABLED` is false
- add regression coverage for disabled and exception fallback paths

Testing
- cd src/api && .venv/bin/pytest -q tests/service/billing/test_runtime_config_billing.py
- python scripts/check_ai_collab_docs.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime configuration endpoint resilience by implementing fallback behavior when billing context initialization fails.
  
* **Tests**
  * Expanded test coverage for runtime configuration billing scenarios, including error handling and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->