### PR TITLE
feat: add preview mode banner inside course page headers

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -41,6 +41,7 @@
 - 听课模式字幕尾部清洗只移除不允许的结束标点，遇到右引号、右括号这类成对符号的结尾符必须保留；即使这些结尾符后面还跟着句号、逗号等待过滤标点，也要按从右向左的顺序先保留结尾符、再剥离无效标点，并补齐 `。”`、`），`、`？”。` 一类回归测试。
 - 听课模式移动端 fullscreen header 的标题文案不要硬编码白色，优先继承 `markdown-flow-ui` 的 `--slide-mobile-fullscreen-chrome-foreground`，这样宿主侧浅色毛玻璃 header 和返回按钮颜色才能保持一致。
 - 阅读模式首个渲染项的顶部留白要在统一容器层处理，优先把 `loading`、首个 content、首个 ask 和首个 interaction 都视为“第一个 element”，共用同一套 top padding，避免只改普通内容块导致首屏间距不一致。
+- `/c/:id` 页面 preview 模式如果要在 learner header 增加提示 banner，优先作为 header 内部第二行渲染，并同步抬高 mobile sticky header 高度、desktop header 占位和正文 top padding，不要把 banner 放成 header 同级导致吸顶和内容错位。
 - 学习页初始化排查如果需要给 QA 或运营直接复现链路，优先提供 `debug=1` 这类显式 URL 开关，把请求层、`1001` 鉴权恢复链路和页面初始化日志同步显示在页内调试面板，而不是只依赖远程控制台。
 
 ## Skills Index

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
@@ -1,17 +1,25 @@
 .ChatMobileHeader {
   display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
+  flex-direction: column;
   flex: 0 0 var(--mobile-chat-header-height, 44px);
   flex-shrink: 0;
   min-height: var(--mobile-chat-header-height, 44px);
   max-height: var(--mobile-chat-header-height, 44px);
   background: var(--base-background, #fff);
-  padding: 6px 20px;
+  padding: 0;
   height: var(--mobile-chat-header-height, 44px);
   width: 100%;
   box-sizing: border-box;
   border-bottom: 1px solid var(--base-border, #e5e5e5);
+
+  .headerRow {
+    display: flex;
+    width: 100%;
+    min-height: 44px;
+    align-items: center;
+    padding: 6px 20px;
+    box-sizing: border-box;
+  }
 
   .actionGroup {
     display: inline-flex;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
@@ -11,6 +11,7 @@ import { useDisclosure } from '@/c-common/hooks/useDisclosure';
 import { shifu } from '@/c-service/Shifu';
 import CourseHeaderSummary from './CourseHeaderSummary';
 import LearningModeSwitch from './LearningModeSwitch';
+import PreviewHeaderBanner from './PreviewHeaderBanner';
 
 export const ChatMobileHeader = ({
   className,
@@ -26,8 +27,9 @@ export const ChatMobileHeader = ({
     shifu.ControlTypes.MOBILE_HEADER_ICON_POPOVER,
   );
 
-  const { showLearningModeToggle } = useSystemStore(
+  const { previewMode, showLearningModeToggle } = useSystemStore(
     useShallow(state => ({
+      previewMode: state.previewMode,
       showLearningModeToggle: state.showLearningModeToggle,
     })),
   );
@@ -47,27 +49,30 @@ export const ChatMobileHeader = ({
           />
         </div>
       ) : null}
-      <CourseHeaderSummary />
+      {previewMode ? <PreviewHeaderBanner /> : null}
+      <div className={styles.headerRow}>
+        <CourseHeaderSummary />
 
-      <div className={styles.actionGroup}>
-        {showLearningModeToggle ? <LearningModeSwitch /> : null}
+        <div className={styles.actionGroup}>
+          {showLearningModeToggle ? <LearningModeSwitch /> : null}
 
-        <button
-          type='button'
-          aria-label={
-            navOpen
-              ? t('module.chat.closeCatalog')
-              : t('module.chat.openCatalog')
-          }
-          className={styles.iconButton}
-          onClick={onSettingClick}
-        >
-          <MenuIcon
-            size={20}
-            strokeWidth={2}
-            className='text-neutral-500'
-          />
-        </button>
+          <button
+            type='button'
+            aria-label={
+              navOpen
+                ? t('module.chat.closeCatalog')
+                : t('module.chat.openCatalog')
+            }
+            className={styles.iconButton}
+            onClick={onSettingClick}
+          >
+            <MenuIcon
+              size={20}
+              strokeWidth={2}
+              className='text-neutral-500'
+            />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -12,7 +12,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    padding: 0 20px;
+    padding: 0;
     background: linear-gradient(
       180deg,
       var(--base-background, #fff) 0%,
@@ -23,6 +23,15 @@
     font-size: 14px;
     color: var(--base-muted-foreground, #737373);
     line-height: 20px;
+
+    .headerMain {
+      display: flex;
+      width: 100%;
+      min-height: 64px;
+      align-items: center;
+      padding: 0 20px;
+      box-sizing: border-box;
+    }
 
     .headerContent {
       min-width: 0;
@@ -41,14 +50,30 @@
     }
 
     .headerActions {
-      position: absolute;
-      right: 20px;
-      top: 50%;
-      transform: translateY(-50%);
       display: inline-flex;
       align-items: center;
       gap: 8px;
+      margin-left: auto;
+      flex-shrink: 0;
     }
+  }
+
+  .previewHeader {
+    height: 104px;
+    align-items: flex-start;
+    padding: 0;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    .headerMain {
+      min-height: 64px;
+    }
+  }
+
+  .previewHeaderBanner {
+    order: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .headerMobile {
@@ -200,6 +225,16 @@
     overflow-y: auto;
     padding-top: 64px;
     box-sizing: border-box;
+  }
+
+  &.previewModeDesktop {
+    .chatComponents {
+      padding-top: 104px;
+    }
+
+    .UserSettings {
+      margin-top: 104px;
+    }
   }
 
   .chatComponentsHidden {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -109,7 +109,10 @@ export const ChatUi = ({
       {
         showHeader ? (
           <div
-            className={cn(styles.header, previewMode ? styles.previewHeader : '')}
+            className={cn(
+              styles.header,
+              previewMode ? styles.previewHeader : '',
+            )}
           >
             {previewMode ? (
               <PreviewHeaderBanner className={styles.previewHeaderBanner} />

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -14,6 +14,7 @@ import MarkdownFlowLink from '@/components/ui/MarkdownFlowLink';
 import type { ListenMobileViewModeChangeHandler } from './listenModeTypes';
 import CourseHeaderSummary from '../CourseHeaderSummary';
 import LearningModeSwitch from '../LearningModeSwitch';
+import PreviewHeaderBanner from '../PreviewHeaderBanner';
 
 interface ChatUiProps {
   chapterId: string;
@@ -92,6 +93,9 @@ export const ChatUi = ({
       className={cn(
         styles.ChatUi,
         frameLayout === FRAME_LAYOUT_MOBILE ? styles.mobile : '',
+        previewMode && frameLayout !== FRAME_LAYOUT_MOBILE
+          ? styles.previewModeDesktop
+          : '',
         isListenMode ? styles.listenMode : '',
         isListenMode && isListenPlayerVisible
           ? styles.listenModeWithPlayer
@@ -104,20 +108,27 @@ export const ChatUi = ({
     >
       {
         showHeader ? (
-          <div className={styles.header}>
-            <div className={styles.headerContent}>
-              <CourseHeaderSummary
-                courseAvatar={courseAvatar}
-                courseName={courseName}
-                className={styles.courseSummary}
-                titleClassName={styles.courseSummaryTitle}
-              />
-            </div>
-            {showModeToggle ? (
-              <div className={styles.headerActions}>
-                <LearningModeSwitch size='desktop' />
-              </div>
+          <div
+            className={cn(styles.header, previewMode ? styles.previewHeader : '')}
+          >
+            {previewMode ? (
+              <PreviewHeaderBanner className={styles.previewHeaderBanner} />
             ) : null}
+            <div className={styles.headerMain}>
+              <div className={styles.headerContent}>
+                <CourseHeaderSummary
+                  courseAvatar={courseAvatar}
+                  courseName={courseName}
+                  className={styles.courseSummary}
+                  titleClassName={styles.courseSummaryTitle}
+                />
+              </div>
+              {showModeToggle ? (
+                <div className={styles.headerActions}>
+                  <LearningModeSwitch size='desktop' />
+                </div>
+              ) : null}
+            </div>
           </div>
         ) : null
         // <div className={styles.headerMobile}></div>

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -12,6 +12,10 @@
   overflow: hidden;
   position: relative;
 
+  &.listen-reveal-wrapper--preview {
+    padding-top: 136px !important;
+  }
+
   &.mobile {
     padding: 0 !important;
     height: 100%;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1330,6 +1330,7 @@ const ListenModeSlideRenderer = ({
     <div
       className={cn(
         'listen-reveal-wrapper',
+        previewMode && !mobileStyle && 'listen-reveal-wrapper--preview',
         mobileStyle ? 'mobile bg-white' : 'bg-[var(--color-slide-desktop-bg)]',
       )}
       ref={chatRef}

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
@@ -14,11 +14,11 @@ export const PreviewHeaderBanner = ({
   return (
     <div
       className={cn(
-        'w-full bg-primary/10 text-[var(--primary,#0F63EE)]',
+        'w-full bg-sky-100 text-sky-800',
         className,
       )}
     >
-      <div className='flex min-h-10 w-full items-center px-4 py-2 text-[14px] font-medium leading-5 md:text-[15px]'>
+      <div className='flex min-h-10 w-full items-center justify-center px-4 py-2 text-center text-[14px] font-medium leading-5 md:text-[15px]'>
         {t('module.preview.previewModeBanner')}
       </div>
     </div>

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
@@ -1,0 +1,28 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+
+interface PreviewHeaderBannerProps {
+  className?: string;
+}
+
+export const PreviewHeaderBanner = ({
+  className,
+}: PreviewHeaderBannerProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={cn(
+        'w-full bg-primary/10 text-[var(--primary,#0F63EE)]',
+        className,
+      )}
+    >
+      <div className='flex min-h-10 w-full items-center px-4 py-2 text-[14px] font-medium leading-5 md:text-[15px]'>
+        {t('module.preview.previewModeBanner')}
+      </div>
+    </div>
+  );
+};
+
+export default memo(PreviewHeaderBanner);

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
@@ -12,12 +12,7 @@ export const PreviewHeaderBanner = ({
   const { t } = useTranslation();
 
   return (
-    <div
-      className={cn(
-        'w-full bg-sky-100 text-sky-800',
-        className,
-      )}
-    >
+    <div className={cn('w-full bg-sky-100 text-sky-800', className)}>
       <div className='flex min-h-10 w-full items-center justify-center px-4 py-2 text-center text-[14px] font-medium leading-5 md:text-[15px]'>
         {t('module.preview.previewModeBanner')}
       </div>

--- a/src/cook-web/src/app/c/[[...id]]/page.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/page.module.scss
@@ -31,4 +31,8 @@
       max-height: var(--mobile-chat-header-height);
     }
   }
+
+  &.previewMode {
+    --mobile-chat-header-height: 84px;
+  }
 }

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -743,6 +743,7 @@ export default function ChatPage() {
       data-testid='course-chat-page'
       className={clsx(
         styles.newChatPage,
+        previewMode ? styles.previewMode : '',
         isListenMode ? styles.listenMode : '',
         mobileStyle ? 'flex-col' : 'h-screen flex-row',
         'flex',

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -1708,6 +1708,7 @@ export type I18nKey =
   | 'module.permission.user.login'
   | 'module.preview.llmError'
   | 'module.preview.previewAll'
+  | 'module.preview.previewModeBanner'
   | 'module.profiles.add'
   | 'module.profiles.addNewVariable'
   | 'module.profiles.cancel'

--- a/src/i18n/en-US/modules/preview.json
+++ b/src/i18n/en-US/modules/preview.json
@@ -1,5 +1,6 @@
 {
   "__namespace__": "module.preview",
   "llmError": "LLM Invocation Error",
-  "previewAll": "Preview Course"
+  "previewAll": "Preview Course",
+  "previewModeBanner": "This link is a preview link and is only visible to the course publisher"
 }

--- a/src/i18n/zh-CN/modules/preview.json
+++ b/src/i18n/zh-CN/modules/preview.json
@@ -1,5 +1,6 @@
 {
   "__namespace__": "module.preview",
   "llmError": "LLM 调用错误",
-  "previewAll": "预览"
+  "previewAll": "预览",
+  "previewModeBanner": "当前链接为预览链接，仅课程发布者可查看"
 }


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preview mode banner displayed as the second line in the page header, indicating the link is a preview visible only to course publishers.

* **Localization**
  * Added English and Chinese translations for preview mode banner messaging.

* **Style**
  * Adjusted header heights, spacing, and layout styling on mobile and desktop to accommodate the preview banner and prevent content misalignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1731)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->