### PR TITLE
fix: prevent white screen on admin billing scroll

### DIFF
--- a/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
+++ b/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
@@ -96,7 +96,7 @@ export function AdminBillingPageClient({
 
   return (
     <div
-      className='h-full min-h-0 overflow-hidden bg-stone-50 p-0'
+      className='h-full min-h-0 overflow-hidden overscroll-none bg-stone-50 p-0'
       data-testid='admin-billing-page'
     >
       <div className='flex h-full min-h-0 flex-col px-1 pb-6'>

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -287,6 +287,9 @@ describe('AdminBillingPage', () => {
     const packagesPanel = screen.getByTestId('admin-billing-packages-panel');
 
     expect(screen.getByTestId('admin-billing-page')).toBeInTheDocument();
+    expect(screen.getByTestId('admin-billing-page')).toHaveClass(
+      'overscroll-none',
+    );
     expect(packagesPanel).toHaveClass('flex-1');
     expect(packagesPanel).toHaveClass('overflow-y-auto');
     expect(


### PR DESCRIPTION
Summary
- prevent viewport overscroll white-screen flashes on the admin billing details page
- add a regression assertion for the billing page root overscroll behavior

Testing
- cd src/cook-web && npm test -- --runInBand src/app/admin/billing/page.test.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling on the admin billing page to enhance scroll behavior.

* **Tests**
  * Tests updated to verify the new styling is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->