### PR TITLE
fix: restore debug preview billing token context

### DIFF
--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -3475,7 +3475,6 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             set_language(original_language)
 
     @app.route(path_prefix + "/ask/preview", methods=["POST"])
-    @bypass_token_validation
     def ask_preview_api():
         """
         Preview ask provider output with current settings
@@ -3756,7 +3755,6 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         return make_common_response(config)
 
     @app.route(path_prefix + "/tts/preview", methods=["POST"])
-    @bypass_token_validation
     def tts_preview_api():
         """
         Preview TTS with specified settings

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -1,6 +1,5 @@
 from types import SimpleNamespace
 
-from flask import request
 from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 from flaskr.service.learn.ask_provider_adapters import AskProviderError
@@ -55,7 +54,32 @@ class _FakeLangfuseClient:
         return trace
 
 
+def _mock_authenticated_user(
+    monkeypatch,
+    user_bid: str = "preview-user-1",
+    *,
+    is_creator: bool = False,
+) -> SimpleNamespace:
+    user = SimpleNamespace(
+        user_id=user_bid,
+        language="en-US",
+        is_creator=is_creator,
+        is_operator=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: user,
+        raising=False,
+    )
+    return user
+
+
+def _auth_headers(token: str = "preview-token") -> dict[str, str]:
+    return {"Token": token}
+
+
 def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
+    _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
     def fake_stream_ask_provider_response(*args, **kwargs):
@@ -77,6 +101,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
 
     resp = test_client.post(
         "/api/shifu/ask/preview",
+        headers=_auth_headers(),
         json={
             "query": "hello",
             "ask_model": "gpt-test",
@@ -114,6 +139,8 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
 
 
 def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
+    _mock_authenticated_user(monkeypatch)
+
     def fake_stream_ask_provider_response(*args, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
@@ -130,6 +157,7 @@ def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
 
     resp = test_client.post(
         "/api/shifu/ask/preview",
+        headers=_auth_headers(),
         json={
             "query": "hello",
             "ask_model": "gpt-test",
@@ -154,9 +182,12 @@ def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
     assert "provider failed" in payload["data"]["provider_error"]
 
 
-def test_ask_preview_route_rejects_empty_query(test_client):
+def test_ask_preview_route_rejects_empty_query(monkeypatch, test_client):
+    _mock_authenticated_user(monkeypatch)
+
     resp = test_client.post(
         "/api/shifu/ask/preview",
+        headers=_auth_headers(),
         json={
             "query": "",
             "ask_model": "gpt-test",
@@ -176,6 +207,8 @@ def test_ask_preview_route_rejects_empty_query(test_client):
 def test_ask_preview_route_provider_only_does_not_require_ask_model(
     monkeypatch, test_client
 ):
+    _mock_authenticated_user(monkeypatch)
+
     def fake_stream_ask_provider_response(*args, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
@@ -190,6 +223,7 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 
     resp = test_client.post(
         "/api/shifu/ask/preview",
+        headers=_auth_headers(),
         json={
             "query": "hello",
             "ask_provider_config": {
@@ -216,6 +250,8 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 def test_ask_preview_route_provider_only_accepts_coze_workflow(
     monkeypatch, test_client
 ):
+    _mock_authenticated_user(monkeypatch)
+
     def fake_stream_ask_provider_response(*args, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
@@ -230,6 +266,7 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 
     resp = test_client.post(
         "/api/shifu/ask/preview",
+        headers=_auth_headers(),
         json={
             "query": "hello",
             "ask_provider_config": {
@@ -253,18 +290,86 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
     assert payload["data"]["fallback_used"] is False
 
 
-def test_ask_preview_route_passes_debug_usage_context_for_creator(
+def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
     monkeypatch, test_client
 ):
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
-    def _inject_request_user() -> None:
-        request.user = SimpleNamespace(
-            user_id="creator-debug-1",
-            language="en-US",
-            is_creator=True,
-        )
+    _mock_authenticated_user(monkeypatch, "creator-token-1", is_creator=True)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.route.admit_creator_usage",
+        lambda _app, creator_bid, usage_scene: captured.setdefault(
+            "admission",
+            {
+                "creator_bid": creator_bid,
+                "usage_scene": usage_scene,
+            },
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.route.get_langfuse_client",
+        lambda: fake_langfuse,
+        raising=False,
+    )
+
+    def fake_chat_llm(*args, **kwargs):
+        _ = args
+        captured["chat_llm"] = kwargs
+        yield SimpleNamespace(content="debug answer")
+
+    def fake_stream_ask_provider_response(*args, **kwargs):
+        _ = args
+        runtime = kwargs.get("runtime")
+        assert runtime is not None
+        yield from runtime.llm_stream_factory()
+
+    monkeypatch.setattr(
+        "flaskr.api.llm.chat_llm",
+        fake_chat_llm,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.ask_provider_adapters.stream_ask_provider_response",
+        fake_stream_ask_provider_response,
+        raising=False,
+    )
+
+    resp = test_client.post(
+        "/api/shifu/ask/preview",
+        headers={"Token": "creator-token"},
+        json={
+            "query": "hello",
+            "ask_model": "gpt-test",
+            "ask_provider_config": {
+                "provider": "llm",
+                "mode": "provider_only",
+                "config": {},
+            },
+        },
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert captured["admission"] == {
+        "creator_bid": "creator-token-1",
+        "usage_scene": BILL_USAGE_SCENE_DEBUG,
+    }
+    chat_llm_kwargs = captured["chat_llm"]
+    assert chat_llm_kwargs["billable"] == 1
+    usage_context = chat_llm_kwargs["usage_context"]
+    assert usage_context.user_bid == "creator-token-1"
+    assert usage_context.usage_scene == BILL_USAGE_SCENE_DEBUG
+    assert usage_context.billable == 1
+
+
+def test_ask_preview_route_passes_debug_usage_context_for_creator(
+    monkeypatch, test_client
+):
+    fake_langfuse = _FakeLangfuseClient()
+    captured: dict[str, object] = {}
 
     def fake_chat_llm(*args, **kwargs):
         _ = args
@@ -277,49 +382,44 @@ def test_ask_preview_route_passes_debug_usage_context_for_creator(
         assert runtime is not None
         yield from runtime.llm_stream_factory()
 
-    before_request_funcs = test_client.application.before_request_funcs.setdefault(
-        None, []
+    _mock_authenticated_user(monkeypatch, "creator-debug-1", is_creator=True)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.route.get_langfuse_client",
+        lambda: fake_langfuse,
+        raising=False,
     )
-    before_request_funcs.append(_inject_request_user)
-    try:
-        monkeypatch.setattr(
-            "flaskr.service.shifu.route.get_langfuse_client",
-            lambda: fake_langfuse,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            "flaskr.service.shifu.route.admit_creator_usage",
-            lambda _app, creator_bid, usage_scene: {
-                "creator_bid": creator_bid,
-                "usage_scene": usage_scene,
-            },
-            raising=False,
-        )
-        monkeypatch.setattr(
-            "flaskr.api.llm.chat_llm",
-            fake_chat_llm,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            "flaskr.service.learn.ask_provider_adapters.stream_ask_provider_response",
-            fake_stream_ask_provider_response,
-            raising=False,
-        )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.route.admit_creator_usage",
+        lambda _app, creator_bid, usage_scene: {
+            "creator_bid": creator_bid,
+            "usage_scene": usage_scene,
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.api.llm.chat_llm",
+        fake_chat_llm,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.ask_provider_adapters.stream_ask_provider_response",
+        fake_stream_ask_provider_response,
+        raising=False,
+    )
 
-        resp = test_client.post(
-            "/api/shifu/ask/preview",
-            json={
-                "query": "hello",
-                "ask_model": "gpt-test",
-                "ask_provider_config": {
-                    "provider": "llm",
-                    "mode": "provider_only",
-                    "config": {},
-                },
+    resp = test_client.post(
+        "/api/shifu/ask/preview",
+        headers=_auth_headers(),
+        json={
+            "query": "hello",
+            "ask_model": "gpt-test",
+            "ask_provider_config": {
+                "provider": "llm",
+                "mode": "provider_only",
+                "config": {},
             },
-        )
-    finally:
-        before_request_funcs.remove(_inject_request_user)
+        },
+    )
 
     payload = resp.get_json(force=True)
 

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -15,6 +15,8 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
     assert source.count("_admit_creator_debug_usage()") >= 3
     assert "def ask_preview_api():" in source
     assert "def tts_preview_api():" in source
+    assert "@bypass_token_validation\n    def ask_preview_api():" not in source
+    assert "@bypass_token_validation\n    def tts_preview_api():" not in source
 
 
 def test_shifu_ask_preview_routes_pass_debug_usage_context_into_chat_llm() -> None:

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -69,7 +69,7 @@ import { useToast } from '@/hooks/useToast';
 import ModelList from '@/components/model-list';
 import { useEnvStore } from '@/c-store';
 import { TITLE_MAX_LENGTH } from '@/c-constants/uiConstants';
-import { useShifu } from '@/store';
+import { useShifu, useUserStore } from '@/store';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import {
   AskProviderSchemaValidationError,
@@ -1027,11 +1027,17 @@ export default function ShifuSettingDialog({
     closeTtsPreviewStream();
 
     const baseUrl = getResolvedBaseURL();
+    const token = useUserStore.getState().getToken();
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-Request-ID': uuidv4().replace(/-/g, ''),
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+      headers.Token = token;
+    }
     const source = new SSE(`${baseUrl}/api/shifu/tts/preview`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Request-ID': uuidv4().replace(/-/g, ''),
-      },
+      headers,
       payload: JSON.stringify({
         provider: resolvedProvider,
         model: ttsModel || '',


### PR DESCRIPTION
## Summary
- Require normal auth for teacher/creator debug preview endpoints by removing `@bypass_token_validation` from `/api/shifu/ask/preview` and `/api/shifu/tts/preview`.
- Send the current login token on the TTS preview SSE request so teacher TTS debugging uses the same authenticated context as ask preview.
- Update route coverage to exercise authenticated preview requests and assert these debug preview routes do not bypass token validation.

## Root Cause
- Teacher course debugging calls `/api/shifu/ask/preview` and `/api/shifu/tts/preview`.
- These endpoints were marked with `@bypass_token_validation`, so the global auth hook skipped them and did not set `request.user`.
- Debug billing admission therefore saw no creator user, left usage non-billable, and no settlement ledger entry was enqueued.

## Tests
- `pytest tests/service/shifu/test_ask_preview_route.py tests/service/shifu/test_tts_preview_helper.py tests/service/shifu/test_billing_debug_admission_contracts.py -q`
- `git diff --check -- src/api/flaskr/service/shifu/route.py src/api/tests/service/shifu/test_ask_preview_route.py src/api/tests/service/shifu/test_billing_debug_admission_contracts.py src/cook-web/src/components/shifu-setting/ShifuSetting.tsx`
- `npm run lint-file -- src/components/shifu-setting/ShifuSetting.tsx`
- pre-commit hooks during `git commit --amend` in a clean worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview features now enforce proper token authentication instead of bypassing validation, improving security.

* **Tests**
  * Updated preview route tests to properly authenticate requests and verify billing behavior for authenticated creators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1758)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->