### PR TITLE
feat: split credit balance and detail number formats

### DIFF
--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -26,7 +26,7 @@ import type {
   BillingWalletBucket,
 } from '@/types/billing';
 import {
-  formatBillingCredits,
+  formatBillingCreditDetail,
   formatBillingCompactDateTime,
   registerBillingTranslationUsage,
   resolveBillingBucketCategoryLabel,
@@ -201,7 +201,7 @@ export function BillingCreditDetailsPanel({
     [activeSubscriptionEffectiveTo, bucketList?.items, hasActiveSubscription],
   );
 
-  const totalCreditsLabel = formatBillingCredits(
+  const totalCreditsLabel = formatBillingCreditDetail(
     overview?.wallet.available_credits || 0,
     i18n.language,
   );
@@ -291,7 +291,7 @@ export function BillingCreditDetailsPanel({
                       {resolveBillingBucketCategoryLabel(t, row.category)}
                     </div>
                     <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
-                      {formatBillingCredits(
+                      {formatBillingCreditDetail(
                         row.availableCredits,
                         i18n.language,
                       )}

--- a/src/cook-web/src/components/billing/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/components/billing/BillingRecentActivitySection.tsx
@@ -10,7 +10,7 @@ import type { BillingLedgerItem, BillingPagedResponse } from '@/types/billing';
 import { BILLING_SECTION_TITLE_CLASS } from './billingSectionTitleClass';
 import {
   buildBillingSwrKey,
-  formatBillingCredits,
+  formatBillingCreditDetail,
   formatBillingDateTime,
   registerBillingTranslationUsage,
   resolveBillingLedgerReasonLabel,
@@ -21,7 +21,10 @@ const RECENT_ITEMS_LIMIT = 10;
 
 function formatSignedCredits(value: number, locale: string): string {
   const normalizedValue = Number(value || 0);
-  const formatted = formatBillingCredits(Math.abs(normalizedValue), locale);
+  const formatted = formatBillingCreditDetail(
+    Math.abs(normalizedValue),
+    locale,
+  );
   if (normalizedValue > 0) {
     return `+${formatted}`;
   }

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -172,12 +172,8 @@ describe('formatBillingCreditDetail', () => {
   });
 
   test('keeps thousands separators across locales', () => {
-    expect(formatBillingCreditDetail(1234567.89, 'en-US')).toBe(
-      '1,234,567.89',
-    );
-    expect(formatBillingCreditDetail(1234567.89, 'zh-CN')).toBe(
-      '1,234,567.89',
-    );
+    expect(formatBillingCreditDetail(1234567.89, 'en-US')).toBe('1,234,567.89');
+    expect(formatBillingCreditDetail(1234567.89, 'zh-CN')).toBe('1,234,567.89');
   });
 
   test('falls back to zero for non-finite or nullish input', () => {

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -1,6 +1,7 @@
 import {
   formatBillingCreditAmount,
   formatBillingCreditBalance,
+  formatBillingCreditDetail,
   formatBillingCredits,
   formatBillingNumber,
   formatBillingPlanInterval,
@@ -134,11 +135,17 @@ describe('formatBillingCredits', () => {
 });
 
 describe('formatBillingCreditBalance', () => {
-  test('keeps thousands separators and meaningful decimals', () => {
+  test('floors fractional balances to integers and keeps thousands separators', () => {
     expect(formatBillingCreditBalance(5)).toBe('5');
-    expect(formatBillingCreditBalance(1.25)).toBe('1.25');
+    expect(formatBillingCreditBalance(1.25)).toBe('1');
+    expect(formatBillingCreditBalance(1.99)).toBe('1');
     expect(formatBillingCreditBalance(10000)).toBe('10,000');
-    expect(formatBillingCreditBalance(32277.76)).toBe('32,277.76');
+    expect(formatBillingCreditBalance(32277.76)).toBe('32,277');
+  });
+
+  test('falls back to zero for non-finite or nullish input', () => {
+    expect(formatBillingCreditBalance(NaN)).toBe('0');
+    expect(formatBillingCreditBalance(Number.POSITIVE_INFINITY)).toBe('0');
   });
 });
 
@@ -147,6 +154,37 @@ describe('formatBillingCreditAmount', () => {
     expect(formatBillingCreditAmount(5)).toBe('5');
     expect(formatBillingCreditAmount(10000)).toBe('10,000');
     expect(formatBillingCreditAmount(3200.88)).toBe('3,200.88');
+  });
+});
+
+describe('formatBillingCreditDetail', () => {
+  test('always renders exactly two fraction digits', () => {
+    expect(formatBillingCreditDetail(0, 'en-US')).toBe('0.00');
+    expect(formatBillingCreditDetail(100, 'en-US')).toBe('100.00');
+    expect(formatBillingCreditDetail(1.5, 'en-US')).toBe('1.50');
+    expect(formatBillingCreditDetail(23105, 'en-US')).toBe('23,105.00');
+    expect(formatBillingCreditDetail(32277.76, 'en-US')).toBe('32,277.76');
+  });
+
+  test('rounds values with more than two fraction digits', () => {
+    expect(formatBillingCreditDetail(1.999, 'en-US')).toBe('2.00');
+    expect(formatBillingCreditDetail(0.005, 'en-US')).toBe('0.01');
+  });
+
+  test('keeps thousands separators across locales', () => {
+    expect(formatBillingCreditDetail(1234567.89, 'en-US')).toBe(
+      '1,234,567.89',
+    );
+    expect(formatBillingCreditDetail(1234567.89, 'zh-CN')).toBe(
+      '1,234,567.89',
+    );
+  });
+
+  test('falls back to zero for non-finite or nullish input', () => {
+    expect(formatBillingCreditDetail(NaN, 'en-US')).toBe('0.00');
+    expect(formatBillingCreditDetail(Number.POSITIVE_INFINITY, 'en-US')).toBe(
+      '0.00',
+    );
   });
 });
 

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -259,6 +259,7 @@ const BILLING_DISPLAY_RULE = {
 type FormatBillingNumberOptions = {
   currency?: string;
   maximumFractionDigits?: number;
+  minimumFractionDigits?: number;
 };
 
 export function formatBillingNumber(
@@ -269,7 +270,9 @@ export function formatBillingNumber(
   const n = Number(value ?? 0);
   const safe = Number.isFinite(n) ? n : 0;
   return new Intl.NumberFormat(locale || 'en-US', {
-    minimumFractionDigits: BILLING_DISPLAY_RULE.minimumFractionDigits,
+    minimumFractionDigits:
+      options?.minimumFractionDigits ??
+      BILLING_DISPLAY_RULE.minimumFractionDigits,
     maximumFractionDigits:
       options?.maximumFractionDigits ??
       BILLING_DISPLAY_RULE.maximumFractionDigits,
@@ -288,11 +291,23 @@ export function formatBillingCredits(value: number, locale: string): string {
 }
 
 export function formatBillingCreditBalance(value: number): string {
-  return formatBillingNumber(value, 'en-US');
+  const numeric = Number(value ?? 0);
+  const floored = Number.isFinite(numeric) ? Math.floor(numeric) : 0;
+  return formatBillingNumber(floored, 'en-US', { maximumFractionDigits: 0 });
 }
 
 export function formatBillingCreditAmount(value: number): string {
   return formatBillingNumber(value, 'en-US');
+}
+
+export function formatBillingCreditDetail(
+  value: number,
+  locale: string,
+): string {
+  return formatBillingNumber(value, locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 }
 
 export function formatBillingPrice(


### PR DESCRIPTION
## Summary
- Split the unified credit number rule into two role-specific formatters: wallet balance now floors to integers (`formatBillingCreditBalance`), while ledger and bucket details always render two fraction digits (`formatBillingCreditDetail`).
- Open up `minimumFractionDigits` on `formatBillingNumber` so the new detail formatter reuses the same `Intl.NumberFormat` entry point and stays consistent with the existing rule from #1700.
- Switch `BillingCreditDetailsPanel` and `BillingRecentActivitySection` to the new detail formatter so the bucket table and recent activity rows align visually across integer and fractional values.

## Test plan
- [ ] `cd src/cook-web && npm run test -- billing` (covers `formatBillingCreditBalance`, `formatBillingCreditDetail`, NaN/Infinity fallbacks, and locale separators)
- [ ] Manually verify the credit details panel: total available credits and per-bucket rows show two decimals (e.g. `23,105.00`, `1.50`).
- [ ] Manually verify the recent activity ledger: signed amounts render with `+` / `−` and two decimals.
- [ ] Manually verify the wallet balance card displays floored integers (e.g. `32,277` for a `32,277.76` raw value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Credit balance calculations now display as whole numbers instead of fractional values.

* **Improvements**
  * Enhanced billing credit detail display with consistent two-decimal precision.
  * Improved locale-aware number formatting across billing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->