### PR TITLE
fix: keep shared-permission dropdown above dialogs

### DIFF
--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -6,6 +6,9 @@ import { Check, ChevronRight, Circle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+// Keep dropdown content above dialog (`101`) and alert dialog (`111`) layers.
+const DROPDOWN_MENU_CONTENT_LAYER_CLASS = 'z-[112]';
+
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
@@ -47,7 +50,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      DROPDOWN_MENU_CONTENT_LAYER_CLASS,
       className,
     )}
     {...props}
@@ -65,7 +69,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        DROPDOWN_MENU_CONTENT_LAYER_CLASS,
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- raise shared dropdown menu content above dialog and alert dialog layers
- apply the layer fix to both dropdown content and nested submenus
- keep the change scoped to `DropdownMenu` only to avoid unrelated popover regressions

## Testing
- `cd src/cook-web && npm run lint-file -- src/components/ui/DropdownMenu.tsx`
- `cd src/cook-web && npm run lint-file -- src/components/ui/Popover.tsx`
- `cd src/cook-web && npm run lint-file -- src/components/order/ImportActivationDialog.tsx`
- `cd src/cook-web && npm run type-check` *(currently blocked by pre-existing error in `src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx:1409`)*