### PR TITLE
fix: validate TTS audio before upload

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -53,8 +53,7 @@ from flaskr.api.tts import (
 )
 from flaskr.service.tts import preprocess_for_tts
 from flaskr.service.tts.audio_utils import (
-    concat_audio_best_effort,
-    get_audio_duration_ms,
+    assemble_audio_for_upload,
 )
 from flaskr.service.tts.audio_record_utils import (
     build_completed_audio_record,
@@ -63,6 +62,7 @@ from flaskr.service.tts.audio_record_utils import (
 from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
+    select_subtitle_cues_for_segments,
 )
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.service.tts.validation import validate_tts_settings_strict
@@ -754,6 +754,7 @@ def _finalize_tts_stream_audio(
     *,
     audio_parts: list[bytes],
     subtitle_cues: list[dict] | None,
+    segment_durations_ms: list[int] | None = None,
     audio_bid: str,
     audio_settings,
     voice_settings,
@@ -767,11 +768,31 @@ def _finalize_tts_stream_audio(
     shifu_bid: str = "",
     position: int | None = None,
 ) -> tuple[str, int]:
-    final_audio = concat_audio_best_effort(audio_parts)
+    assembly_result = assemble_audio_for_upload(
+        audio_parts,
+        segment_durations_ms=segment_durations_ms,
+        output_format="mp3",
+    )
+    final_audio = assembly_result.audio_data
     if not final_audio:
         raise ValueError("No audio data produced")
 
-    duration_ms = int(get_audio_duration_ms(final_audio, format="mp3") or 0)
+    duration_ms = int(assembly_result.duration_ms or 0)
+    uploaded_subtitle_cues = select_subtitle_cues_for_segments(
+        subtitle_cues,
+        assembly_result.included_segment_indices,
+        duration_ms=duration_ms,
+    )
+    if subtitle_cues is not None:
+        subtitle_cues[:] = uploaded_subtitle_cues
+    if assembly_result.used_fallback:
+        logger.warning(
+            "TTS final audio fell back to first decodable segment. "
+            "audio_bid=%s included_segments=%s source_segments=%s",
+            audio_bid,
+            assembly_result.included_segment_indices,
+            assembly_result.source_segment_count,
+        )
     oss_url, bucket_name = upload_audio_to_oss(app, final_audio, audio_bid)
 
     if persist_audio:
@@ -793,8 +814,8 @@ def _finalize_tts_stream_audio(
             voice_settings=voice_settings,
             tts_model=tts_model or "",
             text_length=len(cleaned_text or ""),
-            segment_count=segment_count,
-            subtitle_cues=subtitle_cues,
+            segment_count=assembly_result.segment_count or segment_count,
+            subtitle_cues=uploaded_subtitle_cues,
         )
         save_audio_record(audio_record, commit=True)
 
@@ -1004,6 +1025,10 @@ def _yield_stream_tts_audio_segments(
         stats["total_word_count"] = int(stats.get("total_word_count", 0)) + int(
             word_count or 0
         )
+        stats["total_duration_ms"] = int(stats.get("total_duration_ms", 0)) + int(
+            duration_ms or 0
+        )
+        stats.setdefault("segment_durations_ms", []).append(int(duration_ms or 0))
         _record_stream_segment_usage(
             app,
             usage_context,
@@ -1208,11 +1233,13 @@ def stream_generated_block_audio(
                     )
                     segment_count = int(stats.get("segment_count", 0))
                     total_word_count = int(stats.get("total_word_count", 0))
+                    total_duration_ms = int(stats.get("total_duration_ms", 0))
 
                     oss_url, duration_ms = _finalize_tts_stream_audio(
                         app,
                         audio_parts=audio_parts,
                         subtitle_cues=subtitle_cues,
+                        segment_durations_ms=stats.get("segment_durations_ms"),
                         audio_bid=audio_bid,
                         audio_settings=audio_settings,
                         voice_settings=voice_settings,
@@ -1236,7 +1263,7 @@ def stream_generated_block_audio(
                         raw_text=speakable_text or "",
                         cleaned_text=cleaned_segment or "",
                         total_word_count=total_word_count,
-                        duration_ms=int(duration_ms or 0),
+                        duration_ms=int(total_duration_ms or duration_ms or 0),
                         segment_count=segment_count,
                         usage_metadata=usage_metadata,
                     )
@@ -1307,11 +1334,13 @@ def stream_generated_block_audio(
             )
             segment_count = int(stats.get("segment_count", 0))
             total_word_count = int(stats.get("total_word_count", 0))
+            total_duration_ms = int(stats.get("total_duration_ms", 0))
 
             oss_url, duration_ms = _finalize_tts_stream_audio(
                 app,
                 audio_parts=audio_parts,
                 subtitle_cues=subtitle_cues,
+                segment_durations_ms=stats.get("segment_durations_ms"),
                 audio_bid=audio_bid,
                 audio_settings=audio_settings,
                 voice_settings=voice_settings,
@@ -1334,7 +1363,7 @@ def stream_generated_block_audio(
                 raw_text=raw_text,
                 cleaned_text=cleaned_text,
                 total_word_count=total_word_count,
-                duration_ms=int(duration_ms or 0),
+                duration_ms=int(total_duration_ms or duration_ms or 0),
                 segment_count=segment_count,
                 usage_metadata=usage_metadata,
             )
@@ -1417,11 +1446,13 @@ def stream_preview_tts_audio(
             )
             segment_count = int(stats.get("segment_count", 0))
             total_word_count = int(stats.get("total_word_count", 0))
+            total_duration_ms = int(stats.get("total_duration_ms", 0))
 
             oss_url, duration_ms = _finalize_tts_stream_audio(
                 app,
                 audio_parts=audio_parts,
                 subtitle_cues=subtitle_cues,
+                segment_durations_ms=stats.get("segment_durations_ms"),
                 audio_bid=audio_bid,
                 audio_settings=audio_settings,
                 voice_settings=voice_settings,
@@ -1440,7 +1471,7 @@ def stream_preview_tts_audio(
                 raw_text=text or "",
                 cleaned_text=cleaned_text,
                 total_word_count=total_word_count,
-                duration_ms=int(duration_ms or 0),
+                duration_ms=int(total_duration_ms or duration_ms or 0),
                 segment_count=segment_count,
                 usage_metadata=usage_metadata,
             )

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -6,6 +6,7 @@ This module provides audio concatenation and processing functions using pydub/ff
 
 import io
 import logging
+from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
 from flaskr.common.log import AppLoggerProxy
@@ -15,6 +16,28 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 # Crossfading sentence boundaries can clip or duplicate phonemes, which is
 # especially noticeable in Chinese playback.
 DEFAULT_CROSSFADE_MS = 0
+_MP3_128K_BYTES_PER_MS = 16
+
+
+@dataclass(frozen=True)
+class AudioAssemblyResult:
+    """Final audio selected for upload after validating it can be decoded."""
+
+    audio_data: bytes
+    duration_ms: int
+    source_segment_count: int
+    included_segment_indices: tuple[int, ...]
+    used_fallback: bool = False
+    fallback_reason: str = ""
+
+    @property
+    def segment_count(self) -> int:
+        return len(self.included_segment_indices)
+
+    @property
+    def is_complete(self) -> bool:
+        return self.segment_count == self.source_segment_count
+
 
 # Try to import pydub, which wraps ffmpeg
 try:
@@ -29,6 +52,38 @@ except ImportError:
 def is_audio_processing_available() -> bool:
     """Check if audio processing is available."""
     return PYDUB_AVAILABLE
+
+
+def _estimate_audio_duration_ms(audio_data: bytes) -> int:
+    return int(len(audio_data or b"") / _MP3_128K_BYTES_PER_MS)
+
+
+def _probe_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> int | None:
+    if not audio_data:
+        return None
+    if not PYDUB_AVAILABLE:
+        return None
+
+    try:
+        audio_io = io.BytesIO(audio_data)
+        audio = AudioSegment.from_file(audio_io, format=format)
+        return len(audio)
+    except Exception:
+        return None
+
+
+def _resolve_result_duration_ms(
+    *,
+    audio_data: bytes,
+    probed_duration_ms: int | None = None,
+    preferred_duration_ms: int | None = None,
+    format: str = "mp3",
+) -> int:
+    if preferred_duration_ms is not None and preferred_duration_ms > 0:
+        return int(preferred_duration_ms)
+    if probed_duration_ms is not None:
+        return int(probed_duration_ms)
+    return get_audio_duration_ms(audio_data, format=format)
 
 
 def concat_audio_mp3(
@@ -124,24 +179,112 @@ def concat_audio_best_effort(
     segments: Sequence[bytes], output_format: str = "mp3"
 ) -> bytes:
     """
-    Concatenate audio segments with graceful fallback when processing is unavailable.
+    Concatenate audio segments into upload-safe bytes.
 
-    Falls back to raw byte-join if pydub/ffmpeg are not available or fail.
+    Falls back to the first decodable segment instead of raw byte-joining MP3
+    files, which can produce invalid uploaded audio.
     """
-    if not segments:
-        return b""
-    if len(segments) == 1:
-        return segments[0]
+    return assemble_audio_for_upload(segments, output_format=output_format).audio_data
 
-    if is_audio_processing_available():
-        try:
-            return concat_audio_mp3(list(segments), output_format=output_format)
-        except Exception as exc:
-            logger.warning(
-                "Audio concatenation failed; falling back to byte-join: %s", exc
-            )
 
-    return b"".join(segments)
+def assemble_audio_for_upload(
+    segments: Sequence[bytes],
+    *,
+    segment_durations_ms: Optional[Sequence[int]] = None,
+    segment_indices: Optional[Sequence[int]] = None,
+    input_format: str = "mp3",
+    output_format: str = "mp3",
+) -> AudioAssemblyResult:
+    """
+    Build uploadable audio and validate the selected bytes are decodable.
+
+    Multi-segment MP3s must be decoded and re-exported before upload. If that
+    fails, return the first decodable segment rather than uploading a raw
+    byte-join. If no segment can be decoded, raise ``ValueError``.
+    """
+    source_segment_count = len(segments or [])
+    segment_index_values = list(segment_indices or range(source_segment_count))
+
+    def _segment_index_for_position(position: int) -> int:
+        if position < len(segment_index_values):
+            return int(segment_index_values[position] or 0)
+        return position
+
+    indexed_segments = [
+        (_segment_index_for_position(index), segment_data)
+        for index, segment_data in enumerate(segments or [])
+        if segment_data
+    ]
+    if not indexed_segments:
+        raise ValueError("No audio data produced")
+    if not PYDUB_AVAILABLE:
+        raise ValueError("Audio processing is required to validate TTS output")
+
+    duration_by_index: dict[int, int] = {}
+    if segment_durations_ms is not None:
+        duration_by_index = {
+            _segment_index_for_position(index): max(int(duration_ms or 0), 0)
+            for index, duration_ms in enumerate(segment_durations_ms)
+        }
+
+    if len(indexed_segments) == 1:
+        index, segment_data = indexed_segments[0]
+        probed_duration_ms = _probe_audio_duration_ms(segment_data, format=input_format)
+        if probed_duration_ms is None:
+            raise ValueError("No decodable audio segments to upload")
+        return AudioAssemblyResult(
+            audio_data=segment_data,
+            duration_ms=_resolve_result_duration_ms(
+                audio_data=segment_data,
+                probed_duration_ms=probed_duration_ms,
+                preferred_duration_ms=duration_by_index.get(index),
+                format=input_format,
+            ),
+            source_segment_count=source_segment_count,
+            included_segment_indices=(index,),
+        )
+
+    segment_payloads = [segment_data for _index, segment_data in indexed_segments]
+    try:
+        final_audio = concat_audio_mp3(segment_payloads, output_format=output_format)
+        probed_duration_ms = _probe_audio_duration_ms(final_audio, format=output_format)
+        if probed_duration_ms is None:
+            raise ValueError("Concatenated audio failed validation")
+        return AudioAssemblyResult(
+            audio_data=final_audio,
+            duration_ms=int(probed_duration_ms),
+            source_segment_count=source_segment_count,
+            included_segment_indices=tuple(index for index, _data in indexed_segments),
+        )
+    except Exception as exc:
+        fallback_reason = str(exc)
+        logger.warning(
+            "Audio assembly failed; trying first decodable segment fallback. "
+            "segments=%s error_type=%s",
+            len(indexed_segments),
+            type(exc).__name__,
+        )
+        logger.debug("Audio assembly failure details: %s", exc, exc_info=True)
+
+    for index, segment_data in indexed_segments:
+        probed_duration_ms = _probe_audio_duration_ms(segment_data, format=input_format)
+        if probed_duration_ms is None:
+            continue
+        return AudioAssemblyResult(
+            audio_data=segment_data,
+            duration_ms=_resolve_result_duration_ms(
+                audio_data=segment_data,
+                probed_duration_ms=probed_duration_ms,
+                preferred_duration_ms=duration_by_index.get(index),
+                format=input_format,
+            ),
+            source_segment_count=source_segment_count,
+            included_segment_indices=(index,),
+            used_fallback=True,
+            fallback_reason=fallback_reason,
+        )
+
+    raise ValueError("No decodable audio segments to upload")
 
 
 def export_audio_range_best_effort(
@@ -203,13 +346,20 @@ def get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> int:
     if not PYDUB_AVAILABLE:
         # Rough estimate based on bitrate (128kbps for MP3)
         # 128kbps = 16KB/s, so duration = size_bytes / 16000 * 1000
-        return int(len(audio_data) / 16000 * 1000)
+        return _estimate_audio_duration_ms(audio_data)
 
     try:
         audio_io = io.BytesIO(audio_data)
         audio = AudioSegment.from_file(audio_io, format=format)
         return len(audio)  # pydub returns duration in ms
     except Exception as e:
-        logger.error(f"Error getting audio duration: {e}")
+        logger.warning(
+            "Audio duration probe failed; using bitrate estimate. "
+            "bytes=%s format=%s error_type=%s",
+            len(audio_data or b""),
+            format,
+            type(e).__name__,
+        )
+        logger.debug("Audio duration probe failure details: %s", e, exc_info=True)
         # Fallback to estimate
-        return int(len(audio_data) / 16000 * 1000)
+        return _estimate_audio_duration_ms(audio_data)

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -38,8 +38,7 @@ from flaskr.api.tts import (
 )
 from flaskr.service.tts import preprocess_for_tts
 from flaskr.service.tts.audio_utils import (
-    concat_audio_best_effort,
-    get_audio_duration_ms,
+    assemble_audio_for_upload,
 )
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.common.log import AppLoggerProxy
@@ -773,6 +772,7 @@ def synthesize_long_text_to_oss(
 
     if max_workers == 1:
         audio_parts: list[bytes] = []
+        audio_durations_ms: list[int] = []
         with app.app_context():
             for index, segment_text in enumerate(segments):
                 segment_start = time.monotonic()
@@ -784,6 +784,8 @@ def synthesize_long_text_to_oss(
                     provider_name=provider,
                 )
                 audio_parts.append(result.audio_data)
+                result_duration_ms = int(result.duration_ms or 0)
+                audio_durations_ms.append(result_duration_ms)
                 if usage_context is not None:
                     segment_length = len(segment_text or "")
                     total_word_count += int(result.word_count or 0)
@@ -798,7 +800,7 @@ def synthesize_long_text_to_oss(
                         output=segment_length,
                         total=segment_length,
                         word_count=int(result.word_count or 0),
-                        duration_ms=int(result.duration_ms or 0),
+                        duration_ms=result_duration_ms,
                         latency_ms=latency_ms,
                         record_level=1,
                         parent_usage_bid=usage_parent_bid,
@@ -815,6 +817,7 @@ def synthesize_long_text_to_oss(
                 provider,
             )
         audio_parts = [b""] * len(segments)
+        audio_durations_ms = [0] * len(segments)
         segment_map = {idx: segment for idx, segment in enumerate(segments)}
 
         def _synthesize_in_app_context(segment_text: str):
@@ -842,6 +845,8 @@ def synthesize_long_text_to_oss(
                 index = future_map[future]
                 result = future.result()
                 audio_parts[index] = result.audio_data
+                result_duration_ms = int(result.duration_ms or 0)
+                audio_durations_ms[index] = result_duration_ms
                 if usage_context is not None:
                     segment_text = segment_map.get(index, "")
                     segment_length = len(segment_text or "")
@@ -856,7 +861,7 @@ def synthesize_long_text_to_oss(
                         output=segment_length,
                         total=segment_length,
                         word_count=int(result.word_count or 0),
-                        duration_ms=int(result.duration_ms or 0),
+                        duration_ms=result_duration_ms,
                         latency_ms=0,
                         record_level=1,
                         parent_usage_bid=usage_parent_bid,
@@ -865,11 +870,18 @@ def synthesize_long_text_to_oss(
                         extra=usage_metadata,
                     )
 
-    final_audio = concat_audio_best_effort(audio_parts)
+    assembly_result = assemble_audio_for_upload(
+        audio_parts,
+        segment_durations_ms=audio_durations_ms,
+        output_format="mp3",
+    )
+    final_audio = assembly_result.audio_data
     if not final_audio:
         raise ValueError("No audio data produced")
 
-    duration_ms = get_audio_duration_ms(final_audio, format="mp3")
+    duration_ms = assembly_result.duration_ms
+    generated_duration_ms = sum(int(item or 0) for item in audio_durations_ms)
+    metered_duration_ms = generated_duration_ms or duration_ms
 
     audio_bid = (audio_bid or "").strip() or uuid.uuid4().hex
     with app.app_context():
@@ -889,7 +901,7 @@ def synthesize_long_text_to_oss(
             output=cleaned_length,
             total=cleaned_length,
             word_count=total_word_count,
-            duration_ms=int(duration_ms or 0),
+            duration_ms=int(metered_duration_ms or 0),
             latency_ms=0,
             record_level=0,
             parent_usage_bid="",

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -30,7 +30,7 @@ from flaskr.api.tts import (
 from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
 from flaskr.service.tts import preprocess_for_tts
 from flaskr.service.tts.audio_utils import (
-    concat_audio_best_effort,
+    assemble_audio_for_upload,
     export_audio_range_best_effort,
     get_audio_duration_ms,
 )
@@ -42,6 +42,7 @@ from flaskr.service.tts.audio_record_utils import (
 from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
+    select_subtitle_cues_for_segments,
 )
 from flaskr.service.metering import UsageContext
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD
@@ -867,6 +868,8 @@ class StreamingTTSProcessor:
 
         all_segments.sort(key=lambda x: x[0])
         audio_data_list = [s[1] for s in all_segments]
+        audio_durations_ms = [int(s[2] or 0) for s in all_segments]
+        segment_indices = [int(s[0] or 0) for s in all_segments]
         effective_subtitle_cues = (
             normalize_subtitle_cues(subtitle_cues)
             if subtitle_cues
@@ -879,8 +882,32 @@ class StreamingTTSProcessor:
         )
 
         try:
-            final_audio = concat_audio_best_effort(audio_data_list)
-            final_duration_ms = get_audio_duration_ms(final_audio)
+            assembly_result = assemble_audio_for_upload(
+                audio_data_list,
+                segment_durations_ms=audio_durations_ms,
+                segment_indices=segment_indices,
+                output_format="mp3",
+            )
+            final_audio = assembly_result.audio_data
+            final_duration_ms = int(assembly_result.duration_ms or 0)
+            uploaded_subtitle_cues = select_subtitle_cues_for_segments(
+                effective_subtitle_cues,
+                assembly_result.included_segment_indices,
+                duration_ms=final_duration_ms,
+            )
+            uploaded_event_subtitle_cues = select_subtitle_cues_for_segments(
+                effective_event_subtitle_cues,
+                assembly_result.included_segment_indices,
+                duration_ms=final_duration_ms,
+            )
+            if assembly_result.used_fallback:
+                logger.warning(
+                    "TTS final audio fell back to first decodable segment. "
+                    "audio_bid=%s included_segments=%s source_segments=%s",
+                    self._audio_bid,
+                    assembly_result.included_segment_indices,
+                    assembly_result.source_segment_count,
+                )
             file_size = len(final_audio)
 
             from flaskr.service.tts.tts_handler import upload_audio_to_oss
@@ -906,8 +933,8 @@ class StreamingTTSProcessor:
                 voice_settings=self.voice_settings,
                 tts_model=self.tts_model or "",
                 text_length=cleaned_text_length,
-                segment_count=len(audio_data_list),
-                subtitle_cues=effective_subtitle_cues,
+                segment_count=assembly_result.segment_count or len(audio_data_list),
+                subtitle_cues=uploaded_subtitle_cues,
             )
             save_audio_record(audio_record, commit=commit)
 
@@ -924,7 +951,7 @@ class StreamingTTSProcessor:
                 raw_text=raw_text or "",
                 cleaned_text=cleaned_text or "",
                 total_word_count=self._word_count_total,
-                duration_ms=final_duration_ms or 0,
+                duration_ms=sum(audio_durations_ms) or final_duration_ms or 0,
                 segment_count=len(audio_data_list),
                 voice_settings=self.voice_settings,
                 audio_settings=self.audio_settings,
@@ -943,9 +970,7 @@ class StreamingTTSProcessor:
                     stream_element_number=self.stream_element_number,
                     stream_element_type=self.stream_element_type,
                     av_contract=self.av_contract,
-                    subtitle_cues=normalize_subtitle_cues(
-                        effective_event_subtitle_cues
-                    ),
+                    subtitle_cues=normalize_subtitle_cues(uploaded_event_subtitle_cues),
                 ),
             )
 

--- a/src/api/flaskr/service/tts/subtitle_utils.py
+++ b/src/api/flaskr/service/tts/subtitle_utils.py
@@ -76,3 +76,42 @@ def append_subtitle_cue(
         }
     )
     return subtitle_cues
+
+
+def select_subtitle_cues_for_segments(
+    subtitle_cues: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None,
+    segment_indices: tuple[int, ...] | list[int],
+    *,
+    duration_ms: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return cues for uploaded audio segments, rebased to the selected audio."""
+
+    selected_indices = {int(index or 0) for index in segment_indices}
+    selected_cues = [
+        cue
+        for cue in normalize_subtitle_cues(subtitle_cues)
+        if int(cue.get("segment_index", 0) or 0) in selected_indices
+    ]
+    if not selected_cues:
+        return []
+
+    base_start_ms = min(int(cue.get("start_ms", 0) or 0) for cue in selected_cues)
+    max_duration_ms = int(duration_ms) if duration_ms is not None else None
+    rebased_cues: list[dict[str, Any]] = []
+    for cue in selected_cues:
+        start_ms = max(int(cue.get("start_ms", 0) or 0) - base_start_ms, 0)
+        end_ms = max(
+            int(cue.get("end_ms", start_ms) or start_ms) - base_start_ms, start_ms
+        )
+        if max_duration_ms is not None:
+            if start_ms >= max_duration_ms:
+                continue
+            end_ms = min(end_ms, max_duration_ms)
+        rebased_cues.append(
+            {
+                **cue,
+                "start_ms": start_ms,
+                "end_ms": end_ms,
+            }
+        )
+    return normalize_subtitle_cues(rebased_cues)

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -191,12 +191,19 @@ class TestGeneratedBlockListenTtsElementFirst:
             _fake_yield_tts_segments,
         )
         monkeypatch.setattr(
-            "flaskr.service.learn.learn_funcs.concat_audio_best_effort",
-            lambda parts: b"".join(parts),
-        )
-        monkeypatch.setattr(
-            "flaskr.service.learn.learn_funcs.get_audio_duration_ms",
-            lambda *_args, **_kwargs: 1000,
+            "flaskr.service.learn.learn_funcs.assemble_audio_for_upload",
+            lambda parts, **_kwargs: type(
+                "AssemblyResult",
+                (),
+                {
+                    "audio_data": b"".join(parts),
+                    "duration_ms": 1000,
+                    "included_segment_indices": tuple(range(len(parts))),
+                    "source_segment_count": len(parts),
+                    "segment_count": len(parts),
+                    "used_fallback": False,
+                },
+            )(),
         )
         monkeypatch.setattr(
             "flaskr.service.learn.learn_funcs.upload_audio_to_oss",
@@ -387,12 +394,19 @@ class TestGeneratedBlockListenTtsElementFirst:
             _fake_yield_tts_segments,
         )
         monkeypatch.setattr(
-            "flaskr.service.learn.learn_funcs.concat_audio_best_effort",
-            lambda parts: b"".join(parts),
-        )
-        monkeypatch.setattr(
-            "flaskr.service.learn.learn_funcs.get_audio_duration_ms",
-            lambda *_args, **_kwargs: 1000,
+            "flaskr.service.learn.learn_funcs.assemble_audio_for_upload",
+            lambda parts, **_kwargs: type(
+                "AssemblyResult",
+                (),
+                {
+                    "audio_data": b"".join(parts),
+                    "duration_ms": 1000,
+                    "included_segment_indices": tuple(range(len(parts))),
+                    "source_segment_count": len(parts),
+                    "segment_count": len(parts),
+                    "used_fallback": False,
+                },
+            )(),
         )
         monkeypatch.setattr(
             "flaskr.service.learn.learn_funcs.upload_audio_to_oss",
@@ -425,3 +439,82 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         assert complete_positions == [0, 1]
         assert synthesized_texts == ["A", "Second page."]
+
+    def test_finalize_tts_stream_audio_fallback_matches_uploaded_audio(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from flaskr.service.learn.learn_funcs import _finalize_tts_stream_audio
+
+        monkeypatch.setattr(
+            "flaskr.service.learn.learn_funcs.assemble_audio_for_upload",
+            lambda parts, **_kwargs: SimpleNamespace(
+                audio_data=parts[0],
+                duration_ms=123,
+                included_segment_indices=(0,),
+                source_segment_count=len(parts),
+                segment_count=1,
+                used_fallback=True,
+            ),
+        )
+        monkeypatch.setattr(
+            "flaskr.service.learn.learn_funcs.upload_audio_to_oss",
+            lambda _app, _audio_bytes, audio_bid: (
+                f"https://example.com/{audio_bid}.mp3",
+                "test-bucket",
+            ),
+        )
+
+        saved_records = []
+        monkeypatch.setattr(
+            "flaskr.service.learn.learn_funcs.save_audio_record",
+            lambda record, commit=True: saved_records.append(record),
+        )
+
+        subtitle_cues = [
+            {
+                "text": "First sentence.",
+                "start_ms": 0,
+                "end_ms": 123,
+                "segment_index": 0,
+            },
+            {
+                "text": "Second sentence.",
+                "start_ms": 123,
+                "end_ms": 456,
+                "segment_index": 1,
+            },
+        ]
+
+        _oss_url, duration_ms = _finalize_tts_stream_audio(
+            self.app,
+            audio_parts=[b"first-audio", b"second-audio"],
+            segment_durations_ms=[123, 333],
+            subtitle_cues=subtitle_cues,
+            audio_bid="fallback-audio",
+            audio_settings=SimpleNamespace(format="mp3", sample_rate=24000),
+            voice_settings=SimpleNamespace(
+                voice_id="voice",
+                speed=1.0,
+                pitch=0,
+                emotion="",
+                volume=1.0,
+            ),
+            tts_model="test-model",
+            cleaned_text="First sentence. Second sentence.",
+            segment_count=2,
+            persist_audio=True,
+            generated_block_bid="generated-fallback",
+            progress_record_bid="progress-fallback",
+            user_bid="user-fallback",
+            shifu_bid="shifu-fallback",
+        )
+
+        assert duration_ms == 123
+        assert [cue["text"] for cue in subtitle_cues] == ["First sentence."]
+        assert saved_records[0].duration_ms == 123
+        assert saved_records[0].segment_count == 1
+        assert [cue["text"] for cue in saved_records[0].subtitle_cues] == [
+            "First sentence."
+        ]

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -39,6 +39,14 @@ class _FakeAudioSegment:
         duration = int(segment_io.getvalue().decode("utf-8"))
         return _FakeSegment(duration)
 
+    @staticmethod
+    def from_file(segment_io: io.BytesIO, format="mp3"):
+        _ = format
+        payload = segment_io.getvalue().decode("utf-8")
+        if payload.startswith("duration="):
+            payload = payload.removeprefix("duration=")
+        return _FakeSegment(int(payload))
+
 
 class _PartiallyBrokenAudioSegment:
     @staticmethod
@@ -47,6 +55,24 @@ class _PartiallyBrokenAudioSegment:
         if payload == b"BAD":
             raise ValueError("Decoding failed")
         return _FakeSegment(int(payload.decode("utf-8")))
+
+    @staticmethod
+    def from_file(segment_io: io.BytesIO, format="mp3"):
+        _ = format
+        payload = segment_io.getvalue()
+        if payload == b"BAD":
+            raise ValueError("Decoding failed")
+        decoded = payload.decode("utf-8")
+        if decoded.startswith("duration="):
+            decoded = decoded.removeprefix("duration=")
+        return _FakeSegment(int(decoded))
+
+
+class _BrokenAudioSegment:
+    @staticmethod
+    def from_file(segment_io: io.BytesIO, format="mp3"):
+        _ = (segment_io, format)
+        raise ValueError("Decoding failed")
 
 
 def test_concat_audio_mp3_does_not_crossfade_by_default(monkeypatch):
@@ -81,7 +107,7 @@ def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch):
         audio_utils.concat_audio_mp3([b"100", b"BAD", b"80"])
 
 
-def test_concat_audio_best_effort_falls_back_to_byte_join_on_partial_failure(
+def test_concat_audio_best_effort_uses_first_decodable_segment_on_partial_failure(
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -91,4 +117,52 @@ def test_concat_audio_best_effort_falls_back_to_byte_join_on_partial_failure(
 
     output = audio_utils.concat_audio_best_effort([b"100", b"BAD", b"80"])
 
-    assert output == b"100BAD80"
+    assert output == b"100"
+
+
+def test_assemble_audio_for_upload_validates_concatenated_audio(monkeypatch):
+    monkeypatch.setattr(audio_utils, "AudioSegment", _FakeAudioSegment, raising=False)
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    result = audio_utils.assemble_audio_for_upload([b"100", b"80"])
+
+    assert result.audio_data == b"duration=180"
+    assert result.duration_ms == 180
+    assert result.included_segment_indices == (0, 1)
+    assert result.used_fallback is False
+
+
+def test_assemble_audio_for_upload_uses_first_decodable_segment(monkeypatch):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    result = audio_utils.assemble_audio_for_upload(
+        [b"100", b"BAD", b"80"],
+        segment_durations_ms=[101, 0, 80],
+    )
+
+    assert result.audio_data == b"100"
+    assert result.duration_ms == 101
+    assert result.included_segment_indices == (0,)
+    assert result.used_fallback is True
+
+
+def test_assemble_audio_for_upload_raises_when_no_segment_decodes(monkeypatch):
+    monkeypatch.setattr(audio_utils, "AudioSegment", _BrokenAudioSegment, raising=False)
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    with pytest.raises(ValueError, match="No decodable audio segments"):
+        audio_utils.assemble_audio_for_upload([b"BAD"])
+
+
+def test_get_audio_duration_ms_downgrades_decode_failure_log(monkeypatch, caplog):
+    monkeypatch.setattr(audio_utils, "AudioSegment", _BrokenAudioSegment, raising=False)
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    with caplog.at_level("WARNING"):
+        duration_ms = audio_utils.get_audio_duration_ms(b"not-audio")
+
+    assert duration_ms == 0
+    assert not [record for record in caplog.records if record.levelname == "ERROR"]

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -23,6 +23,17 @@ def _sse_line(payload):
     return f"data: {json.dumps(payload)}"
 
 
+def _assembly_result(parts, duration_ms):
+    return SimpleNamespace(
+        audio_data=b"".join(parts),
+        duration_ms=duration_ms,
+        included_segment_indices=tuple(range(len(parts))),
+        source_segment_count=len(parts),
+        segment_count=len(parts),
+        used_fallback=False,
+    )
+
+
 def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
@@ -200,8 +211,8 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
         ),
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 1000),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -328,8 +339,8 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
         ),
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 1000),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -457,8 +468,8 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 3000),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -603,8 +614,8 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 3000),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -736,8 +747,8 @@ def test_streaming_tts_minimax_http_stream_offsets_later_requests_by_provider_en
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 2200),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -872,8 +883,8 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 2000),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -1025,8 +1036,8 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 5400),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -1179,8 +1190,8 @@ def test_streaming_tts_minimax_http_stream_updates_same_count_provider_cues(
         _fake_export,
     )
     monkeypatch.setattr(
-        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+        lambda parts, **_kwargs: _assembly_result(parts, 6364),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -66,12 +66,15 @@ class TestStreamingTtsSubtitles:
             ),
         )
         monkeypatch.setattr(
-            "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-            lambda parts: b"".join(parts),
-        )
-        monkeypatch.setattr(
-            "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-            lambda _audio: 240,
+            "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+            lambda parts, **_kwargs: SimpleNamespace(
+                audio_data=b"".join(parts),
+                duration_ms=240,
+                included_segment_indices=tuple(range(len(parts))),
+                source_segment_count=len(parts),
+                segment_count=len(parts),
+                used_fallback=False,
+            ),
         )
         monkeypatch.setattr(
             "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -144,3 +147,104 @@ class TestStreamingTtsSubtitles:
             "First sentence.",
             "Second sentence.",
         ]
+
+    def test_streaming_tts_final_audio_fallback_limits_persisted_subtitles(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
+
+        monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.is_tts_configured",
+            lambda _provider: True,
+        )
+        monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.should_use_minimax_http_stream",
+            lambda _provider: False,
+        )
+        monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.assemble_audio_for_upload",
+            lambda parts, **_kwargs: SimpleNamespace(
+                audio_data=parts[0],
+                duration_ms=120,
+                included_segment_indices=(0,),
+                source_segment_count=len(parts),
+                segment_count=1,
+                used_fallback=True,
+            ),
+        )
+        monkeypatch.setattr(
+            "flaskr.service.tts.tts_handler.upload_audio_to_oss",
+            lambda _app, _audio, audio_bid: (
+                f"https://example.com/{audio_bid}.mp3",
+                "test-bucket",
+            ),
+        )
+
+        saved_records = []
+        usage_records = []
+        monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.build_completed_audio_record",
+            lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+        monkeypatch.setattr(
+            "flaskr.service.tts.streaming_tts.save_audio_record",
+            lambda record, commit=True: saved_records.append(record),
+        )
+        monkeypatch.setattr(
+            "flaskr.service.tts.tts_usage_recorder.record_tts_aggregated_usage",
+            lambda **kwargs: usage_records.append(kwargs),
+        )
+
+        processor = StreamingTTSProcessor(
+            app=self.app,
+            generated_block_bid="generated-streaming-fallback",
+            outline_bid="outline-streaming-fallback",
+            progress_record_bid="progress-streaming-fallback",
+            user_bid="user-streaming-fallback",
+            shifu_bid="shifu-streaming-fallback",
+            tts_provider="minimax",
+            tts_model="test-model",
+        )
+        processor._word_count_total = 4
+
+        events = list(
+            processor._yield_audio_complete_from_segments(
+                all_segments=[
+                    (0, b"first-audio", 120, "First sentence."),
+                    (1, b"second-audio", 240, "Second sentence."),
+                ],
+                raw_text="First sentence. Second sentence.",
+                cleaned_text="First sentence. Second sentence.",
+                cleaned_text_length=33,
+                subtitle_cues=[
+                    {
+                        "text": "First sentence.",
+                        "start_ms": 0,
+                        "end_ms": 120,
+                        "segment_index": 0,
+                    },
+                    {
+                        "text": "Second sentence.",
+                        "start_ms": 120,
+                        "end_ms": 360,
+                        "segment_index": 1,
+                    },
+                ],
+            )
+        )
+
+        audio_complete = [
+            event for event in events if event.type == GeneratedType.AUDIO_COMPLETE
+        ][0]
+        assert audio_complete.content.duration_ms == 120
+        assert [cue.text for cue in audio_complete.content.subtitle_cues] == [
+            "First sentence."
+        ]
+        assert [cue["text"] for cue in saved_records[0].subtitle_cues] == [
+            "First sentence."
+        ]
+        assert saved_records[0].segment_count == 1
+        assert usage_records[0]["duration_ms"] == 360


### PR DESCRIPTION
## Summary
- Prevent raw byte-joined MP3 uploads after audio assembly failure
- Validate final upload audio through `assemble_audio_for_upload`
- Fall back to the first decodable segment when full assembly cannot be decoded
- Rebase/filter subtitles to match the actually uploaded audio
- Downgrade duration-probe decode failures from error to warning/debug

## Tests
- `cd src/api && pytest tests/service/tts/test_audio_utils.py tests/service/tts/test_streaming_tts_subtitles.py tests/service/tts/test_minimax_http_streaming.py tests/service/learn/test_generated_block_tts_av_mode.py -q`
- `cd src/api && ruff check flaskr/service/tts/audio_utils.py flaskr/service/tts/pipeline.py flaskr/service/tts/streaming_tts.py flaskr/service/tts/subtitle_utils.py flaskr/service/learn/learn_funcs.py tests/service/tts/test_audio_utils.py tests/service/tts/test_streaming_tts_subtitles.py tests/service/tts/test_minimax_http_streaming.py tests/service/learn/test_generated_block_tts_av_mode.py`
- `cd src/api && ruff format --check flaskr/service/tts/audio_utils.py flaskr/service/tts/pipeline.py flaskr/service/tts/streaming_tts.py flaskr/service/tts/subtitle_utils.py flaskr/service/learn/learn_funcs.py tests/service/tts/test_audio_utils.py tests/service/tts/test_streaming_tts_subtitles.py tests/service/tts/test_minimax_http_streaming.py tests/service/learn/test_generated_block_tts_av_mode.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subtitle accuracy for generated audio by ensuring subtitles match the audio segments actually included in the final output.
  * Enhanced audio generation robustness with better fallback handling during segment assembly.

* **Improvements**
  * More accurate audio duration tracking for usage metering and billing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1729)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->