### PR TITLE
fix: fall back to request origin for public URLs

### DIFF
--- a/src/api/flaskr/common/public_urls.py
+++ b/src/api/flaskr/common/public_urls.py
@@ -43,7 +43,7 @@ def resolve_public_origin() -> str:
     if configured_origin:
         return configured_origin
 
-    request_origin = _request_origin() if _allow_request_origin_fallback() else ""
+    request_origin = _request_origin()
     if request_origin:
         return request_origin
 
@@ -62,16 +62,15 @@ def _request_origin() -> str:
     if not has_request_context():
         return ""
 
+    origin = _first_header_value(request.headers.get("Origin"))
+    if origin and origin.lower() != "null":
+        return _normalize_origin(origin)
+
     forwarded_proto = _first_header_value(request.headers.get("X-Forwarded-Proto"))
     forwarded_host = _first_header_value(request.headers.get("X-Forwarded-Host"))
     scheme = forwarded_proto or request.scheme
     host = forwarded_host or request.host
     return _normalize_origin(f"{scheme}://{host}")
-
-
-def _allow_request_origin_fallback() -> bool:
-    env = str(get_config("ENV", "production") or "production").strip().lower()
-    return env in {"dev", "development", "local", "test", "testing"}
 
 
 def _normalize_origin(value: str) -> str:

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -21,7 +21,6 @@ def _reset_config_cache(*keys: str) -> None:
 @pytest.fixture(autouse=True)
 def clear_public_url_config_cache():
     keys = (
-        "ENV",
         "HOST_URL",
         "PATH_PREFIX",
         "WECHATPAY_APP_ID",
@@ -79,14 +78,13 @@ def test_public_urls_use_path_prefix_for_backend_callbacks(
 def test_public_urls_fall_back_to_forwarded_request_origin(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv("ENV", "testing")
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.setenv("PATH_PREFIX", "/api")
-    _reset_config_cache("ENV", "HOST_URL", "PATH_PREFIX")
+    _reset_config_cache("HOST_URL", "PATH_PREFIX")
 
     app = Flask(__name__)
     with app.test_request_context(
-        "/api/runtime-config",
+        "/api/orders",
         headers={
             "X-Forwarded-Proto": "https",
             "X-Forwarded-Host": "forwarded.example.com",
@@ -96,19 +94,44 @@ def test_public_urls_fall_back_to_forwarded_request_origin(
             build_google_oauth_callback_url()
             == "https://forwarded.example.com/login/google-callback"
         )
+        assert (
+            build_alipay_notify_url()
+            == "https://forwarded.example.com/api/callback/alipay-notify"
+        )
+        assert (
+            build_wechatpay_notify_url()
+            == "https://forwarded.example.com/api/callback/wechatpay-notify"
+        )
+        assert (
+            build_stripe_learner_result_url()
+            == "https://forwarded.example.com/payment/stripe/result"
+        )
+        assert (
+            build_stripe_billing_result_url(canceled=True)
+            == "https://forwarded.example.com/payment/stripe/billing-result"
+            "?canceled=1"
+        )
 
 
-def test_public_urls_reject_request_origin_fallback_in_production(
+def test_public_urls_prefer_origin_header_when_host_url_missing(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv("ENV", "production")
     monkeypatch.delenv("HOST_URL", raising=False)
-    _reset_config_cache("ENV", "HOST_URL")
+    _reset_config_cache("HOST_URL")
 
     app = Flask(__name__)
-    with app.test_request_context("/api/runtime-config"):
-        with pytest.raises(RuntimeError, match="HOST_URL must be configured"):
-            build_google_oauth_callback_url()
+    with app.test_request_context(
+        "/api/runtime-config",
+        headers={
+            "Origin": "https://frontend.example.com",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "forwarded.example.com",
+        },
+    ):
+        assert (
+            build_stripe_learner_result_url()
+            == "https://frontend.example.com/payment/stripe/result"
+        )
 
 
 def test_public_urls_reject_host_url_with_path(monkeypatch: pytest.MonkeyPatch):

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -204,6 +204,36 @@ def test_runtime_config_returns_billing_extensions_for_custom_domain(
     }
 
 
+def test_runtime_config_uses_origin_header_for_google_redirect_when_host_url_missing(
+    runtime_config_client,
+    monkeypatch,
+) -> None:
+    original_route_get_config = config_route.get_config
+
+    def get_config_override(key, default=""):
+        if key == "HOST_URL":
+            return ""
+        return original_route_get_config(key, default)
+
+    monkeypatch.setattr(config_route, "get_config", get_config_override)
+    monkeypatch.setattr(public_urls, "get_config", get_config_override)
+
+    response = runtime_config_client.get(
+        "/api/runtime-config",
+        headers={
+            "Origin": "https://frontend-origin.example.com",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "forwarded.example.com",
+        },
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert response.status_code == 200
+    assert payload["googleOauthRedirect"] == (
+        "https://frontend-origin.example.com/login/google-callback"
+    )
+
+
 def test_runtime_config_keeps_global_branding_when_host_binding_is_not_effective(
     runtime_config_client,
 ) -> None:


### PR DESCRIPTION
## Summary
- Centralize HOST_URL fallback in build_public_url/resolve_public_origin instead of special-casing runtime-config or Google.
- When HOST_URL is not configured, public URL builders derive the origin from Origin, then X-Forwarded-Proto/Host, then request.host_url.
- This now applies consistently to Google OAuth callback, Alipay/WeChat notify URLs, and Stripe result URLs.

## Tests
- cd src/api && pytest -q tests/common/test_public_urls.py tests/service/billing/test_runtime_config_billing.py tests/service/order/test_provider_public_urls.py
- cd src/api && pytest -q tests/service/order/test_legacy_purchase_flow.py::test_legacy_stripe_checkout_urls_are_derived_from_host_url tests/service/billing/test_billing_write_routes.py::TestBillingWriteRoutes::test_subscription_checkout_creates_draft_subscription_and_pending_order