### PR TITLE
feat: open operator detail pages in new tabs

### DIFF
--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -11,11 +11,12 @@ import { ErrorWithCode } from '@/lib/request';
 import OperationsPage from './page';
 
 const mockReplace = jest.fn();
-const mockPush = jest.fn();
+const mockWindowOpen = jest.fn();
 const mockToast = jest.fn();
 const mockErrorDisplay = jest.fn();
 const mockCopyText = jest.fn();
 const originalLocation = window.location;
+const originalOpen = window.open;
 const originalFetch = global.fetch;
 const originalWindow = global.window;
 const RETRY_LABEL = 'retry';
@@ -46,7 +47,6 @@ const mockUserState: {
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: mockReplace,
-    push: mockPush,
   }),
 }));
 
@@ -399,6 +399,11 @@ describe('OperationsPage', () => {
         search: '',
       },
     });
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      writable: true,
+      value: mockWindowOpen,
+    });
   });
 
   afterAll(() => {
@@ -406,11 +411,16 @@ describe('OperationsPage', () => {
       configurable: true,
       value: originalLocation,
     });
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      writable: true,
+      value: originalOpen,
+    });
   });
 
   beforeEach(() => {
     mockReplace.mockReset();
-    mockPush.mockReset();
+    mockWindowOpen.mockReset();
     mockToast.mockReset();
     mockErrorDisplay.mockReset();
     mockCopyText.mockReset();
@@ -578,7 +588,11 @@ describe('OperationsPage', () => {
         name: 'Course 1',
       }),
     );
-    expect(mockPush).toHaveBeenCalledWith('/admin/operations/course-1');
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      '/admin/operations/course-1',
+      '_blank',
+      'noopener,noreferrer',
+    );
 
     const firstRow = screen.getByText('Course 1').closest('tr');
     expect(firstRow).not.toBeNull();

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -11,12 +11,10 @@ import { ErrorWithCode } from '@/lib/request';
 import OperationsPage from './page';
 
 const mockReplace = jest.fn();
-const mockWindowOpen = jest.fn();
 const mockToast = jest.fn();
 const mockErrorDisplay = jest.fn();
 const mockCopyText = jest.fn();
 const originalLocation = window.location;
-const originalOpen = window.open;
 const originalFetch = global.fetch;
 const originalWindow = global.window;
 const RETRY_LABEL = 'retry';
@@ -48,6 +46,22 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: mockReplace,
   }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.PropsWithChildren<{ href: string }>) => (
+    <a
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock('@/api', () => ({
@@ -399,11 +413,6 @@ describe('OperationsPage', () => {
         search: '',
       },
     });
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      writable: true,
-      value: mockWindowOpen,
-    });
   });
 
   afterAll(() => {
@@ -411,16 +420,10 @@ describe('OperationsPage', () => {
       configurable: true,
       value: originalLocation,
     });
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      writable: true,
-      value: originalOpen,
-    });
   });
 
   beforeEach(() => {
     mockReplace.mockReset();
-    mockWindowOpen.mockReset();
     mockToast.mockReset();
     mockErrorDisplay.mockReset();
     mockCopyText.mockReset();
@@ -583,15 +586,17 @@ describe('OperationsPage', () => {
   test('navigates from course name and transfers creator from the action menu', async () => {
     await renderAndWaitForLoadedPage();
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'Course 1',
-      }),
-    );
-    expect(mockWindowOpen).toHaveBeenCalledWith(
+    expect(screen.getByRole('link', { name: 'Course 1' })).toHaveAttribute(
+      'href',
       '/admin/operations/course-1',
+    );
+    expect(screen.getByRole('link', { name: 'Course 1' })).toHaveAttribute(
+      'target',
       '_blank',
-      'noopener,noreferrer',
+    );
+    expect(screen.getByRole('link', { name: 'Course 1' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer',
     );
 
     const firstRow = screen.getByText('Course 1').closest('tr');

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -9,7 +9,6 @@ import React, {
   type CSSProperties,
 } from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronUp, Copy, X } from 'lucide-react';
 import api from '@/api';
@@ -335,7 +334,6 @@ const ClearableTextInput = ({
  * t('module.operationsCourse.transferCreatorDialog.confirmDescriptionTargetPrefix')
  */
 const OperationsPage = () => {
-  const router = useRouter();
   const { t, i18n } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
   const { toast } = useToast();
@@ -691,7 +689,7 @@ const OperationsPage = () => {
     if (!detailUrl) {
       return;
     }
-    router.push(detailUrl);
+    window.open(detailUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handlePromptDetailOpenChange = useCallback((nextOpen: boolean) => {

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import React, {
   useCallback,
   useEffect,
@@ -682,14 +683,6 @@ const OperationsPage = () => {
       return;
     }
     fetchCourses(nextPage, filters, quickFilter);
-  };
-
-  const handleDetailClick = (course: AdminOperationCourseItem) => {
-    const detailUrl = buildAdminOperationsCourseDetailUrl(course.shifu_bid);
-    if (!detailUrl) {
-      return;
-    }
-    window.open(detailUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handlePromptDetailOpenChange = useCallback((nextOpen: boolean) => {
@@ -1557,6 +1550,9 @@ const OperationsPage = () => {
                 {courses.map(course => {
                   const creatorDisplay = resolveActorDisplay(course, 'creator');
                   const updaterDisplay = resolveActorDisplay(course, 'updater');
+                  const detailUrl = buildAdminOperationsCourseDetailUrl(
+                    course.shifu_bid,
+                  );
 
                   return (
                     <TableRow key={course.shifu_bid}>
@@ -1570,16 +1566,24 @@ const OperationsPage = () => {
                         className='whitespace-nowrap border-r border-border last:border-r-0 overflow-hidden text-center text-ellipsis'
                         style={getColumnStyle('courseName')}
                       >
-                        <button
-                          type='button'
-                          className='mx-auto block max-w-full text-center text-primary transition-colors hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
-                          onClick={() => handleDetailClick(course)}
-                        >
-                          {renderTooltipText(
+                        {detailUrl ? (
+                          <Link
+                            href={detailUrl}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            className='mx-auto block max-w-full text-center text-primary transition-colors hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2'
+                          >
+                            {renderTooltipText(
+                              course.course_name,
+                              'truncate text-center',
+                            )}
+                          </Link>
+                        ) : (
+                          renderTooltipText(
                             course.course_name,
                             'truncate text-center',
-                          )}
-                        </button>
+                          )
+                        )}
                       </TableCell>
                       <TableCell
                         className='border-r border-border last:border-r-0 whitespace-nowrap overflow-hidden text-center text-ellipsis'

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -10,10 +10,8 @@ import api from '@/api';
 import AdminOperationUsersPage from './page';
 
 const mockReplace = jest.fn();
-const mockWindowOpen = jest.fn();
 const mockMutateBillingOverview = jest.fn();
 const originalLocation = window.location;
-const originalOpen = window.open;
 const mockGrantDialogPrefix = 'grant-dialog-';
 const mockGrantSuccessLabel = 'mock-grant-success';
 const buildGrantDialogLabel = (userBid: string) =>
@@ -287,7 +285,6 @@ const mockGetAdminOperationUserDetail =
 describe('AdminOperationUsersPage', () => {
   beforeEach(() => {
     mockReplace.mockReset();
-    mockWindowOpen.mockReset();
     mockMutateBillingOverview.mockReset();
     mockGetAdminOperationUsersOverview.mockReset();
     mockGetAdminOperationUsers.mockReset();
@@ -411,22 +408,12 @@ describe('AdminOperationUsersPage', () => {
         search: '',
       },
     });
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      writable: true,
-      value: mockWindowOpen,
-    });
   });
 
   afterAll(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: originalLocation,
-    });
-    Object.defineProperty(window, 'open', {
-      configurable: true,
-      writable: true,
-      value: originalOpen,
     });
   });
 
@@ -484,18 +471,38 @@ describe('AdminOperationUsersPage', () => {
         name: 'module.operationsUser.table.createdCourses (2)',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'user-1' })).toHaveAttribute(
+      'href',
+      '/admin/operations/users/user-1',
+    );
+    expect(screen.getByRole('link', { name: 'user-1' })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+    expect(screen.getByRole('link', { name: 'user-1' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer',
+    );
     expect(
       screen.getByRole('link', { name: 'user-1@example.com' }),
     ).toHaveAttribute('href', '/admin/operations/users/user-1');
-    fireEvent.click(screen.getByRole('link', { name: 'user-1@example.com' }));
-    expect(mockWindowOpen).toHaveBeenCalledWith(
-      '/admin/operations/users/user-1',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    expect(
+      screen.getByRole('link', { name: 'user-1@example.com' }),
+    ).toHaveAttribute('target', '_blank');
+    expect(
+      screen.getByRole('link', { name: 'user-1@example.com' }),
+    ).toHaveAttribute('rel', 'noopener noreferrer');
     expect(screen.getByRole('link', { name: '35.5' })).toHaveAttribute(
       'href',
       '/admin/operations/users/user-1#credits',
+    );
+    expect(screen.getByRole('link', { name: '35.5' })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+    expect(screen.getByRole('link', { name: '35.5' })).toHaveAttribute(
+      'rel',
+      'noopener noreferrer',
     );
     expect(
       screen.getByRole('button', {
@@ -947,6 +954,12 @@ describe('AdminOperationUsersPage', () => {
     expect(
       await screen.findByRole('link', { name: 'user-no-contact' }),
     ).toHaveAttribute('href', '/admin/operations/users/user-no-contact');
+    expect(
+      screen.getByRole('link', { name: 'user-no-contact' }),
+    ).toHaveAttribute('target', '_blank');
+    expect(
+      screen.getByRole('link', { name: 'user-no-contact' }),
+    ).toHaveAttribute('rel', 'noopener noreferrer');
     const row = screen
       .getByRole('link', { name: 'user-no-contact' })
       .closest('tr');

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -10,8 +10,10 @@ import api from '@/api';
 import AdminOperationUsersPage from './page';
 
 const mockReplace = jest.fn();
+const mockWindowOpen = jest.fn();
 const mockMutateBillingOverview = jest.fn();
 const originalLocation = window.location;
+const originalOpen = window.open;
 const mockGrantDialogPrefix = 'grant-dialog-';
 const mockGrantSuccessLabel = 'mock-grant-success';
 const buildGrantDialogLabel = (userBid: string) =>
@@ -285,6 +287,7 @@ const mockGetAdminOperationUserDetail =
 describe('AdminOperationUsersPage', () => {
   beforeEach(() => {
     mockReplace.mockReset();
+    mockWindowOpen.mockReset();
     mockMutateBillingOverview.mockReset();
     mockGetAdminOperationUsersOverview.mockReset();
     mockGetAdminOperationUsers.mockReset();
@@ -408,12 +411,22 @@ describe('AdminOperationUsersPage', () => {
         search: '',
       },
     });
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      writable: true,
+      value: mockWindowOpen,
+    });
   });
 
   afterAll(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: originalLocation,
+    });
+    Object.defineProperty(window, 'open', {
+      configurable: true,
+      writable: true,
+      value: originalOpen,
     });
   });
 
@@ -474,6 +487,12 @@ describe('AdminOperationUsersPage', () => {
     expect(
       screen.getByRole('link', { name: 'user-1@example.com' }),
     ).toHaveAttribute('href', '/admin/operations/users/user-1');
+    fireEvent.click(screen.getByRole('link', { name: 'user-1@example.com' }));
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      '/admin/operations/users/user-1',
+      '_blank',
+      'noopener,noreferrer',
+    );
     expect(screen.getByRole('link', { name: '35.5' })).toHaveAttribute(
       'href',
       '/admin/operations/users/user-1#credits',

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -413,6 +413,18 @@ export default function AdminOperationUsersPage() {
       maxWidth: COLUMN_MAX_WIDTH,
     });
 
+  const handleUserDetailClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>, userBid: string) => {
+      const userDetailUrl = buildAdminOperationsUserDetailUrl(userBid);
+      if (!userDetailUrl) {
+        return;
+      }
+      event.preventDefault();
+      window.open(userDetailUrl, '_blank', 'noopener,noreferrer');
+    },
+    [],
+  );
+
   const resolveStatusLabel = useCallback(
     (status: string) => {
       const normalized =
@@ -1348,6 +1360,9 @@ export default function AdminOperationUsersPage() {
                           {userDetailUrl ? (
                             <Link
                               href={userDetailUrl}
+                              onClick={event =>
+                                handleUserDetailClick(event, user.user_bid)
+                              }
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(user.user_bid)}
@@ -1367,6 +1382,9 @@ export default function AdminOperationUsersPage() {
                           ) : userDetailUrl && primaryContact ? (
                             <Link
                               href={userDetailUrl}
+                              onClick={event =>
+                                handleUserDetailClick(event, user.user_bid)
+                              }
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(primaryContact)}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -413,18 +413,6 @@ export default function AdminOperationUsersPage() {
       maxWidth: COLUMN_MAX_WIDTH,
     });
 
-  const handleUserDetailClick = useCallback(
-    (event: React.MouseEvent<HTMLAnchorElement>, userBid: string) => {
-      const userDetailUrl = buildAdminOperationsUserDetailUrl(userBid);
-      if (!userDetailUrl) {
-        return;
-      }
-      event.preventDefault();
-      window.open(userDetailUrl, '_blank', 'noopener,noreferrer');
-    },
-    [],
-  );
-
   const resolveStatusLabel = useCallback(
     (status: string) => {
       const normalized =
@@ -1360,9 +1348,8 @@ export default function AdminOperationUsersPage() {
                           {userDetailUrl ? (
                             <Link
                               href={userDetailUrl}
-                              onClick={event =>
-                                handleUserDetailClick(event, user.user_bid)
-                              }
+                              target='_blank'
+                              rel='noopener noreferrer'
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(user.user_bid)}
@@ -1382,9 +1369,8 @@ export default function AdminOperationUsersPage() {
                           ) : userDetailUrl && primaryContact ? (
                             <Link
                               href={userDetailUrl}
-                              onClick={event =>
-                                handleUserDetailClick(event, user.user_bid)
-                              }
+                              target='_blank'
+                              rel='noopener noreferrer'
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(primaryContact)}
@@ -1474,6 +1460,8 @@ export default function AdminOperationUsersPage() {
                           {userDetailUrl && user.available_credits ? (
                             <Link
                               href={`${userDetailUrl}#credits`}
+                              target='_blank'
+                              rel='noopener noreferrer'
                               className='text-primary transition-colors hover:text-primary/80 hover:underline'
                             >
                               {renderTooltipText(


### PR DESCRIPTION
Summary
- open operator course detail pages in a new browser tab from the course list
- open operator user detail pages in a new browser tab from the user list
- update the related page tests to assert window.open behavior

Testing
- cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.test.tsx --watch=false
- cd src/cook-web && npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UX Improvements**
  * Links in admin operations and user management pages now open in new browser tabs with enhanced security attributes, allowing users to maintain context while viewing linked details.

* **Tests**
  * Updated test suites to verify link behavior and security attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1757)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->