### PR TITLE
[codex] fix TTS concat zero crossfade

### DIFF
--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -86,10 +86,7 @@ def concat_audio_mp3(
                     len(combined),
                     len(segment),
                 )
-                if safe_crossfade_ms > 0:
-                    combined = combined.append(segment, crossfade=safe_crossfade_ms)
-                else:
-                    combined = combined.append(segment)
+                combined = combined.append(segment, crossfade=safe_crossfade_ms)
 
         except Exception as e:
             failed_segments.append(i)

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -14,7 +14,7 @@ class _FakeSegment:
     def __len__(self):
         return self.duration_ms
 
-    def append(self, other, crossfade=0):
+    def append(self, other, crossfade=100):
         _FakeSegment.append_crossfades.append(crossfade)
         if crossfade > len(self):
             raise ValueError(


### PR DESCRIPTION
## Summary
- pass an explicit zero crossfade into pydub when TTS concatenation is configured for no overlap
- update the audio utility fake to preserve pydub default crossfade behavior in tests

## Root Cause
`AudioSegment.append(segment)` defaults to a 100ms crossfade. For short MiniMax TTS segments, for example 99ms, pydub raises `Crossfade is longer than the appended AudioSegment`. The fallback then byte-joins MP3 blobs, producing audio that can later fail ffmpeg duration probing with `Invalid frame size`.

## Validation
- `pytest tests/service/tts -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio segment concatenation to consistently apply crossfade transitions between segments, ensuring smoother blending when combining multiple audio clips.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1739)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->