### PR TITLE
fix: update login captcha refresh flow

### DIFF
--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -310,7 +310,6 @@ export function PhoneLogin({
             }
           }}
           onRefresh={() => {
-            setCaptchaError('');
             resetCaptchaChallenge({ clearError: true });
           }}
         />

--- a/src/cook-web/src/components/auth/PhoneLogin.tsx
+++ b/src/cook-web/src/components/auth/PhoneLogin.tsx
@@ -311,7 +311,7 @@ export function PhoneLogin({
           }}
           onRefresh={() => {
             setCaptchaError('');
-            void refreshCaptchaSilently();
+            resetCaptchaChallenge({ clearError: true });
           }}
         />
 


### PR DESCRIPTION
Summary
- keep the login captcha refresh behavior aligned with the latest reset handler
- fix the remaining refresh callback reference so the current branch builds again
- preserve the verified captcha flow while refreshing and clearing on failure or resend reset

Testing
- cd src/cook-web && npm test -- --runInBand src/components/auth/PhoneLogin.test.tsx
- cd src/cook-web && npm run lint -- --file src/components/auth/PhoneLogin.tsx --file src/components/auth/PhoneLogin.test.tsx
- cd src/cook-web && npm run type-check (fails on existing unrelated error in src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx:1408)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved CAPTCHA reset handling during phone login flow—CAPTCHA input now clears after verification failures and refreshes when SMS countdown expires.

## Tests
* Enhanced test coverage for CAPTCHA behavior during countdown expiration and verification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->