### PR TITLE
fix: TTS invalid MiniMax stream audio fallback

### DIFF
--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -31,6 +31,40 @@ def is_audio_processing_available() -> bool:
     return PYDUB_AVAILABLE
 
 
+def _estimated_duration_ms(audio_data: bytes) -> int:
+    # Rough estimate based on bitrate (128kbps for MP3):
+    # 128kbps = 16KB/s, so duration = size_bytes / 16000 * 1000.
+    return int(len(audio_data or b"") / 16000 * 1000)
+
+
+def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3"):
+    audio_io = io.BytesIO(audio_data)
+    if input_format == "mp3" and hasattr(AudioSegment, "from_mp3"):
+        return AudioSegment.from_mp3(audio_io)
+    return AudioSegment.from_file(audio_io, format=input_format)
+
+
+def try_get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> Optional[int]:
+    """Return decoded audio duration, or None when the bytes are not decodable."""
+    if not audio_data:
+        return 0
+    if not PYDUB_AVAILABLE:
+        return _estimated_duration_ms(audio_data)
+
+    try:
+        audio = _load_audio_segment(audio_data, input_format=format)
+        return len(audio)
+    except Exception as exc:
+        logger.debug(
+            "Audio duration decode failed: format=%s bytes=%s error=%s",
+            format,
+            len(audio_data or b""),
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
 def concat_audio_mp3(
     segments: List[bytes],
     output_format: str = "mp3",
@@ -73,8 +107,7 @@ def concat_audio_mp3(
     for i, segment_data in enumerate(segments):
         try:
             # Load audio segment from bytes
-            segment_io = io.BytesIO(segment_data)
-            segment = AudioSegment.from_mp3(segment_io)
+            segment = _load_audio_segment(segment_data, input_format="mp3")
 
             if combined is None:
                 combined = segment
@@ -117,28 +150,105 @@ def concat_audio_mp3(
     return output_data
 
 
+def _concat_decodable_audio_segments(
+    segments: Sequence[bytes],
+    *,
+    input_format: str = "mp3",
+    output_format: str = "mp3",
+) -> bytes:
+    if not is_audio_processing_available():
+        return b""
+
+    combined = None
+    skipped_segments: list[int] = []
+
+    for index, segment_data in enumerate(segments):
+        if not segment_data:
+            skipped_segments.append(index)
+            continue
+        try:
+            segment = _load_audio_segment(segment_data, input_format=input_format)
+        except Exception as exc:
+            skipped_segments.append(index)
+            logger.warning(
+                "Skipping undecodable audio segment %s (%s bytes): %s",
+                index,
+                len(segment_data or b""),
+                exc,
+            )
+            continue
+
+        if combined is None:
+            combined = segment
+        else:
+            combined = combined.append(segment, crossfade=0)
+
+    if combined is None:
+        return b""
+
+    output_io = io.BytesIO()
+    combined.export(output_io, format=output_format, bitrate="128k")
+
+    if skipped_segments:
+        logger.warning(
+            "Audio fallback skipped undecodable segments: %s",
+            ", ".join(str(index) for index in skipped_segments),
+        )
+
+    return output_io.getvalue()
+
+
 def concat_audio_best_effort(
     segments: Sequence[bytes], output_format: str = "mp3"
 ) -> bytes:
     """
     Concatenate audio segments with graceful fallback when processing is unavailable.
 
-    Falls back to raw byte-join if pydub/ffmpeg are not available or fail.
+    Never raw-byte-joins multiple MP3 files. If normal concatenation fails, it
+    re-exports the decodable subset so callers upload a standalone audio file.
     """
     if not segments:
         return b""
     if len(segments) == 1:
-        return segments[0]
+        only_segment = segments[0] or b""
+        if not only_segment:
+            return b""
+        if (
+            is_audio_processing_available()
+            and try_get_audio_duration_ms(only_segment, format=output_format) is None
+        ):
+            logger.warning(
+                "Dropping undecodable single audio segment (%s bytes)",
+                len(only_segment),
+            )
+            return b""
+        return only_segment
 
     if is_audio_processing_available():
         try:
             return concat_audio_mp3(list(segments), output_format=output_format)
         except Exception as exc:
             logger.warning(
-                "Audio concatenation failed; falling back to byte-join: %s", exc
+                "Audio concatenation failed; re-exporting decodable segments: %s", exc
             )
+            fallback_audio = _concat_decodable_audio_segments(
+                segments,
+                input_format=output_format,
+                output_format=output_format,
+            )
+            if fallback_audio:
+                return fallback_audio
+            logger.warning("Audio fallback found no decodable segments")
+            return b""
 
-    return b"".join(segments)
+    first_segment = next((segment for segment in segments if segment), b"")
+    if len(segments) > 1 and first_segment:
+        logger.warning(
+            "Audio processing unavailable; using the first segment instead of raw "
+            "byte-joining %s segments",
+            len(segments),
+        )
+    return first_segment
 
 
 def export_audio_range_best_effort(
@@ -164,25 +274,26 @@ def export_audio_range_best_effort(
 
     if is_audio_processing_available():
         try:
-            audio_io = io.BytesIO(audio_data)
-            audio = AudioSegment.from_file(audio_io, format=input_format)
-            start = min(safe_start_ms, len(audio))
-            end = (
-                len(audio)
-                if safe_end_ms is None
-                else min(max(safe_end_ms, start), len(audio))
-            )
-            sliced = audio[start:end]
-            if len(sliced) <= 0:
-                return b"", 0
-            output_io = io.BytesIO()
-            sliced.export(output_io, format=output_format, bitrate="128k")
-            return output_io.getvalue(), len(sliced)
+            audio = _load_audio_segment(audio_data, input_format=input_format)
         except Exception as exc:
             logger.debug("Audio range export failed: %s", exc, exc_info=True)
+            return b"", 0
+
+        start = min(safe_start_ms, len(audio))
+        end = (
+            len(audio)
+            if safe_end_ms is None
+            else min(max(safe_end_ms, start), len(audio))
+        )
+        sliced = audio[start:end]
+        if len(sliced) <= 0:
+            return b"", 0
+        output_io = io.BytesIO()
+        sliced.export(output_io, format=output_format, bitrate="128k")
+        return output_io.getvalue(), len(sliced)
 
     if safe_start_ms == 0 and safe_end_ms is None:
-        return audio_data, get_audio_duration_ms(audio_data, format=input_format)
+        return audio_data, _estimated_duration_ms(audio_data)
     return b"", 0
 
 
@@ -197,16 +308,14 @@ def get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> int:
     Returns:
         Duration in milliseconds
     """
-    if not PYDUB_AVAILABLE:
-        # Rough estimate based on bitrate (128kbps for MP3)
-        # 128kbps = 16KB/s, so duration = size_bytes / 16000 * 1000
-        return int(len(audio_data) / 16000 * 1000)
+    duration_ms = try_get_audio_duration_ms(audio_data, format=format)
+    if duration_ms is not None:
+        return duration_ms
 
-    try:
-        audio_io = io.BytesIO(audio_data)
-        audio = AudioSegment.from_file(audio_io, format=format)
-        return len(audio)  # pydub returns duration in ms
-    except Exception as e:
-        logger.error(f"Error getting audio duration: {e}")
-        # Fallback to estimate
-        return int(len(audio_data) / 16000 * 1000)
+    logger.warning(
+        "Could not decode audio duration; falling back to bitrate estimate "
+        "(format=%s, bytes=%s)",
+        format,
+        len(audio_data or b""),
+    )
+    return _estimated_duration_ms(audio_data)

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -33,6 +33,7 @@ from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
     export_audio_range_best_effort,
     get_audio_duration_ms,
+    try_get_audio_duration_ms,
 )
 from flaskr.common.log import AppLoggerProxy
 from flaskr.service.tts.audio_record_utils import (
@@ -119,6 +120,14 @@ class TTSSegment:
     latency_ms: int = 0
     error: Optional[str] = None
     is_ready: bool = False
+
+
+@dataclass
+class _MinimaxFallbackAudio:
+    audio_data: bytes
+    duration_ms: int
+    word_count: int
+    audio_format: str
 
 
 class StreamingTTSProcessor:
@@ -1062,6 +1071,14 @@ class StreamingTTSProcessor:
 
         try:
             final_audio = concat_audio_best_effort(audio_data_list)
+            if not final_audio:
+                logger.warning(
+                    "No decodable audio data produced during TTS finalization. "
+                    "segments=%s, audio_bid=%s",
+                    len(audio_data_list),
+                    self._audio_bid,
+                )
+                return
             final_duration_ms = get_audio_duration_ms(final_audio)
             file_size = len(final_audio)
 
@@ -1140,6 +1157,57 @@ class StreamingTTSProcessor:
         except Exception as e:
             logger.error(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
 
+    def _synthesize_minimax_complete_fallback(
+        self,
+        provider: MinimaxTTSProvider,
+        *,
+        request_text: str,
+        request_format: str,
+        request_index: int,
+    ) -> Optional[_MinimaxFallbackAudio]:
+        try:
+            result = provider.synthesize(
+                text=request_text,
+                voice_settings=self.voice_settings,
+                audio_settings=self.audio_settings,
+                model=self.tts_model,
+            )
+        except Exception as exc:
+            logger.warning(
+                "MiniMax complete synthesis fallback failed. request_index=%s, "
+                "text_length=%s, error=%s",
+                request_index,
+                len(request_text or ""),
+                exc,
+            )
+            logger.debug("MiniMax complete synthesis fallback traceback", exc_info=True)
+            return None
+
+        audio_data = result.audio_data or b""
+        audio_format = (
+            result.format or request_format or self.audio_settings.format or "mp3"
+        )
+        decoded_duration_ms = try_get_audio_duration_ms(
+            audio_data,
+            format=audio_format,
+        )
+        if decoded_duration_ms is None or decoded_duration_ms <= 0:
+            logger.warning(
+                "MiniMax complete synthesis fallback returned undecodable audio. "
+                "request_index=%s, bytes=%s, format=%s",
+                request_index,
+                len(audio_data),
+                audio_format,
+            )
+            return None
+
+        return _MinimaxFallbackAudio(
+            audio_data=audio_data,
+            duration_ms=int(result.duration_ms or decoded_duration_ms or 0),
+            word_count=int(result.word_count or 0),
+            audio_format=audio_format,
+        )
+
     def _finalize_minimax_http_stream(
         self,
         *,
@@ -1170,6 +1238,7 @@ class StreamingTTSProcessor:
             request_format = self.audio_settings.format or "mp3"
             request_subtitles: list[dict[str, Any]] = []
             request_final_subtitle_cues: list[dict[str, Any]] = []
+            request_final_subtitle_cues_are_provider = False
             request_live_subtitle_cues: list[dict[str, Any]] = []
 
             for chunk in provider.stream_synthesize(
@@ -1209,10 +1278,12 @@ class StreamingTTSProcessor:
 
                 if chunk.is_final:
                     if request_duration_ms <= 0:
-                        request_duration_ms = get_audio_duration_ms(
+                        decoded_duration_ms = try_get_audio_duration_ms(
                             accumulated_audio,
                             format=request_format or "mp3",
                         )
+                        if decoded_duration_ms is not None:
+                            request_duration_ms = int(decoded_duration_ms or 0)
                     if progressive_request_subtitle_cues and (
                         self._subtitle_cues_cover_text(
                             progressive_request_subtitle_cues,
@@ -1220,6 +1291,7 @@ class StreamingTTSProcessor:
                         )
                     ):
                         request_final_subtitle_cues = progressive_request_subtitle_cues
+                        request_final_subtitle_cues_are_provider = True
                         target_end_ms = max(
                             request_subtitle_coverage_end_ms, source_emitted_ms
                         )
@@ -1278,11 +1350,25 @@ class StreamingTTSProcessor:
                     and source_emitted_ms == 0
                     and target_end_ms >= int(request_duration_ms or 0)
                 ):
-                    audio_piece = accumulated_audio
-                    piece_duration_ms = request_duration_ms or get_audio_duration_ms(
-                        audio_piece,
+                    decoded_duration_ms = try_get_audio_duration_ms(
+                        accumulated_audio,
                         format=request_format or "mp3",
                     )
+                    if decoded_duration_ms is not None and decoded_duration_ms > 0:
+                        audio_piece = accumulated_audio
+                        piece_duration_ms = int(
+                            request_duration_ms or decoded_duration_ms
+                        )
+                    else:
+                        logger.warning(
+                            "MiniMax HTTP stream produced undecodable final audio; "
+                            "will try complete synthesis fallback. request_index=%s, "
+                            "bytes=%s, format=%s, trace_id=%s",
+                            request_index,
+                            len(accumulated_audio or b""),
+                            request_format or "mp3",
+                            getattr(chunk, "trace_id", ""),
+                        )
 
                 if not audio_piece or piece_duration_ms <= 0:
                     continue
@@ -1309,6 +1395,19 @@ class StreamingTTSProcessor:
                 )
                 yield event
 
+            fallback_audio: Optional[_MinimaxFallbackAudio] = None
+            if live_request_emitted_ms <= 0:
+                fallback_audio = self._synthesize_minimax_complete_fallback(
+                    provider,
+                    request_text=request_text,
+                    request_format=request_format,
+                    request_index=request_index,
+                )
+                if fallback_audio is not None:
+                    request_duration_ms = int(fallback_audio.duration_ms or 0)
+                    if fallback_audio.word_count:
+                        request_word_count = int(fallback_audio.word_count or 0)
+
             if request_duration_ms <= 0:
                 request_duration_ms = source_emitted_ms or live_request_emitted_ms
             if request_word_count:
@@ -1323,6 +1422,7 @@ class StreamingTTSProcessor:
                     request_text,
                 ):
                     request_final_subtitle_cues = request_subtitle_cues
+                    request_final_subtitle_cues_are_provider = True
                 else:
                     if request_subtitle_cues:
                         logger.debug(
@@ -1343,6 +1443,37 @@ class StreamingTTSProcessor:
                             offset_ms=subtitle_offset_ms,
                         )
                     )
+            if (
+                fallback_audio is not None
+                and not request_final_subtitle_cues_are_provider
+            ):
+                request_final_subtitle_cues = (
+                    self._build_minimax_fallback_subtitle_cues(
+                        request_text,
+                        duration_ms=int(fallback_audio.duration_ms or 0),
+                        offset_ms=subtitle_offset_ms,
+                    )
+                )
+            if fallback_audio is not None and live_request_emitted_ms <= 0:
+                live_request_emitted_ms = int(fallback_audio.duration_ms or 0)
+                request_live_subtitle_cues = (
+                    self._build_minimax_live_request_subtitle_cues(
+                        request_final_subtitle_cues,
+                        provider_offset_ms=subtitle_offset_ms,
+                        live_offset_ms=live_offset_ms,
+                        live_request_end_ms=live_request_emitted_ms,
+                    )
+                )
+                progressive_subtitle_cues = normalize_subtitle_cues(
+                    list(live_subtitle_cues or []) + request_live_subtitle_cues
+                )
+                _segment_index, event = self._store_stream_audio_segment(
+                    audio_data=fallback_audio.audio_data,
+                    duration_ms=fallback_audio.duration_ms,
+                    text=request_text,
+                    subtitle_cues=progressive_subtitle_cues,
+                )
+                yield event
             final_subtitle_cues.extend(request_final_subtitle_cues)
             if not request_live_subtitle_cues and live_request_emitted_ms > 0:
                 request_live_subtitle_cues = (

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -28,6 +28,13 @@ class _FakeSegment:
             )
         return _FakeSegment(self.duration_ms + len(other) - crossfade)
 
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            start = int(key.start or 0)
+            stop = int(key.stop if key.stop is not None else self.duration_ms)
+            return _FakeSegment(max(stop - start, 0))
+        return self
+
     def export(self, output_io, format="mp3", bitrate="128k"):
         _ = (format, bitrate)
         output_io.write(f"duration={self.duration_ms}".encode("utf-8"))
@@ -81,7 +88,7 @@ def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch):
         audio_utils.concat_audio_mp3([b"100", b"BAD", b"80"])
 
 
-def test_concat_audio_best_effort_falls_back_to_byte_join_on_partial_failure(
+def test_concat_audio_best_effort_reexports_decodable_segments_on_partial_failure(
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -91,4 +98,44 @@ def test_concat_audio_best_effort_falls_back_to_byte_join_on_partial_failure(
 
     output = audio_utils.concat_audio_best_effort([b"100", b"BAD", b"80"])
 
-    assert output == b"100BAD80"
+    assert output == b"duration=180"
+
+
+def test_concat_audio_best_effort_drops_undecodable_single_segment(monkeypatch):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    output = audio_utils.concat_audio_best_effort([b"BAD"])
+
+    assert output == b""
+
+
+def test_concat_audio_best_effort_drops_undecodable_multiple_segments(monkeypatch):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    output = audio_utils.concat_audio_best_effort([b"BAD", b"BAD"])
+
+    assert output == b""
+
+
+def test_export_audio_range_does_not_return_invalid_bytes_after_decode_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
+    )
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
+
+    output, duration_ms = audio_utils.export_audio_range_best_effort(
+        b"BAD",
+        start_ms=0,
+        end_ms=None,
+    )
+
+    assert output == b""
+    assert duration_ms == 0

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -400,6 +400,130 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     ]
 
 
+def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
+    monkeypatch,
+):
+    from flaskr.service.learn.learn_dtos import GeneratedType
+    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
+
+    stream_calls = []
+    synthesize_calls = []
+
+    class _FakeMinimaxProvider:
+        def stream_synthesize(self, **kwargs):
+            stream_calls.append(kwargs["text"])
+            yield SimpleNamespace(
+                audio_data=b"broken-stream-mp3",
+                is_final=True,
+                duration_ms=0,
+                format="mp3",
+                word_count=0,
+                subtitles=[],
+                trace_id="trace-invalid-audio",
+            )
+
+        def synthesize(self, **kwargs):
+            synthesize_calls.append(kwargs["text"])
+            return SimpleNamespace(
+                audio_data=b"complete-mp3",
+                duration_ms=1200,
+                format="mp3",
+                word_count=12,
+            )
+
+    def _fake_try_get_duration(audio_data, format="mp3"):
+        _ = format
+        if audio_data == b"broken-stream-mp3":
+            return None
+        if audio_data == b"complete-mp3":
+            return 1200
+        return 1200
+
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.is_tts_configured", lambda _provider: True
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.should_use_minimax_http_stream",
+        lambda _provider: True,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.MinimaxTTSProvider", _FakeMinimaxProvider
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.export_audio_range_best_effort",
+        lambda _audio_data, **_kwargs: (b"", 0),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.try_get_audio_duration_ms",
+        _fake_try_get_duration,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
+        lambda parts, output_format="mp3": b"".join(parts),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
+        lambda _audio, format="mp3": 1200,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.build_completed_audio_record",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.streaming_tts.save_audio_record",
+        lambda _record, commit=True: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_handler.upload_audio_to_oss",
+        lambda _app, _audio, audio_bid: (f"https://example.com/{audio_bid}.mp3", "b"),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_usage_recorder.record_tts_aggregated_usage",
+        lambda **_kwargs: None,
+    )
+
+    processor = StreamingTTSProcessor(
+        app=SimpleNamespace(),
+        generated_block_bid="generated-http-stream-invalid-audio",
+        outline_bid="outline",
+        progress_record_bid="progress",
+        user_bid="user",
+        shifu_bid="shifu",
+        tts_provider="minimax",
+        tts_model="speech-2.8-turbo",
+    )
+    assert list(processor.process_chunk("First sentence. Second sentence.")) == []
+
+    events = list(processor.finalize(commit=False))
+    audio_segments = [
+        event for event in events if event.type == GeneratedType.AUDIO_SEGMENT
+    ]
+    audio_complete = [
+        event for event in events if event.type == GeneratedType.AUDIO_COMPLETE
+    ]
+
+    assert stream_calls == ["First sentence.\nSecond sentence."]
+    assert synthesize_calls == ["First sentence.\nSecond sentence."]
+    assert len(audio_segments) == 1
+    assert audio_segments[0].content.duration_ms == 1200
+    assert [cue.text for cue in audio_segments[0].content.subtitle_cues] == [
+        "First sentence.",
+        "Second sentence.",
+    ]
+    assert [
+        (cue.start_ms, cue.end_ms) for cue in audio_segments[0].content.subtitle_cues
+    ] == [
+        (0, 581),
+        (581, 1200),
+    ]
+    assert len(audio_complete) == 1
+    assert audio_complete[0].content.duration_ms == 1200
+
+
 def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitles(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- stop TTS audio assembly from raw-byte-joining MP3 files after concat/decode failures
- validate MiniMax HTTP stream bytes before duration probing or upload
- fall back to MiniMax complete synthesis when stream bytes are not decodable, and skip final upload if no decodable audio remains

## Root Cause
The deployed crossfade fix removed one concat failure, but the remaining RUN listen-mode path could still call duration probing on MiniMax HTTP stream bytes that were not a standalone MP3. The same utility layer also still had unsafe fallbacks that could pass invalid bytes forward after decoding failed.

Live evidence for the reported 2026-05-11 21:40:50 CST failure: shifu `0e7ca20063f0451cbd75f21c03e5ac92` is using TTS provider `minimax`, model `speech-2.8-turbo`, voice `audiobook_male_1`.

## Validation
- `pytest tests/service/tts -q`
- `pytest tests/service/learn/test_generated_block_tts_av_mode.py -q`
- `ruff check flaskr/service/tts/audio_utils.py flaskr/service/tts/streaming_tts.py tests/service/tts/test_audio_utils.py tests/service/tts/test_minimax_http_streaming.py`
- `ruff format --check flaskr/service/tts/audio_utils.py flaskr/service/tts/streaming_tts.py tests/service/tts/test_audio_utils.py tests/service/tts/test_minimax_http_streaming.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio concatenation to gracefully handle and skip undecodable audio segments instead of failing completely
  * Added automatic fallback synthesis path when streaming text-to-speech fails to produce usable audio during operation
  * Enhanced audio processing pipeline with more robust duration estimation capabilities and reliable fallback mechanisms when standard decoding methods are unavailable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1741)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->