### PR TITLE
feat: add operator user overview cards

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -90,6 +90,8 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseRatingListDTO,
     AdminOperationCourseRatingSummaryDTO,
     AdminOperationCourseUserDTO,
+    AdminOperationUserListDTO,
+    AdminOperationUserOverviewDTO,
     AdminOperationUserCreditGrantResultDTO,
     AdminOperationUserCreditGrantRequestDTO,
     AdminOperationCourseSummaryDTO,
@@ -166,6 +168,32 @@ OPERATOR_USER_ROLE_REGULAR = "regular"
 OPERATOR_USER_ROLE_CREATOR = "creator"
 OPERATOR_USER_ROLE_OPERATOR = "operator"
 OPERATOR_USER_ROLE_LEARNER = "learner"
+OPERATOR_USER_QUICK_FILTER_CREATOR = "creator"
+OPERATOR_USER_QUICK_FILTER_LEARNER = "learner"
+OPERATOR_USER_QUICK_FILTER_REGISTERED = "registered"
+OPERATOR_USER_QUICK_FILTER_PAID = "paid"
+OPERATOR_USER_QUICK_FILTER_CREATED_LAST_30D = "created_last_30d"
+OPERATOR_USER_QUICK_FILTER_REGISTERED_LAST_30D = "registered_last_30d"
+OPERATOR_USER_QUICK_FILTER_LEARNING_ACTIVE_30D = "learning_active_30d"
+OPERATOR_USER_QUICK_FILTER_PAID_LAST_30D = "paid_last_30d"
+OPERATOR_USER_QUICK_FILTER_GUEST = "guest"
+OPERATOR_USER_QUICK_FILTER_VALUES = {
+    OPERATOR_USER_QUICK_FILTER_CREATOR,
+    OPERATOR_USER_QUICK_FILTER_LEARNER,
+    OPERATOR_USER_QUICK_FILTER_REGISTERED,
+    OPERATOR_USER_QUICK_FILTER_PAID,
+    OPERATOR_USER_QUICK_FILTER_CREATED_LAST_30D,
+    OPERATOR_USER_QUICK_FILTER_REGISTERED_LAST_30D,
+    OPERATOR_USER_QUICK_FILTER_LEARNING_ACTIVE_30D,
+    OPERATOR_USER_QUICK_FILTER_PAID_LAST_30D,
+    OPERATOR_USER_QUICK_FILTER_GUEST,
+}
+OPERATOR_USER_REGISTRATION_CREDENTIAL_PROVIDERS = (
+    "phone",
+    "email",
+    "google",
+    "wechat",
+)
 OPERATOR_USER_REGISTRATION_SOURCE_PHONE = "phone"
 OPERATOR_USER_REGISTRATION_SOURCE_EMAIL = "email"
 OPERATOR_USER_REGISTRATION_SOURCE_GOOGLE = "google"
@@ -855,6 +883,28 @@ def _resolve_operator_user_status(raw_state: object) -> str:
     )
 
 
+def _resolve_operator_user_quick_filter(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return ""
+    if normalized not in OPERATOR_USER_QUICK_FILTER_VALUES:
+        raise_param_error("quick_filter")
+    return normalized
+
+
+def _resolve_recent_days_window(
+    days: int,
+    now: Optional[datetime] = None,
+) -> tuple[datetime, datetime]:
+    safe_days = max(int(days or 0), 1)
+    current = now or datetime.now()
+    start = (current - timedelta(days=safe_days - 1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    end = current.replace(hour=23, minute=59, second=59, microsecond=0)
+    return start, end
+
+
 def _build_operator_user_roles(
     *,
     is_creator: bool,
@@ -904,6 +954,81 @@ def _build_learner_user_bid_subquery():
         AiCourseAuth.user_id != "",
     )
     return order_query.union(progress_query, permission_query).subquery()
+
+
+def _build_recent_learning_active_user_bid_subquery(
+    *,
+    since: datetime,
+):
+    activity_at = db.func.coalesce(
+        LearnProgressRecord.updated_at,
+        LearnProgressRecord.created_at,
+    )
+    return (
+        db.session.query(LearnProgressRecord.user_bid.label("user_bid"))
+        .filter(
+            LearnProgressRecord.deleted == 0,
+            LearnProgressRecord.status != LEARN_STATUS_RESET,
+            LearnProgressRecord.user_bid != "",
+            activity_at >= since,
+        )
+        .distinct()
+        .subquery()
+    )
+
+
+def _build_recent_paid_user_bid_subquery(
+    *,
+    since: datetime,
+):
+    return (
+        db.session.query(Order.user_bid.label("user_bid"))
+        .filter(
+            Order.deleted == 0,
+            Order.status == ORDER_STATUS_SUCCESS,
+            Order.user_bid != "",
+            Order.created_at >= since,
+        )
+        .distinct()
+        .subquery()
+    )
+
+
+def _build_registered_user_timestamp_subquery():
+    registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
+    credential_subquery = (
+        db.session.query(
+            AuthCredential.user_bid.label("user_bid"),
+            db.func.min(AuthCredential.created_at).label("registered_at"),
+        )
+        .filter(
+            AuthCredential.deleted == 0,
+            AuthCredential.state == CREDENTIAL_STATE_VERIFIED,
+            AuthCredential.provider_name.in_(
+                OPERATOR_USER_REGISTRATION_CREDENTIAL_PROVIDERS
+            ),
+            AuthCredential.user_bid != "",
+        )
+        .group_by(AuthCredential.user_bid)
+        .subquery()
+    )
+    return (
+        db.session.query(
+            UserEntity.user_bid.label("user_bid"),
+            db.func.coalesce(
+                credential_subquery.c.registered_at, UserEntity.created_at
+            ).label("registered_at"),
+        )
+        .outerjoin(
+            credential_subquery, credential_subquery.c.user_bid == UserEntity.user_bid
+        )
+        .filter(
+            UserEntity.deleted == 0,
+            UserEntity.state.in_(registered_states),
+            UserEntity.user_bid != "",
+        )
+        .subquery()
+    )
 
 
 def _load_learner_user_bids(user_bids: Optional[Sequence[str]] = None) -> Set[str]:
@@ -3818,12 +3943,81 @@ def get_operator_course_chapter_detail(
         )
 
 
+def _build_operator_user_overview() -> AdminOperationUserOverviewDTO:
+    base_query = UserEntity.query.filter(UserEntity.deleted == 0)
+    registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
+    learner_subquery = _build_learner_user_bid_subquery()
+    registered_timestamp_subquery = _build_registered_user_timestamp_subquery()
+    recent_window_start, recent_window_end = _resolve_recent_days_window(30)
+    recent_learning_subquery = _build_recent_learning_active_user_bid_subquery(
+        since=recent_window_start
+    )
+    recent_paid_subquery = _build_recent_paid_user_bid_subquery(
+        since=recent_window_start
+    )
+
+    learner_user_count = (
+        db.session.query(db.func.count(db.distinct(learner_subquery.c.user_bid)))
+        .join(UserEntity, UserEntity.user_bid == learner_subquery.c.user_bid)
+        .filter(UserEntity.deleted == 0)
+        .scalar()
+        or 0
+    )
+    learning_active_30d_user_count = (
+        db.session.query(
+            db.func.count(db.distinct(recent_learning_subquery.c.user_bid))
+        )
+        .join(UserEntity, UserEntity.user_bid == recent_learning_subquery.c.user_bid)
+        .filter(UserEntity.deleted == 0)
+        .scalar()
+        or 0
+    )
+    registered_last_30d_user_count = (
+        db.session.query(
+            db.func.count(db.distinct(registered_timestamp_subquery.c.user_bid))
+        )
+        .filter(
+            registered_timestamp_subquery.c.registered_at >= recent_window_start,
+            registered_timestamp_subquery.c.registered_at <= recent_window_end,
+        )
+        .scalar()
+        or 0
+    )
+    paid_last_30d_user_count = (
+        db.session.query(db.func.count(db.distinct(recent_paid_subquery.c.user_bid)))
+        .join(UserEntity, UserEntity.user_bid == recent_paid_subquery.c.user_bid)
+        .filter(UserEntity.deleted == 0)
+        .scalar()
+        or 0
+    )
+
+    return AdminOperationUserOverviewDTO(
+        total_user_count=base_query.count(),
+        registered_user_count=base_query.filter(
+            UserEntity.state.in_(registered_states)
+        ).count(),
+        creator_user_count=base_query.filter(UserEntity.is_creator == 1).count(),
+        learner_user_count=int(learner_user_count),
+        paid_user_count=base_query.filter(UserEntity.state == USER_STATE_PAID).count(),
+        created_last_30d_user_count=base_query.filter(
+            UserEntity.created_at >= recent_window_start,
+            UserEntity.created_at <= recent_window_end,
+        ).count(),
+        registered_last_30d_user_count=int(registered_last_30d_user_count),
+        learning_active_30d_user_count=int(learning_active_30d_user_count),
+        paid_last_30d_user_count=int(paid_last_30d_user_count),
+        guest_user_count=base_query.filter(
+            UserEntity.state == USER_STATE_UNREGISTERED
+        ).count(),
+    )
+
+
 def list_operator_users(
     app: Flask,
     page_index: int,
     page_size: int,
     filters: Optional[dict] = None,
-) -> PageNationDTO:
+) -> AdminOperationUserListDTO:
     with app.app_context():
         safe_page_index = max(int(page_index or 1), 1)
         safe_page_size = min(
@@ -3831,6 +4025,7 @@ def list_operator_users(
             OPERATOR_USER_LIST_MAX_PAGE_SIZE,
         )
         filters = filters or {}
+        summary = _build_operator_user_overview()
 
         user_bid = str(filters.get("user_bid", "") or "").strip()
         identifier = str(
@@ -3839,6 +4034,9 @@ def list_operator_users(
         nickname = str(filters.get("nickname", "") or "").strip()
         user_status = str(filters.get("user_status", "") or "").strip().lower()
         user_role = str(filters.get("user_role", "") or "").strip().lower()
+        quick_filter = _resolve_operator_user_quick_filter(
+            filters.get("quick_filter", "")
+        )
         start_time = filters.get("start_time")
         end_time = filters.get("end_time")
 
@@ -3863,10 +4061,7 @@ def list_operator_users(
         if user_role == OPERATOR_USER_ROLE_OPERATOR:
             query = query.filter(UserEntity.is_operator == 1)
         elif user_role == OPERATOR_USER_ROLE_CREATOR:
-            query = query.filter(
-                UserEntity.is_operator == 0,
-                UserEntity.is_creator == 1,
-            )
+            query = query.filter(UserEntity.is_creator == 1)
         elif user_role == OPERATOR_USER_ROLE_LEARNER:
             learner_subquery = _build_learner_user_bid_subquery()
             query = query.filter(
@@ -3888,8 +4083,77 @@ def list_operator_users(
         if identifier:
             matching_user_bids = _find_matching_user_bids_by_identifier(identifier)
             if not matching_user_bids:
-                return PageNationDTO(safe_page_index, safe_page_size, 0, [])
+                return AdminOperationUserListDTO(
+                    safe_page_index,
+                    safe_page_size,
+                    0,
+                    [],
+                    summary=summary,
+                )
             query = query.filter(UserEntity.user_bid.in_(list(matching_user_bids)))
+        if quick_filter:
+            registered_timestamp_subquery = None
+            recent_window_start, recent_window_end = _resolve_recent_days_window(30)
+            if quick_filter == OPERATOR_USER_QUICK_FILTER_CREATOR:
+                query = query.filter(UserEntity.is_creator == 1)
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_LEARNER:
+                learner_subquery = _build_learner_user_bid_subquery()
+                query = query.filter(
+                    UserEntity.user_bid.in_(
+                        db.session.query(learner_subquery.c.user_bid)
+                    )
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_REGISTERED:
+                query = query.filter(
+                    UserEntity.state.in_(
+                        [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
+                    )
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_PAID:
+                query = query.filter(UserEntity.state == USER_STATE_PAID)
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_CREATED_LAST_30D:
+                query = query.filter(
+                    UserEntity.created_at >= recent_window_start,
+                    UserEntity.created_at <= recent_window_end,
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_REGISTERED_LAST_30D:
+                registered_timestamp_subquery = (
+                    _build_registered_user_timestamp_subquery()
+                )
+                query = query.filter(
+                    UserEntity.user_bid.in_(
+                        db.session.query(
+                            registered_timestamp_subquery.c.user_bid
+                        ).filter(
+                            registered_timestamp_subquery.c.registered_at
+                            >= recent_window_start,
+                            registered_timestamp_subquery.c.registered_at
+                            <= recent_window_end,
+                        )
+                    )
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_LEARNING_ACTIVE_30D:
+                recent_learning_subquery = (
+                    _build_recent_learning_active_user_bid_subquery(
+                        since=recent_window_start
+                    )
+                )
+                query = query.filter(
+                    UserEntity.user_bid.in_(
+                        db.session.query(recent_learning_subquery.c.user_bid)
+                    )
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_PAID_LAST_30D:
+                recent_paid_subquery = _build_recent_paid_user_bid_subquery(
+                    since=recent_window_start
+                )
+                query = query.filter(
+                    UserEntity.user_bid.in_(
+                        db.session.query(recent_paid_subquery.c.user_bid)
+                    )
+                )
+            elif quick_filter == OPERATOR_USER_QUICK_FILTER_GUEST:
+                query = query.filter(UserEntity.state == USER_STATE_UNREGISTERED)
 
         total = query.count()
         page_offset = (safe_page_index - 1) * safe_page_size
@@ -3927,7 +4191,13 @@ def list_operator_users(
             )
             for user in page_items
         ]
-        return PageNationDTO(safe_page_index, safe_page_size, total, items)
+        return AdminOperationUserListDTO(
+            safe_page_index,
+            safe_page_size,
+            total,
+            items,
+            summary=summary,
+        )
 
 
 def get_operator_user_detail(

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -901,7 +901,8 @@ def _resolve_recent_days_window(
     start = (current - timedelta(days=safe_days - 1)).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
-    end = current.replace(hour=23, minute=59, second=59, microsecond=0)
+    end_of_day = current.replace(hour=23, minute=59, second=59, microsecond=999999)
+    end = min(end_of_day, current)
     return start, end
 
 
@@ -959,6 +960,7 @@ def _build_learner_user_bid_subquery():
 def _build_recent_learning_active_user_bid_subquery(
     *,
     since: datetime,
+    until: datetime,
 ):
     activity_at = db.func.coalesce(
         LearnProgressRecord.updated_at,
@@ -971,6 +973,7 @@ def _build_recent_learning_active_user_bid_subquery(
             LearnProgressRecord.status != LEARN_STATUS_RESET,
             LearnProgressRecord.user_bid != "",
             activity_at >= since,
+            activity_at <= until,
         )
         .distinct()
         .subquery()
@@ -980,6 +983,7 @@ def _build_recent_learning_active_user_bid_subquery(
 def _build_recent_paid_user_bid_subquery(
     *,
     since: datetime,
+    until: datetime,
 ):
     return (
         db.session.query(Order.user_bid.label("user_bid"))
@@ -988,6 +992,7 @@ def _build_recent_paid_user_bid_subquery(
             Order.status == ORDER_STATUS_SUCCESS,
             Order.user_bid != "",
             Order.created_at >= since,
+            Order.created_at <= until,
         )
         .distinct()
         .subquery()
@@ -3944,35 +3949,33 @@ def get_operator_course_chapter_detail(
 
 
 def _build_operator_user_overview() -> AdminOperationUserOverviewDTO:
-    base_query = UserEntity.query.filter(UserEntity.deleted == 0)
     registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
     learner_subquery = _build_learner_user_bid_subquery()
     registered_timestamp_subquery = _build_registered_user_timestamp_subquery()
     recent_window_start, recent_window_end = _resolve_recent_days_window(30)
     recent_learning_subquery = _build_recent_learning_active_user_bid_subquery(
-        since=recent_window_start
+        since=recent_window_start,
+        until=recent_window_end,
     )
     recent_paid_subquery = _build_recent_paid_user_bid_subquery(
-        since=recent_window_start
+        since=recent_window_start,
+        until=recent_window_end,
     )
-
-    learner_user_count = (
+    learner_user_count_subquery = (
         db.session.query(db.func.count(db.distinct(learner_subquery.c.user_bid)))
         .join(UserEntity, UserEntity.user_bid == learner_subquery.c.user_bid)
         .filter(UserEntity.deleted == 0)
-        .scalar()
-        or 0
+        .scalar_subquery()
     )
-    learning_active_30d_user_count = (
+    learning_active_30d_user_count_subquery = (
         db.session.query(
             db.func.count(db.distinct(recent_learning_subquery.c.user_bid))
         )
         .join(UserEntity, UserEntity.user_bid == recent_learning_subquery.c.user_bid)
         .filter(UserEntity.deleted == 0)
-        .scalar()
-        or 0
+        .scalar_subquery()
     )
-    registered_last_30d_user_count = (
+    registered_last_30d_user_count_subquery = (
         db.session.query(
             db.func.count(db.distinct(registered_timestamp_subquery.c.user_bid))
         )
@@ -3980,35 +3983,80 @@ def _build_operator_user_overview() -> AdminOperationUserOverviewDTO:
             registered_timestamp_subquery.c.registered_at >= recent_window_start,
             registered_timestamp_subquery.c.registered_at <= recent_window_end,
         )
-        .scalar()
-        or 0
+        .scalar_subquery()
     )
-    paid_last_30d_user_count = (
+    paid_last_30d_user_count_subquery = (
         db.session.query(db.func.count(db.distinct(recent_paid_subquery.c.user_bid)))
         .join(UserEntity, UserEntity.user_bid == recent_paid_subquery.c.user_bid)
         .filter(UserEntity.deleted == 0)
-        .scalar()
-        or 0
+        .scalar_subquery()
+    )
+    summary = (
+        db.session.query(
+            db.func.count(UserEntity.user_bid).label("total_user_count"),
+            db.func.coalesce(
+                db.func.sum(
+                    case((UserEntity.state.in_(registered_states), 1), else_=0)
+                ),
+                0,
+            ).label("registered_user_count"),
+            db.func.coalesce(
+                db.func.sum(case((UserEntity.is_creator == 1, 1), else_=0)),
+                0,
+            ).label("creator_user_count"),
+            db.func.coalesce(learner_user_count_subquery, 0).label(
+                "learner_user_count"
+            ),
+            db.func.coalesce(
+                db.func.sum(case((UserEntity.state == USER_STATE_PAID, 1), else_=0)),
+                0,
+            ).label("paid_user_count"),
+            db.func.coalesce(
+                db.func.sum(
+                    case(
+                        (
+                            and_(
+                                UserEntity.created_at >= recent_window_start,
+                                UserEntity.created_at <= recent_window_end,
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("created_last_30d_user_count"),
+            db.func.coalesce(registered_last_30d_user_count_subquery, 0).label(
+                "registered_last_30d_user_count"
+            ),
+            db.func.coalesce(learning_active_30d_user_count_subquery, 0).label(
+                "learning_active_30d_user_count"
+            ),
+            db.func.coalesce(paid_last_30d_user_count_subquery, 0).label(
+                "paid_last_30d_user_count"
+            ),
+            db.func.coalesce(
+                db.func.sum(
+                    case((UserEntity.state == USER_STATE_UNREGISTERED, 1), else_=0)
+                ),
+                0,
+            ).label("guest_user_count"),
+        )
+        .filter(UserEntity.deleted == 0)
+        .one()
     )
 
     return AdminOperationUserOverviewDTO(
-        total_user_count=base_query.count(),
-        registered_user_count=base_query.filter(
-            UserEntity.state.in_(registered_states)
-        ).count(),
-        creator_user_count=base_query.filter(UserEntity.is_creator == 1).count(),
-        learner_user_count=int(learner_user_count),
-        paid_user_count=base_query.filter(UserEntity.state == USER_STATE_PAID).count(),
-        created_last_30d_user_count=base_query.filter(
-            UserEntity.created_at >= recent_window_start,
-            UserEntity.created_at <= recent_window_end,
-        ).count(),
-        registered_last_30d_user_count=int(registered_last_30d_user_count),
-        learning_active_30d_user_count=int(learning_active_30d_user_count),
-        paid_last_30d_user_count=int(paid_last_30d_user_count),
-        guest_user_count=base_query.filter(
-            UserEntity.state == USER_STATE_UNREGISTERED
-        ).count(),
+        total_user_count=int(summary.total_user_count or 0),
+        registered_user_count=int(summary.registered_user_count or 0),
+        creator_user_count=int(summary.creator_user_count or 0),
+        learner_user_count=int(summary.learner_user_count or 0),
+        paid_user_count=int(summary.paid_user_count or 0),
+        created_last_30d_user_count=int(summary.created_last_30d_user_count or 0),
+        registered_last_30d_user_count=int(summary.registered_last_30d_user_count or 0),
+        learning_active_30d_user_count=int(summary.learning_active_30d_user_count or 0),
+        paid_last_30d_user_count=int(summary.paid_last_30d_user_count or 0),
+        guest_user_count=int(summary.guest_user_count or 0),
     )
 
 
@@ -4092,7 +4140,6 @@ def list_operator_users(
                 )
             query = query.filter(UserEntity.user_bid.in_(list(matching_user_bids)))
         if quick_filter:
-            registered_timestamp_subquery = None
             recent_window_start, recent_window_end = _resolve_recent_days_window(30)
             if quick_filter == OPERATOR_USER_QUICK_FILTER_CREATOR:
                 query = query.filter(UserEntity.is_creator == 1)
@@ -4135,7 +4182,8 @@ def list_operator_users(
             elif quick_filter == OPERATOR_USER_QUICK_FILTER_LEARNING_ACTIVE_30D:
                 recent_learning_subquery = (
                     _build_recent_learning_active_user_bid_subquery(
-                        since=recent_window_start
+                        since=recent_window_start,
+                        until=recent_window_end,
                     )
                 )
                 query = query.filter(
@@ -4145,7 +4193,8 @@ def list_operator_users(
                 )
             elif quick_filter == OPERATOR_USER_QUICK_FILTER_PAID_LAST_30D:
                 recent_paid_subquery = _build_recent_paid_user_bid_subquery(
-                    since=recent_window_start
+                    since=recent_window_start,
+                    until=recent_window_end,
                 )
                 query = query.filter(
                     UserEntity.user_bid.in_(

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -202,6 +203,102 @@ class AdminOperationUserSummaryDTO(BaseModel):
 
     def __json__(self) -> dict[str, Any]:
         return self.model_dump()
+
+
+@register_schema_to_swagger
+class AdminOperationUserOverviewDTO(BaseModel):
+    """Overview metrics shown in the operator user list."""
+
+    total_user_count: int = Field(default=0, description="Total users", required=False)
+    registered_user_count: int = Field(
+        default=0,
+        description="Users whose current status is registered, trial, or paid",
+        required=False,
+    )
+    creator_user_count: int = Field(
+        default=0, description="Users with creator identity", required=False
+    )
+    learner_user_count: int = Field(
+        default=0,
+        description="Users with learner identity or learning access",
+        required=False,
+    )
+    paid_user_count: int = Field(
+        default=0, description="Users whose status is paid", required=False
+    )
+    created_last_30d_user_count: int = Field(
+        default=0,
+        description="Users created in the last 30 calendar days",
+        required=False,
+    )
+    registered_last_30d_user_count: int = Field(
+        default=0,
+        description="Users who completed registration in the last 30 calendar days",
+        required=False,
+    )
+    learning_active_30d_user_count: int = Field(
+        default=0,
+        description="Distinct users with learning activity in the last 30 days",
+        required=False,
+    )
+    paid_last_30d_user_count: int = Field(
+        default=0,
+        description="Distinct users with successful payments in the last 30 days",
+        required=False,
+    )
+    guest_user_count: int = Field(
+        default=0, description="Users whose status is unregistered", required=False
+    )
+
+    def __json__(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
+@register_schema_to_swagger
+class AdminOperationUserListDTO(BaseModel):
+    """Paginated operator user list with overview metrics."""
+
+    page: int = Field(..., description="page", required=False)
+    page_size: int = Field(..., description="page_size", required=False)
+    total: int = Field(..., description="total", required=False)
+    page_count: int = Field(..., description="page_count", required=False)
+    data: list[AdminOperationUserSummaryDTO] = Field(
+        default_factory=list, description="data", required=False
+    )
+    summary: AdminOperationUserOverviewDTO = Field(
+        default_factory=AdminOperationUserOverviewDTO,
+        description="overview summary",
+        required=False,
+    )
+
+    def __init__(
+        self,
+        page: int,
+        page_size: int,
+        total: int,
+        data: list[AdminOperationUserSummaryDTO],
+        summary: AdminOperationUserOverviewDTO | None = None,
+    ) -> None:
+        safe_page_size = int(page_size or 0)
+        resolved_summary = summary or AdminOperationUserOverviewDTO()
+        super().__init__(
+            page=page,
+            page_size=page_size,
+            total=total,
+            page_count=math.ceil(total / safe_page_size if safe_page_size > 0 else 0),
+            data=data,
+            summary=resolved_summary,
+        )
+
+    def __json__(self) -> dict[str, Any]:
+        return {
+            "page": self.page,
+            "page_size": self.page_size,
+            "total": self.total,
+            "page_count": self.page_count,
+            "items": [item.__json__() for item in self.data],
+            "summary": self.summary.__json__(),
+        }
 
 
 @register_schema_to_swagger

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -643,6 +643,10 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
               type: string
               required: false
               description: regular, creator, learner, or operator
+            - name: quick_filter
+              type: string
+              required: false
+              description: creator, learner, registered, paid, created_last_30d, registered_last_30d, learning_active_30d, paid_last_30d, guest
             - name: start_time
               type: string
               required: false
@@ -663,7 +667,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                 message:
                                     type: string
                                 data:
-                                    $ref: "#/components/schemas/PageNationDTO"
+                                    $ref: "#/components/schemas/AdminOperationUserListDTO"
         """
         _require_operator()
         page_index = request.args.get("page_index", 1)
@@ -683,6 +687,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             "nickname": request.args.get("nickname", ""),
             "user_status": request.args.get("user_status", ""),
             "user_role": request.args.get("user_role", ""),
+            "quick_filter": request.args.get("quick_filter", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -761,6 +761,135 @@ def test_list_operator_users_returns_overview_summary_and_applies_quick_filters(
     assert [item.user_bid for item in recent_paid_result.data] == ["user-paid"]
 
 
+def test_list_operator_users_recent_windows_exclude_future_records_and_keep_microseconds(
+    app, monkeypatch
+):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 5, 6, 23, 59, 59, 250000, tzinfo=tz)
+
+    monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
+
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="user-created-in-range",
+            identify="created-in-range@example.com",
+            nickname="Created In Range",
+            state=USER_STATE_REGISTERED,
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 125000),
+            updated_at=datetime(2026, 5, 6, 23, 59, 59, 125000),
+            providers=[("email", "created-in-range@example.com")],
+            credential_created_at=datetime(2026, 5, 6, 23, 59, 59, 125000),
+        )
+        _seed_user(
+            app,
+            user_bid="user-created-future",
+            identify="created-future@example.com",
+            nickname="Created Future",
+            state=USER_STATE_REGISTERED,
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 750000),
+            updated_at=datetime(2026, 5, 6, 23, 59, 59, 750000),
+            providers=[("email", "created-future@example.com")],
+            credential_created_at=datetime(2026, 5, 6, 23, 59, 59, 750000),
+        )
+        _seed_user(
+            app,
+            user_bid="user-learning-in-range",
+            identify="learning-in-range@example.com",
+            nickname="Learning In Range",
+            state=USER_STATE_REGISTERED,
+            created_at=datetime(2026, 4, 1, 9, 0, 0),
+            updated_at=datetime(2026, 4, 1, 9, 0, 0),
+            providers=[("email", "learning-in-range@example.com")],
+            credential_created_at=datetime(2026, 4, 1, 9, 0, 0),
+        )
+        _seed_user(
+            app,
+            user_bid="user-learning-future",
+            identify="learning-future@example.com",
+            nickname="Learning Future",
+            state=USER_STATE_REGISTERED,
+            created_at=datetime(2026, 4, 1, 10, 0, 0),
+            updated_at=datetime(2026, 4, 1, 10, 0, 0),
+            providers=[("email", "learning-future@example.com")],
+            credential_created_at=datetime(2026, 4, 1, 10, 0, 0),
+        )
+        _seed_user(
+            app,
+            user_bid="user-paid-in-range",
+            identify="paid-in-range@example.com",
+            nickname="Paid In Range",
+            state=USER_STATE_PAID,
+            created_at=datetime(2026, 4, 1, 8, 0, 0),
+            updated_at=datetime(2026, 4, 1, 8, 0, 0),
+            providers=[("email", "paid-in-range@example.com")],
+            credential_created_at=datetime(2026, 4, 1, 8, 0, 0),
+        )
+        _seed_user(
+            app,
+            user_bid="user-paid-future",
+            identify="paid-future@example.com",
+            nickname="Paid Future",
+            state=USER_STATE_PAID,
+            created_at=datetime(2026, 4, 1, 9, 0, 0),
+            updated_at=datetime(2026, 4, 1, 9, 0, 0),
+            providers=[("email", "paid-future@example.com")],
+            credential_created_at=datetime(2026, 4, 1, 9, 0, 0),
+        )
+        _seed_learn_progress(
+            shifu_bid="course-learning-in-range",
+            outline_item_bid="lesson-learning-in-range",
+            user_bid="user-learning-in-range",
+            status=LEARN_STATUS_IN_PROGRESS,
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 125000),
+        )
+        _seed_learn_progress(
+            shifu_bid="course-learning-future",
+            outline_item_bid="lesson-learning-future",
+            user_bid="user-learning-future",
+            status=LEARN_STATUS_IN_PROGRESS,
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 750000),
+        )
+        _seed_success_order(
+            order_bid="order-paid-in-range",
+            shifu_bid="course-paid-in-range",
+            user_bid="user-paid-in-range",
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 125000),
+        )
+        _seed_success_order(
+            order_bid="order-paid-future",
+            shifu_bid="course-paid-future",
+            user_bid="user-paid-future",
+            created_at=datetime(2026, 5, 6, 23, 59, 59, 750000),
+        )
+
+        result = list_operator_users(app, 1, 20, {})
+        created_last_30d_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "created_last_30d"}
+        )
+        learning_active_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "learning_active_30d"}
+        )
+        paid_last_30d_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "paid_last_30d"}
+        )
+
+    assert result.summary.created_last_30d_user_count == 1
+    assert result.summary.learning_active_30d_user_count == 1
+    assert result.summary.paid_last_30d_user_count == 1
+    assert [item.user_bid for item in created_last_30d_result.data] == [
+        "user-created-in-range"
+    ]
+    assert [item.user_bid for item in learning_active_result.data] == [
+        "user-learning-in-range"
+    ]
+    assert [item.user_bid for item in paid_last_30d_result.data] == [
+        "user-paid-in-range"
+    ]
+
+
 def test_list_operator_users_caps_page_size(app):
     with app.app_context():
         _seed_user(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -8,6 +8,7 @@ import pytest
 import sys
 
 from flaskr.dao import db
+from flaskr.service.shifu import admin as admin_module
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -30,7 +31,6 @@ from flaskr.service.billing.models import (
     BillingSubscription,
     CreditLedgerEntry,
 )
-from flaskr.service.common.dtos import PageNationDTO
 from flaskr.service.learn.models import LearnProgressRecord
 from flaskr.service.order.consts import (
     LEARN_STATUS_COMPLETED,
@@ -46,6 +46,8 @@ from flaskr.service.shifu.admin import (
 )
 from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserCreditGrantRequestDTO,
+    AdminOperationUserListDTO,
+    AdminOperationUserOverviewDTO,
     AdminOperationUserSummaryDTO,
 )
 from flaskr.service.shifu.models import (
@@ -165,6 +167,7 @@ def _seed_user(
     created_at: datetime,
     updated_at: datetime,
     providers: list[tuple[str, str]] | None = None,
+    credential_created_at: datetime | None = None,
 ):
     entity = create_user_entity(
         user_bid=user_bid,
@@ -180,7 +183,7 @@ def _seed_user(
     db.session.flush()
 
     for provider_name, identifier in providers or []:
-        upsert_credential(
+        credential = upsert_credential(
             app,
             user_bid=user_bid,
             provider_name=provider_name,
@@ -190,6 +193,9 @@ def _seed_user(
             metadata={},
             verified=True,
         )
+        if credential_created_at:
+            credential.created_at = credential_created_at
+            credential.updated_at = credential_created_at
     db.session.commit()
     db.session.remove()
 
@@ -500,7 +506,7 @@ def test_list_operator_users_returns_paginated_summaries_with_resolved_metadata(
 
         result = list_operator_users(app, 1, 1, {})
 
-    assert isinstance(result, PageNationDTO)
+    assert isinstance(result, AdminOperationUserListDTO)
     assert result.total == 2
     assert len(result.data) == 1
     item = result.data[0]
@@ -571,6 +577,49 @@ def test_list_operator_users_filters_by_identifier_status_role_and_created_time(
     assert result.data[0].created_courses == []
 
 
+def test_list_operator_users_filters_creator_role_includes_operator_creators(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="operator-creator",
+            identify="13900003333",
+            nickname="Operator Creator",
+            state=USER_STATE_REGISTERED,
+            is_creator=True,
+            is_operator=True,
+            created_at=datetime(2026, 4, 3, 9, 0, 0),
+            updated_at=datetime(2026, 4, 3, 10, 0, 0),
+            providers=[("phone", "13900003333")],
+        )
+        _seed_user(
+            app,
+            user_bid="creator-only",
+            identify="13900004444",
+            nickname="Creator Only",
+            state=USER_STATE_REGISTERED,
+            is_creator=True,
+            created_at=datetime(2026, 4, 2, 9, 0, 0),
+            updated_at=datetime(2026, 4, 2, 10, 0, 0),
+            providers=[("phone", "13900004444")],
+        )
+
+        result = list_operator_users(
+            app,
+            1,
+            20,
+            {
+                "user_role": "creator",
+            },
+        )
+
+    assert [item.user_bid for item in result.data] == [
+        "operator-creator",
+        "creator-only",
+    ]
+    assert result.data[0].user_roles == ["operator", "creator"]
+    assert result.data[1].user_roles == ["creator"]
+
+
 def test_list_operator_users_filters_by_email_identifier(app):
     with app.app_context():
         _seed_user(
@@ -602,6 +651,116 @@ def test_list_operator_users_filters_by_email_identifier(app):
     assert result.data[0].created_courses == []
 
 
+def test_list_operator_users_returns_overview_summary_and_applies_quick_filters(
+    app, monkeypatch
+):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 5, 6, 12, 0, 0, tzinfo=tz)
+
+    monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
+
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="user-guest",
+            identify="guest@example.com",
+            nickname="Guest User",
+            state=USER_STATE_UNREGISTERED,
+            created_at=datetime(2026, 5, 5, 9, 0, 0),
+            updated_at=datetime(2026, 5, 5, 10, 0, 0),
+            providers=[("email", "guest@example.com")],
+        )
+        _seed_user(
+            app,
+            user_bid="user-creator",
+            identify="creator@example.com",
+            nickname="Creator User",
+            state=USER_STATE_REGISTERED,
+            is_creator=True,
+            created_at=datetime(2026, 5, 1, 9, 0, 0),
+            updated_at=datetime(2026, 5, 1, 10, 0, 0),
+            providers=[("email", "creator@example.com")],
+            credential_created_at=datetime(2026, 5, 1, 9, 0, 0),
+        )
+        _seed_user(
+            app,
+            user_bid="user-learner",
+            identify="learner@example.com",
+            nickname="Learner User",
+            state=USER_STATE_REGISTERED,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "learner@example.com")],
+            credential_created_at=datetime(2026, 4, 20, 9, 0, 0),
+        )
+        _seed_user(
+            app,
+            user_bid="user-paid",
+            identify="paid@example.com",
+            nickname="Paid User",
+            state=USER_STATE_PAID,
+            created_at=datetime(2026, 4, 1, 9, 0, 0),
+            updated_at=datetime(2026, 4, 1, 10, 0, 0),
+            providers=[("email", "paid@example.com")],
+            credential_created_at=datetime(2026, 5, 2, 8, 0, 0),
+        )
+        _seed_learn_progress(
+            shifu_bid="course-learning-active",
+            outline_item_bid="lesson-learning-active",
+            user_bid="user-learner",
+            status=LEARN_STATUS_IN_PROGRESS,
+            created_at=datetime(2026, 5, 4, 8, 0, 0),
+        )
+        _seed_success_order(
+            order_bid="order-paid-recent",
+            shifu_bid="course-paid-recent",
+            user_bid="user-paid",
+            created_at=datetime(2026, 5, 3, 8, 0, 0),
+        )
+
+        result = list_operator_users(app, 1, 20, {})
+        learner_result = list_operator_users(app, 1, 20, {"quick_filter": "learner"})
+        recent_paid_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "paid_last_30d"}
+        )
+        registered_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "registered"}
+        )
+        recent_registered_result = list_operator_users(
+            app, 1, 20, {"quick_filter": "registered_last_30d"}
+        )
+
+    assert isinstance(result, AdminOperationUserListDTO)
+    assert isinstance(result.summary, AdminOperationUserOverviewDTO)
+    assert result.summary.total_user_count == 4
+    assert result.summary.registered_user_count == 3
+    assert result.summary.creator_user_count == 1
+    assert result.summary.learner_user_count == 2
+    assert result.summary.paid_user_count == 1
+    assert result.summary.created_last_30d_user_count == 3
+    assert result.summary.registered_last_30d_user_count == 3
+    assert result.summary.learning_active_30d_user_count == 1
+    assert result.summary.paid_last_30d_user_count == 1
+    assert result.summary.guest_user_count == 1
+    assert [item.user_bid for item in registered_result.data] == [
+        "user-creator",
+        "user-learner",
+        "user-paid",
+    ]
+    assert [item.user_bid for item in recent_registered_result.data] == [
+        "user-creator",
+        "user-learner",
+        "user-paid",
+    ]
+    assert [item.user_bid for item in learner_result.data] == [
+        "user-learner",
+        "user-paid",
+    ]
+    assert [item.user_bid for item in recent_paid_result.data] == ["user-paid"]
+
+
 def test_list_operator_users_caps_page_size(app):
     with app.app_context():
         _seed_user(
@@ -627,7 +786,7 @@ def test_list_operator_users_caps_page_size(app):
 
         result = list_operator_users(app, 1, 999, {})
 
-    assert isinstance(result, PageNationDTO)
+    assert isinstance(result, AdminOperationUserListDTO)
     assert result.page_size == 100
     assert result.total == 2
     assert len(result.data) == 2
@@ -1831,6 +1990,7 @@ def test_admin_operation_users_route_returns_filtered_payload(
     assert response.status_code == 200
     assert payload["code"] == 0
     assert payload["data"]["total"] == 1
+    assert payload["data"]["summary"]["total_user_count"] == 2
     assert payload["data"]["items"] == [
         {
             "user_bid": "user-route-1",

--- a/src/cook-web/src/app/admin/operations/operation-user-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-user-types.ts
@@ -46,7 +46,21 @@ export type AdminOperationUserItem = {
   updated_at: string;
 };
 
+export type AdminOperationUserOverview = {
+  total_user_count: number;
+  registered_user_count: number;
+  creator_user_count: number;
+  learner_user_count: number;
+  paid_user_count: number;
+  created_last_30d_user_count: number;
+  registered_last_30d_user_count: number;
+  learning_active_30d_user_count: number;
+  paid_last_30d_user_count: number;
+  guest_user_count: number;
+};
+
 export type AdminOperationUserListResponse = {
+  summary?: AdminOperationUserOverview;
   items: AdminOperationUserItem[];
   page: number;
   page_count: number;

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -16,7 +16,22 @@ const mockGrantDialogPrefix = 'grant-dialog-';
 const mockGrantSuccessLabel = 'mock-grant-success';
 const buildGrantDialogLabel = (userBid: string) =>
   `${mockGrantDialogPrefix}${userBid}`;
-const translationCache = new Map<string, { t: (key: string) => string }>();
+const translationCache = new Map<
+  string,
+  { t: (key: string) => string; i18n: { language: string } }
+>();
+const DEFAULT_OVERVIEW = {
+  total_user_count: 128,
+  registered_user_count: 102,
+  creator_user_count: 24,
+  learner_user_count: 78,
+  paid_user_count: 35,
+  created_last_30d_user_count: 12,
+  registered_last_30d_user_count: 10,
+  learning_active_30d_user_count: 18,
+  paid_last_30d_user_count: 9,
+  guest_user_count: 6,
+};
 const baseTranslation = (namespace?: string | string[]) => {
   const ns = Array.isArray(namespace) ? namespace[0] : namespace;
   const cacheKey = ns || 'translation';
@@ -24,6 +39,9 @@ const baseTranslation = (namespace?: string | string[]) => {
     translationCache.set(cacheKey, {
       t: (key: string) => {
         return ns && ns !== 'translation' ? `${ns}.${key}` : key;
+      },
+      i18n: {
+        language: 'en-US',
       },
     });
   }
@@ -241,6 +259,18 @@ jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
   ),
 }));
 
+jest.mock('@/components/ui/tooltip', () => ({
+  __esModule: true,
+  TooltipProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+  }: React.PropsWithChildren<{ asChild?: boolean }>) => <>{children}</>,
+  TooltipContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+}));
+
 const mockGetAdminOperationUsers = api.getAdminOperationUsers as jest.Mock;
 
 describe('AdminOperationUsersPage', () => {
@@ -252,6 +282,7 @@ describe('AdminOperationUsersPage', () => {
     mockUserState.isGuest = false;
     mockUserState.userInfo = { is_operator: true };
     mockGetAdminOperationUsers.mockResolvedValue({
+      summary: DEFAULT_OVERVIEW,
       items: [
         {
           user_bid: 'user-1',
@@ -334,6 +365,7 @@ describe('AdminOperationUsersPage', () => {
         nickname: '',
         user_status: '',
         user_role: '',
+        quick_filter: '',
         start_time: '',
         end_time: '',
       });
@@ -342,6 +374,10 @@ describe('AdminOperationUsersPage', () => {
     expect(
       await screen.findByText('module.operationsUser.title'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText('module.operationsUser.overview.title'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
     expect(await screen.findByText('user-1')).toBeInTheDocument();
     expect(screen.getByText('user-1@example.com')).toBeInTheDocument();
     expect(screen.getByText('Nick')).toBeInTheDocument();
@@ -464,9 +500,148 @@ describe('AdminOperationUsersPage', () => {
         nickname: '',
         user_status: '',
         user_role: 'creator',
+        quick_filter: '',
         start_time: '',
         end_time: '',
       });
+    });
+  });
+
+  test('clicking the paid users overview card syncs status and quick filter', async () => {
+    render(<AdminOperationUsersPage />);
+
+    await screen.findByText('module.operationsUser.title');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.overview.metrics.paidUsers',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          user_status: 'paid',
+          quick_filter: 'paid',
+          identifier: '',
+          nickname: '',
+        }),
+      );
+    });
+
+    expect(
+      screen.getByText('module.operationsUser.overview.activeFilter'),
+    ).toBeInTheDocument();
+  });
+
+  test('clicking the registered users overview card applies the registered quick filter', async () => {
+    render(<AdminOperationUsersPage />);
+
+    await screen.findByText('module.operationsUser.title');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.overview.metrics.registeredUsers',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: 'registered',
+          user_status: '',
+          identifier: '',
+          nickname: '',
+        }),
+      );
+    });
+  });
+
+  test('clicking the active learning overview card applies and clears the quick filter chip', async () => {
+    render(<AdminOperationUsersPage />);
+
+    await screen.findByText('module.operationsUser.title');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /module\.operationsUser\.overview\.metrics\.learningActive30d/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: 'learning_active_30d',
+        }),
+      );
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /module\.operationsUser\.overview\.metrics\.learningActive30d common\.core\.close/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: '',
+          user_status: '',
+          user_role: '',
+          start_time: '',
+          end_time: '',
+        }),
+      );
+    });
+  });
+
+  test('clicking the new users overview card syncs the calendar-day date range', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-06T10:00:00Z'));
+
+    try {
+      render(<AdminOperationUsersPage />);
+
+      await screen.findByText('module.operationsUser.title');
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /module\.operationsUser\.overview\.metrics\.newUsers30d/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            quick_filter: 'created_last_30d',
+            start_time: '2026-04-07',
+            end_time: '2026-05-06',
+          }),
+        );
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('clicking the recent registered overview card applies the quick filter without overriding created-at range', async () => {
+    render(<AdminOperationUsersPage />);
+
+    await screen.findByText('module.operationsUser.title');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /module\.operationsUser\.overview\.metrics\.registeredUsers30d/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: 'registered_last_30d',
+          start_time: '',
+          end_time: '',
+        }),
+      );
     });
   });
 

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -645,6 +645,49 @@ describe('AdminOperationUsersPage', () => {
     });
   });
 
+  test('reinitializing the page clears the stale quick filter state', async () => {
+    const { rerender } = render(<AdminOperationUsersPage />);
+
+    await screen.findByText('module.operationsUser.title');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.overview.metrics.paidUsers',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: 'paid',
+          user_status: 'paid',
+        }),
+      );
+    });
+
+    mockUserState.isInitialized = false;
+    rerender(<AdminOperationUsersPage />);
+
+    mockUserState.isInitialized = true;
+    rerender(<AdminOperationUsersPage />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quick_filter: '',
+          user_status: '',
+          user_role: '',
+          start_time: '',
+          end_time: '',
+        }),
+      );
+    });
+
+    expect(
+      screen.queryByText('module.operationsUser.overview.activeFilter'),
+    ).not.toBeInTheDocument();
+  });
+
   test('keeps nickname visible when collapsed and shifts remaining filters forward when expanded', async () => {
     render(<AdminOperationUsersPage />);
 

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
@@ -50,7 +51,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
-import { TooltipProvider } from '@/components/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { BILLING_OVERVIEW_SWR_KEY } from '@/hooks/useBillingData';
@@ -69,6 +75,7 @@ import type {
   AdminOperationUserCourseItem,
   AdminOperationUserItem,
   AdminOperationUserListResponse,
+  AdminOperationUserOverview,
 } from '../operation-user-types';
 
 type UserFilters = {
@@ -80,11 +87,40 @@ type UserFilters = {
   end_time: string;
 };
 
+type UserQuickFilterKey =
+  | ''
+  | 'creator'
+  | 'learner'
+  | 'registered'
+  | 'paid'
+  | 'created_last_30d'
+  | 'registered_last_30d'
+  | 'learning_active_30d'
+  | 'paid_last_30d'
+  | 'guest';
+
 type ErrorState = { message: string; code?: number };
 
 const PAGE_SIZE = 20;
 const ALL_OPTION_VALUE = '__all__';
 const EMPTY_STATE_LABEL = '--';
+const USER_STATUS_UNREGISTERED = 'unregistered';
+const USER_STATUS_PAID = 'paid';
+const USER_QUICK_FILTER_CREATOR = 'creator';
+const USER_QUICK_FILTER_LEARNER = 'learner';
+const USER_QUICK_FILTER_REGISTERED = 'registered';
+const USER_QUICK_FILTER_PAID = 'paid';
+const USER_QUICK_FILTER_CREATED_LAST_30D = 'created_last_30d';
+const USER_QUICK_FILTER_REGISTERED_LAST_30D = 'registered_last_30d';
+const USER_QUICK_FILTER_LEARNING_ACTIVE_30D = 'learning_active_30d';
+const USER_QUICK_FILTER_PAID_LAST_30D = 'paid_last_30d';
+const USER_QUICK_FILTER_GUEST = 'guest';
+const QUICK_FILTER_STRUCTURED_FIELDS = new Set<keyof UserFilters>([
+  'user_status',
+  'user_role',
+  'start_time',
+  'end_time',
+]);
 const COLUMN_MIN_WIDTH = 90;
 const COLUMN_MAX_WIDTH = 420;
 const COLUMN_WIDTH_STORAGE_KEY = 'adminOperationsUsersColumnWidths';
@@ -107,6 +143,18 @@ const DEFAULT_COLUMN_WIDTHS = {
   updatedAt: 180,
   action: 120,
 } as const;
+const EMPTY_USER_OVERVIEW: AdminOperationUserOverview = {
+  total_user_count: 0,
+  registered_user_count: 0,
+  creator_user_count: 0,
+  learner_user_count: 0,
+  paid_user_count: 0,
+  created_last_30d_user_count: 0,
+  registered_last_30d_user_count: 0,
+  learning_active_30d_user_count: 0,
+  paid_last_30d_user_count: 0,
+  guest_user_count: 0,
+};
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
 const createDefaultFilters = (): UserFilters => ({
   identifier: '',
@@ -116,6 +164,37 @@ const createDefaultFilters = (): UserFilters => ({
   start_time: '',
   end_time: '',
 });
+
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const buildCreatedLast30DaysFilters = (): Pick<
+  UserFilters,
+  'start_time' | 'end_time'
+> => {
+  const endDate = new Date();
+  const startDate = new Date(endDate);
+  startDate.setDate(endDate.getDate() - 29);
+  return {
+    start_time: formatLocalDate(startDate),
+    end_time: formatLocalDate(endDate),
+  };
+};
+
+const handleOverviewCardKeyDown = (
+  event: React.KeyboardEvent<HTMLElement>,
+  onActivate: () => void,
+) => {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+  event.preventDefault();
+  onActivate();
+};
 
 const renderTooltipText = (text?: string, className?: string) => {
   return (
@@ -207,6 +286,28 @@ const CourseListPreview = ({
 /**
  * t('module.operationsUser.title')
  * t('module.operationsUser.emptyList')
+ * t('module.operationsUser.overview.title')
+ * t('module.operationsUser.overview.activeFilter')
+ * t('module.operationsUser.overview.metrics.totalUsers')
+ * t('module.operationsUser.overview.metrics.registeredUsers')
+ * t('module.operationsUser.overview.metrics.creators')
+ * t('module.operationsUser.overview.metrics.learners')
+ * t('module.operationsUser.overview.metrics.paidUsers')
+ * t('module.operationsUser.overview.metrics.newUsers30d')
+ * t('module.operationsUser.overview.metrics.registeredUsers30d')
+ * t('module.operationsUser.overview.metrics.learningActive30d')
+ * t('module.operationsUser.overview.metrics.paidUsers30d')
+ * t('module.operationsUser.overview.metrics.guests')
+ * t('module.operationsUser.overview.tooltips.totalUsers')
+ * t('module.operationsUser.overview.tooltips.registeredUsers')
+ * t('module.operationsUser.overview.tooltips.creators')
+ * t('module.operationsUser.overview.tooltips.learners')
+ * t('module.operationsUser.overview.tooltips.paidUsers')
+ * t('module.operationsUser.overview.tooltips.newUsers30d')
+ * t('module.operationsUser.overview.tooltips.registeredUsers30d')
+ * t('module.operationsUser.overview.tooltips.learningActive30d')
+ * t('module.operationsUser.overview.tooltips.paidUsers30d')
+ * t('module.operationsUser.overview.tooltips.guests')
  * t('module.operationsUser.filters.mobile')
  * t('module.operationsUser.filters.email')
  * t('module.operationsUser.filters.nickname')
@@ -286,6 +387,8 @@ export default function AdminOperationUsersPage() {
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ErrorState | null>(null);
+  const [userOverview, setUserOverview] =
+    useState<AdminOperationUserOverview>(EMPTY_USER_OVERVIEW);
   const [users, setUsers] = useState<AdminOperationUserItem[]>([]);
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(0);
@@ -300,6 +403,7 @@ export default function AdminOperationUsersPage() {
   const [appliedFilters, setAppliedFilters] = useState<UserFilters>(() =>
     createDefaultFilters(),
   );
+  const [quickFilter, setQuickFilter] = useState<UserQuickFilterKey>('');
   const requestIdRef = useRef(0);
   const { mutate } = useSWRConfig();
   const lastRequestedPageRef = useRef(1);
@@ -394,7 +498,12 @@ export default function AdminOperationUsersPage() {
   );
 
   const fetchUsers = useCallback(
-    async (targetPage: number, filters: UserFilters) => {
+    async (
+      targetPage: number,
+      filters: UserFilters,
+      nextQuickFilter?: UserQuickFilterKey,
+    ) => {
+      const resolvedQuickFilter = nextQuickFilter ?? '';
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       lastRequestedPageRef.current = targetPage;
@@ -408,12 +517,14 @@ export default function AdminOperationUsersPage() {
           nickname: filters.nickname.trim(),
           user_status: filters.user_status,
           user_role: filters.user_role,
+          quick_filter: resolvedQuickFilter,
           start_time: filters.start_time,
           end_time: filters.end_time,
         })) as AdminOperationUserListResponse;
         if (requestId !== requestIdRef.current) {
           return;
         }
+        setUserOverview(response.summary ?? EMPTY_USER_OVERVIEW);
         setUsers(response.items || []);
         setPageIndex(response.page || targetPage);
         setPageCount(response.page_count || 0);
@@ -426,6 +537,7 @@ export default function AdminOperationUsersPage() {
           message: resolvedError.message || t('common.core.networkError'),
           code: resolvedError.code,
         });
+        setUserOverview(EMPTY_USER_OVERVIEW);
         setUsers([]);
         setPageCount(0);
       } finally {
@@ -441,20 +553,82 @@ export default function AdminOperationUsersPage() {
     if (!isReady) {
       return;
     }
-    void fetchUsers(1, appliedFilters);
-  }, [appliedFilters, fetchUsers, isReady]);
+    const initialFilters = createDefaultFilters();
+    setDraftFilters(initialFilters);
+    setAppliedFilters(initialFilters);
+    void fetchUsers(1, initialFilters, '');
+  }, [fetchUsers, isReady]);
+
+  const clearQuickFilterIfConflicted = useCallback(
+    (key: keyof UserFilters, value: string) => {
+      if (!quickFilter) {
+        return;
+      }
+      if (!QUICK_FILTER_STRUCTURED_FIELDS.has(key)) {
+        return;
+      }
+
+      if (quickFilter === USER_QUICK_FILTER_PAID && key === 'user_status') {
+        if (value === USER_STATUS_PAID) {
+          return;
+        }
+        setQuickFilter('');
+        return;
+      }
+
+      if (quickFilter === USER_QUICK_FILTER_GUEST && key === 'user_status') {
+        if (value === USER_STATUS_UNREGISTERED) {
+          return;
+        }
+        setQuickFilter('');
+        return;
+      }
+
+      if (quickFilter === USER_QUICK_FILTER_CREATED_LAST_30D) {
+        const expected = buildCreatedLast30DaysFilters();
+        if (
+          (key === 'start_time' && value !== expected.start_time) ||
+          (key === 'end_time' && value !== expected.end_time)
+        ) {
+          setQuickFilter('');
+          return;
+        }
+        if (key === 'user_status' || key === 'user_role') {
+          setQuickFilter('');
+        }
+        return;
+      }
+
+      setQuickFilter('');
+    },
+    [quickFilter],
+  );
+
+  const updateDraftFilter = useCallback(
+    (key: keyof UserFilters, value: string) => {
+      clearQuickFilterIfConflicted(key, value);
+      setDraftFilters(current => ({
+        ...current,
+        [key]: value,
+      }));
+    },
+    [clearQuickFilterIfConflicted],
+  );
 
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
     setAppliedFilters(nextFilters);
     setPageIndex(1);
+    void fetchUsers(1, nextFilters, quickFilter);
   };
 
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
+    setQuickFilter('');
     setPageIndex(1);
+    void fetchUsers(1, nextFilters, '');
   };
 
   const handlePageChange = (nextPage: number) => {
@@ -462,15 +636,15 @@ export default function AdminOperationUsersPage() {
       return;
     }
     setPageIndex(nextPage);
-    void fetchUsers(nextPage, appliedFilters);
+    void fetchUsers(nextPage, appliedFilters, quickFilter);
   };
 
   const handleGrantSuccess = useCallback(() => {
-    void fetchUsers(pageIndex, appliedFilters);
+    void fetchUsers(pageIndex, appliedFilters, quickFilter);
     void mutate(
       buildBillingSwrKey(BILLING_OVERVIEW_SWR_KEY, getBrowserTimeZone()),
     );
-  }, [appliedFilters, fetchUsers, mutate, pageIndex]);
+  }, [appliedFilters, fetchUsers, mutate, pageIndex, quickFilter]);
 
   const renderResizeHandle = (key: ColumnKey) => (
     <span
@@ -521,6 +695,124 @@ export default function AdminOperationUsersPage() {
     },
   ];
 
+  const applyQuickFilter = useCallback(
+    (targetQuickFilter: UserQuickFilterKey) => {
+      if (targetQuickFilter && targetQuickFilter === quickFilter) {
+        const cleared = createDefaultFilters();
+        setDraftFilters(cleared);
+        setAppliedFilters(cleared);
+        setQuickFilter('');
+        setPageIndex(1);
+        void fetchUsers(1, cleared, '');
+        return;
+      }
+
+      const nextFilters = createDefaultFilters();
+      if (targetQuickFilter === USER_QUICK_FILTER_PAID) {
+        nextFilters.user_status = USER_STATUS_PAID;
+      } else if (targetQuickFilter === USER_QUICK_FILTER_GUEST) {
+        nextFilters.user_status = USER_STATUS_UNREGISTERED;
+      } else if (targetQuickFilter === USER_QUICK_FILTER_CREATED_LAST_30D) {
+        Object.assign(nextFilters, buildCreatedLast30DaysFilters());
+      }
+
+      setDraftFilters(nextFilters);
+      setAppliedFilters(nextFilters);
+      setQuickFilter(targetQuickFilter);
+      setPageIndex(1);
+      void fetchUsers(1, nextFilters, targetQuickFilter);
+    },
+    [fetchUsers, quickFilter],
+  );
+
+  const overviewCards = useMemo(
+    () => [
+      {
+        key: 'total',
+        label: tOperationsUsers('overview.metrics.totalUsers'),
+        value: userOverview.total_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.totalUsers'),
+        quickFilterKey: '' as UserQuickFilterKey,
+      },
+      {
+        key: 'registered',
+        label: tOperationsUsers('overview.metrics.registeredUsers'),
+        value: userOverview.registered_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.registeredUsers'),
+        quickFilterKey: USER_QUICK_FILTER_REGISTERED as UserQuickFilterKey,
+      },
+      {
+        key: 'paid',
+        label: tOperationsUsers('overview.metrics.paidUsers'),
+        value: userOverview.paid_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.paidUsers'),
+        quickFilterKey: USER_QUICK_FILTER_PAID as UserQuickFilterKey,
+      },
+      {
+        key: 'creators',
+        label: tOperationsUsers('overview.metrics.creators'),
+        value: userOverview.creator_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.creators'),
+        quickFilterKey: USER_QUICK_FILTER_CREATOR as UserQuickFilterKey,
+      },
+      {
+        key: 'learners',
+        label: tOperationsUsers('overview.metrics.learners'),
+        value: userOverview.learner_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.learners'),
+        quickFilterKey: USER_QUICK_FILTER_LEARNER as UserQuickFilterKey,
+      },
+      {
+        key: 'guests',
+        label: tOperationsUsers('overview.metrics.guests'),
+        value: userOverview.guest_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.guests'),
+        quickFilterKey: USER_QUICK_FILTER_GUEST as UserQuickFilterKey,
+      },
+      {
+        key: 'new-30d',
+        label: tOperationsUsers('overview.metrics.newUsers30d'),
+        value: userOverview.created_last_30d_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.newUsers30d'),
+        quickFilterKey:
+          USER_QUICK_FILTER_CREATED_LAST_30D as UserQuickFilterKey,
+      },
+      {
+        key: 'registered-30d',
+        label: tOperationsUsers('overview.metrics.registeredUsers30d'),
+        value: userOverview.registered_last_30d_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.registeredUsers30d'),
+        quickFilterKey:
+          USER_QUICK_FILTER_REGISTERED_LAST_30D as UserQuickFilterKey,
+      },
+      {
+        key: 'learning-active-30d',
+        label: tOperationsUsers('overview.metrics.learningActive30d'),
+        value: userOverview.learning_active_30d_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.learningActive30d'),
+        quickFilterKey:
+          USER_QUICK_FILTER_LEARNING_ACTIVE_30D as UserQuickFilterKey,
+      },
+      {
+        key: 'paid-30d',
+        label: tOperationsUsers('overview.metrics.paidUsers30d'),
+        value: userOverview.paid_last_30d_user_count,
+        tooltip: tOperationsUsers('overview.tooltips.paidUsers30d'),
+        quickFilterKey: USER_QUICK_FILTER_PAID_LAST_30D as UserQuickFilterKey,
+      },
+    ],
+    [tOperationsUsers, userOverview],
+  );
+
+  const activeQuickFilterCard = useMemo(() => {
+    if (!quickFilter) {
+      return null;
+    }
+    return (
+      overviewCards.find(card => card.quickFilterKey === quickFilter) ?? null
+    );
+  }, [overviewCards, quickFilter]);
+
   const collapsedFilterItems = [
     {
       key: 'identifier',
@@ -530,12 +822,7 @@ export default function AdminOperationUsersPage() {
           value={draftFilters.identifier}
           placeholder={identifierLabel}
           clearLabel={t('common.core.close')}
-          onChange={value =>
-            setDraftFilters(current => ({
-              ...current,
-              identifier: value,
-            }))
-          }
+          onChange={value => updateDraftFilter('identifier', value)}
         />
       ),
     },
@@ -547,12 +834,7 @@ export default function AdminOperationUsersPage() {
           value={draftFilters.nickname}
           placeholder={tOperationsUsers('filters.nickname')}
           clearLabel={t('common.core.close')}
-          onChange={value =>
-            setDraftFilters(current => ({
-              ...current,
-              nickname: value,
-            }))
-          }
+          onChange={value => updateDraftFilter('nickname', value)}
         />
       ),
     },
@@ -567,10 +849,10 @@ export default function AdminOperationUsersPage() {
         <Select
           value={draftFilters.user_status || ALL_OPTION_VALUE}
           onValueChange={value =>
-            setDraftFilters(current => ({
-              ...current,
-              user_status: value === ALL_OPTION_VALUE ? '' : value,
-            }))
+            updateDraftFilter(
+              'user_status',
+              value === ALL_OPTION_VALUE ? '' : value,
+            )
           }
         >
           <SelectTrigger>
@@ -599,10 +881,10 @@ export default function AdminOperationUsersPage() {
         <Select
           value={draftFilters.user_role || ALL_OPTION_VALUE}
           onValueChange={value =>
-            setDraftFilters(current => ({
-              ...current,
-              user_role: value === ALL_OPTION_VALUE ? '' : value,
-            }))
+            updateDraftFilter(
+              'user_role',
+              value === ALL_OPTION_VALUE ? '' : value,
+            )
           }
         >
           <SelectTrigger>
@@ -631,13 +913,10 @@ export default function AdminOperationUsersPage() {
           placeholder={`${t('module.operationsCourse.filters.startTime')} ~ ${t('module.operationsCourse.filters.endTime')}`}
           resetLabel={t('module.order.filters.reset')}
           clearLabel={t('common.core.close')}
-          onChange={({ start, end }) =>
-            setDraftFilters(current => ({
-              ...current,
-              start_time: start,
-              end_time: end,
-            }))
-          }
+          onChange={({ start, end }) => {
+            updateDraftFilter('start_time', start);
+            updateDraftFilter('end_time', end);
+          }}
         />
       ),
     },
@@ -654,7 +933,11 @@ export default function AdminOperationUsersPage() {
           errorCode={error.code || 0}
           errorMessage={error.message}
           onRetry={() =>
-            fetchUsers(lastRequestedPageRef.current, appliedFilters)
+            fetchUsers(
+              lastRequestedPageRef.current,
+              appliedFilters,
+              quickFilter,
+            )
           }
         />
       </div>
@@ -671,8 +954,72 @@ export default function AdminOperationUsersPage() {
             </h1>
           </div>
 
+          <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm'>
+            <div className='mb-3'>
+              <h2 className='text-base font-semibold text-foreground'>
+                {tOperationsUsers('overview.title')}
+              </h2>
+            </div>
+            <div className='grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-5'>
+              {overviewCards.map(card => (
+                <div
+                  role='button'
+                  tabIndex={0}
+                  key={card.key}
+                  aria-label={card.label}
+                  className='group rounded-lg border border-border/70 bg-muted/20 p-4 text-left transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
+                  onClick={() => applyQuickFilter(card.quickFilterKey)}
+                  onKeyDown={event =>
+                    handleOverviewCardKeyDown(event, () =>
+                      applyQuickFilter(card.quickFilterKey),
+                    )
+                  }
+                >
+                  <div className='flex items-center gap-1 text-sm text-muted-foreground'>
+                    <span>{card.label}</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type='button'
+                          aria-label={card.tooltip}
+                          className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                          onClick={event => event.stopPropagation()}
+                          onKeyDown={event => event.stopPropagation()}
+                        >
+                          <QuestionMarkCircleIcon className='h-4 w-4' />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent className='max-w-56 text-left leading-5'>
+                        {card.tooltip}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
+                    {card.value.toLocaleString()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
           <div className='rounded-xl border border-border bg-white p-4 mb-5 shadow-sm transition-all'>
             <div className='space-y-4'>
+              {activeQuickFilterCard ? (
+                <div className='flex flex-wrap items-center gap-2'>
+                  <span className='text-sm text-muted-foreground'>
+                    {tOperationsUsers('overview.activeFilter')}
+                  </span>
+                  <button
+                    type='button'
+                    aria-label={`${activeQuickFilterCard.label} ${t('common.core.close')}`}
+                    className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
+                    onClick={() => applyQuickFilter('')}
+                  >
+                    <span>{activeQuickFilterCard.label}</span>
+                    <X className='h-3.5 w-3.5' />
+                  </button>
+                </div>
+              ) : null}
               <div
                 className={cn(
                   'grid gap-4',

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -185,17 +185,6 @@ const buildCreatedLast30DaysFilters = (): Pick<
   };
 };
 
-const handleOverviewCardKeyDown = (
-  event: React.KeyboardEvent<HTMLElement>,
-  onActivate: () => void,
-) => {
-  if (event.key !== 'Enter' && event.key !== ' ') {
-    return;
-  }
-  event.preventDefault();
-  onActivate();
-};
-
 const renderTooltipText = (text?: string, className?: string) => {
   return (
     <AdminTooltipText
@@ -556,6 +545,7 @@ export default function AdminOperationUsersPage() {
     const initialFilters = createDefaultFilters();
     setDraftFilters(initialFilters);
     setAppliedFilters(initialFilters);
+    setQuickFilter('');
     void fetchUsers(1, initialFilters, '');
   }, [fetchUsers, isReady]);
 
@@ -963,28 +953,29 @@ export default function AdminOperationUsersPage() {
             <div className='grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-5'>
               {overviewCards.map(card => (
                 <div
-                  role='button'
-                  tabIndex={0}
                   key={card.key}
-                  aria-label={card.label}
-                  className='group rounded-lg border border-border/70 bg-muted/20 p-4 text-left transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
-                  onClick={() => applyQuickFilter(card.quickFilterKey)}
-                  onKeyDown={event =>
-                    handleOverviewCardKeyDown(event, () =>
-                      applyQuickFilter(card.quickFilterKey),
-                    )
-                  }
+                  className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
                 >
-                  <div className='flex items-center gap-1 text-sm text-muted-foreground'>
-                    <span>{card.label}</span>
+                  <div className='flex items-start justify-between gap-2'>
+                    <button
+                      type='button'
+                      aria-label={card.label}
+                      className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                      onClick={() => applyQuickFilter(card.quickFilterKey)}
+                    >
+                      <div className='text-sm text-muted-foreground'>
+                        {card.label}
+                      </div>
+                      <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
+                        {card.value.toLocaleString()}
+                      </div>
+                    </button>
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
                           type='button'
                           aria-label={card.tooltip}
                           className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                          onClick={event => event.stopPropagation()}
-                          onKeyDown={event => event.stopPropagation()}
                         >
                           <QuestionMarkCircleIcon className='h-4 w-4' />
                         </button>
@@ -993,9 +984,6 @@ export default function AdminOperationUsersPage() {
                         {card.tooltip}
                       </TooltipContent>
                     </Tooltip>
-                  </div>
-                  <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                    {card.value.toLocaleString()}
                   </div>
                 </div>
               ))}

--- a/src/i18n/en-US/modules/operations-user.json
+++ b/src/i18n/en-US/modules/operations-user.json
@@ -181,6 +181,34 @@
     "unknown": "Unknown",
     "wechat": "WeChat"
   },
+  "overview": {
+    "activeFilter": "Quick Filter",
+    "metrics": {
+      "creators": "Creators",
+      "guests": "Guests",
+      "learners": "Learners",
+      "learningActive30d": "Active Learners (30d)",
+      "newUsers30d": "New Users (30d)",
+      "paidUsers": "Paid Users",
+      "paidUsers30d": "Paid Users (30d)",
+      "registeredUsers": "Registered Users",
+      "registeredUsers30d": "Registered Users (30d)",
+      "totalUsers": "Total Users"
+    },
+    "title": "Overview",
+    "tooltips": {
+      "creators": "Creator users",
+      "guests": "Guest users",
+      "learners": "Users with learning records",
+      "learningActive30d": "Users with learning activity in the last 30 days",
+      "newUsers30d": "New users in the last 30 days",
+      "paidUsers": "Users in paid status (including imported activations)",
+      "paidUsers30d": "Users who paid successfully in the last 30 days (including imported activations)",
+      "registeredUsers": "Registered users",
+      "registeredUsers30d": "Users who completed registration in the last 30 days",
+      "totalUsers": "All users"
+    }
+  },
   "registrationSourceLabels": {
     "email": "Email",
     "google": "Google",

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -181,6 +181,34 @@
     "unknown": "未知",
     "wechat": "微信"
   },
+  "overview": {
+    "activeFilter": "快捷筛选",
+    "metrics": {
+      "creators": "创作者数",
+      "guests": "游客数",
+      "learners": "学习者数",
+      "learningActive30d": "近30天活跃学习用户",
+      "newUsers30d": "近30天新增用户",
+      "paidUsers": "付费用户数",
+      "paidUsers30d": "近30天付费用户",
+      "registeredUsers": "注册用户数",
+      "registeredUsers30d": "近30天注册用户",
+      "totalUsers": "总用户数"
+    },
+    "title": "数据概览",
+    "tooltips": {
+      "creators": "创作者数量",
+      "guests": "游客状态用户数量",
+      "learners": "有学习记录的用户数量",
+      "learningActive30d": "近 30 天有学习行为的用户数量",
+      "newUsers30d": "近 30 天新增用户数量",
+      "paidUsers": "付费状态用户数量（含开通导入）",
+      "paidUsers30d": "近 30 天成功付费用户数量（含开通导入）",
+      "registeredUsers": "已注册用户数量",
+      "registeredUsers30d": "近 30 天完成注册的用户数量",
+      "totalUsers": "全部用户数量"
+    }
+  },
   "registrationSourceLabels": {
     "email": "邮箱",
     "google": "Google",


### PR DESCRIPTION
Summary
- add overview cards to the operator user management page with 10 user metrics and quick-filter interactions
- return overview summary data and quick_filter support from the operator users API
- align registered-user timing, creator filtering, tooltip copy, and coverage across frontend and backend

Testing
- cd src/cook-web && npm test -- --runInBand src/app/admin/operations/users/page.test.tsx
- cd src/cook-web && npm run type-check
- cd src/api && ./.venv/bin/pytest -q tests/service/shifu/test_admin_users.py
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview metrics cards on the admin operator users page (registered, paid, active learners, new users 30d) with interactive tooltips.
  * Expanded quick-filter options (creator, learner, registered, paid, guest and 30-day activity variants) with active filter UI and date-range synchronization.
  * Admin user list now includes a summary of aggregated metrics used by the UI.

* **Documentation**
  * Added overview translations for en-US and zh-CN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->