### PR TITLE
fix: stabilize admin wechat initialization

### DIFF
--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -52,6 +52,21 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+jest.mock('@/components/contact/ContactSideRail', () => ({
+  __esModule: true,
+  CONTACT_RAIL_I18N_KEY: 'component.navigation.contactUs',
+  ContactSideRail: ({ label }: { label?: string }) =>
+    mockEnvState.contactUsUrl ? (
+      <a
+        href={mockEnvState.contactUsUrl}
+        rel='noopener noreferrer'
+        target='_blank'
+      >
+        {label ?? 'component.navigation.contactUs'}
+      </a>
+    ) : null,
+}));
+
 jest.mock('@/c-common/hooks/useDisclosure', () => ({
   useDisclosure: () => ({
     open: false,
@@ -87,7 +102,9 @@ jest.mock('@/c-store/envStore', () => ({
 const mockUserStoreState = {
   isInitialized: true,
   isGuest: false,
+  isLoggedIn: true,
   userInfo: {
+    user_id: 'user-1',
     is_operator: false,
   },
 };
@@ -348,9 +365,16 @@ describe('AdminLayout', () => {
     mockEnvState.billingEnabled = 'true';
     mockUserStoreState.isInitialized = true;
     mockUserStoreState.isGuest = false;
+    mockUserStoreState.isLoggedIn = true;
     mockUserStoreState.userInfo = {
+      user_id: 'user-1',
       is_operator: false,
     };
+    Object.assign(window.location, {
+      href: 'http://localhost:3000',
+      pathname: '/',
+      search: '',
+    });
     mockMutateBillingOverview.mockReset();
     mockUseBillingOverview.mockReturnValue({
       data: buildBillingOverview({}),
@@ -363,6 +387,7 @@ describe('AdminLayout', () => {
   test('shows sidebar loading placeholder before user state is ready', () => {
     mockUserStoreState.isInitialized = false;
     mockUserStoreState.userInfo = null as unknown as {
+      user_id: string;
       is_operator: false;
     };
 
@@ -381,7 +406,9 @@ describe('AdminLayout', () => {
   test('keeps sidebar in loading state for guests before redirect completes', () => {
     mockUserStoreState.isInitialized = true;
     mockUserStoreState.isGuest = true;
+    mockUserStoreState.isLoggedIn = false;
     mockUserStoreState.userInfo = null as unknown as {
+      user_id: string;
       is_operator: false;
     };
 
@@ -395,6 +422,28 @@ describe('AdminLayout', () => {
     expect(
       screen.queryByRole('link', { name: 'common.core.shifu' }),
     ).not.toBeInTheDocument();
+  });
+
+  test('keeps sidebar loading when user info is missing after initialization', () => {
+    mockUserStoreState.isInitialized = true;
+    mockUserStoreState.isGuest = false;
+    mockUserStoreState.isLoggedIn = true;
+    mockUserStoreState.userInfo = null as unknown as {
+      user_id: string;
+      is_operator: false;
+    };
+
+    render(
+      <AdminLayout>
+        <div>{childText}</div>
+      </AdminLayout>,
+    );
+
+    expect(screen.getByLabelText('admin-sidebar-loading')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'common.core.shifu' }),
+    ).not.toBeInTheDocument();
+    expect(window.location.href).toBe('http://localhost:3000');
   });
 
   test('renders the shared contact side rail for admin routes', () => {
@@ -433,7 +482,9 @@ describe('AdminLayout', () => {
   test('redirects guests to login from admin routes handled only by the layout', async () => {
     mockUserStoreState.isInitialized = true;
     mockUserStoreState.isGuest = true;
+    mockUserStoreState.isLoggedIn = false;
     mockUserStoreState.userInfo = null as unknown as {
+      user_id: string;
       is_operator: false;
     };
     Object.assign(window.location, {
@@ -455,10 +506,12 @@ describe('AdminLayout', () => {
     });
   });
 
-  test('renders sidebar once initialization completes even if user info is unavailable', () => {
+  test('keeps sidebar loading until user info resolves after initialization', () => {
     mockUserStoreState.isInitialized = true;
     mockUserStoreState.isGuest = false;
+    mockUserStoreState.isLoggedIn = true;
     mockUserStoreState.userInfo = null as unknown as {
+      user_id: string;
       is_operator: false;
     };
 
@@ -468,12 +521,10 @@ describe('AdminLayout', () => {
       </AdminLayout>,
     );
 
+    expect(screen.getByLabelText('admin-sidebar-loading')).toBeInTheDocument();
     expect(
-      screen.queryByLabelText('admin-sidebar-loading'),
+      screen.queryByRole('link', { name: 'common.core.shifu' }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'common.core.shifu' }),
-    ).toBeInTheDocument();
   });
 
   test('links the admin logo to the configured home URL', () => {
@@ -513,7 +564,7 @@ describe('AdminLayout', () => {
     expect(
       screen.getByText('module.billing.sidebar.nonMemberBalanceTitle'),
     ).toBeInTheDocument();
-    expect(screen.getByText('12500')).toBeInTheDocument();
+    expect(screen.getByText('12,500')).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
         name: 'module.billing.sidebar.usageCta',
@@ -553,7 +604,9 @@ describe('AdminLayout', () => {
       '/admin/billing?tab=packages',
     );
     expect(screen.queryByText(/0(?:\.0+)?/)).not.toBeInTheDocument();
-    expect(screen.getByText('--')).toBeInTheDocument();
+    expect(
+      screen.getByText('module.billing.sidebar.placeholderValue'),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
         name: 'module.billing.sidebar.usageCta',

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -22,13 +22,22 @@ const MainInterface = ({
   const pathname = usePathname();
   const isInitialized = useUserStore(state => state.isInitialized);
   const isGuest = useUserStore(state => state.isGuest);
+  const isLoggedIn = useUserStore(state => state.isLoggedIn);
+  const currentUserId = useUserStore(state => state.userInfo?.user_id || '');
   const isOperator = useUserStore(state =>
     Boolean(state.userInfo?.is_operator),
   );
-  const menuReady = isInitialized && !isGuest;
+  const hasAuthenticatedAdminSession = isInitialized && isLoggedIn && !isGuest;
+  const hasResolvedAdminSession =
+    hasAuthenticatedAdminSession && Boolean(currentUserId);
+  const menuReady = hasResolvedAdminSession;
 
   useEffect(() => {
-    if (!isInitialized || !isGuest || typeof window === 'undefined') {
+    if (
+      !isInitialized ||
+      hasAuthenticatedAdminSession ||
+      typeof window === 'undefined'
+    ) {
       return;
     }
 
@@ -36,7 +45,7 @@ const MainInterface = ({
       window.location.pathname + window.location.search,
     );
     window.location.href = `/login?redirect=${currentPath}`;
-  }, [isGuest, isInitialized]);
+  }, [hasAuthenticatedAdminSession, isInitialized]);
 
   useEffect(() => {
     document.title = t('common.core.adminTitle');

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -471,11 +471,15 @@ const ScriptManagementPage = () => {
       } catch (error) {
         console.error('Failed to ensure admin creator permissions:', error);
         if (!cancelled) {
-          const resolvedError = error as ErrorWithCode;
-          setError({
-            message: resolvedError.message || t('common.core.unknownError'),
-            code: resolvedError.code,
-          });
+          if (error instanceof ErrorWithCode) {
+            setError({ message: error.message, code: error.code });
+          } else {
+            const message =
+              error instanceof Error
+                ? error.message
+                : t('common.core.unknownError');
+            setError({ message, code: 0 });
+          }
           setAdminReady(false);
         }
       }

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -177,7 +177,11 @@ const ScriptManagementPage = () => {
   const { t, i18n } = useTranslation();
   const isInitialized = useUserStore(state => state.isInitialized);
   const isGuest = useUserStore(state => state.isGuest);
+  const isLoggedIn = useUserStore(state => state.isLoggedIn);
   const currentUserId = useUserStore(state => state.userInfo?.user_id || '');
+  const hasAuthenticatedAdminSession = isInitialized && isLoggedIn && !isGuest;
+  const hasResolvedAdminSession =
+    hasAuthenticatedAdminSession && Boolean(currentUserId);
   const [courseCreatorUrl, setCourseCreatorUrl] = useState<string | null>(null);
   const [adminReady, setAdminReady] = useState(false);
   const [activeTab, setActiveTab] = useState<'all' | 'archived'>('all');
@@ -410,15 +414,21 @@ const ScriptManagementPage = () => {
   }, [archiveLoading, archiveTarget, canManageArchive, t, toast]);
 
   useEffect(() => {
-    if (!isInitialized || !adminReady) {
+    if (!hasResolvedAdminSession || !adminReady) {
       return;
     }
     resetListAndFetch();
-  }, [activeTab, i18n.language, isInitialized, adminReady, resetListAndFetch]);
+  }, [
+    activeTab,
+    adminReady,
+    hasResolvedAdminSession,
+    i18n.language,
+    resetListAndFetch,
+  ]);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container || !isInitialized || !adminReady) return;
+    if (!container || !hasResolvedAdminSession || !adminReady) return;
 
     const observer = new IntersectionObserver(
       entries => {
@@ -431,24 +441,21 @@ const ScriptManagementPage = () => {
 
     observer.observe(container);
     return () => observer.disconnect();
-  }, [hasMore, isInitialized, adminReady]);
+  }, [adminReady, hasMore, hasResolvedAdminSession]);
 
   // Centralized login check - redirect if not logged in after initialization
   useEffect(() => {
-    if (isInitialized && isGuest) {
+    if (isInitialized && !hasAuthenticatedAdminSession) {
       const currentPath = encodeURIComponent(
         window.location.pathname + window.location.search,
       );
       window.location.href = `/login?redirect=${currentPath}`;
       return;
     }
-  }, [isInitialized, isGuest]);
+  }, [hasAuthenticatedAdminSession, isInitialized]);
 
   useEffect(() => {
-    if (!isInitialized) {
-      return;
-    }
-    if (isGuest) {
+    if (!hasResolvedAdminSession) {
       setAdminReady(false);
       return;
     }
@@ -456,12 +463,20 @@ const ScriptManagementPage = () => {
     let cancelled = false;
     const ensureAdminPermissions = async () => {
       try {
+        setError(null);
         await api.ensureAdminCreator({});
-      } catch (error) {
-        console.error('Failed to ensure admin creator permissions:', error);
-      } finally {
         if (!cancelled) {
           setAdminReady(true);
+        }
+      } catch (error) {
+        console.error('Failed to ensure admin creator permissions:', error);
+        if (!cancelled) {
+          const resolvedError = error as ErrorWithCode;
+          setError({
+            message: resolvedError.message || t('common.core.unknownError'),
+            code: resolvedError.code,
+          });
+          setAdminReady(false);
         }
       }
     };
@@ -472,7 +487,7 @@ const ScriptManagementPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [isInitialized, isGuest]);
+  }, [hasResolvedAdminSession, t]);
 
   if (error) {
     return (

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -184,6 +184,7 @@ const ScriptManagementPage = () => {
     hasAuthenticatedAdminSession && Boolean(currentUserId);
   const [courseCreatorUrl, setCourseCreatorUrl] = useState<string | null>(null);
   const [adminReady, setAdminReady] = useState(false);
+  const [permissionRetryNonce, setPermissionRetryNonce] = useState(0);
   const [activeTab, setActiveTab] = useState<'all' | 'archived'>('all');
   const [shifus, setShifus] = useState<Shifu[]>([]);
   const [loading, setLoading] = useState(false);
@@ -491,7 +492,7 @@ const ScriptManagementPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [hasResolvedAdminSession, t]);
+  }, [hasResolvedAdminSession, permissionRetryNonce, t]);
 
   if (error) {
     return (
@@ -500,7 +501,9 @@ const ScriptManagementPage = () => {
           errorCode={error.code || 0}
           errorMessage={error.message}
           onRetry={() => {
-            resetListAndFetch();
+            setError(null);
+            setAdminReady(false);
+            setPermissionRetryNonce(value => value + 1);
           }}
         />
       </div>

--- a/src/cook-web/src/store/useUserStore.test.ts
+++ b/src/cook-web/src/store/useUserStore.test.ts
@@ -1,3 +1,5 @@
+import { useUserStore } from './useUserStore';
+
 const mockGetUserInfo = jest.fn();
 const mockRegisterTmp = jest.fn();
 const mockIdentifyUmamiUser = jest.fn();
@@ -53,8 +55,6 @@ jest.mock('@/lib/google-oauth-session', () => ({
 jest.mock('@/c-common/tools/tracking', () => ({
   identifyUmamiUser: (...args: unknown[]) => mockIdentifyUmamiUser(...args),
 }));
-
-import { useUserStore } from './useUserStore';
 
 describe('useUserStore.initUser', () => {
   beforeEach(() => {

--- a/src/cook-web/src/store/useUserStore.test.ts
+++ b/src/cook-web/src/store/useUserStore.test.ts
@@ -1,0 +1,100 @@
+const mockGetUserInfo = jest.fn();
+const mockRegisterTmp = jest.fn();
+const mockIdentifyUmamiUser = jest.fn();
+const mockChangeLanguage = jest.fn();
+
+let mockTokenState = {
+  token: '',
+  faked: false,
+};
+
+jest.mock('@/c-api/user', () => ({
+  getUserInfo: (...args: unknown[]) => mockGetUserInfo(...args),
+  registerTmp: (...args: unknown[]) => mockRegisterTmp(...args),
+}));
+
+jest.mock('@/c-service/storeUtil', () => ({
+  tokenTool: {
+    get: jest.fn(() => ({ ...mockTokenState })),
+    set: jest.fn(({ token, faked }: { token: string; faked: boolean }) => {
+      mockTokenState = { token, faked };
+    }),
+    remove: jest.fn(() => {
+      mockTokenState = { token: '', faked: false };
+    }),
+  },
+}));
+
+jest.mock('@/c-utils/common', () => ({
+  genUuid: jest.fn(() => 'guest-temp-id'),
+}));
+
+jest.mock('@/c-utils/debugConsole', () => ({
+  debugError: jest.fn(),
+  debugInfo: jest.fn(),
+  debugWarn: jest.fn(),
+}));
+
+jest.mock('@/c-utils/urlUtils', () => ({
+  removeParamFromUrl: jest.fn((url: string) => url),
+}));
+
+jest.mock('@/i18n', () => ({
+  __esModule: true,
+  default: {
+    changeLanguage: (...args: unknown[]) => mockChangeLanguage(...args),
+  },
+}));
+
+jest.mock('@/lib/google-oauth-session', () => ({
+  clearGoogleOAuthSession: jest.fn(),
+}));
+
+jest.mock('@/c-common/tools/tracking', () => ({
+  identifyUmamiUser: (...args: unknown[]) => mockIdentifyUmamiUser(...args),
+}));
+
+import { useUserStore } from './useUserStore';
+
+describe('useUserStore.initUser', () => {
+  beforeEach(() => {
+    mockTokenState = {
+      token: '',
+      faked: false,
+    };
+    mockGetUserInfo.mockReset();
+    mockRegisterTmp.mockReset();
+    mockIdentifyUmamiUser.mockReset();
+    mockChangeLanguage.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    useUserStore.setState({
+      userInfo: null,
+      isGuest: false,
+      isLoggedIn: false,
+      isInitialized: false,
+      _initializingPromise: null,
+    });
+  });
+
+  test('falls back to guest state when guest bootstrap fails before any token exists', async () => {
+    mockRegisterTmp.mockRejectedValueOnce(new Error('guest bootstrap failed'));
+
+    await useUserStore.getState().initUser();
+
+    expect(mockRegisterTmp).toHaveBeenCalledWith({ temp_id: 'guest-temp-id' });
+    expect(useUserStore.getState()).toMatchObject({
+      userInfo: null,
+      isGuest: true,
+      isLoggedIn: false,
+      isInitialized: true,
+      _initializingPromise: null,
+    });
+    expect(mockTokenState).toEqual({
+      token: '',
+      faked: false,
+    });
+    expect(mockIdentifyUmamiUser).not.toHaveBeenCalled();
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/src/cook-web/src/store/useUserStore.ts
+++ b/src/cook-web/src/store/useUserStore.ts
@@ -218,6 +218,7 @@ export const useUserStore = create<
         const tokenData = tokenTool.get();
         const initialToken = tokenData.token;
         let tokenChangedDuringFetch = false;
+        let appliedGuestFallbackWithoutToken = false;
         debugInfo('[auth-chain] initUser start', {
           hasInitialToken: Boolean(initialToken),
           isGuestToken: tokenData.faked,
@@ -293,6 +294,19 @@ export const useUserStore = create<
             return;
           }
 
+          // Keep admin and other protected surfaces out of a false
+          // authenticated state when guest bootstrap fails before any token exists.
+          if (!initialToken && !latestTokenData.token) {
+            appliedGuestFallbackWithoutToken = true;
+            set({
+              userInfo: null,
+              isGuest: true,
+              isLoggedIn: false,
+              isInitialized: true,
+            });
+            return;
+          }
+
           // Only reset to guest if it's a clear authentication error (not network or server issues)
           if (
             error?.status === 403 ||
@@ -325,6 +339,9 @@ export const useUserStore = create<
             );
           }
         } finally {
+          if (appliedGuestFallbackWithoutToken) {
+            return;
+          }
           get()._updateUserStatus();
         }
       })();

--- a/src/cook-web/src/store/userProvider.test.tsx
+++ b/src/cook-web/src/store/userProvider.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { UserProvider } from './userProvider';
+
+const mockInitUser = jest.fn();
+const mockUpdateWechatCode = jest.fn();
+const mockWechatLogin = jest.fn();
+const mockParseUrlParams = jest.fn();
+const mockInWechat = jest.fn();
+const mockInMiniProgram = jest.fn();
+
+const mockEnvState = {
+  runtimeConfigLoaded: true,
+  enableWxcode: 'true',
+  appId: 'wx-app-id',
+};
+
+const mockSystemState = {
+  wechatCode: '',
+  updateWechatCode: (...args: unknown[]) => mockUpdateWechatCode(...args),
+};
+
+const mockUserState = {
+  initUser: (...args: unknown[]) => mockInitUser(...args),
+  isInitialized: false,
+};
+
+jest.mock('@/c-store', () => ({
+  __esModule: true,
+  useEnvStore: (selector: (state: typeof mockEnvState) => unknown) =>
+    selector(mockEnvState),
+  useSystemStore: (selector: (state: typeof mockSystemState) => unknown) =>
+    selector(mockSystemState),
+}));
+
+jest.mock('@/store', () => ({
+  __esModule: true,
+  useUserStore: (selector: (state: typeof mockUserState) => unknown) =>
+    selector(mockUserState),
+}));
+
+jest.mock('@/c-utils/urlUtils', () => ({
+  parseUrlParams: () => mockParseUrlParams(),
+}));
+
+jest.mock('@/c-constants/uiConstants', () => ({
+  inWechat: () => mockInWechat(),
+  inMiniProgram: () => mockInMiniProgram(),
+  wechatLogin: (...args: unknown[]) => mockWechatLogin(...args),
+}));
+
+describe('UserProvider', () => {
+  beforeEach(() => {
+    mockInitUser.mockReset();
+    mockUpdateWechatCode.mockReset();
+    mockWechatLogin.mockReset();
+    mockParseUrlParams.mockReset();
+    mockInWechat.mockReset();
+    mockInMiniProgram.mockReset();
+
+    mockEnvState.runtimeConfigLoaded = true;
+    mockEnvState.enableWxcode = 'true';
+    mockEnvState.appId = 'wx-app-id';
+
+    mockSystemState.wechatCode = '';
+    mockUserState.isInitialized = false;
+
+    Object.assign(window.location, {
+      href: 'https://app.ai-shifu.cn/admin',
+      pathname: '/admin',
+      search: '',
+    });
+  });
+
+  test('redirects admin route to WeChat OAuth before init when wxcode is missing', async () => {
+    mockInWechat.mockReturnValue(true);
+    mockInMiniProgram.mockReturnValue(false);
+    mockParseUrlParams.mockReturnValue({});
+
+    render(
+      <UserProvider>
+        <div aria-label='content' />
+      </UserProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockWechatLogin).toHaveBeenCalledWith({ appId: 'wx-app-id' });
+    });
+    expect(mockInitUser).not.toHaveBeenCalled();
+    expect(mockUpdateWechatCode).not.toHaveBeenCalled();
+  });
+
+  test('hydrates wxcode from admin url and continues init', async () => {
+    mockInWechat.mockReturnValue(true);
+    mockInMiniProgram.mockReturnValue(false);
+    mockParseUrlParams.mockReturnValue({ code: 'wx-code-1' });
+
+    render(
+      <UserProvider>
+        <div aria-label='content' />
+      </UserProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateWechatCode).toHaveBeenCalledWith('wx-code-1');
+      expect(mockInitUser).toHaveBeenCalledTimes(1);
+    });
+    expect(mockWechatLogin).not.toHaveBeenCalled();
+  });
+
+  test('continues init on admin route when wxcode is enabled but appId is missing', async () => {
+    mockEnvState.appId = '';
+    mockInWechat.mockReturnValue(true);
+    mockInMiniProgram.mockReturnValue(false);
+    mockParseUrlParams.mockReturnValue({});
+
+    render(
+      <UserProvider>
+        <div aria-label='content' />
+      </UserProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockInitUser).toHaveBeenCalledTimes(1);
+    });
+    expect(mockWechatLogin).not.toHaveBeenCalled();
+    expect(mockUpdateWechatCode).not.toHaveBeenCalled();
+  });
+});

--- a/src/cook-web/src/store/userProvider.test.tsx
+++ b/src/cook-web/src/store/userProvider.test.tsx
@@ -126,4 +126,25 @@ describe('UserProvider', () => {
     expect(mockWechatLogin).not.toHaveBeenCalled();
     expect(mockUpdateWechatCode).not.toHaveBeenCalled();
   });
+
+  test('keeps course-route wxcode waiting in the shared provider without triggering OAuth redirect', () => {
+    mockInWechat.mockReturnValue(true);
+    mockInMiniProgram.mockReturnValue(false);
+    mockParseUrlParams.mockReturnValue({});
+    Object.assign(window.location, {
+      href: 'https://app.ai-shifu.cn/c/test-course',
+      pathname: '/c/test-course',
+      search: '',
+    });
+
+    render(
+      <UserProvider>
+        <div aria-label='content' />
+      </UserProvider>,
+    );
+
+    expect(mockInitUser).not.toHaveBeenCalled();
+    expect(mockWechatLogin).not.toHaveBeenCalled();
+    expect(mockUpdateWechatCode).not.toHaveBeenCalled();
+  });
 });

--- a/src/cook-web/src/store/userProvider.tsx
+++ b/src/cook-web/src/store/userProvider.tsx
@@ -35,7 +35,12 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
     const onCourseRoute = pathname.startsWith('/c');
     const onAdminRoute = pathname.startsWith('/admin');
 
-    if (wxcodeEnabled && (onCourseRoute || onAdminRoute) && inWechat() && !inMiniProgram()) {
+    if (
+      wxcodeEnabled &&
+      (onCourseRoute || onAdminRoute) &&
+      inWechat() &&
+      !inMiniProgram()
+    ) {
       const params = parseUrlParams() as Record<string, string | undefined>;
       const codeInUrl = params.code;
 

--- a/src/cook-web/src/store/userProvider.tsx
+++ b/src/cook-web/src/store/userProvider.tsx
@@ -30,17 +30,12 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
 
     const wxcodeEnabled =
       typeof enableWxcode === 'string' && enableWxcode.toLowerCase() === 'true';
-    const onWxcodeProtectedRoute =
-      typeof window !== 'undefined' &&
-      (window.location.pathname.startsWith('/c') ||
-        window.location.pathname.startsWith('/admin'));
+    const pathname =
+      typeof window !== 'undefined' ? window.location.pathname : '';
+    const onCourseRoute = pathname.startsWith('/c');
+    const onAdminRoute = pathname.startsWith('/admin');
 
-    if (
-      wxcodeEnabled &&
-      onWxcodeProtectedRoute &&
-      inWechat() &&
-      !inMiniProgram()
-    ) {
+    if (wxcodeEnabled && (onCourseRoute || onAdminRoute) && inWechat() && !inMiniProgram()) {
       const params = parseUrlParams() as Record<string, string | undefined>;
       const codeInUrl = params.code;
 
@@ -49,8 +44,14 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
       }
 
       if (!codeInUrl && !wechatCode) {
-        if (appId) {
+        if (onAdminRoute && appId) {
           wechatLogin({ appId });
+          return;
+        }
+
+        if (onCourseRoute) {
+          // `/c` keeps its existing route-local OAuth redirect flow and only
+          // waits here until that path hydrates a usable wxcode.
           return;
         }
       }

--- a/src/cook-web/src/store/userProvider.tsx
+++ b/src/cook-web/src/store/userProvider.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect } from 'react';
 
-import { inWechat } from '@/c-constants/uiConstants';
+import {
+  inMiniProgram,
+  inWechat,
+  wechatLogin,
+} from '@/c-constants/uiConstants';
 import { useEnvStore, useSystemStore } from '@/c-store';
 import { parseUrlParams } from '@/c-utils/urlUtils';
 import { useUserStore } from '@/store';
@@ -15,6 +19,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const runtimeConfigLoaded = useEnvStore(state => state.runtimeConfigLoaded);
   const enableWxcode = useEnvStore(state => state.enableWxcode);
+  const appId = useEnvStore(state => state.appId);
   const wechatCode = useSystemStore(state => state.wechatCode);
   const updateWechatCode = useSystemStore(state => state.updateWechatCode);
 
@@ -25,19 +30,29 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
 
     const wxcodeEnabled =
       typeof enableWxcode === 'string' && enableWxcode.toLowerCase() === 'true';
-    const onCourseRoute =
+    const onWxcodeProtectedRoute =
       typeof window !== 'undefined' &&
-      window.location.pathname.startsWith('/c');
+      (window.location.pathname.startsWith('/c') ||
+        window.location.pathname.startsWith('/admin'));
 
-    if (wxcodeEnabled && onCourseRoute && inWechat()) {
+    if (
+      wxcodeEnabled &&
+      onWxcodeProtectedRoute &&
+      inWechat() &&
+      !inMiniProgram()
+    ) {
       const params = parseUrlParams() as Record<string, string | undefined>;
       const codeInUrl = params.code;
+
       if (codeInUrl && codeInUrl !== wechatCode) {
         updateWechatCode(codeInUrl);
       }
-      // Wait until the OAuth code is available so require_tmp can carry it
-      if (!wechatCode && !codeInUrl) {
-        return;
+
+      if (!codeInUrl && !wechatCode) {
+        if (appId) {
+          wechatLogin({ appId });
+          return;
+        }
       }
     }
 
@@ -47,6 +62,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [
     runtimeConfigLoaded,
     enableWxcode,
+    appId,
     wechatCode,
     updateWechatCode,
     initUser,


### PR DESCRIPTION
## Summary
- add wxcode bootstrap for `/admin` in the shared `UserProvider`
- fall back to guest state when guest bootstrap fails before any token exists
- tighten admin session gating so incomplete user info does not render admin as ready
- add focused tests for user provider, user store, and admin layout flows

## Why
New users opening `/admin` inside WeChat could hit an inconsistent auth/init state and see an error page. This change aligns `/admin` with the existing WeChat bootstrap path and prevents false authenticated admin states.

## Verification
- `cd src/cook-web && npx jest src/store/userProvider.test.tsx src/store/useUserStore.test.ts src/app/admin/layout.test.tsx --runInBand`
- `cd src/cook-web && npx eslint src/store/userProvider.tsx src/store/userProvider.test.tsx src/store/useUserStore.ts src/store/useUserStore.test.ts src/app/admin/layout.tsx src/app/admin/page.tsx src/app/admin/layout.test.tsx`

## Notes
- `cd src/cook-web && npm run type-check` is still blocked by an existing unrelated error in `src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx:1409`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes billing sidebar: credit amounts show thousand separators (e.g., 12,500) and zero-credits use the configured placeholder.

* **Improvements**
  * Tighter admin authentication gating and more reliable redirect behavior.
  * Sidebar loading and error handling refined for admin pages.
  * WeChat OAuth/init flow improved to better handle code parsing and login triggers.
  * User initialization now cleanly falls back to guest state when recovery fails.

* **Tests**
  * Added/updated tests covering admin layout, user store, and provider behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1751)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->