### PR TITLE
feat: add section learning stacked bar chart to dashboard course detail

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -149,7 +149,7 @@ services:
       - ./observability/otel-collector-config.yml:/etc/otel-collector-config.yml
 
   ai-shifu-prometheus:
-    image: prom/prometheus:v1.5.1
+    image: prom/prometheus:latest
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus

--- a/src/api/flaskr/service/dashboard/dtos.py
+++ b/src/api/flaskr/service/dashboard/dtos.py
@@ -174,6 +174,68 @@ class DashboardCourseDetailMetricsDTO(BaseModel):
 
 
 @register_schema_to_swagger
+class DashboardCourseDetailSectionChartDTO(BaseModel):
+    """Dashboard chart point for per-section learning and follow-up stats."""
+
+    chapter_outline_item_bid: str = Field(
+        ..., description="Parent chapter outline item bid", required=False
+    )
+    chapter_title: str = Field(
+        ..., description="Parent chapter title", required=False
+    )
+    section_outline_item_bid: str = Field(
+        ..., description="Section outline item bid", required=False
+    )
+    section_title: str = Field(
+        ..., description="Section title", required=False
+    )
+    position: str = Field(
+        ..., description="Section outline position", required=False
+    )
+    learning_user_count: int = Field(
+        ..., description="Distinct learner count for this section", required=False
+    )
+    learning_record_count: int = Field(
+        ..., description="Total learning record count for this section", required=False
+    )
+    follow_up_user_count: int = Field(
+        ..., description="Distinct follow-up user count for this section", required=False
+    )
+    follow_up_question_count: int = Field(
+        ..., description="Total follow-up question count for this section", required=False
+    )
+
+    def __json__(self) -> Dict[str, Any]:
+        return {
+            "chapter_outline_item_bid": self.chapter_outline_item_bid,
+            "chapter_title": self.chapter_title,
+            "section_outline_item_bid": self.section_outline_item_bid,
+            "section_title": self.section_title,
+            "position": self.position,
+            "learning_user_count": self.learning_user_count,
+            "learning_record_count": self.learning_record_count,
+            "follow_up_user_count": self.follow_up_user_count,
+            "follow_up_question_count": self.follow_up_question_count,
+        }
+
+
+@register_schema_to_swagger
+class DashboardCourseDetailChartsDTO(BaseModel):
+    """Dashboard detail chart data."""
+
+    sections: List[DashboardCourseDetailSectionChartDTO] = Field(
+        default_factory=list,
+        description="Per-section learning and follow-up stats",
+        required=False,
+    )
+
+    def __json__(self) -> Dict[str, Any]:
+        return {
+            "sections": [item.__json__() for item in self.sections],
+        }
+
+
+@register_schema_to_swagger
 class DashboardCourseDetailDTO(BaseModel):
     """Dashboard detail response payload."""
 
@@ -183,9 +245,15 @@ class DashboardCourseDetailDTO(BaseModel):
     metrics: DashboardCourseDetailMetricsDTO = Field(
         ..., description="Course detail metrics", required=False
     )
+    charts: DashboardCourseDetailChartsDTO = Field(
+        default_factory=DashboardCourseDetailChartsDTO,
+        description="Course detail chart data",
+        required=False,
+    )
 
     def __json__(self) -> Dict[str, Any]:
         return {
             "basic_info": self.basic_info.__json__(),
             "metrics": self.metrics.__json__(),
+            "charts": self.charts.__json__(),
         }

--- a/src/api/flaskr/service/dashboard/dtos.py
+++ b/src/api/flaskr/service/dashboard/dtos.py
@@ -180,18 +180,12 @@ class DashboardCourseDetailSectionChartDTO(BaseModel):
     chapter_outline_item_bid: str = Field(
         ..., description="Parent chapter outline item bid", required=False
     )
-    chapter_title: str = Field(
-        ..., description="Parent chapter title", required=False
-    )
+    chapter_title: str = Field(..., description="Parent chapter title", required=False)
     section_outline_item_bid: str = Field(
         ..., description="Section outline item bid", required=False
     )
-    section_title: str = Field(
-        ..., description="Section title", required=False
-    )
-    position: str = Field(
-        ..., description="Section outline position", required=False
-    )
+    section_title: str = Field(..., description="Section title", required=False)
+    position: str = Field(..., description="Section outline position", required=False)
     learning_user_count: int = Field(
         ..., description="Distinct learner count for this section", required=False
     )
@@ -199,10 +193,14 @@ class DashboardCourseDetailSectionChartDTO(BaseModel):
         ..., description="Total learning record count for this section", required=False
     )
     follow_up_user_count: int = Field(
-        ..., description="Distinct follow-up user count for this section", required=False
+        ...,
+        description="Distinct follow-up user count for this section",
+        required=False,
     )
     follow_up_question_count: int = Field(
-        ..., description="Total follow-up question count for this section", required=False
+        ...,
+        description="Total follow-up question count for this section",
+        required=False,
     )
 
     def __json__(self) -> Dict[str, Any]:

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -13,8 +13,10 @@ from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.dashboard.dtos import (
     DashboardCourseDetailBasicInfoDTO,
+    DashboardCourseDetailChartsDTO,
     DashboardCourseDetailDTO,
     DashboardCourseDetailMetricsDTO,
+    DashboardCourseDetailSectionChartDTO,
     DashboardEntryCourseItemDTO,
     DashboardEntryDTO,
     DashboardEntrySummaryDTO,
@@ -196,6 +198,165 @@ def _load_course_leaf_outline_bids(shifu_bid: str) -> List[str]:
         for outline_item_bid in visible_bids
         if outline_item_bid not in visible_parent_bids
     )
+
+
+def _outline_position_key(position: object) -> Tuple[Tuple[int, int | str], ...]:
+    normalized_position = str(position or "").strip()
+    if not normalized_position:
+        return ()
+
+    key_parts: List[Tuple[int, int | str]] = []
+    for part in normalized_position.split("."):
+        normalized_part = part.strip()
+        if not normalized_part:
+            continue
+        if normalized_part.isdigit():
+            key_parts.append((0, int(normalized_part)))
+        else:
+            key_parts.append((1, normalized_part))
+    return tuple(key_parts)
+
+
+def _build_section_learning_chart(
+    shifu_bid: str,
+) -> List[DashboardCourseDetailSectionChartDTO]:
+    outline_items_query = PublishedOutlineItem.query.filter(
+        PublishedOutlineItem.shifu_bid == shifu_bid,
+        PublishedOutlineItem.deleted == 0,
+        PublishedOutlineItem.hidden == 0,
+    ).order_by(PublishedOutlineItem.id.asc())
+    outline_item_map: Dict[str, PublishedOutlineItem] = {}
+    visible_parent_bids: Set[str] = set()
+    for item in outline_items_query.yield_per(1000):
+        outline_item_bid = str(item.outline_item_bid or "").strip()
+        parent_bid = str(item.parent_bid or "").strip()
+        if not outline_item_bid:
+            continue
+        outline_item_map[outline_item_bid] = item
+        if parent_bid:
+            visible_parent_bids.add(parent_bid)
+
+    visible_section_bids = {
+        outline_item_bid
+        for outline_item_bid in outline_item_map.keys()
+        if outline_item_bid not in visible_parent_bids
+    }
+    ordered_sections = sorted(
+        [
+            outline_item_map[outline_item_bid]
+            for outline_item_bid in visible_section_bids
+        ],
+        key=lambda item: (
+            _outline_position_key(getattr(item, "position", "")),
+            int(getattr(item, "id", 0) or 0),
+        ),
+    )
+
+    learning_user_rows = (
+        db.session.query(
+            LearnProgressRecord.outline_item_bid,
+            db.func.count(db.func.distinct(LearnProgressRecord.user_bid)),
+            db.func.count(LearnProgressRecord.id),
+        )
+        .filter(
+            LearnProgressRecord.shifu_bid == shifu_bid,
+            LearnProgressRecord.deleted == 0,
+            LearnProgressRecord.status != LEARN_STATUS_RESET,
+        )
+        .group_by(LearnProgressRecord.outline_item_bid)
+    )
+    learning_stats_map: Dict[str, Tuple[int, int]] = {}
+    for (
+        outline_item_bid,
+        user_count,
+        record_count,
+    ) in learning_user_rows.yield_per(1000):
+        normalized_bid = str(outline_item_bid or "").strip()
+        if not normalized_bid:
+            continue
+        learning_stats_map[normalized_bid] = (
+            int(user_count or 0),
+            int(record_count or 0),
+        )
+
+    follow_up_user_rows = (
+        db.session.query(
+            LearnGeneratedBlock.outline_item_bid,
+            db.func.count(db.func.distinct(LearnGeneratedBlock.user_bid)),
+            db.func.count(LearnGeneratedBlock.id),
+        )
+        .filter(
+            LearnGeneratedBlock.shifu_bid == shifu_bid,
+            LearnGeneratedBlock.deleted == 0,
+            LearnGeneratedBlock.status == 1,
+            LearnGeneratedBlock.type == BLOCK_TYPE_MDASK_VALUE,
+            LearnGeneratedBlock.role == ROLE_STUDENT,
+        )
+        .group_by(LearnGeneratedBlock.outline_item_bid)
+    )
+    follow_up_stats_map: Dict[str, Tuple[int, int]] = {}
+    for (
+        outline_item_bid,
+        user_count,
+        question_count,
+    ) in follow_up_user_rows.yield_per(1000):
+        normalized_bid = str(outline_item_bid or "").strip()
+        if not normalized_bid:
+            continue
+        follow_up_stats_map[normalized_bid] = (
+            int(user_count or 0),
+            int(question_count or 0),
+        )
+
+    section_chapter: Dict[str, Tuple[str, str]] = {}
+    for outline_item_bid in visible_section_bids:
+        cur = outline_item_bid
+        visited: Set[str] = set()
+        chapter_bid = outline_item_bid
+        chapter_title = str(outline_item_map[outline_item_bid].title or "").strip()
+        while cur and cur not in visited:
+            visited.add(cur)
+            item = outline_item_map.get(cur)
+            if item is None:
+                break
+            parent_bid = str(getattr(item, "parent_bid", "") or "").strip()
+            if not parent_bid or parent_bid not in outline_item_map:
+                break
+            chapter_bid = parent_bid
+            chapter_title = str(outline_item_map[parent_bid].title or "").strip()
+            cur = parent_bid
+        section_chapter[outline_item_bid] = (chapter_bid, chapter_title)
+
+    chart_items: List[DashboardCourseDetailSectionChartDTO] = []
+    for section_outline_item_bid in [
+        str(s.outline_item_bid or "").strip() for s in ordered_sections
+    ]:
+        section = outline_item_map[section_outline_item_bid]
+        learning_user, learning_record = learning_stats_map.get(
+            section_outline_item_bid, (0, 0)
+        )
+        follow_up_user, follow_up_question = follow_up_stats_map.get(
+            section_outline_item_bid, (0, 0)
+        )
+        chapter_outline_item_bid, chapter_title = section_chapter[
+            section_outline_item_bid
+        ]
+
+        chart_items.append(
+            DashboardCourseDetailSectionChartDTO(
+                chapter_outline_item_bid=chapter_outline_item_bid,
+                chapter_title=chapter_title,
+                section_outline_item_bid=section_outline_item_bid,
+                section_title=str(section.title or "").strip(),
+                position=str(section.position or "").strip(),
+                learning_user_count=learning_user,
+                learning_record_count=learning_record,
+                follow_up_user_count=follow_up_user,
+                follow_up_question_count=follow_up_question,
+            )
+        )
+
+    return chart_items
 
 
 def _load_course_learner_bids(shifu_bid: str) -> Set[str]:
@@ -671,6 +832,7 @@ def build_dashboard_course_detail(
             normalized_shifu_bid,
             learner_count,
         )
+        sections = _build_section_learning_chart(normalized_shifu_bid)
 
         return DashboardCourseDetailDTO(
             basic_info=DashboardCourseDetailBasicInfoDTO(
@@ -708,4 +870,5 @@ def build_dashboard_course_detail(
                 ),
                 avg_learning_duration_seconds=avg_learning_duration_seconds,
             ),
+            charts=DashboardCourseDetailChartsDTO(sections=sections),
         )

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -224,7 +224,7 @@ def _build_section_learning_chart(
         PublishedOutlineItem.shifu_bid == shifu_bid,
         PublishedOutlineItem.deleted == 0,
         PublishedOutlineItem.hidden == 0,
-    ).order_by(PublishedOutlineItem.id.asc())
+    )
     outline_item_map: Dict[str, PublishedOutlineItem] = {}
     visible_parent_bids: Set[str] = set()
     for item in outline_items_query.yield_per(1000):
@@ -247,8 +247,8 @@ def _build_section_learning_chart(
             for outline_item_bid in visible_section_bids
         ],
         key=lambda item: (
-            _outline_position_key(getattr(item, "position", "")),
-            int(getattr(item, "id", 0) or 0),
+            _outline_position_key(item.position),
+            int(item.id or 0),
         ),
     )
 
@@ -313,13 +313,13 @@ def _build_section_learning_chart(
         cur = outline_item_bid
         visited: Set[str] = set()
         chapter_bid = outline_item_bid
-        chapter_title = str(outline_item_map[outline_item_bid].title or "").strip()
+        chapter_title = ""
         while cur and cur not in visited:
             visited.add(cur)
             item = outline_item_map.get(cur)
             if item is None:
                 break
-            parent_bid = str(getattr(item, "parent_bid", "") or "").strip()
+            parent_bid = str(item.parent_bid or "").strip()
             if not parent_bid or parent_bid not in outline_item_map:
                 break
             chapter_bid = parent_bid
@@ -328,10 +328,8 @@ def _build_section_learning_chart(
         section_chapter[outline_item_bid] = (chapter_bid, chapter_title)
 
     chart_items: List[DashboardCourseDetailSectionChartDTO] = []
-    for section_outline_item_bid in [
-        str(s.outline_item_bid or "").strip() for s in ordered_sections
-    ]:
-        section = outline_item_map[section_outline_item_bid]
+    for section in ordered_sections:
+        section_outline_item_bid = str(section.outline_item_bid or "").strip()
         learning_user, learning_record = learning_stats_map.get(
             section_outline_item_bid, (0, 0)
         )

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -1498,7 +1498,9 @@ class TestDashboardRoutes:
         sections = payload["data"]["charts"]["sections"]
         assert len(sections) == 2
 
-        lesson1 = next(s for s in sections if s["section_outline_item_bid"] == "lesson-1")
+        lesson1 = next(
+            s for s in sections if s["section_outline_item_bid"] == "lesson-1"
+        )
         assert lesson1["section_title"] == "Lesson 1"
         assert lesson1["chapter_title"] == "Chapter 1"
         assert lesson1["learning_user_count"] == 2
@@ -1506,7 +1508,9 @@ class TestDashboardRoutes:
         assert lesson1["follow_up_user_count"] == 2
         assert lesson1["follow_up_question_count"] == 3
 
-        lesson2 = next(s for s in sections if s["section_outline_item_bid"] == "lesson-2")
+        lesson2 = next(
+            s for s in sections if s["section_outline_item_bid"] == "lesson-2"
+        )
         assert lesson2["section_title"] == "Lesson 2"
         assert lesson2["chapter_title"] == "Chapter 1"
         assert lesson2["learning_user_count"] == 1

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -1332,3 +1332,184 @@ class TestDashboardRoutes:
         assert resp.status_code == 200
         assert payload["code"] != 0
         assert payload["message"] == "Course not found"
+
+    def test_course_detail_returns_section_learning_chart(
+        self,
+        monkeypatch,
+        test_client,
+        app,
+    ):
+        self._mock_request_user(monkeypatch)
+
+        now = datetime.utcnow()
+        with app.app_context():
+            self._seed_dashboard_course(
+                shifu_bid="course-section-chart",
+                title="Section Chart Course",
+            )
+            self._seed_outline_item(
+                shifu_bid="course-section-chart",
+                outline_item_bid="chapter-1",
+                title="Chapter 1",
+                position="1",
+            )
+            self._seed_outline_item(
+                shifu_bid="course-section-chart",
+                outline_item_bid="lesson-1",
+                title="Lesson 1",
+                parent_bid="chapter-1",
+                position="1.1",
+            )
+            self._seed_outline_item(
+                shifu_bid="course-section-chart",
+                outline_item_bid="lesson-2",
+                title="Lesson 2",
+                parent_bid="chapter-1",
+                position="1.2",
+            )
+            self._seed_outline_item(
+                shifu_bid="course-section-chart",
+                outline_item_bid="lesson-hidden",
+                title="Hidden Lesson",
+                parent_bid="chapter-1",
+                position="1.3",
+                hidden=1,
+            )
+
+            # 2 learners with progress in lesson-1, 1 in lesson-2
+            db.session.add_all(
+                [
+                    LearnProgressRecord(
+                        progress_record_bid="sec-prog-1",
+                        shifu_bid="course-section-chart",
+                        outline_item_bid="lesson-1",
+                        user_bid="learner-1",
+                        status=LEARN_STATUS_IN_PROGRESS,
+                        block_position=0,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    LearnProgressRecord(
+                        progress_record_bid="sec-prog-2",
+                        shifu_bid="course-section-chart",
+                        outline_item_bid="lesson-1",
+                        user_bid="learner-2",
+                        status=LEARN_STATUS_COMPLETED,
+                        block_position=0,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    LearnProgressRecord(
+                        progress_record_bid="sec-prog-3",
+                        shifu_bid="course-section-chart",
+                        outline_item_bid="lesson-2",
+                        user_bid="learner-1",
+                        status=LEARN_STATUS_IN_PROGRESS,
+                        block_position=0,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                ]
+            )
+            # Follow-up questions
+            db.session.add_all(
+                [
+                    LearnGeneratedBlock(
+                        generated_block_bid="sec-ask-1",
+                        progress_record_bid="sec-prog-1",
+                        user_bid="learner-1",
+                        block_bid="",
+                        outline_item_bid="lesson-1",
+                        shifu_bid="course-section-chart",
+                        type=BLOCK_TYPE_MDASK_VALUE,
+                        role=ROLE_STUDENT,
+                        generated_content="Q1",
+                        position=1,
+                        block_content_conf="",
+                        status=1,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    LearnGeneratedBlock(
+                        generated_block_bid="sec-ask-2",
+                        progress_record_bid="sec-prog-2",
+                        user_bid="learner-2",
+                        block_bid="",
+                        outline_item_bid="lesson-1",
+                        shifu_bid="course-section-chart",
+                        type=BLOCK_TYPE_MDASK_VALUE,
+                        role=ROLE_STUDENT,
+                        generated_content="Q2",
+                        position=2,
+                        block_content_conf="",
+                        status=1,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    LearnGeneratedBlock(
+                        generated_block_bid="sec-ask-3",
+                        progress_record_bid="sec-prog-2",
+                        user_bid="learner-2",
+                        block_bid="",
+                        outline_item_bid="lesson-1",
+                        shifu_bid="course-section-chart",
+                        type=BLOCK_TYPE_MDASK_VALUE,
+                        role=ROLE_STUDENT,
+                        generated_content="Q3",
+                        position=3,
+                        block_content_conf="",
+                        status=1,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    # Teacher role - should be excluded from follow-up counts
+                    LearnGeneratedBlock(
+                        generated_block_bid="sec-ask-teacher",
+                        progress_record_bid="sec-prog-1",
+                        user_bid="learner-1",
+                        block_bid="",
+                        outline_item_bid="lesson-1",
+                        shifu_bid="course-section-chart",
+                        type=BLOCK_TYPE_MDASK_VALUE,
+                        role=ROLE_TEACHER,
+                        generated_content="Ignore",
+                        position=4,
+                        block_content_conf="",
+                        status=1,
+                        deleted=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                ]
+            )
+            db.session.commit()
+
+        resp = test_client.get("/api/dashboard/shifus/course-section-chart/detail")
+        payload = resp.get_json(force=True)
+
+        assert resp.status_code == 200
+        assert payload["code"] == 0
+        sections = payload["data"]["charts"]["sections"]
+        assert len(sections) == 2
+
+        lesson1 = next(s for s in sections if s["section_outline_item_bid"] == "lesson-1")
+        assert lesson1["section_title"] == "Lesson 1"
+        assert lesson1["chapter_title"] == "Chapter 1"
+        assert lesson1["learning_user_count"] == 2
+        assert lesson1["learning_record_count"] == 2
+        assert lesson1["follow_up_user_count"] == 2
+        assert lesson1["follow_up_question_count"] == 3
+
+        lesson2 = next(s for s in sections if s["section_outline_item_bid"] == "lesson-2")
+        assert lesson2["section_title"] == "Lesson 2"
+        assert lesson2["chapter_title"] == "Chapter 1"
+        assert lesson2["learning_user_count"] == 1
+        assert lesson2["learning_record_count"] == 1
+        assert lesson2["follow_up_user_count"] == 0
+        assert lesson2["follow_up_question_count"] == 0

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.test.tsx
@@ -90,6 +90,21 @@ jest.mock('@/components/ErrorDisplay', () => ({
   ),
 }));
 
+jest.mock('@/components/charts/EChart', () => ({
+  __esModule: true,
+  default: ({ option }: { option: unknown }) => (
+    <div
+      data-testid='section-learning-chart'
+      data-option={JSON.stringify(option)}
+    />
+  ),
+}));
+
+const getRenderedChartOption = () =>
+  JSON.parse(
+    screen.getByTestId('section-learning-chart').dataset.option || '{}',
+  );
+
 describe('AdminDashboardCourseDetailPage', () => {
   beforeEach(() => {
     mockParams = { shifu_bid: 'shifu-1' };
@@ -97,7 +112,7 @@ describe('AdminDashboardCourseDetailPage', () => {
     mockPush.mockReset();
   });
 
-  test('renders real course detail data and keeps placeholder sections', async () => {
+  test('renders real course detail with section learning stacked bar chart', async () => {
     mockGetDashboardCourseDetail.mockResolvedValue({
       basic_info: {
         shifu_bid: 'shifu-1',
@@ -116,6 +131,32 @@ describe('AdminDashboardCourseDetailPage', () => {
         total_follow_up_count: 8,
         avg_follow_up_count_per_learner: '4.00',
         avg_learning_duration_seconds: 3661,
+      },
+      charts: {
+        sections: [
+          {
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            section_outline_item_bid: 'lesson-1',
+            section_title: 'Lesson 1',
+            position: '1.1',
+            learning_user_count: 10,
+            learning_record_count: 25,
+            follow_up_user_count: 3,
+            follow_up_question_count: 8,
+          },
+          {
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            section_outline_item_bid: 'lesson-2',
+            section_title: 'Lesson 2',
+            position: '1.2',
+            learning_user_count: 5,
+            learning_record_count: 12,
+            follow_up_user_count: 0,
+            follow_up_question_count: 0,
+          },
+        ],
       },
     });
 
@@ -153,8 +194,34 @@ describe('AdminDashboardCourseDetailPage', () => {
       screen.getByText('module.dashboard.detail.charts.title'),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByText('module.dashboard.detail.charts.placeholder').length,
-    ).toBe(4);
+      screen.getByText('module.dashboard.detail.charts.sectionLearningTitle'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('section-learning-chart')).toBeInTheDocument();
+
+    const option = getRenderedChartOption();
+    expect(option.series).toHaveLength(4);
+    expect(option.series[0].name).toBe(
+      'module.dashboard.detail.charts.learningUserCount',
+    );
+    expect(option.series[1].name).toBe(
+      'module.dashboard.detail.charts.learningRecordCount',
+    );
+    expect(option.series[2].name).toBe(
+      'module.dashboard.detail.charts.followUpUserCount',
+    );
+    expect(option.series[3].name).toBe(
+      'module.dashboard.detail.charts.followUpQuestionCount',
+    );
+    expect(option.series[0].data).toEqual([10, 5]);
+    expect(option.series[1].data).toEqual([25, 12]);
+    expect(option.series[2].data).toEqual([3, 0]);
+    expect(option.series[3].data).toEqual([8, 0]);
+    expect(option.xAxis.data).toEqual(['Lesson 1', 'Lesson 2']);
+    expect(option.series[0].stack).toBe('total');
+    expect(option.series[1].stack).toBe('total');
+    expect(option.series[2].stack).toBe('total');
+    expect(option.series[3].stack).toBe('total');
+
     expect(
       screen.getByText('module.dashboard.detail.learners.empty'),
     ).toBeInTheDocument();
@@ -179,6 +246,9 @@ describe('AdminDashboardCourseDetailPage', () => {
         total_follow_up_count: 8,
         avg_follow_up_count_per_learner: '4.00',
         avg_learning_duration_seconds: 3661,
+      },
+      charts: {
+        sections: [],
       },
     });
 
@@ -220,6 +290,9 @@ describe('AdminDashboardCourseDetailPage', () => {
           total_follow_up_count: 0,
           avg_follow_up_count_per_learner: '0.00',
           avg_learning_duration_seconds: 0,
+        },
+        charts: {
+          sections: [],
         },
       });
 

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
@@ -17,6 +17,8 @@ import {
   BreadcrumbSeparator,
 } from '@/components/ui/Breadcrumb';
 import { Card, CardContent } from '@/components/ui/Card';
+import ChartCard from '@/components/charts/ChartCard';
+import EChart from '@/components/charts/EChart';
 import {
   Table,
   TableBody,
@@ -27,6 +29,8 @@ import {
 } from '@/components/ui/Table';
 import { ErrorWithCode } from '@/lib/request';
 import { getBrowserTimeZone } from '@/lib/browser-timezone';
+import { buildSectionLearningChartOption } from '@/lib/dashboard/section-learning-chart';
+import type { SectionChartLabels } from '@/lib/dashboard/section-learning-chart';
 import { useUserStore } from '@/store';
 import type { DashboardCourseDetailResponse } from '@/types/dashboard';
 import { buildAdminOrdersUrl } from '../admin-dashboard-routes';
@@ -51,6 +55,9 @@ const EMPTY_DETAIL: DashboardCourseDetailResponse = {
     total_follow_up_count: 0,
     avg_follow_up_count_per_learner: '0.00',
     avg_learning_duration_seconds: 0,
+  },
+  charts: {
+    sections: [],
   },
 };
 
@@ -114,12 +121,34 @@ export default function AdminDashboardCourseDetailPage() {
   const emptyValue = '--';
   const orderListUrl = buildAdminOrdersUrl(shifuBid);
 
-  const chartLabels = [
-    t('module.dashboard.detail.charts.questionsByChapter'),
-    t('module.dashboard.detail.charts.questionsByTime'),
-    t('module.dashboard.detail.charts.learningTrend'),
-    t('module.dashboard.detail.charts.chapterProgress'),
-  ];
+  const sectionChartLabels = useMemo<SectionChartLabels>(
+    () => ({
+      learningUserCount: t(
+        'module.dashboard.detail.charts.learningUserCount',
+      ),
+      learningRecordCount: t(
+        'module.dashboard.detail.charts.learningRecordCount',
+      ),
+      followUpUserCount: t(
+        'module.dashboard.detail.charts.followUpUserCount',
+      ),
+      followUpQuestionCount: t(
+        'module.dashboard.detail.charts.followUpQuestionCount',
+      ),
+    }),
+    [t],
+  );
+
+  const sectionChartOption = useMemo(
+    () =>
+      buildSectionLearningChartOption(
+        detail.charts.sections || [],
+        sectionChartLabels,
+      ),
+    [detail.charts.sections, sectionChartLabels],
+  );
+
+  const sectionChartHasData = (detail.charts.sections || []).length > 0;
   const learnerTableColumnLabels = [
     t('module.dashboard.detail.learners.columns.name'),
     t('module.dashboard.detail.learners.columns.progress'),
@@ -371,20 +400,22 @@ export default function AdminDashboardCourseDetailPage() {
           <h2 className='text-base font-semibold text-foreground'>
             {t('module.dashboard.detail.charts.title')}
           </h2>
-          <div className='grid grid-cols-1 gap-4 xl:grid-cols-2'>
-            {chartLabels.map(chartLabel => (
-              <Card key={chartLabel}>
-                <CardContent className='flex h-56 flex-col p-5'>
-                  <div className='text-sm font-medium text-foreground'>
-                    {chartLabel}
-                  </div>
-                  <div className='mt-4 flex flex-1 items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 text-sm text-muted-foreground'>
-                    {t('module.dashboard.detail.charts.placeholder')}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+          <ChartCard
+            title={t('module.dashboard.detail.charts.sectionLearningTitle')}
+            contentClassName='min-h-[380px]'
+          >
+            {sectionChartHasData ? (
+              <EChart
+                option={sectionChartOption}
+                style={{ height: 360, width: '100%' }}
+                notMerge
+              />
+            ) : (
+              <div className='flex h-[360px] items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 text-sm text-muted-foreground'>
+                {t('module.dashboard.detail.charts.emptySections')}
+              </div>
+            )}
+          </ChartCard>
         </div>
 
         <Card>

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
@@ -123,15 +123,11 @@ export default function AdminDashboardCourseDetailPage() {
 
   const sectionChartLabels = useMemo<SectionChartLabels>(
     () => ({
-      learningUserCount: t(
-        'module.dashboard.detail.charts.learningUserCount',
-      ),
+      learningUserCount: t('module.dashboard.detail.charts.learningUserCount'),
       learningRecordCount: t(
         'module.dashboard.detail.charts.learningRecordCount',
       ),
-      followUpUserCount: t(
-        'module.dashboard.detail.charts.followUpUserCount',
-      ),
+      followUpUserCount: t('module.dashboard.detail.charts.followUpUserCount'),
       followUpQuestionCount: t(
         'module.dashboard.detail.charts.followUpQuestionCount',
       ),

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
@@ -164,8 +164,14 @@ export default function AdminDashboardCourseDetailPage() {
       const response = (await api.getDashboardCourseDetail({
         shifu_bid: shifuBid,
         ...(timezone ? { timezone } : {}),
-      })) as DashboardCourseDetailResponse;
-      setDetail(response || EMPTY_DETAIL);
+      })) as Partial<DashboardCourseDetailResponse> | null;
+      setDetail({
+        ...EMPTY_DETAIL,
+        ...(response ?? {}),
+        basic_info: { ...EMPTY_DETAIL.basic_info, ...(response?.basic_info ?? {}) },
+        metrics: { ...EMPTY_DETAIL.metrics, ...(response?.metrics ?? {}) },
+        charts: { sections: response?.charts?.sections ?? [] },
+      });
     } catch (err) {
       setDetail(EMPTY_DETAIL);
       if (err instanceof ErrorWithCode) {

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/page.tsx
@@ -168,7 +168,10 @@ export default function AdminDashboardCourseDetailPage() {
       setDetail({
         ...EMPTY_DETAIL,
         ...(response ?? {}),
-        basic_info: { ...EMPTY_DETAIL.basic_info, ...(response?.basic_info ?? {}) },
+        basic_info: {
+          ...EMPTY_DETAIL.basic_info,
+          ...(response?.basic_info ?? {}),
+        },
         metrics: { ...EMPTY_DETAIL.metrics, ...(response?.metrics ?? {}) },
         charts: { sections: response?.charts?.sections ?? [] },
       });

--- a/src/cook-web/src/lib/dashboard/section-learning-chart.ts
+++ b/src/cook-web/src/lib/dashboard/section-learning-chart.ts
@@ -97,10 +97,26 @@ export const buildSectionLearningChartOption = (
       : undefined,
     series: (
       [
-        [labels.learningUserCount, (s: DashboardCourseDetailSectionChart) => s.learning_user_count, '#2563eb'],
-        [labels.learningRecordCount, (s: DashboardCourseDetailSectionChart) => s.learning_record_count, '#60a5fa'],
-        [labels.followUpUserCount, (s: DashboardCourseDetailSectionChart) => s.follow_up_user_count, '#16a34a'],
-        [labels.followUpQuestionCount, (s: DashboardCourseDetailSectionChart) => s.follow_up_question_count, '#86efac'],
+        [
+          labels.learningUserCount,
+          (s: DashboardCourseDetailSectionChart) => s.learning_user_count,
+          '#2563eb',
+        ],
+        [
+          labels.learningRecordCount,
+          (s: DashboardCourseDetailSectionChart) => s.learning_record_count,
+          '#60a5fa',
+        ],
+        [
+          labels.followUpUserCount,
+          (s: DashboardCourseDetailSectionChart) => s.follow_up_user_count,
+          '#16a34a',
+        ],
+        [
+          labels.followUpQuestionCount,
+          (s: DashboardCourseDetailSectionChart) => s.follow_up_question_count,
+          '#86efac',
+        ],
       ] as const
     ).map(([name, extract, color]) => ({
       type: 'bar',

--- a/src/cook-web/src/lib/dashboard/section-learning-chart.ts
+++ b/src/cook-web/src/lib/dashboard/section-learning-chart.ts
@@ -1,0 +1,129 @@
+import type { EChartsOption } from 'echarts';
+import type { DashboardCourseDetailSectionChart } from '@/types/dashboard';
+
+const MAX_AXIS_LABEL_LENGTH = 18;
+const DATAZOOM_THRESHOLD = 20;
+
+export type SectionChartLabels = {
+  learningUserCount: string;
+  learningRecordCount: string;
+  followUpUserCount: string;
+  followUpQuestionCount: string;
+};
+
+export const buildSectionLearningChartOption = (
+  sections: DashboardCourseDetailSectionChart[],
+  labels: SectionChartLabels,
+): EChartsOption => {
+  const shouldScroll = sections.length > DATAZOOM_THRESHOLD;
+
+  return {
+    grid: {
+      top: 16,
+      left: 28,
+      right: 28,
+      bottom: shouldScroll ? 80 : 40,
+      containLabel: true,
+    },
+    legend: {
+      show: true,
+      bottom: shouldScroll ? 50 : 0,
+      itemWidth: 12,
+      itemHeight: 12,
+      textStyle: { color: '#475569', fontSize: 12 },
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params: unknown) => {
+        const items = Array.isArray(params) ? params : [];
+        if (!items.length) {
+          return '';
+        }
+        const dataIndex =
+          typeof items[0] === 'object' &&
+          items[0] !== null &&
+          'dataIndex' in items[0]
+            ? Number(items[0].dataIndex)
+            : 0;
+        const section = sections[dataIndex];
+        if (!section) {
+          return '';
+        }
+        const header =
+          section.chapter_title && section.section_title
+            ? `${escapeHtml(section.chapter_title)} / ${escapeHtml(section.section_title)}`
+            : escapeHtml(section.section_title || section.chapter_title || '');
+        const lines = [
+          header,
+          `${labels.learningUserCount}: ${section.learning_user_count}`,
+          `${labels.learningRecordCount}: ${section.learning_record_count}`,
+          `${labels.followUpUserCount}: ${section.follow_up_user_count}`,
+          `${labels.followUpQuestionCount}: ${section.follow_up_question_count}`,
+        ];
+        return lines.join('<br/>');
+      },
+    },
+    xAxis: {
+      type: 'category',
+      data: sections.map(s => truncateChartLabel(s.section_title)),
+      axisTick: { show: false },
+      axisLine: { lineStyle: { color: '#e2e8f0' } },
+      axisLabel: { color: '#475569' },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: { lineStyle: { color: '#eef2f7' } },
+      axisLabel: { color: '#64748b' },
+    },
+    dataZoom: shouldScroll
+      ? [
+          {
+            type: 'slider',
+            xAxisIndex: 0,
+            height: 14,
+            bottom: 12,
+            start: 0,
+            end: Math.min(
+              ((DATAZOOM_THRESHOLD - 1) / sections.length) * 100,
+              100,
+            ),
+            filterMode: 'none',
+          },
+        ]
+      : undefined,
+    series: (
+      [
+        [labels.learningUserCount, (s: DashboardCourseDetailSectionChart) => s.learning_user_count, '#2563eb'],
+        [labels.learningRecordCount, (s: DashboardCourseDetailSectionChart) => s.learning_record_count, '#60a5fa'],
+        [labels.followUpUserCount, (s: DashboardCourseDetailSectionChart) => s.follow_up_user_count, '#16a34a'],
+        [labels.followUpQuestionCount, (s: DashboardCourseDetailSectionChart) => s.follow_up_question_count, '#86efac'],
+      ] as const
+    ).map(([name, extract, color]) => ({
+      type: 'bar',
+      name,
+      data: sections.map(extract),
+      stack: 'total',
+      barMaxWidth: 32,
+      itemStyle: { color },
+    })),
+  };
+};
+
+const truncateChartLabel = (value: string): string => {
+  if (value.length <= MAX_AXIS_LABEL_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_AXIS_LABEL_LENGTH)}...`;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');

--- a/src/cook-web/src/types/dashboard.ts
+++ b/src/cook-web/src/types/dashboard.ts
@@ -44,7 +44,24 @@ export type DashboardCourseDetailMetrics = {
   avg_learning_duration_seconds: number;
 };
 
+export type DashboardCourseDetailSectionChart = {
+  chapter_outline_item_bid: string;
+  chapter_title: string;
+  section_outline_item_bid: string;
+  section_title: string;
+  position: string;
+  learning_user_count: number;
+  learning_record_count: number;
+  follow_up_user_count: number;
+  follow_up_question_count: number;
+};
+
+export type DashboardCourseDetailCharts = {
+  sections: DashboardCourseDetailSectionChart[];
+};
+
 export type DashboardCourseDetailResponse = {
   basic_info: DashboardCourseDetailBasicInfo;
   metrics: DashboardCourseDetailMetrics;
+  charts: DashboardCourseDetailCharts;
 };

--- a/src/i18n/en-US/modules/dashboard.json
+++ b/src/i18n/en-US/modules/dashboard.json
@@ -10,10 +10,16 @@
     },
     "charts": {
       "chapterProgress": "Chapter Progress Distribution",
+      "followUpQuestionCount": "Follow-Up Questions",
+      "followUpUserCount": "Follow-Up Users",
+      "learningRecordCount": "Learning Records",
       "learningTrend": "Learning Activity Trend",
+      "learningUserCount": "Learning Users",
       "placeholder": "Charts are coming soon",
       "questionsByChapter": "Follow-up Questions by Chapter",
       "questionsByTime": "Follow-up Questions by Time",
+      "emptySections": "No section data",
+      "sectionLearningTitle": "Learning & Follow-Up by Section",
       "title": "Charts"
     },
     "courseIdLabel": "Course ID",

--- a/src/i18n/en-US/modules/dashboard.json
+++ b/src/i18n/en-US/modules/dashboard.json
@@ -10,6 +10,7 @@
     },
     "charts": {
       "chapterProgress": "Chapter Progress Distribution",
+      "emptySections": "No section data",
       "followUpQuestionCount": "Follow-Up Questions",
       "followUpUserCount": "Follow-Up Users",
       "learningRecordCount": "Learning Records",
@@ -18,7 +19,6 @@
       "placeholder": "Charts are coming soon",
       "questionsByChapter": "Follow-up Questions by Chapter",
       "questionsByTime": "Follow-up Questions by Time",
-      "emptySections": "No section data",
       "sectionLearningTitle": "Learning & Follow-Up by Section",
       "title": "Charts"
     },

--- a/src/i18n/zh-CN/modules/dashboard.json
+++ b/src/i18n/zh-CN/modules/dashboard.json
@@ -10,6 +10,7 @@
     },
     "charts": {
       "chapterProgress": "章节学习进度分布图",
+      "emptySections": "暂无小节数据",
       "followUpQuestionCount": "追问次数",
       "followUpUserCount": "追问人数",
       "learningRecordCount": "学习次数",
@@ -18,7 +19,6 @@
       "placeholder": "图表能力建设中，敬请期待",
       "questionsByChapter": "追问数量按章节分布图",
       "questionsByTime": "追问数量按时间分布图",
-      "emptySections": "暂无小节数据",
       "sectionLearningTitle": "各小节学习与追问统计",
       "title": "图表区"
     },

--- a/src/i18n/zh-CN/modules/dashboard.json
+++ b/src/i18n/zh-CN/modules/dashboard.json
@@ -10,10 +10,16 @@
     },
     "charts": {
       "chapterProgress": "章节学习进度分布图",
+      "followUpQuestionCount": "追问次数",
+      "followUpUserCount": "追问人数",
+      "learningRecordCount": "学习次数",
       "learningTrend": "学习活跃趋势图",
+      "learningUserCount": "学习人数",
       "placeholder": "图表能力建设中，敬请期待",
       "questionsByChapter": "追问数量按章节分布图",
       "questionsByTime": "追问数量按时间分布图",
+      "emptySections": "暂无小节数据",
+      "sectionLearningTitle": "各小节学习与追问统计",
       "title": "图表区"
     },
     "courseIdLabel": "课程 ID",


### PR DESCRIPTION
## Summary

- Replace 4 chart placeholders on the dashboard course detail page with a vertical stacked bar chart showing per-section learning and follow-up metrics
- Each section has one stacked bar with 4 segments: learning users, learning records, follow-up users, follow-up questions
- dataZoom slider appears when there are more than 20 sections

## Changes

### Backend (`src/api/`)
- New DTOs: `DashboardCourseDetailSectionChartDTO` (8 fields), `DashboardCourseDetailChartsDTO`
- New `_build_section_learning_chart()` in `dashboard/funcs.py` — aggregates per-section metrics from `LearnProgressRecord` and `LearnGeneratedBlock`
- Added `charts` field to `DashboardCourseDetailDTO`
- New test: `test_course_detail_returns_section_learning_chart`

### Frontend (`src/cook-web/`)
- New `section-learning-chart.ts` — ECharts stacked bar chart builder with 4 series (blue theme for learning, green theme for follow-up)
- Updated course detail page to render real chart instead of 4 empty placeholders
- 6 new i18n keys in zh-CN and en-US
- Updated page tests with EChart mock and assertions

### Fix
- Fixed Prometheus image tag in `docker-compose.dev.yml` (`v1.5.1` → `latest`)

## Test Plan

- [x] Backend: `cd src/api && pytest tests/service/dashboard/test_dashboard_routes.py -q` (7 tests pass)
- [x] Frontend: `cd src/cook-web && npm run type-check` (zero errors)
- [x] Frontend: `cd src/cook-web && npm run lint` (clean)
- [ ] Manual: visit course detail page, verify stacked bar chart renders with legend, tooltip, and dataZoom for >20 sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a section learning chart to the course dashboard visualizing learning engagement metrics (distinct learners and record counts) and follow-up question activity (distinct users and question counts) grouped by course section.
  * Chart adapts for large course structures with automatic data zoom controls when displaying more than twenty sections, with full internationalization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->