### PR TITLE
feat: unify credit and price number display rule

### DIFF
--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import api from '@/api';
 import { useToast } from '@/hooks/useToast';
+import { formatBillingCredits } from '@/lib/billing';
 import { ErrorWithCode } from '@/lib/request';
 import { Button } from '@/components/ui/Button';
 import {
@@ -146,7 +147,7 @@ export default function UserCreditGrantDialog({
   onOpenChange,
   onGranted,
 }: UserCreditGrantDialogProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperationsUsers } = useTranslation('module.operationsUser');
   const { toast } = useToast();
   const hasActiveSubscription = Boolean(user?.has_active_subscription);
@@ -346,7 +347,10 @@ export default function UserCreditGrantDialog({
                   label={tOperationsUsers(
                     'grantDialog.summary.availableCredits',
                   )}
-                  value={user?.available_credits || '0'}
+                  value={formatBillingCredits(
+                    Number(user?.available_credits || 0),
+                    i18n.language,
+                  )}
                 />
                 <SummaryField
                   label={tOperationsUsers(

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -30,6 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { formatBillingCredits } from '@/lib/billing';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
 import { cn } from '@/lib/utils';
@@ -391,7 +392,7 @@ const CreditLedgerTable = ({
   onPageChange: (page: number) => void;
   onRetry: () => void;
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperationsUsers } = useTranslation('module.operationsUser');
 
   if (error) {
@@ -497,13 +498,31 @@ const CreditLedgerTable = ({
                       </TableCell>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={item.amount}
+                          text={
+                            item.amount === '' ||
+                            item.amount === null ||
+                            item.amount === undefined
+                              ? ''
+                              : formatBillingCredits(
+                                  Number(item.amount),
+                                  i18n.language,
+                                )
+                          }
                           emptyValue={EMPTY_VALUE}
                         />
                       </TableCell>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={item.balance_after}
+                          text={
+                            item.balance_after === '' ||
+                            item.balance_after === null ||
+                            item.balance_after === undefined
+                              ? ''
+                              : formatBillingCredits(
+                                  Number(item.balance_after),
+                                  i18n.language,
+                                )
+                          }
                           emptyValue={EMPTY_VALUE}
                         />
                       </TableCell>
@@ -555,7 +574,7 @@ const CreditLedgerTable = ({
 };
 
 export default function AdminOperationUserDetailPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperationsUsers } = useTranslation('module.operationsUser');
   const { t: tOperationsCourse } = useTranslation('module.operationsCourse');
   const router = useRouter();
@@ -981,19 +1000,40 @@ export default function AdminOperationUserDetailPage() {
                         label={tOperationsUsers(
                           'detail.creditsOverviewLabels.availableCredits',
                         )}
-                        value={creditSummary.available_credits}
+                        value={
+                          creditSummary.available_credits
+                            ? formatBillingCredits(
+                                Number(creditSummary.available_credits),
+                                i18n.language,
+                              )
+                            : ''
+                        }
                       />
                       <InfoItem
                         label={tOperationsUsers(
                           'detail.creditsOverviewLabels.subscriptionCredits',
                         )}
-                        value={creditSummary.subscription_credits}
+                        value={
+                          creditSummary.subscription_credits
+                            ? formatBillingCredits(
+                                Number(creditSummary.subscription_credits),
+                                i18n.language,
+                              )
+                            : ''
+                        }
                       />
                       <InfoItem
                         label={tOperationsUsers(
                           'detail.creditsOverviewLabels.topupCredits',
                         )}
-                        value={creditSummary.topup_credits}
+                        value={
+                          creditSummary.topup_credits
+                            ? formatBillingCredits(
+                                Number(creditSummary.topup_credits),
+                                i18n.language,
+                              )
+                            : ''
+                        }
                       />
                       <InfoItem
                         label={creditExpireAtLabel}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -54,7 +54,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { BILLING_OVERVIEW_SWR_KEY } from '@/hooks/useBillingData';
-import { buildBillingSwrKey } from '@/lib/billing';
+import { buildBillingSwrKey, formatBillingCredits } from '@/lib/billing';
 import { getBrowserTimeZone } from '@/lib/browser-timezone';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { cn } from '@/lib/utils';
@@ -266,7 +266,7 @@ const CourseListPreview = ({
  * t('module.user.defaultUserName')
  */
 export default function AdminOperationUsersPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperationsUsers } = useTranslation('module.operationsUser');
   const { t: tOperationsCourse } = useTranslation('module.operationsCourse');
   const { isReady } = useOperatorGuard();
@@ -1051,12 +1051,22 @@ export default function AdminOperationUsersPage() {
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(
-                                user.available_credits || EMPTY_STATE_LABEL,
+                                user.available_credits
+                                  ? formatBillingCredits(
+                                      Number(user.available_credits),
+                                      i18n.language,
+                                    )
+                                  : EMPTY_STATE_LABEL,
                               )}
                             </Link>
                           ) : (
                             renderTooltipText(
-                              user.available_credits || EMPTY_STATE_LABEL,
+                              user.available_credits
+                                ? formatBillingCredits(
+                                    Number(user.available_credits),
+                                    i18n.language,
+                                  )
+                                : EMPTY_STATE_LABEL,
                             )
                           )}
                         </TableCell>

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -204,7 +204,6 @@ export function BillingCreditDetailsPanel({
   const totalCreditsLabel = formatBillingCredits(
     overview?.wallet.available_credits || 0,
     i18n.language,
-    2,
   );
   const neverExpiresLabel = t('module.billing.ledger.neverExpires');
   const topupAvailabilityLabel = t(
@@ -295,7 +294,6 @@ export function BillingCreditDetailsPanel({
                       {formatBillingCredits(
                         row.availableCredits,
                         i18n.language,
-                        2,
                       )}
                     </div>
                     <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>

--- a/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
+++ b/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
@@ -134,7 +134,6 @@ export async function GET() {
   "wechatAppId": "wx973eb6079c64d030",
   "enableWechatCode": true,
   "billingEnabled": true,
-  "billingCreditPrecision": 2,
   "alwaysShowLessonTree": "true",
   "logoWideUrl": "",
   "logoSquareUrl": "",

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -2,14 +2,15 @@ import {
   formatBillingCreditAmount,
   formatBillingCreditBalance,
   formatBillingCredits,
+  formatBillingNumber,
   formatBillingPlanInterval,
+  formatBillingPrice,
   extractBillingPingxxQrCode,
   parseBillingDateValue,
   resolveBillingLedgerUsageType,
   resolveBillingLedgerReasonLabel,
   resolveBillingPlanCreditsLabel,
   resolveBillingPlanValidityLabel,
-  setBillingCreditPrecision,
 } from '@/lib/billing';
 import type { BillingLedgerItem, BillingPlan } from '@/types/billing';
 import type { BillingCheckoutResult } from '@/types/billing';
@@ -47,21 +48,58 @@ const dailyPlan: BillingPlan = {
   price_amount: 390,
 };
 
-describe('resolveBillingPlanCreditsLabel', () => {
-  afterEach(() => {
-    setBillingCreditPrecision();
+describe('formatBillingNumber (unified display rule)', () => {
+  test('drops the decimal point for integer values', () => {
+    expect(formatBillingNumber(1000, 'en-US')).toBe('1,000');
+    expect(formatBillingNumber(0, 'en-US')).toBe('0');
+    expect(formatBillingNumber(50000, 'en-US')).toBe('50,000');
   });
 
-  test('formats credits with fixed two-decimal precision by default', () => {
-    expect(formatBillingCredits(5, 'en-US')).toBe('5.00');
+  test('strips trailing zeros and caps at two fraction digits', () => {
+    expect(formatBillingNumber(50.5, 'en-US')).toBe('50.5');
+    expect(formatBillingNumber(50.5, 'zh-CN')).toBe('50.5');
+    expect(formatBillingNumber(50.567, 'en-US')).toBe('50.57');
+    expect(formatBillingNumber(0.01, 'en-US')).toBe('0.01');
+  });
+
+  test('groups thousands for large numbers across locales', () => {
+    expect(formatBillingNumber(1234567, 'en-US')).toBe('1,234,567');
+    expect(formatBillingNumber(1234567, 'zh-CN')).toBe('1,234,567');
+    expect(formatBillingNumber(1234567.89, 'en-US')).toBe('1,234,567.89');
+  });
+
+  test('falls back to zero for non-finite or nullish input', () => {
+    expect(formatBillingNumber(NaN, 'en-US')).toBe('0');
+    expect(formatBillingNumber(null, 'en-US')).toBe('0');
+    expect(formatBillingNumber(undefined, 'en-US')).toBe('0');
+    expect(formatBillingNumber(Number(''), 'en-US')).toBe('0');
+  });
+
+  test('renders narrow currency symbol when currency option is set', () => {
+    expect(formatBillingNumber(99, 'zh-CN', { currency: 'CNY' })).toBe('¥99');
+    expect(formatBillingNumber(0.01, 'zh-CN', { currency: 'CNY' })).toBe(
+      '¥0.01',
+    );
+    expect(formatBillingNumber(99.5, 'zh-CN', { currency: 'CNY' })).toBe(
+      '¥99.5',
+    );
+    expect(formatBillingNumber(99, 'en-US', { currency: 'CNY' })).toBe('¥99');
+    expect(formatBillingNumber(99.5, 'en-US', { currency: 'USD' })).toBe(
+      '$99.5',
+    );
+  });
+});
+
+describe('formatBillingCredits', () => {
+  test('renders integers without decimals and groups thousands', () => {
+    expect(formatBillingCredits(5, 'en-US')).toBe('5');
+    expect(formatBillingCredits(10000, 'en-US')).toBe('10,000');
+  });
+
+  test('keeps meaningful decimals up to two places', () => {
     expect(formatBillingCredits(1.25, 'en-US')).toBe('1.25');
-    expect(formatBillingCredits(10000, 'en-US')).toBe('10,000.00');
-  });
-
-  test('formats credits with runtime-configured precision', () => {
-    setBillingCreditPrecision(2);
     expect(formatBillingCredits(1.256, 'en-US')).toBe('1.26');
-    expect(formatBillingCredits(10000, 'en-US')).toBe('10,000.00');
+    expect(formatBillingCredits(50.5, 'en-US')).toBe('50.5');
   });
 
   test('uses monthly credits copy for monthly plans', () => {
@@ -80,7 +118,7 @@ describe('resolveBillingPlanCreditsLabel', () => {
     });
 
     expect(resolveBillingPlanCreditsLabel(t, yearlyPlan)).toBe(
-      'module.billing.package.creditSummary.yearly:10000',
+      'module.billing.package.creditSummary.yearly:10,000',
     );
   });
 
@@ -96,19 +134,43 @@ describe('resolveBillingPlanCreditsLabel', () => {
 });
 
 describe('formatBillingCreditBalance', () => {
-  test('drops decimals and thousands separators for balance displays', () => {
+  test('keeps thousands separators and meaningful decimals', () => {
     expect(formatBillingCreditBalance(5)).toBe('5');
-    expect(formatBillingCreditBalance(1.25)).toBe('1');
-    expect(formatBillingCreditBalance(10000)).toBe('10000');
-    expect(formatBillingCreditBalance(32277.76)).toBe('32277');
+    expect(formatBillingCreditBalance(1.25)).toBe('1.25');
+    expect(formatBillingCreditBalance(10000)).toBe('10,000');
+    expect(formatBillingCreditBalance(32277.76)).toBe('32,277.76');
   });
 });
 
 describe('formatBillingCreditAmount', () => {
-  test('drops decimals and thousands separators for plan and topup credits', () => {
+  test('keeps thousands separators and meaningful decimals', () => {
     expect(formatBillingCreditAmount(5)).toBe('5');
-    expect(formatBillingCreditAmount(10000)).toBe('10000');
-    expect(formatBillingCreditAmount(3200.88)).toBe('3200');
+    expect(formatBillingCreditAmount(10000)).toBe('10,000');
+    expect(formatBillingCreditAmount(3200.88)).toBe('3,200.88');
+  });
+});
+
+describe('formatBillingPrice', () => {
+  test('formats minor units to currency without trailing zeros', () => {
+    expect(formatBillingPrice(1, 'CNY', 'zh-CN')).toBe('¥0.01');
+    expect(formatBillingPrice(9900, 'CNY', 'zh-CN')).toBe('¥99');
+    expect(formatBillingPrice(9950, 'CNY', 'zh-CN')).toBe('¥99.5');
+    expect(formatBillingPrice(123456700, 'CNY', 'zh-CN')).toBe('¥1,234,567');
+  });
+
+  test('uses narrow symbol so CNY renders as ¥ across locales', () => {
+    expect(formatBillingPrice(9900, 'CNY', 'en-US')).toBe('¥99');
+  });
+
+  test('supports other currencies', () => {
+    expect(formatBillingPrice(9950, 'USD', 'en-US')).toBe('$99.5');
+  });
+
+  test('falls back to zero for nullish input', () => {
+    expect(formatBillingPrice(0, 'CNY', 'zh-CN')).toBe('¥0');
+    expect(formatBillingPrice(null as unknown as number, 'CNY', 'zh-CN')).toBe(
+      '¥0',
+    );
   });
 });
 

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -166,6 +166,18 @@ describe('formatBillingPrice', () => {
     expect(formatBillingPrice(9950, 'USD', 'en-US')).toBe('$99.5');
   });
 
+  test('handles 0-decimal currency (JPY) without dividing by 100', () => {
+    expect(formatBillingPrice(100, 'JPY', 'en-US')).toBe('¥100');
+    expect(formatBillingPrice(100, 'JPY', 'zh-CN')).toBe('¥100');
+    expect(formatBillingPrice(1234567, 'JPY', 'en-US')).toBe('¥1,234,567');
+  });
+
+  test('handles 3-decimal currency (KWD) preserving full precision', () => {
+    expect(formatBillingPrice(1, 'KWD', 'en-US')).toBe('KWD 0.001');
+    expect(formatBillingPrice(1000, 'KWD', 'en-US')).toBe('KWD 1');
+    expect(formatBillingPrice(1234, 'KWD', 'en-US')).toBe('KWD 1.234');
+  });
+
   test('falls back to zero for nullish input', () => {
     expect(formatBillingPrice(0, 'CNY', 'zh-CN')).toBe('¥0');
     expect(formatBillingPrice(null as unknown as number, 'CNY', 'zh-CN')).toBe(

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -258,6 +258,7 @@ const BILLING_DISPLAY_RULE = {
 
 type FormatBillingNumberOptions = {
   currency?: string;
+  maximumFractionDigits?: number;
 };
 
 export function formatBillingNumber(
@@ -268,7 +269,9 @@ export function formatBillingNumber(
   const n = Number(value ?? 0);
   const safe = Number.isFinite(n) ? n : 0;
   return new Intl.NumberFormat(locale || 'en-US', {
-    ...BILLING_DISPLAY_RULE,
+    minimumFractionDigits: BILLING_DISPLAY_RULE.minimumFractionDigits,
+    maximumFractionDigits:
+      options?.maximumFractionDigits ?? BILLING_DISPLAY_RULE.maximumFractionDigits,
     ...(options?.currency
       ? {
           style: 'currency',
@@ -296,9 +299,20 @@ export function formatBillingPrice(
   currency: string,
   locale: string,
 ): string {
-  return formatBillingNumber(Number(amountInMinor || 0) / 100, locale, {
-    currency: currency || 'CNY',
-  });
+  const resolvedCurrency = currency || 'CNY';
+  const fractionDigits =
+    new Intl.NumberFormat(locale || 'en-US', {
+      style: 'currency',
+      currency: resolvedCurrency,
+    }).resolvedOptions().maximumFractionDigits ?? 2;
+  return formatBillingNumber(
+    Number(amountInMinor || 0) / 10 ** fractionDigits,
+    locale,
+    {
+      currency: resolvedCurrency,
+      maximumFractionDigits: fractionDigits,
+    },
+  );
 }
 
 export function resolveBillingSubscriptionStatusLabel(

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -250,44 +250,45 @@ const BILLING_RENEWAL_EVENT_STATUS_KEYS: Record<
 const BILLING_OFFSETLESS_DATETIME_RE =
   /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/;
 const BILLING_LEGACY_SOURCE_OFFSET = '+08:00';
-const DEFAULT_BILL_CREDIT_PRECISION = 2;
-const MAX_BILL_CREDIT_PRECISION = 10;
 
-let billingCreditPrecision = DEFAULT_BILL_CREDIT_PRECISION;
+const BILLING_DISPLAY_RULE = {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+} as const;
 
-function normalizeBillingCreditPrecision(value?: number | null): number {
-  const numericValue = Number(value);
-  if (!Number.isFinite(numericValue)) {
-    return DEFAULT_BILL_CREDIT_PRECISION;
-  }
-  return Math.min(
-    MAX_BILL_CREDIT_PRECISION,
-    Math.max(0, Math.trunc(numericValue)),
-  );
-}
+type FormatBillingNumberOptions = {
+  currency?: string;
+};
 
-export function setBillingCreditPrecision(value?: number | null): void {
-  billingCreditPrecision = normalizeBillingCreditPrecision(value);
-}
-
-export function formatBillingCredits(
-  value: number,
+export function formatBillingNumber(
+  value: unknown,
   locale: string,
-  precision: number = billingCreditPrecision,
+  options?: FormatBillingNumberOptions,
 ): string {
-  const normalizedPrecision = normalizeBillingCreditPrecision(precision);
-  return new Intl.NumberFormat(locale, {
-    minimumFractionDigits: normalizedPrecision,
-    maximumFractionDigits: normalizedPrecision,
-  }).format(Number(value || 0));
+  const n = Number(value ?? 0);
+  const safe = Number.isFinite(n) ? n : 0;
+  return new Intl.NumberFormat(locale || 'en-US', {
+    ...BILLING_DISPLAY_RULE,
+    ...(options?.currency
+      ? {
+          style: 'currency',
+          currency: options.currency,
+          currencyDisplay: 'narrowSymbol',
+        }
+      : {}),
+  }).format(safe);
+}
+
+export function formatBillingCredits(value: number, locale: string): string {
+  return formatBillingNumber(value, locale);
 }
 
 export function formatBillingCreditBalance(value: number): string {
-  return String(Math.trunc(Number(value || 0)));
+  return formatBillingNumber(value, 'en-US');
 }
 
 export function formatBillingCreditAmount(value: number): string {
-  return String(Math.trunc(Number(value || 0)));
+  return formatBillingNumber(value, 'en-US');
 }
 
 export function formatBillingPrice(
@@ -295,11 +296,9 @@ export function formatBillingPrice(
   currency: string,
   locale: string,
 ): string {
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
+  return formatBillingNumber(Number(amountInMinor || 0) / 100, locale, {
     currency: currency || 'CNY',
-    maximumFractionDigits: 2,
-  }).format(Number(amountInMinor || 0) / 100);
+  });
 }
 
 export function resolveBillingSubscriptionStatusLabel(

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -271,7 +271,8 @@ export function formatBillingNumber(
   return new Intl.NumberFormat(locale || 'en-US', {
     minimumFractionDigits: BILLING_DISPLAY_RULE.minimumFractionDigits,
     maximumFractionDigits:
-      options?.maximumFractionDigits ?? BILLING_DISPLAY_RULE.maximumFractionDigits,
+      options?.maximumFractionDigits ??
+      BILLING_DISPLAY_RULE.maximumFractionDigits,
     ...(options?.currency
       ? {
           style: 'currency',

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -5,7 +5,6 @@ import { EnvStoreState } from '@/c-types/store';
 import { redirectToHomeUrlIfRootPath } from '@/lib/utils';
 import { getBoolEnv } from '@/c-utils/envUtils';
 import { getDynamicApiBaseUrl } from '@/config/environment';
-import { setBillingCreditPrecision } from '@/lib/billing';
 
 const normalizeStringArray = (value: unknown, fallback: string[]): string[] => {
   if (Array.isArray(value)) {
@@ -139,7 +138,6 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  setBillingCreditPrecision(runtimeConfig?.billingCreditPrecision);
   if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl)) {
     return;
   }


### PR DESCRIPTION
## Summary

- Introduce a single `formatBillingNumber` + `BILLING_DISPLAY_RULE` entry in `src/cook-web/src/lib/billing.ts` so every credit-related screen shares one rule: integers drop trailing `.00`, fractions strip trailing zeros up to 2 places, thousands carry comma separators, prices keep `narrowSymbol` currency display.
- Reduce the four legacy helpers (`formatBillingCredits`, `formatBillingCreditBalance`, `formatBillingCreditAmount`, `formatBillingPrice`) to thin adapters over the unified entry, eliminating the prior split between `Math.trunc` paths and `Intl.NumberFormat` paths.
- Wire in the unified rule at the four spots that previously rendered raw backend strings (operations user list `available_credits`, user detail ledger amount/balance + credit summary cards, grant-credits dialog summary). Course-order pages and the user list `total_paid_amount` column are intentionally untouched.
- Drop the unused `billingCreditPrecision` runtime config knob, its bootstrap call in `initializeEnvData.ts`, and all related dead helpers.

## Test plan

- [x] `npm run test -- src/lib/__tests__/billing.test.ts` — 28/28 passing, covering integer/decimal/thousands/currency/null cases for both `formatBillingNumber` and the four adapters
- [x] `npm run type-check` — clean
- [x] `npm run lint` — exit 0, no new warnings on touched files
- [ ] Manual: `/admin/billing?tab=overview` shows `1,000 积分` and `¥99` (not `¥99.00`)
- [ ] Manual: `/admin/billing?tab=details` shows `+50.5` / `-1,234.5` correctly, including signed values
- [ ] Manual: `/admin/operations/users/<bid>` ledger `amount` and `balance_after` columns plus the three credit summary cards render with thousands separators
- [ ] Manual: `/admin/operations/users` available credits column renders with thousands; `total_paid_amount` column unchanged
- [ ] Manual: `/admin/operations/orders` "学习订单" tab is unchanged (regression check that course-order pages were not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Billing credits consistently formatted with thousands separators and predictable decimals across admin user lists, user detail pages, and billing panels
  * Currency display standardized (narrow symbols) and locale-aware for improved readability

* **Tests**
  * Updated billing tests to validate the unified number and currency formatting rules

* **Documentation**
  * Example environment config updated to remove legacy precision field from the sample response
<!-- end of auto-generated comment: release notes by coderabbit.ai -->