### PR TITLE
feat: add operator course credit usage tab

### DIFF
--- a/docs/exec-plans/active/operator-course-detail-tab-splitting.md
+++ b/docs/exec-plans/active/operator-course-detail-tab-splitting.md
@@ -1,0 +1,122 @@
+# Operator Course Detail Tab Splitting
+
+## Purpose / Big Picture
+
+Keep `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx` as the route
+entry for the operator course detail page, but progressively split heavy tab UI
+into dedicated local components so the page stays reviewable and safe to extend.
+Phase A focuses only on the credit usage tab because it is the newest and most
+self-contained block. Later phases can split the users tab and the chapters tab
+without changing backend contracts.
+
+## Progress
+
+- [x] 2026-05-13 18:10 CST: Reviewed the course detail page structure and
+  confirmed the credit usage tab is the safest first extraction target.
+- [x] 2026-05-13 18:35 CST: Split the credit usage tab into a dedicated sibling
+  component while keeping request/state orchestration in `page.tsx`.
+- [x] 2026-05-13 18:45 CST: Recorded the later users/chapters split order in the
+  requirement and optimization docs.
+- [ ] 2026-05-13 18:50 CST: Split the users tab into a dedicated local
+  component after the credit usage extraction stabilizes.
+- [ ] 2026-05-13 18:50 CST: Split the chapters table and chapter-detail display
+  helpers after the users tab extraction stabilizes.
+
+## Surprises & Discoveries
+
+- The page had already grown past 3,000 lines before the credit usage block was
+  extracted, so even “small” tab additions now create high review overhead.
+- The credit usage tab owns its own column-sizing behavior and filter rendering,
+  which makes it a good first split candidate without forcing route-level state
+  changes.
+- The repository already contains a reusable `ClearableTextInput` under
+  `src/cook-web/src/app/admin/operations/orders/orderUiShared.tsx`, which can be
+  reused instead of adding another one-off input implementation.
+
+## Decision Log
+
+- Decision: split only the credit usage tab in this pass.
+  - Why: it keeps the refactor aligned with the active feature branch and avoids
+    mixing older chapter/user logic into the same regression surface.
+- Decision: keep data fetching, tab switching, and route context in
+  `page.tsx`.
+  - Why: this preserves current behavior and leaves later extractions with a
+    stable orchestration layer.
+- Decision: record later tab splits in docs now instead of trying to finish the
+  whole page in one pass.
+  - Why: the user explicitly wants staged follow-up work, not a one-shot page
+    rewrite.
+
+## Outcomes & Retrospective
+
+- Phase A should leave the course detail page functionally unchanged for
+  operators while reducing the size of `page.tsx` and isolating the newest tab.
+- If this pattern proves stable, the same route-orchestration plus local-tab
+  rendering split can be repeated for the users and chapters areas.
+
+## Context and Orientation
+
+Relevant files:
+
+- `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
+- `src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx`
+- `src/cook-web/src/app/admin/operations/operation-course-types.ts`
+- `src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx`
+- `docs/product-specs/operator-course-detail-page.md`
+- `docs/需求和优化.md`
+
+The page already owns three bottom tabs: chapters, users, and credit usage.
+This plan does not redesign their behavior. It only changes where tab-local UI
+lives.
+
+## Plan of Work
+
+1. Isolate the credit usage tab rendering into a sibling component.
+2. Keep page-level request/state orchestration in `page.tsx`.
+3. Reuse existing shared admin UI pieces where possible.
+4. Record the next split order in the requirement and optimization docs.
+5. Validate with focused frontend tests and lightweight static checks.
+
+## Concrete Steps
+
+1. Add or reuse shared UI types needed by both `page.tsx` and the new credit
+   usage component.
+2. Create `CourseCreditUsageTab.tsx` beside the route entry.
+3. Move tab-local filter rendering, table rendering, pagination rendering, and
+   column-width behavior into the new component.
+4. Replace the inline credit usage tab JSX in `page.tsx` with the new
+   component.
+5. Update docs with the future split sequence.
+6. Run the focused course detail frontend test and local syntax/diff checks.
+
+## Validation and Acceptance
+
+- The course detail page still opens and switches tabs as before.
+- The credit usage tab still loads on demand and shows the same filters, rows,
+  and pagination behavior.
+- The existing focused test at
+  `src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx` passes.
+- No new syntax errors are introduced in touched frontend files.
+
+## Idempotence and Recovery
+
+- Re-running the refactor should be safe because the route-level contracts do
+  not change.
+- If a later tab split stalls, the page remains usable because each extraction
+  is scoped to one tab at a time.
+- If column-width behavior regresses, the fallback is to keep the route-level
+  fetch/state work intact and restore only the extracted tab component.
+
+## Interfaces and Dependencies
+
+- Frontend route entry: `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx`
+- Shared admin UI pieces:
+  - `AdminTableShell`
+  - `AdminPagination`
+  - `AdminDateRangeFilter`
+  - `useAdminResizableColumns`
+- Shared typed contract surface:
+  `src/cook-web/src/app/admin/operations/operation-course-types.ts`
+- Documentation surfaces:
+  - `docs/product-specs/operator-course-detail-page.md`
+  - `docs/需求和优化.md`

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -7,6 +7,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 ## Active
 
 - [Agent-First Harness Phase 2](./active/agent-first-harness-phase-2.md)
+- [Operator Course Detail Tab Splitting](./active/operator-course-detail-tab-splitting.md)
 
 ## Completed
 

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -18,6 +18,7 @@
 | `docs/design-docs/primary-surface-rules.md` | Primary Surface Rules Completion | `design-doc` | `implemented` | `repo` | `2026-04-17` | `true` |
 | `docs/engineering-baseline.md` | Engineering Baseline | `root-doc` | `reference` | `repo` | `2026-04-17` | `true` |
 | `docs/exec-plans/active/agent-first-harness-phase-2.md` | Agent-First Harness Phase 2 | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/operator-course-detail-tab-splitting.md` | Operator Course Detail Tab Splitting | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/agent-first-harness-migration.md` | Agent-First Harness Migration | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/tech-debt-tracker.md` | Tech Debt Tracker | `exec-plan-support` | `active` | `repo` | `2026-04-17` | `true` |
 | `docs/generated/harness-gardening-summary.md` | Harness Gardening Summary | `generated-doc` | `reference` | `repo` | `2026-04-17` | `true` |
@@ -25,7 +26,7 @@
 | `docs/product-specs/dashboard-entry-page.md` | Dashboard Entry Page (v2) Technical Design | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/mdflow-element-backfill.md` | MDFlow Element Backfill | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/mobile-404-sequencing-followup.md` | Mobile 404 Follow-up: Sequencing Improvement Plan | `product-spec` | `implemented` | `frontend` | `2026-04-17` | `true` |
-| `docs/product-specs/operator-course-detail-page.md` | Operator Course Detail Page | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
+| `docs/product-specs/operator-course-detail-page.md` | Operator Course Detail Page | `product-spec` | `implemented` | `shared` | `2026-05-13` | `true` |
 | `docs/product-specs/operator-course-visit-analytics.md` | Operator Course Visit Analytics | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |
 | `docs/product-specs/operator-role.md` | Operator Role Design | `product-spec` | `implemented` | `shared` | `2026-05-12` | `true` |
 | `docs/product-specs/operator-user-management.md` | Operator User Management | `product-spec` | `implemented` | `shared` | `2026-04-17` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `7`
 - Product specs: `10`
 - References: `3`
-- Active ExecPlans: `1`
+- Active ExecPlans: `2`
 - Completed ExecPlans: `1`
 
 ## Boundary Baseline

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -11,7 +11,7 @@ User-facing workflow and page behavior specifications live here.
 - [Mobile 404 Follow-up: Sequencing Improvement Plan](../product-specs/mobile-404-sequencing-followup.md)
   - Status: `implemented` | Owner: `frontend` | Last reviewed: `2026-04-17` | Canonical: `true`
 - [Operator Course Detail Page](../product-specs/operator-course-detail-page.md)
-  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
+  - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-05-13` | Canonical: `true`
 - [Operator Course Visit Analytics](../product-specs/operator-course-visit-analytics.md)
   - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-04-17` | Canonical: `true`
 - [Operator Role Design](../product-specs/operator-role.md)

--- a/docs/product-specs/operator-course-detail-page.md
+++ b/docs/product-specs/operator-course-detail-page.md
@@ -81,6 +81,34 @@ The backend detail payload should return:
   - reduce the size and review risk of `page.tsx`
   - allow later tab-level iteration without re-reading the whole detail page
 
+### Credit Usage Aggregation Follow-up
+
+- The current credit-usage list is settlement-accurate, but it is too granular
+  for operator inspection because it shows one row per settled `usage_bid`.
+- The operator-facing view should evolve without changing billing or settlement
+  behavior.
+- Implemented in this branch:
+  - add a grouped credit-usage view for operators
+  - keep grouping on the backend so pagination, totals, and ordering remain
+    correct
+  - use `progress_record_bid` as the primary grouping key
+  - keep rows without `progress_record_bid` as standalone rows instead of
+    forcing them into a group
+- Grouped rows should summarize:
+  - latest consumed time
+  - learner account
+  - nickname
+  - chapter
+  - lesson
+  - usage mode summary
+  - usage count
+  - total consumed credits
+  - model summary
+- Future extension:
+  - keep the grouped view as the default operator overview
+  - later add grouped-to-raw drill-down so operators can inspect underlying
+    usage rows without replacing grouped view as the primary mode
+
 ### Verification
 
 - Add focused backend tests for the new operator detail response

--- a/docs/product-specs/operator-course-detail-page.md
+++ b/docs/product-specs/operator-course-detail-page.md
@@ -2,7 +2,7 @@
 title: Operator Course Detail Page
 status: implemented
 owner_surface: shared
-last_reviewed: 2026-04-17
+last_reviewed: 2026-05-13
 canonical: true
 ---
 
@@ -61,6 +61,25 @@ The backend detail payload should return:
 - Keep the page aligned with the existing admin detail card style used in dashboard pages
 - Use i18n keys in `module.operationsCourse`
 - Keep the bottom section optimized for inspection rather than rich editing
+- Keep `src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx` as the route
+  entry and orchestration layer, but split heavy bottom-tab UI into dedicated
+  local components as the page grows
+
+### Frontend Structure Follow-up
+
+- Current preferred split order:
+  1. credit usage tab
+  2. users tab
+  3. chapter tab table / detail helpers
+- Split rules:
+  - do not change existing backend contracts while only restructuring UI
+  - keep route params, operator guard, tab switching, and data-fetch orchestration
+    in `page.tsx`
+  - move tab-local rendering, column sizing, and filter presentation into
+    dedicated sibling components
+- Goal:
+  - reduce the size and review risk of `page.tsx`
+  - allow later tab-level iteration without re-reading the whole detail page
 
 ### Verification
 

--- a/docs/product-specs/operator-course-detail-page.md
+++ b/docs/product-specs/operator-course-detail-page.md
@@ -91,7 +91,8 @@ The backend detail payload should return:
   - add a grouped credit-usage view for operators
   - keep grouping on the backend so pagination, totals, and ordering remain
     correct
-  - use `progress_record_bid` as the primary grouping key
+  - use `progress_record_bid + usage_mode` as the primary grouping key so
+    learning, listen, and follow-up rows stay separate
   - keep rows without `progress_record_bid` as standalone rows instead of
     forcing them into a group
 - Grouped rows should summarize:
@@ -101,7 +102,6 @@ The backend detail payload should return:
   - chapter
   - lesson
   - usage mode summary
-  - usage count
   - total consumed credits
   - model summary
 - Future extension:

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -53,7 +53,6 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_SCENE_PROD,
-    BILL_USAGE_TYPE_LLM,
     BILL_USAGE_TYPE_TTS,
 )
 from flaskr.service.metering.models import BillUsageRecord
@@ -2977,7 +2976,9 @@ def _build_credit_usage_user_keyword_filter(
     )
 
     if "@" in normalized:
-        credential_identifier_filter = db.func.lower(AuthCredential.identifier) == normalized
+        credential_identifier_filter = (
+            db.func.lower(AuthCredential.identifier) == normalized
+        )
         user_identifier_filter = db.func.lower(UserEntity.user_identify) == normalized
     elif normalized.isdigit():
         credential_identifier_filter = AuthCredential.identifier == normalized
@@ -3946,9 +3947,7 @@ def get_operator_course_credit_usages(
             )
 
         total = (
-            db.session.query(db.func.count())
-            .select_from(query.subquery())
-            .scalar()
+            db.session.query(db.func.count()).select_from(query.subquery()).scalar()
             or 0
         )
         if total == 0:

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -354,6 +354,23 @@ def _build_course_credit_usage_model_display(provider: str, model: str) -> str:
     return normalized_provider or normalized_model
 
 
+def _build_course_credit_usage_group_key(
+    progress_record_bid: str,
+    usage_mode: str,
+    usage_bid: str,
+) -> str:
+    normalized_progress_record_bid = str(progress_record_bid or "").strip()
+    normalized_usage_mode = str(usage_mode or "").strip()
+    normalized_usage_bid = str(usage_bid or "").strip()
+    if normalized_progress_record_bid:
+        return (
+            f"{normalized_progress_record_bid}:{normalized_usage_mode}"
+            if normalized_usage_mode
+            else normalized_progress_record_bid
+        )
+    return normalized_usage_bid
+
+
 def _build_operator_course_credit_usage_item(
     *,
     usage_row: BillUsageRecord,
@@ -4124,7 +4141,12 @@ def get_operator_course_credit_usages(
         grouped_order: list[str] = []
         for item in raw_items:
             progress_record_bid = str(item.progress_record_bid or "").strip()
-            group_key = progress_record_bid or str(item.usage_bid or "").strip()
+            usage_mode = str(item.usage_mode or "").strip()
+            group_key = _build_course_credit_usage_group_key(
+                progress_record_bid=progress_record_bid,
+                usage_mode=usage_mode,
+                usage_bid=str(item.usage_bid or "").strip(),
+            )
             if not group_key:
                 continue
 
@@ -4141,11 +4163,6 @@ def get_operator_course_credit_usages(
                     "base_item": item,
                     "usage_count": 1,
                     "consumed_credits": Decimal(str(item.consumed_credits or 0)),
-                    "usage_modes": (
-                        {str(item.usage_mode or "").strip()}
-                        if item.usage_mode
-                        else set()
-                    ),
                     "model_entries": model_entries,
                 }
                 grouped_order.append(group_key)
@@ -4153,9 +4170,6 @@ def get_operator_course_credit_usages(
 
             payload["usage_count"] += 1
             payload["consumed_credits"] += Decimal(str(item.consumed_credits or 0))
-            usage_mode = str(item.usage_mode or "").strip()
-            if usage_mode:
-                payload["usage_modes"].add(usage_mode)
             model_display = _build_course_credit_usage_model_display(
                 item.provider,
                 item.model,
@@ -4167,13 +4181,6 @@ def get_operator_course_credit_usages(
         for group_key in grouped_order:
             payload = grouped_payloads[group_key]
             base_item = payload["base_item"]
-            usage_modes = payload["usage_modes"]
-            if len(usage_modes) == 1:
-                usage_mode = next(iter(usage_modes))
-            elif len(usage_modes) > 1:
-                usage_mode = COURSE_CREDIT_USAGE_MODE_MIXED
-            else:
-                usage_mode = ""
             model_entries = payload["model_entries"]
             primary_provider = ""
             primary_model = ""
@@ -4193,7 +4200,7 @@ def get_operator_course_credit_usages(
                     chapter_title=base_item.chapter_title,
                     lesson_outline_item_bid=base_item.lesson_outline_item_bid,
                     lesson_title=base_item.lesson_title,
-                    usage_mode=usage_mode,
+                    usage_mode=base_item.usage_mode,
                     provider=primary_provider,
                     model=primary_model,
                     usage_count=payload["usage_count"],

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -6,7 +6,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
 from flask import Flask, current_app
-from sqlalchemy import and_, case, or_
+from sqlalchemy import and_, case, not_, or_
 from sqlalchemy.orm import defer
 
 from flaskr.common.cache_provider import cache as redis
@@ -40,6 +40,7 @@ from flaskr.service.billing.models import (
     CreditWalletBucket,
 )
 from flaskr.service.billing.primitives import (
+    credit_decimal_to_number,
     quantize_credit_amount as _quantize_credit_amount,
 )
 from flaskr.service.billing.queries import (
@@ -52,7 +53,10 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_SCENE_PROD,
+    BILL_USAGE_TYPE_LLM,
+    BILL_USAGE_TYPE_TTS,
 )
+from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.learn.learn_dtos import ElementType
 from flaskr.service.learn.listen_element_payloads import _deserialize_payload
 from flaskr.service.learn.const import (
@@ -77,6 +81,8 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseDetailBasicInfoDTO,
     AdminOperationCourseDetailChapterDTO,
     AdminOperationCourseDetailDTO,
+    AdminOperationCourseCreditUsageItemDTO,
+    AdminOperationCourseCreditUsageListDTO,
     AdminOperationCourseFollowUpCurrentRecordDTO,
     AdminOperationCourseFollowUpDetailBasicInfoDTO,
     AdminOperationCourseFollowUpDetailDTO,
@@ -216,6 +222,10 @@ OPERATOR_USER_REGISTRATION_SOURCE_IMPORTED = "imported"
 OPERATOR_USER_REGISTRATION_SOURCE_UNKNOWN = "unknown"
 COURSE_FOLLOW_UP_LIST_MAX_PAGE_SIZE = 100
 COURSE_RATING_LIST_MAX_PAGE_SIZE = 100
+COURSE_CREDIT_USAGE_LIST_MAX_PAGE_SIZE = 100
+COURSE_CREDIT_USAGE_MODE_LEARN = "learn"
+COURSE_CREDIT_USAGE_MODE_LISTEN = "listen"
+COURSE_CREDIT_USAGE_MODE_ASK = "ask"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_REWARD = "reward"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_COMPENSATION = "compensation"
 OPERATOR_USER_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION = "align_subscription"
@@ -293,6 +303,58 @@ def _resolve_course_rating_sort_by(value: str) -> str:
     if normalized == "score_asc":
         return normalized
     return ""
+
+
+def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:
+    usage_type = int(getattr(row, "usage_type", 0) or 0)
+    if usage_type == BILL_USAGE_TYPE_TTS:
+        return COURSE_CREDIT_USAGE_MODE_LISTEN
+
+    metadata = _normalize_metadata_json(getattr(row, "extra", None))
+    generation_name = str(metadata.get("generation_name", "") or "").strip().lower()
+    if (
+        "/user_follow_ask/" in generation_name
+        or generation_name.startswith("lesson_ask/")
+        or generation_name.startswith("lesson_preview_ask/")
+    ):
+        return COURSE_CREDIT_USAGE_MODE_ASK
+
+    return COURSE_CREDIT_USAGE_MODE_LEARN
+
+
+def _resolve_course_credit_usage_mode_filter(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {
+        "",
+        "all",
+        COURSE_CREDIT_USAGE_MODE_LEARN,
+        COURSE_CREDIT_USAGE_MODE_LISTEN,
+        COURSE_CREDIT_USAGE_MODE_ASK,
+    }:
+        return normalized
+    return ""
+
+
+def _build_course_credit_usage_ask_filter() -> Any:
+    generation_name = db.func.lower(
+        BillUsageRecord.extra["generation_name"].as_string()
+    )
+    return or_(
+        generation_name.contains("/user_follow_ask/"),
+        generation_name.startswith("lesson_ask/"),
+        generation_name.startswith("lesson_preview_ask/"),
+    )
+
+
+def _build_course_credit_usage_learn_filter() -> Any:
+    generation_name = db.func.lower(
+        BillUsageRecord.extra["generation_name"].as_string()
+    )
+    return or_(
+        generation_name.is_(None),
+        generation_name == "",
+        not_(_build_course_credit_usage_ask_filter()),
+    )
 
 
 def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
@@ -2897,6 +2959,60 @@ def _build_follow_up_user_keyword_filter(
     return or_(credential_match_exists, user_match_exists)
 
 
+def _build_credit_usage_user_keyword_filter(
+    user_bid_column: Any, keyword: str
+) -> Any | None:
+    normalized = _normalize_identifier(keyword)
+    if not normalized:
+        return None
+
+    nickname_match_exists = (
+        db.session.query(UserEntity.id)
+        .filter(
+            UserEntity.user_bid == user_bid_column,
+            UserEntity.deleted == 0,
+            UserEntity.nickname.ilike(f"%{normalized}%"),
+        )
+        .exists()
+    )
+
+    if "@" in normalized:
+        credential_identifier_filter = db.func.lower(AuthCredential.identifier) == normalized
+        user_identifier_filter = db.func.lower(UserEntity.user_identify) == normalized
+    elif normalized.isdigit():
+        credential_identifier_filter = AuthCredential.identifier == normalized
+        user_identifier_filter = UserEntity.user_identify == normalized
+    else:
+        return nickname_match_exists
+
+    credential_match_exists = (
+        db.session.query(AuthCredential.id)
+        .filter(
+            AuthCredential.user_bid == user_bid_column,
+            AuthCredential.deleted == 0,
+            AuthCredential.provider_name.in_(["phone", "email", "google"]),
+            credential_identifier_filter,
+        )
+        .exists()
+    )
+
+    user_identifier_match_exists = (
+        db.session.query(UserEntity.id)
+        .filter(
+            UserEntity.user_bid == user_bid_column,
+            UserEntity.deleted == 0,
+            user_identifier_filter,
+        )
+        .exists()
+    )
+
+    return or_(
+        nickname_match_exists,
+        credential_match_exists,
+        user_identifier_match_exists,
+    )
+
+
 def _resolve_follow_up_matching_outline_bids(
     outline_context_map: Dict[str, Dict[str, str]],
     chapter_keyword: str,
@@ -3736,6 +3852,189 @@ def get_operator_course_users(
         end = start + safe_page_size
         paged_items = items[start:end]
         return PageNationDTO(safe_page_index, safe_page_size, total, paged_items)
+
+
+def get_operator_course_credit_usages(
+    app: Flask,
+    *,
+    shifu_bid: str,
+    page_index: int,
+    page_size: int,
+    filters: Optional[dict] = None,
+) -> AdminOperationCourseCreditUsageListDTO:
+    with app.app_context():
+        normalized_shifu_bid = str(shifu_bid or "").strip()
+        if not normalized_shifu_bid:
+            raise_param_error("shifu_bid is required")
+
+        safe_page_index = max(int(page_index or 1), 1)
+        safe_page_size = min(
+            max(int(page_size or 20), 1),
+            COURSE_CREDIT_USAGE_LIST_MAX_PAGE_SIZE,
+        )
+        filters = filters or {}
+
+        _detail_source, outline_items = _load_operator_course_outline_items(
+            normalized_shifu_bid
+        )
+        outline_context_map = _build_course_outline_context_map(outline_items)
+
+        keyword = str(filters.get("keyword", "") or "").strip()
+        mode_filter = _resolve_course_credit_usage_mode_filter(
+            str(filters.get("mode", "") or "")
+        )
+        start_time = filters.get("start_time")
+        end_time = filters.get("end_time")
+
+        if str(filters.get("mode", "") or "").strip() and not mode_filter:
+            raise_param_error("mode")
+
+        credit_usage_ledger_totals = (
+            db.session.query(
+                CreditLedgerEntry.source_bid.label("usage_bid"),
+                db.func.sum(CreditLedgerEntry.amount).label("ledger_amount"),
+            )
+            .filter(
+                CreditLedgerEntry.deleted == 0,
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+                CreditLedgerEntry.source_type == CREDIT_SOURCE_TYPE_USAGE,
+            )
+            .group_by(CreditLedgerEntry.source_bid)
+            .subquery()
+        )
+
+        query = db.session.query(
+            BillUsageRecord,
+            credit_usage_ledger_totals.c.ledger_amount,
+        ).join(
+            credit_usage_ledger_totals,
+            credit_usage_ledger_totals.c.usage_bid == BillUsageRecord.usage_bid,
+        )
+
+        query = query.filter(
+            BillUsageRecord.shifu_bid == normalized_shifu_bid,
+            BillUsageRecord.deleted == 0,
+            BillUsageRecord.billable == 1,
+            BillUsageRecord.status == 0,
+            BillUsageRecord.record_level == 0,
+            BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
+            credit_usage_ledger_totals.c.ledger_amount < 0,
+        )
+
+        user_keyword_filter = _build_credit_usage_user_keyword_filter(
+            BillUsageRecord.user_bid,
+            keyword,
+        )
+        if user_keyword_filter is not None:
+            query = query.filter(user_keyword_filter)
+        if start_time:
+            query = query.filter(BillUsageRecord.created_at >= start_time)
+        if end_time:
+            query = query.filter(BillUsageRecord.created_at <= end_time)
+
+        if mode_filter == COURSE_CREDIT_USAGE_MODE_LISTEN:
+            query = query.filter(BillUsageRecord.usage_type == BILL_USAGE_TYPE_TTS)
+        elif mode_filter == COURSE_CREDIT_USAGE_MODE_ASK:
+            query = query.filter(
+                BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
+                _build_course_credit_usage_ask_filter(),
+            )
+        elif mode_filter == COURSE_CREDIT_USAGE_MODE_LEARN:
+            query = query.filter(
+                BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
+                _build_course_credit_usage_learn_filter(),
+            )
+
+        total = (
+            db.session.query(db.func.count())
+            .select_from(query.subquery())
+            .scalar()
+            or 0
+        )
+        if total == 0:
+            return AdminOperationCourseCreditUsageListDTO(
+                items=[],
+                page=safe_page_index,
+                page_size=safe_page_size,
+                total=0,
+                page_count=0,
+            )
+
+        start = (safe_page_index - 1) * safe_page_size
+        rows = (
+            query.order_by(BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc())
+            .offset(start)
+            .limit(safe_page_size)
+            .all()
+        )
+
+        user_map = _load_user_map(
+            sorted(
+                {
+                    str(getattr(usage_row, "user_bid", "") or "").strip()
+                    for usage_row, _ledger_amount in rows
+                    if str(getattr(usage_row, "user_bid", "") or "").strip()
+                }
+            )
+        )
+
+        items: list[AdminOperationCourseCreditUsageItemDTO] = []
+        for usage_row, ledger_amount in rows:
+            usage_mode = _resolve_course_credit_usage_mode(usage_row)
+            user_bid = str(getattr(usage_row, "user_bid", "") or "").strip()
+            outline_item_bid = str(
+                getattr(usage_row, "outline_item_bid", "") or ""
+            ).strip()
+            created_at = getattr(usage_row, "created_at", None)
+            context = outline_context_map.get(
+                outline_item_bid,
+                {
+                    "chapter_outline_item_bid": "",
+                    "chapter_title": "",
+                    "lesson_outline_item_bid": outline_item_bid,
+                    "lesson_title": "",
+                },
+            )
+            user = user_map.get(user_bid, {})
+            consumed_credits = credit_decimal_to_number(
+                abs(Decimal(str(ledger_amount or 0)))
+            )
+
+            items.append(
+                AdminOperationCourseCreditUsageItemDTO(
+                    usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
+                    progress_record_bid=str(
+                        getattr(usage_row, "progress_record_bid", "") or ""
+                    ),
+                    generated_block_bid=str(
+                        getattr(usage_row, "generated_block_bid", "") or ""
+                    ),
+                    user_bid=user_bid,
+                    mobile=str(user.get("mobile", "") or ""),
+                    email=str(user.get("email", "") or ""),
+                    nickname=str(user.get("nickname", "") or ""),
+                    chapter_outline_item_bid=str(
+                        context.get("chapter_outline_item_bid", "") or ""
+                    ),
+                    chapter_title=str(context.get("chapter_title", "") or ""),
+                    lesson_outline_item_bid=str(
+                        context.get("lesson_outline_item_bid", "") or ""
+                    ),
+                    lesson_title=str(context.get("lesson_title", "") or ""),
+                    usage_mode=usage_mode,
+                    provider=str(getattr(usage_row, "provider", "") or ""),
+                    model=str(getattr(usage_row, "model", "") or ""),
+                    consumed_credits=consumed_credits,
+                    created_at=_format_operator_datetime(created_at),
+                )
+            )
+        return AdminOperationCourseCreditUsageListDTO(
+            items=items,
+            page=safe_page_index,
+            page_size=safe_page_size,
+            total=total,
+            page_count=math.ceil(total / safe_page_size) if safe_page_size else 0,
+        )
 
 
 def get_operator_course_follow_ups(

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -222,9 +222,12 @@ OPERATOR_USER_REGISTRATION_SOURCE_UNKNOWN = "unknown"
 COURSE_FOLLOW_UP_LIST_MAX_PAGE_SIZE = 100
 COURSE_RATING_LIST_MAX_PAGE_SIZE = 100
 COURSE_CREDIT_USAGE_LIST_MAX_PAGE_SIZE = 100
+COURSE_CREDIT_USAGE_VIEW_GROUPED = "grouped"
+COURSE_CREDIT_USAGE_VIEW_RAW = "raw"
 COURSE_CREDIT_USAGE_MODE_LEARN = "learn"
 COURSE_CREDIT_USAGE_MODE_LISTEN = "listen"
 COURSE_CREDIT_USAGE_MODE_ASK = "ask"
+COURSE_CREDIT_USAGE_MODE_MIXED = "mixed"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_REWARD = "reward"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_COMPENSATION = "compensation"
 OPERATOR_USER_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION = "align_subscription"
@@ -332,6 +335,90 @@ def _resolve_course_credit_usage_mode_filter(value: str) -> str:
     }:
         return normalized
     return ""
+
+
+def _resolve_course_credit_usage_view(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"", COURSE_CREDIT_USAGE_VIEW_GROUPED}:
+        return COURSE_CREDIT_USAGE_VIEW_GROUPED
+    if normalized == COURSE_CREDIT_USAGE_VIEW_RAW:
+        return normalized
+    return ""
+
+
+def _build_course_credit_usage_model_display(provider: str, model: str) -> str:
+    normalized_provider = str(provider or "").strip()
+    normalized_model = str(model or "").strip()
+    if normalized_provider and normalized_model:
+        return f"{normalized_provider} / {normalized_model}"
+    return normalized_provider or normalized_model
+
+
+def _build_operator_course_credit_usage_item(
+    *,
+    usage_row: BillUsageRecord,
+    ledger_amount: Any,
+    user_map: Dict[str, Dict[str, Any]],
+    outline_context_map: Dict[str, Dict[str, str]],
+    group_key: str = "",
+    usage_count: int = 1,
+    usage_mode: str = "",
+    provider: str = "",
+    model: str = "",
+    model_variant_count: int = 0,
+    consumed_credits: Any = None,
+    created_at: Any = None,
+) -> AdminOperationCourseCreditUsageItemDTO:
+    user_bid = str(getattr(usage_row, "user_bid", "") or "").strip()
+    outline_item_bid = str(getattr(usage_row, "outline_item_bid", "") or "").strip()
+    context = outline_context_map.get(
+        outline_item_bid,
+        {
+            "chapter_outline_item_bid": "",
+            "chapter_title": "",
+            "lesson_outline_item_bid": outline_item_bid,
+            "lesson_title": "",
+        },
+    )
+    user = user_map.get(user_bid, {})
+    resolved_provider = str(
+        provider or getattr(usage_row, "provider", "") or ""
+    ).strip()
+    resolved_model = str(model or getattr(usage_row, "model", "") or "").strip()
+    resolved_usage_mode = usage_mode or _resolve_course_credit_usage_mode(usage_row)
+    resolved_created_at = (
+        created_at if created_at is not None else getattr(usage_row, "created_at", None)
+    )
+    if consumed_credits in ("", None):
+        resolved_consumed_credits = credit_decimal_to_number(
+            abs(Decimal(str(ledger_amount or 0)))
+        )
+    else:
+        resolved_consumed_credits = credit_decimal_to_number(
+            Decimal(str(consumed_credits or 0))
+        )
+
+    return AdminOperationCourseCreditUsageItemDTO(
+        group_key=group_key or str(getattr(usage_row, "usage_bid", "") or ""),
+        usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
+        progress_record_bid=str(getattr(usage_row, "progress_record_bid", "") or ""),
+        generated_block_bid=str(getattr(usage_row, "generated_block_bid", "") or ""),
+        user_bid=user_bid,
+        mobile=str(user.get("mobile", "") or ""),
+        email=str(user.get("email", "") or ""),
+        nickname=str(user.get("nickname", "") or ""),
+        chapter_outline_item_bid=str(context.get("chapter_outline_item_bid", "") or ""),
+        chapter_title=str(context.get("chapter_title", "") or ""),
+        lesson_outline_item_bid=str(context.get("lesson_outline_item_bid", "") or ""),
+        lesson_title=str(context.get("lesson_title", "") or ""),
+        usage_mode=resolved_usage_mode,
+        provider=resolved_provider,
+        model=resolved_model,
+        usage_count=max(int(usage_count or 0), 1),
+        model_variant_count=max(int(model_variant_count or 0), 0),
+        consumed_credits=resolved_consumed_credits,
+        created_at=_format_operator_datetime(resolved_created_at),
+    )
 
 
 def _build_course_credit_usage_generation_name_expr() -> Any:
@@ -3894,11 +3981,14 @@ def get_operator_course_credit_usages(
         mode_filter = _resolve_course_credit_usage_mode_filter(
             str(filters.get("mode", "") or "")
         )
+        view = _resolve_course_credit_usage_view(str(filters.get("view", "") or ""))
         start_time = filters.get("start_time")
         end_time = filters.get("end_time")
 
         if str(filters.get("mode", "") or "").strip() and not mode_filter:
             raise_param_error("mode")
+        if str(filters.get("view", "") or "").strip() and not view:
+            raise_param_error("view")
 
         # Limit ledger aggregation to this course's production usage rows first.
         course_credit_usage_bids = (
@@ -3975,26 +4065,19 @@ def get_operator_course_credit_usages(
                 _build_course_credit_usage_learn_filter(generation_name_expr),
             )
 
-        total = (
-            db.session.query(db.func.count()).select_from(query.subquery()).scalar()
-            or 0
-        )
-        if total == 0:
+        rows = query.order_by(
+            BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc()
+        ).all()
+
+        if not rows:
             return AdminOperationCourseCreditUsageListDTO(
+                view=view or COURSE_CREDIT_USAGE_VIEW_GROUPED,
                 items=[],
                 page=safe_page_index,
                 page_size=safe_page_size,
                 total=0,
                 page_count=0,
             )
-
-        start = (safe_page_index - 1) * safe_page_size
-        rows = (
-            query.order_by(BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc())
-            .offset(start)
-            .limit(safe_page_size)
-            .all()
-        )
 
         user_map = _load_user_map(
             sorted(
@@ -4006,58 +4089,128 @@ def get_operator_course_credit_usages(
             )
         )
 
-        items: list[AdminOperationCourseCreditUsageItemDTO] = []
+        raw_items: list[AdminOperationCourseCreditUsageItemDTO] = []
         for usage_row, ledger_amount in rows:
-            usage_mode = _resolve_course_credit_usage_mode(usage_row)
-            user_bid = str(getattr(usage_row, "user_bid", "") or "").strip()
-            outline_item_bid = str(
-                getattr(usage_row, "outline_item_bid", "") or ""
-            ).strip()
-            created_at = getattr(usage_row, "created_at", None)
-            context = outline_context_map.get(
-                outline_item_bid,
-                {
-                    "chapter_outline_item_bid": "",
-                    "chapter_title": "",
-                    "lesson_outline_item_bid": outline_item_bid,
-                    "lesson_title": "",
-                },
+            model_display = _build_course_credit_usage_model_display(
+                str(getattr(usage_row, "provider", "") or ""),
+                str(getattr(usage_row, "model", "") or ""),
             )
-            user = user_map.get(user_bid, {})
-            consumed_credits = credit_decimal_to_number(
-                abs(Decimal(str(ledger_amount or 0)))
-            )
-
-            items.append(
-                AdminOperationCourseCreditUsageItemDTO(
-                    usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
-                    progress_record_bid=str(
-                        getattr(usage_row, "progress_record_bid", "") or ""
-                    ),
-                    generated_block_bid=str(
-                        getattr(usage_row, "generated_block_bid", "") or ""
-                    ),
-                    user_bid=user_bid,
-                    mobile=str(user.get("mobile", "") or ""),
-                    email=str(user.get("email", "") or ""),
-                    nickname=str(user.get("nickname", "") or ""),
-                    chapter_outline_item_bid=str(
-                        context.get("chapter_outline_item_bid", "") or ""
-                    ),
-                    chapter_title=str(context.get("chapter_title", "") or ""),
-                    lesson_outline_item_bid=str(
-                        context.get("lesson_outline_item_bid", "") or ""
-                    ),
-                    lesson_title=str(context.get("lesson_title", "") or ""),
-                    usage_mode=usage_mode,
-                    provider=str(getattr(usage_row, "provider", "") or ""),
-                    model=str(getattr(usage_row, "model", "") or ""),
-                    consumed_credits=consumed_credits,
-                    created_at=_format_operator_datetime(created_at),
+            raw_items.append(
+                _build_operator_course_credit_usage_item(
+                    usage_row=usage_row,
+                    ledger_amount=ledger_amount,
+                    user_map=user_map,
+                    outline_context_map=outline_context_map,
+                    group_key=str(getattr(usage_row, "usage_bid", "") or ""),
+                    usage_count=1,
+                    usage_mode=_resolve_course_credit_usage_mode(usage_row),
+                    model_variant_count=1 if model_display else 0,
                 )
             )
+        if view == COURSE_CREDIT_USAGE_VIEW_RAW:
+            total = len(raw_items)
+            start = (safe_page_index - 1) * safe_page_size
+            paged_items = raw_items[start : start + safe_page_size]
+            return AdminOperationCourseCreditUsageListDTO(
+                view=COURSE_CREDIT_USAGE_VIEW_RAW,
+                items=paged_items,
+                page=safe_page_index,
+                page_size=safe_page_size,
+                total=total,
+                page_count=math.ceil(total / safe_page_size) if safe_page_size else 0,
+            )
+
+        grouped_payloads: Dict[str, Dict[str, Any]] = {}
+        grouped_order: list[str] = []
+        for item in raw_items:
+            progress_record_bid = str(item.progress_record_bid or "").strip()
+            group_key = progress_record_bid or str(item.usage_bid or "").strip()
+            if not group_key:
+                continue
+
+            payload = grouped_payloads.get(group_key)
+            if payload is None:
+                model_entries: Dict[str, tuple[str, str]] = {}
+                model_display = _build_course_credit_usage_model_display(
+                    item.provider,
+                    item.model,
+                )
+                if model_display:
+                    model_entries[model_display] = (item.provider, item.model)
+                grouped_payloads[group_key] = {
+                    "base_item": item,
+                    "usage_count": 1,
+                    "consumed_credits": Decimal(str(item.consumed_credits or 0)),
+                    "usage_modes": (
+                        {str(item.usage_mode or "").strip()}
+                        if item.usage_mode
+                        else set()
+                    ),
+                    "model_entries": model_entries,
+                }
+                grouped_order.append(group_key)
+                continue
+
+            payload["usage_count"] += 1
+            payload["consumed_credits"] += Decimal(str(item.consumed_credits or 0))
+            usage_mode = str(item.usage_mode or "").strip()
+            if usage_mode:
+                payload["usage_modes"].add(usage_mode)
+            model_display = _build_course_credit_usage_model_display(
+                item.provider,
+                item.model,
+            )
+            if model_display and model_display not in payload["model_entries"]:
+                payload["model_entries"][model_display] = (item.provider, item.model)
+
+        grouped_items: list[AdminOperationCourseCreditUsageItemDTO] = []
+        for group_key in grouped_order:
+            payload = grouped_payloads[group_key]
+            base_item = payload["base_item"]
+            usage_modes = payload["usage_modes"]
+            if len(usage_modes) == 1:
+                usage_mode = next(iter(usage_modes))
+            elif len(usage_modes) > 1:
+                usage_mode = COURSE_CREDIT_USAGE_MODE_MIXED
+            else:
+                usage_mode = ""
+            model_entries = payload["model_entries"]
+            primary_provider = ""
+            primary_model = ""
+            if model_entries:
+                primary_provider, primary_model = next(iter(model_entries.values()))
+            grouped_items.append(
+                AdminOperationCourseCreditUsageItemDTO(
+                    group_key=group_key,
+                    usage_bid=base_item.usage_bid,
+                    progress_record_bid=base_item.progress_record_bid,
+                    generated_block_bid=base_item.generated_block_bid,
+                    user_bid=base_item.user_bid,
+                    mobile=base_item.mobile,
+                    email=base_item.email,
+                    nickname=base_item.nickname,
+                    chapter_outline_item_bid=base_item.chapter_outline_item_bid,
+                    chapter_title=base_item.chapter_title,
+                    lesson_outline_item_bid=base_item.lesson_outline_item_bid,
+                    lesson_title=base_item.lesson_title,
+                    usage_mode=usage_mode,
+                    provider=primary_provider,
+                    model=primary_model,
+                    usage_count=payload["usage_count"],
+                    model_variant_count=len(model_entries),
+                    consumed_credits=credit_decimal_to_number(
+                        payload["consumed_credits"]
+                    ),
+                    created_at=base_item.created_at,
+                )
+            )
+
+        total = len(grouped_items)
+        start = (safe_page_index - 1) * safe_page_size
+        paged_items = grouped_items[start : start + safe_page_size]
         return AdminOperationCourseCreditUsageListDTO(
-            items=items,
+            view=COURSE_CREDIT_USAGE_VIEW_GROUPED,
+            items=paged_items,
             page=safe_page_index,
             page_size=safe_page_size,
             total=total,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -334,9 +334,15 @@ def _resolve_course_credit_usage_mode_filter(value: str) -> str:
     return ""
 
 
-def _build_course_credit_usage_ask_filter() -> Any:
-    generation_name = db.func.lower(
-        BillUsageRecord.extra["generation_name"].as_string()
+def _build_course_credit_usage_generation_name_expr() -> Any:
+    return db.func.lower(BillUsageRecord.extra["generation_name"].as_string())
+
+
+def _build_course_credit_usage_ask_filter(generation_name: Any | None = None) -> Any:
+    generation_name = (
+        generation_name
+        if generation_name is not None
+        else _build_course_credit_usage_generation_name_expr()
     )
     return or_(
         generation_name.contains("/user_follow_ask/"),
@@ -345,14 +351,18 @@ def _build_course_credit_usage_ask_filter() -> Any:
     )
 
 
-def _build_course_credit_usage_learn_filter() -> Any:
-    generation_name = db.func.lower(
-        BillUsageRecord.extra["generation_name"].as_string()
+def _build_course_credit_usage_learn_filter(
+    generation_name: Any | None = None,
+) -> Any:
+    generation_name = (
+        generation_name
+        if generation_name is not None
+        else _build_course_credit_usage_generation_name_expr()
     )
     return or_(
         generation_name.is_(None),
         generation_name == "",
-        not_(_build_course_credit_usage_ask_filter()),
+        not_(_build_course_credit_usage_ask_filter(generation_name)),
     )
 
 
@@ -3890,10 +3900,28 @@ def get_operator_course_credit_usages(
         if str(filters.get("mode", "") or "").strip() and not mode_filter:
             raise_param_error("mode")
 
+        # Limit ledger aggregation to this course's production usage rows first.
+        course_credit_usage_bids = (
+            db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
+            .filter(
+                BillUsageRecord.shifu_bid == normalized_shifu_bid,
+                BillUsageRecord.deleted == 0,
+                BillUsageRecord.billable == 1,
+                BillUsageRecord.status == 0,
+                BillUsageRecord.record_level == 0,
+                BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
+            )
+            .subquery()
+        )
+
         credit_usage_ledger_totals = (
             db.session.query(
                 CreditLedgerEntry.source_bid.label("usage_bid"),
                 db.func.sum(CreditLedgerEntry.amount).label("ledger_amount"),
+            )
+            .join(
+                course_credit_usage_bids,
+                course_credit_usage_bids.c.usage_bid == CreditLedgerEntry.source_bid,
             )
             .filter(
                 CreditLedgerEntry.deleted == 0,
@@ -3933,17 +3961,18 @@ def get_operator_course_credit_usages(
         if end_time:
             query = query.filter(BillUsageRecord.created_at <= end_time)
 
+        generation_name_expr = _build_course_credit_usage_generation_name_expr()
         if mode_filter == COURSE_CREDIT_USAGE_MODE_LISTEN:
             query = query.filter(BillUsageRecord.usage_type == BILL_USAGE_TYPE_TTS)
         elif mode_filter == COURSE_CREDIT_USAGE_MODE_ASK:
             query = query.filter(
                 BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
-                _build_course_credit_usage_ask_filter(),
+                _build_course_credit_usage_ask_filter(generation_name_expr),
             )
         elif mode_filter == COURSE_CREDIT_USAGE_MODE_LEARN:
             query = query.filter(
                 BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
-                _build_course_credit_usage_learn_filter(),
+                _build_course_credit_usage_learn_filter(generation_name_expr),
             )
 
         total = (

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -883,6 +883,79 @@ class AdminOperationCourseRatingListDTO(BaseModel):
 
 
 @register_schema_to_swagger
+class AdminOperationCourseCreditUsageItemDTO(BaseModel):
+    """Operator-facing course credit usage row."""
+
+    usage_bid: str = Field(..., description="Usage business identifier", required=False)
+    progress_record_bid: str = Field(
+        default="",
+        description="Progress record business identifier",
+        required=False,
+    )
+    generated_block_bid: str = Field(
+        default="",
+        description="Generated block business identifier",
+        required=False,
+    )
+    user_bid: str = Field(..., description="User business identifier", required=False)
+    mobile: str = Field(..., description="User mobile", required=False)
+    email: str = Field(..., description="User email", required=False)
+    nickname: str = Field(..., description="User nickname", required=False)
+    chapter_outline_item_bid: str = Field(
+        default="",
+        description="Chapter outline item business identifier",
+        required=False,
+    )
+    chapter_title: str = Field(default="", description="Chapter title", required=False)
+    lesson_outline_item_bid: str = Field(
+        default="",
+        description="Lesson outline item business identifier",
+        required=False,
+    )
+    lesson_title: str = Field(default="", description="Lesson title", required=False)
+    usage_mode: str = Field(
+        default="",
+        description="Credit usage mode: learn/listen/ask",
+        required=False,
+    )
+    provider: str = Field(default="", description="Provider name", required=False)
+    model: str = Field(default="", description="Provider model", required=False)
+    consumed_credits: int | float = Field(
+        default=0,
+        description="Consumed credits",
+        required=False,
+    )
+    created_at: str = Field(default="", description="Created at", required=False)
+
+    def __json__(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
+@register_schema_to_swagger
+class AdminOperationCourseCreditUsageListDTO(BaseModel):
+    """Operator-facing course credit usage list payload."""
+
+    items: list[AdminOperationCourseCreditUsageItemDTO] = Field(
+        default_factory=list,
+        description="Paginated credit usage rows",
+        required=False,
+    )
+    page: int = Field(..., description="Page index", required=False)
+    page_size: int = Field(..., description="Page size", required=False)
+    total: int = Field(..., description="Total row count", required=False)
+    page_count: int = Field(..., description="Page count", required=False)
+
+    def __json__(self) -> dict[str, Any]:
+        return {
+            "items": [item.__json__() for item in self.items],
+            "page": self.page,
+            "page_size": self.page_size,
+            "total": self.total,
+            "page_count": self.page_count,
+        }
+
+
+@register_schema_to_swagger
 class AdminOperationCourseFollowUpDetailBasicInfoDTO(BaseModel):
     """Operator-facing course follow-up detail basic information."""
 

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from flaskr.common.swagger import register_schema_to_swagger
 
@@ -886,6 +886,13 @@ class AdminOperationCourseRatingListDTO(BaseModel):
 class AdminOperationCourseCreditUsageItemDTO(BaseModel):
     """Operator-facing course credit usage row."""
 
+    model_config = ConfigDict(protected_namespaces=())
+
+    group_key: str = Field(
+        default="",
+        description="Grouped row business key or raw usage key",
+        required=False,
+    )
     usage_bid: str = Field(..., description="Usage business identifier", required=False)
     progress_record_bid: str = Field(
         default="",
@@ -920,6 +927,16 @@ class AdminOperationCourseCreditUsageItemDTO(BaseModel):
     )
     provider: str = Field(default="", description="Provider name", required=False)
     model: str = Field(default="", description="Provider model", required=False)
+    usage_count: int = Field(
+        default=1,
+        description="Grouped usage row count",
+        required=False,
+    )
+    model_variant_count: int = Field(
+        default=0,
+        description="Distinct provider/model count inside the row",
+        required=False,
+    )
     consumed_credits: int | float = Field(
         default=0,
         description="Consumed credits",
@@ -935,6 +952,11 @@ class AdminOperationCourseCreditUsageItemDTO(BaseModel):
 class AdminOperationCourseCreditUsageListDTO(BaseModel):
     """Operator-facing course credit usage list payload."""
 
+    view: str = Field(
+        default="grouped",
+        description="Response view mode: grouped/raw",
+        required=False,
+    )
     items: list[AdminOperationCourseCreditUsageItemDTO] = Field(
         default_factory=list,
         description="Paginated credit usage rows",
@@ -947,6 +969,7 @@ class AdminOperationCourseCreditUsageListDTO(BaseModel):
 
     def __json__(self) -> dict[str, Any]:
         return {
+            "view": self.view,
             "items": [item.__json__() for item in self.items],
             "page": self.page,
             "page_size": self.page_size,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1632,6 +1632,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
               type: string
               required: false
               description: Credit usage mode filter
+            - name: view
+              in: query
+              type: string
+              required: false
+              description: Credit usage view mode, grouped or raw
             - name: start_time
               in: query
               type: string
@@ -1660,6 +1665,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         filters = {
             "keyword": request.args.get("keyword", ""),
             "mode": request.args.get("mode", ""),
+            "view": request.args.get("view", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -112,6 +112,7 @@ from flaskr.service.shifu.shifu_draft_funcs import (
 )
 from flaskr.service.shifu.admin import (
     OPERATOR_ORDER_LIST_MAX_PAGE_SIZE,
+    get_operator_course_credit_usages,
     get_operator_course_overview,
     get_operator_course_follow_up_detail,
     get_operator_course_follow_ups,
@@ -1587,6 +1588,89 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         }
         return make_common_response(
             get_operator_course_users(
+                app,
+                shifu_bid=shifu_bid,
+                page_index=page_index,
+                page_size=page_size,
+                filters=filters,
+            )
+        )
+
+    @app.route(
+        path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages",
+        methods=["GET"],
+    )
+    def admin_operation_course_credit_usages(shifu_bid: str):
+        """
+        Get operator course credit usage list
+        ---
+        tags:
+            - Shifu
+        parameters:
+            - name: shifu_bid
+              in: path
+              type: string
+              required: true
+              description: Course shifu bid
+            - name: page
+              in: query
+              type: integer
+              required: false
+              description: Page index
+            - name: page_size
+              in: query
+              type: integer
+              required: false
+              description: Page size
+            - name: keyword
+              in: query
+              type: string
+              required: false
+              description: User keyword
+            - name: mode
+              in: query
+              type: string
+              required: false
+              description: Credit usage mode filter
+            - name: start_time
+              in: query
+              type: string
+              required: false
+              description: Inclusive filter start time
+            - name: end_time
+              in: query
+              type: string
+              required: false
+              description: Inclusive filter end time
+        responses:
+            200:
+                description: Operator course credit usage list
+        """
+        _require_operator()
+        page_index = _parse_positive_query_int(
+            request.args.get("page"),
+            field_name="page",
+            default=1,
+        )
+        page_size = _parse_positive_query_int(
+            request.args.get("page_size"),
+            field_name="page_size",
+            default=20,
+        )
+        filters = {
+            "keyword": request.args.get("keyword", ""),
+            "mode": request.args.get("mode", ""),
+            "start_time": _parse_datetime_filter(
+                request.args.get("start_time", ""),
+                is_end=False,
+            ),
+            "end_time": _parse_datetime_filter(
+                request.args.get("end_time", ""),
+                is_end=True,
+            ),
+        }
+        return make_common_response(
+            get_operator_course_credit_usages(
                 app,
                 shifu_bid=shifu_bid,
                 page_index=page_index,

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -10,6 +10,11 @@ import pytest
 
 from flaskr.dao import db
 from flaskr.service.common.models import AppException, ERROR_CODE
+from flaskr.service.billing.consts import (
+    CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+    CREDIT_SOURCE_TYPE_USAGE,
+)
+from flaskr.service.billing.models import CreditLedgerEntry
 from flaskr.service.learn.const import (
     LEARN_STATUS_COMPLETED,
     LEARN_STATUS_IN_PROGRESS,
@@ -25,6 +30,13 @@ from flaskr.service.learn.models import (
 )
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS, ORDER_STATUS_TO_BE_PAID
 from flaskr.service.order.models import Order
+from flaskr.service.metering.consts import (
+    BILL_USAGE_SCENE_PREVIEW,
+    BILL_USAGE_SCENE_PROD,
+    BILL_USAGE_TYPE_LLM,
+    BILL_USAGE_TYPE_TTS,
+)
+from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.promo.consts import (
     COUPON_STATUS_USED,
     PROMO_CAMPAIGN_APPLICATION_STATUS_APPLIED,
@@ -60,6 +72,8 @@ from flaskr.service.user.repository import create_user_entity, upsert_credential
 
 
 def _clear_tables() -> None:
+    db.session.query(CreditLedgerEntry).delete()
+    db.session.query(BillUsageRecord).delete()
     db.session.query(LearnLessonFeedback).delete()
     db.session.query(LearnGeneratedElement).delete()
     db.session.query(LearnGeneratedBlock).delete()
@@ -259,6 +273,79 @@ def _seed_follow_up_pair(
             deleted=0,
             created_at=answer_created_at,
             updated_at=answer_created_at,
+        )
+    )
+
+
+def _seed_credit_usage(
+    *,
+    usage_bid: str,
+    user_bid: str,
+    shifu_bid: str,
+    outline_item_bid: str,
+    usage_type: int,
+    provider: str,
+    model: str,
+    consumed_credits: Decimal,
+    created_at: datetime,
+    progress_record_bid: str = "",
+    generated_block_bid: str = "",
+    usage_scene: int = BILL_USAGE_SCENE_PROD,
+    record_level: int = 0,
+    extra: dict | None = None,
+) -> None:
+    db.session.add(
+        BillUsageRecord(
+            usage_bid=usage_bid,
+            parent_usage_bid="",
+            user_bid=user_bid,
+            shifu_bid=shifu_bid,
+            outline_item_bid=outline_item_bid,
+            progress_record_bid=progress_record_bid,
+            generated_block_bid=generated_block_bid,
+            audio_bid="",
+            request_id="",
+            trace_id="",
+            usage_type=usage_type,
+            record_level=record_level,
+            usage_scene=usage_scene,
+            provider=provider,
+            model=model,
+            is_stream=1,
+            input=100,
+            input_cache=0,
+            output=200,
+            total=300,
+            word_count=0,
+            duration_ms=0,
+            latency_ms=500,
+            segment_index=0,
+            segment_count=0,
+            billable=1,
+            status=0,
+            error_message="",
+            extra=extra or {},
+            created_at=created_at,
+            updated_at=created_at,
+        )
+    )
+    db.session.add(
+        CreditLedgerEntry(
+            ledger_bid=f"ledger-{usage_bid}",
+            creator_bid="creator-1",
+            wallet_bid="wallet-1",
+            wallet_bucket_bid="bucket-1",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+            source_type=CREDIT_SOURCE_TYPE_USAGE,
+            source_bid=usage_bid,
+            idempotency_key=f"usage:{usage_bid}:consume",
+            amount=-consumed_credits,
+            balance_after=Decimal("100"),
+            expires_at=None,
+            consumable_from=created_at,
+            metadata_json={},
+            created_at=created_at,
+            updated_at=created_at,
         )
     )
 
@@ -1684,6 +1771,362 @@ def test_admin_operation_course_users_route_marks_redeem_orders_as_paid(
     assert paid_only_payload["code"] == 0
     assert paid_only_payload["data"]["total"] == 1
     assert paid_only_payload["data"]["items"][0]["user_bid"] == "redeem-user"
+
+
+def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(
+            app,
+            user_bid="student-1",
+            phone="13900001235",
+            email="student1@example.com",
+        )
+        _seed_user(
+            app,
+            user_bid="student-2",
+            phone="13900001236",
+            email="student2@example.com",
+        )
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            parent_bid="chapter-1",
+            title="Lesson 1",
+            position="1.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-2",
+            title="Chapter 2",
+            position="2",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-2",
+            parent_bid="chapter-2",
+            title="Lesson 2",
+            position="2.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+
+        _seed_credit_usage(
+            usage_bid="usage-learn-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-1",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("5"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        _seed_credit_usage(
+            usage_bid="usage-learn-2",
+            user_bid="student-2",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-2",
+            progress_record_bid="progress-3",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1-mini",
+            consumed_credits=Decimal("2"),
+            created_at=datetime(2026, 4, 3, 8, 0, 0),
+            extra={},
+        )
+        _seed_credit_usage(
+            usage_bid="usage-ask-1",
+            user_bid="student-2",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-2",
+            progress_record_bid="progress-2",
+            generated_block_bid="answer-ask-1",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1-mini",
+            consumed_credits=Decimal("3"),
+            created_at=datetime(2026, 4, 5, 11, 0, 0),
+            extra={"generation_name": "lesson_ask/user_follow_ask/Lesson 2"},
+        )
+        _seed_credit_usage(
+            usage_bid="usage-listen-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-1",
+            generated_block_bid="audio-block-1",
+            usage_type=BILL_USAGE_TYPE_TTS,
+            provider="volcengine",
+            model="cancan-2.0",
+            consumed_credits=Decimal("12"),
+            created_at=datetime(2026, 4, 6, 12, 0, 0),
+        )
+        _seed_credit_usage(
+            usage_bid="usage-preview-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-preview",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1-nano",
+            consumed_credits=Decimal("1"),
+            created_at=datetime(2026, 4, 7, 12, 0, 0),
+            usage_scene=BILL_USAGE_SCENE_PREVIEW,
+            extra={"generation_name": "lesson_preview/run_llm/Lesson 1"},
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["total"] == 4
+    assert [item["usage_bid"] for item in payload["data"]["items"]] == [
+        "usage-listen-1",
+        "usage-ask-1",
+        "usage-learn-1",
+        "usage-learn-2",
+    ]
+    assert payload["data"]["items"][0]["usage_mode"] == "listen"
+    assert payload["data"]["items"][0]["consumed_credits"] == 12
+    assert payload["data"]["items"][1]["usage_mode"] == "ask"
+    assert payload["data"]["items"][1]["email"] == "student2@example.com"
+    assert payload["data"]["items"][1]["chapter_title"] == "Chapter 2"
+    assert payload["data"]["items"][2]["usage_mode"] == "learn"
+    assert payload["data"]["items"][3]["usage_mode"] == "learn"
+
+    filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&keyword=student2@example.com&mode=ask&start_time=2026-04-05&end_time=2026-04-05",
+        headers={"Token": "test-token"},
+    )
+    filtered_payload = filtered_response.get_json(force=True)
+
+    assert filtered_response.status_code == 200
+    assert filtered_payload["code"] == 0
+    assert filtered_payload["data"]["total"] == 1
+    assert filtered_payload["data"]["items"][0]["usage_bid"] == "usage-ask-1"
+
+    phone_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&keyword=13900001235&mode=listen",
+        headers={"Token": "test-token"},
+    )
+    phone_filtered_payload = phone_filtered_response.get_json(force=True)
+
+    assert phone_filtered_response.status_code == 200
+    assert phone_filtered_payload["code"] == 0
+    assert phone_filtered_payload["data"]["total"] == 1
+    assert phone_filtered_payload["data"]["items"][0]["usage_bid"] == "usage-listen-1"
+
+    learn_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&mode=learn",
+        headers={"Token": "test-token"},
+    )
+    learn_filtered_payload = learn_filtered_response.get_json(force=True)
+
+    assert learn_filtered_response.status_code == 200
+    assert learn_filtered_payload["code"] == 0
+    assert learn_filtered_payload["data"]["total"] == 2
+    assert [item["usage_bid"] for item in learn_filtered_payload["data"]["items"]] == [
+        "usage-learn-1",
+        "usage-learn-2",
+    ]
+
+    paged_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=2&page_size=2",
+        headers={"Token": "test-token"},
+    )
+    paged_payload = paged_response.get_json(force=True)
+
+    assert paged_response.status_code == 200
+    assert paged_payload["code"] == 0
+    assert paged_payload["data"]["total"] == 4
+    assert [item["usage_bid"] for item in paged_payload["data"]["items"]] == [
+        "usage-learn-1",
+        "usage-learn-2",
+    ]
+
+    partial_phone_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&keyword=1390000123",
+        headers={"Token": "test-token"},
+    )
+    partial_phone_filtered_payload = partial_phone_filtered_response.get_json(
+        force=True
+    )
+
+    assert partial_phone_filtered_response.status_code == 200
+    assert partial_phone_filtered_payload["code"] == 0
+    assert partial_phone_filtered_payload["data"]["total"] == 0
+
+    nickname_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&keyword=studen",
+        headers={"Token": "test-token"},
+    )
+    nickname_filtered_payload = nickname_filtered_response.get_json(force=True)
+
+    assert nickname_filtered_response.status_code == 200
+    assert nickname_filtered_payload["code"] == 0
+    assert nickname_filtered_payload["data"]["total"] == 4
+
+
+def test_admin_operation_course_credit_usages_route_rejects_invalid_mode(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=datetime(2026, 4, 1, 9, 0, 0),
+            updated_at=datetime(2026, 4, 1, 9, 0, 0),
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20&mode=invalid_mode",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == "Params Error mode"
+
+
+def test_admin_operation_course_credit_usages_route_aggregates_split_ledgers(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 2, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(
+            app,
+            user_bid="student-1",
+            phone="13900001235",
+            email="student1@example.com",
+        )
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            parent_bid="chapter-1",
+            title="Lesson 1",
+            position="1.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_credit_usage(
+            usage_bid="usage-split-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-1",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("5"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        db.session.add(
+            CreditLedgerEntry(
+                ledger_bid="ledger-usage-split-1-extra",
+                creator_bid="creator-1",
+                wallet_bid="wallet-1",
+                wallet_bucket_bid="bucket-2",
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+                source_type=CREDIT_SOURCE_TYPE_USAGE,
+                source_bid="usage-split-1",
+                idempotency_key="usage:usage-split-1:consume:extra",
+                amount=Decimal("-3"),
+                balance_after=Decimal("97"),
+                expires_at=None,
+                consumable_from=datetime(2026, 4, 4, 10, 0, 0),
+                metadata_json={},
+                created_at=datetime(2026, 4, 4, 10, 0, 1),
+                updated_at=datetime(2026, 4, 4, 10, 0, 1),
+            )
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["total"] == 1
+    assert len(payload["data"]["items"]) == 1
+    assert payload["data"]["items"][0]["usage_bid"] == "usage-split-1"
+    assert payload["data"]["items"][0]["consumed_credits"] == 8
 
 
 def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1773,7 +1773,7 @@ def test_admin_operation_course_users_route_marks_redeem_orders_as_paid(
     assert paid_only_payload["data"]["items"][0]["user_bid"] == "redeem-user"
 
 
-def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
+def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_filters(
     app,
     test_client,
     monkeypatch,
@@ -1918,20 +1918,22 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
 
     assert response.status_code == 200
     assert payload["code"] == 0
-    assert payload["data"]["total"] == 4
-    assert [item["usage_bid"] for item in payload["data"]["items"]] == [
-        "usage-listen-1",
-        "usage-ask-1",
-        "usage-learn-1",
-        "usage-learn-2",
+    assert payload["data"]["view"] == "grouped"
+    assert payload["data"]["total"] == 3
+    assert [item["group_key"] for item in payload["data"]["items"]] == [
+        "progress-1",
+        "progress-2",
+        "progress-3",
     ]
-    assert payload["data"]["items"][0]["usage_mode"] == "listen"
-    assert payload["data"]["items"][0]["consumed_credits"] == 12
+    assert payload["data"]["items"][0]["usage_bid"] == "usage-listen-1"
+    assert payload["data"]["items"][0]["usage_mode"] == "mixed"
+    assert payload["data"]["items"][0]["usage_count"] == 2
+    assert payload["data"]["items"][0]["model_variant_count"] == 2
+    assert payload["data"]["items"][0]["consumed_credits"] == 17
     assert payload["data"]["items"][1]["usage_mode"] == "ask"
     assert payload["data"]["items"][1]["email"] == "student2@example.com"
     assert payload["data"]["items"][1]["chapter_title"] == "Chapter 2"
     assert payload["data"]["items"][2]["usage_mode"] == "learn"
-    assert payload["data"]["items"][3]["usage_mode"] == "learn"
 
     filtered_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
@@ -1943,6 +1945,7 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
     assert filtered_response.status_code == 200
     assert filtered_payload["code"] == 0
     assert filtered_payload["data"]["total"] == 1
+    assert filtered_payload["data"]["items"][0]["group_key"] == "progress-2"
     assert filtered_payload["data"]["items"][0]["usage_bid"] == "usage-ask-1"
 
     phone_filtered_response = test_client.get(
@@ -1955,7 +1958,9 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
     assert phone_filtered_response.status_code == 200
     assert phone_filtered_payload["code"] == 0
     assert phone_filtered_payload["data"]["total"] == 1
-    assert phone_filtered_payload["data"]["items"][0]["usage_bid"] == "usage-listen-1"
+    assert phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1"
+    assert phone_filtered_payload["data"]["items"][0]["usage_count"] == 1
+    assert phone_filtered_payload["data"]["items"][0]["consumed_credits"] == 12
 
     learn_filtered_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
@@ -1967,10 +1972,12 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
     assert learn_filtered_response.status_code == 200
     assert learn_filtered_payload["code"] == 0
     assert learn_filtered_payload["data"]["total"] == 2
-    assert [item["usage_bid"] for item in learn_filtered_payload["data"]["items"]] == [
-        "usage-learn-1",
-        "usage-learn-2",
+    assert [item["group_key"] for item in learn_filtered_payload["data"]["items"]] == [
+        "progress-1",
+        "progress-3",
     ]
+    assert learn_filtered_payload["data"]["items"][0]["usage_mode"] == "learn"
+    assert learn_filtered_payload["data"]["items"][0]["consumed_credits"] == 5
 
     paged_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=2&page_size=2",
@@ -1980,10 +1987,9 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
 
     assert paged_response.status_code == 200
     assert paged_payload["code"] == 0
-    assert paged_payload["data"]["total"] == 4
-    assert [item["usage_bid"] for item in paged_payload["data"]["items"]] == [
-        "usage-learn-1",
-        "usage-learn-2",
+    assert paged_payload["data"]["total"] == 3
+    assert [item["group_key"] for item in paged_payload["data"]["items"]] == [
+        "progress-3",
     ]
 
     partial_phone_filtered_response = test_client.get(
@@ -2008,7 +2014,26 @@ def test_admin_operation_course_credit_usages_route_returns_rows_and_filters(
 
     assert nickname_filtered_response.status_code == 200
     assert nickname_filtered_payload["code"] == 0
-    assert nickname_filtered_payload["data"]["total"] == 4
+    assert nickname_filtered_payload["data"]["total"] == 3
+
+    raw_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
+        "&view=raw",
+        headers={"Token": "test-token"},
+    )
+    raw_payload = raw_response.get_json(force=True)
+
+    assert raw_response.status_code == 200
+    assert raw_payload["code"] == 0
+    assert raw_payload["data"]["view"] == "raw"
+    assert raw_payload["data"]["total"] == 4
+    assert [item["group_key"] for item in raw_payload["data"]["items"]] == [
+        "usage-listen-1",
+        "usage-ask-1",
+        "usage-learn-1",
+        "usage-learn-2",
+    ]
+    assert raw_payload["data"]["items"][0]["usage_mode"] == "listen"
 
 
 def test_admin_operation_course_credit_usages_route_rejects_invalid_mode(
@@ -2037,6 +2062,117 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_mode(
     assert response.status_code == 200
     assert payload["code"] == ERROR_CODE["server.common.paramsError"]
     assert payload["message"] == "Params Error mode"
+
+
+def test_admin_operation_course_credit_usages_route_rejects_invalid_view(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=datetime(2026, 4, 1, 9, 0, 0),
+            updated_at=datetime(2026, 4, 1, 9, 0, 0),
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20&view=invalid_view",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == "Params Error view"
+
+
+def test_admin_operation_course_credit_usages_grouped_view_keeps_rows_without_progress_separate(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 2, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(app, user_bid="student-1", phone="13900001235")
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            parent_bid="chapter-1",
+            title="Lesson 1",
+            position="1.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_credit_usage(
+            usage_bid="usage-no-progress-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("2"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        _seed_credit_usage(
+            usage_bid="usage-no-progress-2",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1-mini",
+            consumed_credits=Decimal("3"),
+            created_at=datetime(2026, 4, 4, 11, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["view"] == "grouped"
+    assert payload["data"]["total"] == 2
+    assert [item["group_key"] for item in payload["data"]["items"]] == [
+        "usage-no-progress-2",
+        "usage-no-progress-1",
+    ]
+    assert payload["data"]["items"][0]["usage_count"] == 1
+    assert payload["data"]["items"][1]["usage_count"] == 1
 
 
 def test_admin_operation_course_credit_usages_route_aggregates_split_ledgers(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1919,21 +1919,23 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert response.status_code == 200
     assert payload["code"] == 0
     assert payload["data"]["view"] == "grouped"
-    assert payload["data"]["total"] == 3
+    assert payload["data"]["total"] == 4
     assert [item["group_key"] for item in payload["data"]["items"]] == [
-        "progress-1",
-        "progress-2",
-        "progress-3",
+        "progress-1:listen",
+        "progress-2:ask",
+        "progress-1:learn",
+        "progress-3:learn",
     ]
     assert payload["data"]["items"][0]["usage_bid"] == "usage-listen-1"
-    assert payload["data"]["items"][0]["usage_mode"] == "mixed"
-    assert payload["data"]["items"][0]["usage_count"] == 2
-    assert payload["data"]["items"][0]["model_variant_count"] == 2
-    assert payload["data"]["items"][0]["consumed_credits"] == 17
+    assert payload["data"]["items"][0]["usage_mode"] == "listen"
+    assert payload["data"]["items"][0]["usage_count"] == 1
+    assert payload["data"]["items"][0]["model_variant_count"] == 1
+    assert payload["data"]["items"][0]["consumed_credits"] == 12
     assert payload["data"]["items"][1]["usage_mode"] == "ask"
     assert payload["data"]["items"][1]["email"] == "student2@example.com"
     assert payload["data"]["items"][1]["chapter_title"] == "Chapter 2"
     assert payload["data"]["items"][2]["usage_mode"] == "learn"
+    assert payload["data"]["items"][2]["consumed_credits"] == 5
 
     filtered_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"
@@ -1945,7 +1947,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert filtered_response.status_code == 200
     assert filtered_payload["code"] == 0
     assert filtered_payload["data"]["total"] == 1
-    assert filtered_payload["data"]["items"][0]["group_key"] == "progress-2"
+    assert filtered_payload["data"]["items"][0]["group_key"] == "progress-2:ask"
     assert filtered_payload["data"]["items"][0]["usage_bid"] == "usage-ask-1"
 
     phone_filtered_response = test_client.get(
@@ -1958,7 +1960,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert phone_filtered_response.status_code == 200
     assert phone_filtered_payload["code"] == 0
     assert phone_filtered_payload["data"]["total"] == 1
-    assert phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1"
+    assert phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1:listen"
     assert phone_filtered_payload["data"]["items"][0]["usage_count"] == 1
     assert phone_filtered_payload["data"]["items"][0]["consumed_credits"] == 12
 
@@ -1973,8 +1975,8 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert learn_filtered_payload["code"] == 0
     assert learn_filtered_payload["data"]["total"] == 2
     assert [item["group_key"] for item in learn_filtered_payload["data"]["items"]] == [
-        "progress-1",
-        "progress-3",
+        "progress-1:learn",
+        "progress-3:learn",
     ]
     assert learn_filtered_payload["data"]["items"][0]["usage_mode"] == "learn"
     assert learn_filtered_payload["data"]["items"][0]["consumed_credits"] == 5
@@ -1987,9 +1989,10 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
 
     assert paged_response.status_code == 200
     assert paged_payload["code"] == 0
-    assert paged_payload["data"]["total"] == 3
+    assert paged_payload["data"]["total"] == 4
     assert [item["group_key"] for item in paged_payload["data"]["items"]] == [
-        "progress-3",
+        "progress-1:learn",
+        "progress-3:learn",
     ]
 
     partial_phone_filtered_response = test_client.get(
@@ -2014,7 +2017,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
 
     assert nickname_filtered_response.status_code == 200
     assert nickname_filtered_payload["code"] == 0
-    assert nickname_filtered_payload["data"]["total"] == 3
+    assert nickname_filtered_payload["data"]["total"] == 4
 
     raw_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20"

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1960,7 +1960,9 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert phone_filtered_response.status_code == 200
     assert phone_filtered_payload["code"] == 0
     assert phone_filtered_payload["data"]["total"] == 1
-    assert phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1:listen"
+    assert (
+        phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1:listen"
+    )
     assert phone_filtered_payload["data"]["items"][0]["usage_count"] == 1
     assert phone_filtered_payload["data"]["items"][0]["consumed_credits"] == 12
 

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -155,6 +155,8 @@ const api = {
     'GET /shifu/admin/operations/courses/{shifu_bid}/detail',
   getAdminOperationCourseUsers:
     'GET /shifu/admin/operations/courses/{shifu_bid}/users',
+  getAdminOperationCourseCreditUsages:
+    'GET /shifu/admin/operations/courses/{shifu_bid}/credit-usages',
   getAdminOperationCourseRatings:
     'GET /shifu/admin/operations/courses/{shifu_bid}/ratings',
   getAdminOperationCourseFollowUps:

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
-import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { ClearableTextInput } from '@/app/admin/operations/orders/orderUiShared';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
@@ -52,7 +51,6 @@ type CreditUsageColumnKey =
   | 'mode'
   | 'chapter'
   | 'lesson'
-  | 'usageCount'
   | 'credits'
   | 'model';
 
@@ -67,7 +65,6 @@ const CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS = {
   mode: 110,
   chapter: 160,
   lesson: 160,
-  usageCount: 100,
   credits: 120,
   model: 220,
 } as const;
@@ -125,7 +122,7 @@ export default function CourseCreditUsageTab({
   onPageChange: (page: number) => void;
 }) {
   const { t } = useTranslation();
-  const { t: tOperations, i18n } = useTranslation('module.operationsCourse');
+  const { t: tOperations } = useTranslation('module.operationsCourse');
   const {
     setColumnWidths,
     getColumnStyle,
@@ -233,7 +230,6 @@ export default function CourseCreditUsageTab({
       mode: row => [resolveModeLabel(row.usage_mode)],
       chapter: row => [row.chapter_title || emptyValue],
       lesson: row => [row.lesson_title || emptyValue],
-      usageCount: row => [String(row.usage_count || 0)],
       credits: row => [String(row.consumed_credits || 0)],
       model: row => [resolveModelDisplay(row)],
     };
@@ -244,7 +240,6 @@ export default function CourseCreditUsageTab({
       mode: 5.5,
       chapter: 6,
       lesson: 6,
-      usageCount: 5,
       credits: 5.5,
       model: 6,
     };
@@ -403,7 +398,7 @@ export default function CourseCreditUsageTab({
           loading={loading}
           isEmpty={!error && rows.length === 0}
           emptyContent={tOperations('detail.creditUsage.table.empty')}
-          emptyColSpan={9}
+          emptyColSpan={8}
           withTooltipProvider={!error}
           tableWrapperClassName='overflow-auto'
           loadingClassName='min-h-[240px]'
@@ -511,16 +506,6 @@ export default function CourseCreditUsageTab({
                           ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
                           'h-10 whitespace-nowrap bg-muted/80 text-xs',
                         )}
-                        style={getColumnStyle('usageCount')}
-                      >
-                        {tOperations('detail.creditUsage.table.usageCount')}
-                        {renderResizeHandle('usageCount')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
                         style={getColumnStyle('credits')}
                       >
                         {tOperations('detail.creditUsage.table.credits')}
@@ -602,17 +587,6 @@ export default function CourseCreditUsageTab({
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-[180px]'
                           />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
-                          style={getColumnStyle('usageCount')}
-                        >
-                          <span className='font-medium tabular-nums text-foreground'>
-                            {formatAdminCount(
-                              row.usage_count || 0,
-                              i18n.language,
-                            )}
-                          </span>
                         </TableCell>
                         <TableCell
                           className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -241,7 +241,10 @@ export default function CourseCreditUsageTab({
         }
         const required = texts.reduce(
           (maxWidth, text) =>
-            Math.max(maxWidth, estimateColumnWidth(text, multiplierMap[key] ?? 7)),
+            Math.max(
+              maxWidth,
+              estimateColumnWidth(text, multiplierMap[key] ?? 7),
+            ),
           Number(CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS[key]),
         );
         if (
@@ -312,7 +315,9 @@ export default function CourseCreditUsageTab({
               <Select
                 value={filtersDraft.mode}
                 onValueChange={value =>
-                  onModeChange(value as AdminOperationCourseCreditUsageModeFilter)
+                  onModeChange(
+                    value as AdminOperationCourseCreditUsageModeFilter,
+                  )
                 }
               >
                 <SelectTrigger className='h-9'>
@@ -341,7 +346,9 @@ export default function CourseCreditUsageTab({
               <AdminDateRangeFilter
                 startValue={filtersDraft.startTime}
                 endValue={filtersDraft.endTime}
-                triggerAriaLabel={tOperations('detail.creditUsage.filters.time')}
+                triggerAriaLabel={tOperations(
+                  'detail.creditUsage.filters.time',
+                )}
                 placeholder={tOperations(
                   'detail.creditUsage.filters.timePlaceholder',
                 )}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { ClearableTextInput } from '@/app/admin/operations/orders/orderUiShared';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
@@ -51,6 +52,7 @@ type CreditUsageColumnKey =
   | 'mode'
   | 'chapter'
   | 'lesson'
+  | 'usageCount'
   | 'credits'
   | 'model';
 
@@ -65,6 +67,7 @@ const CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS = {
   mode: 110,
   chapter: 160,
   lesson: 160,
+  usageCount: 100,
   credits: 120,
   model: 220,
 } as const;
@@ -122,7 +125,7 @@ export default function CourseCreditUsageTab({
   onPageChange: (page: number) => void;
 }) {
   const { t } = useTranslation();
-  const { t: tOperations } = useTranslation('module.operationsCourse');
+  const { t: tOperations, i18n } = useTranslation('module.operationsCourse');
   const {
     setColumnWidths,
     getColumnStyle,
@@ -177,6 +180,9 @@ export default function CourseCreditUsageTab({
       if (mode === 'ask') {
         return tOperations('detail.creditUsage.modes.ask');
       }
+      if (mode === 'mixed') {
+        return tOperations('detail.creditUsage.modes.mixed');
+      }
       return formatUnknownEnumLabel(
         tOperations('detail.creditUsage.modes.unknown'),
         mode,
@@ -189,12 +195,17 @@ export default function CourseCreditUsageTab({
     (row: AdminOperationCourseCreditUsageItem) => {
       const provider = row.provider?.trim() || '';
       const model = row.model?.trim() || '';
-      if (provider && model) {
-        return `${provider} / ${model}`;
+      const baseDisplay =
+        provider && model ? `${provider} / ${model}` : provider || model || '';
+      if (row.model_variant_count > 1 && baseDisplay) {
+        return tOperations('detail.creditUsage.modelSummary.multiple', {
+          model: baseDisplay,
+          count: row.model_variant_count,
+        });
       }
-      return provider || model || emptyValue;
+      return baseDisplay || emptyValue;
     },
-    [emptyValue],
+    [emptyValue, tOperations],
   );
 
   useEffect(() => {
@@ -222,6 +233,7 @@ export default function CourseCreditUsageTab({
       mode: row => [resolveModeLabel(row.usage_mode)],
       chapter: row => [row.chapter_title || emptyValue],
       lesson: row => [row.lesson_title || emptyValue],
+      usageCount: row => [String(row.usage_count || 0)],
       credits: row => [String(row.consumed_credits || 0)],
       model: row => [resolveModelDisplay(row)],
     };
@@ -232,6 +244,7 @@ export default function CourseCreditUsageTab({
       mode: 5.5,
       chapter: 6,
       lesson: 6,
+      usageCount: 5,
       credits: 5.5,
       model: 6,
     };
@@ -390,7 +403,7 @@ export default function CourseCreditUsageTab({
           loading={loading}
           isEmpty={!error && rows.length === 0}
           emptyContent={tOperations('detail.creditUsage.table.empty')}
-          emptyColSpan={8}
+          emptyColSpan={9}
           withTooltipProvider={!error}
           tableWrapperClassName='overflow-auto'
           loadingClassName='min-h-[240px]'
@@ -498,6 +511,16 @@ export default function CourseCreditUsageTab({
                           ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
                           'h-10 whitespace-nowrap bg-muted/80 text-xs',
                         )}
+                        style={getColumnStyle('usageCount')}
+                      >
+                        {tOperations('detail.creditUsage.table.usageCount')}
+                        {renderResizeHandle('usageCount')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
                         style={getColumnStyle('credits')}
                       >
                         {tOperations('detail.creditUsage.table.credits')}
@@ -518,7 +541,7 @@ export default function CourseCreditUsageTab({
                   <TableBody>
                     {emptyRow}
                     {rows.map(row => (
-                      <TableRow key={row.usage_bid}>
+                      <TableRow key={row.group_key || row.usage_bid}>
                         <TableCell
                           className='py-2.5 border-r border-border text-center text-xs text-muted-foreground/65 last:border-r-0'
                           style={getColumnStyle('createdAt')}
@@ -579,6 +602,17 @@ export default function CourseCreditUsageTab({
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-[180px]'
                           />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('usageCount')}
+                        >
+                          <span className='font-medium tabular-nums text-foreground'>
+                            {formatAdminCount(
+                              row.usage_count || 0,
+                              i18n.language,
+                            )}
+                          </span>
                         </TableCell>
                         <TableCell
                           className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -1,0 +1,602 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import AdminTableShell from '@/app/admin/components/AdminTableShell';
+import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
+import {
+  ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+  ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+  ADMIN_TABLE_RESIZE_HANDLE_CLASS,
+} from '@/app/admin/components/adminTableStyles';
+import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { ClearableTextInput } from '@/app/admin/operations/orders/orderUiShared';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent } from '@/components/ui/Card';
+import { Label } from '@/components/ui/Label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+import { ContactMode } from '@/lib/resolve-contact-mode';
+import { cn } from '@/lib/utils';
+import type {
+  AdminOperationCourseCreditUsageFilters,
+  AdminOperationCourseCreditUsageItem,
+  AdminOperationCourseCreditUsageListResponse,
+  AdminOperationCourseCreditUsageModeFilter,
+} from '../operation-course-types';
+
+type ErrorState = { message: string; code?: number };
+
+type CreditUsageColumnKey =
+  | 'createdAt'
+  | 'account'
+  | 'nickname'
+  | 'mode'
+  | 'chapter'
+  | 'lesson'
+  | 'credits'
+  | 'model';
+
+const CREDIT_USAGE_COLUMN_MIN_WIDTH = 80;
+const CREDIT_USAGE_COLUMN_MAX_WIDTH = 360;
+const CREDIT_USAGE_COLUMN_WIDTH_STORAGE_KEY =
+  'adminOperationCourseCreditUsageColumnWidths';
+const CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS = {
+  createdAt: 170,
+  account: 170,
+  nickname: 140,
+  mode: 110,
+  chapter: 160,
+  lesson: 160,
+  credits: 120,
+  model: 220,
+} as const;
+const CREDIT_USAGE_COLUMN_KEYS = Object.keys(
+  CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS,
+) as CreditUsageColumnKey[];
+const FILTER_ALL_OPTION = 'all';
+
+function formatUnknownEnumLabel(label: string, rawValue?: string) {
+  const normalizedValue = (rawValue || '').trim();
+  if (!normalizedValue) {
+    return label;
+  }
+
+  const wrapper = /[^\x00-\x7F]/.test(`${label}${normalizedValue}`)
+    ? ['（', '）']
+    : [' (', ')'];
+  return `${label}${wrapper[0]}${normalizedValue}${wrapper[1]}`;
+}
+
+function estimateColumnWidth(text: string, multiplier = 7) {
+  if (!text) {
+    return CREDIT_USAGE_COLUMN_MIN_WIDTH;
+  }
+  return text.length * multiplier + 24;
+}
+
+export default function CourseCreditUsageTab({
+  filtersDraft,
+  data,
+  loading,
+  error,
+  contactMode,
+  defaultUserName,
+  emptyValue,
+  onKeywordChange,
+  onModeChange,
+  onDateRangeChange,
+  onSearch,
+  onReset,
+  onPageChange,
+}: {
+  filtersDraft: AdminOperationCourseCreditUsageFilters;
+  data: AdminOperationCourseCreditUsageListResponse;
+  loading: boolean;
+  error: ErrorState | null;
+  contactMode: ContactMode;
+  defaultUserName: string;
+  emptyValue: string;
+  onKeywordChange: (value: string) => void;
+  onModeChange: (value: AdminOperationCourseCreditUsageModeFilter) => void;
+  onDateRangeChange: (value: { start: string; end: string }) => void;
+  onSearch: () => void;
+  onReset: () => void;
+  onPageChange: (page: number) => void;
+}) {
+  const { t } = useTranslation();
+  const { t: tOperations } = useTranslation('module.operationsCourse');
+  const {
+    setColumnWidths,
+    getColumnStyle,
+    getResizeHandleProps,
+    isManualColumn,
+    clampWidth,
+  } = useAdminResizableColumns<CreditUsageColumnKey>({
+    storageKey: CREDIT_USAGE_COLUMN_WIDTH_STORAGE_KEY,
+    defaultWidths: CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS,
+    minWidth: CREDIT_USAGE_COLUMN_MIN_WIDTH,
+    maxWidth: CREDIT_USAGE_COLUMN_MAX_WIDTH,
+  });
+
+  const clearLabel = useMemo(() => t('common.core.close'), [t]);
+  const rows = useMemo(() => data.items || [], [data.items]);
+  const currentPage = data.page || 1;
+  const pageCount = Math.max(data.page_count || 0, 1);
+  const keywordPlaceholder = useMemo(
+    () =>
+      contactMode === 'email'
+        ? tOperations('detail.creditUsage.filters.userKeywordPlaceholderEmail')
+        : tOperations('detail.creditUsage.filters.userKeywordPlaceholderPhone'),
+    [contactMode, tOperations],
+  );
+  const accountLabel = useMemo(
+    () =>
+      contactMode === 'email'
+        ? tOperations('detail.usersTable.accountEmail')
+        : tOperations('detail.usersTable.accountPhone'),
+    [contactMode, tOperations],
+  );
+
+  const resolveAccount = useCallback(
+    (row: AdminOperationCourseCreditUsageItem) => {
+      const preferred = contactMode === 'email' ? row.email : row.mobile;
+      return preferred || emptyValue;
+    },
+    [contactMode, emptyValue],
+  );
+
+  const resolveModeLabel = useCallback(
+    (mode?: string) => {
+      if (mode === 'learn') {
+        return tOperations('detail.creditUsage.modes.learn');
+      }
+      if (mode === 'listen') {
+        return tOperations('detail.creditUsage.modes.listen');
+      }
+      if (mode === 'ask') {
+        return tOperations('detail.creditUsage.modes.ask');
+      }
+      return formatUnknownEnumLabel(
+        tOperations('detail.creditUsage.modes.unknown'),
+        mode,
+      );
+    },
+    [tOperations],
+  );
+
+  const resolveModelDisplay = useCallback(
+    (row: AdminOperationCourseCreditUsageItem) => {
+      const provider = row.provider?.trim() || '';
+      const model = row.model?.trim() || '';
+      if (provider && model) {
+        return `${provider} / ${model}`;
+      }
+      return provider || model || emptyValue;
+    },
+    [emptyValue],
+  );
+
+  useEffect(() => {
+    if (!rows.length) {
+      setColumnWidths(prev => {
+        const next = { ...prev };
+        CREDIT_USAGE_COLUMN_KEYS.forEach(key => {
+          if (!isManualColumn(key)) {
+            next[key] = CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS[key];
+          }
+        });
+        return next;
+      });
+      return;
+    }
+
+    const nextWidths: Partial<Record<CreditUsageColumnKey, number>> = {};
+    const columnValueExtractors: Record<
+      CreditUsageColumnKey,
+      (row: AdminOperationCourseCreditUsageItem) => string[]
+    > = {
+      createdAt: row => [row.created_at || emptyValue],
+      account: row => [resolveAccount(row)],
+      nickname: row => [row.nickname || defaultUserName],
+      mode: row => [resolveModeLabel(row.usage_mode)],
+      chapter: row => [row.chapter_title || emptyValue],
+      lesson: row => [row.lesson_title || emptyValue],
+      credits: row => [String(row.consumed_credits || 0)],
+      model: row => [resolveModelDisplay(row)],
+    };
+    const multiplierMap: Partial<Record<CreditUsageColumnKey, number>> = {
+      createdAt: 5,
+      account: 6,
+      nickname: 6,
+      mode: 5.5,
+      chapter: 6,
+      lesson: 6,
+      credits: 5.5,
+      model: 6,
+    };
+
+    rows.forEach(row => {
+      CREDIT_USAGE_COLUMN_KEYS.forEach(key => {
+        const texts = columnValueExtractors[key](row).filter(Boolean);
+        if (!texts.length) {
+          return;
+        }
+        const required = texts.reduce(
+          (maxWidth, text) =>
+            Math.max(maxWidth, estimateColumnWidth(text, multiplierMap[key] ?? 7)),
+          Number(CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS[key]),
+        );
+        if (
+          !nextWidths[key] ||
+          required > (nextWidths[key] ?? CREDIT_USAGE_COLUMN_MIN_WIDTH)
+        ) {
+          nextWidths[key] = required;
+        }
+      });
+    });
+
+    setColumnWidths(prev => {
+      const next = { ...prev };
+      CREDIT_USAGE_COLUMN_KEYS.forEach(key => {
+        if (!isManualColumn(key)) {
+          next[key] = clampWidth(
+            nextWidths[key] ?? CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS[key],
+          );
+        }
+      });
+      return next;
+    });
+  }, [
+    clampWidth,
+    defaultUserName,
+    emptyValue,
+    isManualColumn,
+    resolveAccount,
+    resolveModeLabel,
+    resolveModelDisplay,
+    rows,
+    setColumnWidths,
+  ]);
+
+  const renderResizeHandle = (key: CreditUsageColumnKey) => (
+    <span
+      className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
+      {...getResizeHandleProps(key)}
+    />
+  );
+
+  return (
+    <Card className='overflow-hidden border-border/80 shadow-sm ring-1 ring-border/40'>
+      <CardContent className='space-y-3 px-6 py-6'>
+        <form
+          className='rounded-xl border border-border bg-muted/20 p-3'
+          onSubmit={event => {
+            event.preventDefault();
+            onSearch();
+          }}
+        >
+          <div className='flex flex-col gap-3 xl:flex-row xl:items-end'>
+            <div className='flex flex-1 flex-col gap-2'>
+              <Label className='text-xs font-medium text-muted-foreground'>
+                {tOperations('detail.creditUsage.filters.userKeyword')}
+              </Label>
+              <ClearableTextInput
+                value={filtersDraft.keyword}
+                placeholder={keywordPlaceholder}
+                clearLabel={t('module.chat.lessonFeedbackClearInput')}
+                onChange={onKeywordChange}
+              />
+            </div>
+            <div className='flex flex-1 flex-col gap-2'>
+              <Label className='text-xs font-medium text-muted-foreground'>
+                {tOperations('detail.creditUsage.filters.mode')}
+              </Label>
+              <Select
+                value={filtersDraft.mode}
+                onValueChange={value =>
+                  onModeChange(value as AdminOperationCourseCreditUsageModeFilter)
+                }
+              >
+                <SelectTrigger className='h-9'>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={FILTER_ALL_OPTION}>
+                    {tOperations('detail.creditUsage.filters.modeAll')}
+                  </SelectItem>
+                  <SelectItem value='learn'>
+                    {tOperations('detail.creditUsage.modes.learn')}
+                  </SelectItem>
+                  <SelectItem value='listen'>
+                    {tOperations('detail.creditUsage.modes.listen')}
+                  </SelectItem>
+                  <SelectItem value='ask'>
+                    {tOperations('detail.creditUsage.modes.ask')}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className='flex flex-1 flex-col gap-2'>
+              <Label className='text-xs font-medium text-muted-foreground'>
+                {tOperations('detail.creditUsage.filters.time')}
+              </Label>
+              <AdminDateRangeFilter
+                startValue={filtersDraft.startTime}
+                endValue={filtersDraft.endTime}
+                triggerAriaLabel={tOperations('detail.creditUsage.filters.time')}
+                placeholder={tOperations(
+                  'detail.creditUsage.filters.timePlaceholder',
+                )}
+                resetLabel={tOperations('detail.creditUsage.filters.reset')}
+                clearLabel={clearLabel}
+                onChange={({ start, end }) => onDateRangeChange({ start, end })}
+              />
+            </div>
+            <div className='flex min-h-9 shrink-0 items-center justify-start gap-2 xl:justify-end'>
+              <Button
+                type='button'
+                variant='outline'
+                className='h-9 px-4'
+                onClick={onReset}
+                disabled={loading}
+              >
+                {t('module.order.filters.reset')}
+              </Button>
+              <Button
+                type='submit'
+                className='h-9 px-4'
+                disabled={loading}
+              >
+                {t('module.order.filters.search')}
+              </Button>
+            </div>
+          </div>
+          <div className='mt-3 pl-3 text-sm text-muted-foreground'>
+            {tOperations('detail.creditUsage.count', {
+              count: data.total,
+            })}
+          </div>
+        </form>
+
+        <AdminTableShell
+          loading={loading}
+          isEmpty={!error && rows.length === 0}
+          emptyContent={tOperations('detail.creditUsage.table.empty')}
+          emptyColSpan={8}
+          withTooltipProvider={!error}
+          tableWrapperClassName='overflow-auto'
+          loadingClassName='min-h-[240px]'
+          footer={
+            pageCount > 1 ? (
+              <AdminPagination
+                pageIndex={currentPage}
+                pageCount={pageCount}
+                onPageChange={onPageChange}
+                prevLabel={t('module.order.paginationPrev', 'Previous')}
+                nextLabel={t('module.order.paginationNext', 'Next')}
+                prevAriaLabel={t(
+                  'module.order.paginationPrevAriaLabel',
+                  'Go to previous page',
+                )}
+                nextAriaLabel={t(
+                  'module.order.paginationNextAriaLabel',
+                  'Go to next page',
+                )}
+                className='mx-0 w-auto justify-end'
+              />
+            ) : null
+          }
+          table={
+            error ? (
+              <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
+                <div className='space-y-2'>
+                  <div className='text-sm font-medium text-destructive'>
+                    {error.message}
+                  </div>
+                  {typeof error.code === 'number' ? (
+                    <div className='text-xs text-muted-foreground'>
+                      {error.code}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              emptyRow => (
+                <Table className='table-auto'>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('createdAt')}
+                      >
+                        {tOperations('detail.creditUsage.table.createdAt')}
+                        {renderResizeHandle('createdAt')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('account')}
+                      >
+                        {accountLabel}
+                        {renderResizeHandle('account')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('nickname')}
+                      >
+                        {tOperations('detail.creditUsage.table.nickname')}
+                        {renderResizeHandle('nickname')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('mode')}
+                      >
+                        {tOperations('detail.creditUsage.table.mode')}
+                        {renderResizeHandle('mode')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('chapter')}
+                      >
+                        {tOperations('detail.creditUsage.table.chapter')}
+                        {renderResizeHandle('chapter')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('lesson')}
+                      >
+                        {tOperations('detail.creditUsage.table.lesson')}
+                        {renderResizeHandle('lesson')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('credits')}
+                      >
+                        {tOperations('detail.creditUsage.table.credits')}
+                        {renderResizeHandle('credits')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
+                        style={getColumnStyle('model')}
+                      >
+                        {tOperations('detail.creditUsage.table.model')}
+                        {renderResizeHandle('model')}
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {emptyRow}
+                    {rows.map(row => (
+                      <TableRow key={row.usage_bid}>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-xs text-muted-foreground/65 last:border-r-0'
+                          style={getColumnStyle('createdAt')}
+                        >
+                          <AdminTooltipText
+                            text={formatAdminNaiveDateTime(row.created_at)}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-full tabular-nums'
+                          />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('account')}
+                        >
+                          <AdminTooltipText
+                            text={resolveAccount(row)}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-[180px] font-semibold text-foreground'
+                          />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('nickname')}
+                        >
+                          <AdminTooltipText
+                            text={row.nickname || defaultUserName}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-[140px]'
+                          />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center last:border-r-0'
+                          style={getColumnStyle('mode')}
+                        >
+                          <Badge
+                            variant='outline'
+                            className='border-0 bg-transparent px-0 py-0 text-xs font-medium text-foreground shadow-none'
+                          >
+                            {resolveModeLabel(row.usage_mode)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('chapter')}
+                        >
+                          <AdminTooltipText
+                            text={row.chapter_title}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-[180px]'
+                          />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('lesson')}
+                        >
+                          <AdminTooltipText
+                            text={row.lesson_title}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-[180px]'
+                          />
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('credits')}
+                        >
+                          <span className='font-medium tabular-nums text-foreground'>
+                            {row.consumed_credits}
+                          </span>
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 text-center text-sm text-foreground'
+                          style={getColumnStyle('model')}
+                        >
+                          <AdminTooltipText
+                            text={resolveModelDisplay(row)}
+                            emptyValue={emptyValue}
+                            className='mx-auto block max-w-[220px]'
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )
+            )
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -136,7 +136,10 @@ export default function CourseCreditUsageTab({
     maxWidth: CREDIT_USAGE_COLUMN_MAX_WIDTH,
   });
 
-  const clearLabel = useMemo(() => t('common.core.close'), [t]);
+  const clearLabel = useMemo(
+    () => t('module.chat.lessonFeedbackClearInput'),
+    [t],
+  );
   const rows = useMemo(() => data.items || [], [data.items]);
   const currentPage = data.page || 1;
   const pageCount = Math.max(data.page_count || 0, 1);

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -536,7 +536,7 @@ export default function CourseCreditUsageTab({
                           <AdminTooltipText
                             text={resolveAccount(row)}
                             emptyValue={emptyValue}
-                            className='mx-auto block max-w-[180px] font-semibold text-foreground'
+                            className='mx-auto block max-w-[180px] text-foreground'
                           />
                         </TableCell>
                         <TableCell

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -13,6 +13,7 @@ const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockGetAdminOperationCourseDetail = jest.fn();
 const mockGetAdminOperationCourseUsers = jest.fn();
+const mockGetAdminOperationCourseCreditUsages = jest.fn();
 const mockGetAdminOperationCourseChapterDetail = jest.fn();
 const mockCopyText = jest.fn();
 const mockToastShow = jest.fn();
@@ -50,6 +51,8 @@ jest.mock('@/api', () => ({
       mockGetAdminOperationCourseDetail(...args),
     getAdminOperationCourseUsers: (...args: unknown[]) =>
       mockGetAdminOperationCourseUsers(...args),
+    getAdminOperationCourseCreditUsages: (...args: unknown[]) =>
+      mockGetAdminOperationCourseCreditUsages(...args),
     getAdminOperationCourseChapterDetail: (...args: unknown[]) =>
       mockGetAdminOperationCourseChapterDetail(...args),
   },
@@ -253,11 +256,23 @@ describe('AdminOperationCourseDetailPage', () => {
     });
   };
 
+  const openCreditUsageTab = async () => {
+    fireEvent.click(
+      await screen.findByRole('tab', {
+        name: /module\.operationsCourse\.detail\.creditUsageTab/,
+      }),
+    );
+    await screen.findByRole('button', {
+      name: 'module.order.filters.search',
+    });
+  };
+
   beforeEach(() => {
     mockReplace.mockReset();
     mockPush.mockReset();
     mockGetAdminOperationCourseDetail.mockReset();
     mockGetAdminOperationCourseUsers.mockReset();
+    mockGetAdminOperationCourseCreditUsages.mockReset();
     mockGetAdminOperationCourseChapterDetail.mockReset();
     mockCopyText.mockReset();
     mockToastShow.mockReset();
@@ -295,6 +310,32 @@ describe('AdminOperationCourseDetailPage', () => {
           last_learning_at: '2026-04-08T11:30:00Z',
           joined_at: '2026-04-07T09:00:00Z',
           last_login_at: '2026-04-08T12:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+    mockGetAdminOperationCourseCreditUsages.mockResolvedValue({
+      items: [
+        {
+          usage_bid: 'usage-1',
+          progress_record_bid: 'progress-1',
+          generated_block_bid: '',
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          chapter_outline_item_bid: 'chapter-1',
+          chapter_title: 'Chapter 1',
+          lesson_outline_item_bid: 'lesson-1',
+          lesson_title: 'Lesson 1',
+          usage_mode: 'listen',
+          provider: 'volcengine',
+          model: 'cancan-2.0',
+          consumed_credits: 12,
+          created_at: '2026-04-08T12:30:00Z',
         },
       ],
       page: 1,
@@ -429,6 +470,37 @@ describe('AdminOperationCourseDetailPage', () => {
     );
 
     expect(mockPush).toHaveBeenCalledWith('/admin/operations');
+  });
+
+  test('loads credit usage tab on demand and renders credit rows', async () => {
+    render(<AdminOperationCourseDetailPage />);
+
+    expect(mockGetAdminOperationCourseCreditUsages).not.toHaveBeenCalled();
+
+    await openCreditUsageTab();
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseCreditUsages).toHaveBeenCalledWith({
+        shifu_bid: 'course-1',
+        page: 1,
+        page_size: 20,
+        keyword: '',
+        mode: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+
+    expect(
+      screen.getByText('module.operationsCourse.detail.creditUsage.filters.userKeyword'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        'module.operationsCourse.detail.creditUsage.modes.listen',
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('volcengine / cancan-2.0')).toBeInTheDocument();
+    expect(screen.getAllByText('12').length).toBeGreaterThan(0);
   });
 
   test('formats course metrics and learning progress without grouping in Chinese locale', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -492,7 +492,9 @@ describe('AdminOperationCourseDetailPage', () => {
     });
 
     expect(
-      screen.getByText('module.operationsCourse.detail.creditUsage.filters.userKeyword'),
+      screen.getByText(
+        'module.operationsCourse.detail.creditUsage.filters.userKeyword',
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -318,9 +318,11 @@ describe('AdminOperationCourseDetailPage', () => {
       total: 1,
     });
     mockGetAdminOperationCourseCreditUsages.mockResolvedValue({
+      view: 'grouped',
       items: [
         {
-          usage_bid: 'usage-1',
+          group_key: 'progress-1',
+          usage_bid: 'usage-2',
           progress_record_bid: 'progress-1',
           generated_block_bid: '',
           user_bid: 'student-1',
@@ -331,10 +333,12 @@ describe('AdminOperationCourseDetailPage', () => {
           chapter_title: 'Chapter 1',
           lesson_outline_item_bid: 'lesson-1',
           lesson_title: 'Lesson 1',
-          usage_mode: 'listen',
+          usage_mode: 'mixed',
           provider: 'volcengine',
           model: 'cancan-2.0',
-          consumed_credits: 12,
+          usage_count: 2,
+          model_variant_count: 2,
+          consumed_credits: 17,
           created_at: '2026-04-08T12:30:00Z',
         },
       ],
@@ -484,6 +488,7 @@ describe('AdminOperationCourseDetailPage', () => {
         shifu_bid: 'course-1',
         page: 1,
         page_size: 20,
+        view: 'grouped',
         keyword: '',
         mode: '',
         start_time: '',
@@ -498,11 +503,21 @@ describe('AdminOperationCourseDetailPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        'module.operationsCourse.detail.creditUsage.modes.listen',
+        'module.operationsCourse.detail.creditUsage.modes.mixed',
       ).length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText('volcengine / cancan-2.0')).toBeInTheDocument();
-    expect(screen.getAllByText('12').length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        'module.operationsCourse.detail.creditUsage.modelSummary.multiple',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'module.operationsCourse.detail.creditUsage.table.usageCount',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+    expect(screen.getByText('17')).toBeInTheDocument();
   });
 
   test('formats course metrics and learning progress without grouping in Chinese locale', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -321,7 +321,7 @@ describe('AdminOperationCourseDetailPage', () => {
       view: 'grouped',
       items: [
         {
-          group_key: 'progress-1',
+          group_key: 'progress-1:learn',
           usage_bid: 'usage-2',
           progress_record_bid: 'progress-1',
           generated_block_bid: '',
@@ -333,9 +333,9 @@ describe('AdminOperationCourseDetailPage', () => {
           chapter_title: 'Chapter 1',
           lesson_outline_item_bid: 'lesson-1',
           lesson_title: 'Lesson 1',
-          usage_mode: 'mixed',
-          provider: 'volcengine',
-          model: 'cancan-2.0',
+          usage_mode: 'learn',
+          provider: 'qwen',
+          model: 'qwen/deepseek-v4-a',
           usage_count: 2,
           model_variant_count: 2,
           consumed_credits: 17,
@@ -503,7 +503,7 @@ describe('AdminOperationCourseDetailPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        'module.operationsCourse.detail.creditUsage.modes.mixed',
+        'module.operationsCourse.detail.creditUsage.modes.learn',
       ).length,
     ).toBeGreaterThan(0);
     expect(
@@ -512,11 +512,10 @@ describe('AdminOperationCourseDetailPage', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         'module.operationsCourse.detail.creditUsage.table.usageCount',
       ),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+    ).not.toBeInTheDocument();
     expect(screen.getByText('17')).toBeInTheDocument();
   });
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -150,6 +150,7 @@ const EMPTY_COURSE_USERS_RESPONSE: AdminOperationCourseUsersResponse = {
 
 const EMPTY_COURSE_CREDIT_USAGE_RESPONSE: AdminOperationCourseCreditUsageListResponse =
   {
+    view: 'grouped',
     items: [],
     page: 1,
     page_count: 0,
@@ -353,12 +354,15 @@ function ClearableTextInput({
  * t('module.operationsCourse.detail.creditUsage.modes.learn')
  * t('module.operationsCourse.detail.creditUsage.modes.listen')
  * t('module.operationsCourse.detail.creditUsage.modes.ask')
+ * t('module.operationsCourse.detail.creditUsage.modes.mixed')
  * t('module.operationsCourse.detail.creditUsage.modes.unknown')
+ * t('module.operationsCourse.detail.creditUsage.modelSummary.multiple')
  * t('module.operationsCourse.detail.creditUsage.table.createdAt')
  * t('module.operationsCourse.detail.creditUsage.table.nickname')
  * t('module.operationsCourse.detail.creditUsage.table.mode')
  * t('module.operationsCourse.detail.creditUsage.table.chapter')
  * t('module.operationsCourse.detail.creditUsage.table.lesson')
+ * t('module.operationsCourse.detail.creditUsage.table.usageCount')
  * t('module.operationsCourse.detail.creditUsage.table.credits')
  * t('module.operationsCourse.detail.creditUsage.table.model')
  * t('module.operationsCourse.detail.creditUsage.table.empty')
@@ -588,6 +592,7 @@ export default function AdminOperationCourseDetailPage() {
           shifu_bid: shifuBid,
           page: targetPage,
           page_size: COURSE_CREDIT_USAGE_PAGE_SIZE,
+          view: 'grouped',
           keyword: resolvedFilters.keyword.trim(),
           mode:
             resolvedFilters.mode === FILTER_ALL_OPTION
@@ -600,6 +605,7 @@ export default function AdminOperationCourseDetailPage() {
           return;
         }
         setCourseCreditUsages({
+          view: response?.view || 'grouped',
           items: response?.items || [],
           page: response?.page || targetPage,
           page_count: response?.page_count || 0,

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -59,12 +59,15 @@ import {
   buildAdminOperationsCourseRatingsUrl,
 } from '../operation-course-routes';
 import type {
+  AdminOperationCourseCreditUsageFilters,
+  AdminOperationCourseCreditUsageListResponse,
   AdminOperationCourseChapterDetailResponse,
   AdminOperationCourseDetailChapter,
   AdminOperationCourseDetailResponse,
   AdminOperationCourseUserItem,
   AdminOperationCourseUsersResponse,
 } from '../operation-course-types';
+import CourseCreditUsageTab from './CourseCreditUsageTab';
 import useOperatorGuard from '../useOperatorGuard';
 
 type ErrorState = { message: string; code?: number };
@@ -80,7 +83,7 @@ type CourseUserFilters = {
   learningStatus: string;
   paymentStatus: CourseUserPaymentStatus;
 };
-type CourseDetailTab = 'chapters' | 'users';
+type CourseDetailTab = 'chapters' | 'users' | 'creditUsage';
 
 const EMPTY_CHAPTER_DETAIL: AdminOperationCourseChapterDetailResponse = {
   outline_item_bid: '',
@@ -134,6 +137,7 @@ const USER_COLUMN_KEYS = Object.keys(
   USER_COLUMN_DEFAULT_WIDTHS,
 ) as UserColumnKey[];
 const USER_PAGE_SIZE = 20;
+const COURSE_CREDIT_USAGE_PAGE_SIZE = 20;
 const FILTER_ALL_OPTION = 'all';
 
 const EMPTY_COURSE_USERS_RESPONSE: AdminOperationCourseUsersResponse = {
@@ -143,6 +147,15 @@ const EMPTY_COURSE_USERS_RESPONSE: AdminOperationCourseUsersResponse = {
   page_size: USER_PAGE_SIZE,
   total: 0,
 };
+
+const EMPTY_COURSE_CREDIT_USAGE_RESPONSE: AdminOperationCourseCreditUsageListResponse =
+  {
+    items: [],
+    page: 1,
+    page_count: 0,
+    page_size: COURSE_CREDIT_USAGE_PAGE_SIZE,
+    total: 0,
+  };
 
 const EMPTY_DETAIL: AdminOperationCourseDetailResponse = {
   basic_info: {
@@ -194,6 +207,13 @@ const createCourseUserFilters = (): CourseUserFilters => ({
   userRole: FILTER_ALL_OPTION,
   learningStatus: FILTER_ALL_OPTION,
   paymentStatus: FILTER_ALL_OPTION,
+});
+
+const createCourseCreditUsageFilters = (): AdminOperationCourseCreditUsageFilters => ({
+  keyword: '',
+  mode: FILTER_ALL_OPTION,
+  startTime: '',
+  endTime: '',
 });
 
 function ClearableTextInput({
@@ -317,6 +337,30 @@ function ClearableTextInput({
  * t('module.operationsCourse.detail.usersTable.action')
  * t('module.operationsCourse.detail.usersTable.empty')
  * t('module.operationsCourse.detail.usersTable.detailAction')
+ * t('module.operationsCourse.detail.creditUsageTab')
+ * t('module.operationsCourse.detail.creditUsage.title')
+ * t('module.operationsCourse.detail.creditUsage.description')
+ * t('module.operationsCourse.detail.creditUsage.count')
+ * t('module.operationsCourse.detail.creditUsage.filters.userKeyword')
+ * t('module.operationsCourse.detail.creditUsage.filters.userKeywordPlaceholderPhone')
+ * t('module.operationsCourse.detail.creditUsage.filters.userKeywordPlaceholderEmail')
+ * t('module.operationsCourse.detail.creditUsage.filters.mode')
+ * t('module.operationsCourse.detail.creditUsage.filters.modeAll')
+ * t('module.operationsCourse.detail.creditUsage.filters.time')
+ * t('module.operationsCourse.detail.creditUsage.filters.timePlaceholder')
+ * t('module.operationsCourse.detail.creditUsage.filters.reset')
+ * t('module.operationsCourse.detail.creditUsage.modes.learn')
+ * t('module.operationsCourse.detail.creditUsage.modes.listen')
+ * t('module.operationsCourse.detail.creditUsage.modes.ask')
+ * t('module.operationsCourse.detail.creditUsage.modes.unknown')
+ * t('module.operationsCourse.detail.creditUsage.table.createdAt')
+ * t('module.operationsCourse.detail.creditUsage.table.nickname')
+ * t('module.operationsCourse.detail.creditUsage.table.mode')
+ * t('module.operationsCourse.detail.creditUsage.table.chapter')
+ * t('module.operationsCourse.detail.creditUsage.table.lesson')
+ * t('module.operationsCourse.detail.creditUsage.table.credits')
+ * t('module.operationsCourse.detail.creditUsage.table.model')
+ * t('module.operationsCourse.detail.creditUsage.table.empty')
  * t('module.operationsCourse.detail.userRole.operator')
  * t('module.operationsCourse.detail.userRole.creator')
  * t('module.operationsCourse.detail.userRole.student')
@@ -361,6 +405,24 @@ export default function AdminOperationCourseDetailPage() {
   );
   const [courseUserPage, setCourseUserPage] = useState(1);
   const courseUsersRequestIdRef = useRef(0);
+  const [courseCreditUsageFiltersDraft, setCourseCreditUsageFiltersDraft] =
+    useState<AdminOperationCourseCreditUsageFilters>(
+      createCourseCreditUsageFilters,
+    );
+  const [courseCreditUsageFilters, setCourseCreditUsageFilters] =
+    useState<AdminOperationCourseCreditUsageFilters>(
+      createCourseCreditUsageFilters,
+    );
+  const [courseCreditUsages, setCourseCreditUsages] =
+    useState<AdminOperationCourseCreditUsageListResponse>(
+      EMPTY_COURSE_CREDIT_USAGE_RESPONSE,
+    );
+  const [courseCreditUsagesLoading, setCourseCreditUsagesLoading] =
+    useState(false);
+  const [courseCreditUsagesError, setCourseCreditUsagesError] =
+    useState<ErrorState | null>(null);
+  const [courseCreditUsagePage, setCourseCreditUsagePage] = useState(1);
+  const courseCreditUsagesRequestIdRef = useRef(0);
   const {
     setColumnWidths: setChapterColumnWidths,
     getColumnStyle: getChapterColumnStyle,
@@ -385,7 +447,6 @@ export default function AdminOperationCourseDetailPage() {
     minWidth: USER_COLUMN_MIN_WIDTH,
     maxWidth: USER_COLUMN_MAX_WIDTH,
   });
-
   const shifuBid = Array.isArray(params?.shifu_bid)
     ? params.shifu_bid[0] || ''
     : params?.shifu_bid || '';
@@ -422,7 +483,6 @@ export default function AdminOperationCourseDetailPage() {
         : tOperations('detail.usersTable.accountPhone'),
     [contactMode, tOperations],
   );
-
   const fetchDetail = useCallback(async () => {
     if (!shifuBid.trim()) {
       setError({ message: unknownErrorMessage });
@@ -505,6 +565,67 @@ export default function AdminOperationCourseDetailPage() {
     [courseUserFilters, shifuBid, unknownErrorMessage],
   );
 
+  const fetchCourseCreditUsages = useCallback(
+    async (
+      targetPage: number,
+      nextFilters?: AdminOperationCourseCreditUsageFilters,
+    ) => {
+      if (!shifuBid.trim()) {
+        setCourseCreditUsagesError({ message: unknownErrorMessage });
+        setCourseCreditUsages(EMPTY_COURSE_CREDIT_USAGE_RESPONSE);
+        return;
+      }
+
+      const resolvedFilters = nextFilters ?? courseCreditUsageFilters;
+      const requestId = courseCreditUsagesRequestIdRef.current + 1;
+      courseCreditUsagesRequestIdRef.current = requestId;
+      setCourseCreditUsagesLoading(true);
+      setCourseCreditUsagesError(null);
+
+      try {
+        const response = (await api.getAdminOperationCourseCreditUsages({
+          shifu_bid: shifuBid,
+          page: targetPage,
+          page_size: COURSE_CREDIT_USAGE_PAGE_SIZE,
+          keyword: resolvedFilters.keyword.trim(),
+          mode:
+            resolvedFilters.mode === FILTER_ALL_OPTION
+              ? ''
+              : resolvedFilters.mode,
+          start_time: resolvedFilters.startTime,
+          end_time: resolvedFilters.endTime,
+        })) as AdminOperationCourseCreditUsageListResponse;
+        if (requestId !== courseCreditUsagesRequestIdRef.current) {
+          return;
+        }
+        setCourseCreditUsages({
+          items: response?.items || [],
+          page: response?.page || targetPage,
+          page_count: response?.page_count || 0,
+          page_size: response?.page_size || COURSE_CREDIT_USAGE_PAGE_SIZE,
+          total: response?.total || 0,
+        });
+      } catch (err) {
+        if (requestId !== courseCreditUsagesRequestIdRef.current) {
+          return;
+        }
+        setCourseCreditUsages(EMPTY_COURSE_CREDIT_USAGE_RESPONSE);
+        if (err instanceof ErrorWithCode) {
+          setCourseCreditUsagesError({ message: err.message, code: err.code });
+        } else if (err instanceof Error) {
+          setCourseCreditUsagesError({ message: err.message });
+        } else {
+          setCourseCreditUsagesError({ message: unknownErrorMessage });
+        }
+      } finally {
+        if (requestId === courseCreditUsagesRequestIdRef.current) {
+          setCourseCreditUsagesLoading(false);
+        }
+      }
+    },
+    [courseCreditUsageFilters, shifuBid, unknownErrorMessage],
+  );
+
   useEffect(() => {
     if (!isReady) {
       return;
@@ -518,6 +639,19 @@ export default function AdminOperationCourseDetailPage() {
     }
     fetchCourseUsers(courseUserPage, courseUserFilters);
   }, [activeTab, courseUserFilters, courseUserPage, fetchCourseUsers, isReady]);
+
+  useEffect(() => {
+    if (!isReady || activeTab !== 'creditUsage') {
+      return;
+    }
+    fetchCourseCreditUsages(courseCreditUsagePage, courseCreditUsageFilters);
+  }, [
+    activeTab,
+    courseCreditUsageFilters,
+    courseCreditUsagePage,
+    fetchCourseCreditUsages,
+    isReady,
+  ]);
 
   const formatUnknownEnumLabel = useCallback(
     (labelKey: string, rawValue?: string) => {
@@ -790,6 +924,39 @@ export default function AdminOperationCourseDetailPage() {
       setCourseUserPage(nextPage);
     },
     [courseUserPageCount, currentCourseUserPage],
+  );
+
+
+  const handleCourseCreditUsageSearch = useCallback(() => {
+    const nextFilters = {
+      ...courseCreditUsageFiltersDraft,
+      keyword: courseCreditUsageFiltersDraft.keyword.trim(),
+    };
+    setCourseCreditUsageFilters(nextFilters);
+    setCourseCreditUsagePage(1);
+  }, [courseCreditUsageFiltersDraft]);
+
+  const handleCourseCreditUsageReset = useCallback(() => {
+    const nextFilters = createCourseCreditUsageFilters();
+    setCourseCreditUsageFiltersDraft(nextFilters);
+    setCourseCreditUsageFilters(nextFilters);
+    setCourseCreditUsagePage(1);
+  }, []);
+
+  const handleCourseCreditUsagePageChange = useCallback(
+    (nextPage: number) => {
+      const currentPage = courseCreditUsages.page || 1;
+      const pageCount = Math.max(courseCreditUsages.page_count || 0, 1);
+      if (
+        nextPage < 1 ||
+        nextPage > pageCount ||
+        nextPage === currentPage
+      ) {
+        return;
+      }
+      setCourseCreditUsagePage(nextPage);
+    },
+    [courseCreditUsages.page, courseCreditUsages.page_count],
   );
 
   const chapterRows = useMemo(
@@ -1210,6 +1377,7 @@ export default function AdminOperationCourseDetailPage() {
     ],
   );
 
+
   const renderChapterResizeHandle = (key: ChapterColumnKey) => (
     <span
       className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
@@ -1223,6 +1391,7 @@ export default function AdminOperationCourseDetailPage() {
       {...getUserResizeHandleProps(key)}
     />
   );
+
 
   const basicInfoItems = useMemo(
     () => [
@@ -1290,6 +1459,7 @@ export default function AdminOperationCourseDetailPage() {
   useEffect(() => {
     autoAdjustUserColumns(courseUserRows);
   }, [autoAdjustUserColumns, courseUserRows]);
+
 
   if (!isReady) {
     return <Loading />;
@@ -1419,6 +1589,9 @@ export default function AdminOperationCourseDetailPage() {
                   <TabsTrigger value='users'>
                     {tOperations('detail.users')}
                   </TabsTrigger>
+                  <TabsTrigger value='creditUsage'>
+                    {tOperations('detail.creditUsageTab')}
+                  </TabsTrigger>
                 </TabsList>
               </div>
 
@@ -1427,12 +1600,7 @@ export default function AdminOperationCourseDetailPage() {
                 className='mt-0'
               >
                 <Card>
-                  <CardHeader className='pb-4'>
-                    <CardTitle className='text-base font-semibold tracking-normal'>
-                      {tOperations('detail.chapters')}
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className='pt-0'>
+                  <CardContent className='pt-6'>
                     <AdminTableShell
                       loading={false}
                       isEmpty={chapterRows.length === 0}
@@ -1740,17 +1908,7 @@ export default function AdminOperationCourseDetailPage() {
                 className='mt-0'
               >
                 <Card className='overflow-hidden border-border/80 shadow-sm ring-1 ring-border/40'>
-                  <CardHeader className='gap-1.5 border-b border-border/70 bg-muted/[0.08] px-6 pb-2.5 pt-4'>
-                    <div className='flex flex-col gap-1 md:flex-row md:items-baseline md:gap-3'>
-                      <CardTitle className='text-base font-semibold tracking-normal'>
-                        {tOperations('detail.users')}
-                      </CardTitle>
-                      <p className='text-sm text-muted-foreground'>
-                        {tOperations('detail.usersDescription')}
-                      </p>
-                    </div>
-                  </CardHeader>
-                  <CardContent className='space-y-3 px-6 pb-6 pt-2.5'>
+                  <CardContent className='space-y-3 px-6 py-6'>
                     <form
                       className='rounded-xl border border-border bg-muted/20 p-3'
                       onSubmit={event => {
@@ -2227,6 +2385,43 @@ export default function AdminOperationCourseDetailPage() {
                     />
                   </CardContent>
                 </Card>
+              </TabsContent>
+
+              <TabsContent
+                value='creditUsage'
+                className='mt-0'
+              >
+                <CourseCreditUsageTab
+                  filtersDraft={courseCreditUsageFiltersDraft}
+                  data={courseCreditUsages}
+                  loading={courseCreditUsagesLoading}
+                  error={courseCreditUsagesError}
+                  contactMode={contactMode}
+                  defaultUserName={defaultUserName}
+                  emptyValue={emptyValue}
+                  onKeywordChange={value =>
+                    setCourseCreditUsageFiltersDraft(prev => ({
+                      ...prev,
+                      keyword: value,
+                    }))
+                  }
+                  onModeChange={value =>
+                    setCourseCreditUsageFiltersDraft(prev => ({
+                      ...prev,
+                      mode: value,
+                    }))
+                  }
+                  onDateRangeChange={({ start, end }) =>
+                    setCourseCreditUsageFiltersDraft(prev => ({
+                      ...prev,
+                      startTime: start,
+                      endTime: end,
+                    }))
+                  }
+                  onSearch={handleCourseCreditUsageSearch}
+                  onReset={handleCourseCreditUsageReset}
+                  onPageChange={handleCourseCreditUsagePageChange}
+                />
               </TabsContent>
             </Tabs>
           </div>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -209,12 +209,13 @@ const createCourseUserFilters = (): CourseUserFilters => ({
   paymentStatus: FILTER_ALL_OPTION,
 });
 
-const createCourseCreditUsageFilters = (): AdminOperationCourseCreditUsageFilters => ({
-  keyword: '',
-  mode: FILTER_ALL_OPTION,
-  startTime: '',
-  endTime: '',
-});
+const createCourseCreditUsageFilters =
+  (): AdminOperationCourseCreditUsageFilters => ({
+    keyword: '',
+    mode: FILTER_ALL_OPTION,
+    startTime: '',
+    endTime: '',
+  });
 
 function ClearableTextInput({
   value,
@@ -926,7 +927,6 @@ export default function AdminOperationCourseDetailPage() {
     [courseUserPageCount, currentCourseUserPage],
   );
 
-
   const handleCourseCreditUsageSearch = useCallback(() => {
     const nextFilters = {
       ...courseCreditUsageFiltersDraft,
@@ -947,11 +947,7 @@ export default function AdminOperationCourseDetailPage() {
     (nextPage: number) => {
       const currentPage = courseCreditUsages.page || 1;
       const pageCount = Math.max(courseCreditUsages.page_count || 0, 1);
-      if (
-        nextPage < 1 ||
-        nextPage > pageCount ||
-        nextPage === currentPage
-      ) {
+      if (nextPage < 1 || nextPage > pageCount || nextPage === currentPage) {
         return;
       }
       setCourseCreditUsagePage(nextPage);
@@ -1377,7 +1373,6 @@ export default function AdminOperationCourseDetailPage() {
     ],
   );
 
-
   const renderChapterResizeHandle = (key: ChapterColumnKey) => (
     <span
       className={ADMIN_TABLE_RESIZE_HANDLE_CLASS}
@@ -1391,7 +1386,6 @@ export default function AdminOperationCourseDetailPage() {
       {...getUserResizeHandleProps(key)}
     />
   );
-
 
   const basicInfoItems = useMemo(
     () => [
@@ -1459,7 +1453,6 @@ export default function AdminOperationCourseDetailPage() {
   useEffect(() => {
     autoAdjustUserColumns(courseUserRows);
   }, [autoAdjustUserColumns, courseUserRows]);
-
 
   if (!isReady) {
     return <Loading />;

--- a/src/cook-web/src/app/admin/operations/operation-course-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-course-types.ts
@@ -136,7 +136,10 @@ export type AdminOperationCourseCreditUsageMode =
   | 'learn'
   | 'listen'
   | 'ask'
+  | 'mixed'
   | LooseString;
+
+export type AdminOperationCourseCreditUsageView = 'grouped' | 'raw';
 
 export type AdminOperationCourseCreditUsageModeFilter =
   | 'all'
@@ -152,6 +155,7 @@ export type AdminOperationCourseCreditUsageFilters = {
 };
 
 export type AdminOperationCourseCreditUsageItem = {
+  group_key: string;
   usage_bid: string;
   progress_record_bid: string;
   generated_block_bid: string;
@@ -166,11 +170,14 @@ export type AdminOperationCourseCreditUsageItem = {
   usage_mode: AdminOperationCourseCreditUsageMode;
   provider: string;
   model: string;
+  usage_count: number;
+  model_variant_count: number;
   consumed_credits: number;
   created_at: string;
 };
 
 export type AdminOperationCourseCreditUsageListResponse = {
+  view: AdminOperationCourseCreditUsageView;
   items: AdminOperationCourseCreditUsageItem[];
   page: number;
   page_count: number;

--- a/src/cook-web/src/app/admin/operations/operation-course-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-course-types.ts
@@ -132,6 +132,52 @@ export type AdminOperationCourseUsersResponse = {
   total: number;
 };
 
+export type AdminOperationCourseCreditUsageMode =
+  | 'learn'
+  | 'listen'
+  | 'ask'
+  | LooseString;
+
+export type AdminOperationCourseCreditUsageModeFilter =
+  | 'all'
+  | 'learn'
+  | 'listen'
+  | 'ask';
+
+export type AdminOperationCourseCreditUsageFilters = {
+  keyword: string;
+  mode: AdminOperationCourseCreditUsageModeFilter;
+  startTime: string;
+  endTime: string;
+};
+
+export type AdminOperationCourseCreditUsageItem = {
+  usage_bid: string;
+  progress_record_bid: string;
+  generated_block_bid: string;
+  user_bid: string;
+  mobile: string;
+  email: string;
+  nickname: string;
+  chapter_outline_item_bid: string;
+  chapter_title: string;
+  lesson_outline_item_bid: string;
+  lesson_title: string;
+  usage_mode: AdminOperationCourseCreditUsageMode;
+  provider: string;
+  model: string;
+  consumed_credits: number;
+  created_at: string;
+};
+
+export type AdminOperationCourseCreditUsageListResponse = {
+  items: AdminOperationCourseCreditUsageItem[];
+  page: number;
+  page_count: number;
+  page_size: number;
+  total: number;
+};
+
 export type AdminOperationCourseFollowUpSummary = {
   follow_up_count: number;
   user_count: number;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1406,15 +1406,7 @@ const ListenModeSlideRenderer = ({
             copyButtonText: t('module.renderUi.core.copyCode'),
             copiedButtonText: t('module.renderUi.core.copied'),
           }}
-          bufferingText={{
-            waitingForAudio: t(
-              'module.chat.slideAudioBufferingWaitingForAudio',
-            ),
-            loadingAudio: t('module.chat.slideAudioBufferingLoadingAudio'),
-            waitingForMoreAudio: t(
-              'module.chat.slideAudioBufferingWaitingForMoreAudio',
-            ),
-          }}
+          bufferingText={t('module.chat.slideAudioBufferingLoadingAudio')}
           onPlayerVisibilityChange={handlePlayerVisibilityChange}
           onStepChange={handleStepChange}
           interactionDefaultValueOptions={

--- a/src/cook-web/src/types/markdown-flow-ui.d.ts
+++ b/src/cook-web/src/types/markdown-flow-ui.d.ts
@@ -21,12 +21,6 @@ declare module 'markdown-flow-ui/slide' {
   }
 
   interface SlideProps {
-    bufferingText?:
-      | string
-      | {
-          waitingForAudio?: string;
-          loadingAudio?: string;
-          waitingForMoreAudio?: string;
-        };
+    bufferingText?: string;
   }
 }

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -221,8 +221,40 @@
       "student": "Student"
     },
     "users": "Users",
+    "creditUsageTab": "Credit Usage",
     "usersCount": "{count} course users",
     "usersDescription": "Review course-related users, their learning progress, payment status, and recent activity.",
+    "creditUsage": {
+      "title": "Credit Usage",
+      "description": "Review credit consumption records for this course.",
+      "count": "{count} records",
+      "filters": {
+        "userKeyword": "User",
+        "userKeywordPlaceholderPhone": "Enter phone or nickname",
+        "userKeywordPlaceholderEmail": "Enter email or nickname",
+        "mode": "Usage mode",
+        "modeAll": "All",
+        "time": "Time",
+        "timePlaceholder": "Select time range",
+        "reset": "Reset"
+      },
+      "modes": {
+        "learn": "Learning",
+        "listen": "Listen",
+        "ask": "Follow-up",
+        "unknown": "Unknown mode"
+      },
+      "table": {
+        "createdAt": "Consumed At",
+        "nickname": "Nickname",
+        "mode": "Usage Mode",
+        "chapter": "Chapter",
+        "lesson": "Lesson",
+        "credits": "Credits Consumed",
+        "model": "Model",
+        "empty": "No credit usage records"
+      }
+    },
     "usersFilters": {
       "all": "All",
       "learningStatus": "Learning Status",

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -74,7 +74,7 @@
         "userKeywordPlaceholderPhone": "Enter phone or nickname"
       },
       "modelSummary": {
-        "multiple": "{{model}} and {{count}} models"
+        "multiple": "{model} and {count} models"
       },
       "modes": {
         "ask": "Follow-up",

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -73,21 +73,26 @@
         "userKeywordPlaceholderEmail": "Enter email or nickname",
         "userKeywordPlaceholderPhone": "Enter phone or nickname"
       },
+      "modelSummary": {
+        "multiple": "{{model}} and {{count}} models"
+      },
       "modes": {
         "ask": "Follow-up",
         "learn": "Learning",
         "listen": "Listen",
+        "mixed": "Mixed",
         "unknown": "Unknown mode"
       },
       "table": {
         "chapter": "Chapter",
         "createdAt": "Consumed At",
-        "credits": "Credits Consumed",
+        "credits": "Total Credits Consumed",
         "empty": "No credit usage records",
         "lesson": "Lesson",
         "mode": "Usage Mode",
         "model": "Model",
-        "nickname": "Nickname"
+        "nickname": "Nickname",
+        "usageCount": "Usage Count"
       },
       "title": "Credit Usage"
     },

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -60,6 +60,38 @@
       "has": "Has",
       "unknown": "Unknown"
     },
+    "creditUsage": {
+      "count": "{count} records",
+      "description": "Review credit consumption records for this course.",
+      "filters": {
+        "mode": "Usage mode",
+        "modeAll": "All",
+        "reset": "Reset",
+        "time": "Time",
+        "timePlaceholder": "Select time range",
+        "userKeyword": "User",
+        "userKeywordPlaceholderEmail": "Enter email or nickname",
+        "userKeywordPlaceholderPhone": "Enter phone or nickname"
+      },
+      "modes": {
+        "ask": "Follow-up",
+        "learn": "Learning",
+        "listen": "Listen",
+        "unknown": "Unknown mode"
+      },
+      "table": {
+        "chapter": "Chapter",
+        "createdAt": "Consumed At",
+        "credits": "Credits Consumed",
+        "empty": "No credit usage records",
+        "lesson": "Lesson",
+        "mode": "Usage Mode",
+        "model": "Model",
+        "nickname": "Nickname"
+      },
+      "title": "Credit Usage"
+    },
+    "creditUsageTab": "Credit Usage",
     "fields": {
       "courseId": "Course ID",
       "courseName": "Course Name",
@@ -221,40 +253,8 @@
       "student": "Student"
     },
     "users": "Users",
-    "creditUsageTab": "Credit Usage",
     "usersCount": "{count} course users",
     "usersDescription": "Review course-related users, their learning progress, payment status, and recent activity.",
-    "creditUsage": {
-      "title": "Credit Usage",
-      "description": "Review credit consumption records for this course.",
-      "count": "{count} records",
-      "filters": {
-        "userKeyword": "User",
-        "userKeywordPlaceholderPhone": "Enter phone or nickname",
-        "userKeywordPlaceholderEmail": "Enter email or nickname",
-        "mode": "Usage mode",
-        "modeAll": "All",
-        "time": "Time",
-        "timePlaceholder": "Select time range",
-        "reset": "Reset"
-      },
-      "modes": {
-        "learn": "Learning",
-        "listen": "Listen",
-        "ask": "Follow-up",
-        "unknown": "Unknown mode"
-      },
-      "table": {
-        "createdAt": "Consumed At",
-        "nickname": "Nickname",
-        "mode": "Usage Mode",
-        "chapter": "Chapter",
-        "lesson": "Lesson",
-        "credits": "Credits Consumed",
-        "model": "Model",
-        "empty": "No credit usage records"
-      }
-    },
     "usersFilters": {
       "all": "All",
       "learningStatus": "Learning Status",

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -221,8 +221,40 @@
       "student": "Apprenant"
     },
     "users": "Utilisateurs",
+    "creditUsageTab": "Consommation de crédits",
     "usersCount": "{count} utilisateurs du cours",
     "usersDescription": "Consulter les utilisateurs liés au cours, leur progression d’apprentissage, leur statut de paiement et leur activité récente.",
+    "creditUsage": {
+      "title": "Consommation de crédits",
+      "description": "Consulter les enregistrements de consommation de crédits de ce cours.",
+      "count": "{count} enregistrements",
+      "filters": {
+        "userKeyword": "Utilisateur",
+        "userKeywordPlaceholderPhone": "Saisir un téléphone ou un pseudonyme",
+        "userKeywordPlaceholderEmail": "Saisir un e-mail ou un pseudonyme",
+        "mode": "Scène d'utilisation",
+        "modeAll": "Tous",
+        "time": "Heure",
+        "timePlaceholder": "Sélectionner une plage horaire",
+        "reset": "Réinitialiser"
+      },
+      "modes": {
+        "learn": "Apprentissage",
+        "listen": "Écoute",
+        "ask": "Relance",
+        "unknown": "Scène inconnue"
+      },
+      "table": {
+        "createdAt": "Heure de consommation",
+        "nickname": "Surnom",
+        "mode": "Scène",
+        "chapter": "Chapitre",
+        "lesson": "Leçon",
+        "credits": "Crédits consommés",
+        "model": "Modèle",
+        "empty": "Aucun enregistrement de consommation de crédits"
+      }
+    },
     "usersFilters": {
       "all": "Tous",
       "learningStatus": "Statut d’apprentissage",

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -74,7 +74,7 @@
         "userKeywordPlaceholderPhone": "Saisir un téléphone ou un pseudonyme"
       },
       "modelSummary": {
-        "multiple": "{{model}} et {{count}} modèles"
+        "multiple": "{model} et {count} modèles"
       },
       "modes": {
         "ask": "Relance",

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -73,21 +73,26 @@
         "userKeywordPlaceholderEmail": "Saisir un e-mail ou un pseudonyme",
         "userKeywordPlaceholderPhone": "Saisir un téléphone ou un pseudonyme"
       },
+      "modelSummary": {
+        "multiple": "{{model}} et {{count}} modèles"
+      },
       "modes": {
         "ask": "Relance",
         "learn": "Apprentissage",
         "listen": "Écoute",
+        "mixed": "Mixte",
         "unknown": "Scène inconnue"
       },
       "table": {
         "chapter": "Chapitre",
         "createdAt": "Heure de consommation",
-        "credits": "Crédits consommés",
+        "credits": "Total des crédits consommés",
         "empty": "Aucun enregistrement de consommation de crédits",
         "lesson": "Leçon",
         "mode": "Scène",
         "model": "Modèle",
-        "nickname": "Surnom"
+        "nickname": "Surnom",
+        "usageCount": "Nombre d'utilisations"
       },
       "title": "Consommation de crédits"
     },

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -60,6 +60,38 @@
       "has": "Présent",
       "unknown": "Inconnu"
     },
+    "creditUsage": {
+      "count": "{count} enregistrements",
+      "description": "Consulter les enregistrements de consommation de crédits de ce cours.",
+      "filters": {
+        "mode": "Scène d'utilisation",
+        "modeAll": "Tous",
+        "reset": "Réinitialiser",
+        "time": "Heure",
+        "timePlaceholder": "Sélectionner une plage horaire",
+        "userKeyword": "Utilisateur",
+        "userKeywordPlaceholderEmail": "Saisir un e-mail ou un pseudonyme",
+        "userKeywordPlaceholderPhone": "Saisir un téléphone ou un pseudonyme"
+      },
+      "modes": {
+        "ask": "Relance",
+        "learn": "Apprentissage",
+        "listen": "Écoute",
+        "unknown": "Scène inconnue"
+      },
+      "table": {
+        "chapter": "Chapitre",
+        "createdAt": "Heure de consommation",
+        "credits": "Crédits consommés",
+        "empty": "Aucun enregistrement de consommation de crédits",
+        "lesson": "Leçon",
+        "mode": "Scène",
+        "model": "Modèle",
+        "nickname": "Surnom"
+      },
+      "title": "Consommation de crédits"
+    },
+    "creditUsageTab": "Consommation de crédits",
     "fields": {
       "courseId": "ID du cours",
       "courseName": "Nom du cours",
@@ -221,40 +253,8 @@
       "student": "Apprenant"
     },
     "users": "Utilisateurs",
-    "creditUsageTab": "Consommation de crédits",
     "usersCount": "{count} utilisateurs du cours",
     "usersDescription": "Consulter les utilisateurs liés au cours, leur progression d’apprentissage, leur statut de paiement et leur activité récente.",
-    "creditUsage": {
-      "title": "Consommation de crédits",
-      "description": "Consulter les enregistrements de consommation de crédits de ce cours.",
-      "count": "{count} enregistrements",
-      "filters": {
-        "userKeyword": "Utilisateur",
-        "userKeywordPlaceholderPhone": "Saisir un téléphone ou un pseudonyme",
-        "userKeywordPlaceholderEmail": "Saisir un e-mail ou un pseudonyme",
-        "mode": "Scène d'utilisation",
-        "modeAll": "Tous",
-        "time": "Heure",
-        "timePlaceholder": "Sélectionner une plage horaire",
-        "reset": "Réinitialiser"
-      },
-      "modes": {
-        "learn": "Apprentissage",
-        "listen": "Écoute",
-        "ask": "Relance",
-        "unknown": "Scène inconnue"
-      },
-      "table": {
-        "createdAt": "Heure de consommation",
-        "nickname": "Surnom",
-        "mode": "Scène",
-        "chapter": "Chapitre",
-        "lesson": "Leçon",
-        "credits": "Crédits consommés",
-        "model": "Modèle",
-        "empty": "Aucun enregistrement de consommation de crédits"
-      }
-    },
     "usersFilters": {
       "all": "Tous",
       "learningStatus": "Statut d’apprentissage",

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -60,6 +60,38 @@
       "has": "有",
       "unknown": "未知"
     },
+    "creditUsage": {
+      "count": "{count} 条记录",
+      "description": "查看该课程的积分消耗记录。",
+      "filters": {
+        "mode": "消耗场景",
+        "modeAll": "全部",
+        "reset": "重置",
+        "time": "时间",
+        "timePlaceholder": "选择时间范围",
+        "userKeyword": "用户",
+        "userKeywordPlaceholderEmail": "输入邮箱 / 昵称",
+        "userKeywordPlaceholderPhone": "输入手机号 / 昵称"
+      },
+      "modes": {
+        "ask": "追问",
+        "learn": "学习",
+        "listen": "听课",
+        "unknown": "未知场景"
+      },
+      "table": {
+        "chapter": "章节",
+        "createdAt": "消耗时间",
+        "credits": "消耗积分",
+        "empty": "暂无积分消耗记录",
+        "lesson": "小节",
+        "mode": "消耗场景",
+        "model": "模型",
+        "nickname": "昵称"
+      },
+      "title": "积分消耗"
+    },
+    "creditUsageTab": "积分消耗",
     "fields": {
       "courseId": "课程ID",
       "courseName": "课程名",
@@ -221,40 +253,8 @@
       "student": "学员"
     },
     "users": "用户数据",
-    "creditUsageTab": "积分消耗",
     "usersCount": "共 {count} 课程用户",
     "usersDescription": "查看课程相关用户的学习进度、付费情况与最近活跃时间。",
-    "creditUsage": {
-      "title": "积分消耗",
-      "description": "查看该课程的积分消耗记录。",
-      "count": "{count} 条记录",
-      "filters": {
-        "userKeyword": "用户",
-        "userKeywordPlaceholderPhone": "输入手机号 / 昵称",
-        "userKeywordPlaceholderEmail": "输入邮箱 / 昵称",
-        "mode": "消耗场景",
-        "modeAll": "全部",
-        "time": "时间",
-        "timePlaceholder": "选择时间范围",
-        "reset": "重置"
-      },
-      "modes": {
-        "learn": "学习",
-        "listen": "听课",
-        "ask": "追问",
-        "unknown": "未知场景"
-      },
-      "table": {
-        "createdAt": "消耗时间",
-        "nickname": "昵称",
-        "mode": "消耗场景",
-        "chapter": "章节",
-        "lesson": "小节",
-        "credits": "消耗积分",
-        "model": "模型",
-        "empty": "暂无积分消耗记录"
-      }
-    },
     "usersFilters": {
       "all": "全部",
       "learningStatus": "学习状态",

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -74,7 +74,7 @@
         "userKeywordPlaceholderPhone": "输入手机号 / 昵称"
       },
       "modelSummary": {
-        "multiple": "{{model}} 等 {{count}} 个"
+        "multiple": "{model} 等 {count} 个"
       },
       "modes": {
         "ask": "追问",

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -73,21 +73,26 @@
         "userKeywordPlaceholderEmail": "输入邮箱 / 昵称",
         "userKeywordPlaceholderPhone": "输入手机号 / 昵称"
       },
+      "modelSummary": {
+        "multiple": "{{model}} 等 {{count}} 个"
+      },
       "modes": {
         "ask": "追问",
         "learn": "学习",
         "listen": "听课",
+        "mixed": "混合",
         "unknown": "未知场景"
       },
       "table": {
         "chapter": "章节",
         "createdAt": "消耗时间",
-        "credits": "消耗积分",
+        "credits": "总消耗积分",
         "empty": "暂无积分消耗记录",
         "lesson": "小节",
         "mode": "消耗场景",
         "model": "模型",
-        "nickname": "昵称"
+        "nickname": "昵称",
+        "usageCount": "消耗次数"
       },
       "title": "积分消耗"
     },

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -221,8 +221,40 @@
       "student": "学员"
     },
     "users": "用户数据",
+    "creditUsageTab": "积分消耗",
     "usersCount": "共 {count} 课程用户",
     "usersDescription": "查看课程相关用户的学习进度、付费情况与最近活跃时间。",
+    "creditUsage": {
+      "title": "积分消耗",
+      "description": "查看该课程的积分消耗记录。",
+      "count": "{count} 条记录",
+      "filters": {
+        "userKeyword": "用户",
+        "userKeywordPlaceholderPhone": "输入手机号 / 昵称",
+        "userKeywordPlaceholderEmail": "输入邮箱 / 昵称",
+        "mode": "消耗场景",
+        "modeAll": "全部",
+        "time": "时间",
+        "timePlaceholder": "选择时间范围",
+        "reset": "重置"
+      },
+      "modes": {
+        "learn": "学习",
+        "listen": "听课",
+        "ask": "追问",
+        "unknown": "未知场景"
+      },
+      "table": {
+        "createdAt": "消耗时间",
+        "nickname": "昵称",
+        "mode": "消耗场景",
+        "chapter": "章节",
+        "lesson": "小节",
+        "credits": "消耗积分",
+        "model": "模型",
+        "empty": "暂无积分消耗记录"
+      }
+    },
     "usersFilters": {
       "all": "全部",
       "learningStatus": "学习状态",


### PR DESCRIPTION
## Summary
- add operator course credit usage API, DTOs, route, and regression tests
- add the credit usage tab with filters, pagination, i18n, and lazy loading on the operator course detail page
- extract the credit usage tab into a dedicated local component and record the later tab-splitting plan in docs

## Validation
- `cd src/api && python -m pytest -q tests/service/shifu/test_admin_course_detail.py`
- `cd src/cook-web && npm test -- --runInBand --runTestsByPath 'src/app/admin/operations/[shifu_bid]/page.test.tsx'`
- `cd src/cook-web && npx eslint 'src/app/admin/operations/[shifu_bid]/page.tsx' 'src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx' 'src/app/admin/operations/[shifu_bid]/page.test.tsx' src/app/admin/operations/operation-course-types.ts src/api/api.ts`
- `git diff --check`
- `python -m py_compile src/api/flaskr/service/shifu/admin.py src/api/flaskr/service/shifu/admin_dtos.py src/api/flaskr/service/shifu/route.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Credit Usage tab to course detail with filters (keyword, mode, date range), paginated grouped or raw views, and a detailed consumption table.

* **API**
  * Added operator-facing course credit-usage endpoint returning grouped or raw paginated results with filtering and aggregation.

* **Types**
  * Introduced client/server types for credit-usage items, filters, views, and list responses.

* **Tests**
  * Added coverage for lazy loading, filtering, pagination, grouping/aggregation, validation, and error cases.

* **Documentation**
  * Updated product spec and exec plan with tab-splitting guidance and review date.

* **Internationalization**
  * Added credit-usage UI translations (en/fr/zh).

* **UI**
  * Simplified audio buffering text to a single localized message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1756)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
