### PR TITLE
fix: lesson completion loading

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1165,11 +1165,12 @@ describe('useChatLogicHook stream cleanup', () => {
 
   it('stops auto-continuation after the current lesson reports completed', async () => {
     const params = buildBaseParams();
-    renderHook(() => useChatLogicHook(params), {
+    const { result } = renderHook(() => useChatLogicHook(params), {
       wrapper,
     });
 
     await waitFor(() => expect(activeRun).toBeDefined());
+    await waitFor(() => expect(result.current.isOutputInProgress).toBe(true));
     const initialRunCount = mockGetRunMessage.mock.calls.length;
 
     await act(async () => {
@@ -1208,6 +1209,8 @@ describe('useChatLogicHook stream cleanup', () => {
       status_value: 'completed',
     });
     expect(mockGetRunMessage).toHaveBeenCalledTimes(initialRunCount);
+    await waitFor(() => expect(result.current.isOutputInProgress).toBe(false));
+    expect(activeRun?.source.close).toHaveBeenCalled();
   });
 
   it('keeps interaction elements that arrive after lesson completion updates', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -82,7 +82,7 @@ interface LessonFeedbackPopupState {
 }
 
 const LESSON_FEEDBACK_DISMISS_CACHE_LIMIT = 200;
-const RUN_STREAM_IDLE_TIMEOUT_MS = 15000;
+const RUN_STREAM_IDLE_TIMEOUT_MS = 3000;
 const STREAM_TIMEOUT_ITEM_BID_PREFIX = 'stream-timeout-error';
 const DEFAULT_LISTEN_AUDIO_POSITION = 0;
 const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
@@ -1814,6 +1814,14 @@ function useChatLogicHook({
               // response.type === SSE_OUTPUT_TYPE.BREAK ||
               response.type === SSE_OUTPUT_TYPE.TEXT_END
             ) {
+              if (response.is_terminal === true) {
+                cleanupRunStreamState();
+                try {
+                  source?.close?.();
+                } catch {}
+                return;
+              }
+
               const completedElementBid =
                 currentBlockIdRef.current || blockId || '';
               setCurrentStreamingElementBid('');


### PR DESCRIPTION
## Summary
- stop the learner run loading state immediately when the terminal `done` event arrives
- close the active SSE source on terminal completion instead of waiting for readyState close
- restore the run idle timeout to the existing 3s test contract

## Root cause
The lesson completion stream can emit `done.is_terminal=true` before the SSE close event reaches the client. The hook previously waited for close cleanup, so the read-mode streaming dots and output-in-progress state could remain visible after a lesson finished.

## Validation
- npm test -- useChatLogicHook.test.tsx --runInBand
- npm run lint -- --file src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx --file src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
- git diff --check

Note: npm run type-check still fails on an unrelated existing `fr-FR` language type mismatch in src/components/shifu-edit/ShifuEdit.tsx.