### PR TITLE
fix: localize captcha errors and preserve input

### DIFF
--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -275,8 +275,19 @@ def set_language(language):
     _thread_local.language = language
 
 
+def clear_language():
+    if hasattr(_thread_local, "language"):
+        delattr(_thread_local, "language")
+
+
 def get_i18n_list(app: Flask):
     return list(_translations.keys())
 
 
-__all__ = ["_", "set_language", "get_i18n_list", "load_translations"]
+__all__ = [
+    "_",
+    "set_language",
+    "clear_language",
+    "get_i18n_list",
+    "load_translations",
+]

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -7,6 +7,7 @@ import json
 import traceback
 import decimal
 from flaskr.common.shifu_context import clear_shifu_context
+from flaskr.i18n import clear_language
 
 
 by_pass_login_func = [
@@ -55,6 +56,7 @@ def register_common_handler(app: Flask) -> Flask:
     def teardown_shifu_context(exception):
         # Ensure shifu context does not leak between requests on the same worker thread
         clear_shifu_context()
+        clear_language()
 
     return app
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -47,6 +47,29 @@ from flaskr.dao import db
 from flaskr.i18n import set_language
 
 
+def _extract_request_language(payload: dict | None = None) -> str | None:
+    if isinstance(payload, dict):
+        language = payload.get("language")
+        if language:
+            return str(language).strip()
+
+    accept_language = request.headers.get("Accept-Language", "")
+    if not accept_language:
+        return None
+
+    first_part = accept_language.split(",")[0].strip()
+    if not first_part:
+        return None
+
+    return first_part.split(";")[0].strip() or None
+
+
+def _apply_request_language(payload: dict | None = None) -> None:
+    language = _extract_request_language(payload)
+    if language:
+        set_language(language)
+
+
 def optional_token_validation(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -284,6 +307,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         tags:
            - user
         """
+        _apply_request_language()
         return make_common_response(create_captcha_challenge(app))
 
     @app.route(path_prefix + "/captcha/verify", methods=["POST"])
@@ -297,6 +321,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         """
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
+        _apply_request_language(payload)
         captcha_id = payload.get("captcha_id", None)
         captcha_code = payload.get("captcha_code", None)
         if not captcha_id:
@@ -357,6 +382,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         """
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
+        _apply_request_language(payload)
         mobile = payload.get("mobile", None)
         captcha_ticket = payload.get("captcha_ticket", None)
         if not mobile:
@@ -381,6 +407,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         """
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
+        _apply_request_language(payload)
         mobile = payload.get("mobile", None)
         if not mobile:
             raise_param_error("mobile")

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -130,6 +130,18 @@ def test_send_sms_code_requires_captcha_ticket(test_client, app):
     assert body["code"] == 1009
 
 
+def test_send_sms_code_localizes_missing_captcha_ticket_message(test_client, app):
+    response, body = _post_json(
+        test_client,
+        "/api/user/send_sms_code",
+        {"mobile": "13800138000", "language": "zh-CN"},
+    )
+
+    assert response.status_code == 200
+    assert body["code"] == 1009
+    assert body["message"] == "图形验证码错误"
+
+
 def test_send_sms_code_consumes_ticket_once(test_client, app, monkeypatch):
     import flaskr.service.user.utils as user_utils
 

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -67,6 +67,27 @@ def test_captcha_verify_rejects_wrong_code(test_client, app):
     assert body["code"] == 1009
 
 
+def test_captcha_verify_localizes_wrong_code_message(test_client, app):
+    captcha = _get_captcha(test_client, app)
+
+    response = test_client.post(
+        "/api/user/captcha/verify",
+        data=json.dumps(
+            {
+                "captcha_id": captcha["captcha_id"],
+                "captcha_code": "9999",
+                "language": "zh-CN",
+            }
+        ),
+        content_type="application/json",
+    )
+    body = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert body["code"] == 1009
+    assert body["message"] == "图形验证码错误"
+
+
 def test_captcha_verify_deletes_after_attempt_limit(test_client, app):
     original_attempts = app.config.get("CAPTCHA_MAX_VERIFY_ATTEMPTS")
     app.config["CAPTCHA_MAX_VERIFY_ATTEMPTS"] = 1

--- a/src/cook-web/src/c-components/Settings/SetPasswordModal.tsx
+++ b/src/cook-web/src/c-components/Settings/SetPasswordModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SettingBaseModal from './SettingBaseModal';
@@ -61,6 +61,7 @@ export const SetPasswordModal = ({
   const [passwordError, setPasswordError] = useState('');
   const [confirmError, setConfirmError] = useState('');
   const [captchaError, setCaptchaError] = useState('');
+  const previousCountdownRef = useRef(0);
   const {
     captchaImage,
     captchaCode,
@@ -105,6 +106,18 @@ export const SetPasswordModal = ({
 
     return () => clearInterval(timer);
   }, [countdown, open]);
+
+  useEffect(() => {
+    if (!open || method !== 'phone') {
+      previousCountdownRef.current = countdown;
+      return;
+    }
+    if (previousCountdownRef.current > 0 && countdown === 0) {
+      setCaptchaError('');
+      void refreshCaptcha().catch(() => {});
+    }
+    previousCountdownRef.current = countdown;
+  }, [countdown, method, open, refreshCaptcha]);
 
   const validatePassword = useCallback(
     (value: string) => {
@@ -170,8 +183,8 @@ export const SetPasswordModal = ({
         await apiService.sendSmsCode({
           mobile: identifier,
           captcha_ticket: captchaTicket,
+          language: i18n.language,
         });
-        void refreshCaptcha().catch(() => {});
       } else {
         await apiService.sendEmailCode({
           email: identifier,
@@ -185,9 +198,6 @@ export const SetPasswordModal = ({
       });
       setCountdown(60);
     } catch {
-      if (method === 'phone') {
-        void refreshCaptcha().catch(() => {});
-      }
       // Errors are handled by request wrapper
     } finally {
       setIsSending(false);

--- a/src/cook-web/src/c-components/Settings/SetPasswordModal.tsx
+++ b/src/cook-web/src/c-components/Settings/SetPasswordModal.tsx
@@ -113,7 +113,7 @@ export const SetPasswordModal = ({
       return;
     }
     if (previousCountdownRef.current > 0 && countdown === 0) {
-      setCaptchaError('');
+      setCaptchaError(prev => (prev ? '' : prev));
       void refreshCaptcha().catch(() => {});
     }
     previousCountdownRef.current = countdown;

--- a/src/cook-web/src/components/auth/ImageCaptchaInput.tsx
+++ b/src/cook-web/src/components/auth/ImageCaptchaInput.tsx
@@ -45,7 +45,7 @@ export function ImageCaptchaInput({
           autoComplete='off'
           disabled={disabled || isLoading}
           className={cn(
-            'text-base sm:text-sm uppercase',
+            'text-base uppercase placeholder:normal-case sm:text-sm',
             error && 'border-red-500',
           )}
         />

--- a/src/cook-web/src/components/auth/PhoneLogin.test.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.test.tsx
@@ -125,12 +125,68 @@ describe('PhoneLogin captcha flow', () => {
       expect(apiService.verifyCaptcha).toHaveBeenCalledWith({
         captcha_id: 'captcha-id',
         captcha_code: '0000',
+        language: 'en-US',
       }),
     );
     expect(apiService.sendSmsCode).toHaveBeenCalledWith({
       mobile: '13800138000',
       captcha_ticket: 'captcha-ticket',
+      language: 'en-US',
     });
+  });
+
+  test('keeps captcha input after verification failure', async () => {
+    (apiService.verifyCaptcha as jest.Mock).mockRejectedValue(
+      new Error('Image captcha is incorrect'),
+    );
+
+    render(<PhoneLogin onLoginSuccess={jest.fn()} />);
+
+    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('module.auth.phone'), {
+      target: { value: '13800138000' },
+    });
+    fireEvent.change(screen.getByTestId('captcha-input'), {
+      target: { value: '0000' },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith({
+        title: 'module.auth.captchaVerifyFailed',
+        description: 'Image captcha is incorrect',
+        variant: 'destructive',
+      }),
+    );
+    expect(screen.getByTestId('captcha-input')).toHaveValue('0000');
+    expect(apiService.getCaptcha).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps captcha input after sending SMS successfully', async () => {
+    render(<PhoneLogin onLoginSuccess={jest.fn()} />);
+
+    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('module.auth.phone'), {
+      target: { value: '13800138000' },
+    });
+    fireEvent.change(screen.getByTestId('captcha-input'), {
+      target: { value: '0000' },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
+
+    await waitFor(() =>
+      expect(apiService.sendSmsCode).toHaveBeenCalledWith({
+        mobile: '13800138000',
+        captcha_ticket: 'captcha-ticket',
+        language: 'en-US',
+      }),
+    );
+    expect(screen.getByTestId('captcha-input')).toHaveValue('0000');
+    expect(apiService.getCaptcha).toHaveBeenCalledTimes(1);
   });
 
   test('logs in through SMS login after code is entered', async () => {

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -2,7 +2,7 @@
 
 import type React from 'react';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
@@ -40,6 +40,7 @@ export function PhoneLogin({
   const [phoneError, setPhoneError] = useState('');
   const [captchaError, setCaptchaError] = useState('');
   const [showTermsDialog, setShowTermsDialog] = useState(false);
+  const previousCountdownRef = useRef(0);
   const { t } = useTranslation();
   const { loginWithSmsCode, sendSmsCode } = useAuth({
     onSuccess: onLoginSuccess,
@@ -129,13 +130,21 @@ export function PhoneLogin({
     setPhoneOtp(normalizeOtp(e.target.value));
   };
 
-  const refreshCaptchaSilently = async () => {
+  const refreshCaptchaSilently = useCallback(async () => {
     try {
       await refreshCaptcha();
     } catch {
       // The API request layer displays failures; keep the current UI stable.
     }
-  };
+  }, [refreshCaptcha]);
+
+  useEffect(() => {
+    if (previousCountdownRef.current > 0 && countdown === 0) {
+      setCaptchaError('');
+      void refreshCaptchaSilently();
+    }
+    previousCountdownRef.current = countdown;
+  }, [countdown, refreshCaptchaSilently]);
 
   const getCaptchaTicket = async () => {
     if (!captchaCode.trim()) {
@@ -158,7 +167,6 @@ export function PhoneLogin({
         description: message,
         variant: 'destructive',
       });
-      await refreshCaptchaSilently();
       return '';
     }
   };
@@ -176,7 +184,6 @@ export function PhoneLogin({
 
       if (response.code == 0) {
         startOtpFlow();
-        void refreshCaptchaSilently();
         toast({
           title: t('module.auth.sendSuccess'),
           description: t('module.auth.checkYourSms'),
@@ -185,14 +192,12 @@ export function PhoneLogin({
     } catch (error) {
       if (isSmsRateLimitedError(error)) {
         startOtpFlow();
-        void refreshCaptchaSilently();
         toast({
           title: t('module.auth.checkYourSms'),
           description: t('server.user.smsSendTooFrequent'),
         });
         return;
       }
-      void refreshCaptchaSilently();
       // Error already handled in sendSmsCode
     } finally {
       setIsLoading(false);

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -140,7 +140,7 @@ export function PhoneLogin({
 
   useEffect(() => {
     if (previousCountdownRef.current > 0 && countdown === 0) {
-      setCaptchaError('');
+      setCaptchaError(prev => (prev ? '' : prev));
       void refreshCaptchaSilently();
     }
     previousCountdownRef.current = countdown;

--- a/src/cook-web/src/hooks/useAuth.ts
+++ b/src/cook-web/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { useToast } from '@/hooks/useToast';
 import { useUserStore } from '@/store';
 import apiService from '@/api';
 import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
 import type { UserInfo } from '@/c-types';
 import { useTracking } from '@/c-common/hooks/useTracking';
 
@@ -196,7 +197,11 @@ export function useAuth(options: UseAuthOptions = {}) {
   const sendSmsCode = async (mobile: string, captchaTicket: string) => {
     try {
       const response = await callWithTokenRefresh(() =>
-        apiService.sendSmsCode({ mobile, captcha_ticket: captchaTicket }),
+        apiService.sendSmsCode({
+          mobile,
+          captcha_ticket: captchaTicket,
+          language: i18n.language,
+        }),
       );
 
       if (response.code !== 0) {

--- a/src/cook-web/src/hooks/useCaptchaTicket.ts
+++ b/src/cook-web/src/hooks/useCaptchaTicket.ts
@@ -79,7 +79,9 @@ export function useCaptchaTicket(enabled = true) {
 
   const verifyCaptcha = useCallback(async () => {
     if (!captchaId || !captchaCode.trim()) {
-      const error = new Error('Captcha is required') as ApiError;
+      const error = new Error(
+        i18n.t('module.auth.captchaRequired'),
+      ) as ApiError;
       error.code = 1009;
       throw error;
     }

--- a/src/cook-web/src/hooks/useCaptchaTicket.ts
+++ b/src/cook-web/src/hooks/useCaptchaTicket.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import apiService from '@/api';
+import i18n from '@/i18n';
 
 type ApiEnvelope<T> = {
   code?: number;
@@ -45,19 +46,25 @@ export function useCaptchaTicket(enabled = true) {
   const [captchaCode, setCaptchaCode] = useState('');
   const [isCaptchaLoading, setIsCaptchaLoading] = useState(false);
 
-  const refreshCaptcha = useCallback(async () => {
-    setIsCaptchaLoading(true);
-    try {
-      const response = await apiService.getCaptcha({});
-      const captcha = unwrapApiPayload<CaptchaChallenge>(response);
-      setCaptchaId(captcha.captcha_id);
-      setCaptchaImage(captcha.image);
-      setCaptchaCode('');
-      return captcha;
-    } finally {
-      setIsCaptchaLoading(false);
-    }
-  }, []);
+  const refreshCaptcha = useCallback(
+    async (options?: { clearCode?: boolean }) => {
+      const clearCode = options?.clearCode ?? true;
+      setIsCaptchaLoading(true);
+      try {
+        const response = await apiService.getCaptcha({});
+        const captcha = unwrapApiPayload<CaptchaChallenge>(response);
+        setCaptchaId(captcha.captcha_id);
+        setCaptchaImage(captcha.image);
+        if (clearCode) {
+          setCaptchaCode('');
+        }
+        return captcha;
+      } finally {
+        setIsCaptchaLoading(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!enabled) {
@@ -79,6 +86,7 @@ export function useCaptchaTicket(enabled = true) {
     const response = await apiService.verifyCaptcha({
       captcha_id: captchaId,
       captcha_code: captchaCode.trim(),
+      language: i18n.language,
     });
     const ticket = unwrapApiPayload<CaptchaTicket>(response);
     return ticket.captcha_ticket;


### PR DESCRIPTION
# Summary
- localize captcha challenge, verification, and SMS-send errors based on the request language
- preserve the entered image captcha after verification failures and successful SMS sends until the resend countdown finishes
- align the English image captcha placeholder casing with the other auth inputs

# Testing
- cd src/api && ./.venv/bin/pytest -q tests/service/user/test_captcha_routes.py
- cd src/cook-web && npm test -- --runInBand src/components/auth/PhoneLogin.test.tsx
- cd src/cook-web && npm run type-check
- pre-commit run -a
