### PR TITLE
[codex] Disable TTS for follow-up asks

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Callable, Generator, Iterable, Optional, Union
 from flaskr.service.learn.const import (
+    INPUT_TYPE_ASK,
     ROLE_STUDENT,
     ROLE_TEACHER,
     CONTEXT_INTERACTION_NEXT,
@@ -1372,7 +1373,11 @@ class RunScriptContextV2:
         )
 
     def _should_stream_tts(self) -> bool:
-        return (not self._preview_mode) and bool(getattr(self, "_listen", False))
+        return (
+            (not self._preview_mode)
+            and getattr(self, "_input_type", None) != INPUT_TYPE_ASK
+            and bool(getattr(self, "_listen", False))
+        )
 
     def _try_create_tts_processor(
         self,

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -427,6 +427,8 @@ def run_script(
     lock_retry_sleep_seconds = 0.2
     heartbeat_interval = float(app.config.get("SSE_HEARTBEAT_INTERVAL", 0.5))
     lock_key = _get_run_script_lock_key(app, user_bid, outline_bid)
+    is_ask = input_type == INPUT_TYPE_ASK
+    runtime_listen = bool(listen) and not is_ask
     # Learner run SSE now always speaks the element protocol. The listen flag
     # still controls run-time behaviors such as segmented TTS generation.
     use_element_protocol = True
@@ -437,7 +439,6 @@ def run_script(
         user_bid=user_bid,
     )
     stream_element_adapter = element_adapter
-    is_ask = input_type == INPUT_TYPE_ASK
     if is_ask:
         # Ask (follow-up) requests use a counting semaphore instead of the main mutex
         # so they can run in parallel with the main lesson stream (up to
@@ -508,7 +509,7 @@ def run_script(
                     input_type=input_type,
                     reload_generated_block_bid=reload_generated_block_bid,
                     reload_element_bid=reload_element_bid,
-                    listen=listen,
+                    listen=runtime_listen,
                     preview_mode=preview_mode,
                     stop_event=stop_event,
                     element_adapter=element_adapter,
@@ -707,7 +708,7 @@ def run_script(
                         event_type=GeneratedType.BREAK.value,
                         content="",
                         element_adapter=stream_element_adapter,
-                        is_terminal=False if listen else None,
+                        is_terminal=False if runtime_listen else None,
                     )
                     if not _should_suppress_live_payload(block_end_event):
                         yield _to_sse_chunk(block_end_event)

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -604,6 +604,7 @@ class StreamTtsGateTests(unittest.TestCase):
     def test_should_stream_tts_respects_preview_and_listen(self):
         ctx = _make_context()
 
+        ctx._input_type = "normal"
         ctx._preview_mode = False
         ctx._listen = True
         self.assertTrue(ctx._should_stream_tts())
@@ -613,6 +614,10 @@ class StreamTtsGateTests(unittest.TestCase):
 
         ctx._preview_mode = True
         ctx._listen = True
+        self.assertFalse(ctx._should_stream_tts())
+
+        ctx._preview_mode = False
+        ctx._input_type = "ask"
         self.assertFalse(ctx._should_stream_tts())
 
     def test_iter_stream_result_with_idle_callback_drains_while_waiting(self):

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -404,6 +404,50 @@ def test_run_script_ask_mode_uses_element_protocol(monkeypatch):
         assert events[1]["is_terminal"] is True
 
 
+def test_run_script_ask_mode_ignores_listen_flag(monkeypatch):
+    app = _make_test_app()
+    _patch_fake_element_adapter(monkeypatch)
+    with app.app_context():
+        lock = FakeLock([True])
+        cache = FakeCacheProvider(lock)
+        observed: dict[str, object] = {}
+        monkeypatch.setattr(runscript_v2, "cache_provider", cache)
+
+        def fake_run_script_inner(**_kwargs):
+            observed["listen"] = _kwargs["listen"]
+            yield RunMarkdownFlowDTO(
+                outline_bid="outline-1",
+                generated_block_bid="generated-ask",
+                type=GeneratedType.CONTENT,
+                content="answer chunk",
+            )
+            yield RunMarkdownFlowDTO(
+                outline_bid="outline-1",
+                generated_block_bid="generated-ask",
+                type=GeneratedType.BREAK,
+                content="",
+            )
+
+        monkeypatch.setattr(runscript_v2, "run_script_inner", fake_run_script_inner)
+
+        chunks = list(
+            runscript_v2.run_script(
+                app=app,
+                shifu_bid="shifu-1",
+                outline_bid="outline-1",
+                user_bid="user-1",
+                input="follow-up question",
+                input_type="ask",
+                listen=True,
+            )
+        )
+        events = _parse_sse_events(chunks)
+
+        assert observed["listen"] is False
+        assert [event["type"] for event in events] == ["element", "done"]
+        assert events[-1]["is_terminal"] is True
+
+
 def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeypatch):
     app = Flask(__name__)
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import AskBlock from './AskBlock';
+import { AppContext } from '../AppContext';
+import { SSE_OUTPUT_TYPE } from '@/c-api/studyV2';
+import { useAskStateStore } from './useAskStateStore';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/c-utils/markdownUtils', () => ({
+  fixMarkdownStream: (_previous: string, delta: string) => delta,
+}));
+
+jest.mock('markdown-flow-ui/renderer', () => ({
+  ContentRender: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownFlowInput: ({
+    value,
+    onChange,
+    onSend,
+  }: {
+    value: string;
+    onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onSend: () => void;
+  }) => (
+    <div>
+      <textarea
+        aria-label='ask-input'
+        value={value}
+        onChange={onChange}
+      />
+      <button onClick={onSend}>send</button>
+    </div>
+  ),
+}));
+
+jest.mock('@/hooks/useToast', () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock('next/image', () => {
+  return function MockImage({ alt, src }: { alt?: string; src?: string }) {
+    return (
+      <img
+        alt={alt || ''}
+        src={src || ''}
+      />
+    );
+  };
+});
+
+jest.mock('@/c-assets/newchat/light/icon_shifu.svg', () => ({
+  __esModule: true,
+  default: '/icon_shifu.svg',
+}));
+
+jest.mock('@/c-store/useCourseStore', () => ({
+  useCourseStore: (selector?: (state: { courseAvatar: string }) => unknown) => {
+    const state = { courseAvatar: '' };
+    return selector ? selector(state) : state;
+  },
+}));
+
+const mockSystemState: {
+  showLearningModeToggle: boolean;
+  learningMode: 'read' | 'listen';
+} = {
+  showLearningModeToggle: true,
+  learningMode: 'read',
+};
+
+jest.mock('@/c-store/useSystemStore', () => ({
+  useSystemStore: (selector?: (state: typeof mockSystemState) => unknown) => {
+    return selector ? selector(mockSystemState) : mockSystemState;
+  },
+}));
+
+const mockCheckIsRunning = jest.fn();
+const mockGetRunMessage = jest.fn();
+
+jest.mock('@/c-api/studyV2', () => ({
+  BLOCK_TYPE: {
+    CONTENT: 'content',
+    INTERACTION: 'interaction',
+    ASK: 'ask',
+    ANSWER: 'answer',
+    ERROR: 'error_message',
+  },
+  SSE_INPUT_TYPE: {
+    NORMAL: 'normal',
+    ASK: 'ask',
+  },
+  SSE_OUTPUT_TYPE: {
+    ELEMENT: 'element',
+    CONTENT: 'content',
+    ERROR: 'error',
+    BREAK: 'break',
+    ASK: 'ask',
+    TEXT_END: 'done',
+    HEARTBEAT: 'heartbeat',
+  },
+  checkIsRunning: (...args: unknown[]) => mockCheckIsRunning(...args),
+  getRunMessage: (...args: unknown[]) => mockGetRunMessage(...args),
+}));
+
+type Listener = (event?: Event) => void;
+
+class MockRunSource {
+  readyState = 0;
+
+  private listeners = new Map<string, Listener[]>();
+
+  addEventListener = jest.fn((type: string, listener: Listener) => {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  });
+
+  close = jest.fn(() => {
+    this.readyState = 2;
+    this.emit('readystatechange');
+  });
+
+  emit(type: string, event?: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+describe('AskBlock', () => {
+  let activeRun:
+    | {
+        source: MockRunSource;
+        onMessage: (response: {
+          type: string;
+          content?: string | Record<string, unknown>;
+        }) => Promise<void> | void;
+      }
+    | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    activeRun = undefined;
+    mockSystemState.showLearningModeToggle = true;
+    mockSystemState.learningMode = 'read';
+    useAskStateStore.getState().clearLessonScope();
+    mockCheckIsRunning.mockResolvedValue({
+      is_running: false,
+      running_time: 0,
+    });
+    mockGetRunMessage.mockImplementation(
+      (
+        _shifuBid: string,
+        _outlineBid: string,
+        _previewMode: boolean,
+        _body: Record<string, unknown>,
+        onMessage: (response: {
+          type: string;
+          content?: string | Record<string, unknown>;
+        }) => Promise<void> | void,
+      ) => {
+        const source = new MockRunSource();
+        activeRun = { source, onMessage };
+        return source;
+      },
+    );
+  });
+
+  it.each(['read', 'listen'] as const)(
+    'sends follow-up requests without TTS in %s mode',
+    async learningMode => {
+      mockSystemState.learningMode = learningMode;
+
+      render(
+        <AppContext.Provider
+          value={{
+            isLoggedIn: false,
+            mobileStyle: false,
+            userInfo: null,
+            theme: 'light',
+            frameLayout: 0,
+          }}
+        >
+          <AskBlock
+            isExpanded={true}
+            shifu_bid='shifu-1'
+            outline_bid='lesson-1'
+            element_bid='block-1'
+            askList={[]}
+          />
+        </AppContext.Provider>,
+      );
+
+      fireEvent.change(screen.getByLabelText('ask-input'), {
+        target: { value: 'follow up question' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+      await waitFor(() => expect(activeRun).toBeDefined());
+      expect(mockGetRunMessage.mock.calls[0][3]).toMatchObject({
+        input: 'follow up question',
+        input_type: 'ask',
+        listen: false,
+        reload_generated_block_bid: 'block-1',
+        reload_element_bid: 'block-1',
+      });
+
+      await act(async () => {
+        await activeRun?.onMessage({
+          type: SSE_OUTPUT_TYPE.CONTENT,
+          content: 'answer chunk',
+        });
+      });
+
+      expect(screen.getByText('follow up question')).toBeInTheDocument();
+      expect(screen.getByText('answer chunk')).toBeInTheDocument();
+
+      await act(async () => {
+        await activeRun?.onMessage({
+          type: SSE_OUTPUT_TYPE.BREAK,
+        });
+      });
+
+      await waitFor(() => expect(activeRun?.source.close).toHaveBeenCalled());
+    },
+  );
+
+  it('updates the live answer when the server emits answer element patches', async () => {
+    render(
+      <AppContext.Provider
+        value={{
+          isLoggedIn: false,
+          mobileStyle: false,
+          userInfo: null,
+          theme: 'light',
+          frameLayout: 0,
+        }}
+      >
+        <AskBlock
+          isExpanded={true}
+          shifu_bid='shifu-1'
+          outline_bid='lesson-1'
+          element_bid='block-1'
+          askList={[]}
+        />
+      </AppContext.Provider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('ask-input'), {
+      target: { value: 'follow up question' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        type: 'element',
+        content: {
+          element_type: 'answer',
+          content: 'first chunk',
+        },
+      });
+    });
+
+    expect(screen.getByText('first chunk')).toBeInTheDocument();
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        type: 'element',
+        content: {
+          element_type: 'answer',
+          content: 'first chunk and more',
+        },
+      });
+    });
+
+    expect(screen.getByText('first chunk and more')).toBeInTheDocument();
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        type: SSE_OUTPUT_TYPE.TEXT_END,
+      });
+    });
+
+    await waitFor(() => expect(activeRun?.source.close).toHaveBeenCalled());
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -24,7 +24,6 @@ import { AppContext } from '../AppContext';
 import { BLOCK_TYPE } from '@/c-api/studyV2';
 import { Avatar, AvatarImage } from '@/components/ui/Avatar';
 import { useCourseStore } from '@/c-store/useCourseStore';
-import { useSystemStore } from '@/c-store/useSystemStore';
 import {
   EMPTY_ASK_MESSAGE_LIST,
   normalizeAskMessageList,
@@ -67,9 +66,6 @@ export default function AskBlock({
   const copiedButtonText = t('module.renderUi.core.copied');
   const { mobileStyle } = useContext(AppContext);
   const courseAvatar = useCourseStore(state => state.courseAvatar);
-  const shouldUseListenMode = useSystemStore(
-    state => state.showLearningModeToggle,
-  );
   const ensureLessonScope = useAskStateStore(state => state.ensureLessonScope);
   const hydrateAskList = useAskStateStore(state => state.hydrateAskList);
   const setAskList = useAskStateStore(state => state.setAskList);
@@ -250,7 +246,7 @@ export default function AskBlock({
         input_type: SSE_INPUT_TYPE.ASK,
         reload_generated_block_bid: element_bid,
         reload_element_bid: element_bid,
-        listen: shouldUseListenMode,
+        listen: false,
       },
       async response => {
         try {
@@ -338,7 +334,6 @@ export default function AskBlock({
     finalizeStreamingMessage,
     replaceStreamingAnswerMessage,
     setAskList,
-    shouldUseListenMode,
     updateStreamingAnswerMessage,
   ]);
   const handleInputChange = useCallback(


### PR DESCRIPTION
## Summary
- Force follow-up ask requests to use text-only streaming from the frontend.
- Guard backend learn streaming so `input_type=ask` ignores `listen=true` from any client.
- Add frontend and backend regression coverage for ask requests staying off the TTS path.

## Root Cause
Follow-up asks reused the listen capability flag, so TTS-capable courses could send `listen=true` for asks. The backend then waited on ask TTS finalization before terminal stream events, keeping the answer loading indicator visible after text content had already finished.

## Validation
- `pytest tests/service/learn/test_context_v2.py::StreamTtsGateTests::test_should_stream_tts_respects_preview_and_listen tests/service/learn/test_runscript_v2_lock.py::test_run_script_ask_mode_uses_element_protocol tests/service/learn/test_runscript_v2_lock.py::test_run_script_ask_mode_ignores_listen_flag -q`
- `pytest tests/service/learn/test_runscript_v2_lock.py -q`
- `npm test -- AskBlock.test.tsx --runInBand`
- `git diff --check`
- `npx prettier --check src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx`

## Notes
- `npm run type-check` currently fails on an unrelated existing error in `ListenModeSlideRenderer.tsx:1409` where `bufferingText` is typed as `string` but receives an object.