### PR TITLE
feat: unify admin number formatting

### DIFF
--- a/src/cook-web/src/app/admin/lib/numberFormat.ts
+++ b/src/cook-web/src/app/admin/lib/numberFormat.ts
@@ -1,0 +1,6 @@
+export {
+  formatAdminCount,
+  formatAdminCredits,
+  formatAdminNumber,
+  formatAdminPrice,
+} from '@/lib/admin-number-format';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -14,6 +14,7 @@ const mockGetAdminOperationCourseFollowUps = jest.fn();
 const mockGetAdminOperationCourseFollowUpDetail = jest.fn();
 const mockTranslationCache = new Map<string, { t: (key: string) => string }>();
 const mockBrowserTimeZone = jest.fn(() => 'UTC');
+let mockLanguage = 'en-US';
 const SHEET_CLOSE_LABEL = 'close-sheet';
 const mockEnvState = {
   loginMethodsEnabled: ['phone'],
@@ -76,7 +77,14 @@ jest.mock('react-i18next', () => ({
         t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
       });
     }
-    return mockTranslationCache.get(cacheKey)!;
+    return {
+      ...mockTranslationCache.get(cacheKey)!,
+      i18n: {
+        get language() {
+          return mockLanguage;
+        },
+      },
+    };
   },
 }));
 
@@ -156,6 +164,7 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     mockGetAdminOperationCourseFollowUpDetail.mockReset();
     mockBrowserTimeZone.mockReset();
     mockBrowserTimeZone.mockReturnValue('UTC');
+    mockLanguage = 'en-US';
     mockEnvState.loginMethodsEnabled = ['phone'];
     mockEnvState.defaultLoginMethod = 'phone';
     mockUserState.isInitialized = true;
@@ -286,6 +295,30 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     );
 
     expect(mockPush).toHaveBeenCalledWith('/admin/operations/course-1');
+  });
+
+  test('formats follow-up summary counts without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationCourseFollowUps.mockResolvedValueOnce({
+      summary: {
+        follow_up_count: 76384,
+        user_count: 12000,
+        lesson_count: 9000,
+        latest_follow_up_at: '2026-04-05T11:02:00Z',
+      },
+      items: [],
+      page: 1,
+      page_size: 20,
+      total: 0,
+      page_count: 1,
+    });
+
+    render(<AdminOperationCourseFollowUpsPage />);
+
+    expect(await screen.findByText('76384')).toBeInTheDocument();
+    expect(screen.getByText('12000')).toBeInTheDocument();
+    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
+    expect(screen.queryByText('12,000')).not.toBeInTheDocument();
   });
 
   test('submits filters and opens the detail drawer', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
@@ -118,8 +119,8 @@ const createFollowUpFilters = (): FollowUpFilters => ({
   endTime: '',
 });
 
-const formatCount = (value: number): string =>
-  Number.isFinite(value) ? value.toLocaleString() : '--';
+const formatCount = (value: number, locale: string): string =>
+  formatAdminCount(value, locale);
 
 const formatValue = (value: string | undefined | null, emptyValue: string) => {
   const normalizedValue = value?.trim() || '';
@@ -288,7 +289,7 @@ function ClearableTextInput({
 export default function AdminOperationCourseFollowUpsPage() {
   const router = useRouter();
   const params = useParams<{ shifu_bid?: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
   const { isReady } = useOperatorGuard();
   const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
@@ -496,19 +497,19 @@ export default function AdminOperationCourseFollowUpsPage() {
       {
         key: 'followUpCount',
         label: tOperations('detail.followUps.summary.followUpCount'),
-        value: formatCount(followUps.summary.follow_up_count),
+        value: formatCount(followUps.summary.follow_up_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'userCount',
         label: tOperations('detail.followUps.summary.userCount'),
-        value: formatCount(followUps.summary.user_count),
+        value: formatCount(followUps.summary.user_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'lessonCount',
         label: tOperations('detail.followUps.summary.lessonCount'),
-        value: formatCount(followUps.summary.lesson_count),
+        value: formatCount(followUps.summary.lesson_count, i18n.language),
         tone: 'number' as const,
       },
       {
@@ -520,7 +521,7 @@ export default function AdminOperationCourseFollowUpsPage() {
         tone: 'timestamp' as const,
       },
     ],
-    [emptyValue, followUps.summary, tOperations],
+    [emptyValue, followUps.summary, i18n.language, tOperations],
   );
 
   const resolveUserSecondary = useCallback(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -18,6 +18,7 @@ const mockCopyText = jest.fn();
 const mockToastShow = jest.fn();
 const mockToastFail = jest.fn();
 const mockTranslationCache = new Map<string, { t: (key: string) => string }>();
+let mockLanguage = 'en-US';
 const mockEnvState = {
   currencySymbol: '¥',
   loginMethodsEnabled: ['phone'],
@@ -91,7 +92,14 @@ jest.mock('react-i18next', () => ({
         t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
       });
     }
-    return mockTranslationCache.get(cacheKey)!;
+    return {
+      ...mockTranslationCache.get(cacheKey)!,
+      i18n: {
+        get language() {
+          return mockLanguage;
+        },
+      },
+    };
   },
 }));
 
@@ -254,6 +262,7 @@ describe('AdminOperationCourseDetailPage', () => {
     mockCopyText.mockReset();
     mockToastShow.mockReset();
     mockToastFail.mockReset();
+    mockLanguage = 'en-US';
     mockEnvState.currencySymbol = '¥';
     mockEnvState.loginMethodsEnabled = ['phone'];
     mockEnvState.defaultLoginMethod = 'phone';
@@ -420,6 +429,64 @@ describe('AdminOperationCourseDetailPage', () => {
     );
 
     expect(mockPush).toHaveBeenCalledWith('/admin/operations');
+  });
+
+  test('formats course metrics and learning progress without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          user_role: 'student',
+          learned_lesson_count: 1000,
+          total_lesson_count: 2000,
+          learning_status: 'learning',
+          is_paid: true,
+          total_paid_amount: '88',
+          last_learning_at: '2026-04-08T11:30:00Z',
+          joined_at: '2026-04-07T09:00:00Z',
+          last_login_at: '2026-04-08T12:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+    mockGetAdminOperationCourseDetail.mockResolvedValueOnce({
+      basic_info: {
+        shifu_bid: 'course-1',
+        course_name: 'Course One',
+        course_status: 'published',
+        creator_user_bid: 'creator-1',
+        creator_mobile: '13800001234',
+        creator_email: '',
+        creator_nickname: 'Alice',
+        created_at: '2026-04-08T10:00:00Z',
+        updated_at: '2026-04-08T11:00:00Z',
+      },
+      metrics: {
+        visit_count_30d: 76384,
+        learner_count: 12000,
+        order_count: 4000,
+        order_amount: '88',
+        follow_up_count: 9000,
+        rating_score: '4.2',
+      },
+      chapters: [],
+    });
+
+    render(<AdminOperationCourseDetailPage />);
+
+    expect(await screen.findByText('76384')).toBeInTheDocument();
+    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
+
+    await openUsersTab();
+    expect(screen.getByText('1000 / 2000')).toBeInTheDocument();
+    expect(screen.queryByText('1,000 / 2,000')).not.toBeInTheDocument();
   });
 
   test('navigates to follow-up page from the follow-up metric card', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -175,14 +176,18 @@ const flattenChapters = (
     ...flattenChapters(chapter.children || [], depth + 1),
   ]);
 
-const formatCount = (value: number): string =>
-  Number.isFinite(value) ? value.toLocaleString() : '--';
+const formatCount = (value: number, locale: string): string =>
+  formatAdminCount(value, locale);
 
 const formatLearningProgress = (
   learnedLessonCount: number,
   totalLessonCount: number,
+  locale: string,
 ): string =>
-  `${formatCount(learnedLessonCount)} / ${formatCount(totalLessonCount)}`;
+  `${formatCount(learnedLessonCount, locale)} / ${formatCount(
+    totalLessonCount,
+    locale,
+  )}`;
 
 const createCourseUserFilters = (): CourseUserFilters => ({
   keyword: '',
@@ -326,7 +331,7 @@ function ClearableTextInput({
 export default function AdminOperationCourseDetailPage() {
   const router = useRouter();
   const params = useParams<{ shifu_bid?: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
   const { isReady } = useOperatorGuard();
   const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
@@ -638,15 +643,15 @@ export default function AdminOperationCourseDetailPage() {
     () => [
       {
         label: tOperations('detail.metricsLabels.visitCount30d'),
-        value: formatCount(detail.metrics.visit_count_30d),
+        value: formatCount(detail.metrics.visit_count_30d, i18n.language),
       },
       {
         label: tOperations('detail.metricsLabels.learnerCount'),
-        value: formatCount(detail.metrics.learner_count),
+        value: formatCount(detail.metrics.learner_count, i18n.language),
       },
       {
         label: tOperations('detail.metricsLabels.orderCount'),
-        value: formatCount(detail.metrics.order_count),
+        value: formatCount(detail.metrics.order_count, i18n.language),
         onClick: ordersPageUrl ? () => router.push(ordersPageUrl) : undefined,
         actionLabel: tOperations('detail.orders.openMetric'),
       },
@@ -656,7 +661,7 @@ export default function AdminOperationCourseDetailPage() {
       },
       {
         label: tOperations('detail.metricsLabels.followUpCount'),
-        value: formatCount(detail.metrics.follow_up_count),
+        value: formatCount(detail.metrics.follow_up_count, i18n.language),
         onClick: followUpPageUrl
           ? () => router.push(followUpPageUrl)
           : undefined,
@@ -674,6 +679,7 @@ export default function AdminOperationCourseDetailPage() {
       detail.metrics,
       emptyValue,
       followUpPageUrl,
+      i18n.language,
       ordersPageUrl,
       ratingsPageUrl,
       router,
@@ -1017,7 +1023,7 @@ export default function AdminOperationCourseDetailPage() {
         followUpCount: chapter => [
           chapter.node_type === 'chapter'
             ? emptyValue
-            : formatCount(chapter.follow_up_count),
+            : formatCount(chapter.follow_up_count, i18n.language),
         ],
         ratingScore: chapter => [
           chapter.node_type === 'chapter'
@@ -1027,7 +1033,7 @@ export default function AdminOperationCourseDetailPage() {
         ratingCount: chapter => [
           chapter.node_type === 'chapter'
             ? emptyValue
-            : formatCount(chapter.rating_count),
+            : formatCount(chapter.rating_count, i18n.language),
         ],
         updatedAt: chapter => [chapter.updated_at],
       };
@@ -1084,6 +1090,7 @@ export default function AdminOperationCourseDetailPage() {
     [
       clampChapterWidth,
       estimateChapterColumnWidth,
+      i18n.language,
       isManualChapterColumn,
       resolveContentStatusLabel,
       resolveLearningPermissionLabel,
@@ -1120,6 +1127,7 @@ export default function AdminOperationCourseDetailPage() {
           formatLearningProgress(
             user.learned_lesson_count,
             user.total_lesson_count,
+            i18n.language,
           ),
         ],
         learningStatus: user => [
@@ -1191,6 +1199,7 @@ export default function AdminOperationCourseDetailPage() {
       defaultUserName,
       emptyValue,
       estimateUserColumnWidth,
+      i18n.language,
       isManualUserColumn,
       resolveCourseUserAccount,
       resolveCourseUserLearningStatusLabel,
@@ -1691,7 +1700,10 @@ export default function AdminOperationCourseDetailPage() {
                                   >
                                     {chapter.node_type === 'chapter'
                                       ? emptyValue
-                                      : formatCount(chapter.follow_up_count)}
+                                      : formatCount(
+                                          chapter.follow_up_count,
+                                          i18n.language,
+                                        )}
                                   </TableCell>
                                   <TableCell
                                     className='py-2.5 whitespace-nowrap border-r border-border text-center text-sm text-muted-foreground/75 last:border-r-0'
@@ -1707,7 +1719,10 @@ export default function AdminOperationCourseDetailPage() {
                                   >
                                     {chapter.node_type === 'chapter'
                                       ? emptyValue
-                                      : formatCount(chapter.rating_count)}
+                                      : formatCount(
+                                          chapter.rating_count,
+                                          i18n.language,
+                                        )}
                                   </TableCell>
                                 </TableRow>
                               );
@@ -2117,6 +2132,7 @@ export default function AdminOperationCourseDetailPage() {
                                         {formatLearningProgress(
                                           row.learned_lesson_count,
                                           row.total_lesson_count,
+                                          i18n.language,
                                         )}
                                       </span>
                                     </TableCell>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -6,6 +6,7 @@ const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockGetAdminOperationCourseRatings = jest.fn();
 const mockTranslationCache = new Map<string, { t: (key: string) => string }>();
+let mockLanguage = 'en-US';
 const mockEnvState = {
   loginMethodsEnabled: ['phone'],
   defaultLoginMethod: 'phone',
@@ -61,7 +62,14 @@ jest.mock('react-i18next', () => ({
         t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
       });
     }
-    return mockTranslationCache.get(cacheKey)!;
+    return {
+      ...mockTranslationCache.get(cacheKey)!,
+      i18n: {
+        get language() {
+          return mockLanguage;
+        },
+      },
+    };
   },
 }));
 
@@ -150,6 +158,7 @@ describe('AdminOperationCourseRatingsPage', () => {
     mockReplace.mockReset();
     mockPush.mockReset();
     mockGetAdminOperationCourseRatings.mockReset();
+    mockLanguage = 'en-US';
     mockEnvState.loginMethodsEnabled = ['phone'];
     mockEnvState.defaultLoginMethod = 'phone';
     mockUserState.isInitialized = true;
@@ -247,6 +256,30 @@ describe('AdminOperationCourseRatingsPage', () => {
     );
 
     expect(mockPush).toHaveBeenCalledWith('/admin/operations/course-1');
+  });
+
+  test('formats rating summary counts without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
+      summary: {
+        average_score: '4.5',
+        rating_count: 76384,
+        user_count: 12000,
+        latest_rated_at: '2026-04-05T11:02:00Z',
+      },
+      items: [],
+      page: 1,
+      page_size: 20,
+      total: 0,
+      page_count: 1,
+    });
+
+    render(<AdminOperationCourseRatingsPage />);
+
+    expect(await screen.findByText('76384')).toBeInTheDocument();
+    expect(screen.getByText('12000')).toBeInTheDocument();
+    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
+    expect(screen.queryByText('12,000')).not.toBeInTheDocument();
   });
 
   test('submits search filters including score, mode, comment filter, sort, and rating time', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
@@ -108,8 +109,8 @@ const createRatingFilters = (): RatingFilters => ({
   endTime: '',
 });
 
-const formatCount = (value: number): string =>
-  Number.isFinite(value) ? value.toLocaleString() : '--';
+const formatCount = (value: number, locale: string): string =>
+  formatAdminCount(value, locale);
 
 const formatValue = (value: string | undefined | null, emptyValue: string) => {
   const normalizedValue = value?.trim() || '';
@@ -273,7 +274,7 @@ function ClearableTextInput({
  * t('module.operationsCourse.detail.ratings.table.guestUser')
  */
 export default function AdminOperationCourseRatingsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
   const router = useRouter();
   const params = useParams<{ shifu_bid?: string | string[] }>();
@@ -434,13 +435,13 @@ export default function AdminOperationCourseRatingsPage() {
       {
         key: 'ratingCount',
         label: tOperations('detail.ratings.summary.ratingCount'),
-        value: formatCount(ratings.summary.rating_count),
+        value: formatCount(ratings.summary.rating_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'userCount',
         label: tOperations('detail.ratings.summary.userCount'),
-        value: formatCount(ratings.summary.user_count),
+        value: formatCount(ratings.summary.user_count, i18n.language),
         tone: 'number' as const,
       },
       {
@@ -451,7 +452,7 @@ export default function AdminOperationCourseRatingsPage() {
         tone: 'timestamp' as const,
       },
     ],
-    [emptyValue, ratings.summary, tOperations],
+    [emptyValue, i18n.language, ratings.summary, tOperations],
   );
 
   const resolveUserSecondary = useCallback(

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -3,6 +3,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
+import {
+  formatAdminCredits,
+  formatAdminPrice,
+} from '@/app/admin/lib/numberFormat';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -13,11 +17,7 @@ import {
   SheetTitle,
 } from '@/components/ui/Sheet';
 import { ErrorWithCode } from '@/lib/request';
-import {
-  formatBillingCredits,
-  formatBillingDateTime,
-  formatBillingPrice,
-} from '@/lib/billing';
+import { formatBillingDateTime } from '@/lib/billing';
 import type { AdminOperationCreditOrderDetailResponse } from '../operation-credit-order-types';
 import {
   resolveOperationCreditOrderKindLabel,
@@ -307,7 +307,7 @@ export default function CreditOrderDetailDialog({
                 <DetailRow
                   label={tOperationsOrder('creditOrders.table.creditAmount')}
                   value={tOperationsOrder('creditOrders.creditAmountValue', {
-                    credits: formatBillingCredits(order.credit_amount, locale),
+                    credits: formatAdminCredits(order.credit_amount, locale),
                   })}
                 />
                 <DetailRow
@@ -325,7 +325,7 @@ export default function CreditOrderDetailDialog({
                 />
                 <DetailRow
                   label={t('module.order.fields.payable')}
-                  value={formatBillingPrice(
+                  value={formatAdminPrice(
                     order.payable_amount,
                     order.currency,
                     locale,
@@ -333,7 +333,7 @@ export default function CreditOrderDetailDialog({
                 />
                 <DetailRow
                   label={t('module.order.fields.paid')}
-                  value={formatBillingPrice(
+                  value={formatAdminPrice(
                     order.paid_amount,
                     order.currency,
                     locale,
@@ -372,7 +372,7 @@ export default function CreditOrderDetailDialog({
                       'creditOrders.detail.labels.grantedCredits',
                     )}
                     value={tOperationsOrder('creditOrders.creditAmountValue', {
-                      credits: formatBillingCredits(
+                      credits: formatAdminCredits(
                         grant.granted_credits,
                         locale,
                       ),

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -13,6 +13,7 @@ const TRANSLATION_OVERRIDES: Record<string, string> = {
   'module.operationsOrder.creditOrders.productIntervals.year': 'Yearly',
   'module.operationsOrder.creditOrders.productNameFormat': 'Yearly - Advanced',
 };
+let mockLanguage = 'en-US';
 
 const baseTranslation = (namespace?: string | string[]) => {
   const ns = Array.isArray(namespace) ? namespace[0] : namespace;
@@ -95,7 +96,9 @@ jest.mock('react-i18next', () => ({
   useTranslation: (namespace?: string | string[]) => ({
     ...baseTranslation(namespace),
     i18n: {
-      language: 'en-US',
+      get language() {
+        return mockLanguage;
+      },
     },
   }),
 }));
@@ -192,6 +195,7 @@ describe('CreditOrdersTab', () => {
   beforeEach(() => {
     mockGetAdminOperationCreditOrders.mockReset();
     mockGetAdminOperationCreditOrderDetail.mockReset();
+    mockLanguage = 'en-US';
     window.localStorage.clear();
 
     mockGetAdminOperationCreditOrders.mockResolvedValue({
@@ -335,6 +339,25 @@ describe('CreditOrdersTab', () => {
       screen.queryByText('module.billing.catalog.topups.default.title'),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('creator-topup-small')).not.toBeInTheDocument();
+  });
+
+  test('formats credit amounts and paid amounts without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+
+    render(<CreditOrdersTab />);
+
+    expect(
+      await screen.findByText(
+        'module.operationsOrder.creditOrders.creditAmountValue:5000',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('¥8000')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.creditOrders.creditAmountValue:5,000',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('¥8,000')).not.toBeInTheDocument();
   });
 
   test('submits filters and opens detail sheet', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -33,12 +33,14 @@ import {
   TableRow,
 } from '@/components/ui/Table';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import {
+  formatAdminCredits,
+  formatAdminPrice,
+} from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import {
-  formatBillingCredits,
   formatBillingDateTime,
-  formatBillingPrice,
   resolveBillingOrderStatusLabel,
 } from '@/lib/billing';
 import { ErrorWithCode } from '@/lib/request';
@@ -719,13 +721,13 @@ export default function CreditOrdersTab() {
                     const creditAmountLabel = tOperationsOrder(
                       'creditOrders.creditAmountValue',
                       {
-                        credits: formatBillingCredits(
+                        credits: formatAdminCredits(
                           order.credit_amount,
                           locale,
                         ),
                       },
                     );
-                    const paidAmountLabel = formatBillingPrice(
+                    const paidAmountLabel = formatAdminPrice(
                       order.paid_amount,
                       order.currency,
                       locale,

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -21,6 +21,7 @@ const originalWindow = global.window;
 const RETRY_LABEL = 'retry';
 const LONG_COURSE_PROMPT =
   'You are a patient course assistant. Help learners build understanding step by step, summarize key ideas clearly, and always connect each answer back to the course context.';
+let mockLanguage = 'en-US';
 const DEFAULT_OVERVIEW = {
   total_course_count: 24,
   draft_course_count: 8,
@@ -89,6 +90,11 @@ jest.mock('react-i18next', () => ({
         return params?.count !== undefined
           ? `${resolvedKey}:${params.count}`
           : resolvedKey;
+      },
+      i18n: {
+        get language() {
+          return mockLanguage;
+        },
       },
     };
   },
@@ -408,6 +414,7 @@ describe('OperationsPage', () => {
     mockGetAdminOperationCourses.mockReset();
     mockGetAdminOperationCoursePrompt.mockReset();
     mockTransferAdminOperationCourseCreator.mockReset();
+    mockLanguage = 'en-US';
     mockUserState.isInitialized = true;
     mockUserState.isGuest = false;
     mockUserState.userInfo = {
@@ -537,6 +544,26 @@ describe('OperationsPage', () => {
     expect(
       scopedRow.queryByText('module.user.defaultUserName'),
     ).not.toBeInTheDocument();
+  });
+
+  test('formats overview counts without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationCourses.mockResolvedValueOnce({
+      summary: {
+        ...DEFAULT_OVERVIEW,
+        total_course_count: 76384,
+      },
+      items: [],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 0,
+    });
+
+    await renderAndWaitForLoadedPage();
+
+    expect(screen.getByText('76384')).toBeInTheDocument();
+    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
   });
 
   test('navigates from course name and transfers creator from the action menu', async () => {

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -18,6 +18,7 @@ import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -224,8 +225,8 @@ const renderTooltipText = (text?: string, className?: string) => {
   );
 };
 
-const formatCount = (value: number): string =>
-  Number.isFinite(value) ? value.toLocaleString() : EMPTY_STATE_LABEL;
+const formatCount = (value: number, locale: string): string =>
+  formatAdminCount(value, locale, EMPTY_STATE_LABEL);
 
 type ClearableTextInputProps = {
   value: string;
@@ -335,7 +336,7 @@ const ClearableTextInput = ({
  */
 const OperationsPage = () => {
   const router = useRouter();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
   const { toast } = useToast();
   const { isInitialized, isGuest, isReady } = useOperatorGuard();
@@ -1300,7 +1301,7 @@ const OperationsPage = () => {
                         {card.label}
                       </div>
                       <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                        {formatCount(card.value)}
+                        {formatCount(card.value, i18n.language)}
                       </div>
                     </button>
                     <TooltipProvider delayDuration={0}>

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
@@ -7,6 +7,7 @@ const mockToast = jest.fn();
 const mockGrantAdminOperationUserCredits =
   api.grantAdminOperationUserCredits as jest.Mock;
 const translationCache = new Map<string, { t: (key: string) => string }>();
+let mockLanguage = 'en-US';
 const baseTranslation = (namespace?: string | string[]) => {
   const ns = Array.isArray(namespace) ? namespace[0] : namespace;
   const cacheKey = ns || 'translation';
@@ -26,7 +27,14 @@ jest.mock('@/api', () => ({
 }));
 
 jest.mock('react-i18next', () => ({
-  useTranslation: (namespace?: string | string[]) => baseTranslation(namespace),
+  useTranslation: (namespace?: string | string[]) => ({
+    ...baseTranslation(namespace),
+    i18n: {
+      get language() {
+        return mockLanguage;
+      },
+    },
+  }),
 }));
 
 jest.mock('@/hooks/useToast', () => ({
@@ -229,6 +237,7 @@ describe('UserCreditGrantDialog', () => {
   beforeEach(() => {
     mockToast.mockReset();
     mockGrantAdminOperationUserCredits.mockReset();
+    mockLanguage = 'en-US';
     mockGrantAdminOperationUserCredits.mockResolvedValue({
       user_bid: 'user-1',
       amount: '10',
@@ -269,6 +278,22 @@ describe('UserCreditGrantDialog', () => {
       ),
     ).toBeInTheDocument();
     expect(mockGrantAdminOperationUserCredits).not.toHaveBeenCalled();
+  });
+
+  test('formats current available credits without grouping in Chinese locale', () => {
+    mockLanguage = 'zh-CN';
+
+    render(
+      <UserCreditGrantDialog
+        open
+        user={{ ...baseUser, available_credits: '10000' }}
+        onOpenChange={jest.fn()}
+        onGranted={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('10000')).toBeInTheDocument();
+    expect(screen.queryByText('10,000')).not.toBeInTheDocument();
   });
 
   test('submits a confirmed grant and reports success', async () => {

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import api from '@/api';
+import { formatAdminCredits } from '@/app/admin/lib/numberFormat';
 import { useToast } from '@/hooks/useToast';
-import { formatBillingCredits } from '@/lib/billing';
 import { ErrorWithCode } from '@/lib/request';
 import { Button } from '@/components/ui/Button';
 import {
@@ -347,7 +347,7 @@ export default function UserCreditGrantDialog({
                   label={tOperationsUsers(
                     'grantDialog.summary.availableCredits',
                   )}
-                  value={formatBillingCredits(
+                  value={formatAdminCredits(
                     Number(user?.available_credits || 0),
                     i18n.language,
                   )}

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -8,6 +8,7 @@ const mockRefresh = jest.fn();
 const mockScrollIntoView = jest.fn();
 const mockBrowserTimeZone = jest.fn(() => 'UTC');
 let currentUserBid = 'user-1';
+let mockLanguage = 'en-US';
 const translationCache = new Map<string, { t: (key: string) => string }>();
 const baseTranslation = (namespace?: string | string[]) => {
   const ns = Array.isArray(namespace) ? namespace[0] : namespace;
@@ -92,7 +93,14 @@ jest.mock('@/lib/browser-timezone', () => ({
 }));
 
 jest.mock('react-i18next', () => ({
-  useTranslation: (namespace?: string | string[]) => baseTranslation(namespace),
+  useTranslation: (namespace?: string | string[]) => ({
+    ...baseTranslation(namespace),
+    i18n: {
+      get language() {
+        return mockLanguage;
+      },
+    },
+  }),
 }));
 
 jest.mock('@/components/ui/tooltip', () => ({
@@ -260,6 +268,7 @@ describe('AdminOperationUserDetailPage', () => {
 
   beforeEach(() => {
     currentUserBid = 'user-1';
+    mockLanguage = 'en-US';
     mockPush.mockReset();
     mockRefresh.mockReset();
     mockScrollIntoView.mockReset();
@@ -334,6 +343,39 @@ describe('AdminOperationUserDetailPage', () => {
     ).toHaveAttribute('href', '/admin/operations/course-1');
     expect(screen.getByText('25% (1/4)')).toBeInTheDocument();
     expect(pageContainer).not.toHaveClass('overflow-auto');
+  });
+
+  test('formats credits without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationUserDetail.mockResolvedValueOnce({
+      ...detailResponse,
+      available_credits: '10000',
+      subscription_credits: '10000',
+      topup_credits: '5000',
+    });
+    mockGetAdminOperationUserCredits.mockResolvedValueOnce({
+      ...creditsResponse,
+      summary: {
+        ...creditsResponse.summary,
+        available_credits: '10000',
+        subscription_credits: '10000',
+        topup_credits: '5000',
+      },
+      items: [
+        {
+          ...creditsResponse.items[0],
+          amount: '5000',
+          balance_after: '10000',
+        },
+      ],
+    });
+
+    render(<AdminOperationUserDetailPage />);
+
+    expect((await screen.findAllByText('10000')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('5000').length).toBeGreaterThan(0);
+    expect(screen.queryByText('10,000')).not.toBeInTheDocument();
+    expect(screen.queryByText('5,000')).not.toBeInTheDocument();
   });
 
   test('renders detail timestamps in the viewer timezone when UTC crosses local day boundaries', async () => {

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
+import { formatAdminCredits } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -30,7 +31,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { formatBillingCredits } from '@/lib/billing';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
 import { cn } from '@/lib/utils';
@@ -503,7 +503,7 @@ const CreditLedgerTable = ({
                             item.amount === null ||
                             item.amount === undefined
                               ? ''
-                              : formatBillingCredits(
+                              : formatAdminCredits(
                                   Number(item.amount),
                                   i18n.language,
                                 )
@@ -518,7 +518,7 @@ const CreditLedgerTable = ({
                             item.balance_after === null ||
                             item.balance_after === undefined
                               ? ''
-                              : formatBillingCredits(
+                              : formatAdminCredits(
                                   Number(item.balance_after),
                                   i18n.language,
                                 )
@@ -1002,7 +1002,7 @@ export default function AdminOperationUserDetailPage() {
                         )}
                         value={
                           creditSummary.available_credits
-                            ? formatBillingCredits(
+                            ? formatAdminCredits(
                                 Number(creditSummary.available_credits),
                                 i18n.language,
                               )
@@ -1015,7 +1015,7 @@ export default function AdminOperationUserDetailPage() {
                         )}
                         value={
                           creditSummary.subscription_credits
-                            ? formatBillingCredits(
+                            ? formatAdminCredits(
                                 Number(creditSummary.subscription_credits),
                                 i18n.language,
                               )
@@ -1028,7 +1028,7 @@ export default function AdminOperationUserDetailPage() {
                         )}
                         value={
                           creditSummary.topup_credits
-                            ? formatBillingCredits(
+                            ? formatAdminCredits(
                                 Number(creditSummary.topup_credits),
                                 i18n.language,
                               )

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -16,6 +16,7 @@ const mockGrantDialogPrefix = 'grant-dialog-';
 const mockGrantSuccessLabel = 'mock-grant-success';
 const buildGrantDialogLabel = (userBid: string) =>
   `${mockGrantDialogPrefix}${userBid}`;
+let mockLanguage = 'en-US';
 const translationCache = new Map<
   string,
   { t: (key: string) => string; i18n: { language: string } }
@@ -41,7 +42,9 @@ const baseTranslation = (namespace?: string | string[]) => {
         return ns && ns !== 'translation' ? `${ns}.${key}` : key;
       },
       i18n: {
-        language: 'en-US',
+        get language() {
+          return mockLanguage;
+        },
       },
     });
   }
@@ -278,6 +281,7 @@ describe('AdminOperationUsersPage', () => {
     mockReplace.mockReset();
     mockMutateBillingOverview.mockReset();
     mockGetAdminOperationUsers.mockReset();
+    mockLanguage = 'en-US';
     mockUserState.isInitialized = true;
     mockUserState.isGuest = false;
     mockUserState.userInfo = { is_operator: true };
@@ -425,6 +429,52 @@ describe('AdminOperationUsersPage', () => {
         name: 'module.operationsUser.actions.moreForUser',
       }),
     ).toBeInTheDocument();
+  });
+
+  test('formats overview counts and credits without grouping in Chinese locale', async () => {
+    mockLanguage = 'zh-CN';
+    mockGetAdminOperationUsers.mockResolvedValueOnce({
+      summary: {
+        ...DEFAULT_OVERVIEW,
+        total_user_count: 76384,
+      },
+      items: [
+        {
+          user_bid: 'user-1',
+          mobile: '13812345678',
+          email: 'user-1@example.com',
+          nickname: 'Nick',
+          user_status: 'paid',
+          user_role: 'operator',
+          user_roles: ['operator'],
+          login_methods: ['phone'],
+          registration_source: 'google',
+          language: 'zh-CN',
+          learning_courses: [],
+          created_courses: [],
+          total_paid_amount: '88.50',
+          available_credits: '10000',
+          subscription_credits: '10000',
+          topup_credits: '0',
+          credits_expire_at: '2026-05-01T00:00:00Z',
+          last_login_at: '2026-04-15T09:00:00Z',
+          last_learning_at: '2026-04-15T10:00:00Z',
+          created_at: '2026-04-14T10:00:00Z',
+          updated_at: '2026-04-14T11:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+
+    render(<AdminOperationUsersPage />);
+
+    expect(await screen.findByText('76384')).toBeInTheDocument();
+    expect(screen.getByText('10000')).toBeInTheDocument();
+    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
+    expect(screen.queryByText('10,000')).not.toBeInTheDocument();
   });
 
   test('opens the credit grant dialog from the action menu', async () => {

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -12,6 +12,10 @@ import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import {
+  formatAdminCount,
+  formatAdminCredits,
+} from '@/app/admin/lib/numberFormat';
+import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
   getAdminStickyRightCellClass,
@@ -60,7 +64,7 @@ import {
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { BILLING_OVERVIEW_SWR_KEY } from '@/hooks/useBillingData';
-import { buildBillingSwrKey, formatBillingCredits } from '@/lib/billing';
+import { buildBillingSwrKey } from '@/lib/billing';
 import { getBrowserTimeZone } from '@/lib/browser-timezone';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { cn } from '@/lib/utils';
@@ -967,7 +971,7 @@ export default function AdminOperationUsersPage() {
                         {card.label}
                       </div>
                       <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                        {card.value.toLocaleString()}
+                        {formatAdminCount(card.value, i18n.language)}
                       </div>
                     </button>
                     <Tooltip>
@@ -1387,7 +1391,7 @@ export default function AdminOperationUsersPage() {
                             >
                               {renderTooltipText(
                                 user.available_credits
-                                  ? formatBillingCredits(
+                                  ? formatAdminCredits(
                                       Number(user.available_credits),
                                       i18n.language,
                                     )
@@ -1397,7 +1401,7 @@ export default function AdminOperationUsersPage() {
                           ) : (
                             renderTooltipText(
                               user.available_credits
-                                ? formatBillingCredits(
+                                ? formatAdminCredits(
                                     Number(user.available_credits),
                                     i18n.language,
                                   )

--- a/src/cook-web/src/lib/__tests__/admin-number-format.test.ts
+++ b/src/cook-web/src/lib/__tests__/admin-number-format.test.ts
@@ -1,0 +1,46 @@
+import {
+  formatAdminCount,
+  formatAdminCredits,
+  formatAdminPrice,
+} from '@/lib/admin-number-format';
+
+describe('formatAdminCount', () => {
+  test('hides grouping for Chinese locales', () => {
+    expect(formatAdminCount(76384, 'zh-CN')).toBe('76384');
+    expect(formatAdminCount(1234567, 'zh-HK')).toBe('1234567');
+  });
+
+  test('keeps grouping for non-Chinese locales', () => {
+    expect(formatAdminCount(76384, 'en-US')).toBe('76,384');
+    expect(formatAdminCount(1234567, 'fr-FR')).toBe('1 234 567');
+  });
+
+  test('returns the provided empty value for non-finite input', () => {
+    expect(formatAdminCount(undefined, 'zh-CN')).toBe('--');
+    expect(formatAdminCount(Number.NaN, 'en-US', 'N/A')).toBe('N/A');
+  });
+});
+
+describe('formatAdminCredits', () => {
+  test('applies locale-aware grouping rules', () => {
+    expect(formatAdminCredits(10000, 'zh-CN')).toBe('10000');
+    expect(formatAdminCredits(10000, 'en-US')).toBe('10,000');
+  });
+
+  test('preserves meaningful decimals', () => {
+    expect(formatAdminCredits(50.5, 'zh-CN')).toBe('50.5');
+    expect(formatAdminCredits(12345.67, 'en-US')).toBe('12,345.67');
+  });
+});
+
+describe('formatAdminPrice', () => {
+  test('formats Chinese admin prices without grouping', () => {
+    expect(formatAdminPrice(123456700, 'CNY', 'zh-CN')).toBe('¥1234567');
+    expect(formatAdminPrice(9950, 'CNY', 'zh-CN')).toBe('¥99.5');
+  });
+
+  test('formats non-Chinese admin prices with grouping', () => {
+    expect(formatAdminPrice(123456700, 'CNY', 'en-US')).toBe('¥1,234,567');
+    expect(formatAdminPrice(9950, 'USD', 'en-US')).toBe('$99.5');
+  });
+});

--- a/src/cook-web/src/lib/admin-number-format.ts
+++ b/src/cook-web/src/lib/admin-number-format.ts
@@ -12,7 +12,9 @@ const DEFAULT_ADMIN_NUMBER_FORMAT = {
 } as const;
 
 const shouldUseAdminNumberGrouping = (locale?: string | null): boolean => {
-  const normalizedLocale = String(locale || '').trim().toLowerCase();
+  const normalizedLocale = String(locale || '')
+    .trim()
+    .toLowerCase();
   return !normalizedLocale.startsWith('zh');
 };
 

--- a/src/cook-web/src/lib/admin-number-format.ts
+++ b/src/cook-web/src/lib/admin-number-format.ts
@@ -1,0 +1,85 @@
+'use client';
+
+type AdminNumberFormatOptions = {
+  currency?: string;
+  maximumFractionDigits?: number;
+  minimumFractionDigits?: number;
+};
+
+const DEFAULT_ADMIN_NUMBER_FORMAT = {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+} as const;
+
+const shouldUseAdminNumberGrouping = (locale?: string | null): boolean => {
+  const normalizedLocale = String(locale || '').trim().toLowerCase();
+  return !normalizedLocale.startsWith('zh');
+};
+
+export function formatAdminNumber(
+  value: unknown,
+  locale: string,
+  options?: AdminNumberFormatOptions,
+): string {
+  const numeric = Number(value ?? 0);
+  const safeValue = Number.isFinite(numeric) ? numeric : 0;
+
+  return new Intl.NumberFormat(locale || 'en-US', {
+    useGrouping: shouldUseAdminNumberGrouping(locale),
+    minimumFractionDigits:
+      options?.minimumFractionDigits ??
+      DEFAULT_ADMIN_NUMBER_FORMAT.minimumFractionDigits,
+    maximumFractionDigits:
+      options?.maximumFractionDigits ??
+      DEFAULT_ADMIN_NUMBER_FORMAT.maximumFractionDigits,
+    ...(options?.currency
+      ? {
+          style: 'currency',
+          currency: options.currency,
+          currencyDisplay: 'narrowSymbol',
+        }
+      : {}),
+  }).format(safeValue);
+}
+
+export function formatAdminCount(
+  value: unknown,
+  locale: string,
+  emptyValue = '--',
+): string {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return emptyValue;
+  }
+
+  return formatAdminNumber(numeric, locale, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}
+
+export function formatAdminCredits(value: unknown, locale: string): string {
+  return formatAdminNumber(value, locale);
+}
+
+export function formatAdminPrice(
+  amountInMinor: number,
+  currency: string,
+  locale: string,
+): string {
+  const resolvedCurrency = currency || 'CNY';
+  const fractionDigits =
+    new Intl.NumberFormat(locale || 'en-US', {
+      style: 'currency',
+      currency: resolvedCurrency,
+    }).resolvedOptions().maximumFractionDigits ?? 2;
+
+  return formatAdminNumber(
+    Number(amountInMinor || 0) / 10 ** fractionDigits,
+    locale,
+    {
+      currency: resolvedCurrency,
+      maximumFractionDigits: fractionDigits,
+    },
+  );
+}

--- a/src/cook-web/src/lib/admin-number-format.ts
+++ b/src/cook-web/src/lib/admin-number-format.ts
@@ -1,5 +1,3 @@
-'use client';
-
 type AdminNumberFormatOptions = {
   currency?: string;
   maximumFractionDigits?: number;
@@ -18,15 +16,36 @@ const shouldUseAdminNumberGrouping = (locale?: string | null): boolean => {
   return !normalizedLocale.startsWith('zh');
 };
 
-export function formatAdminNumber(
-  value: unknown,
+const adminNumberFormatterCache = new Map<string, Intl.NumberFormat>();
+
+const buildAdminNumberFormatterKey = (
   locale: string,
   options?: AdminNumberFormatOptions,
-): string {
-  const numeric = Number(value ?? 0);
-  const safeValue = Number.isFinite(numeric) ? numeric : 0;
+): string => {
+  return JSON.stringify({
+    locale: locale || 'en-US',
+    useGrouping: shouldUseAdminNumberGrouping(locale),
+    currency: options?.currency || '',
+    minimumFractionDigits:
+      options?.minimumFractionDigits ??
+      DEFAULT_ADMIN_NUMBER_FORMAT.minimumFractionDigits,
+    maximumFractionDigits:
+      options?.maximumFractionDigits ??
+      DEFAULT_ADMIN_NUMBER_FORMAT.maximumFractionDigits,
+  });
+};
 
-  return new Intl.NumberFormat(locale || 'en-US', {
+const getAdminNumberFormatter = (
+  locale: string,
+  options?: AdminNumberFormatOptions,
+): Intl.NumberFormat => {
+  const cacheKey = buildAdminNumberFormatterKey(locale, options);
+  const cachedFormatter = adminNumberFormatterCache.get(cacheKey);
+  if (cachedFormatter) {
+    return cachedFormatter;
+  }
+
+  const formatter = new Intl.NumberFormat(locale || 'en-US', {
     useGrouping: shouldUseAdminNumberGrouping(locale),
     minimumFractionDigits:
       options?.minimumFractionDigits ??
@@ -41,7 +60,20 @@ export function formatAdminNumber(
           currencyDisplay: 'narrowSymbol',
         }
       : {}),
-  }).format(safeValue);
+  });
+  adminNumberFormatterCache.set(cacheKey, formatter);
+  return formatter;
+};
+
+export function formatAdminNumber(
+  value: unknown,
+  locale: string,
+  options?: AdminNumberFormatOptions,
+): string {
+  const numeric = Number(value ?? 0);
+  const safeValue = Number.isFinite(numeric) ? numeric : 0;
+
+  return getAdminNumberFormatter(locale, options).format(safeValue);
 }
 
 export function formatAdminCount(


### PR DESCRIPTION
# Summary

Align operator/admin number formatting with the active UI language.

- add a dedicated admin number formatter that hides grouping for Chinese locales and keeps grouping for non-Chinese locales
- apply the formatter to operator overview cards, course detail metrics, follow-up and rating summaries, and operator credit-related views
- add targeted tests covering Chinese and English formatting behavior across the updated admin pages

## Verification

- `cd src/cook-web && npm run test -- --runInBand src/lib/__tests__/admin-number-format.test.ts`
- `cd src/cook-web && npm run test -- --runInBand src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx src/app/admin/operations/users/UserCreditGrantDialog.test.tsx`
- `cd src/cook-web && npm run test -- --runInBand --runTestsByPath 'src/app/admin/operations/[shifu_bid]/page.test.tsx' 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx' 'src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx' 'src/app/admin/operations/users/[user_bid]/page.test.tsx'`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npx eslint src/lib/admin-number-format.ts src/lib/__tests__/admin-number-format.test.ts src/app/admin/lib/numberFormat.ts src/app/admin/operations/page.tsx src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.tsx src/app/admin/operations/users/page.test.tsx 'src/app/admin/operations/[shifu_bid]/page.tsx' 'src/app/admin/operations/[shifu_bid]/page.test.tsx' 'src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx' 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx' 'src/app/admin/operations/[shifu_bid]/ratings/page.tsx' 'src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx' src/app/admin/operations/users/UserCreditGrantDialog.tsx src/app/admin/operations/users/UserCreditGrantDialog.test.tsx 'src/app/admin/operations/users/[user_bid]/page.tsx' 'src/app/admin/operations/users/[user_bid]/page.test.tsx' src/app/admin/operations/orders/CreditOrdersTab.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx src/app/admin/operations/orders/CreditOrderDetailDialog.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced locale-aware number formatting in the admin dashboard with proper thousands-grouping support for different languages.
  * Numbers now format without grouping separators for Chinese locale and with proper grouping for other locales.

* **Refactor**
  * Updated admin pages (operations, orders, users) to use standardized number formatting utilities.

* **Tests**
  * Added comprehensive test coverage for locale-specific number formatting across admin components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->