### PR TITLE
feat: add operator order overview cards

### DIFF
--- a/src/api/flaskr/service/billing/api.py
+++ b/src/api/flaskr/service/billing/api.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from flaskr.service.billing.read_models import (
+    build_operator_credit_orders_overview,
     build_operator_credit_orders_page,
     get_operator_credit_order_detail,
 )
 
 __all__ = [
+    "build_operator_credit_orders_overview",
     "build_operator_credit_orders_page",
     "get_operator_credit_order_detail",
 ]

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -527,6 +527,19 @@ class OperatorCreditOrderDTO(BillingBaseDTO):
 
 
 @register_schema_to_swagger
+class OperatorCreditOrderOverviewDTO(BillingBaseDTO):
+    total_order_count: int = 0
+    paid_order_count: int = 0
+    pending_order_count: int = 0
+    refunded_order_count: int = 0
+    closed_order_count: int = 0
+    canceled_order_count: int = 0
+    credit_amount_total: int | float = 0
+    paid_amount_total: int = 0
+    currency: str = "CNY"
+
+
+@register_schema_to_swagger
 class OperatorCreditOrdersPageDTO(BillingBaseDTO):
     items: list[OperatorCreditOrderDTO]
     page: int

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -534,7 +534,7 @@ class OperatorCreditOrderOverviewDTO(BillingBaseDTO):
     refunded_order_count: int = 0
     closed_order_count: int = 0
     canceled_order_count: int = 0
-    credit_amount_total: int | float = 0
+    available_credit_total: int | float = 0
     paid_amount_total: int = 0
     currency: str = "CNY"
     paid_amount_totals_by_currency: dict[str, int] = Field(default_factory=dict)

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -537,6 +537,7 @@ class OperatorCreditOrderOverviewDTO(BillingBaseDTO):
     credit_amount_total: int | float = 0
     paid_amount_total: int = 0
     currency: str = "CNY"
+    paid_amount_totals_by_currency: dict[str, int] = Field(default_factory=dict)
 
 
 @register_schema_to_swagger

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1368,9 +1368,7 @@ def build_operator_credit_orders_overview(
             refunded_order_count=int(summary.refunded_order_count or 0),
             closed_order_count=int(summary.closed_order_count or 0),
             canceled_order_count=int(summary.canceled_order_count or 0),
-            available_credit_total=credit_decimal_to_number(
-                available_credit_total
-            ),
+            available_credit_total=credit_decimal_to_number(available_credit_total),
             paid_amount_total=paid_amount_total,
             currency=str(currency or ""),
             paid_amount_totals_by_currency=paid_amount_totals_by_currency,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1276,10 +1276,6 @@ def build_operator_credit_orders_overview(
         )
         summary = (
             BillingOrder.query.outerjoin(
-                BillingProduct,
-                BillingProduct.product_bid == BillingOrder.product_bid,
-            )
-            .outerjoin(
                 grant_totals_subquery,
                 grant_totals_subquery.c.source_bid == BillingOrder.bill_order_bid,
             )

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1259,27 +1259,8 @@ def build_operator_credit_orders_overview(
     """Return aggregate metrics for operator creator credit orders."""
 
     with app.app_context():
-        grant_totals_subquery = (
-            db.session.query(
-                CreditLedgerEntry.source_bid.label("source_bid"),
-                db.func.coalesce(
-                    db.func.sum(CreditLedgerEntry.amount),
-                    0,
-                ).label("granted_credits"),
-            )
-            .filter(
-                CreditLedgerEntry.deleted == 0,
-                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-            )
-            .group_by(CreditLedgerEntry.source_bid)
-            .subquery()
-        )
         summary = (
-            BillingOrder.query.outerjoin(
-                grant_totals_subquery,
-                grant_totals_subquery.c.source_bid == BillingOrder.bill_order_bid,
-            )
-            .with_entities(
+            BillingOrder.query.with_entities(
                 db.func.count(BillingOrder.id).label("total_order_count"),
                 db.func.coalesce(
                     db.func.sum(
@@ -1331,21 +1312,6 @@ def build_operator_credit_orders_overview(
                         case(
                             (
                                 BillingOrder.status == BILLING_ORDER_STATUS_PAID,
-                                db.func.coalesce(
-                                    grant_totals_subquery.c.granted_credits,
-                                    0,
-                                ),
-                            ),
-                            else_=0,
-                        )
-                    ),
-                    0,
-                ).label("credit_amount_total"),
-                db.func.coalesce(
-                    db.func.sum(
-                        case(
-                            (
-                                BillingOrder.status == BILLING_ORDER_STATUS_PAID,
                                 BillingOrder.paid_amount,
                             ),
                             else_=0,
@@ -1356,6 +1322,16 @@ def build_operator_credit_orders_overview(
             )
             .filter(BillingOrder.deleted == 0)
             .one()
+        )
+        available_credit_total = (
+            db.session.query(
+                db.func.coalesce(
+                    db.func.sum(CreditWallet.available_credits),
+                    0,
+                )
+            )
+            .filter(CreditWallet.deleted == 0)
+            .scalar()
         )
         paid_amount_rows = (
             db.session.query(
@@ -1392,7 +1368,9 @@ def build_operator_credit_orders_overview(
             refunded_order_count=int(summary.refunded_order_count or 0),
             closed_order_count=int(summary.closed_order_count or 0),
             canceled_order_count=int(summary.canceled_order_count or 0),
-            credit_amount_total=credit_decimal_to_number(summary.credit_amount_total),
+            available_credit_total=credit_decimal_to_number(
+                available_credit_total
+            ),
             paid_amount_total=paid_amount_total,
             currency=str(currency or ""),
             paid_amount_totals_by_currency=paid_amount_totals_by_currency,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1268,31 +1268,46 @@ def build_operator_credit_orders_overview(
                 db.func.count(BillingOrder.id).label("total_order_count"),
                 db.func.coalesce(
                     db.func.sum(
-                        case((BillingOrder.status == BILLING_ORDER_STATUS_PAID, 1), else_=0)
+                        case(
+                            (BillingOrder.status == BILLING_ORDER_STATUS_PAID, 1),
+                            else_=0,
+                        )
                     ),
                     0,
                 ).label("paid_order_count"),
                 db.func.coalesce(
                     db.func.sum(
-                        case((BillingOrder.status == BILLING_ORDER_STATUS_PENDING, 1), else_=0)
+                        case(
+                            (BillingOrder.status == BILLING_ORDER_STATUS_PENDING, 1),
+                            else_=0,
+                        )
                     ),
                     0,
                 ).label("pending_order_count"),
                 db.func.coalesce(
                     db.func.sum(
-                        case((BillingOrder.status == BILLING_ORDER_STATUS_REFUNDED, 1), else_=0)
+                        case(
+                            (BillingOrder.status == BILLING_ORDER_STATUS_REFUNDED, 1),
+                            else_=0,
+                        )
                     ),
                     0,
                 ).label("refunded_order_count"),
                 db.func.coalesce(
                     db.func.sum(
-                        case((BillingOrder.status == BILLING_ORDER_STATUS_TIMEOUT, 1), else_=0)
+                        case(
+                            (BillingOrder.status == BILLING_ORDER_STATUS_TIMEOUT, 1),
+                            else_=0,
+                        )
                     ),
                     0,
                 ).label("closed_order_count"),
                 db.func.coalesce(
                     db.func.sum(
-                        case((BillingOrder.status == BILLING_ORDER_STATUS_CANCELED, 1), else_=0)
+                        case(
+                            (BillingOrder.status == BILLING_ORDER_STATUS_CANCELED, 1),
+                            else_=0,
+                        )
                     ),
                     0,
                 ).label("canceled_order_count"),

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1138,6 +1138,7 @@ def build_operator_credit_orders_page(
     bill_order_bid: str = "",
     credit_order_kind: str = "",
     status: str = "",
+    has_available_credits: bool = False,
     payment_provider: str = "",
     start_time: Any = "",
     end_time: Any = "",
@@ -1191,6 +1192,17 @@ def build_operator_credit_orders_page(
 
         if status_code is not None:
             query = query.filter(BillingOrder.status == status_code)
+
+        if has_available_credits:
+            query = query.filter(
+                db.session.query(CreditWalletBucket.id)
+                .filter(
+                    CreditWalletBucket.deleted == 0,
+                    CreditWalletBucket.source_bid == BillingOrder.bill_order_bid,
+                    CreditWalletBucket.available_credits > 0,
+                )
+                .exists()
+            )
 
         if normalized_payment_provider:
             query = query.filter(

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1307,18 +1307,6 @@ def build_operator_credit_orders_overview(
                     ),
                     0,
                 ).label("canceled_order_count"),
-                db.func.coalesce(
-                    db.func.sum(
-                        case(
-                            (
-                                BillingOrder.status == BILLING_ORDER_STATUS_PAID,
-                                BillingOrder.paid_amount,
-                            ),
-                            else_=0,
-                        )
-                    ),
-                    0,
-                ).label("paid_amount_total"),
             )
             .filter(BillingOrder.deleted == 0)
             .one()

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -8,6 +8,7 @@ from typing import Any
 from flask import Flask
 from sqlalchemy import case, or_
 
+from flaskr.dao import db
 from flaskr.i18n import _ as translate
 from flaskr.i18n import get_current_language, set_language
 from flaskr.service.common.models import raise_error, raise_param_error
@@ -21,7 +22,9 @@ from .consts import (
     BILLING_DOMAIN_BINDING_STATUS_FAILED,
     BILLING_DOMAIN_BINDING_STATUS_PENDING,
     BILLING_DOMAIN_BINDING_STATUS_VERIFIED,
+    BILLING_ORDER_STATUS_CANCELED,
     BILLING_ORDER_STATUS_FAILED,
+    BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,
     BILLING_ORDER_STATUS_REFUNDED,
     BILLING_ORDER_STATUS_TIMEOUT,
@@ -60,6 +63,7 @@ from .dtos import (
     BillingOrdersPageDTO,
     BillingPlanDTO,
     OperatorCreditOrderDetailDTO,
+    OperatorCreditOrderOverviewDTO,
     OperatorCreditOrdersPageDTO,
     BillingSubscriptionsPageDTO,
     BillingTopupProductDTO,
@@ -1246,6 +1250,92 @@ def build_operator_credit_orders_page(
             page_count=payload.page_count,
             page_size=payload.page_size,
             total=payload.total,
+        )
+
+
+def build_operator_credit_orders_overview(
+    app: Flask,
+) -> OperatorCreditOrderOverviewDTO:
+    """Return aggregate metrics for operator creator credit orders."""
+
+    with app.app_context():
+        summary = (
+            BillingOrder.query.outerjoin(
+                BillingProduct,
+                BillingProduct.product_bid == BillingOrder.product_bid,
+            )
+            .with_entities(
+                db.func.count(BillingOrder.id).label("total_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((BillingOrder.status == BILLING_ORDER_STATUS_PAID, 1), else_=0)
+                    ),
+                    0,
+                ).label("paid_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((BillingOrder.status == BILLING_ORDER_STATUS_PENDING, 1), else_=0)
+                    ),
+                    0,
+                ).label("pending_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((BillingOrder.status == BILLING_ORDER_STATUS_REFUNDED, 1), else_=0)
+                    ),
+                    0,
+                ).label("refunded_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((BillingOrder.status == BILLING_ORDER_STATUS_TIMEOUT, 1), else_=0)
+                    ),
+                    0,
+                ).label("closed_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((BillingOrder.status == BILLING_ORDER_STATUS_CANCELED, 1), else_=0)
+                    ),
+                    0,
+                ).label("canceled_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case(
+                            (
+                                BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+                                db.func.coalesce(BillingProduct.credit_amount, 0),
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("credit_amount_total"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case(
+                            (
+                                BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+                                BillingOrder.paid_amount,
+                            ),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("paid_amount_total"),
+                db.func.max(BillingOrder.currency).label("currency"),
+            )
+            .filter(BillingOrder.deleted == 0)
+            .one()
+        )
+
+        return OperatorCreditOrderOverviewDTO(
+            total_order_count=int(summary.total_order_count or 0),
+            paid_order_count=int(summary.paid_order_count or 0),
+            pending_order_count=int(summary.pending_order_count or 0),
+            refunded_order_count=int(summary.refunded_order_count or 0),
+            closed_order_count=int(summary.closed_order_count or 0),
+            canceled_order_count=int(summary.canceled_order_count or 0),
+            credit_amount_total=credit_decimal_to_number(summary.credit_amount_total),
+            paid_amount_total=int(summary.paid_amount_total or 0),
+            currency=str(summary.currency or "CNY"),
         )
 
 

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1259,10 +1259,29 @@ def build_operator_credit_orders_overview(
     """Return aggregate metrics for operator creator credit orders."""
 
     with app.app_context():
+        grant_totals_subquery = (
+            db.session.query(
+                CreditLedgerEntry.source_bid.label("source_bid"),
+                db.func.coalesce(
+                    db.func.sum(CreditLedgerEntry.amount),
+                    0,
+                ).label("granted_credits"),
+            )
+            .filter(
+                CreditLedgerEntry.deleted == 0,
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            )
+            .group_by(CreditLedgerEntry.source_bid)
+            .subquery()
+        )
         summary = (
             BillingOrder.query.outerjoin(
                 BillingProduct,
                 BillingProduct.product_bid == BillingOrder.product_bid,
+            )
+            .outerjoin(
+                grant_totals_subquery,
+                grant_totals_subquery.c.source_bid == BillingOrder.bill_order_bid,
             )
             .with_entities(
                 db.func.count(BillingOrder.id).label("total_order_count"),
@@ -1316,7 +1335,10 @@ def build_operator_credit_orders_overview(
                         case(
                             (
                                 BillingOrder.status == BILLING_ORDER_STATUS_PAID,
-                                db.func.coalesce(BillingProduct.credit_amount, 0),
+                                db.func.coalesce(
+                                    grant_totals_subquery.c.granted_credits,
+                                    0,
+                                ),
                             ),
                             else_=0,
                         )
@@ -1335,11 +1357,37 @@ def build_operator_credit_orders_overview(
                     ),
                     0,
                 ).label("paid_amount_total"),
-                db.func.max(BillingOrder.currency).label("currency"),
             )
             .filter(BillingOrder.deleted == 0)
             .one()
         )
+        paid_amount_rows = (
+            db.session.query(
+                BillingOrder.currency.label("currency"),
+                db.func.coalesce(
+                    db.func.sum(BillingOrder.paid_amount),
+                    0,
+                ).label("paid_amount_total"),
+            )
+            .filter(
+                BillingOrder.deleted == 0,
+                BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+            )
+            .group_by(BillingOrder.currency)
+            .all()
+        )
+        paid_amount_totals_by_currency = {
+            str(row.currency or "CNY"): int(row.paid_amount_total or 0)
+            for row in paid_amount_rows
+        }
+        if len(paid_amount_totals_by_currency) == 1:
+            currency, paid_amount_total = next(
+                iter(paid_amount_totals_by_currency.items())
+            )
+        elif len(paid_amount_totals_by_currency) == 0:
+            currency, paid_amount_total = "CNY", 0
+        else:
+            currency, paid_amount_total = "", 0
 
         return OperatorCreditOrderOverviewDTO(
             total_order_count=int(summary.total_order_count or 0),
@@ -1349,8 +1397,9 @@ def build_operator_credit_orders_overview(
             closed_order_count=int(summary.closed_order_count or 0),
             canceled_order_count=int(summary.canceled_order_count or 0),
             credit_amount_total=credit_decimal_to_number(summary.credit_amount_total),
-            paid_amount_total=int(summary.paid_amount_total or 0),
-            currency=str(summary.currency or "CNY"),
+            paid_amount_total=paid_amount_total,
+            currency=str(currency or ""),
+            paid_amount_totals_by_currency=paid_amount_totals_by_currency,
         )
 
 

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, Dict, List, Optional
 
 from flask import Flask, current_app
+from sqlalchemy import case
 
 from flaskr.dao import db
 from flaskr.service.common.dtos import PageNationDTO
@@ -22,6 +23,7 @@ from flaskr.service.order.admin_dtos import (
     OrderAdminActivityDTO,
     OrderAdminCouponDTO,
     OrderAdminDetailDTO,
+    OrderAdminOverviewDTO,
     OrderAdminPaymentDTO,
     OrderAdminSummaryDTO,
 )
@@ -1003,6 +1005,59 @@ def list_operator_orders(
             for order in orders
         ]
         return PageNationDTO(page_index, page_size, total, items)
+
+
+def get_operator_order_overview(app: Flask) -> OrderAdminOverviewDTO:
+    """Return aggregate metrics for operator learning orders."""
+    with app.app_context():
+        summary = (
+            db.session.query(
+                db.func.count(Order.id).label("total_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((Order.status == ORDER_STATUS_SUCCESS, 1), else_=0)
+                    ),
+                    0,
+                ).label("paid_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((Order.status == ORDER_STATUS_TO_BE_PAID, 1), else_=0)
+                    ),
+                    0,
+                ).label("pending_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((Order.status == ORDER_STATUS_REFUND, 1), else_=0)
+                    ),
+                    0,
+                ).label("refunded_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case((Order.status == ORDER_STATUS_TIMEOUT, 1), else_=0)
+                    ),
+                    0,
+                ).label("closed_order_count"),
+                db.func.coalesce(
+                    db.func.sum(
+                        case(
+                            (Order.status == ORDER_STATUS_SUCCESS, Order.paid_price),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("paid_amount_total"),
+            )
+            .filter(Order.deleted == 0)
+            .one()
+        )
+        return OrderAdminOverviewDTO(
+            total_order_count=int(summary.total_order_count or 0),
+            paid_order_count=int(summary.paid_order_count or 0),
+            pending_order_count=int(summary.pending_order_count or 0),
+            refunded_order_count=int(summary.refunded_order_count or 0),
+            closed_order_count=int(summary.closed_order_count or 0),
+            paid_amount_total=_format_decimal(summary.paid_amount_total),
+        )
 
 
 def _load_order_activities(order_bid: str) -> List[OrderAdminActivityDTO]:

--- a/src/api/flaskr/service/order/admin_dtos.py
+++ b/src/api/flaskr/service/order/admin_dtos.py
@@ -8,6 +8,52 @@ from flaskr.common.swagger import register_schema_to_swagger
 
 
 @register_schema_to_swagger
+class OrderAdminOverviewDTO(BaseModel):
+    """Overview metrics shown above the operator learning order list."""
+
+    total_order_count: int = Field(
+        default=0,
+        description="Total visible order count",
+        required=False,
+    )
+    paid_order_count: int = Field(
+        default=0,
+        description="Visible paid order count",
+        required=False,
+    )
+    pending_order_count: int = Field(
+        default=0,
+        description="Visible pending order count",
+        required=False,
+    )
+    refunded_order_count: int = Field(
+        default=0,
+        description="Visible refunded order count",
+        required=False,
+    )
+    closed_order_count: int = Field(
+        default=0,
+        description="Visible closed order count",
+        required=False,
+    )
+    paid_amount_total: str = Field(
+        default="0",
+        description="Total paid amount for successful orders",
+        required=False,
+    )
+
+    def __json__(self):
+        return {
+            "total_order_count": self.total_order_count,
+            "paid_order_count": self.paid_order_count,
+            "pending_order_count": self.pending_order_count,
+            "refunded_order_count": self.refunded_order_count,
+            "closed_order_count": self.closed_order_count,
+            "paid_amount_total": self.paid_amount_total,
+        }
+
+
+@register_schema_to_swagger
 class OrderAdminSummaryDTO(BaseModel):
     """Summary information for an order in admin views."""
 

--- a/src/api/flaskr/service/order/api.py
+++ b/src/api/flaskr/service/order/api.py
@@ -6,6 +6,7 @@ from flaskr.service.order.admin import (
     _load_shifu_map,
     _load_user_map,
     get_operator_order_detail,
+    get_operator_order_overview,
     list_operator_orders,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "_load_shifu_map",
     "_load_user_map",
     "get_operator_order_detail",
+    "get_operator_order_overview",
     "list_operator_orders",
 ]

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -302,7 +302,7 @@ def _parse_boolean_query_param(
         return True
     if normalized in {"false", "0", "no"}:
         return False
-    raise_param_error(field_name)
+    raise_param_error(f"{field_name} is not a boolean")
 
 
 def _parse_positive_query_int(

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -285,6 +285,26 @@ def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | No
     raise_param_error("datetime format invalid")
 
 
+def _parse_boolean_query_param(
+    raw_value: object,
+    *,
+    field_name: str,
+    default: bool = False,
+) -> bool:
+    if raw_value is None:
+        return default
+    if isinstance(raw_value, bool):
+        return raw_value
+    normalized = str(raw_value).strip().lower()
+    if not normalized:
+        return default
+    if normalized in {"true", "1", "yes"}:
+        return True
+    if normalized in {"false", "0", "no"}:
+        return False
+    raise_param_error(field_name)
+
+
 def _parse_positive_query_int(
     raw_value: object,
     *,
@@ -921,6 +941,10 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             - name: payment_provider
               type: string
               required: false
+            - name: has_available_credits
+              type: boolean
+              required: false
+              description: Only include orders whose granted credits still have remaining balance
             - name: start_time
               type: string
               required: false
@@ -953,6 +977,10 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 bill_order_bid=request.args.get("bill_order_bid", ""),
                 credit_order_kind=request.args.get("credit_order_kind", ""),
                 status=request.args.get("status", ""),
+                has_available_credits=_parse_boolean_query_param(
+                    request.args.get("has_available_credits"),
+                    field_name="has_available_credits",
+                ),
                 payment_provider=request.args.get("payment_provider", ""),
                 start_time=_parse_datetime_filter(
                     request.args.get("start_time", ""),

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -57,6 +57,7 @@ from flaskr.framework.plugin.inject import inject
 from flaskr.service.common.models import raise_param_error, raise_error, ERROR_CODE
 from flaskr.service.billing.admission import admit_creator_usage
 from flaskr.service.billing.api import (
+    build_operator_credit_orders_overview,
     build_operator_credit_orders_page,
     get_operator_credit_order_detail,
 )
@@ -127,6 +128,7 @@ from flaskr.service.shifu.admin import (
 )
 from flaskr.service.order.api import (
     get_operator_order_detail,
+    get_operator_order_overview,
     list_operator_orders,
 )
 from flaskr.service.promo.api import (
@@ -835,6 +837,30 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             list_operator_orders(app, page_index, page_size, filters)
         )
 
+    @app.route(path_prefix + "/admin/operations/orders/overview", methods=["GET"])
+    def admin_operations_order_overview():
+        """
+        Operator learning order overview
+        ---
+        tags:
+            - Order
+        responses:
+            200:
+                description: Operator-visible learning order overview metrics
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                code:
+                                    type: integer
+                                message:
+                                    type: string
+                                data:
+                                    $ref: "#/components/schemas/OrderAdminOverviewDTO"
+        """
+        _require_operator()
+        return make_common_response(get_operator_order_overview(app))
+
     @app.route(
         path_prefix + "/admin/operations/orders/<order_bid>/detail",
         methods=["GET"],
@@ -938,6 +964,33 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 ),
             )
         )
+
+    @app.route(
+        path_prefix + "/admin/operations/orders/credits/overview",
+        methods=["GET"],
+    )
+    def admin_operations_credit_order_overview():
+        """
+        Operator credit order overview
+        ---
+        tags:
+            - Order
+        responses:
+            200:
+                description: Operator-visible credit order overview metrics
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                code:
+                                    type: integer
+                                message:
+                                    type: string
+                                data:
+                                    $ref: "#/components/schemas/OperatorCreditOrderOverviewDTO"
+        """
+        _require_operator()
+        return make_common_response(build_operator_credit_orders_overview(app))
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["GET"])
     def admin_operations_promotion_coupons():

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -253,6 +253,68 @@ def test_build_operator_credit_orders_overview_returns_aggregates():
     assert result.credit_amount_total == 20
     assert result.paid_amount_total == 19900
     assert result.currency == "CNY"
+    assert result.paid_amount_totals_by_currency == {"CNY": 19900}
+
+
+def test_build_operator_credit_orders_overview_uses_grant_amounts_and_currency_map():
+    app = _build_app()
+
+    with app.app_context():
+        product_ref = (
+            BillingProduct.query.filter(
+                BillingProduct.product_bid == "bill-product-topup-small"
+            )
+            .order_by(BillingProduct.id.desc())
+            .first()
+        )
+        assert product_ref is not None
+        product_ref.credit_amount = Decimal("999.0000000000")
+        product_ref.deleted = 1
+        dao.db.session.add(
+            BillingOrder(
+                bill_order_bid="bill-order-topup-usd-1",
+                creator_bid="creator-2",
+                order_type=BILLING_ORDER_TYPE_TOPUP,
+                product_bid="bill-product-topup-small",
+                subscription_bid="",
+                currency="USD",
+                payable_amount=2999,
+                paid_amount=2999,
+                payment_provider="stripe",
+                channel="checkout_session",
+                provider_reference_id="charge_topup_usd_1",
+                status=BILLING_ORDER_STATUS_PAID,
+                paid_at=datetime(2026, 4, 28, 10, 0, 0),
+                created_at=datetime(2026, 4, 28, 9, 0, 0),
+            )
+        )
+        dao.db.session.add(
+            CreditLedgerEntry(
+                ledger_bid="ledger-grant-topup-usd-1",
+                creator_bid="creator-2",
+                wallet_bid="wallet-2",
+                wallet_bucket_bid="bucket-2b",
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                source_bid="bill-order-topup-usd-1",
+                idempotency_key="grant:bill-order-topup-usd-1",
+                amount=Decimal("30.0000000000"),
+                balance_after=Decimal("22030.0000000000"),
+                consumable_from=datetime(2026, 4, 28, 10, 0, 0),
+                expires_at=datetime(2026, 5, 28, 10, 0, 0),
+            )
+        )
+        dao.db.session.commit()
+
+    result = build_operator_credit_orders_overview(app)
+
+    assert result.credit_amount_total == 50
+    assert result.paid_amount_total == 0
+    assert result.currency == ""
+    assert result.paid_amount_totals_by_currency == {
+        "CNY": 19900,
+        "USD": 2999,
+    }
 
 
 def test_get_operator_credit_order_detail_returns_grant_and_metadata():

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -12,6 +12,9 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_TOPUP,
+    CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+    CREDIT_BUCKET_CATEGORY_TOPUP,
+    CREDIT_BUCKET_STATUS_ACTIVE,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
     CREDIT_SOURCE_TYPE_SUBSCRIPTION,
     CREDIT_SOURCE_TYPE_TOPUP,
@@ -26,6 +29,7 @@ from flaskr.service.billing.models import (
     BillingProduct,
     CreditLedgerEntry,
     CreditWallet,
+    CreditWalletBucket,
 )
 from flaskr.service.billing.read_models import (
     build_operator_credit_orders_overview,
@@ -178,6 +182,44 @@ def _build_app() -> Flask:
                 ),
             ]
         )
+        dao.db.session.add_all(
+            [
+                CreditWalletBucket(
+                    wallet_bucket_bid="bucket-1",
+                    wallet_bid="wallet-1",
+                    creator_bid="creator-1",
+                    bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+                    source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                    source_bid="bill-order-topup-1",
+                    priority=10,
+                    original_credits=Decimal("20.0000000000"),
+                    available_credits=Decimal("20.0000000000"),
+                    reserved_credits=Decimal("0"),
+                    consumed_credits=Decimal("0"),
+                    expired_credits=Decimal("0"),
+                    effective_from=datetime(2026, 4, 27, 10, 0, 0),
+                    effective_to=datetime(2026, 5, 27, 10, 0, 0),
+                    status=CREDIT_BUCKET_STATUS_ACTIVE,
+                ),
+                CreditWalletBucket(
+                    wallet_bucket_bid="bucket-2",
+                    wallet_bid="wallet-2",
+                    creator_bid="creator-2",
+                    bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                    source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                    source_bid="bill-order-plan-1",
+                    priority=10,
+                    original_credits=Decimal("22000.0000000000"),
+                    available_credits=Decimal("0"),
+                    reserved_credits=Decimal("0"),
+                    consumed_credits=Decimal("22000.0000000000"),
+                    expired_credits=Decimal("0"),
+                    effective_from=datetime(2026, 4, 26, 10, 0, 0),
+                    effective_to=datetime(2027, 4, 26, 10, 0, 0),
+                    status=CREDIT_BUCKET_STATUS_ACTIVE,
+                ),
+            ]
+        )
         dao.db.session.commit()
     return app
 
@@ -213,6 +255,20 @@ def test_build_operator_credit_orders_page_supports_product_keyword_search():
     result = build_operator_credit_orders_page(
         app,
         product_keyword="20",
+        page_index=1,
+        page_size=20,
+    )
+
+    assert result.total == 1
+    assert result.items[0].bill_order_bid == "bill-order-topup-1"
+
+
+def test_build_operator_credit_orders_page_filters_orders_with_available_credits():
+    app = _build_app()
+
+    result = build_operator_credit_orders_page(
+        app,
+        has_available_credits=True,
         page_index=1,
         page_size=20,
     )

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -25,6 +25,7 @@ from flaskr.service.billing.models import (
     BillingOrder,
     BillingProduct,
     CreditLedgerEntry,
+    CreditWallet,
 )
 from flaskr.service.billing.read_models import (
     build_operator_credit_orders_overview,
@@ -157,6 +158,26 @@ def _build_app() -> Flask:
                 expires_at=datetime(2027, 4, 26, 10, 0, 0),
             )
         )
+        dao.db.session.add_all(
+            [
+                CreditWallet(
+                    wallet_bid="wallet-1",
+                    creator_bid="creator-1",
+                    available_credits=Decimal("20.0000000000"),
+                    reserved_credits=Decimal("0"),
+                    lifetime_granted_credits=Decimal("20.0000000000"),
+                    lifetime_consumed_credits=Decimal("0"),
+                ),
+                CreditWallet(
+                    wallet_bid="wallet-2",
+                    creator_bid="creator-2",
+                    available_credits=Decimal("0"),
+                    reserved_credits=Decimal("0"),
+                    lifetime_granted_credits=Decimal("0"),
+                    lifetime_consumed_credits=Decimal("0"),
+                ),
+            ]
+        )
         dao.db.session.commit()
     return app
 
@@ -250,13 +271,13 @@ def test_build_operator_credit_orders_overview_returns_aggregates():
     assert result.refunded_order_count == 0
     assert result.closed_order_count == 0
     assert result.canceled_order_count == 0
-    assert result.credit_amount_total == 20
+    assert result.available_credit_total == 20
     assert result.paid_amount_total == 19900
     assert result.currency == "CNY"
     assert result.paid_amount_totals_by_currency == {"CNY": 19900}
 
 
-def test_build_operator_credit_orders_overview_uses_grant_amounts_and_currency_map():
+def test_build_operator_credit_orders_overview_uses_available_credits_and_currency_map():
     app = _build_app()
 
     with app.app_context():
@@ -304,11 +325,16 @@ def test_build_operator_credit_orders_overview_uses_grant_amounts_and_currency_m
                 expires_at=datetime(2026, 5, 28, 10, 0, 0),
             )
         )
+        wallet = CreditWallet.query.filter(
+            CreditWallet.creator_bid == "creator-2"
+        ).one()
+        wallet.available_credits = Decimal("30.0000000000")
+        wallet.lifetime_granted_credits = Decimal("30.0000000000")
         dao.db.session.commit()
 
     result = build_operator_credit_orders_overview(app)
 
-    assert result.credit_amount_total == 50
+    assert result.available_credit_total == 50
     assert result.paid_amount_total == 0
     assert result.currency == ""
     assert result.paid_amount_totals_by_currency == {

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -18,6 +18,7 @@ from flaskr.service.billing.consts import (
 )
 from flaskr.service.billing.dtos import (
     OperatorCreditOrderDetailDTO,
+    OperatorCreditOrderOverviewDTO,
     OperatorCreditOrdersPageDTO,
 )
 from flaskr.service.billing.models import (
@@ -26,6 +27,7 @@ from flaskr.service.billing.models import (
     CreditLedgerEntry,
 )
 from flaskr.service.billing.read_models import (
+    build_operator_credit_orders_overview,
     build_operator_credit_orders_page,
     get_operator_credit_order_detail,
 )
@@ -234,6 +236,23 @@ def test_build_operator_credit_orders_page_keeps_orders_for_deleted_products():
     assert searched_result.total == 1
     assert searched_result.items[0].bill_order_bid == "bill-order-topup-1"
     assert searched_result.items[0].product_code == "creator-topup-small"
+
+
+def test_build_operator_credit_orders_overview_returns_aggregates():
+    app = _build_app()
+
+    result = build_operator_credit_orders_overview(app)
+
+    assert isinstance(result, OperatorCreditOrderOverviewDTO)
+    assert result.total_order_count == 2
+    assert result.paid_order_count == 1
+    assert result.pending_order_count == 0
+    assert result.refunded_order_count == 0
+    assert result.closed_order_count == 0
+    assert result.canceled_order_count == 0
+    assert result.credit_amount_total == 20
+    assert result.paid_amount_total == 19900
+    assert result.currency == "CNY"
 
 
 def test_get_operator_credit_order_detail_returns_grant_and_metadata():

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -525,6 +525,27 @@ def test_admin_operation_credit_orders_route_forwards_available_credit_filter(
     assert builder_mock.call_args.kwargs["has_available_credits"] is True
 
 
+def test_admin_operation_credit_orders_route_rejects_invalid_available_credit_filter(
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/orders/credits",
+        query_string={
+            "has_available_credits": "maybe",
+        },
+        headers={"Token": "test-token"},
+    )
+
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] != 0
+    assert "has_available_credits is not a boolean" in payload["message"]
+
+
 def test_admin_operation_credit_order_detail_route_returns_detail(
     test_client,
     monkeypatch,

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -491,6 +491,40 @@ def test_admin_operation_credit_orders_route_returns_operator_page(
     builder_mock.assert_called_once()
 
 
+def test_admin_operation_credit_orders_route_forwards_available_credit_filter(
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    expected = OperatorCreditOrdersPageDTO(
+        items=[],
+        page=1,
+        page_count=0,
+        page_size=20,
+        total=0,
+    )
+
+    with patch(
+        "flaskr.service.shifu.route.build_operator_credit_orders_page",
+        return_value=expected,
+    ) as builder_mock:
+        response = test_client.get(
+            "/api/shifu/admin/operations/orders/credits",
+            query_string={
+                "has_available_credits": "true",
+            },
+            headers={"Token": "test-token"},
+        )
+
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    builder_mock.assert_called_once()
+    assert builder_mock.call_args.kwargs["has_available_credits"] is True
+
+
 def test_admin_operation_credit_order_detail_route_returns_detail(
     test_client,
     monkeypatch,

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -19,12 +19,17 @@ from flaskr.service.order.admin import (
     _apply_order_source_filter,
     _load_matching_user_bids_for_keyword,
     get_operator_order_detail,
+    get_operator_order_overview,
     get_order_detail,
     list_operator_orders,
     list_orders,
     _resolve_order_source,
 )
-from flaskr.service.order.admin_dtos import OrderAdminDetailDTO, OrderAdminSummaryDTO
+from flaskr.service.order.admin_dtos import (
+    OrderAdminDetailDTO,
+    OrderAdminOverviewDTO,
+    OrderAdminSummaryDTO,
+)
 
 
 class DummyOrder:
@@ -282,6 +287,34 @@ def test_list_operator_orders_applies_order_source_filter():
         query_mock, ORDER_SOURCE_COUPON_REDEEM
     )
     assert isinstance(result, PageNationDTO)
+
+
+def test_get_operator_order_overview_returns_aggregates():
+    app = Flask(__name__)
+    summary = SimpleNamespace(
+        total_order_count=12,
+        paid_order_count=7,
+        pending_order_count=2,
+        refunded_order_count=1,
+        closed_order_count=2,
+        paid_amount_total="456.78",
+    )
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+    query_mock.one.return_value = summary
+
+    with patch("flaskr.service.order.admin.db") as db_mock:
+        db_mock.session.query.return_value = query_mock
+
+        result = get_operator_order_overview(app)
+
+    assert isinstance(result, OrderAdminOverviewDTO)
+    assert result.total_order_count == 12
+    assert result.paid_order_count == 7
+    assert result.pending_order_count == 2
+    assert result.refunded_order_count == 1
+    assert result.closed_order_count == 2
+    assert result.paid_amount_total == "456.78"
 
 
 def test_get_operator_order_detail_returns_detail_dto():

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -104,9 +104,12 @@ const api = {
   importActivationOrder: 'POST /order/admin/orders/import-activation',
   getAdminOperationUsersOverview: 'GET /shifu/admin/operations/users/overview',
   getAdminOperationUsers: 'GET /shifu/admin/operations/users',
+  getAdminOperationOrdersOverview: 'GET /shifu/admin/operations/orders/overview',
   getAdminOperationOrders: 'GET /shifu/admin/operations/orders',
   getAdminOperationOrderDetail:
     'GET /shifu/admin/operations/orders/{order_bid}/detail',
+  getAdminOperationCreditOrdersOverview:
+    'GET /shifu/admin/operations/orders/credits/overview',
   getAdminOperationCreditOrders: 'GET /shifu/admin/operations/orders/credits',
   getAdminOperationCreditOrderDetail:
     'GET /shifu/admin/operations/orders/credits/{bill_order_bid}/detail',

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -104,7 +104,8 @@ const api = {
   importActivationOrder: 'POST /order/admin/orders/import-activation',
   getAdminOperationUsersOverview: 'GET /shifu/admin/operations/users/overview',
   getAdminOperationUsers: 'GET /shifu/admin/operations/users',
-  getAdminOperationOrdersOverview: 'GET /shifu/admin/operations/orders/overview',
+  getAdminOperationOrdersOverview:
+    'GET /shifu/admin/operations/orders/overview',
   getAdminOperationOrders: 'GET /shifu/admin/operations/orders',
   getAdminOperationOrderDetail:
     'GET /shifu/admin/operations/orders/{order_bid}/detail',

--- a/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
@@ -56,6 +56,18 @@ export type AdminOperationCreditOrderListResponse = {
   total: number;
 };
 
+export type AdminOperationCreditOrderOverview = {
+  total_order_count: number;
+  paid_order_count: number;
+  pending_order_count: number;
+  refunded_order_count: number;
+  closed_order_count: number;
+  canceled_order_count: number;
+  credit_amount_total: number;
+  paid_amount_total: number;
+  currency: string;
+};
+
 export type AdminOperationCreditOrderDetailResponse = {
   order: AdminOperationCreditOrderItem;
   metadata: Record<string, unknown> | null;

--- a/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
@@ -66,6 +66,7 @@ export type AdminOperationCreditOrderOverview = {
   credit_amount_total: number;
   paid_amount_total: number;
   currency: string;
+  paid_amount_totals_by_currency: Record<string, number>;
 };
 
 export type AdminOperationCreditOrderDetailResponse = {

--- a/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-credit-order-types.ts
@@ -63,7 +63,7 @@ export type AdminOperationCreditOrderOverview = {
   refunded_order_count: number;
   closed_order_count: number;
   canceled_order_count: number;
-  credit_amount_total: number;
+  available_credit_total: number;
   paid_amount_total: number;
   currency: string;
   paid_amount_totals_by_currency: Record<string, number>;

--- a/src/cook-web/src/app/admin/operations/operation-order-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-order-types.ts
@@ -37,6 +37,15 @@ export type AdminOperationOrderListResponse = {
   total: number;
 };
 
+export type AdminOperationOrderOverview = {
+  total_order_count: number;
+  paid_order_count: number;
+  pending_order_count: number;
+  refunded_order_count: number;
+  closed_order_count: number;
+  paid_amount_total: string;
+};
+
 export type AdminOperationOrderActivity = {
   active_id: string;
   active_name: string;

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -208,9 +208,10 @@ describe('CreditOrdersTab', () => {
       refunded_order_count: 1,
       closed_order_count: 1,
       canceled_order_count: 1,
-      credit_amount_total: 5024,
+      available_credit_total: 5024,
       paid_amount_total: 819900,
       currency: 'CNY',
+      paid_amount_totals_by_currency: { CNY: 819900 },
     });
 
     mockGetAdminOperationCreditOrders.mockResolvedValue({

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -61,6 +61,7 @@ jest.mock('next/link', () => ({
 jest.mock('@/api', () => ({
   __esModule: true,
   default: {
+    getAdminOperationCreditOrdersOverview: jest.fn(),
     getAdminOperationCreditOrders: jest.fn(),
     getAdminOperationCreditOrderDetail: jest.fn(),
   },
@@ -188,15 +189,29 @@ jest.mock('@/components/ui/Sheet', () => ({
 
 const mockGetAdminOperationCreditOrders =
   api.getAdminOperationCreditOrders as jest.Mock;
+const mockGetAdminOperationCreditOrdersOverview =
+  api.getAdminOperationCreditOrdersOverview as jest.Mock;
 const mockGetAdminOperationCreditOrderDetail =
   api.getAdminOperationCreditOrderDetail as jest.Mock;
 
 describe('CreditOrdersTab', () => {
   beforeEach(() => {
+    mockGetAdminOperationCreditOrdersOverview.mockReset();
     mockGetAdminOperationCreditOrders.mockReset();
     mockGetAdminOperationCreditOrderDetail.mockReset();
     mockLanguage = 'en-US';
     window.localStorage.clear();
+    mockGetAdminOperationCreditOrdersOverview.mockResolvedValue({
+      total_order_count: 12,
+      paid_order_count: 7,
+      pending_order_count: 2,
+      refunded_order_count: 1,
+      closed_order_count: 1,
+      canceled_order_count: 1,
+      credit_amount_total: 5024,
+      paid_amount_total: 819900,
+      currency: 'CNY',
+    });
 
     mockGetAdminOperationCreditOrders.mockResolvedValue({
       items: [
@@ -319,6 +334,7 @@ describe('CreditOrdersTab', () => {
     render(<CreditOrdersTab />);
 
     await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrdersOverview).toHaveBeenCalledWith({});
       expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledWith({
         page_index: 1,
         page_size: 20,
@@ -339,6 +355,34 @@ describe('CreditOrdersTab', () => {
       screen.queryByText('module.billing.catalog.topups.default.title'),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('creator-topup-small')).not.toBeInTheDocument();
+  });
+
+  test('clicks overview card to switch credit order status filter', async () => {
+    render(<CreditOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsOrder.creditOrders.overview.metrics.pendingOrders',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        creator_keyword: '',
+        product_keyword: '',
+        credit_order_kind: '',
+        status: 'pending',
+        payment_provider: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
   });
 
   test('formats credit amounts and paid amounts without grouping in Chinese locale', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -361,34 +361,26 @@ describe('CreditOrdersTab', () => {
       screen.queryByText('module.billing.catalog.topups.default.title'),
     ).not.toBeInTheDocument();
     expect(screen.queryByText('creator-topup-small')).not.toBeInTheDocument();
-  });
-
-  test('clicks overview card to switch credit order status filter', async () => {
-    render(<CreditOrdersTab />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
-    });
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.pendingOrders\b/,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
-        page_index: 1,
-        page_size: 20,
-        creator_keyword: '',
-        product_keyword: '',
-        credit_order_kind: '',
-        status: 'pending',
-        payment_provider: '',
-        start_time: '',
-        end_time: '',
-      });
-    });
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.creditOrders.overview.metrics.pendingOrders',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.creditOrders.overview.metrics.refundedOrders',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.creditOrders.overview.metrics.closedOrders',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.creditOrders.overview.metrics.canceledOrders',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   test('activates and clears the paid overview card without refetching the default paid credit view', async () => {
@@ -466,6 +458,39 @@ describe('CreditOrdersTab', () => {
         product_keyword: '',
         credit_order_kind: '',
         status: 'paid',
+        payment_provider: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+  });
+
+  test('clicks available credits overview card to filter orders with remaining credits', async () => {
+    render(<CreditOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.creditAmount\b/,
+      }),
+    );
+
+    expect(
+      await screen.findByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        creator_keyword: '',
+        product_keyword: '',
+        credit_order_kind: '',
+        status: 'paid',
+        has_available_credits: true,
         payment_provider: '',
         start_time: '',
         end_time: '',

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -334,7 +334,9 @@ describe('CreditOrdersTab', () => {
     render(<CreditOrdersTab />);
 
     await waitFor(() => {
-      expect(mockGetAdminOperationCreditOrdersOverview).toHaveBeenCalledWith({});
+      expect(mockGetAdminOperationCreditOrdersOverview).toHaveBeenCalledWith(
+        {},
+      );
       expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledWith({
         page_index: 1,
         page_size: 20,

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -498,6 +498,56 @@ describe('CreditOrdersTab', () => {
     });
   });
 
+  test('preserves available credits quick filter when refining with search', async () => {
+    render(<CreditOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.creditAmount\b/,
+      }),
+    );
+
+    await screen.findByText('module.operationsOrder.overview.activeFilter');
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'module.operationsOrder.creditOrders.filters.creatorKeywordPlaceholderPhone',
+      ),
+      {
+        target: { value: '13800138000' },
+      },
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsOrder.filters.search',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        creator_keyword: '13800138000',
+        product_keyword: '',
+        credit_order_kind: '',
+        status: 'paid',
+        has_available_credits: true,
+        payment_provider: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+
+    expect(
+      screen.getByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+  });
+
   test('formats credit amounts and paid amounts without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';
 

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -351,6 +351,9 @@ describe('CreditOrdersTab', () => {
     });
 
     expect(await screen.findByText('bill-order-1')).toBeInTheDocument();
+    expect(
+      screen.queryByText('module.operationsOrder.overview.activeFilter'),
+    ).not.toBeInTheDocument();
     expect(screen.getByText('24-credit pack')).toBeInTheDocument();
     expect(await screen.findByText('Yearly - Advanced')).toBeInTheDocument();
     expect(
@@ -368,7 +371,7 @@ describe('CreditOrdersTab', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'module.operationsOrder.creditOrders.overview.metrics.pendingOrders',
+        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.pendingOrders\b/,
       }),
     );
 
@@ -385,6 +388,37 @@ describe('CreditOrdersTab', () => {
         end_time: '',
       });
     });
+  });
+
+  test('activates and clears the paid overview card without refetching the default paid credit view', async () => {
+    render(<CreditOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.paidOrders\b/,
+      }),
+    );
+
+    expect(
+      await screen.findByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+    expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+
+    const clearButtons = screen.getAllByRole('button', {
+      name: /module\.operationsOrder\.creditOrders\.overview\.metrics\.paidOrders/,
+    });
+    fireEvent.click(clearButtons[clearButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('module.operationsOrder.overview.activeFilter'),
+      ).not.toBeInTheDocument();
+    });
+    expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
   });
 
   test('formats credit amounts and paid amounts without grouping in Chinese locale', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -421,6 +421,57 @@ describe('CreditOrdersTab', () => {
     expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
   });
 
+  test('activates and clears the total overview card while restoring the default paid credit view', async () => {
+    render(<CreditOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.creditOrders\.overview\.metrics\.totalOrders\b/,
+      }),
+    );
+
+    expect(
+      await screen.findByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        creator_keyword: '',
+        product_keyword: '',
+        credit_order_kind: '',
+        status: '',
+        payment_provider: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+
+    const clearButtons = screen.getAllByRole('button', {
+      name: /module\.operationsOrder\.creditOrders\.overview\.metrics\.totalOrders/,
+    });
+    fireEvent.click(clearButtons[clearButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCreditOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        creator_keyword: '',
+        product_keyword: '',
+        credit_order_kind: '',
+        status: 'paid',
+        payment_provider: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+  });
+
   test('formats credit amounts and paid amounts without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';
 

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -170,9 +170,10 @@ export default function CreditOrdersTab() {
   const [expanded, setExpanded] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<ErrorState | null>(null);
-  const [overview, setOverview] = React.useState<AdminOperationCreditOrderOverview>(
-    EMPTY_CREDIT_ORDER_OVERVIEW,
-  );
+  const [overview, setOverview] =
+    React.useState<AdminOperationCreditOrderOverview>(
+      EMPTY_CREDIT_ORDER_OVERVIEW,
+    );
   const [overviewError, setOverviewError] = React.useState(false);
   const [activeOverviewStatus, setActiveOverviewStatus] = React.useState<
     string | null
@@ -219,8 +220,9 @@ export default function CreditOrdersTab() {
 
   const fetchOverview = React.useCallback(async () => {
     try {
-      const response =
-        (await api.getAdminOperationCreditOrdersOverview({})) as AdminOperationCreditOrderOverview;
+      const response = (await api.getAdminOperationCreditOrdersOverview(
+        {},
+      )) as AdminOperationCreditOrderOverview;
       setOverview({
         ...EMPTY_CREDIT_ORDER_OVERVIEW,
         ...response,
@@ -345,7 +347,9 @@ export default function CreditOrdersTab() {
         key: 'closed',
         label: tOperationsOrder('creditOrders.overview.metrics.closedOrders'),
         value: formatAdminCount(overview.closed_order_count, locale),
-        tooltip: tOperationsOrder('creditOrders.overview.tooltips.closedOrders'),
+        tooltip: tOperationsOrder(
+          'creditOrders.overview.tooltips.closedOrders',
+        ),
         status: 'timeout',
       },
       {
@@ -384,8 +388,8 @@ export default function CreditOrdersTab() {
   const activeOverviewCard = React.useMemo(
     () =>
       activeOverviewStatus
-        ? overviewCards.find(card => card.status === activeOverviewStatus) ??
-          null
+        ? (overviewCards.find(card => card.status === activeOverviewStatus) ??
+          null)
         : null,
     [activeOverviewStatus, overviewCards],
   );

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -35,10 +35,10 @@ import {
 } from '@/components/ui/Table';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import {
+  formatAdminCount,
   formatAdminCredits,
   formatAdminPrice,
 } from '@/app/admin/lib/numberFormat';
-import { formatAdminCount } from '@/lib/admin-number-format';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { resolveBillingOrderStatusLabel } from '@/lib/billing';

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -291,12 +291,12 @@ export default function CreditOrdersTab() {
       if (activeOverviewStatus === status) {
         return;
       }
-      const nextStatus = status || '';
+      const nextStatus = status;
       if (activeOverviewStatus === null) {
         setOverviewStatusBeforeApply(appliedFilters.status || null);
       }
       if (appliedFilters.status === nextStatus) {
-        setActiveOverviewStatus(nextStatus || null);
+        setActiveOverviewStatus(nextStatus);
         setDraftFilters(current =>
           current.status === nextStatus
             ? current
@@ -311,7 +311,7 @@ export default function CreditOrdersTab() {
         ...appliedFilters,
         status: nextStatus,
       };
-      setActiveOverviewStatus(nextStatus || null);
+      setActiveOverviewStatus(nextStatus);
       setDraftFilters(nextFilters);
       setAppliedFilters(nextFilters);
       setPageIndex(1);
@@ -447,7 +447,7 @@ export default function CreditOrdersTab() {
 
   const activeOverviewCard = React.useMemo(
     () =>
-      activeOverviewStatus
+      activeOverviewStatus !== null
         ? (overviewCards.find(card => card.status === activeOverviewStatus) ??
           null)
         : null,

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -38,6 +38,7 @@ import {
   formatAdminCredits,
   formatAdminPrice,
 } from '@/app/admin/lib/numberFormat';
+import { formatAdminCount } from '@/lib/admin-number-format';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { resolveBillingOrderStatusLabel } from '@/lib/billing';
@@ -56,7 +57,9 @@ import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
 import type {
   AdminOperationCreditOrderItem,
   AdminOperationCreditOrderListResponse,
+  AdminOperationCreditOrderOverview,
 } from '../operation-credit-order-types';
+import OrderOverviewSection from './OrderOverviewSection';
 import CreditOrderDetailDialog from './CreditOrderDetailDialog';
 import {
   ALL_OPTION_VALUE,
@@ -76,6 +79,13 @@ type CreditOrderFilters = {
 };
 
 type ErrorState = { message: string; code?: number };
+type OverviewCard = {
+  key: string;
+  label: string;
+  value: string;
+  tooltip: string;
+  status?: string;
+};
 
 const PAGE_SIZE = 20;
 const COLUMN_MIN_WIDTH = 90;
@@ -94,6 +104,18 @@ const DEFAULT_COLUMN_WIDTHS = {
   orderId: 220,
   action: 120,
 } as const;
+
+const EMPTY_CREDIT_ORDER_OVERVIEW: AdminOperationCreditOrderOverview = {
+  total_order_count: 0,
+  paid_order_count: 0,
+  pending_order_count: 0,
+  refunded_order_count: 0,
+  closed_order_count: 0,
+  canceled_order_count: 0,
+  credit_amount_total: 0,
+  paid_amount_total: 0,
+  currency: 'CNY',
+};
 
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
 
@@ -148,6 +170,13 @@ export default function CreditOrdersTab() {
   const [expanded, setExpanded] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<ErrorState | null>(null);
+  const [overview, setOverview] = React.useState<AdminOperationCreditOrderOverview>(
+    EMPTY_CREDIT_ORDER_OVERVIEW,
+  );
+  const [overviewError, setOverviewError] = React.useState(false);
+  const [activeOverviewStatus, setActiveOverviewStatus] = React.useState<
+    string | null
+  >(null);
   const [orders, setOrders] = React.useState<AdminOperationCreditOrderItem[]>(
     [],
   );
@@ -187,6 +216,21 @@ export default function CreditOrdersTab() {
       'creditOrders.filters.creatorKeywordPlaceholderPhone',
     );
   }, [contactType, tOperationsOrder]);
+
+  const fetchOverview = React.useCallback(async () => {
+    try {
+      const response =
+        (await api.getAdminOperationCreditOrdersOverview({})) as AdminOperationCreditOrderOverview;
+      setOverview({
+        ...EMPTY_CREDIT_ORDER_OVERVIEW,
+        ...response,
+      });
+      setOverviewError(false);
+    } catch {
+      setOverview(EMPTY_CREDIT_ORDER_OVERVIEW);
+      setOverviewError(true);
+    }
+  }, []);
 
   const fetchOrders = React.useCallback(
     async (targetPage: number, filters: CreditOrderFilters) => {
@@ -238,18 +282,124 @@ export default function CreditOrdersTab() {
     [t],
   );
 
+  const applyStatusQuickFilter = React.useCallback(
+    (status: string) => {
+      if (activeOverviewStatus === status) {
+        return;
+      }
+      const nextFilters = {
+        ...appliedFilters,
+        status,
+      };
+      setActiveOverviewStatus(status || null);
+      setDraftFilters(nextFilters);
+      setAppliedFilters(nextFilters);
+      setPageIndex(1);
+    },
+    [activeOverviewStatus, appliedFilters],
+  );
+
+  React.useEffect(() => {
+    void fetchOverview();
+  }, [fetchOverview]);
+
   React.useEffect(() => {
     void fetchOrders(1, appliedFilters);
   }, [appliedFilters, fetchOrders]);
 
+  const overviewCards = React.useMemo<OverviewCard[]>(
+    () => [
+      {
+        key: 'total',
+        label: tOperationsOrder('creditOrders.overview.metrics.totalOrders'),
+        value: formatAdminCount(overview.total_order_count, locale),
+        tooltip: tOperationsOrder('creditOrders.overview.tooltips.totalOrders'),
+        status: '',
+      },
+      {
+        key: 'paid',
+        label: tOperationsOrder('creditOrders.overview.metrics.paidOrders'),
+        value: formatAdminCount(overview.paid_order_count, locale),
+        tooltip: tOperationsOrder('creditOrders.overview.tooltips.paidOrders'),
+        status: 'paid',
+      },
+      {
+        key: 'pending',
+        label: tOperationsOrder('creditOrders.overview.metrics.pendingOrders'),
+        value: formatAdminCount(overview.pending_order_count, locale),
+        tooltip: tOperationsOrder(
+          'creditOrders.overview.tooltips.pendingOrders',
+        ),
+        status: 'pending',
+      },
+      {
+        key: 'refunded',
+        label: tOperationsOrder('creditOrders.overview.metrics.refundedOrders'),
+        value: formatAdminCount(overview.refunded_order_count, locale),
+        tooltip: tOperationsOrder(
+          'creditOrders.overview.tooltips.refundedOrders',
+        ),
+        status: 'refunded',
+      },
+      {
+        key: 'closed',
+        label: tOperationsOrder('creditOrders.overview.metrics.closedOrders'),
+        value: formatAdminCount(overview.closed_order_count, locale),
+        tooltip: tOperationsOrder('creditOrders.overview.tooltips.closedOrders'),
+        status: 'timeout',
+      },
+      {
+        key: 'canceled',
+        label: tOperationsOrder('creditOrders.overview.metrics.canceledOrders'),
+        value: formatAdminCount(overview.canceled_order_count, locale),
+        tooltip: tOperationsOrder(
+          'creditOrders.overview.tooltips.canceledOrders',
+        ),
+        status: 'canceled',
+      },
+      {
+        key: 'credit-amount',
+        label: tOperationsOrder('creditOrders.overview.metrics.creditAmount'),
+        value: tOperationsOrder('creditOrders.creditAmountValue', {
+          credits: formatAdminCredits(overview.credit_amount_total, locale),
+        }),
+        tooltip: tOperationsOrder(
+          'creditOrders.overview.tooltips.creditAmount',
+        ),
+      },
+      {
+        key: 'paid-amount',
+        label: tOperationsOrder('creditOrders.overview.metrics.paidAmount'),
+        value: formatAdminPrice(
+          overview.paid_amount_total,
+          overview.currency,
+          locale,
+        ),
+        tooltip: tOperationsOrder('creditOrders.overview.tooltips.paidAmount'),
+      },
+    ],
+    [locale, overview, tOperationsOrder],
+  );
+
+  const activeOverviewCard = React.useMemo(
+    () =>
+      activeOverviewStatus
+        ? overviewCards.find(card => card.status === activeOverviewStatus) ??
+          null
+        : null,
+    [activeOverviewStatus, overviewCards],
+  );
+
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
+    setActiveOverviewStatus(null);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
 
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
+    setActiveOverviewStatus(null);
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
@@ -483,6 +633,28 @@ export default function CreditOrdersTab() {
     <div className='h-full p-0'>
       <TooltipProvider delayDuration={150}>
         <div className='mx-auto flex h-full max-w-7xl flex-col overflow-hidden'>
+          <OrderOverviewSection
+            title={tOperationsOrder('overview.title')}
+            cards={overviewCards.map(card => ({
+              key: card.key,
+              label: card.label,
+              value: card.value,
+              tooltip: card.tooltip,
+              onClick:
+                'status' in card
+                  ? () => applyStatusQuickFilter(card.status ?? '')
+                  : undefined,
+            }))}
+            activeCardLabel={activeOverviewCard?.label ?? null}
+            activeFilterLabel={tOperationsOrder('overview.activeFilter')}
+            clearLabel={t('common.core.close')}
+            staleMessage={
+              overviewError ? tOperationsOrder('overview.staleData') : null
+            }
+            onClearActive={() => applyStatusQuickFilter('')}
+            gridClassName='min-[1680px]:grid-cols-4'
+          />
+
           <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm transition-all'>
             <div className='space-y-4'>
               <div

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -67,6 +67,7 @@ import {
   EMPTY_STATE_LABEL,
   renderTooltipText,
 } from './orderUiShared';
+import { useOverviewStatusQuickFilter } from './useOverviewStatusQuickFilter';
 
 type CreditOrderFilters = {
   creator_keyword: string;
@@ -176,11 +177,6 @@ export default function CreditOrdersTab() {
       EMPTY_CREDIT_ORDER_OVERVIEW,
     );
   const [overviewError, setOverviewError] = React.useState(false);
-  const [activeOverviewStatus, setActiveOverviewStatus] = React.useState<
-    string | null
-  >(null);
-  const [overviewStatusBeforeApply, setOverviewStatusBeforeApply] =
-    React.useState<string | null>(null);
   const [orders, setOrders] = React.useState<AdminOperationCreditOrderItem[]>(
     [],
   );
@@ -194,6 +190,17 @@ export default function CreditOrdersTab() {
   );
   const [appliedFilters, setAppliedFilters] =
     React.useState<CreditOrderFilters>(() => createDefaultFilters());
+  const {
+    activeOverviewStatus,
+    applyStatusQuickFilter,
+    clearOverviewQuickFilter,
+    resetOverviewQuickFilterState,
+  } = useOverviewStatusQuickFilter<CreditOrderFilters>({
+    appliedFilters,
+    setDraftFilters,
+    setAppliedFilters,
+    setPageIndex,
+  });
   const requestIdRef = React.useRef(0);
   const lastRequestedPageRef = React.useRef(1);
   const { getColumnStyle, getResizeHandleProps } =
@@ -285,65 +292,6 @@ export default function CreditOrdersTab() {
     },
     [t],
   );
-
-  const applyStatusQuickFilter = React.useCallback(
-    (status: string) => {
-      if (activeOverviewStatus === status) {
-        return;
-      }
-      const nextStatus = status;
-      if (activeOverviewStatus === null) {
-        setOverviewStatusBeforeApply(appliedFilters.status || null);
-      }
-      if (appliedFilters.status === nextStatus) {
-        setActiveOverviewStatus(nextStatus);
-        setDraftFilters(current =>
-          current.status === nextStatus
-            ? current
-            : {
-                ...current,
-                status: nextStatus,
-              },
-        );
-        return;
-      }
-      const nextFilters = {
-        ...appliedFilters,
-        status: nextStatus,
-      };
-      setActiveOverviewStatus(nextStatus);
-      setDraftFilters(nextFilters);
-      setAppliedFilters(nextFilters);
-      setPageIndex(1);
-    },
-    [activeOverviewStatus, appliedFilters],
-  );
-
-  const clearOverviewQuickFilter = React.useCallback(() => {
-    if (activeOverviewStatus === null) {
-      return;
-    }
-    const restoredStatus = overviewStatusBeforeApply ?? '';
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
-    setDraftFilters(current =>
-      current.status === restoredStatus
-        ? current
-        : {
-            ...current,
-            status: restoredStatus,
-          },
-    );
-    if (appliedFilters.status === restoredStatus) {
-      return;
-    }
-    const nextFilters = {
-      ...appliedFilters,
-      status: restoredStatus,
-    };
-    setAppliedFilters(nextFilters);
-    setPageIndex(1);
-  }, [activeOverviewStatus, appliedFilters, overviewStatusBeforeApply]);
 
   React.useEffect(() => {
     void fetchOverview();
@@ -456,16 +404,14 @@ export default function CreditOrdersTab() {
 
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
+    resetOverviewQuickFilterState();
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
 
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
+    resetOverviewQuickFilterState();
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -115,6 +115,7 @@ const EMPTY_CREDIT_ORDER_OVERVIEW: AdminOperationCreditOrderOverview = {
   credit_amount_total: 0,
   paid_amount_total: 0,
   currency: 'CNY',
+  paid_amount_totals_by_currency: {},
 };
 
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
@@ -178,6 +179,8 @@ export default function CreditOrdersTab() {
   const [activeOverviewStatus, setActiveOverviewStatus] = React.useState<
     string | null
   >(null);
+  const [overviewStatusBeforeApply, setOverviewStatusBeforeApply] =
+    React.useState<string | null>(null);
   const [orders, setOrders] = React.useState<AdminOperationCreditOrderItem[]>(
     [],
   );
@@ -229,7 +232,6 @@ export default function CreditOrdersTab() {
       });
       setOverviewError(false);
     } catch {
-      setOverview(EMPTY_CREDIT_ORDER_OVERVIEW);
       setOverviewError(true);
     }
   }, []);
@@ -289,17 +291,59 @@ export default function CreditOrdersTab() {
       if (activeOverviewStatus === status) {
         return;
       }
+      const nextStatus = status || '';
+      if (activeOverviewStatus === null) {
+        setOverviewStatusBeforeApply(appliedFilters.status || null);
+      }
+      if (appliedFilters.status === nextStatus) {
+        setActiveOverviewStatus(nextStatus || null);
+        setDraftFilters(current =>
+          current.status === nextStatus
+            ? current
+            : {
+                ...current,
+                status: nextStatus,
+              },
+        );
+        return;
+      }
       const nextFilters = {
         ...appliedFilters,
-        status,
+        status: nextStatus,
       };
-      setActiveOverviewStatus(status || null);
+      setActiveOverviewStatus(nextStatus || null);
       setDraftFilters(nextFilters);
       setAppliedFilters(nextFilters);
       setPageIndex(1);
     },
     [activeOverviewStatus, appliedFilters],
   );
+
+  const clearOverviewQuickFilter = React.useCallback(() => {
+    if (activeOverviewStatus === null) {
+      return;
+    }
+    const restoredStatus = overviewStatusBeforeApply ?? '';
+    setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
+    setDraftFilters(current =>
+      current.status === restoredStatus
+        ? current
+        : {
+            ...current,
+            status: restoredStatus,
+          },
+    );
+    if (appliedFilters.status === restoredStatus) {
+      return;
+    }
+    const nextFilters = {
+      ...appliedFilters,
+      status: restoredStatus,
+    };
+    setAppliedFilters(nextFilters);
+    setPageIndex(1);
+  }, [activeOverviewStatus, appliedFilters, overviewStatusBeforeApply]);
 
   React.useEffect(() => {
     void fetchOverview();
@@ -374,11 +418,27 @@ export default function CreditOrdersTab() {
       {
         key: 'paid-amount',
         label: tOperationsOrder('creditOrders.overview.metrics.paidAmount'),
-        value: formatAdminPrice(
-          overview.paid_amount_total,
-          overview.currency,
-          locale,
-        ),
+        value: (() => {
+          const paidAmountEntries = Object.entries(
+            overview.paid_amount_totals_by_currency || {},
+          );
+          if (paidAmountEntries.length > 1) {
+            return paidAmountEntries
+              .map(([currency, amount]) =>
+                formatAdminPrice(amount, currency, locale),
+              )
+              .join(' / ');
+          }
+          if (paidAmountEntries.length === 1) {
+            const [currency, amount] = paidAmountEntries[0];
+            return formatAdminPrice(amount, currency, locale);
+          }
+          return formatAdminPrice(
+            overview.paid_amount_total,
+            overview.currency,
+            locale,
+          );
+        })(),
         tooltip: tOperationsOrder('creditOrders.overview.tooltips.paidAmount'),
       },
     ],
@@ -397,6 +457,7 @@ export default function CreditOrdersTab() {
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
     setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
@@ -404,6 +465,7 @@ export default function CreditOrdersTab() {
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
     setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
@@ -655,7 +717,7 @@ export default function CreditOrdersTab() {
             staleMessage={
               overviewError ? tOperationsOrder('overview.staleData') : null
             }
-            onClearActive={() => applyStatusQuickFilter('')}
+            onClearActive={clearOverviewQuickFilter}
             gridClassName='min-[1680px]:grid-cols-4'
           />
 

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -448,14 +448,13 @@ export default function CreditOrdersTab() {
   );
 
   const handleSearch = () => {
-    const nextFilters = {
-      ...draftFilters,
-      has_available_credits:
-        activeOverviewCardKey === 'credit-amount'
-          ? false
-          : draftFilters.has_available_credits,
-    };
-    resetOverviewQuickFilterState();
+    const nextFilters = draftFilters;
+    const shouldPreserveOverviewQuickFilter =
+      activeOverviewCardKey === 'credit-amount' &&
+      nextFilters.has_available_credits;
+    if (!shouldPreserveOverviewQuickFilter) {
+      resetOverviewQuickFilterState();
+    }
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -112,7 +112,7 @@ const EMPTY_CREDIT_ORDER_OVERVIEW: AdminOperationCreditOrderOverview = {
   refunded_order_count: 0,
   closed_order_count: 0,
   canceled_order_count: 0,
-  credit_amount_total: 0,
+  available_credit_total: 0,
   paid_amount_total: 0,
   currency: 'CNY',
   paid_amount_totals_by_currency: {},
@@ -409,7 +409,7 @@ export default function CreditOrdersTab() {
         key: 'credit-amount',
         label: tOperationsOrder('creditOrders.overview.metrics.creditAmount'),
         value: tOperationsOrder('creditOrders.creditAmountValue', {
-          credits: formatAdminCredits(overview.credit_amount_total, locale),
+          credits: formatAdminCredits(overview.available_credit_total, locale),
         }),
         tooltip: tOperationsOrder(
           'creditOrders.overview.tooltips.creditAmount',

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -67,13 +67,13 @@ import {
   EMPTY_STATE_LABEL,
   renderTooltipText,
 } from './orderUiShared';
-import { useOverviewStatusQuickFilter } from './useOverviewStatusQuickFilter';
 
 type CreditOrderFilters = {
   creator_keyword: string;
   product_keyword: string;
   credit_order_kind: string;
   status: string;
+  has_available_credits: boolean;
   payment_provider: string;
   start_time: string;
   end_time: string;
@@ -85,7 +85,7 @@ type OverviewCard = {
   label: string;
   value: string;
   tooltip: string;
-  status?: string;
+  quickFilters?: Partial<CreditOrderFilters>;
 };
 
 const PAGE_SIZE = 20;
@@ -126,10 +126,24 @@ const createDefaultFilters = (): CreditOrderFilters => ({
   product_keyword: '',
   credit_order_kind: '',
   status: 'paid',
+  has_available_credits: false,
   payment_provider: '',
   start_time: '',
   end_time: '',
 });
+
+const areCreditOrderFiltersEqual = (
+  left: CreditOrderFilters,
+  right: CreditOrderFilters,
+): boolean =>
+  left.creator_keyword === right.creator_keyword &&
+  left.product_keyword === right.product_keyword &&
+  left.credit_order_kind === right.credit_order_kind &&
+  left.status === right.status &&
+  left.has_available_credits === right.has_available_credits &&
+  left.payment_provider === right.payment_provider &&
+  left.start_time === right.start_time &&
+  left.end_time === right.end_time;
 
 /**
  * t('module.operationsOrder.creditOrders.emptyList')
@@ -190,17 +204,11 @@ export default function CreditOrdersTab() {
   );
   const [appliedFilters, setAppliedFilters] =
     React.useState<CreditOrderFilters>(() => createDefaultFilters());
-  const {
-    activeOverviewStatus,
-    applyStatusQuickFilter,
-    clearOverviewQuickFilter,
-    resetOverviewQuickFilterState,
-  } = useOverviewStatusQuickFilter<CreditOrderFilters>({
-    appliedFilters,
-    setDraftFilters,
-    setAppliedFilters,
-    setPageIndex,
-  });
+  const [activeOverviewCardKey, setActiveOverviewCardKey] = React.useState<
+    string | null
+  >(null);
+  const [overviewFiltersBeforeApply, setOverviewFiltersBeforeApply] =
+    React.useState<CreditOrderFilters | null>(null);
   const requestIdRef = React.useRef(0);
   const lastRequestedPageRef = React.useRef(1);
   const { getColumnStyle, getResizeHandleProps } =
@@ -259,6 +267,9 @@ export default function CreditOrdersTab() {
           product_keyword: filters.product_keyword.trim(),
           credit_order_kind: filters.credit_order_kind,
           status: filters.status,
+          ...(filters.has_available_credits
+            ? { has_available_credits: true }
+            : {}),
           payment_provider: filters.payment_provider,
           start_time: filters.start_time,
           end_time: filters.end_time,
@@ -301,6 +312,66 @@ export default function CreditOrdersTab() {
     void fetchOrders(1, appliedFilters);
   }, [appliedFilters, fetchOrders]);
 
+  const resetOverviewQuickFilterState = React.useCallback(() => {
+    setActiveOverviewCardKey(null);
+    setOverviewFiltersBeforeApply(null);
+  }, []);
+
+  const applyOverviewQuickFilter = React.useCallback(
+    (cardKey: string, quickFilters: Partial<CreditOrderFilters>) => {
+      if (activeOverviewCardKey === cardKey) {
+        return;
+      }
+      const baselineFilters =
+        activeOverviewCardKey === null
+          ? appliedFilters
+          : overviewFiltersBeforeApply || appliedFilters;
+      if (activeOverviewCardKey === null) {
+        setOverviewFiltersBeforeApply(appliedFilters);
+      }
+      const nextFilters: CreditOrderFilters = {
+        ...baselineFilters,
+        ...quickFilters,
+      };
+      setActiveOverviewCardKey(cardKey);
+      setDraftFilters(current =>
+        areCreditOrderFiltersEqual(current, nextFilters)
+          ? current
+          : nextFilters,
+      );
+      if (areCreditOrderFiltersEqual(appliedFilters, nextFilters)) {
+        return;
+      }
+      setAppliedFilters(nextFilters);
+      setPageIndex(1);
+    },
+    [activeOverviewCardKey, appliedFilters, overviewFiltersBeforeApply],
+  );
+
+  const clearOverviewQuickFilter = React.useCallback(() => {
+    if (activeOverviewCardKey === null) {
+      return;
+    }
+    const restoredFilters =
+      overviewFiltersBeforeApply || createDefaultFilters();
+    resetOverviewQuickFilterState();
+    setDraftFilters(current =>
+      areCreditOrderFiltersEqual(current, restoredFilters)
+        ? current
+        : restoredFilters,
+    );
+    if (areCreditOrderFiltersEqual(appliedFilters, restoredFilters)) {
+      return;
+    }
+    setAppliedFilters(restoredFilters);
+    setPageIndex(1);
+  }, [
+    activeOverviewCardKey,
+    appliedFilters,
+    overviewFiltersBeforeApply,
+    resetOverviewQuickFilterState,
+  ]);
+
   const overviewCards = React.useMemo<OverviewCard[]>(
     () => [
       {
@@ -308,50 +379,20 @@ export default function CreditOrdersTab() {
         label: tOperationsOrder('creditOrders.overview.metrics.totalOrders'),
         value: formatAdminCount(overview.total_order_count, locale),
         tooltip: tOperationsOrder('creditOrders.overview.tooltips.totalOrders'),
-        status: '',
+        quickFilters: {
+          status: '',
+          has_available_credits: false,
+        },
       },
       {
         key: 'paid',
         label: tOperationsOrder('creditOrders.overview.metrics.paidOrders'),
         value: formatAdminCount(overview.paid_order_count, locale),
         tooltip: tOperationsOrder('creditOrders.overview.tooltips.paidOrders'),
-        status: 'paid',
-      },
-      {
-        key: 'pending',
-        label: tOperationsOrder('creditOrders.overview.metrics.pendingOrders'),
-        value: formatAdminCount(overview.pending_order_count, locale),
-        tooltip: tOperationsOrder(
-          'creditOrders.overview.tooltips.pendingOrders',
-        ),
-        status: 'pending',
-      },
-      {
-        key: 'refunded',
-        label: tOperationsOrder('creditOrders.overview.metrics.refundedOrders'),
-        value: formatAdminCount(overview.refunded_order_count, locale),
-        tooltip: tOperationsOrder(
-          'creditOrders.overview.tooltips.refundedOrders',
-        ),
-        status: 'refunded',
-      },
-      {
-        key: 'closed',
-        label: tOperationsOrder('creditOrders.overview.metrics.closedOrders'),
-        value: formatAdminCount(overview.closed_order_count, locale),
-        tooltip: tOperationsOrder(
-          'creditOrders.overview.tooltips.closedOrders',
-        ),
-        status: 'timeout',
-      },
-      {
-        key: 'canceled',
-        label: tOperationsOrder('creditOrders.overview.metrics.canceledOrders'),
-        value: formatAdminCount(overview.canceled_order_count, locale),
-        tooltip: tOperationsOrder(
-          'creditOrders.overview.tooltips.canceledOrders',
-        ),
-        status: 'canceled',
+        quickFilters: {
+          status: 'paid',
+          has_available_credits: false,
+        },
       },
       {
         key: 'credit-amount',
@@ -362,6 +403,10 @@ export default function CreditOrdersTab() {
         tooltip: tOperationsOrder(
           'creditOrders.overview.tooltips.creditAmount',
         ),
+        quickFilters: {
+          status: 'paid',
+          has_available_credits: true,
+        },
       },
       {
         key: 'paid-amount',
@@ -395,16 +440,23 @@ export default function CreditOrdersTab() {
 
   const activeOverviewCard = React.useMemo(
     () =>
-      activeOverviewStatus !== null
-        ? (overviewCards.find(card => card.status === activeOverviewStatus) ??
+      activeOverviewCardKey !== null
+        ? (overviewCards.find(card => card.key === activeOverviewCardKey) ??
           null)
         : null,
-    [activeOverviewStatus, overviewCards],
+    [activeOverviewCardKey, overviewCards],
   );
 
   const handleSearch = () => {
-    const nextFilters = { ...draftFilters };
+    const nextFilters = {
+      ...draftFilters,
+      has_available_credits:
+        activeOverviewCardKey === 'credit-amount'
+          ? false
+          : draftFilters.has_available_credits,
+    };
     resetOverviewQuickFilterState();
+    setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
@@ -652,10 +704,10 @@ export default function CreditOrdersTab() {
               label: card.label,
               value: card.value,
               tooltip: card.tooltip,
-              onClick:
-                'status' in card
-                  ? () => applyStatusQuickFilter(card.status ?? '')
-                  : undefined,
+              onClick: card.quickFilters
+                ? () =>
+                    applyOverviewQuickFilter(card.key, card.quickFilters || {})
+                : undefined,
             }))}
             activeCardLabel={activeOverviewCard?.label ?? null}
             activeFilterLabel={tOperationsOrder('overview.activeFilter')}

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -218,6 +218,9 @@ describe('LearnOrdersTab', () => {
 
     expect(await screen.findByText('order-1')).toBeInTheDocument();
     expect(
+      screen.queryByText('module.operationsOrder.overview.activeFilter'),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByText('module.operationsOrder.totalCount'),
     ).toBeInTheDocument();
   });
@@ -231,7 +234,7 @@ describe('LearnOrdersTab', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'module.operationsOrder.overview.metrics.pendingOrders',
+        name: /^module\.operationsOrder\.overview\.metrics\.pendingOrders\b/,
       }),
     );
 
@@ -250,6 +253,37 @@ describe('LearnOrdersTab', () => {
         end_time: '',
       });
     });
+  });
+
+  test('activates and clears the paid overview card without refetching the default paid view', async () => {
+    render(<LearnOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.overview\.metrics\.paidOrders\b/,
+      }),
+    );
+
+    expect(
+      await screen.findByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+    expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
+
+    const clearButtons = screen.getAllByRole('button', {
+      name: /module\.operationsOrder\.overview\.metrics\.paidOrders/,
+    });
+    fireEvent.click(clearButtons[clearButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('module.operationsOrder.overview.activeFilter'),
+      ).not.toBeInTheDocument();
+    });
+    expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
   });
 
   test('hydrates the course filter from the url query', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -41,6 +41,7 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/api', () => ({
   __esModule: true,
   default: {
+    getAdminOperationOrdersOverview: jest.fn(),
     getAdminOperationOrders: jest.fn(),
   },
 }));
@@ -147,12 +148,23 @@ jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
 }));
 
 const mockGetAdminOperationOrders = api.getAdminOperationOrders as jest.Mock;
+const mockGetAdminOperationOrdersOverview =
+  api.getAdminOperationOrdersOverview as jest.Mock;
 
 describe('LearnOrdersTab', () => {
   beforeEach(() => {
     mockSearchParamsValue = '';
+    mockGetAdminOperationOrdersOverview.mockReset();
     mockGetAdminOperationOrders.mockReset();
     window.localStorage.clear();
+    mockGetAdminOperationOrdersOverview.mockResolvedValue({
+      total_order_count: 10,
+      paid_order_count: 6,
+      pending_order_count: 2,
+      refunded_order_count: 1,
+      closed_order_count: 1,
+      paid_amount_total: '456.78',
+    });
     mockGetAdminOperationOrders.mockResolvedValue({
       items: [
         {
@@ -188,6 +200,7 @@ describe('LearnOrdersTab', () => {
     render(<LearnOrdersTab />);
 
     await waitFor(() => {
+      expect(mockGetAdminOperationOrdersOverview).toHaveBeenCalledWith({});
       expect(mockGetAdminOperationOrders).toHaveBeenCalledWith({
         page_index: 1,
         page_size: 20,
@@ -207,6 +220,36 @@ describe('LearnOrdersTab', () => {
     expect(
       screen.getByText('module.operationsOrder.totalCount'),
     ).toBeInTheDocument();
+  });
+
+  test('clicks overview card to switch status filter', async () => {
+    render(<LearnOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsOrder.overview.metrics.pendingOrders',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        user_keyword: '',
+        order_bid: '',
+        shifu_bid: '',
+        course_name: '',
+        status: '504',
+        order_source: '',
+        payment_channel: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
   });
 
   test('hydrates the course filter from the url query', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -223,36 +223,21 @@ describe('LearnOrdersTab', () => {
     expect(
       screen.getByText('module.operationsOrder.totalCount'),
     ).toBeInTheDocument();
-  });
-
-  test('clicks overview card to switch status filter', async () => {
-    render(<LearnOrdersTab />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
-    });
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: /^module\.operationsOrder\.overview\.metrics\.pendingOrders\b/,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationOrders).toHaveBeenLastCalledWith({
-        page_index: 1,
-        page_size: 20,
-        user_keyword: '',
-        order_bid: '',
-        shifu_bid: '',
-        course_name: '',
-        status: '504',
-        order_source: '',
-        payment_channel: '',
-        start_time: '',
-        end_time: '',
-      });
-    });
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.overview.metrics.pendingOrders',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.overview.metrics.refundedOrders',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'module.operationsOrder.overview.metrics.closedOrders',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   test('activates and clears the paid overview card without refetching the default paid view', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -286,6 +286,61 @@ describe('LearnOrdersTab', () => {
     expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
   });
 
+  test('activates and clears the total overview card while restoring the default paid view', async () => {
+    render(<LearnOrdersTab />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /^module\.operationsOrder\.overview\.metrics\.totalOrders\b/,
+      }),
+    );
+
+    expect(
+      await screen.findByText('module.operationsOrder.overview.activeFilter'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        user_keyword: '',
+        order_bid: '',
+        shifu_bid: '',
+        course_name: '',
+        status: '',
+        order_source: '',
+        payment_channel: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+
+    const clearButtons = screen.getAllByRole('button', {
+      name: /module\.operationsOrder\.overview\.metrics\.totalOrders/,
+    });
+    fireEvent.click(clearButtons[clearButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationOrders).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        user_keyword: '',
+        order_bid: '',
+        shifu_bid: '',
+        course_name: '',
+        status: '502',
+        order_source: '',
+        payment_channel: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+  });
+
   test('hydrates the course filter from the url query', async () => {
     mockSearchParamsValue = 'shifu_bid=course-1';
 

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -361,27 +361,6 @@ export default function LearnOrdersTab() {
         status: '502',
       },
       {
-        key: 'pending',
-        label: tOperationsOrder('overview.metrics.pendingOrders'),
-        value: formatAdminCount(overview.pending_order_count, locale),
-        tooltip: tOperationsOrder('overview.tooltips.pendingOrders'),
-        status: '504',
-      },
-      {
-        key: 'refunded',
-        label: tOperationsOrder('overview.metrics.refundedOrders'),
-        value: formatAdminCount(overview.refunded_order_count, locale),
-        tooltip: tOperationsOrder('overview.tooltips.refundedOrders'),
-        status: '503',
-      },
-      {
-        key: 'closed',
-        label: tOperationsOrder('overview.metrics.closedOrders'),
-        value: formatAdminCount(overview.closed_order_count, locale),
-        tooltip: tOperationsOrder('overview.tooltips.closedOrders'),
-        status: '505',
-      },
-      {
         key: 'paid-amount',
         label: tOperationsOrder('overview.metrics.paidAmount'),
         value: `${currencySymbol}${formatAdminNumber(
@@ -701,6 +680,7 @@ export default function LearnOrdersTab() {
               overviewError ? tOperationsOrder('overview.staleData') : null
             }
             onClearActive={clearOverviewQuickFilter}
+            gridClassName='xl:grid-cols-3 min-[1680px]:grid-cols-3'
           />
 
           <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm transition-all'>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -10,7 +10,10 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
-import { formatAdminCount, formatAdminNumber } from '@/lib/admin-number-format';
+import {
+  formatAdminCount,
+  formatAdminNumber,
+} from '@/app/admin/lib/numberFormat';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -10,6 +10,7 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount, formatAdminNumber } from '@/lib/admin-number-format';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -46,7 +47,9 @@ import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
 import type {
   AdminOperationOrderItem,
   AdminOperationOrderListResponse,
+  AdminOperationOrderOverview,
 } from '../operation-order-types';
+import OrderOverviewSection from './OrderOverviewSection';
 import OperatorOrderDetailSheet from './OperatorOrderDetailSheet';
 import {
   ALL_OPTION_VALUE,
@@ -68,6 +71,13 @@ type OrderFilters = {
 };
 
 type ErrorState = { message: string; code?: number };
+type OverviewCard = {
+  key: string;
+  label: string;
+  value: string;
+  tooltip: string;
+  status?: string;
+};
 
 const PAGE_SIZE = 20;
 const DEFAULT_ORDER_STATUS = '502';
@@ -87,6 +97,15 @@ const DEFAULT_COLUMN_WIDTHS = {
   source: 130,
   action: 120,
 } as const;
+
+const EMPTY_ORDER_OVERVIEW: AdminOperationOrderOverview = {
+  total_order_count: 0,
+  paid_order_count: 0,
+  pending_order_count: 0,
+  refunded_order_count: 0,
+  closed_order_count: 0,
+  paid_amount_total: '0',
+};
 
 type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
 
@@ -188,7 +207,8 @@ export default function LearnOrdersTab() {
     [defaultLoginMethod, loginMethodsEnabled],
   );
   const defaultUserName = useMemo(() => t('module.user.defaultUserName'), [t]);
-  const isEnglish = (i18n?.language || 'en-US').startsWith('en');
+  const locale = i18n?.language || 'en-US';
+  const isEnglish = locale.startsWith('en');
   const filterControlClassName = cn(
     'min-w-0 flex-1',
     isEnglish && 'xl:max-w-[220px]',
@@ -196,6 +216,12 @@ export default function LearnOrdersTab() {
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ErrorState | null>(null);
+  const [overview, setOverview] =
+    useState<AdminOperationOrderOverview>(EMPTY_ORDER_OVERVIEW);
+  const [overviewError, setOverviewError] = useState(false);
+  const [activeOverviewStatus, setActiveOverviewStatus] = useState<
+    string | null
+  >(null);
   const [orders, setOrders] = useState<AdminOperationOrderItem[]>([]);
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(0);
@@ -225,6 +251,21 @@ export default function LearnOrdersTab() {
     }
     return tOperationsOrder('filters.userKeywordPlaceholderPhone');
   }, [contactType, tOperationsOrder]);
+
+  const fetchOverview = useCallback(async () => {
+    try {
+      const response =
+        (await api.getAdminOperationOrdersOverview({})) as AdminOperationOrderOverview;
+      setOverview({
+        ...EMPTY_ORDER_OVERVIEW,
+        ...response,
+      });
+      setOverviewError(false);
+    } catch {
+      setOverview(EMPTY_ORDER_OVERVIEW);
+      setOverviewError(true);
+    }
+  }, []);
 
   const fetchOrders = useCallback(
     async (targetPage: number, filters: OrderFilters) => {
@@ -275,28 +316,111 @@ export default function LearnOrdersTab() {
     [t],
   );
 
+  const applyStatusQuickFilter = useCallback(
+    (status: string) => {
+      if (activeOverviewStatus === status) {
+        return;
+      }
+      const nextFilters = {
+        ...appliedFilters,
+        status,
+      };
+      setActiveOverviewStatus(status || null);
+      setDraftFilters(nextFilters);
+      setAppliedFilters(nextFilters);
+      setPageIndex(1);
+    },
+    [activeOverviewStatus, appliedFilters],
+  );
+
   React.useEffect(() => {
     if (areOrderFiltersEqual(initialFiltersRef.current, initialFilters)) {
       return;
     }
     initialFiltersRef.current = initialFilters;
+    setActiveOverviewStatus(null);
     setDraftFilters(initialFilters);
     setAppliedFilters(initialFilters);
     setPageIndex(1);
   }, [initialFilters]);
 
   React.useEffect(() => {
+    void fetchOverview();
+  }, [fetchOverview]);
+
+  React.useEffect(() => {
     void fetchOrders(1, appliedFilters);
   }, [appliedFilters, fetchOrders]);
 
+  const overviewCards = useMemo<OverviewCard[]>(
+    () => [
+      {
+        key: 'total',
+        label: tOperationsOrder('overview.metrics.totalOrders'),
+        value: formatAdminCount(overview.total_order_count, locale),
+        tooltip: tOperationsOrder('overview.tooltips.totalOrders'),
+        status: '',
+      },
+      {
+        key: 'paid',
+        label: tOperationsOrder('overview.metrics.paidOrders'),
+        value: formatAdminCount(overview.paid_order_count, locale),
+        tooltip: tOperationsOrder('overview.tooltips.paidOrders'),
+        status: '502',
+      },
+      {
+        key: 'pending',
+        label: tOperationsOrder('overview.metrics.pendingOrders'),
+        value: formatAdminCount(overview.pending_order_count, locale),
+        tooltip: tOperationsOrder('overview.tooltips.pendingOrders'),
+        status: '504',
+      },
+      {
+        key: 'refunded',
+        label: tOperationsOrder('overview.metrics.refundedOrders'),
+        value: formatAdminCount(overview.refunded_order_count, locale),
+        tooltip: tOperationsOrder('overview.tooltips.refundedOrders'),
+        status: '503',
+      },
+      {
+        key: 'closed',
+        label: tOperationsOrder('overview.metrics.closedOrders'),
+        value: formatAdminCount(overview.closed_order_count, locale),
+        tooltip: tOperationsOrder('overview.tooltips.closedOrders'),
+        status: '505',
+      },
+      {
+        key: 'paid-amount',
+        label: tOperationsOrder('overview.metrics.paidAmount'),
+        value: `${currencySymbol}${formatAdminNumber(
+          overview.paid_amount_total,
+          locale,
+        )}`,
+        tooltip: tOperationsOrder('overview.tooltips.paidAmount'),
+      },
+    ],
+    [currencySymbol, locale, overview, tOperationsOrder],
+  );
+
+  const activeOverviewCard = useMemo(
+    () =>
+      activeOverviewStatus
+        ? overviewCards.find(card => card.status === activeOverviewStatus) ??
+          null
+        : null,
+    [activeOverviewStatus, overviewCards],
+  );
+
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
+    setActiveOverviewStatus(null);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
 
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
+    setActiveOverviewStatus(null);
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
@@ -566,6 +690,27 @@ export default function LearnOrdersTab() {
     <div className='h-full p-0'>
       <TooltipProvider delayDuration={150}>
         <div className='mx-auto flex h-full max-w-7xl flex-col overflow-hidden'>
+          <OrderOverviewSection
+            title={tOperationsOrder('overview.title')}
+            cards={overviewCards.map(card => ({
+              key: card.key,
+              label: card.label,
+              value: card.value,
+              tooltip: card.tooltip,
+              onClick:
+                'status' in card
+                  ? () => applyStatusQuickFilter(card.status ?? '')
+                  : undefined,
+            }))}
+            activeCardLabel={activeOverviewCard?.label ?? null}
+            activeFilterLabel={tOperationsOrder('overview.activeFilter')}
+            clearLabel={t('common.core.close')}
+            staleMessage={
+              overviewError ? tOperationsOrder('overview.staleData') : null
+            }
+            onClearActive={() => applyStatusQuickFilter('')}
+          />
+
           <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm transition-all'>
             <div className='space-y-4'>
               <div

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -222,6 +222,9 @@ export default function LearnOrdersTab() {
   const [activeOverviewStatus, setActiveOverviewStatus] = useState<
     string | null
   >(null);
+  const [overviewStatusBeforeApply, setOverviewStatusBeforeApply] = useState<
+    string | null
+  >(null);
   const [orders, setOrders] = useState<AdminOperationOrderItem[]>([]);
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(0);
@@ -263,7 +266,6 @@ export default function LearnOrdersTab() {
       });
       setOverviewError(false);
     } catch {
-      setOverview(EMPTY_ORDER_OVERVIEW);
       setOverviewError(true);
     }
   }, []);
@@ -322,11 +324,27 @@ export default function LearnOrdersTab() {
       if (activeOverviewStatus === status) {
         return;
       }
+      const nextStatus = status || '';
+      if (activeOverviewStatus === null) {
+        setOverviewStatusBeforeApply(appliedFilters.status || null);
+      }
+      if (appliedFilters.status === nextStatus) {
+        setActiveOverviewStatus(nextStatus || null);
+        setDraftFilters(current =>
+          current.status === nextStatus
+            ? current
+            : {
+                ...current,
+                status: nextStatus,
+              },
+        );
+        return;
+      }
       const nextFilters = {
         ...appliedFilters,
-        status,
+        status: nextStatus,
       };
-      setActiveOverviewStatus(status || null);
+      setActiveOverviewStatus(nextStatus || null);
       setDraftFilters(nextFilters);
       setAppliedFilters(nextFilters);
       setPageIndex(1);
@@ -334,12 +352,39 @@ export default function LearnOrdersTab() {
     [activeOverviewStatus, appliedFilters],
   );
 
+  const clearOverviewQuickFilter = useCallback(() => {
+    if (activeOverviewStatus === null) {
+      return;
+    }
+    const restoredStatus = overviewStatusBeforeApply ?? '';
+    setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
+    setDraftFilters(current =>
+      current.status === restoredStatus
+        ? current
+        : {
+            ...current,
+            status: restoredStatus,
+          },
+    );
+    if (appliedFilters.status === restoredStatus) {
+      return;
+    }
+    const nextFilters = {
+      ...appliedFilters,
+      status: restoredStatus,
+    };
+    setAppliedFilters(nextFilters);
+    setPageIndex(1);
+  }, [activeOverviewStatus, appliedFilters, overviewStatusBeforeApply]);
+
   React.useEffect(() => {
     if (areOrderFiltersEqual(initialFiltersRef.current, initialFilters)) {
       return;
     }
     initialFiltersRef.current = initialFilters;
     setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
     setDraftFilters(initialFilters);
     setAppliedFilters(initialFilters);
     setPageIndex(1);
@@ -415,6 +460,7 @@ export default function LearnOrdersTab() {
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
     setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
@@ -422,6 +468,7 @@ export default function LearnOrdersTab() {
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
     setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);
@@ -709,7 +756,7 @@ export default function LearnOrdersTab() {
             staleMessage={
               overviewError ? tOperationsOrder('overview.staleData') : null
             }
-            onClearActive={() => applyStatusQuickFilter('')}
+            onClearActive={clearOverviewQuickFilter}
           />
 
           <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm transition-all'>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -254,8 +254,9 @@ export default function LearnOrdersTab() {
 
   const fetchOverview = useCallback(async () => {
     try {
-      const response =
-        (await api.getAdminOperationOrdersOverview({})) as AdminOperationOrderOverview;
+      const response = (await api.getAdminOperationOrdersOverview(
+        {},
+      )) as AdminOperationOrderOverview;
       setOverview({
         ...EMPTY_ORDER_OVERVIEW,
         ...response,
@@ -405,8 +406,8 @@ export default function LearnOrdersTab() {
   const activeOverviewCard = useMemo(
     () =>
       activeOverviewStatus
-        ? overviewCards.find(card => card.status === activeOverviewStatus) ??
-          null
+        ? (overviewCards.find(card => card.status === activeOverviewStatus) ??
+          null)
         : null,
     [activeOverviewStatus, overviewCards],
   );

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -57,6 +57,7 @@ import {
   EMPTY_STATE_LABEL,
   renderTooltipText,
 } from './orderUiShared';
+import { useOverviewStatusQuickFilter } from './useOverviewStatusQuickFilter';
 
 type OrderFilters = {
   user_keyword: string;
@@ -219,12 +220,6 @@ export default function LearnOrdersTab() {
   const [overview, setOverview] =
     useState<AdminOperationOrderOverview>(EMPTY_ORDER_OVERVIEW);
   const [overviewError, setOverviewError] = useState(false);
-  const [activeOverviewStatus, setActiveOverviewStatus] = useState<
-    string | null
-  >(null);
-  const [overviewStatusBeforeApply, setOverviewStatusBeforeApply] = useState<
-    string | null
-  >(null);
   const [orders, setOrders] = useState<AdminOperationOrderItem[]>([]);
   const [pageIndex, setPageIndex] = useState(1);
   const [pageCount, setPageCount] = useState(0);
@@ -237,6 +232,17 @@ export default function LearnOrdersTab() {
   const [appliedFilters, setAppliedFilters] = useState<OrderFilters>(
     () => initialFilters,
   );
+  const {
+    activeOverviewStatus,
+    applyStatusQuickFilter,
+    clearOverviewQuickFilter,
+    resetOverviewQuickFilterState,
+  } = useOverviewStatusQuickFilter<OrderFilters>({
+    appliedFilters,
+    setDraftFilters,
+    setAppliedFilters,
+    setPageIndex,
+  });
   const requestIdRef = useRef(0);
   const lastRequestedPageRef = useRef(1);
   const initialFiltersRef = useRef(initialFilters);
@@ -319,76 +325,16 @@ export default function LearnOrdersTab() {
     [t],
   );
 
-  const applyStatusQuickFilter = useCallback(
-    (status: string) => {
-      if (activeOverviewStatus === status) {
-        return;
-      }
-      const nextStatus = status;
-      if (activeOverviewStatus === null) {
-        setOverviewStatusBeforeApply(appliedFilters.status || null);
-      }
-      if (appliedFilters.status === nextStatus) {
-        setActiveOverviewStatus(nextStatus);
-        setDraftFilters(current =>
-          current.status === nextStatus
-            ? current
-            : {
-                ...current,
-                status: nextStatus,
-              },
-        );
-        return;
-      }
-      const nextFilters = {
-        ...appliedFilters,
-        status: nextStatus,
-      };
-      setActiveOverviewStatus(nextStatus);
-      setDraftFilters(nextFilters);
-      setAppliedFilters(nextFilters);
-      setPageIndex(1);
-    },
-    [activeOverviewStatus, appliedFilters],
-  );
-
-  const clearOverviewQuickFilter = useCallback(() => {
-    if (activeOverviewStatus === null) {
-      return;
-    }
-    const restoredStatus = overviewStatusBeforeApply ?? '';
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
-    setDraftFilters(current =>
-      current.status === restoredStatus
-        ? current
-        : {
-            ...current,
-            status: restoredStatus,
-          },
-    );
-    if (appliedFilters.status === restoredStatus) {
-      return;
-    }
-    const nextFilters = {
-      ...appliedFilters,
-      status: restoredStatus,
-    };
-    setAppliedFilters(nextFilters);
-    setPageIndex(1);
-  }, [activeOverviewStatus, appliedFilters, overviewStatusBeforeApply]);
-
   React.useEffect(() => {
     if (areOrderFiltersEqual(initialFiltersRef.current, initialFilters)) {
       return;
     }
     initialFiltersRef.current = initialFilters;
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
+    resetOverviewQuickFilterState();
     setDraftFilters(initialFilters);
     setAppliedFilters(initialFilters);
     setPageIndex(1);
-  }, [initialFilters]);
+  }, [initialFilters, resetOverviewQuickFilterState]);
 
   React.useEffect(() => {
     void fetchOverview();
@@ -459,16 +405,14 @@ export default function LearnOrdersTab() {
 
   const handleSearch = () => {
     const nextFilters = { ...draftFilters };
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
+    resetOverviewQuickFilterState();
     setAppliedFilters(nextFilters);
     setPageIndex(1);
   };
 
   const handleReset = () => {
     const nextFilters = createDefaultFilters();
-    setActiveOverviewStatus(null);
-    setOverviewStatusBeforeApply(null);
+    resetOverviewQuickFilterState();
     setDraftFilters(nextFilters);
     setAppliedFilters(nextFilters);
     setPageIndex(1);

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -324,12 +324,12 @@ export default function LearnOrdersTab() {
       if (activeOverviewStatus === status) {
         return;
       }
-      const nextStatus = status || '';
+      const nextStatus = status;
       if (activeOverviewStatus === null) {
         setOverviewStatusBeforeApply(appliedFilters.status || null);
       }
       if (appliedFilters.status === nextStatus) {
-        setActiveOverviewStatus(nextStatus || null);
+        setActiveOverviewStatus(nextStatus);
         setDraftFilters(current =>
           current.status === nextStatus
             ? current
@@ -344,7 +344,7 @@ export default function LearnOrdersTab() {
         ...appliedFilters,
         status: nextStatus,
       };
-      setActiveOverviewStatus(nextStatus || null);
+      setActiveOverviewStatus(nextStatus);
       setDraftFilters(nextFilters);
       setAppliedFilters(nextFilters);
       setPageIndex(1);
@@ -450,7 +450,7 @@ export default function LearnOrdersTab() {
 
   const activeOverviewCard = useMemo(
     () =>
-      activeOverviewStatus
+      activeOverviewStatus !== null
         ? (overviewCards.find(card => card.status === activeOverviewStatus) ??
           null)
         : null,

--- a/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
@@ -76,7 +76,6 @@ export default function OrderOverviewSection({
                 {card.onClick ? (
                   <button
                     type='button'
-                    aria-label={card.label}
                     className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
                     onClick={card.onClick}
                   >

--- a/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
@@ -3,7 +3,11 @@
 import React from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { X } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 type OrderOverviewCard = {
@@ -103,7 +107,9 @@ export default function OrderOverviewSection({
 
       {activeCardLabel && onClearActive ? (
         <div className='mt-4 flex flex-wrap items-center gap-2'>
-          <span className='text-sm text-muted-foreground'>{activeFilterLabel}</span>
+          <span className='text-sm text-muted-foreground'>
+            {activeFilterLabel}
+          </span>
           <button
             type='button'
             aria-label={`${activeCardLabel} ${clearLabel}`}

--- a/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import { X } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type OrderOverviewCard = {
+  key: string;
+  label: string;
+  value: string;
+  tooltip: string;
+  onClick?: () => void;
+};
+
+type OrderOverviewSectionProps = {
+  title: string;
+  cards: OrderOverviewCard[];
+  activeCardLabel?: string | null;
+  activeFilterLabel: string;
+  clearLabel: string;
+  staleMessage?: string | null;
+  onClearActive?: () => void;
+  gridClassName?: string;
+};
+
+export default function OrderOverviewSection({
+  title,
+  cards,
+  activeCardLabel,
+  activeFilterLabel,
+  clearLabel,
+  staleMessage,
+  onClearActive,
+  gridClassName,
+}: OrderOverviewSectionProps) {
+  return (
+    <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm'>
+      <div className='mb-3'>
+        <h2 className='text-base font-semibold text-foreground'>{title}</h2>
+      </div>
+
+      {staleMessage ? (
+        <div className='mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
+          {staleMessage}
+        </div>
+      ) : null}
+
+      <div
+        className={cn(
+          'grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4 min-[1680px]:grid-cols-6',
+          gridClassName,
+        )}
+      >
+        {cards.map(card => {
+          const content = (
+            <>
+              <div className='text-sm text-muted-foreground'>{card.label}</div>
+              <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
+                {card.value}
+              </div>
+            </>
+          );
+
+          return (
+            <div
+              key={card.key}
+              className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
+            >
+              <div className='flex items-start justify-between gap-2'>
+                {card.onClick ? (
+                  <button
+                    type='button'
+                    aria-label={card.label}
+                    className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                    onClick={card.onClick}
+                  >
+                    {content}
+                  </button>
+                ) : (
+                  <div className='min-w-0 flex-1'>{content}</div>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type='button'
+                      aria-label={card.tooltip}
+                      className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                    >
+                      <QuestionMarkCircleIcon className='h-4 w-4' />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className='max-w-56 text-left leading-5'>
+                    {card.tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {activeCardLabel && onClearActive ? (
+        <div className='mt-4 flex flex-wrap items-center gap-2'>
+          <span className='text-sm text-muted-foreground'>{activeFilterLabel}</span>
+          <button
+            type='button'
+            aria-label={`${activeCardLabel} ${clearLabel}`}
+            className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
+            onClick={onClearActive}
+          >
+            <span>{activeCardLabel}</span>
+            <X className='h-3.5 w-3.5' />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/cook-web/src/app/admin/operations/orders/useOverviewStatusQuickFilter.ts
+++ b/src/cook-web/src/app/admin/operations/orders/useOverviewStatusQuickFilter.ts
@@ -1,0 +1,116 @@
+import * as React from 'react';
+
+type FiltersWithStatus = {
+  status: string;
+};
+
+type UseOverviewStatusQuickFilterOptions<TFilters extends FiltersWithStatus> = {
+  appliedFilters: TFilters;
+  setDraftFilters: React.Dispatch<React.SetStateAction<TFilters>>;
+  setAppliedFilters: React.Dispatch<React.SetStateAction<TFilters>>;
+  setPageIndex: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export function useOverviewStatusQuickFilter<
+  TFilters extends FiltersWithStatus,
+>({
+  appliedFilters,
+  setDraftFilters,
+  setAppliedFilters,
+  setPageIndex,
+}: UseOverviewStatusQuickFilterOptions<TFilters>) {
+  const [activeOverviewStatus, setActiveOverviewStatus] = React.useState<
+    string | null
+  >(null);
+  const [overviewStatusBeforeApply, setOverviewStatusBeforeApply] =
+    React.useState<string | null>(null);
+
+  const resetOverviewQuickFilterState = React.useCallback(() => {
+    setActiveOverviewStatus(null);
+    setOverviewStatusBeforeApply(null);
+  }, []);
+
+  const applyStatusQuickFilter = React.useCallback(
+    (status: string) => {
+      if (activeOverviewStatus === status) {
+        return;
+      }
+
+      if (activeOverviewStatus === null) {
+        setOverviewStatusBeforeApply(appliedFilters.status || null);
+      }
+
+      if (appliedFilters.status === status) {
+        setActiveOverviewStatus(status);
+        setDraftFilters(current =>
+          current.status === status
+            ? current
+            : {
+                ...current,
+                status,
+              },
+        );
+        return;
+      }
+
+      const nextFilters = {
+        ...appliedFilters,
+        status,
+      };
+      setActiveOverviewStatus(status);
+      setDraftFilters(nextFilters);
+      setAppliedFilters(nextFilters);
+      setPageIndex(1);
+    },
+    [
+      activeOverviewStatus,
+      appliedFilters,
+      setAppliedFilters,
+      setDraftFilters,
+      setPageIndex,
+    ],
+  );
+
+  const clearOverviewQuickFilter = React.useCallback(() => {
+    if (activeOverviewStatus === null) {
+      return;
+    }
+
+    const restoredStatus = overviewStatusBeforeApply ?? '';
+    resetOverviewQuickFilterState();
+    setDraftFilters(current =>
+      current.status === restoredStatus
+        ? current
+        : {
+            ...current,
+            status: restoredStatus,
+          },
+    );
+
+    if (appliedFilters.status === restoredStatus) {
+      return;
+    }
+
+    const nextFilters = {
+      ...appliedFilters,
+      status: restoredStatus,
+    };
+    setAppliedFilters(nextFilters);
+    setPageIndex(1);
+  }, [
+    activeOverviewStatus,
+    appliedFilters,
+    overviewStatusBeforeApply,
+    resetOverviewQuickFilterState,
+    setAppliedFilters,
+    setDraftFilters,
+    setPageIndex,
+  ]);
+
+  return {
+    activeOverviewStatus,
+    applyStatusQuickFilter,
+    clearOverviewQuickFilter,
+    resetOverviewQuickFilterState,
+  };
+}

--- a/src/i18n/en-US/modules/operations-order.json
+++ b/src/i18n/en-US/modules/operations-order.json
@@ -43,6 +43,28 @@
       "plan": "Credit Plan",
       "topup": "Credit Pack"
     },
+    "overview": {
+      "metrics": {
+        "canceledOrders": "Canceled",
+        "closedOrders": "Closed",
+        "creditAmount": "Purchased Credits",
+        "paidAmount": "Paid Amount",
+        "paidOrders": "Paid",
+        "pendingOrders": "Pending",
+        "refundedOrders": "Refunded",
+        "totalOrders": "Total Orders"
+      },
+      "tooltips": {
+        "canceledOrders": "Canceled credit orders",
+        "closedOrders": "Closed credit orders",
+        "creditAmount": "Total credits purchased by paid credit orders",
+        "paidAmount": "Paid amount from credit orders",
+        "paidOrders": "Paid credit orders",
+        "pendingOrders": "Pending credit orders",
+        "refundedOrders": "Refunded credit orders",
+        "totalOrders": "Total credit orders"
+      }
+    },
     "longTerm": "Long term",
     "paymentChannel": {
       "checkoutSession": "Checkout Session"
@@ -76,6 +98,27 @@
     "title": "Order Detail"
   },
   "emptyList": "No order data",
+  "overview": {
+    "activeFilter": "Current filter",
+    "metrics": {
+      "closedOrders": "Closed",
+      "paidAmount": "Paid Amount",
+      "paidOrders": "Paid",
+      "pendingOrders": "Pending",
+      "refundedOrders": "Refunded",
+      "totalOrders": "Total Orders"
+    },
+    "staleData": "Overview failed to load. Refresh to try again.",
+    "title": "Overview",
+    "tooltips": {
+      "closedOrders": "Closed learning orders",
+      "paidAmount": "Paid amount from learning orders",
+      "paidOrders": "Paid learning orders",
+      "pendingOrders": "Pending learning orders",
+      "refundedOrders": "Refunded learning orders",
+      "totalOrders": "Total learning orders"
+    }
+  },
   "filters": {
     "courseId": "Course ID",
     "courseIdPlaceholder": "Course ID",

--- a/src/i18n/en-US/modules/operations-order.json
+++ b/src/i18n/en-US/modules/operations-order.json
@@ -114,21 +114,15 @@
   "overview": {
     "activeFilter": "Current filter",
     "metrics": {
-      "closedOrders": "Closed",
       "paidAmount": "Paid Amount",
       "paidOrders": "Paid",
-      "pendingOrders": "Pending",
-      "refundedOrders": "Refunded",
       "totalOrders": "Total Orders"
     },
     "staleData": "Overview failed to load. Refresh to try again.",
     "title": "Overview",
     "tooltips": {
-      "closedOrders": "Closed learning orders",
       "paidAmount": "Paid amount from learning orders",
       "paidOrders": "Paid learning orders",
-      "pendingOrders": "Pending learning orders",
-      "refundedOrders": "Refunded learning orders",
       "totalOrders": "Total learning orders"
     }
   },

--- a/src/i18n/en-US/modules/operations-order.json
+++ b/src/i18n/en-US/modules/operations-order.json
@@ -43,6 +43,7 @@
       "plan": "Credit Plan",
       "topup": "Credit Pack"
     },
+    "longTerm": "Long term",
     "overview": {
       "metrics": {
         "canceledOrders": "Canceled",
@@ -65,7 +66,6 @@
         "totalOrders": "Total credit orders"
       }
     },
-    "longTerm": "Long term",
     "paymentChannel": {
       "checkoutSession": "Checkout Session"
     },
@@ -98,27 +98,6 @@
     "title": "Order Detail"
   },
   "emptyList": "No order data",
-  "overview": {
-    "activeFilter": "Current filter",
-    "metrics": {
-      "closedOrders": "Closed",
-      "paidAmount": "Paid Amount",
-      "paidOrders": "Paid",
-      "pendingOrders": "Pending",
-      "refundedOrders": "Refunded",
-      "totalOrders": "Total Orders"
-    },
-    "staleData": "Overview failed to load. Refresh to try again.",
-    "title": "Overview",
-    "tooltips": {
-      "closedOrders": "Closed learning orders",
-      "paidAmount": "Paid amount from learning orders",
-      "paidOrders": "Paid learning orders",
-      "pendingOrders": "Pending learning orders",
-      "refundedOrders": "Refunded learning orders",
-      "totalOrders": "Total learning orders"
-    }
-  },
   "filters": {
     "courseId": "Course ID",
     "courseIdPlaceholder": "Course ID",
@@ -139,6 +118,27 @@
     "userKeywordPlaceholder": "User ID / phone / email",
     "userKeywordPlaceholderEmail": "User ID / email",
     "userKeywordPlaceholderPhone": "User ID / phone"
+  },
+  "overview": {
+    "activeFilter": "Current filter",
+    "metrics": {
+      "closedOrders": "Closed",
+      "paidAmount": "Paid Amount",
+      "paidOrders": "Paid",
+      "pendingOrders": "Pending",
+      "refundedOrders": "Refunded",
+      "totalOrders": "Total Orders"
+    },
+    "staleData": "Overview failed to load. Refresh to try again.",
+    "title": "Overview",
+    "tooltips": {
+      "closedOrders": "Closed learning orders",
+      "paidAmount": "Paid amount from learning orders",
+      "paidOrders": "Paid learning orders",
+      "pendingOrders": "Pending learning orders",
+      "refundedOrders": "Refunded learning orders",
+      "totalOrders": "Total learning orders"
+    }
   },
   "source": {
     "couponRedeem": "Coupon Redemption",

--- a/src/i18n/en-US/modules/operations-order.json
+++ b/src/i18n/en-US/modules/operations-order.json
@@ -48,7 +48,7 @@
       "metrics": {
         "canceledOrders": "Canceled",
         "closedOrders": "Closed",
-        "creditAmount": "Purchased Credits",
+        "creditAmount": "Available Credits",
         "paidAmount": "Paid Amount",
         "paidOrders": "Paid",
         "pendingOrders": "Pending",
@@ -58,7 +58,7 @@
       "tooltips": {
         "canceledOrders": "Canceled credit orders",
         "closedOrders": "Closed credit orders",
-        "creditAmount": "Total credits purchased by paid credit orders",
+        "creditAmount": "Total unconsumed credits currently available across all creator accounts for learning, preview, and debug usage",
         "paidAmount": "Paid amount from credit orders",
         "paidOrders": "Paid credit orders",
         "pendingOrders": "Pending credit orders",

--- a/src/i18n/en-US/modules/operations-order.json
+++ b/src/i18n/en-US/modules/operations-order.json
@@ -1,7 +1,7 @@
 {
   "__namespace__": "module.operationsOrder",
   "creditOrders": {
-    "creditAmountValue": "{credits} credits",
+    "creditAmountValue": "{credits}",
     "detail": {
       "description": "View credit order details",
       "labels": {
@@ -46,23 +46,15 @@
     "longTerm": "Long term",
     "overview": {
       "metrics": {
-        "canceledOrders": "Canceled",
-        "closedOrders": "Closed",
         "creditAmount": "Available Credits",
         "paidAmount": "Paid Amount",
         "paidOrders": "Paid",
-        "pendingOrders": "Pending",
-        "refundedOrders": "Refunded",
         "totalOrders": "Total Orders"
       },
       "tooltips": {
-        "canceledOrders": "Canceled credit orders",
-        "closedOrders": "Closed credit orders",
         "creditAmount": "Total unconsumed credits currently available across all creator accounts for learning, preview, and debug usage",
         "paidAmount": "Paid amount from credit orders",
         "paidOrders": "Paid credit orders",
-        "pendingOrders": "Pending credit orders",
-        "refundedOrders": "Refunded credit orders",
         "totalOrders": "Total credit orders"
       }
     },

--- a/src/i18n/zh-CN/modules/operations-order.json
+++ b/src/i18n/zh-CN/modules/operations-order.json
@@ -43,6 +43,28 @@
       "plan": "积分套餐",
       "topup": "积分包"
     },
+    "overview": {
+      "metrics": {
+        "canceledOrders": "已取消",
+        "closedOrders": "已关闭",
+        "creditAmount": "购买积分",
+        "paidAmount": "实付金额",
+        "paidOrders": "已支付",
+        "pendingOrders": "待支付",
+        "refundedOrders": "已退款",
+        "totalOrders": "订单总数"
+      },
+      "tooltips": {
+        "canceledOrders": "已取消积分订单数",
+        "closedOrders": "已关闭积分订单数",
+        "creditAmount": "已支付积分订单购买积分总和",
+        "paidAmount": "已支付积分订单实付金额总和",
+        "paidOrders": "已支付积分订单数",
+        "pendingOrders": "待支付积分订单数",
+        "refundedOrders": "已退款积分订单数",
+        "totalOrders": "积分订单总数"
+      }
+    },
     "longTerm": "长期有效",
     "paymentChannel": {
       "checkoutSession": "Checkout Session"
@@ -76,6 +98,27 @@
     "title": "订单详情"
   },
   "emptyList": "暂无订单数据",
+  "overview": {
+    "activeFilter": "当前筛选",
+    "metrics": {
+      "closedOrders": "已关闭",
+      "paidAmount": "实付金额",
+      "paidOrders": "已支付",
+      "pendingOrders": "待支付",
+      "refundedOrders": "已退款",
+      "totalOrders": "订单总数"
+    },
+    "staleData": "数据概览加载失败，请刷新重试",
+    "title": "数据概览",
+    "tooltips": {
+      "closedOrders": "已关闭学习订单数",
+      "paidAmount": "已支付学习订单实付金额总和",
+      "paidOrders": "已支付学习订单数",
+      "pendingOrders": "待支付学习订单数",
+      "refundedOrders": "已退款学习订单数",
+      "totalOrders": "学习订单总数"
+    }
+  },
   "filters": {
     "courseId": "课程ID",
     "courseIdPlaceholder": "输入课程ID",

--- a/src/i18n/zh-CN/modules/operations-order.json
+++ b/src/i18n/zh-CN/modules/operations-order.json
@@ -48,7 +48,7 @@
       "metrics": {
         "canceledOrders": "已取消",
         "closedOrders": "已关闭",
-        "creditAmount": "购买积分",
+        "creditAmount": "当前可用积分",
         "paidAmount": "实付金额",
         "paidOrders": "已支付",
         "pendingOrders": "待支付",
@@ -58,7 +58,7 @@
       "tooltips": {
         "canceledOrders": "已取消积分订单数",
         "closedOrders": "已关闭积分订单数",
-        "creditAmount": "已支付积分订单购买积分总和",
+        "creditAmount": "当前所有创作者账号中尚未消耗、仍可用于学习、预览和调试的积分总和",
         "paidAmount": "已支付积分订单实付金额总和",
         "paidOrders": "已支付积分订单数",
         "pendingOrders": "待支付积分订单数",

--- a/src/i18n/zh-CN/modules/operations-order.json
+++ b/src/i18n/zh-CN/modules/operations-order.json
@@ -1,7 +1,7 @@
 {
   "__namespace__": "module.operationsOrder",
   "creditOrders": {
-    "creditAmountValue": "{credits} 积分",
+    "creditAmountValue": "{credits}",
     "detail": {
       "description": "查看积分订单详情",
       "labels": {
@@ -46,23 +46,15 @@
     "longTerm": "长期有效",
     "overview": {
       "metrics": {
-        "canceledOrders": "已取消",
-        "closedOrders": "已关闭",
         "creditAmount": "当前可用积分",
         "paidAmount": "实付金额",
         "paidOrders": "已支付",
-        "pendingOrders": "待支付",
-        "refundedOrders": "已退款",
         "totalOrders": "订单总数"
       },
       "tooltips": {
-        "canceledOrders": "已取消积分订单数",
-        "closedOrders": "已关闭积分订单数",
         "creditAmount": "当前所有创作者账号中尚未消耗、仍可用于学习、预览和调试的积分总和",
         "paidAmount": "已支付积分订单实付金额总和",
         "paidOrders": "已支付积分订单数",
-        "pendingOrders": "待支付积分订单数",
-        "refundedOrders": "已退款积分订单数",
         "totalOrders": "积分订单总数"
       }
     },

--- a/src/i18n/zh-CN/modules/operations-order.json
+++ b/src/i18n/zh-CN/modules/operations-order.json
@@ -114,21 +114,15 @@
   "overview": {
     "activeFilter": "当前筛选",
     "metrics": {
-      "closedOrders": "已关闭",
       "paidAmount": "实付金额",
       "paidOrders": "已支付",
-      "pendingOrders": "待支付",
-      "refundedOrders": "已退款",
       "totalOrders": "订单总数"
     },
     "staleData": "数据概览加载失败，请刷新重试",
     "title": "数据概览",
     "tooltips": {
-      "closedOrders": "已关闭学习订单数",
       "paidAmount": "已支付学习订单实付金额总和",
       "paidOrders": "已支付学习订单数",
-      "pendingOrders": "待支付学习订单数",
-      "refundedOrders": "已退款学习订单数",
       "totalOrders": "学习订单总数"
     }
   },

--- a/src/i18n/zh-CN/modules/operations-order.json
+++ b/src/i18n/zh-CN/modules/operations-order.json
@@ -43,6 +43,7 @@
       "plan": "积分套餐",
       "topup": "积分包"
     },
+    "longTerm": "长期有效",
     "overview": {
       "metrics": {
         "canceledOrders": "已取消",
@@ -65,7 +66,6 @@
         "totalOrders": "积分订单总数"
       }
     },
-    "longTerm": "长期有效",
     "paymentChannel": {
       "checkoutSession": "Checkout Session"
     },
@@ -98,27 +98,6 @@
     "title": "订单详情"
   },
   "emptyList": "暂无订单数据",
-  "overview": {
-    "activeFilter": "当前筛选",
-    "metrics": {
-      "closedOrders": "已关闭",
-      "paidAmount": "实付金额",
-      "paidOrders": "已支付",
-      "pendingOrders": "待支付",
-      "refundedOrders": "已退款",
-      "totalOrders": "订单总数"
-    },
-    "staleData": "数据概览加载失败，请刷新重试",
-    "title": "数据概览",
-    "tooltips": {
-      "closedOrders": "已关闭学习订单数",
-      "paidAmount": "已支付学习订单实付金额总和",
-      "paidOrders": "已支付学习订单数",
-      "pendingOrders": "待支付学习订单数",
-      "refundedOrders": "已退款学习订单数",
-      "totalOrders": "学习订单总数"
-    }
-  },
   "filters": {
     "courseId": "课程ID",
     "courseIdPlaceholder": "输入课程ID",
@@ -139,6 +118,27 @@
     "userKeywordPlaceholder": "输入用户 ID / 手机号 / 邮箱",
     "userKeywordPlaceholderEmail": "输入用户 ID / 邮箱",
     "userKeywordPlaceholderPhone": "输入用户 ID / 手机号"
+  },
+  "overview": {
+    "activeFilter": "当前筛选",
+    "metrics": {
+      "closedOrders": "已关闭",
+      "paidAmount": "实付金额",
+      "paidOrders": "已支付",
+      "pendingOrders": "待支付",
+      "refundedOrders": "已退款",
+      "totalOrders": "订单总数"
+    },
+    "staleData": "数据概览加载失败，请刷新重试",
+    "title": "数据概览",
+    "tooltips": {
+      "closedOrders": "已关闭学习订单数",
+      "paidAmount": "已支付学习订单实付金额总和",
+      "paidOrders": "已支付学习订单数",
+      "pendingOrders": "待支付学习订单数",
+      "refundedOrders": "已退款学习订单数",
+      "totalOrders": "学习订单总数"
+    }
   },
   "source": {
     "couponRedeem": "兑换码兑换",


### PR DESCRIPTION
# Summary

Add overview cards for operator learning orders and credit orders, including backend aggregate endpoints, frontend overview cards, quick status filtering from cards, and updated copy for tooltips and filter labels.

- add operator order overview and operator credit order overview APIs
- add shared overview card UI for the operator order management page
- support card-triggered status quick filters without treating default tab status as an active card filter
- update zh/en order overview copy for tooltips, stale-state text, and current filter labels
- add focused frontend tests for learn/credit order overview interactions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin operations dashboard now shows aggregated order and credit-order overviews (including per-currency paid-amount breakdowns) with interactive overview cards, quick-status filters, active-filter indicators, and clear controls. New operator-only overview endpoints and client API mappings added. Credit-order list supports an "has available credits" filter.

* **Components & Hooks**
  * Reusable OrderOverviewSection component and a client hook for managing overview-driven quick filters.

* **Localization**
  * English and Chinese translation keys added/updated for overview metrics and tooltips.

* **Tests**
  * Added unit and UI tests covering overview builders, filters, and interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1745)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->