### PR TITLE
fix: billing expired bucket repair

### DIFF
--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -788,6 +788,79 @@ def _load_grant_ledger_entry_for_order(order: BillingOrder) -> CreditLedgerEntry
     )
 
 
+def _repair_existing_paid_order_grant_bucket(
+    app: Flask,
+    *,
+    order: BillingOrder,
+    grant_entry: CreditLedgerEntry,
+) -> bool:
+    """Repair the mutable bucket snapshot for an already-granted paid order."""
+
+    if _normalize_bid(grant_entry.source_bid) != _normalize_bid(order.bill_order_bid):
+        return False
+
+    bucket = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.creator_bid == order.creator_bid,
+            CreditWalletBucket.wallet_bucket_bid == grant_entry.wallet_bucket_bid,
+        )
+        .order_by(CreditWalletBucket.id.desc())
+        .first()
+    )
+    if bucket is None:
+        return False
+
+    bucket_source_bid = _normalize_bid(bucket.source_bid)
+    if bucket_source_bid and bucket_source_bid != _normalize_bid(order.bill_order_bid):
+        return False
+
+    effective_to = grant_entry.expires_at
+    now = datetime.now()
+    if effective_to is not None and effective_to <= now:
+        return False
+
+    changed = False
+    effective_from = grant_entry.consumable_from
+    if effective_from is not None and bucket.effective_from != effective_from:
+        bucket.effective_from = effective_from
+        changed = True
+    if bucket.effective_to != effective_to:
+        bucket.effective_to = effective_to
+        changed = True
+    if bucket.source_bid != order.bill_order_bid:
+        bucket.source_bid = order.bill_order_bid
+        changed = True
+
+    previous_status = int(bucket.status or 0)
+    if previous_status == CREDIT_BUCKET_STATUS_EXPIRED and (
+        _to_decimal(bucket.available_credits) > 0
+        or _to_decimal(bucket.reserved_credits) > 0
+    ):
+        _prepare_bucket_for_runtime_reuse(bucket)
+        changed = True
+
+    sync_credit_bucket_status(bucket)
+    if int(bucket.status or 0) != previous_status:
+        changed = True
+
+    if not changed:
+        return False
+
+    bucket.updated_at = now
+    db.session.add(bucket)
+
+    wallet = _load_or_create_credit_wallet(app, order.creator_bid)
+    refresh_credit_wallet_snapshot(wallet)
+    persist_credit_wallet_snapshot(
+        wallet,
+        available_credits=wallet.available_credits,
+        reserved_credits=wallet.reserved_credits,
+        updated_at=now,
+    )
+    return True
+
+
 def _should_reserve_subscription_renewal_grant(
     order: BillingOrder,
     *,
@@ -1067,6 +1140,11 @@ def _grant_paid_order_credits(app: Flask, order: BillingOrder) -> bool:
         .first()
     )
     if existing_entry is not None:
+        _repair_existing_paid_order_grant_bucket(
+            app,
+            order=order,
+            grant_entry=existing_entry,
+        )
         _activate_subscription_for_paid_order(app, order)
         return False
 

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -2489,6 +2489,147 @@ class TestBillingWriteRoutes:
             assert grant_entry.amount == Decimal("5.0000000000")
             assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
 
+    def test_paid_subscription_replay_repairs_existing_expired_bucket_status(
+        self, billing_write_client
+    ) -> None:
+        app = billing_write_client["app"]
+        paid_at = datetime(2026, 5, 11, 14, 11, 8)
+        expired_at = datetime(2026, 5, 5, 19, 22, 1)
+
+        with app.app_context():
+            product = BillingProduct.query.filter_by(
+                product_bid="bill-product-plan-monthly"
+            ).one()
+            cycle_end = calculate_self_managed_billing_cycle_end(
+                product,
+                cycle_start_at=paid_at,
+            )
+            wallet = CreditWallet(
+                wallet_bid="wallet-repair-existing-expired",
+                creator_bid="creator-1",
+                available_credits=Decimal("50.0000000000"),
+                reserved_credits=Decimal("0"),
+                lifetime_granted_credits=Decimal("1050.0000000000"),
+                lifetime_consumed_credits=Decimal("9.8500000000"),
+                last_settled_usage_id=0,
+                version=0,
+                created_at=expired_at,
+                updated_at=paid_at,
+            )
+            subscription = BillingSubscription(
+                subscription_bid="sub-repair-existing-expired",
+                creator_bid="creator-1",
+                product_bid="bill-product-plan-monthly",
+                status=BILLING_SUBSCRIPTION_STATUS_DRAFT,
+                billing_provider="pingxx",
+                provider_subscription_id="",
+                provider_customer_id="",
+                current_period_start_at=None,
+                current_period_end_at=None,
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={},
+                created_at=paid_at,
+                updated_at=paid_at,
+            )
+            expired_bucket = CreditWalletBucket(
+                wallet_bucket_bid="bucket-repair-existing-expired",
+                wallet_bid=wallet.wallet_bid,
+                creator_bid="creator-1",
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                source_bid="bill-repair-existing-expired-1",
+                priority=20,
+                original_credits=Decimal("1050.0000000000"),
+                available_credits=Decimal("50.0000000000"),
+                reserved_credits=Decimal("0"),
+                consumed_credits=Decimal("9.8500000000"),
+                expired_credits=Decimal("990.1500000000"),
+                effective_from=paid_at,
+                effective_to=cycle_end,
+                status=CREDIT_BUCKET_STATUS_EXPIRED,
+                metadata_json={
+                    "bill_order_bid": "bill-repair-existing-expired-1",
+                    "subscription_bid": "sub-repair-existing-expired",
+                    "product_bid": "bill-product-plan-monthly",
+                    "payment_provider": "pingxx",
+                },
+                created_at=datetime(2026, 4, 20, 19, 22, 1),
+                updated_at=paid_at,
+            )
+            order = BillingOrder(
+                bill_order_bid="bill-repair-existing-expired-1",
+                creator_bid="creator-1",
+                order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+                product_bid="bill-product-plan-monthly",
+                subscription_bid="sub-repair-existing-expired",
+                currency="CNY",
+                payable_amount=990,
+                paid_amount=990,
+                payment_provider="pingxx",
+                channel="wx_pub_qr",
+                provider_reference_id="ch_repair_existing_expired_1",
+                status=BILLING_ORDER_STATUS_PAID,
+                paid_at=paid_at,
+                metadata_json={},
+            )
+            grant_entry = CreditLedgerEntry(
+                ledger_bid="ledger-repair-existing-expired",
+                creator_bid="creator-1",
+                wallet_bid=wallet.wallet_bid,
+                wallet_bucket_bid=expired_bucket.wallet_bucket_bid,
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                source_bid=order.bill_order_bid,
+                idempotency_key=f"grant:{order.bill_order_bid}",
+                amount=Decimal("50.0000000000"),
+                balance_after=Decimal("50.0000000000"),
+                expires_at=cycle_end,
+                consumable_from=paid_at,
+                metadata_json={
+                    "bill_order_bid": order.bill_order_bid,
+                    "subscription_bid": subscription.subscription_bid,
+                    "product_bid": order.product_bid,
+                    "payment_provider": "pingxx",
+                    "grant_reason": "subscription",
+                    "bucket_credit_state": "available",
+                },
+            )
+            dao.db.session.add(wallet)
+            dao.db.session.add(subscription)
+            dao.db.session.add(expired_bucket)
+            dao.db.session.add(order)
+            dao.db.session.add(grant_entry)
+            dao.db.session.flush()
+
+            granted = grant_paid_order_credits(app, order)
+            dao.db.session.commit()
+
+            wallet = CreditWallet.query.filter_by(creator_bid="creator-1").one()
+            bucket = CreditWalletBucket.query.filter_by(
+                wallet_bucket_bid="bucket-repair-existing-expired"
+            ).one()
+            subscription = BillingSubscription.query.filter_by(
+                subscription_bid="sub-repair-existing-expired"
+            ).one()
+
+            assert granted is False
+            assert (
+                CreditLedgerEntry.query.filter_by(
+                    creator_bid="creator-1",
+                    source_bid="bill-repair-existing-expired-1",
+                    entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                ).count()
+                == 1
+            )
+            assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+            assert bucket.available_credits == Decimal("50.0000000000")
+            assert bucket.effective_from == paid_at
+            assert bucket.effective_to == cycle_end
+            assert wallet.available_credits == Decimal("50.0000000000")
+            assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+            assert subscription.current_period_end_at == cycle_end
+
     def test_refund_paid_stripe_order_marks_order_refunded(
         self, billing_write_client
     ) -> None:


### PR DESCRIPTION
## Summary

- repair already-granted paid billing orders whose reused credit bucket still has an expired runtime status
- keep grant idempotency intact, so replaying a paid order does not grant duplicate subscription credits
- add regression coverage for the Ping++ case where a trial subscription bucket expired before a later paid plan purchase

## Root Cause

For Ping++ self-managed subscription starts, the paid-order grant path can reuse the single runtime subscription bucket. In the observed production case, the paid monthly plan grant ledger and wallet balance were already present, and the bucket effective window had been moved to the paid plan end time, but the reused bucket still carried `expired` status from the prior trial cycle. Runtime consumption and overview paths filter active buckets, so the newly granted subscription credits could appear unusable even though the grant ledger existed.

## Impact

Replaying the paid order side effects now repairs the mutable bucket snapshot when the grant ledger already exists. Expired trial credits stay expired, subscription credits keep the paid subscription expiration, and existing grant entries are not duplicated.

## Validation

- `cd src/api && pytest tests/service/billing/test_billing_write_routes.py -q`
- pre-commit hooks from `git commit`, including ruff, architecture boundaries, translation checks, and backend CJK guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where expired subscription credit buckets were not properly updated during payment order reprocessing. Subscription status and billing cycle dates are now correctly recalculated when orders are replayed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1746)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->