### PR TITLE
fix: refine login captcha refresh behavior

### DIFF
--- a/src/cook-web/src/components/auth/PhoneLogin.test.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.test.tsx
@@ -202,7 +202,9 @@ describe('PhoneLogin captcha flow', () => {
     try {
       render(<PhoneLogin onLoginSuccess={jest.fn()} />);
 
-      await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(apiService.getCaptcha).toHaveBeenCalledTimes(1),
+      );
 
       fireEvent.change(screen.getByLabelText('module.auth.phone'), {
         target: { value: '13800138000' },
@@ -211,7 +213,9 @@ describe('PhoneLogin captcha flow', () => {
         target: { value: '0000' },
       });
       fireEvent.click(screen.getByRole('checkbox'));
-      fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'module.auth.getOtp' }),
+      );
 
       await waitFor(() => expect(apiService.sendSmsCode).toHaveBeenCalled());
 

--- a/src/cook-web/src/components/auth/PhoneLogin.test.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { PhoneLogin } from './PhoneLogin';
 import apiService from '@/api';
@@ -135,7 +135,7 @@ describe('PhoneLogin captcha flow', () => {
     });
   });
 
-  test('keeps captcha input after verification failure', async () => {
+  test('refreshes captcha and clears input after verification failure', async () => {
     (apiService.verifyCaptcha as jest.Mock).mockRejectedValue(
       new Error('Image captcha is incorrect'),
     );
@@ -160,8 +160,10 @@ describe('PhoneLogin captcha flow', () => {
         variant: 'destructive',
       }),
     );
-    expect(screen.getByTestId('captcha-input')).toHaveValue('0000');
-    expect(apiService.getCaptcha).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByTestId('captcha-input')).toHaveValue(''),
+    );
+    expect(apiService.getCaptcha).toHaveBeenCalledTimes(2);
   });
 
   test('keeps captcha input after sending SMS successfully', async () => {
@@ -187,6 +189,34 @@ describe('PhoneLogin captcha flow', () => {
     );
     expect(screen.getByTestId('captcha-input')).toHaveValue('0000');
     expect(apiService.getCaptcha).toHaveBeenCalledTimes(1);
+  });
+
+  test('refreshes captcha and clears input after SMS countdown expires', async () => {
+    jest.useFakeTimers();
+
+    render(<PhoneLogin onLoginSuccess={jest.fn()} />);
+
+    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText('module.auth.phone'), {
+      target: { value: '13800138000' },
+    });
+    fireEvent.change(screen.getByTestId('captcha-input'), {
+      target: { value: '0000' },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
+
+    await waitFor(() => expect(apiService.sendSmsCode).toHaveBeenCalled());
+
+    await act(async () => {
+      jest.advanceTimersByTime(60000);
+    });
+
+    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('captcha-input')).toHaveValue('');
+
+    jest.useRealTimers();
   });
 
   test('logs in through SMS login after code is entered', async () => {

--- a/src/cook-web/src/components/auth/PhoneLogin.test.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.test.tsx
@@ -199,30 +199,33 @@ describe('PhoneLogin captcha flow', () => {
 
   test('refreshes captcha and clears input after SMS countdown expires', async () => {
     jest.useFakeTimers();
+    try {
+      render(<PhoneLogin onLoginSuccess={jest.fn()} />);
 
-    render(<PhoneLogin onLoginSuccess={jest.fn()} />);
+      await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
 
-    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(1));
+      fireEvent.change(screen.getByLabelText('module.auth.phone'), {
+        target: { value: '13800138000' },
+      });
+      fireEvent.change(screen.getByTestId('captcha-input'), {
+        target: { value: '0000' },
+      });
+      fireEvent.click(screen.getByRole('checkbox'));
+      fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
 
-    fireEvent.change(screen.getByLabelText('module.auth.phone'), {
-      target: { value: '13800138000' },
-    });
-    fireEvent.change(screen.getByTestId('captcha-input'), {
-      target: { value: '0000' },
-    });
-    fireEvent.click(screen.getByRole('checkbox'));
-    fireEvent.click(screen.getByRole('button', { name: 'module.auth.getOtp' }));
+      await waitFor(() => expect(apiService.sendSmsCode).toHaveBeenCalled());
 
-    await waitFor(() => expect(apiService.sendSmsCode).toHaveBeenCalled());
+      await act(async () => {
+        jest.advanceTimersByTime(60000);
+      });
 
-    await act(async () => {
-      jest.advanceTimersByTime(60000);
-    });
-
-    await waitFor(() => expect(apiService.getCaptcha).toHaveBeenCalledTimes(2));
-    expect(screen.getByTestId('captcha-input')).toHaveValue('');
-
-    jest.useRealTimers();
+      await waitFor(() =>
+        expect(apiService.getCaptcha).toHaveBeenCalledTimes(2),
+      );
+      expect(screen.getByTestId('captcha-input')).toHaveValue('');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('logs in through SMS login after code is entered', async () => {

--- a/src/cook-web/src/components/auth/PhoneLogin.test.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import { PhoneLogin } from './PhoneLogin';
 import apiService from '@/api';

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -130,30 +130,22 @@ export function PhoneLogin({
     setPhoneOtp(normalizeOtp(e.target.value));
   };
 
-  const refreshCaptchaSilently = useCallback(async () => {
-    try {
-      await refreshCaptcha();
-    } catch {
-      // The API request layer displays failures; keep the current UI stable.
-    }
-  }, [refreshCaptcha]);
-
-  const resetCaptchaAfterFailure = useCallback(async () => {
+  const resetCaptchaChallenge = useCallback((options?: { clearError?: boolean }) => {
     setCaptchaCode('');
-    try {
-      await refreshCaptcha({ clearCode: false });
-    } catch {
-      // The API request layer displays failures; keep the current UI stable.
+    if (options?.clearError) {
+      setCaptchaError('');
     }
+    void refreshCaptcha({ clearCode: false }).catch(() => {
+      // The API request layer displays failures; keep the current UI stable.
+    });
   }, [refreshCaptcha, setCaptchaCode]);
 
   useEffect(() => {
     if (previousCountdownRef.current > 0 && countdown === 0) {
-      setCaptchaError(prev => (prev ? '' : prev));
-      void refreshCaptchaSilently();
+      resetCaptchaChallenge({ clearError: true });
     }
     previousCountdownRef.current = countdown;
-  }, [countdown, refreshCaptchaSilently]);
+  }, [countdown, resetCaptchaChallenge]);
 
   const getCaptchaTicket = async () => {
     if (!captchaCode.trim()) {
@@ -171,7 +163,7 @@ export function PhoneLogin({
     } catch (error: any) {
       const message = error?.message || t('module.auth.captchaVerifyFailed');
       setCaptchaError(message);
-      await resetCaptchaAfterFailure();
+      resetCaptchaChallenge();
       toast({
         title: t('module.auth.captchaVerifyFailed'),
         description: message,

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -138,6 +138,15 @@ export function PhoneLogin({
     }
   }, [refreshCaptcha]);
 
+  const resetCaptchaAfterFailure = useCallback(async () => {
+    setCaptchaCode('');
+    try {
+      await refreshCaptcha({ clearCode: false });
+    } catch {
+      // The API request layer displays failures; keep the current UI stable.
+    }
+  }, [refreshCaptcha, setCaptchaCode]);
+
   useEffect(() => {
     if (previousCountdownRef.current > 0 && countdown === 0) {
       setCaptchaError(prev => (prev ? '' : prev));
@@ -162,6 +171,7 @@ export function PhoneLogin({
     } catch (error: any) {
       const message = error?.message || t('module.auth.captchaVerifyFailed');
       setCaptchaError(message);
+      await resetCaptchaAfterFailure();
       toast({
         title: t('module.auth.captchaVerifyFailed'),
         description: message,

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -130,15 +130,18 @@ export function PhoneLogin({
     setPhoneOtp(normalizeOtp(e.target.value));
   };
 
-  const resetCaptchaChallenge = useCallback((options?: { clearError?: boolean }) => {
-    setCaptchaCode('');
-    if (options?.clearError) {
-      setCaptchaError('');
-    }
-    void refreshCaptcha({ clearCode: false }).catch(() => {
-      // The API request layer displays failures; keep the current UI stable.
-    });
-  }, [refreshCaptcha, setCaptchaCode]);
+  const resetCaptchaChallenge = useCallback(
+    (options?: { clearError?: boolean }) => {
+      setCaptchaCode('');
+      if (options?.clearError) {
+        setCaptchaError('');
+      }
+      void refreshCaptcha({ clearCode: false }).catch(() => {
+        // The API request layer displays failures; keep the current UI stable.
+      });
+    },
+    [refreshCaptcha, setCaptchaCode],
+  );
 
   useEffect(() => {
     if (previousCountdownRef.current > 0 && countdown === 0) {


### PR DESCRIPTION
Summary
- keep the image captcha and input unchanged after a successful SMS request
- refresh the image captcha and clear the input after captcha verification fails
- refresh the image captcha and clear the input after the SMS resend countdown ends

Testing
- cd src/cook-web && npm test -- --runInBand src/components/auth/PhoneLogin.test.tsx
- cd src/cook-web && npm run lint
- cd src/cook-web && npm run type-check (fails on existing unrelated error in src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx:1408)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAPTCHA now automatically resets and refreshes when verification fails.
  * CAPTCHA clears and refreshes after the SMS countdown expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->