### PR TITLE
feat: align billing footnote anchors across plan columns

### DIFF
--- a/src/cook-web/src/components/billing/BillingOverviewFootnote.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewFootnote.tsx
@@ -15,7 +15,7 @@ export function BillingOverviewFootnote() {
     >
       <ul className='space-y-3'>
         <li className='flex gap-2'>
-          <span className='shrink-0 font-medium text-blue-600'>
+          <span className='shrink-0 font-medium'>
             {FOOTNOTE_ENUM_LEARNER}
           </span>
           <div className='flex-1'>
@@ -34,7 +34,7 @@ export function BillingOverviewFootnote() {
           </div>
         </li>
         <li className='flex gap-2'>
-          <span className='shrink-0 font-medium text-blue-600'>
+          <span className='shrink-0 font-medium'>
             {FOOTNOTE_ENUM_VALIDITY}
           </span>
           <div className='flex-1'>

--- a/src/cook-web/src/components/billing/BillingOverviewFootnote.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewFootnote.tsx
@@ -15,9 +15,7 @@ export function BillingOverviewFootnote() {
     >
       <ul className='space-y-3'>
         <li className='flex gap-2'>
-          <span className='shrink-0 font-medium'>
-            {FOOTNOTE_ENUM_LEARNER}
-          </span>
+          <span className='shrink-0 font-medium'>{FOOTNOTE_ENUM_LEARNER}</span>
           <div className='flex-1'>
             {t('module.billing.package.footnote.learnerEstimateIntro')}
             <ol className='mt-1 list-decimal space-y-1 pl-5'>
@@ -34,9 +32,7 @@ export function BillingOverviewFootnote() {
           </div>
         </li>
         <li className='flex gap-2'>
-          <span className='shrink-0 font-medium'>
-            {FOOTNOTE_ENUM_VALIDITY}
-          </span>
+          <span className='shrink-0 font-medium'>{FOOTNOTE_ENUM_VALIDITY}</span>
           <div className='flex-1'>
             {t('module.billing.package.footnote.validity')}
           </div>

--- a/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
+++ b/src/cook-web/src/components/billing/BillingPlanComparisonTable.tsx
@@ -27,10 +27,9 @@ import {
 } from './BillingOverviewCards';
 import styles from './BillingPlanComparisonTable.module.scss';
 
-// Language-neutral typographic enumerators that anchor the leftmost label of
-// each metric row to the matching footnote item. Not user-facing copy, so
-// they stay out of i18n. Only rendered on the first column to avoid
-// repeating the same marker across every plan card.
+// Language-neutral typographic enumerators that anchor each metric row label
+// to the matching footnote item. Not user-facing copy, so they stay out of
+// i18n.
 const ROW_ENUM_LEARNER = '①';
 const ROW_ENUM_VALIDITY = '②';
 
@@ -410,18 +409,14 @@ export function BillingPlanComparisonTable({
             ))}
           </tr>
           <tr className={styles.dataRow}>
-            {columns.map((col, colIdx) => (
+            {columns.map(col => (
               <td
                 key={col.key}
                 className={cn(col.featured && styles.featuredColumn)}
               >
                 <div className={styles.cellLabel}>
                   {t('module.billing.package.table.studentsRowLabel')}
-                  {colIdx === 0 ? (
-                    <span className='ml-1 font-medium text-blue-600'>
-                      {ROW_ENUM_LEARNER}
-                    </span>
-                  ) : null}
+                  <span className='ml-1 font-medium'>{ROW_ENUM_LEARNER}</span>
                 </div>
                 <div className={styles.cellValue}>
                   {col.studentLabel || emptyValue}
@@ -430,18 +425,14 @@ export function BillingPlanComparisonTable({
             ))}
           </tr>
           <tr className={styles.dataRow}>
-            {columns.map((col, colIdx) => (
+            {columns.map(col => (
               <td
                 key={col.key}
                 className={cn(col.featured && styles.featuredColumn)}
               >
                 <div className={styles.cellLabel}>
                   {t('module.billing.package.table.validityRowLabel')}
-                  {colIdx === 0 ? (
-                    <span className='ml-1 font-medium text-blue-600'>
-                      {ROW_ENUM_VALIDITY}
-                    </span>
-                  ) : null}
+                  <span className='ml-1 font-medium'>{ROW_ENUM_VALIDITY}</span>
                 </div>
                 <div className={styles.cellValue}>
                   <span>{col.validityShort || emptyValue}</span>


### PR DESCRIPTION
## Summary
- Drop the blue tint on the ①② markers in both `BillingPlanComparisonTable` and `BillingOverviewFootnote`, so the table anchors and footnote anchors share the same muted treatment.
- Render the row anchors on every plan column instead of only the leftmost one, restoring per-column legibility.

## Test plan
- [ ] Visually confirm the ①② markers appear on every plan column header row in the credit-package comparison table and are no longer blue.
- [ ] Visually confirm the footnote ①② markers below the table are also no longer blue and remain visually balanced.
- [ ] `cd src/cook-web && npm run lint`
- [ ] `cd src/cook-web && npm run type-check` (note: an unrelated pre-existing error in `ListenModeSlideRenderer.tsx` is not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)