### PR TITLE
fix: reactivate reused expired credit buckets

### DIFF
--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -80,7 +80,10 @@ from .subscriptions import (
     repair_topup_grant_expiries,
 )
 from .trials import backfill_missing_creator_trial_credits
-from .wallets import rebuild_credit_wallet_snapshots
+from .wallets import (
+    rebuild_credit_wallet_snapshots,
+    repair_credit_bucket_runtime_statuses,
+)
 
 _PRODUCT_TYPE_LABELS = {
     "custom": BILLING_PRODUCT_TYPE_CUSTOM,
@@ -443,6 +446,35 @@ def register_billing_commands(console) -> None:
             current_app,
             creator_bid=creator_bid,
             subscription_bid=subscription_bid,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="repair-bucket-status")
+    @click.option("--creator-bid", default="", help="Repair one creator.")
+    @click.option(
+        "--wallet-bucket-bid",
+        default="",
+        help="Repair one wallet bucket directly.",
+    )
+    @with_appcontext
+    def repair_bucket_status_command(
+        creator_bid: str,
+        wallet_bucket_bid: str,
+    ) -> None:
+        """Repair expired bucket rows that still carry live credits."""
+
+        if (
+            not str(creator_bid or "").strip()
+            and not str(wallet_bucket_bid or "").strip()
+        ):
+            raise click.ClickException(
+                "Pass --creator-bid or --wallet-bucket-bid for bucket status repair."
+            )
+
+        payload = repair_credit_bucket_runtime_statuses(
+            current_app,
+            creator_bid=creator_bid,
+            wallet_bucket_bid=wallet_bucket_bid,
         )
         _echo_payload(payload)
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -43,6 +43,7 @@ from .consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_BUCKET_STATUS_EXPIRED,
     CREDIT_BUCKET_STATUS_EXHAUSTED,
     CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
@@ -856,6 +857,14 @@ def _expire_credit_bucket_balance_for_transition(
     return available
 
 
+def _prepare_bucket_for_runtime_reuse(bucket: CreditWalletBucket) -> None:
+    """Allow an explicitly re-funded bucket to re-enter runtime status sync."""
+
+    current_status = int(bucket.status or 0)
+    if current_status == CREDIT_BUCKET_STATUS_EXPIRED:
+        bucket.status = CREDIT_BUCKET_STATUS_EXHAUSTED
+
+
 def _upsert_paid_order_credit_bucket(
     app: Flask,
     *,
@@ -935,6 +944,7 @@ def _upsert_paid_order_credit_bucket(
             bucket.effective_to = effective_to
 
     bucket.updated_at = now
+    _prepare_bucket_for_runtime_reuse(bucket)
     sync_credit_bucket_status(bucket)
     db.session.add(bucket)
     return bucket, reserve_grant
@@ -1009,6 +1019,7 @@ def _activate_reserved_subscription_grant_for_order(
         **_build_bucket_metadata_from_order(order),
     }
     bucket.updated_at = now
+    _prepare_bucket_for_runtime_reuse(bucket)
     sync_credit_bucket_status(bucket)
     db.session.add(bucket)
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -436,7 +436,9 @@ def repair_credit_bucket_runtime_statuses(
             CreditWalletBucket.status == CREDIT_BUCKET_STATUS_EXPIRED,
         )
         if normalized_creator_bid:
-            query = query.filter(CreditWalletBucket.creator_bid == normalized_creator_bid)
+            query = query.filter(
+                CreditWalletBucket.creator_bid == normalized_creator_bid
+            )
         if normalized_wallet_bucket_bid:
             query = query.filter(
                 CreditWalletBucket.wallet_bucket_bid == normalized_wallet_bucket_bid

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -419,6 +419,85 @@ def rebuild_credit_wallet_snapshots(
         )
 
 
+def repair_credit_bucket_runtime_statuses(
+    app: Flask,
+    *,
+    creator_bid: str = "",
+    wallet_bucket_bid: str = "",
+) -> dict[str, Any]:
+    """Repair buckets whose runtime status no longer matches their live balance."""
+
+    normalized_creator_bid = str(creator_bid or "").strip()
+    normalized_wallet_bucket_bid = str(wallet_bucket_bid or "").strip()
+    repaired_at = datetime.now()
+    with app.app_context():
+        query = CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.status == CREDIT_BUCKET_STATUS_EXPIRED,
+        )
+        if normalized_creator_bid:
+            query = query.filter(CreditWalletBucket.creator_bid == normalized_creator_bid)
+        if normalized_wallet_bucket_bid:
+            query = query.filter(
+                CreditWalletBucket.wallet_bucket_bid == normalized_wallet_bucket_bid
+            )
+        rows = query.order_by(
+            CreditWalletBucket.created_at.asc(),
+            CreditWalletBucket.id.asc(),
+        ).all()
+
+        buckets = [
+            row
+            for row in rows
+            if (
+                _to_decimal(row.available_credits) > _ZERO
+                or _to_decimal(row.reserved_credits) > _ZERO
+            )
+            and (row.effective_to is None or row.effective_to > repaired_at)
+        ]
+        if not buckets:
+            return {
+                "status": "noop",
+                "creator_bid": normalized_creator_bid or None,
+                "wallet_bucket_bid": normalized_wallet_bucket_bid or None,
+                "repaired_bucket_count": 0,
+                "repaired_bucket_bids": [],
+            }
+
+        wallets: dict[str, CreditWallet] = {}
+        repaired_bucket_bids: list[str] = []
+        for bucket in buckets:
+            bucket.status = CREDIT_BUCKET_STATUS_EXHAUSTED
+            sync_credit_bucket_status(bucket)
+            bucket.updated_at = repaired_at
+            db.session.add(bucket)
+            repaired_bucket_bids.append(bucket.wallet_bucket_bid)
+
+            wallet = wallets.get(bucket.wallet_bid)
+            if wallet is None:
+                wallet = _load_credit_wallet_by_wallet_bid(bucket.wallet_bid)
+                if wallet is not None:
+                    wallets[bucket.wallet_bid] = wallet
+
+        for wallet in wallets.values():
+            refresh_credit_wallet_snapshot(wallet)
+            persist_credit_wallet_snapshot(
+                wallet,
+                available_credits=wallet.available_credits,
+                reserved_credits=wallet.reserved_credits,
+                updated_at=repaired_at,
+            )
+
+        db.session.commit()
+        return {
+            "status": "repaired",
+            "creator_bid": normalized_creator_bid or None,
+            "wallet_bucket_bid": normalized_wallet_bucket_bid or None,
+            "repaired_bucket_count": len(repaired_bucket_bids),
+            "repaired_bucket_bids": repaired_bucket_bids,
+        }
+
+
 def grant_refund_return_credits(
     app: Flask,
     *,

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -287,7 +287,9 @@ def test_billing_repair_topup_expiry_cli_prints_helper_payload(
 def test_billing_repair_bucket_status_cli_requires_explicit_scope(
     billing_cli_runner,
 ) -> None:
-    result = billing_cli_runner.invoke(args=["console", "billing", "repair-bucket-status"])
+    result = billing_cli_runner.invoke(
+        args=["console", "billing", "repair-bucket-status"]
+    )
 
     assert result.exit_code != 0
     assert (

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -284,6 +284,47 @@ def test_billing_repair_topup_expiry_cli_prints_helper_payload(
     assert payload["kwargs"]["creator_bid"] == "creator-cli-1"
 
 
+def test_billing_repair_bucket_status_cli_requires_explicit_scope(
+    billing_cli_runner,
+) -> None:
+    result = billing_cli_runner.invoke(args=["console", "billing", "repair-bucket-status"])
+
+    assert result.exit_code != 0
+    assert (
+        "Pass --creator-bid or --wallet-bucket-bid for bucket status repair."
+        in result.output
+    )
+
+
+def test_billing_repair_bucket_status_cli_prints_helper_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.repair_credit_bucket_runtime_statuses",
+        lambda app, **kwargs: {
+            "status": "repaired",
+            "repaired_bucket_count": 1,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "repair-bucket-status",
+            "--wallet-bucket-bid",
+            "bucket-cli-1",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "repaired"
+    assert payload["kwargs"]["wallet_bucket_bid"] == "bucket-cli-1"
+
+
 def test_billing_repair_subscription_cycle_cli_requires_explicit_scope(
     billing_cli_runner,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -41,6 +41,7 @@ from flaskr.service.billing.wallets import (
     expire_credit_wallet_buckets,
     grant_manual_credit_wallet_balance,
     grant_refund_return_credits,
+    repair_credit_bucket_runtime_statuses,
     rebuild_credit_wallet_snapshots,
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
@@ -131,6 +132,66 @@ def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
         assert ledger.entry_type == CREDIT_LEDGER_ENTRY_TYPE_EXPIRE
         assert ledger.amount == Decimal("-2.5000000000")
         assert ledger.balance_after == Decimal("0E-10")
+
+
+def test_repair_credit_bucket_runtime_statuses_reactivates_live_expired_bucket(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    future_effective_to = datetime(2026, 6, 9, 23, 59, 59)
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-repair-runtime-1",
+            creator_bid="creator-repair-runtime-1",
+            available_credits=Decimal("5.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("105.0000000000"),
+            lifetime_consumed_credits=Decimal("9.8500000000"),
+            last_settled_usage_id=0,
+            version=0,
+            created_at=datetime(2026, 5, 11, 14, 11, 8),
+            updated_at=datetime(2026, 5, 11, 14, 11, 8),
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-repair-runtime-1",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid="creator-repair-runtime-1",
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="bill-repair-runtime-1",
+            priority=20,
+            original_credits=Decimal("105.0000000000"),
+            available_credits=Decimal("5.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("9.8500000000"),
+            expired_credits=Decimal("90.1500000000"),
+            effective_from=datetime(2026, 5, 11, 14, 11, 8),
+            effective_to=future_effective_to,
+            status=CREDIT_BUCKET_STATUS_EXPIRED,
+            metadata_json={},
+            created_at=datetime(2026, 5, 11, 14, 11, 8),
+            updated_at=datetime(2026, 5, 11, 14, 11, 8),
+        )
+        dao.db.session.add(wallet)
+        dao.db.session.add(bucket)
+        dao.db.session.commit()
+
+        payload = repair_credit_bucket_runtime_statuses(
+            billing_wallet_lifecycle_app,
+            creator_bid="creator-repair-runtime-1",
+        )
+
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-repair-runtime-1"
+        ).one()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-repair-runtime-1"
+        ).one()
+
+    assert payload["status"] == "repaired"
+    assert payload["repaired_bucket_count"] == 1
+    assert payload["repaired_bucket_bids"] == ["bucket-repair-runtime-1"]
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert wallet.available_credits == Decimal("5.0000000000")
 
 
 def test_grant_refund_return_credits_creates_subscription_bucket_and_refund_ledger(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -137,7 +137,7 @@ def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
 def test_repair_credit_bucket_runtime_statuses_reactivates_live_expired_bucket(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:
-    future_effective_to = datetime(2026, 6, 9, 23, 59, 59)
+    future_effective_to = datetime(2099, 6, 9, 23, 59, 59)
     with billing_wallet_lifecycle_app.app_context():
         wallet = CreditWallet(
             wallet_bid="wallet-repair-runtime-1",

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -18,6 +18,7 @@ from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_BUCKET_STATUS_EXPIRED,
     BILLING_ORDER_TYPE_TOPUP,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
     CREDIT_LEDGER_ENTRY_TYPE_REFUND,
@@ -2371,6 +2372,117 @@ class TestBillingWriteRoutes:
             assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
             assert subscription.current_period_start_at == bucket.effective_from
             assert subscription.current_period_end_at == bucket.effective_to
+
+    def test_paid_subscription_start_reactivates_reused_expired_bucket(
+        self, billing_write_client
+    ) -> None:
+        app = billing_write_client["app"]
+        paid_at = datetime(2026, 5, 11, 14, 11, 8)
+        expired_at = datetime(2026, 5, 5, 19, 22, 1)
+        renewed_end_at = datetime(2026, 6, 9, 23, 59, 59)
+
+        with app.app_context():
+            wallet = CreditWallet(
+                wallet_bid="wallet-reactivate-expired",
+                creator_bid="creator-1",
+                available_credits=Decimal("0"),
+                reserved_credits=Decimal("0"),
+                lifetime_granted_credits=Decimal("1000.0000000000"),
+                lifetime_consumed_credits=Decimal("9.8500000000"),
+                last_settled_usage_id=0,
+                version=0,
+                created_at=expired_at,
+                updated_at=expired_at,
+            )
+            subscription = BillingSubscription(
+                subscription_bid="sub-reactivate-expired",
+                creator_bid="creator-1",
+                product_bid="bill-product-plan-monthly",
+                status=BILLING_SUBSCRIPTION_STATUS_DRAFT,
+                billing_provider="pingxx",
+                provider_subscription_id="",
+                provider_customer_id="",
+                current_period_start_at=None,
+                current_period_end_at=None,
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={},
+                created_at=paid_at,
+                updated_at=paid_at,
+            )
+            expired_bucket = CreditWalletBucket(
+                wallet_bucket_bid="bucket-reactivate-expired",
+                wallet_bid=wallet.wallet_bid,
+                creator_bid="creator-1",
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                source_bid="bill-trial-expired-1",
+                priority=20,
+                original_credits=Decimal("1000.0000000000"),
+                available_credits=Decimal("0"),
+                reserved_credits=Decimal("0"),
+                consumed_credits=Decimal("9.8500000000"),
+                expired_credits=Decimal("990.1500000000"),
+                effective_from=datetime(2026, 4, 20, 19, 22, 1),
+                effective_to=expired_at,
+                status=CREDIT_BUCKET_STATUS_EXPIRED,
+                metadata_json={
+                    "bill_order_bid": "bill-trial-expired-1",
+                    "subscription_bid": "sub-trial-expired",
+                    "product_bid": BILLING_TRIAL_PRODUCT_BID,
+                    "payment_provider": "manual",
+                },
+                created_at=datetime(2026, 4, 20, 19, 22, 1),
+                updated_at=expired_at,
+            )
+            order = BillingOrder(
+                bill_order_bid="bill-reactivate-expired-1",
+                creator_bid="creator-1",
+                order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+                product_bid="bill-product-plan-monthly",
+                subscription_bid="sub-reactivate-expired",
+                currency="CNY",
+                payable_amount=990,
+                paid_amount=990,
+                payment_provider="pingxx",
+                channel="wx_pub_qr",
+                provider_reference_id="ch_reactivate_expired_1",
+                status=BILLING_ORDER_STATUS_PAID,
+                paid_at=paid_at,
+                metadata_json={},
+            )
+            dao.db.session.add(wallet)
+            dao.db.session.add(subscription)
+            dao.db.session.add(expired_bucket)
+            dao.db.session.add(order)
+            dao.db.session.flush()
+
+            granted = grant_paid_order_credits(app, order)
+            dao.db.session.commit()
+
+            wallet = CreditWallet.query.filter_by(creator_bid="creator-1").one()
+            bucket = CreditWalletBucket.query.filter_by(
+                wallet_bucket_bid="bucket-reactivate-expired"
+            ).one()
+            grant_entry = CreditLedgerEntry.query.filter_by(
+                creator_bid="creator-1",
+                source_bid="bill-reactivate-expired-1",
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            ).one()
+            subscription = BillingSubscription.query.filter_by(
+                subscription_bid="sub-reactivate-expired"
+            ).one()
+
+            assert granted is True
+            assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+            assert bucket.source_bid == "bill-reactivate-expired-1"
+            assert bucket.available_credits == Decimal("5.0000000000")
+            assert bucket.effective_from == paid_at
+            assert bucket.effective_to == renewed_end_at
+            assert wallet.available_credits == Decimal("5.0000000000")
+            assert grant_entry.wallet_bucket_bid == bucket.wallet_bucket_bid
+            assert grant_entry.amount == Decimal("5.0000000000")
+            assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
 
     def test_refund_paid_stripe_order_marks_order_refunded(
         self, billing_write_client

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -2379,9 +2379,11 @@ class TestBillingWriteRoutes:
         app = billing_write_client["app"]
         paid_at = datetime(2026, 5, 11, 14, 11, 8)
         expired_at = datetime(2026, 5, 5, 19, 22, 1)
-        renewed_end_at = datetime(2026, 6, 9, 23, 59, 59)
 
         with app.app_context():
+            product = BillingProduct.query.filter_by(
+                product_bid="bill-product-plan-monthly"
+            ).one()
             wallet = CreditWallet(
                 wallet_bid="wallet-reactivate-expired",
                 creator_bid="creator-1",
@@ -2478,7 +2480,10 @@ class TestBillingWriteRoutes:
             assert bucket.source_bid == "bill-reactivate-expired-1"
             assert bucket.available_credits == Decimal("5.0000000000")
             assert bucket.effective_from == paid_at
-            assert bucket.effective_to == renewed_end_at
+            assert bucket.effective_to == calculate_self_managed_billing_cycle_end(
+                product,
+                cycle_start_at=paid_at,
+            )
             assert wallet.available_credits == Decimal("5.0000000000")
             assert grant_entry.wallet_bucket_bid == bucket.wallet_bucket_bid
             assert grant_entry.amount == Decimal("5.0000000000")


### PR DESCRIPTION
Summary
- reactivate reused expired subscription credit buckets before runtime status sync
- add a billing CLI repair command for expired buckets that still carry live credits
- add regression coverage for both grant reuse and one-off repair flows

Test Plan
- cd src/api && pytest -q tests/service/billing/test_billing_write_routes.py -k "reactivates_reused_expired_bucket or existing_subscription_grant_realigns_future_dated_cycle_on_replay or paid_pingxx_renewal_before_cycle_start_keeps_current_period"
- cd src/api && pytest -q tests/service/billing/test_billing_wallet_lifecycle.py -k "repair_credit_bucket_runtime_statuses_reactivates_live_expired_bucket or expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger"
- cd src/api && pytest -q tests/service/billing/test_billing_cli.py -k "repair_bucket_status or repair_topup_expiry_cli_prints_helper_payload"
- cd src/api && pytest -q tests/service/billing/test_billing_admission.py -k "expired_topup_bucket_even_if_wallet_snapshot_positive"