### PR TITLE
fix: qwen prefixed model fallback

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -496,6 +496,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         default_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         prefix=QWEN_PREFIX,
         extra_models=["deepseek-r1", "deepseek-v3"],
+        wildcard_prefixes=(QWEN_PREFIX,),
         config_hint="QWEN_API_KEY,QWEN_API_URL",
         custom_llm_provider="openai",
         reload_params=_reload_qwen_params,

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -365,6 +365,57 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
     assert models == llm.DEEPSEEK_FALLBACK_MODELS
 
 
+def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
+    captured = {}
+
+    def fake_completion(model, *args, **kwargs):
+        captured["model"] = model
+        captured["kwargs"] = kwargs
+        return iter([FakeResponse("chunk-1", content="ok", finish_reason="stop")])
+
+    monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    provider_state = llm.ProviderState(
+        enabled=True,
+        params={"api_key": "test-key", "api_base": "https://example.com"},
+        models=[],
+        prefix=llm.QWEN_PREFIX,
+        wildcard_prefixes=(llm.QWEN_PREFIX,),
+        reload_params=llm._reload_qwen_params,
+    )
+    monkeypatch.setattr(llm, "PROVIDER_STATES", {"qwen": provider_state})
+    monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {})
+    monkeypatch.setattr(
+        llm,
+        "PROVIDER_CONFIG_HINTS",
+        {"qwen": "QWEN_API_KEY,QWEN_API_URL"},
+    )
+
+    responses = list(
+        llm.chat_llm(
+            app=app,
+            user_id="user-1",
+            span=DummySpan(),
+            model="qwen/deepseek-v4-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            temperature="0.7",
+            generation_name="qwen-test",
+        )
+    )
+
+    assert [resp.result for resp in responses] == ["ok"]
+    assert captured["model"] == "deepseek-v4-flash"
+    assert captured["kwargs"]["temperature"] == 0.7
+    assert captured["kwargs"]["extra_body"] == {"enable_thinking": False}
+
+
+def test_qwen_provider_config_keeps_prefix_fallback():
+    qwen_config = next(
+        config for config in llm.LITELLM_PROVIDER_CONFIGS if config.key == "qwen"
+    )
+
+    assert qwen_config.wildcard_prefixes == (llm.QWEN_PREFIX,)
+
+
 def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     captured_kwargs = {}
 


### PR DESCRIPTION
## Summary
- route qwen-prefixed models through the Qwen provider even when the startup model list does not register an alias
- add regression coverage for qwen/deepseek-v4-flash resolving without a fetched alias

## Root Cause
The production default model is configured as qwen/deepseek-v4-flash. Qwen models were only routable when the provider model-list fetch registered an alias during process startup. If that list was missing or incomplete, chat_llm treated the configured model as unsupported before reaching LiteLLM.

## Validation
- cd src/api && pytest tests/test_llm.py -q
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Qwen AI model integration with improved routing and recognition for Qwen-prefixed models
  * Strengthened provider configuration through comprehensive test validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1755)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->