### PR TITLE
fix: creator trial grants for authoring upgrades

### DIFF
--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -27,11 +27,11 @@
 | `docs/product-specs/mobile-404-sequencing-followup.md` | Mobile 404 Follow-up: Sequencing Improvement Plan | `product-spec` | `implemented` | `frontend` | `2026-04-17` | `true` |
 | `docs/product-specs/operator-course-detail-page.md` | Operator Course Detail Page | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/operator-course-visit-analytics.md` | Operator Course Visit Analytics | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
-| `docs/product-specs/operator-role.md` | Operator Role Design | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
+| `docs/product-specs/operator-role.md` | Operator Role Design | `product-spec` | `implemented` | `shared` | `2026-05-12` | `true` |
 | `docs/product-specs/operator-user-management.md` | Operator User Management | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/password-login-design.md` | Password Login Feature Design | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/teacher-analytics-dashboard.md` | Teacher Analytics Dashboard (v1) | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
-| `docs/product-specs/transfer-course-creator.md` | Operator Course Creator Transfer | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
+| `docs/product-specs/transfer-course-creator.md` | Operator Course Creator Transfer | `product-spec` | `implemented` | `shared` | `2026-05-12` | `true` |
 | `docs/references/architecture-boundaries.md` | Architecture Boundaries | `reference` | `reference` | `repo` | `-` | `true` |
 | `docs/references/i18n.md` | Internationalization (i18n) Guide | `reference` | `reference` | `repo` | `-` | `true` |
 | `docs/references/scripts.md` | Scripts Overview | `reference` | `reference` | `repo` | `-` | `true` |

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -15,7 +15,7 @@ User-facing workflow and page behavior specifications live here.
 - [Operator Course Visit Analytics](../product-specs/operator-course-visit-analytics.md)
   - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
 - [Operator Role Design](../product-specs/operator-role.md)
-  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
+  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-05-12` | Canonical: `true`
 - [Operator User Management](../product-specs/operator-user-management.md)
   - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
 - [Password Login Feature Design](../product-specs/password-login-design.md)
@@ -23,4 +23,4 @@ User-facing workflow and page behavior specifications live here.
 - [Teacher Analytics Dashboard (v1)](../product-specs/teacher-analytics-dashboard.md)
   - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
 - [Operator Course Creator Transfer](../product-specs/transfer-course-creator.md)
-  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
+  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-05-12` | Canonical: `true`

--- a/docs/product-specs/operator-role.md
+++ b/docs/product-specs/operator-role.md
@@ -2,7 +2,7 @@
 title: Operator Role Design
 status: implemented
 owner_surface: shared
-last_reviewed: 2026-04-17
+last_reviewed: 2026-05-12
 canonical: true
 ---
 
@@ -25,7 +25,8 @@ manual database edits.
 ## Goals
 
 - Add a durable account-level `operator` role without replacing `creator`.
-- Preserve all existing creator logic and course-level permission behavior.
+- Preserve existing creator logic while making authoring shared permissions
+  grant the account-level creator capability they require.
 - Ensure the first verified real account in a fresh deployment becomes both a
   creator and an operator.
 - Surface the new role in backend DTOs and frontend user state so future
@@ -64,8 +65,9 @@ mirroring the existing `is_creator` storage pattern.
 - `is_creator`: authoring capability for the user's own course surfaces
 - `is_operator`: platform operations capability for operator-specific admin
   surfaces
-- course owner/shared permissions: unchanged and still independent from account
-  roles
+- course owner/shared `view` permissions: independent from account roles
+- shared `edit` / `publish` permissions: authoring collaboration permissions
+  that grant `is_creator` if the target account is not already a creator
 
 ## Bootstrap Rules
 
@@ -91,6 +93,22 @@ behavior without broadening operator access to every existing creator.
 Keep the existing creator auto-grant flow for explicit admin login context as
 is. Do not extend that automatic flow to `is_operator`, because doing so would
 make operator access too broad for self-hosted deployments.
+
+### Shared permission creator grants
+
+Sharing a course with `view` permission remains a course-level permission only.
+Sharing with `edit` or `publish` grants authoring capability, so the target user
+is promoted to creator and the creator-grant post-auth extensions run after the
+permission transaction commits. The billing trial hook is idempotent and skips
+users who already have an active paid plan, trial subscription, trial order, or
+legacy trial grant.
+
+Historical repair is explicit. Use
+`flask console billing backfill-authoring-permission-creators` for users who
+already have authoring shared permissions but missed the role or trial grant,
+and use `flask console billing backfill-trial-plans --all` for existing
+creators who only missed the trial plan. Deployments must not run either
+backfill automatically at startup.
 
 ### Manual follow-up
 

--- a/docs/product-specs/transfer-course-creator.md
+++ b/docs/product-specs/transfer-course-creator.md
@@ -2,7 +2,7 @@
 title: Operator Course Creator Transfer
 status: implemented
 owner_surface: shared
-last_reviewed: 2026-04-17
+last_reviewed: 2026-05-12
 canonical: true
 ---
 
@@ -24,6 +24,10 @@ permissions.
   grant the two onboarding demo-course permissions using the same logic as the
   shared-permission flow.
 - After transfer, the new user becomes the course creator.
+- If the target user was not already a creator, run the creator-grant
+  post-auth extensions after the ownership transaction commits. This
+  bootstraps the public trial plan through the existing billing hook and remains
+  idempotent when trial credits already exist.
 - Existing shared permissions are preserved as-is.
 - The previous creator does not receive any special fallback permission.
 - Creator-facing ownership checks, dashboard ownership, and order ownership are
@@ -84,12 +88,15 @@ Response body:
 5. If not found, create with `ensure_user_for_identifier(...)`.
 6. If the user is unregistered, promote to `USER_STATE_REGISTERED`.
 7. Upsert the credential for the provided identifier.
-8. Mark the target user as creator with `mark_user_roles(..., is_creator=True)`.
+8. Mark the target user as creator only if they were not already a creator, and
+   remember whether the creator role was granted by this transfer.
 9. Update all rows for the shifu bid in `DraftShifu` and `PublishedShifu` so
    legacy creator checks do not keep matching stale draft revisions.
 10. Commit the ownership update first, then clear both the shifu permission
     cache for the previous and new creator and the cached shifu-creator
     mapping used by request context hydration.
+11. If step 8 granted creator access for the first time, run creator-grant
+    post-auth extensions so billing can create the free trial credits.
 
 ### Reuse
 

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -13,6 +13,7 @@ from flask import current_app
 from flask.cli import with_appcontext
 from flaskr.dao import db
 from flaskr.service.config.models import Config
+from flaskr.service.shifu.models import AiCourseAuth
 from flaskr.service.user.repository import (
     load_user_aggregate,
     load_user_aggregate_by_identifier,
@@ -115,6 +116,194 @@ _PRODUCT_STATUS_LABELS = {
     "active": BILLING_PRODUCT_STATUS_ACTIVE,
     "inactive": BILLING_PRODUCT_STATUS_INACTIVE,
 }
+
+
+def _normalize_cli_bid(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _auth_type_values(raw_auth_type: object) -> set[str]:
+    if raw_auth_type is None:
+        return set()
+    if isinstance(raw_auth_type, (list, tuple, set)):
+        return {
+            str(item).strip().lower() for item in raw_auth_type if str(item).strip()
+        }
+
+    text = str(raw_auth_type or "").strip()
+    if not text or text in {"[]", "null"}:
+        return set()
+    try:
+        parsed = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return {item.strip().lower() for item in text.split(",") if item.strip()}
+
+    if isinstance(parsed, list):
+        return {str(item).strip().lower() for item in parsed if str(item).strip()}
+    if isinstance(parsed, str):
+        return {parsed.strip().lower()} if parsed.strip() else set()
+    return set()
+
+
+def _has_authoring_permission(raw_auth_type: object) -> bool:
+    return bool(_auth_type_values(raw_auth_type).intersection({"edit", "publish"}))
+
+
+def backfill_authoring_permission_creators(
+    app,
+    *,
+    course_bid: str = "",
+    user_bid: str = "",
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    normalized_course_bid = _normalize_cli_bid(course_bid)
+    normalized_user_bid = _normalize_cli_bid(user_bid)
+    normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
+
+    with app.app_context():
+        auth_query = AiCourseAuth.query.filter(AiCourseAuth.status == 1)
+        if normalized_course_bid:
+            auth_query = auth_query.filter(
+                AiCourseAuth.course_id == normalized_course_bid
+            )
+        if normalized_user_bid:
+            auth_query = auth_query.filter(AiCourseAuth.user_id == normalized_user_bid)
+        auth_query = auth_query.order_by(AiCourseAuth.id.asc())
+        if normalized_limit is not None:
+            auth_query = auth_query.limit(normalized_limit)
+
+        auth_rows = auth_query.all()
+        candidates: dict[str, dict[str, Any]] = {}
+        for auth in auth_rows:
+            current_user_bid = _normalize_cli_bid(auth.user_id)
+            if not current_user_bid:
+                continue
+            candidate = candidates.setdefault(
+                current_user_bid,
+                {
+                    "course_bids": set(),
+                    "has_authoring_permission": False,
+                },
+            )
+            current_course_bid = _normalize_cli_bid(auth.course_id)
+            if current_course_bid:
+                candidate["course_bids"].add(current_course_bid)
+            if _has_authoring_permission(auth.auth_type):
+                candidate["has_authoring_permission"] = True
+
+        records: list[dict[str, Any]] = []
+        role_granted_count = 0
+        role_would_grant_count = 0
+        role_skipped_count = 0
+        trial_granted_count = 0
+        trial_skipped_count = 0
+
+        for current_user_bid, candidate in sorted(candidates.items()):
+            record: dict[str, Any] = {
+                "creator_bid": current_user_bid,
+                "course_bids": sorted(candidate["course_bids"]),
+            }
+            if not bool(candidate["has_authoring_permission"]):
+                record.update(
+                    {
+                        "role_status": "skipped",
+                        "role_reason": "non_authoring_permission",
+                        "trial_status": "skipped",
+                        "trial_reason": "non_authoring_permission",
+                    }
+                )
+                role_skipped_count += 1
+                trial_skipped_count += 1
+                records.append(record)
+                continue
+
+            aggregate = load_user_aggregate(current_user_bid, with_credentials=False)
+            if aggregate is None:
+                record.update(
+                    {
+                        "role_status": "skipped",
+                        "role_reason": "user_not_found",
+                        "trial_status": "skipped",
+                        "trial_reason": "user_not_found",
+                    }
+                )
+                role_skipped_count += 1
+                trial_skipped_count += 1
+                records.append(record)
+                continue
+
+            if aggregate.is_creator:
+                record.update(
+                    {
+                        "role_status": "skipped",
+                        "role_reason": "already_creator",
+                    }
+                )
+                role_skipped_count += 1
+            elif dry_run:
+                record.update(
+                    {
+                        "role_status": "would_grant",
+                        "role_reason": None,
+                    }
+                )
+                role_would_grant_count += 1
+            else:
+                mark_user_roles(current_user_bid, is_creator=True)
+                db.session.commit()
+                record.update(
+                    {
+                        "role_status": "granted",
+                        "role_reason": None,
+                    }
+                )
+                role_granted_count += 1
+
+            if dry_run:
+                record.update(
+                    {
+                        "trial_status": "dry_run",
+                        "trial_reason": "dry_run",
+                    }
+                )
+                records.append(record)
+                continue
+
+            trial_payload = backfill_missing_creator_trial_credits(
+                app,
+                creator_bid=current_user_bid,
+            )
+            trial_record = (trial_payload.get("records") or [{}])[0] or {}
+            trial_status = trial_record.get("status") or trial_payload.get("status")
+            trial_reason = trial_record.get("reason") or trial_payload.get("reason")
+            record.update(
+                {
+                    "trial_status": trial_status,
+                    "trial_reason": trial_reason,
+                }
+            )
+            if int(trial_payload.get("granted_count") or 0) > 0:
+                trial_granted_count += 1
+            else:
+                trial_skipped_count += 1
+            records.append(record)
+
+        return {
+            "status": "completed",
+            "dry_run": dry_run,
+            "course_bid": normalized_course_bid or None,
+            "user_bid": normalized_user_bid or None,
+            "limit": normalized_limit,
+            "auth_count": len(auth_rows),
+            "creator_count": len(candidates),
+            "role_granted_count": role_granted_count,
+            "role_would_grant_count": role_would_grant_count,
+            "role_skipped_count": role_skipped_count,
+            "trial_granted_count": trial_granted_count,
+            "trial_skipped_count": trial_skipped_count,
+            "records": records,
+        }
 
 
 def register_billing_commands(console) -> None:
@@ -325,6 +514,56 @@ def register_billing_commands(console) -> None:
             current_app,
             creator_bid=creator_bid,
             limit=limit if process_all else None,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="backfill-authoring-permission-creators")
+    @click.option("--course-bid", default="", help="Limit to one shared course.")
+    @click.option("--user-bid", default="", help="Limit to one shared user.")
+    @click.option(
+        "--limit",
+        type=click.IntRange(min=1),
+        default=None,
+        help="Maximum active permission rows to scan.",
+    )
+    @click.option(
+        "--all",
+        "process_all",
+        is_flag=True,
+        help=(
+            "Scan active shared permissions and grant creator role for "
+            "edit/publish users."
+        ),
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        help="Report role/trial changes without writing creator roles or trial grants.",
+    )
+    @with_appcontext
+    def backfill_authoring_permission_creators_command(
+        course_bid: str,
+        user_bid: str,
+        limit: int | None,
+        process_all: bool,
+        dry_run: bool,
+    ) -> None:
+        """Grant creator role to users with edit/publish shared permissions."""
+
+        has_course_scope = bool(str(course_bid or "").strip())
+        has_user_scope = bool(str(user_bid or "").strip())
+        if not has_course_scope and not has_user_scope and not process_all:
+            raise click.ClickException(
+                "Pass --user-bid, --course-bid, or --all for "
+                "authoring-permission creator backfill."
+            )
+
+        payload = backfill_authoring_permission_creators(
+            current_app,
+            course_bid=course_bid,
+            user_bid=user_bid,
+            limit=limit,
+            dry_run=dry_run,
         )
         _echo_payload(payload)
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -134,7 +134,6 @@ from flaskr.service.user.models import (
 from flaskr.service.user.repository import (
     ensure_user_for_identifier,
     load_user_aggregate_by_identifier,
-    mark_user_roles,
     set_user_state,
     upsert_credential,
 )
@@ -143,6 +142,8 @@ from flaskr.util.uuid import generate_id
 from flaskr.service.user.utils import (
     ensure_demo_course_permissions,
     load_existing_demo_shifu_ids,
+    mark_creator_role_if_needed,
+    run_creator_granted_post_auth,
 )
 
 COURSE_STATUS_PUBLISHED = "published"
@@ -1960,7 +1961,7 @@ def transfer_operator_course_creator(
                 )
                 granted_demo_permissions = True
 
-        mark_user_roles(target_user_bid, is_creator=True)
+        creator_granted_now = mark_creator_role_if_needed(target_user_bid)
         _update_course_creator_bid(normalized_shifu_bid, target_user_bid)
 
         db.session.commit()
@@ -1970,6 +1971,15 @@ def transfer_operator_course_creator(
             )
         _clear_shifu_permission_cache(app, target_user_bid, normalized_shifu_bid)
         _clear_shifu_creator_cache(app, normalized_shifu_bid)
+        if creator_granted_now:
+            run_creator_granted_post_auth(
+                app,
+                user_id=target_user_bid,
+                source="operator_transfer_creator",
+                login_context="admin",
+                created_new_user=created_new_user,
+                language=target_aggregate.user_language,
+            )
         return {
             "shifu_bid": normalized_shifu_bid,
             "previous_creator_user_bid": previous_creator_user_bid,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -91,6 +91,8 @@ from flaskr.service.user.utils import get_user_language
 from flaskr.service.user.utils import (
     ensure_demo_course_permissions,
     load_existing_demo_shifu_ids,
+    mark_creator_role_if_needed,
+    run_creator_granted_post_auth,
 )
 from flaskr.util.uuid import generate_id
 
@@ -1917,8 +1919,10 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             auth_types = ["edit", "publish"]
 
         demo_shifu_ids = load_existing_demo_shifu_ids()
+        creator_upgrade_contexts: dict[str, dict[str, object]] = {}
         for contact in contacts:
             aggregate = aggregate_by_contact.get(contact)
+            created_new_user = False
             should_grant_demo_permissions = False
             if aggregate is None:
                 aggregate, created_new_user = ensure_user_for_identifier(
@@ -1953,6 +1957,16 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 ensure_demo_course_permissions(
                     app, aggregate.user_bid, demo_ids=demo_shifu_ids
                 )
+            if permission in {"edit", "publish"}:
+                creator_granted_now = mark_creator_role_if_needed(aggregate.user_bid)
+                if creator_granted_now:
+                    creator_upgrade_contexts.setdefault(
+                        aggregate.user_bid,
+                        {
+                            "created_new_user": created_new_user,
+                            "language": aggregate.user_language,
+                        },
+                    )
 
             auth = AiCourseAuth.query.filter(
                 AiCourseAuth.course_id == shifu_bid,
@@ -1974,6 +1988,14 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             _clear_shifu_permission_cache(aggregate.user_bid, shifu_bid)
 
         db.session.commit()
+        for user_id, upgrade_context in creator_upgrade_contexts.items():
+            run_creator_granted_post_auth(
+                app,
+                user_id=user_id,
+                source="shifu_permission_grant",
+                created_new_user=bool(upgrade_context.get("created_new_user")),
+                language=str(upgrade_context.get("language") or ""),
+            )
         return make_common_response({"count": len(contacts)})
 
     @app.route(

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -70,6 +70,53 @@ def get_user_language(user):
     return "en-US"
 
 
+def mark_creator_role_if_needed(user_id: str) -> bool:
+    """Mark an existing user as creator and report whether this is a new grant."""
+
+    normalized_user_id = str(user_id or "").strip()
+    if not normalized_user_id:
+        return False
+
+    entity = get_user_entity_by_bid(normalized_user_id)
+    if entity is None:
+        return False
+    if bool(entity.is_creator):
+        return False
+
+    mark_user_roles(normalized_user_id, is_creator=True)
+    return True
+
+
+def run_creator_granted_post_auth(
+    app: Flask,
+    *,
+    user_id: str,
+    source: str,
+    login_context: str | None = None,
+    created_new_user: bool = False,
+    language: str | None = None,
+) -> None:
+    """Run post-auth hooks for flows that grant creator access outside login."""
+
+    normalized_user_id = str(user_id or "").strip()
+    if not normalized_user_id:
+        return
+
+    from flaskr.service.user.post_auth import PostAuthContext, run_post_auth_extensions
+
+    run_post_auth_extensions(
+        app,
+        PostAuthContext(
+            user_id=normalized_user_id,
+            source=source,
+            login_context=login_context,
+            created_new_user=created_new_user,
+            language=language,
+            creator_granted_now=True,
+        ),
+    )
+
+
 # generate token
 def generate_token(app: Flask, user_id: str) -> str:
     def _generate() -> str:
@@ -287,12 +334,7 @@ def ensure_creator_demo_permissions_and_first_lesson(
     The function name is kept for compatibility. First lesson draft creation
     is handled by course creation flows.
     """
-    entity = get_user_entity_by_bid(user_id)
-    creator_granted_now = bool(entity is not None and not bool(entity.is_creator))
-
-    # Mark user as creator in canonical user entity
-    mark_user_roles(user_id, is_creator=True)
-
+    creator_granted_now = mark_creator_role_if_needed(user_id)
     ensure_demo_course_permissions(app, user_id)
     return creator_granted_now
 

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -31,7 +31,9 @@ from flaskr.service.billing.models import (
 )
 from flaskr.service.billing.queries import calculate_self_managed_billing_cycle_end
 from flaskr.service.config.models import Config
+from flaskr.service.shifu.models import AiCourseAuth
 from flaskr.service.user.consts import USER_STATE_REGISTERED
+from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.repository import (
     create_user_entity,
     load_user_aggregate_by_identifier,
@@ -127,6 +129,24 @@ def _seed_billing_cli_user(
         )
 
 
+def _seed_billing_cli_course_auth(
+    *,
+    auth_bid: str,
+    user_bid: str,
+    course_bid: str,
+    auth_types: list[str],
+) -> None:
+    dao.db.session.add(
+        AiCourseAuth(
+            course_auth_id=auth_bid,
+            course_id=course_bid,
+            user_id=user_bid,
+            auth_type=json.dumps(auth_types),
+            status=1,
+        )
+    )
+
+
 def test_billing_backfill_settlement_cli_requires_explicit_scope(
     billing_cli_runner,
 ) -> None:
@@ -212,6 +232,50 @@ def test_billing_backfill_trial_plans_cli_prints_helper_payload(
     assert payload["status"] == "completed"
     assert payload["granted_count"] == 2
     assert payload["kwargs"]["limit"] == 3
+
+
+def test_billing_backfill_authoring_permission_creators_cli_requires_explicit_scope(
+    billing_cli_runner,
+) -> None:
+    result = billing_cli_runner.invoke(
+        args=["console", "billing", "backfill-authoring-permission-creators"]
+    )
+
+    assert result.exit_code != 0
+    assert "Pass --user-bid, --course-bid, or --all" in result.output
+
+
+def test_billing_backfill_authoring_permission_creators_cli_prints_helper_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.backfill_authoring_permission_creators",
+        lambda app, **kwargs: {
+            "status": "completed",
+            "role_granted_count": 1,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "backfill-authoring-permission-creators",
+            "--all",
+            "--limit",
+            "4",
+            "--dry-run",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "completed"
+    assert payload["role_granted_count"] == 1
+    assert payload["kwargs"]["limit"] == 4
+    assert payload["kwargs"]["dry_run"] is True
 
 
 def test_billing_rebuild_wallets_cli_prints_helper_payload(
@@ -734,6 +798,154 @@ def test_billing_backfill_trial_plans_cli_grants_missing_trials_for_creators(
                 creator_bid="creator-cli-non-creator"
             ).count()
             == 0
+        )
+
+
+def test_billing_backfill_authoring_permission_creators_dry_run_does_not_mutate(
+    billing_cli_db_app: Flask,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+
+    with billing_cli_db_app.app_context():
+        dao.db.session.add_all(
+            build_bill_products(product_bids=[BILLING_TRIAL_PRODUCT_BID])
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="authoring-cli-dry-run",
+            identify="authoring-cli-dry-run@example.com",
+            email="authoring-cli-dry-run@example.com",
+            is_creator=False,
+        )
+        _seed_billing_cli_course_auth(
+            auth_bid="auth-authoring-cli-dry-run",
+            user_bid="authoring-cli-dry-run",
+            course_bid="course-authoring-cli-dry-run",
+            auth_types=["edit"],
+        )
+        dao.db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "backfill-authoring-permission-creators",
+            "--all",
+            "--dry-run",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "completed"
+    assert payload["role_would_grant_count"] == 1
+    assert payload["role_granted_count"] == 0
+    assert payload["trial_granted_count"] == 0
+
+    with billing_cli_db_app.app_context():
+        user = UserEntity.query.filter_by(user_bid="authoring-cli-dry-run").one()
+        assert user.is_creator == 0
+        assert (
+            BillingOrder.query.filter_by(creator_bid="authoring-cli-dry-run").count()
+            == 0
+        )
+
+
+def test_billing_backfill_authoring_permission_creators_grants_roles_and_trials(
+    billing_cli_db_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+    monkeypatch.setattr(
+        "flaskr.service.billing.trials._is_billing_enabled",
+        lambda: True,
+    )
+
+    with billing_cli_db_app.app_context():
+        dao.db.session.add_all(
+            build_bill_products(product_bids=[BILLING_TRIAL_PRODUCT_BID])
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="authoring-cli-edit",
+            identify="authoring-cli-edit@example.com",
+            email="authoring-cli-edit@example.com",
+            is_creator=False,
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="authoring-cli-publish",
+            identify="authoring-cli-publish@example.com",
+            email="authoring-cli-publish@example.com",
+            is_creator=False,
+        )
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="authoring-cli-view",
+            identify="authoring-cli-view@example.com",
+            email="authoring-cli-view@example.com",
+            is_creator=False,
+        )
+        _seed_billing_cli_course_auth(
+            auth_bid="auth-authoring-cli-edit",
+            user_bid="authoring-cli-edit",
+            course_bid="course-authoring-cli",
+            auth_types=["edit"],
+        )
+        _seed_billing_cli_course_auth(
+            auth_bid="auth-authoring-cli-publish",
+            user_bid="authoring-cli-publish",
+            course_bid="course-authoring-cli",
+            auth_types=["edit", "publish"],
+        )
+        _seed_billing_cli_course_auth(
+            auth_bid="auth-authoring-cli-view",
+            user_bid="authoring-cli-view",
+            course_bid="course-authoring-cli",
+            auth_types=["view"],
+        )
+        dao.db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "backfill-authoring-permission-creators",
+            "--all",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "completed"
+    assert payload["role_granted_count"] == 2
+    assert payload["role_skipped_count"] == 1
+    assert payload["trial_granted_count"] == 2
+    assert payload["trial_skipped_count"] == 1
+
+    records_by_bid = {item["creator_bid"]: item for item in payload["records"]}
+    assert records_by_bid["authoring-cli-view"]["role_reason"] == (
+        "non_authoring_permission"
+    )
+
+    with billing_cli_db_app.app_context():
+        edit_user = UserEntity.query.filter_by(user_bid="authoring-cli-edit").one()
+        publish_user = UserEntity.query.filter_by(
+            user_bid="authoring-cli-publish"
+        ).one()
+        view_user = UserEntity.query.filter_by(user_bid="authoring-cli-view").one()
+        assert edit_user.is_creator == 1
+        assert publish_user.is_creator == 1
+        assert view_user.is_creator == 0
+        assert (
+            BillingOrder.query.filter_by(creator_bid="authoring-cli-edit").count() == 1
+        )
+        assert (
+            BillingOrder.query.filter_by(creator_bid="authoring-cli-publish").count()
+            == 1
+        )
+        assert (
+            BillingOrder.query.filter_by(creator_bid="authoring-cli-view").count() == 0
         )
 
 

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -5,6 +5,12 @@ from types import SimpleNamespace
 import pytest
 
 import flaskr.dao as dao
+from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
+from flaskr.service.billing.models import BillingOrder, BillingProduct
+from flaskr.service.user.consts import USER_STATE_REGISTERED
+from flaskr.service.user.models import UserInfo as UserEntity
+from flaskr.service.user.repository import create_user_entity, upsert_credential
+from tests.common.fixtures.bill_products import build_bill_products
 
 
 def _get_models():
@@ -61,6 +67,47 @@ def _add_auth(app, shifu_bid: str, user_id: str, status: int):
                 auth_type=json.dumps(["view"]),
                 status=status,
             )
+        )
+        dao.db.session.commit()
+
+
+def _seed_user(app, *, user_bid: str, email: str):
+    with app.app_context():
+        entity = create_user_entity(
+            user_bid=user_bid,
+            identify=email,
+            nickname=f"user-{user_bid}",
+            language="en-US",
+            state=USER_STATE_REGISTERED,
+        )
+        entity.is_creator = 0
+        upsert_credential(
+            app,
+            user_bid=user_bid,
+            provider_name="email",
+            subject_id=email,
+            subject_format="email",
+            identifier=email,
+            metadata={},
+            verified=True,
+        )
+        dao.db.session.commit()
+
+
+def _ensure_trial_billing_enabled(monkeypatch):
+    import flaskr.service.billing.auth_hooks  # noqa: F401
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.trials._is_billing_enabled",
+        lambda: True,
+    )
+    existing = BillingProduct.query.filter_by(
+        product_bid=BILLING_TRIAL_PRODUCT_BID,
+        deleted=0,
+    ).first()
+    if existing is None:
+        dao.db.session.add_all(
+            build_bill_products(product_bids=[BILLING_TRIAL_PRODUCT_BID])
         )
         dao.db.session.commit()
 
@@ -129,3 +176,91 @@ class TestShifuPermissions:
             ).first()
             assert auth is not None
             assert auth.status == 0
+
+    def test_grant_view_permission_does_not_promote_creator(
+        self, monkeypatch, test_client, app
+    ):
+        shifu_bid = "test-permission-grant-view"
+        owner_id = "owner-grant-view"
+        target_user = "user-grant-view"
+        target_email = "viewer-grant@example.com"
+        _seed_shifu(app, shifu_bid, owner_id)
+        _seed_user(app, user_bid=target_user, email=target_email)
+        _mock_user(monkeypatch, owner_id)
+
+        resp = test_client.post(
+            f"/api/shifu/shifus/{shifu_bid}/permissions/grant",
+            json={
+                "contact_type": "email",
+                "contacts": [target_email],
+                "permission": "view",
+            },
+            headers={"Token": "test-token"},
+        )
+        payload = resp.get_json(force=True)
+
+        assert resp.status_code == 200
+        assert payload["code"] == 0
+
+        with app.app_context():
+            user = UserEntity.query.filter_by(user_bid=target_user).one()
+            assert user.is_creator == 0
+            assert BillingOrder.query.filter_by(creator_bid=target_user).count() == 0
+
+    @pytest.mark.parametrize(
+        ("permission", "expected_auth_types"),
+        [
+            ("edit", ["edit"]),
+            ("publish", ["edit", "publish"]),
+        ],
+    )
+    def test_grant_authoring_permission_promotes_creator_and_bootstraps_trial(
+        self,
+        monkeypatch,
+        test_client,
+        app,
+        permission: str,
+        expected_auth_types: list[str],
+    ):
+        shifu_bid = f"test-permission-grant-{permission}"
+        owner_id = f"owner-grant-{permission}"
+        target_user = f"user-grant-{permission}"
+        target_email = f"{permission}-grant@example.com"
+        _seed_shifu(app, shifu_bid, owner_id)
+        _seed_user(app, user_bid=target_user, email=target_email)
+
+        with app.app_context():
+            _ensure_trial_billing_enabled(monkeypatch)
+
+        _mock_user(monkeypatch, owner_id)
+        for _ in range(2):
+            resp = test_client.post(
+                f"/api/shifu/shifus/{shifu_bid}/permissions/grant",
+                json={
+                    "contact_type": "email",
+                    "contacts": [target_email],
+                    "permission": permission,
+                },
+                headers={"Token": "test-token"},
+            )
+            payload = resp.get_json(force=True)
+            assert resp.status_code == 200
+            assert payload["code"] == 0
+
+        with app.app_context():
+            _, AiCourseAuth = _get_models()
+            user = UserEntity.query.filter_by(user_bid=target_user).one()
+            auth = AiCourseAuth.query.filter_by(
+                course_id=shifu_bid,
+                user_id=target_user,
+                status=1,
+            ).one()
+            trial_orders = BillingOrder.query.filter_by(
+                creator_bid=target_user,
+                product_bid=BILLING_TRIAL_PRODUCT_BID,
+                deleted=0,
+            ).all()
+
+            assert user.is_creator == 1
+            assert json.loads(auth.auth_type) == expected_auth_types
+            assert len(trial_orders) == 1

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 import flaskr.dao as dao
+from flaskr.common import config as config_module
 from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
 from flaskr.service.billing.models import BillingOrder, BillingProduct
 from flaskr.service.user.consts import USER_STATE_REGISTERED
@@ -54,6 +55,23 @@ def _mock_user(monkeypatch, user_id: str, is_creator: bool = True):
         raising=False,
     )
     return dummy_user
+
+
+def _clear_config_caches() -> None:
+    try:
+        config_module.__ENHANCED_CONFIG__._cache.clear()
+    except Exception:
+        pass
+    try:
+        if config_module.__INSTANCE__ is not None:
+            config_module.__INSTANCE__.enhanced._cache.clear()
+    except Exception:
+        pass
+
+
+def _allow_email_login(monkeypatch) -> None:
+    monkeypatch.setenv("LOGIN_METHODS_ENABLED", "phone,email")
+    _clear_config_caches()
 
 
 def _add_auth(app, shifu_bid: str, user_id: str, status: int):
@@ -186,6 +204,7 @@ class TestShifuPermissions:
         target_email = "viewer-grant@example.com"
         _seed_shifu(app, shifu_bid, owner_id)
         _seed_user(app, user_bid=target_user, email=target_email)
+        _allow_email_login(monkeypatch)
         _mock_user(monkeypatch, owner_id)
 
         resp = test_client.post(
@@ -228,6 +247,7 @@ class TestShifuPermissions:
         target_email = f"{permission}-grant@example.com"
         _seed_shifu(app, shifu_bid, owner_id)
         _seed_user(app, user_bid=target_user, email=target_email)
+        _allow_email_login(monkeypatch)
 
         with app.app_context():
             _ensure_trial_billing_enabled(monkeypatch)

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 from flaskr.common import config as config_module
 from flaskr.common.shifu_context import _get_shifu_creator_bid_cached
 from flaskr.dao import db
+from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
+from flaskr.service.billing.models import BillingOrder, BillingProduct
 from flaskr.service.shifu.admin import transfer_operator_course_creator
 from flaskr.service.shifu.funcs import shifu_permission_verification
 from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
@@ -17,6 +19,7 @@ from flaskr.service.shifu.utils import get_shifu_creator_bid
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
 from flaskr.service.user.models import AuthCredential, UserInfo as UserEntity
 from flaskr.service.user.repository import create_user_entity, upsert_credential
+from tests.common.fixtures.bill_products import build_bill_products
 
 
 def _seed_user(
@@ -124,6 +127,24 @@ def _clear_config_caches() -> None:
             config_module.__INSTANCE__.enhanced._cache.clear()
     except Exception:
         pass
+
+
+def _ensure_trial_billing_enabled(app, monkeypatch) -> None:
+    import flaskr.service.billing.auth_hooks  # noqa: F401
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.trials._is_billing_enabled",
+        lambda: True,
+    )
+    existing = BillingProduct.query.filter_by(
+        product_bid=BILLING_TRIAL_PRODUCT_BID,
+        deleted=0,
+    ).first()
+    if existing is None:
+        db.session.add_all(
+            build_bill_products(product_bids=[BILLING_TRIAL_PRODUCT_BID])
+        )
+        db.session.commit()
 
 
 def test_transfer_creator_creates_missing_user_and_preserves_shared_auth(
@@ -239,6 +260,69 @@ def test_transfer_creator_promotes_unregistered_existing_user(app, monkeypatch):
         assert target_entity.is_creator == 1
         assert demo_auth is not None
         assert get_shifu_creator_bid(app, shifu_bid) == target_user_bid
+
+
+def test_transfer_creator_bootstraps_trial_when_target_becomes_creator(
+    app, monkeypatch
+):
+    shifu_bid = uuid.uuid4().hex[:32]
+    old_creator_bid = uuid.uuid4().hex[:32]
+    target_user_bid = uuid.uuid4().hex[:32]
+    target_email = f"{uuid.uuid4().hex[:10]}@example.com"
+
+    with app.app_context():
+        _ensure_trial_billing_enabled(app, monkeypatch)
+        _seed_user(app, user_bid=old_creator_bid, email="trial-old@example.com")
+        _seed_user(app, user_bid=target_user_bid, email=target_email)
+        _seed_course(shifu_bid, old_creator_bid)
+        db.session.commit()
+
+        transfer_operator_course_creator(
+            app,
+            shifu_bid=shifu_bid,
+            contact_type="email",
+            identifier=target_email,
+        )
+
+        target_entity = UserEntity.query.filter_by(user_bid=target_user_bid).one()
+        trial_order = BillingOrder.query.filter_by(
+            creator_bid=target_user_bid,
+            product_bid=BILLING_TRIAL_PRODUCT_BID,
+            deleted=0,
+        ).one()
+
+        assert target_entity.is_creator == 1
+        assert trial_order.payment_provider == "manual"
+
+
+def test_transfer_creator_skips_post_auth_when_target_already_creator(app, monkeypatch):
+    shifu_bid = uuid.uuid4().hex[:32]
+    old_creator_bid = uuid.uuid4().hex[:32]
+    target_user_bid = uuid.uuid4().hex[:32]
+    target_email = f"{uuid.uuid4().hex[:10]}@example.com"
+    post_auth_calls: list[dict] = []
+
+    with app.app_context():
+        _seed_user(app, user_bid=old_creator_bid, email="already-old@example.com")
+        _seed_user(app, user_bid=target_user_bid, email=target_email)
+        target_entity = UserEntity.query.filter_by(user_bid=target_user_bid).one()
+        target_entity.is_creator = 1
+        _seed_course(shifu_bid, old_creator_bid)
+        db.session.commit()
+
+        monkeypatch.setattr(
+            "flaskr.service.shifu.admin.run_creator_granted_post_auth",
+            lambda *args, **kwargs: post_auth_calls.append(kwargs),
+        )
+
+        transfer_operator_course_creator(
+            app,
+            shifu_bid=shifu_bid,
+            contact_type="email",
+            identifier=target_email,
+        )
+
+        assert post_auth_calls == []
 
 
 def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):


### PR DESCRIPTION
## Summary
- Trigger creator post-auth hooks when operator transfer grants creator access for the first time.
- Promote shared `edit` / `publish` users to creator and trigger the same trial bootstrap path while keeping `view` share as course-only permission.
- Add an explicit billing CLI backfill for historical authoring-permission users and update product specs plus generated docs.

## Root Cause
The existing transfer flow only wrote `is_creator`, and the shared permission grant flow only wrote `AiCourseAuth`. Neither path reported `creator_granted_now` to post-auth billing hooks, so the free trial plan bootstrap was skipped outside login/admin-ensure flows.

## Validation
- `pytest tests/service/shifu/test_transfer_creator.py tests/service/shifu/test_permissions.py tests/service/user/test_trial_credit_bootstrap.py tests/service/billing/test_billing_cli.py -q`
- `python scripts/check_architecture_boundaries.py`
- `python scripts/check_repo_harness.py`
- `git diff --check`
- commit hooks: ruff, generated harness, architecture boundaries, translation checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users granted edit/publish permissions on shared courses are now automatically promoted to creator status with appropriate access levels.
  * Trial billing credits are automatically provisioned when users become creators through permission grants or course ownership transfers.
  * New CLI utility for backfilling creator roles and trial credits for users with existing shared course authoring permissions.

* **Tests**
  * Added comprehensive test coverage for creator role promotion and trial credit provisioning across permission grant and course transfer workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1748)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->