### PR TITLE
fix: align operator admin local datetime display

### DIFF
--- a/src/cook-web/src/app/admin/lib/dateTime.ts
+++ b/src/cook-web/src/app/admin/lib/dateTime.ts
@@ -1,4 +1,6 @@
 export {
+  formatAdminNaiveDateTime,
   formatAdminUtcDateTime,
+  parseAdminNaiveDateTime,
   parseAdminUtcDateTime,
 } from '@/lib/admin-date-time';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -17,7 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/Sheet';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { cn } from '@/lib/utils';
 import type { AdminOperationCourseFollowUpDetailResponse } from '../../operation-course-types';
 
@@ -300,7 +300,7 @@ export default function FollowUpDetailSheet({
                 <DetailRow
                   label={t('detail.followUps.drawer.fields.followUpTime')}
                   value={
-                    formatAdminUtcDateTime(basicInfo?.created_at) || emptyValue
+                    formatAdminNaiveDateTime(basicInfo?.created_at) || emptyValue
                   }
                 />
                 <DetailRow
@@ -370,7 +370,7 @@ export default function FollowUpDetailSheet({
                             ) : null}
                           </div>
                           <span className='text-xs text-muted-foreground'>
-                            {formatAdminUtcDateTime(item.created_at) ||
+                            {formatAdminNaiveDateTime(item.created_at) ||
                               emptyValue}
                           </span>
                         </div>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -300,7 +300,8 @@ export default function FollowUpDetailSheet({
                 <DetailRow
                   label={t('detail.followUps.drawer.fields.followUpTime')}
                   value={
-                    formatAdminNaiveDateTime(basicInfo?.created_at) || emptyValue
+                    formatAdminNaiveDateTime(basicInfo?.created_at) ||
+                    emptyValue
                   }
                 />
                 <DetailRow

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -17,7 +17,7 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -516,7 +516,7 @@ export default function AdminOperationCourseFollowUpsPage() {
         key: 'latestFollowUpAt',
         label: tOperations('detail.followUps.summary.latestFollowUpAt'),
         value:
-          formatAdminUtcDateTime(followUps.summary.latest_follow_up_at) ||
+          formatAdminNaiveDateTime(followUps.summary.latest_follow_up_at) ||
           emptyValue,
         tone: 'timestamp' as const,
       },
@@ -922,7 +922,7 @@ export default function AdminOperationCourseFollowUpsPage() {
                                       style={getColumnStyle('createdAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           item.created_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -16,7 +16,7 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
@@ -1260,12 +1260,12 @@ export default function AdminOperationCourseDetailPage() {
       {
         label: tOperations('detail.fields.createdAt'),
         value:
-          formatAdminUtcDateTime(detail.basic_info.created_at) || emptyValue,
+          formatAdminNaiveDateTime(detail.basic_info.created_at) || emptyValue,
       },
       {
         label: tOperations('detail.fields.updatedAt'),
         value:
-          formatAdminUtcDateTime(detail.basic_info.updated_at) || emptyValue,
+          formatAdminNaiveDateTime(detail.basic_info.updated_at) || emptyValue,
       },
     ],
     [
@@ -1684,7 +1684,7 @@ export default function AdminOperationCourseDetailPage() {
                                   >
                                     <AdminTooltipText
                                       text={
-                                        formatAdminUtcDateTime(
+                                        formatAdminNaiveDateTime(
                                           chapter.updated_at,
                                         ) || emptyValue
                                       }
@@ -2178,7 +2178,7 @@ export default function AdminOperationCourseDetailPage() {
                                       )}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           row.last_learning_at,
                                         )}
                                         emptyValue={emptyValue}
@@ -2190,7 +2190,7 @@ export default function AdminOperationCourseDetailPage() {
                                       style={getUserColumnStyle('lastLoginAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           row.last_login_at,
                                         )}
                                         emptyValue={emptyValue}
@@ -2202,7 +2202,7 @@ export default function AdminOperationCourseDetailPage() {
                                       style={getUserColumnStyle('joinedAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           row.joined_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -14,7 +14,7 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -448,7 +448,7 @@ export default function AdminOperationCourseRatingsPage() {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminUtcDateTime(ratings.summary.latest_rated_at) || emptyValue,
+          formatAdminNaiveDateTime(ratings.summary.latest_rated_at) || emptyValue,
         tone: 'timestamp' as const,
       },
     ],
@@ -993,7 +993,7 @@ export default function AdminOperationCourseRatingsPage() {
                                       style={getColumnStyle('ratedAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           item.rated_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -448,7 +448,8 @@ export default function AdminOperationCourseRatingsPage() {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminNaiveDateTime(ratings.summary.latest_rated_at) || emptyValue,
+          formatAdminNaiveDateTime(ratings.summary.latest_rated_at) ||
+          emptyValue,
         tone: 'timestamp' as const,
       },
     ],

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   formatAdminCredits,
   formatAdminPrice,
@@ -255,14 +256,14 @@ export default function CreditOrderDetailDialog({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatBillingDateTime(order.created_at, locale) ||
+                    formatAdminNaiveDateTime(order.created_at) ||
                     emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('creditOrders.detail.labels.paidAt')}
                   value={
-                    formatBillingDateTime(order.paid_at, locale) || emptyValue
+                    formatAdminNaiveDateTime(order.paid_at) || emptyValue
                   }
                 />
                 {order.failed_at ? (
@@ -271,7 +272,7 @@ export default function CreditOrderDetailDialog({
                       'creditOrders.detail.labels.failedAt',
                     )}
                     value={
-                      formatBillingDateTime(order.failed_at, locale) ||
+                      formatAdminNaiveDateTime(order.failed_at) ||
                       emptyValue
                     }
                   />

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -256,15 +256,12 @@ export default function CreditOrderDetailDialog({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatAdminNaiveDateTime(order.created_at) ||
-                    emptyValue
+                    formatAdminNaiveDateTime(order.created_at) || emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('creditOrders.detail.labels.paidAt')}
-                  value={
-                    formatAdminNaiveDateTime(order.paid_at) || emptyValue
-                  }
+                  value={formatAdminNaiveDateTime(order.paid_at) || emptyValue}
                 />
                 {order.failed_at ? (
                   <DetailRow
@@ -272,8 +269,7 @@ export default function CreditOrderDetailDialog({
                       'creditOrders.detail.labels.failedAt',
                     )}
                     value={
-                      formatAdminNaiveDateTime(order.failed_at) ||
-                      emptyValue
+                      formatAdminNaiveDateTime(order.failed_at) || emptyValue
                     }
                   />
                 ) : null}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -8,6 +8,7 @@ import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -39,10 +40,7 @@ import {
 } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
-import {
-  formatBillingDateTime,
-  resolveBillingOrderStatusLabel,
-} from '@/lib/billing';
+import { resolveBillingOrderStatusLabel } from '@/lib/billing';
 import { ErrorWithCode } from '@/lib/request';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { cn } from '@/lib/utils';
@@ -755,7 +753,7 @@ export default function CreditOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatBillingDateTime(order.created_at, locale) ||
+                            formatAdminNaiveDateTime(order.created_at) ||
                               EMPTY_STATE_LABEL,
                           )}
                         </TableCell>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -9,7 +9,7 @@ import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -808,7 +808,7 @@ export default function LearnOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatAdminUtcDateTime(order.created_at),
+                            formatAdminNaiveDateTime(order.created_at),
                           )}
                         </TableCell>
                         <TableCell

--- a/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import api from '@/api';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Badge } from '@/components/ui/Badge';
@@ -209,13 +209,13 @@ const OperatorOrderDetailSheet = ({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatAdminUtcDateTime(summary.created_at) || emptyValue
+                    formatAdminNaiveDateTime(summary.created_at) || emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('table.updatedAt')}
                   value={
-                    formatAdminUtcDateTime(summary.updated_at) || emptyValue
+                    formatAdminNaiveDateTime(summary.updated_at) || emptyValue
                   }
                 />
               </Section>

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -17,7 +17,7 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
@@ -1655,7 +1655,7 @@ const OperationsPage = () => {
                         style={getColumnStyle('updatedAt')}
                       >
                         {renderTooltipText(
-                          formatAdminUtcDateTime(course.updated_at),
+                          formatAdminNaiveDateTime(course.updated_at),
                           'mx-auto block',
                         )}
                       </TableCell>
@@ -1664,7 +1664,7 @@ const OperationsPage = () => {
                         style={getColumnStyle('createdAt')}
                       >
                         {renderTooltipText(
-                          formatAdminUtcDateTime(course.created_at),
+                          formatAdminNaiveDateTime(course.created_at),
                           'mx-auto block',
                         )}
                       </TableCell>

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/components/ui/Select';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/RadioGroup';
 import { Textarea } from '@/components/ui/Textarea';
-import { formatOperatorUtcDateTime } from './dateTime';
+import { formatOperatorNaiveDateTime } from './dateTime';
 import type {
   AdminOperationUserCreditGrantRequest,
   AdminOperationUserCreditGrantResponse,
@@ -85,7 +85,7 @@ const resolveCurrentExpiry = (
     return '--';
   }
   if (user.credits_expire_at) {
-    return formatOperatorUtcDateTime(user.credits_expire_at);
+    return formatOperatorNaiveDateTime(user.credits_expire_at);
   }
   if (Number(user.available_credits || 0) > 0) {
     return longTermLabel;

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -35,7 +35,7 @@ import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
 import { cn } from '@/lib/utils';
 import { buildAdminOperationsCourseDetailUrl } from '../../operation-course-routes';
-import { formatOperatorUtcDateTime } from '../dateTime';
+import { formatOperatorNaiveDateTime } from '../dateTime';
 import { normalizeLoginMethodLabelKey } from '../loginMethodUtils';
 import type {
   AdminOperationUserCourseItem,
@@ -470,7 +470,7 @@ const CreditLedgerTable = ({
                     <TableRow key={item.ledger_bid}>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={formatOperatorUtcDateTime(item.created_at)}
+                          text={formatOperatorNaiveDateTime(item.created_at)}
                           emptyValue={EMPTY_VALUE}
                         />
                       </TableCell>
@@ -528,7 +528,7 @@ const CreditLedgerTable = ({
                       </TableCell>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={formatOperatorUtcDateTime(item.expires_at)}
+                          text={formatOperatorNaiveDateTime(item.expires_at)}
                           emptyValue={EMPTY_VALUE}
                         />
                       </TableCell>
@@ -829,7 +829,7 @@ export default function AdminOperationUserDetailPage() {
   };
   const resolveCreditsExpireAt = () => {
     if (creditSummary.credits_expire_at) {
-      return formatOperatorUtcDateTime(creditSummary.credits_expire_at);
+      return formatOperatorNaiveDateTime(creditSummary.credits_expire_at);
     }
     if (Number(creditSummary.available_credits || 0) > 0) {
       return tOperationsUsers('credits.longTerm');
@@ -941,15 +941,15 @@ export default function AdminOperationUserDetailPage() {
                     />
                     <InfoItem
                       label={tOperationsUsers('table.lastLoginAt')}
-                      value={formatOperatorUtcDateTime(detail.last_login_at)}
+                      value={formatOperatorNaiveDateTime(detail.last_login_at)}
                     />
                     <InfoItem
                       label={tOperationsUsers('table.updatedAt')}
-                      value={formatOperatorUtcDateTime(detail.updated_at)}
+                      value={formatOperatorNaiveDateTime(detail.updated_at)}
                     />
                     <InfoItem
                       label={tOperationsUsers('table.createdAt')}
-                      value={formatOperatorUtcDateTime(detail.created_at)}
+                      value={formatOperatorNaiveDateTime(detail.created_at)}
                     />
                   </div>
                 </CardContent>
@@ -977,7 +977,7 @@ export default function AdminOperationUserDetailPage() {
                     />
                     <InfoItem
                       label={tOperationsUsers('table.lastLearningAt')}
-                      value={formatOperatorUtcDateTime(detail.last_learning_at)}
+                      value={formatOperatorNaiveDateTime(detail.last_learning_at)}
                     />
                   </div>
                 </CardContent>

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -977,7 +977,9 @@ export default function AdminOperationUserDetailPage() {
                     />
                     <InfoItem
                       label={tOperationsUsers('table.lastLearningAt')}
-                      value={formatOperatorNaiveDateTime(detail.last_learning_at)}
+                      value={formatOperatorNaiveDateTime(
+                        detail.last_learning_at,
+                      )}
                     />
                   </div>
                 </CardContent>

--- a/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
+++ b/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
@@ -20,9 +20,27 @@ describe('formatOperatorUtcDateTime', () => {
 });
 
 describe('formatOperatorNaiveDateTime', () => {
+  test('formats date-only strings with midnight defaults', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01')).toBe(
+      '2026-05-01 00:00:00',
+    );
+  });
+
+  test('formats minute precision strings with zero seconds', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01 08:30')).toBe(
+      '2026-05-01 08:30:00',
+    );
+  });
+
   test('formats offsetless legacy datetimes without timezone conversion', () => {
     expect(formatOperatorNaiveDateTime('2026-05-01 08:30:15')).toBe(
       '2026-05-01 08:30:15',
+    );
+  });
+
+  test('preserves wall clock time for date-only payloads with timezone markers', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01Z')).toBe(
+      '2026-05-01 00:00:00',
     );
   });
 
@@ -30,5 +48,15 @@ describe('formatOperatorNaiveDateTime', () => {
     expect(formatOperatorNaiveDateTime('2026-05-01T08:30:15Z')).toBe(
       '2026-05-01 08:30:15',
     );
+  });
+
+  test('preserves wall clock time for offset-marked payloads', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01T08:30:15+08:00')).toBe(
+      '2026-05-01 08:30:15',
+    );
+  });
+
+  test('rejects impossible datetimes', () => {
+    expect(formatOperatorNaiveDateTime('2026-99-01 08:30:15')).toBe('');
   });
 });

--- a/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
+++ b/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
@@ -1,4 +1,7 @@
-import { formatOperatorUtcDateTime } from './dateTime';
+import {
+  formatOperatorNaiveDateTime,
+  formatOperatorUtcDateTime,
+} from './dateTime';
 
 jest.mock('@/lib/browser-timezone', () => ({
   getBrowserTimeZone: () => 'UTC',
@@ -13,5 +16,19 @@ describe('formatOperatorUtcDateTime', () => {
 
   test('rejects offsetless legacy datetimes', () => {
     expect(formatOperatorUtcDateTime('2026-05-01 00:00:00')).toBe('');
+  });
+});
+
+describe('formatOperatorNaiveDateTime', () => {
+  test('formats offsetless legacy datetimes without timezone conversion', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01 08:30:15')).toBe(
+      '2026-05-01 08:30:15',
+    );
+  });
+
+  test('preserves wall clock time for legacy UTC-marked payloads', () => {
+    expect(formatOperatorNaiveDateTime('2026-05-01T08:30:15Z')).toBe(
+      '2026-05-01 08:30:15',
+    );
   });
 });

--- a/src/cook-web/src/app/admin/operations/users/dateTime.ts
+++ b/src/cook-web/src/app/admin/operations/users/dateTime.ts
@@ -1,4 +1,6 @@
 export {
+  formatAdminNaiveDateTime as formatOperatorNaiveDateTime,
   formatAdminUtcDateTime as formatOperatorUtcDateTime,
+  parseAdminNaiveDateTime as parseOperatorNaiveDateTime,
   parseAdminUtcDateTime as parseOperatorUtcDateTime,
 } from '@/app/admin/lib/dateTime';

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -71,7 +71,7 @@ import { cn } from '@/lib/utils';
 import { ErrorWithCode } from '@/lib/request';
 import { buildAdminOperationsCourseDetailUrl } from '../operation-course-routes';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
-import { formatOperatorUtcDateTime } from './dateTime';
+import { formatOperatorNaiveDateTime } from './dateTime';
 import { normalizeLoginMethodLabelKey } from './loginMethodUtils';
 import UserCreditGrantDialog from './UserCreditGrantDialog';
 import useOperatorGuard from '../useOperatorGuard';
@@ -480,7 +480,7 @@ export default function AdminOperationUsersPage() {
   const resolveCreditsExpireAtLabel = React.useCallback(
     (user: AdminOperationUserItem) => {
       if (user.credits_expire_at) {
-        return formatOperatorUtcDateTime(user.credits_expire_at);
+        return formatOperatorNaiveDateTime(user.credits_expire_at);
       }
       if (Number(user.available_credits || 0) > 0) {
         return tOperationsUsers('credits.longTerm');
@@ -1420,7 +1420,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLoginAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.last_login_at),
+                            formatOperatorNaiveDateTime(user.last_login_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1428,7 +1428,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLearningAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.last_learning_at),
+                            formatOperatorNaiveDateTime(user.last_learning_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1436,7 +1436,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.created_at),
+                            formatOperatorNaiveDateTime(user.created_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1444,7 +1444,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('updatedAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.updated_at),
+                            formatOperatorNaiveDateTime(user.updated_at),
                           )}
                         </TableCell>
                         <TableCell

--- a/src/cook-web/src/lib/admin-date-time.ts
+++ b/src/cook-web/src/lib/admin-date-time.ts
@@ -71,6 +71,41 @@ export type AdminNaiveDateTimeParts = {
   second: string;
 };
 
+const isValidAdminNaiveDateTime = (
+  parts: AdminNaiveDateTimeParts,
+): boolean => {
+  const year = Number(parts.year);
+  const month = Number(parts.month);
+  const day = Number(parts.day);
+  const hour = Number(parts.hour);
+  const minute = Number(parts.minute);
+  const second = Number(parts.second);
+
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    !Number.isInteger(second)
+  ) {
+    return false;
+  }
+
+  const candidate = new Date(
+    Date.UTC(year, month - 1, day, hour, minute, second),
+  );
+
+  return (
+    candidate.getUTCFullYear() === year &&
+    candidate.getUTCMonth() === month - 1 &&
+    candidate.getUTCDate() === day &&
+    candidate.getUTCHours() === hour &&
+    candidate.getUTCMinutes() === minute &&
+    candidate.getUTCSeconds() === second
+  );
+};
+
 export const parseAdminNaiveDateTime = (
   value: string | null | undefined,
 ): AdminNaiveDateTimeParts | null => {
@@ -84,7 +119,7 @@ export const parseAdminNaiveDateTime = (
     return null;
   }
 
-  return {
+  const parsedValue = {
     year: match[1],
     month: match[2],
     day: match[3],
@@ -92,6 +127,12 @@ export const parseAdminNaiveDateTime = (
     minute: match[5] || '00',
     second: match[6] || '00',
   };
+
+  if (!isValidAdminNaiveDateTime(parsedValue)) {
+    return null;
+  }
+
+  return parsedValue;
 };
 
 export const formatAdminNaiveDateTime = (

--- a/src/cook-web/src/lib/admin-date-time.ts
+++ b/src/cook-web/src/lib/admin-date-time.ts
@@ -71,9 +71,7 @@ export type AdminNaiveDateTimeParts = {
   second: string;
 };
 
-const isValidAdminNaiveDateTime = (
-  parts: AdminNaiveDateTimeParts,
-): boolean => {
+const isValidAdminNaiveDateTime = (parts: AdminNaiveDateTimeParts): boolean => {
   const year = Number(parts.year);
   const month = Number(parts.month);
   const day = Number(parts.day);

--- a/src/cook-web/src/lib/admin-date-time.ts
+++ b/src/cook-web/src/lib/admin-date-time.ts
@@ -4,6 +4,8 @@ import { getBrowserTimeZone } from '@/lib/browser-timezone';
 
 const ISO_DATETIME_WITH_TIMEZONE_RE =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const LOCAL_NAIVE_DATETIME_RE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?$/;
 
 export const parseAdminUtcDateTime = (
   value: string | null | undefined,
@@ -58,4 +60,47 @@ export const formatAdminUtcDateTime = (
   }
 
   return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+};
+
+export type AdminNaiveDateTimeParts = {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+};
+
+export const parseAdminNaiveDateTime = (
+  value: string | null | undefined,
+): AdminNaiveDateTimeParts | null => {
+  const normalizedValue = String(value || '').trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const match = normalizedValue.match(LOCAL_NAIVE_DATETIME_RE);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    year: match[1],
+    month: match[2],
+    day: match[3],
+    hour: match[4] || '00',
+    minute: match[5] || '00',
+    second: match[6] || '00',
+  };
+};
+
+export const formatAdminNaiveDateTime = (
+  value: string | null | undefined,
+): string => {
+  const parsedValue = parseAdminNaiveDateTime(value);
+  if (!parsedValue) {
+    return '';
+  }
+
+  return `${parsedValue.year}-${parsedValue.month}-${parsedValue.day} ${parsedValue.hour}:${parsedValue.minute}:${parsedValue.second}`;
 };


### PR DESCRIPTION
# Summary

Align operator admin time displays with the existing local naive datetime contract for the main operations surfaces.

- add a shared naive admin datetime formatter for local wall-clock values
- switch operator-facing course, user, follow-up, rating, and order pages to the naive formatter
- keep promotions and billing-ledger style zoned timestamps unchanged
- add focused formatter coverage for legacy naive and incorrectly UTC-marked payloads

Verification:
- `npm test -- --runTestsByPath src/app/admin/operations/users/dateTime.test.ts`
- targeted `eslint` on touched files
- `git diff --check`

Notes:
- `npm run type-check` still fails because of an existing unrelated error in `src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx:1408`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced naive (local) datetime formatting for admin dashboard timestamps.

* **Updates**
  * Changed timestamp display from UTC to local time across admin sections: operations, follow-ups, ratings, user accounts, and orders.
  * Improved consistency in datetime presentation throughout admin dashboard for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->