### PR TITLE
fix: course link HTTPS origins

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -19,6 +19,16 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
+    map $http_x_forwarded_proto $ai_shifu_forwarded_proto {
+        default $http_x_forwarded_proto;
+        "" $scheme;
+    }
+
+    map $http_x_forwarded_host $ai_shifu_forwarded_host {
+        default $http_x_forwarded_host;
+        "" $host;
+    }
+
     access_log  /var/log/nginx/access.log  main;
 
     sendfile            on;
@@ -69,6 +79,8 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $ai_shifu_forwarded_proto;
+            proxy_set_header X-Forwarded-Host $ai_shifu_forwarded_host;
         }
         location / {
             proxy_pass http://ai-shifu-cook-web:5000;

--- a/docker/nginx.dev.conf
+++ b/docker/nginx.dev.conf
@@ -19,6 +19,16 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
+    map $http_x_forwarded_proto $ai_shifu_forwarded_proto {
+        default $http_x_forwarded_proto;
+        "" $scheme;
+    }
+
+    map $http_x_forwarded_host $ai_shifu_forwarded_host {
+        default $http_x_forwarded_host;
+        "" $host;
+    }
+
     access_log  /var/log/nginx/access.log  main;
 
     sendfile            on;
@@ -70,6 +80,8 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $ai_shifu_forwarded_proto;
+            proxy_set_header X-Forwarded-Host $ai_shifu_forwarded_host;
         }
 
         location / {

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -68,6 +68,7 @@ from flaskr.service.shifu.shifu_import_export_funcs import export_shifu
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_config
+from flaskr.common.public_urls import resolve_public_origin
 from flaskr.api.langfuse import (
     create_trace_with_root_span,
     finalize_langfuse_trace,
@@ -259,11 +260,7 @@ def _get_request_base_url() -> str:
     """
     Determine the base URL for frontend links.
     """
-    server_name = current_app.config.get("SERVER_NAME")
-    if server_name:
-        scheme = "https" if request.is_secure else "http"
-        return f"{scheme}://{server_name}".rstrip("/")
-    return request.url_root.rstrip("/")
+    return resolve_public_origin()
 
 
 def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | None:

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -100,10 +100,7 @@ def test_shifu_detail_urls_use_forwarded_https_origin(monkeypatch):
         detail = _build_detail_for_base_url(monkeypatch, _get_request_base_url())
 
     assert detail.url == "https://forwarded.example.com/c/course-1"
-    assert (
-        detail.preview_url
-        == "https://forwarded.example.com/c/course-1?preview=true"
-    )
+    assert detail.preview_url == "https://forwarded.example.com/c/course-1?preview=true"
 
 
 def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch):

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+import flaskr.common.config as common_config
+
+
+def _reset_config_cache(*keys: str) -> None:
+    for key in keys:
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+
+
+@pytest.fixture(autouse=True)
+def clear_public_url_config_cache():
+    _reset_config_cache("HOST_URL")
+    yield
+    _reset_config_cache("HOST_URL")
+
+
+def _make_draft(shifu_bid: str = "course-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        shifu_bid=shifu_bid,
+        title="Test Course",
+        description="desc",
+        avatar_res_bid="avatar-1",
+        keywords="test",
+        llm="gpt-test",
+        llm_temperature=Decimal("0.30"),
+        price=Decimal("1.00"),
+        llm_system_prompt="",
+        created_user_bid="owner-1",
+        tts_enabled=False,
+        tts_provider="",
+        tts_model="",
+        tts_voice_id="",
+        tts_speed=None,
+        tts_pitch=0,
+        tts_emotion="",
+        use_learner_language=0,
+        ask_enabled_status=5101,
+        ask_llm="",
+        ask_llm_temperature=Decimal("0.00"),
+        ask_llm_system_prompt="",
+        ask_provider_config="{}",
+    )
+
+
+def _build_detail_for_base_url(monkeypatch, base_url: str):
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    monkeypatch.setattr(
+        shifu_draft_funcs,
+        "get_shifu_res_url",
+        lambda _resource_bid: "",
+        raising=False,
+    )
+    return shifu_draft_funcs.return_shifu_draft_dto(
+        _make_draft(),
+        base_url,
+        readonly=False,
+    )
+
+
+def test_shifu_detail_urls_prefer_host_url(monkeypatch):
+    from flaskr.service.shifu.route import _get_request_base_url
+
+    monkeypatch.setenv("HOST_URL", "https://example.com/")
+    _reset_config_cache("HOST_URL")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/shifu/shifus/course-1/detail",
+        base_url="http://internal.local",
+    ):
+        detail = _build_detail_for_base_url(monkeypatch, _get_request_base_url())
+
+    assert detail.url == "https://example.com/c/course-1"
+    assert detail.preview_url == "https://example.com/c/course-1?preview=true"
+
+
+def test_shifu_detail_urls_use_forwarded_https_origin(monkeypatch):
+    from flaskr.service.shifu.route import _get_request_base_url
+
+    monkeypatch.delenv("HOST_URL", raising=False)
+    _reset_config_cache("HOST_URL")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/shifu/shifus/course-1/detail",
+        base_url="http://internal.local",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "forwarded.example.com",
+        },
+    ):
+        detail = _build_detail_for_base_url(monkeypatch, _get_request_base_url())
+
+    assert detail.url == "https://forwarded.example.com/c/course-1"
+    assert (
+        detail.preview_url
+        == "https://forwarded.example.com/c/course-1?preview=true"
+    )
+
+
+def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch):
+    from flaskr.service.shifu import shifu_publish_funcs
+    from flaskr.service.shifu.route import _get_request_base_url
+
+    monkeypatch.delenv("HOST_URL", raising=False)
+    _reset_config_cache("HOST_URL")
+    monkeypatch.setattr(
+        shifu_publish_funcs,
+        "get_latest_shifu_draft",
+        lambda _shifu_id: _make_draft(_shifu_id),
+        raising=False,
+    )
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/shifu/shifus/course-1/preview",
+        method="POST",
+        base_url="http://internal.local",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "forwarded.example.com",
+        },
+    ):
+        preview_url = shifu_publish_funcs.preview_shifu_draft(
+            app,
+            "user-1",
+            "course-1",
+            {},
+            _get_request_base_url(),
+        )
+
+    assert preview_url == "https://forwarded.example.com/c/course-1?preview=true"
+
+
+def test_shifu_publish_url_builder_uses_public_base():
+    from flaskr.service.shifu.shifu_publish_funcs import _build_frontend_url
+
+    assert (
+        _build_frontend_url("https://example.com/", "/c/course-1")
+        == "https://example.com/c/course-1"
+    )


### PR DESCRIPTION
## Summary
- use the shared public-origin resolver for shifu course links returned by detail, preview, and publish flows
- preserve forwarded proto/host through docker nginx backend API routes
- add focused backend coverage for HOST_URL, forwarded HTTPS origins, preview links, and publish URL building

## Root Cause
Course URLs were built from Flask request scheme/url_root, so HTTPS requests terminating before Flask could still produce http:// course links.

## Validation
- cd src/api && pytest tests/service/shifu/test_shifu_draft_info.py tests/service/shifu/test_shifu_publish_funcs.py tests/service/shifu/test_shifu_public_urls.py tests/common/test_public_urls.py -q
- cd src/api && ruff check flaskr/service/shifu/route.py tests/service/shifu/test_shifu_public_urls.py
- git diff --check
- cd docker && docker compose -f docker-compose.dev.yml config
- cd docker && docker compose -f docker-compose.yml config
- cd docker && docker compose -f docker-compose.latest.yml config
- docker run --rm --add-host ai-shifu-cook-web:127.0.0.1 --add-host ai-shifu-api:127.0.0.1 -v "$PWD/docker/nginx.conf:/etc/nginx/nginx.conf:ro" nginx:latest nginx -t
- docker run --rm --add-host ai-shifu-cook-web-dev:127.0.0.1 --add-host ai-shifu-api-dev:127.0.0.1 -v "$PWD/docker/nginx.dev.conf:/etc/nginx/nginx.conf:ro" nginx:latest nginx -t