### PR TITLE
fix: keep preview variable copy on one line

### DIFF
--- a/src/cook-web/src/components/lesson-preview/VariableList.module.scss
+++ b/src/cook-web/src/components/lesson-preview/VariableList.module.scss
@@ -18,18 +18,26 @@
     display: flex;
     align-items: baseline;
     gap: 8px;
+    flex: 1;
+    min-width: 0;
   }
 
   .title {
     font-size: 16px;
     font-weight: 600;
     color: #0a0a0a;
+    flex-shrink: 0;
   }
 
   .description {
     font-size: 12px;
     margin-left: 8px;
     color: rgba(0, 0, 0, 0.45);
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .link {

--- a/src/cook-web/src/components/lesson-preview/VariableList.module.scss
+++ b/src/cook-web/src/components/lesson-preview/VariableList.module.scss
@@ -27,6 +27,7 @@
     font-weight: 600;
     color: #0a0a0a;
     flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .description {


### PR DESCRIPTION
## Summary
- keep the variable description in the lesson preview header on a single line
- apply truncation and ellipsis through shared layout styles instead of language-specific copy changes
- preserve the existing title hover so the full localized description remains accessible

## Why
English and French translations can wrap onto multiple lines in the course editor debug preview, which breaks the header layout compared with Chinese. This change keeps the UI consistent across locales without special-casing any language.

## Verification
- self-reviewed the scoped style change in `src/cook-web/src/components/lesson-preview/VariableList.module.scss`

## Notes
- This is a style-only change scoped to the variable header description layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved lesson preview display layout with better text truncation and ellipsis handling for titles and descriptions to ensure consistent content visibility across different text lengths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1752)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->