### PR TITLE
feat: secure course preview permissions

### DIFF
--- a/src/api/flaskr/service/learn/preview_permissions.py
+++ b/src/api/flaskr/service/learn/preview_permissions.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from flask import Flask, request
+
+from flaskr.service.common import raise_error
+from flaskr.service.common.dtos import UserInfo
+from flaskr.service.config import get_config
+from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
+
+
+BUILTIN_DEMO_TITLES = {
+    "AI 师傅教学引导",
+    "AI-Shifu Creation Guide",
+}
+
+
+def _extract_preview_token() -> Optional[str]:
+    token = request.cookies.get("token", None)
+    if not token:
+        token = request.args.get("token", None)
+    if not token:
+        token = request.headers.get("Token", None)
+    if not token:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header[7:].strip()
+    if not token and request.method.upper() == "POST" and request.is_json:
+        payload = request.get_json(silent=True) or {}
+        token = payload.get("token", None)
+    return str(token).strip() if token else None
+
+
+def resolve_preview_request_user(app: Flask) -> UserInfo:
+    """Resolve the current user for preview endpoints that bypass global auth."""
+    token = _extract_preview_token()
+    if not token:
+        raise_error("server.user.userNotLogin")
+
+    from flaskr.route import user as user_route
+
+    user = user_route.validate_user(app, token)
+    request.user = user
+    return user
+
+
+def _normalize_auth_types(raw_value: object) -> set[str]:
+    if raw_value is None:
+        return set()
+    if isinstance(raw_value, (set, list, tuple)):
+        return {str(item) for item in raw_value if str(item).strip()}
+    if isinstance(raw_value, str):
+        trimmed = raw_value.strip()
+        if not trimmed:
+            return set()
+        try:
+            parsed = json.loads(trimmed)
+        except json.JSONDecodeError:
+            return {trimmed}
+        if isinstance(parsed, (list, tuple, set)):
+            return {str(item) for item in parsed if str(item).strip()}
+        if isinstance(parsed, str):
+            return {parsed} if parsed.strip() else set()
+    return set()
+
+
+def _auth_types_to_permissions(auth_types: set[str]) -> set[str]:
+    permissions: set[str] = set()
+    for item in auth_types:
+        lowered = item.lower()
+        if lowered in {"view", "read", "readonly"} or lowered == "1":
+            permissions.add("view")
+        if lowered in {"edit", "write"} or lowered == "2":
+            permissions.update({"view", "edit"})
+        if lowered in {"publish"} or lowered == "4":
+            permissions.add("publish")
+    return permissions
+
+
+def _load_course_rows(shifu_bid: str) -> list[object]:
+    rows: list[object] = []
+    for model in (DraftShifu, PublishedShifu):
+        row = (
+            model.query.filter(
+                model.shifu_bid == shifu_bid,
+                model.deleted == 0,
+            )
+            .order_by(model.id.desc())
+            .first()
+        )
+        if row is not None:
+            rows.append(row)
+    return rows
+
+
+def _load_demo_shifu_bids() -> set[str]:
+    demo_bids: set[str] = set()
+    for key in ("DEMO_SHIFU_BID", "DEMO_EN_SHIFU_BID"):
+        try:
+            bid = str(get_config(key, "") or "").strip()
+        except Exception:
+            bid = ""
+        if bid:
+            demo_bids.add(bid)
+    return demo_bids
+
+
+def is_builtin_demo_shifu(app: Flask, shifu_bid: str) -> bool:
+    normalized_shifu_bid = str(shifu_bid or "").strip()
+    if not normalized_shifu_bid:
+        return False
+    if normalized_shifu_bid in _load_demo_shifu_bids():
+        return True
+
+    with app.app_context():
+        for row in _load_course_rows(normalized_shifu_bid):
+            title = str(getattr(row, "title", "") or "").strip()
+            creator_bid = str(getattr(row, "created_user_bid", "") or "").strip()
+            if creator_bid == "system" and title in BUILTIN_DEMO_TITLES:
+                return True
+    return False
+
+
+def _get_shifu_creator_bid(app: Flask, shifu_bid: str) -> Optional[str]:
+    with app.app_context():
+        for row in _load_course_rows(shifu_bid):
+            creator_bid = str(getattr(row, "created_user_bid", "") or "").strip()
+            if creator_bid:
+                return creator_bid
+    return None
+
+
+def _has_preview_permission(app: Flask, user_bid: str, shifu_bid: str) -> bool:
+    with app.app_context():
+        creator_bid = _get_shifu_creator_bid(app, shifu_bid)
+        if creator_bid and creator_bid == user_bid:
+            return True
+
+        auth = AiCourseAuth.query.filter(
+            AiCourseAuth.course_id == shifu_bid,
+            AiCourseAuth.user_id == user_bid,
+            AiCourseAuth.status == 1,
+        ).first()
+        if auth is None:
+            return False
+
+        permissions = _auth_types_to_permissions(_normalize_auth_types(auth.auth_type))
+        return bool(permissions.intersection({"view", "edit", "publish"}))
+
+
+def require_shifu_preview_permission(app: Flask, user_bid: str, shifu_bid: str) -> None:
+    """Require course view permission before exposing draft preview content."""
+    normalized_user_bid = str(user_bid or "").strip()
+    normalized_shifu_bid = str(shifu_bid or "").strip()
+    if not normalized_user_bid:
+        raise_error("server.user.userNotLogin")
+    if not normalized_shifu_bid:
+        raise_error("server.shifu.shifuNotFound")
+
+    if is_builtin_demo_shifu(app, normalized_shifu_bid):
+        return
+
+    creator_bid = _get_shifu_creator_bid(app, normalized_shifu_bid)
+    if not creator_bid:
+        raise_error("server.shifu.shifuNotFound")
+
+    if _has_preview_permission(app, normalized_user_bid, normalized_shifu_bid):
+        return
+
+    raise_error("server.shifu.noPermission")

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -23,6 +23,10 @@ from flaskr.service.learn.lesson_feedback import (
     submit_lesson_feedback,
     list_lesson_feedbacks,
 )
+from flaskr.service.learn.preview_permissions import (
+    require_shifu_preview_permission,
+    resolve_preview_request_user,
+)
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_SCENE_PROD,
@@ -226,6 +230,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
             f"get shifu, shifu_bid: {shifu_bid}, preview_mode: {preview_mode}"
         )
         preview_mode = True if preview_mode.lower() == "true" else False
+        if preview_mode:
+            user = resolve_preview_request_user(app)
+            require_shifu_preview_permission(app, user.user_id, shifu_bid)
         return make_common_response(get_shifu_info(app, shifu_bid, preview_mode))
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/outline-item-tree", methods=["GET"])
@@ -265,6 +272,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         )
         preview_mode = True if preview_mode.lower() == "true" else False
         user_bid = request.user.user_id
+        if preview_mode:
+            require_shifu_preview_permission(app, user_bid, shifu_bid)
         return make_common_response(
             get_outline_item_tree(app, shifu_bid, user_bid, preview_mode)
         )
@@ -333,6 +342,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
             f"run outline item, shifu_bid: {shifu_bid}, outline_bid: {outline_bid}, preview_mode: {preview_mode}, listen: {listen}"
         )
         preview_mode = True if preview_mode.lower() == "true" else False
+        if preview_mode:
+            require_shifu_preview_permission(app, user_bid, shifu_bid)
         _admit_creator_usage_for_shifu(
             shifu_bid,
             BILL_USAGE_SCENE_PREVIEW if preview_mode else BILL_USAGE_SCENE_PROD,
@@ -480,6 +491,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
             preview_request.block_index,
             visual_mode,
         )
+        require_shifu_preview_permission(app, user_bid, shifu_bid)
         _admit_creator_usage_for_shifu(
             shifu_bid,
             BILL_USAGE_SCENE_PREVIEW,
@@ -603,6 +615,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
             True if include_non_navigable.lower() == "true" else False
         )
         user_bid = request.user.user_id
+        if preview_mode:
+            require_shifu_preview_permission(app, user_bid, shifu_bid)
         return make_common_response(
             get_listen_element_record(
                 app,
@@ -849,6 +863,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
             f"get generated content, shifu_bid: {shifu_bid}, generated_block_bid: {generated_block_bid}, preview_mode: {preview_mode}"
         )
         preview_mode = preview_mode.lower() == "true"
+        if preview_mode:
+            require_shifu_preview_permission(app, user_bid, shifu_bid)
         return make_common_response(
             get_generated_content(
                 app, shifu_bid, generated_block_bid, user_bid, preview_mode
@@ -896,6 +912,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         preview_mode = preview_mode.lower() == "true"
         listen = request.args.get("listen", "False")
         listen = listen.lower() == "true"
+        if preview_mode:
+            require_shifu_preview_permission(app, user_bid, shifu_bid)
         # TTS is gated by billing admission, but it should not consume a second
         # creator runtime slot alongside the active learn stream.
         _admit_creator_usage_for_shifu(
@@ -957,6 +975,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         text = payload.get("text") or ""
         preview_mode = request.args.get("preview_mode", "False")
         preview_mode = preview_mode.lower() == "true"
+        require_shifu_preview_permission(app, user_bid, shifu_bid)
         # Preview TTS reuses the same creator admission gate without claiming an
         # extra runtime slot, so authors can preview audio during an active run.
         _admit_creator_usage_for_shifu(

--- a/src/api/tests/service/learn/test_preview_permissions.py
+++ b/src/api/tests/service/learn/test_preview_permissions.py
@@ -1,0 +1,268 @@
+from decimal import Decimal
+import json
+from types import SimpleNamespace
+
+import flaskr.dao as dao
+
+
+def _seed_course(app, shifu_bid: str, owner_bid: str) -> None:
+    from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
+
+    with app.app_context():
+        AiCourseAuth.query.filter_by(course_id=shifu_bid).delete()
+        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
+        PublishedShifu.query.filter_by(shifu_bid=shifu_bid).delete()
+        for model in (DraftShifu, PublishedShifu):
+            dao.db.session.add(
+                model(
+                    shifu_bid=shifu_bid,
+                    title="Preview Course",
+                    description="Preview course description",
+                    avatar_res_bid="",
+                    keywords="preview",
+                    llm="gpt-test",
+                    llm_temperature=Decimal("0"),
+                    llm_system_prompt="",
+                    price=Decimal("0"),
+                    created_user_bid=owner_bid,
+                    updated_user_bid=owner_bid,
+                )
+            )
+        dao.db.session.commit()
+
+
+def _add_course_auth(
+    app,
+    *,
+    shifu_bid: str,
+    user_bid: str,
+    auth_type: list[str],
+    status: int = 1,
+) -> None:
+    from flaskr.service.shifu.models import AiCourseAuth
+
+    with app.app_context():
+        dao.db.session.add(
+            AiCourseAuth(
+                course_auth_id=f"auth-{shifu_bid}-{user_bid}",
+                course_id=shifu_bid,
+                user_id=user_bid,
+                auth_type=json.dumps(auth_type),
+                status=status,
+            )
+        )
+        dao.db.session.commit()
+
+
+def _mock_user(monkeypatch, user_bid: str, *, is_creator: bool = False) -> None:
+    dummy_user = SimpleNamespace(
+        user_id=user_bid,
+        is_creator=is_creator,
+        is_operator=False,
+        language="en-US",
+    )
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: dummy_user,
+        raising=False,
+    )
+
+
+def _assert_no_permission(response) -> None:
+    payload = response.get_json(force=True)
+    assert response.status_code == 200
+    assert payload["code"] == 401
+    assert payload["message"] == "No permission"
+
+
+def test_preview_course_info_allows_creator(monkeypatch, test_client, app):
+    shifu_bid = "preview-permission-owner"
+    owner_bid = "owner-preview-info"
+    _seed_course(app, shifu_bid, owner_bid)
+    _mock_user(monkeypatch, owner_bid, is_creator=True)
+
+    resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["bid"] == shifu_bid
+
+
+def test_preview_course_info_allows_active_view_collaborator(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "preview-permission-collaborator"
+    owner_bid = "owner-preview-collab"
+    collaborator_bid = "user-preview-collab"
+    _seed_course(app, shifu_bid, owner_bid)
+    _add_course_auth(
+        app,
+        shifu_bid=shifu_bid,
+        user_bid=collaborator_bid,
+        auth_type=["view"],
+    )
+    _mock_user(monkeypatch, collaborator_bid)
+
+    resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["bid"] == shifu_bid
+
+
+def test_preview_course_info_rejects_user_without_course_permission(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "preview-permission-denied"
+    _seed_course(app, shifu_bid, "owner-preview-denied")
+    _mock_user(monkeypatch, "user-without-preview")
+
+    resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+
+    _assert_no_permission(resp)
+
+
+def test_preview_course_info_rejects_inactive_or_unknown_permission(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "preview-permission-inactive"
+    owner_bid = "owner-preview-inactive"
+    inactive_user_bid = "user-preview-inactive"
+    unknown_permission_user_bid = "user-preview-unknown-permission"
+    _seed_course(app, shifu_bid, owner_bid)
+    _add_course_auth(
+        app,
+        shifu_bid=shifu_bid,
+        user_bid=inactive_user_bid,
+        auth_type=["view"],
+        status=0,
+    )
+    _add_course_auth(
+        app,
+        shifu_bid=shifu_bid,
+        user_bid=unknown_permission_user_bid,
+        auth_type=["delete"],
+        status=1,
+    )
+
+    _mock_user(monkeypatch, inactive_user_bid)
+    inactive_resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+    _assert_no_permission(inactive_resp)
+
+    _mock_user(monkeypatch, unknown_permission_user_bid)
+    unknown_permission_resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+    _assert_no_permission(unknown_permission_resp)
+
+
+def test_preview_course_info_allows_publish_collaborator(monkeypatch, test_client, app):
+    shifu_bid = "preview-permission-publish"
+    owner_bid = "owner-preview-publish"
+    collaborator_bid = "user-preview-publish"
+    _seed_course(app, shifu_bid, owner_bid)
+    _add_course_auth(
+        app,
+        shifu_bid=shifu_bid,
+        user_bid=collaborator_bid,
+        auth_type=["publish"],
+    )
+    _mock_user(monkeypatch, collaborator_bid)
+
+    resp = test_client.get(
+        f"/api/learn/shifu/{shifu_bid}?preview_mode=true",
+        headers={"Token": "test-token"},
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["bid"] == shifu_bid
+
+
+def test_non_preview_course_info_keeps_anonymous_access(monkeypatch, test_client, app):
+    shifu_bid = "preview-permission-non-preview"
+    _seed_course(app, shifu_bid, "owner-non-preview")
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: (_ for _ in ()).throw(
+            AssertionError("non-preview course info should bypass auth")
+        ),
+        raising=False,
+    )
+
+    resp = test_client.get(f"/api/learn/shifu/{shifu_bid}?preview_mode=false")
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["bid"] == shifu_bid
+
+
+def test_editor_preview_denied_before_admission_and_stream(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "preview-permission-editor-denied"
+    _seed_course(app, shifu_bid, "owner-preview-editor")
+    _mock_user(monkeypatch, "user-preview-editor-denied")
+    monkeypatch.setattr(
+        "flaskr.service.learn.routes.admit_creator_usage",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview admission should not run without permission")
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.context_v2.RunScriptPreviewContextV2.stream_preview",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview stream should not run without permission")
+        ),
+    )
+
+    resp = test_client.post(
+        f"/api/learn/shifu/{shifu_bid}/preview/outline-1",
+        json={"content": "hello", "block_index": 0},
+        headers={"Token": "test-token"},
+    )
+
+    _assert_no_permission(resp)
+
+
+def test_preview_tts_denied_before_admission_and_stream(monkeypatch, test_client, app):
+    shifu_bid = "preview-permission-tts-denied"
+    _seed_course(app, shifu_bid, "owner-preview-tts")
+    _mock_user(monkeypatch, "user-preview-tts-denied")
+    monkeypatch.setattr(
+        "flaskr.service.learn.routes.admit_creator_usage",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview tts admission should not run without permission")
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.routes.stream_preview_tts_audio",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview tts stream should not run without permission")
+        ),
+    )
+
+    resp = test_client.post(
+        f"/api/learn/shifu/{shifu_bid}/tts/preview?preview_mode=true",
+        json={"text": "hello"},
+        headers={"Token": "test-token"},
+    )
+
+    _assert_no_permission(resp)

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -182,6 +182,10 @@ def test_preview_route_skips_admission_and_runtime_slot_for_builtin_demo(
         lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
     )
     monkeypatch.setattr(
+        "flaskr.service.learn.preview_permissions.is_builtin_demo_shifu",
+        lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
+    )
+    monkeypatch.setattr(
         "flaskr.service.learn.routes.admit_creator_usage",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("builtin demo should skip creator admission")


### PR DESCRIPTION
## Summary
- Add a dedicated learn preview permission helper for course preview authorization.
- Gate C-end preview_mode=true read/run/TTS endpoints and editor preview SSE/TTS before billing admission or preview generation.
- Preserve non-preview anonymous course info and built-in demo preview behavior.

## Why
Course preview could expose draft content without checking course permissions. The preview path now requires the course creator or an active collaborator permission with view, edit, or publish access.

## Validation
- `cd src/api && pytest tests/service/learn/ tests/service/shifu/test_permissions.py -q`
- pre-commit hooks during commit, including architecture boundary validation