### PR TITLE
fix: avoid unsupported Gemini reasoning params

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -298,7 +298,6 @@ def _fetch_provider_models(api_key: str, base_url: str | None) -> list[str]:
     return [item.get("id", "") for item in data.get("data", []) if item.get("id")]
 
 
-
 def _is_litellm_repeated_stream_chunk_error(exc: Exception) -> bool:
     message = str(exc)
     return (

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -298,6 +298,15 @@ def _fetch_provider_models(api_key: str, base_url: str | None) -> list[str]:
     return [item.get("id", "") for item in data.get("data", []) if item.get("id")]
 
 
+
+def _is_litellm_repeated_stream_chunk_error(exc: Exception) -> bool:
+    message = str(exc)
+    return (
+        "repeating the same chunk" in message
+        and exc.__class__.__module__.startswith("litellm")
+    )
+
+
 def _stream_litellm_completion(
     app: Flask, model: str, messages: list, params: dict, kwargs: dict
 ):
@@ -855,28 +864,38 @@ def chat_llm(
             params,
             kwargs,
         )
-        for res in response:
-            if start_completion_time is None:
-                start_completion_time = datetime.now()
-            if len(res.choices) and res.choices[0].delta.content:
-                response_text += res.choices[0].delta.content
-                yield LLMStreamResponse(
-                    res.id,
-                    True if res.choices[0].finish_reason else False,
-                    False,
-                    res.choices[0].delta.content,
-                    res.choices[0].finish_reason,
-                    None,
-                )
-            res_usage = getattr(res, "usage", None)
-            if res_usage:
-                input_cache_tokens = _extract_input_cache(res_usage)
-                usage = ModelUsage(
-                    unit="TOKENS",
-                    input=res_usage.prompt_tokens,
-                    output=res_usage.completion_tokens,
-                    total=res_usage.total_tokens,
-                )
+        try:
+            for res in response:
+                if start_completion_time is None:
+                    start_completion_time = datetime.now()
+                if len(res.choices) and res.choices[0].delta.content:
+                    response_text += res.choices[0].delta.content
+                    yield LLMStreamResponse(
+                        res.id,
+                        True if res.choices[0].finish_reason else False,
+                        False,
+                        res.choices[0].delta.content,
+                        res.choices[0].finish_reason,
+                        None,
+                    )
+                res_usage = getattr(res, "usage", None)
+                if res_usage:
+                    input_cache_tokens = _extract_input_cache(res_usage)
+                    usage = ModelUsage(
+                        unit="TOKENS",
+                        input=res_usage.prompt_tokens,
+                        output=res_usage.completion_tokens,
+                        total=res_usage.total_tokens,
+                    )
+        except Exception as exc:
+            if not (_is_litellm_repeated_stream_chunk_error(exc) and response_text):
+                raise
+            app.logger.warning(
+                "LiteLLM repeated streaming chunk detected; ending stream with partial response | model=%s | response_chars=%s | error=%s",
+                invoke_model,
+                len(response_text),
+                exc,
+            )
     else:
         raise_error_with_args(
             "server.llm.modelNotSupported",

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -428,24 +428,25 @@ def _reload_openai_params(model_id: str, temperature: float) -> Dict[str, Any]:
 
 
 def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
-    if model_id.startswith("gemini-2.5-pro"):
-        return {
-            "reasoning_effort": "low",
-            "temperature": temperature,
-        }
-    if model_id.startswith("gemini-3"):
-        return {
-            "reasoning_effort": "low",
-            "temperature": temperature,
-        }
-    if model_id.startswith("gemini"):
-        return {
-            "reasoning_effort": "none",
-            "temperature": temperature,
-        }
-    return {
+    # Gemini thinking is controlled via LiteLLM's reasoning_effort mapping. Some
+    # Gemini model ids are not included in LiteLLM's supported-params table yet,
+    # so explicitly allow reasoning_effort for Gemini requests.
+    params: Dict[str, Any] = {
         "temperature": temperature,
+        "allowed_openai_params": ["reasoning_effort"],
     }
+    if model_id.startswith("gemini-3"):
+        # Gemini 3 Flash-family supports minimal thinking; LiteLLM falls back to
+        # low for Gemini 3 models that do not support minimal.
+        params["reasoning_effort"] = "minimal"
+    elif model_id.startswith("gemini-2.5-pro"):
+        # Gemini 2.5 Pro cannot disable thinking, so use the lowest supported
+        # reasoning level.
+        params["reasoning_effort"] = "low"
+    elif model_id.startswith("gemini"):
+        # Older Gemini models can use the cost-optimized no-thinking mapping.
+        params["reasoning_effort"] = "none"
+    return params
 
 
 def _reload_ark_params(model_id: str, temperature: float) -> Dict[str, Any]:

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -460,6 +460,23 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     assert captured_kwargs["kwargs"]["extra_body"] == {"thinking": {"type": "disabled"}}
 
 
+def test_gemini_params_use_minimal_reasoning_with_explicit_allowlist():
+    params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
+
+    assert params == {
+        "temperature": 0.3,
+        "allowed_openai_params": ["reasoning_effort"],
+        "reasoning_effort": "minimal",
+    }
+
+
+def test_gemini_25_pro_params_use_lowest_supported_reasoning():
+    params = llm._reload_gemini_params("gemini-2.5-pro", 0.3)
+
+    assert params["allowed_openai_params"] == ["reasoning_effort"]
+    assert params["reasoning_effort"] == "low"
+
+
 def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -477,6 +477,41 @@ def test_gemini_25_pro_params_use_lowest_supported_reasoning():
     assert params["reasoning_effort"] == "low"
 
 
+def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, app):
+    class RepeatedChunkError(Exception):
+        __module__ = "litellm.exceptions"
+
+    def fake_completion(*args, **kwargs):
+        yield FakeResponse("chunk-1", content="你好")
+        raise RepeatedChunkError("The model is repeating the same chunk = ！ ！ .")
+
+    monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    provider_state = llm.ProviderState(
+        enabled=True,
+        params={"api_key": "test-key", "api_base": "https://example.com"},
+        models=["gpt-test"],
+        prefix="",
+        wildcard_prefixes=("gpt",),
+    )
+    monkeypatch.setattr(llm, "PROVIDER_STATES", {"openai": provider_state})
+    monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {"gpt-test": ("openai", "gpt-test")})
+    monkeypatch.setattr(llm, "PROVIDER_CONFIG_HINTS", {"openai": "OPENAI_API_KEY"})
+
+    responses = list(
+        llm.chat_llm(
+            app=app,
+            user_id="user-1",
+            span=DummySpan(),
+            model="gpt-test",
+            messages=[{"role": "user", "content": "hello"}],
+            generation_name="chat-test",
+        )
+    )
+
+    assert [resp.result for resp in responses] == ["你好"]
+
+
 def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
 


### PR DESCRIPTION
## Summary
- keep Gemini reasoning control instead of dropping it
- for Gemini 3.x use the lowest reasoning level (`reasoning_effort="minimal"`) and explicitly allow LiteLLM to pass `reasoning_effort` for newly named Gemini models
- for Gemini 2.5 Pro use the lowest supported level (`low`), because Gemini docs say Pro thinking cannot be disabled
- older Gemini models keep the cost-optimized `none` mapping
- tolerate LiteLLM's repeated-streaming-chunk safety error after partial output, ending the stream gracefully instead of turning the learner request into a 500
- add regression coverage for Gemini reasoning params and repeated stream chunk handling

## Docs checked
- LiteLLM Gemini provider docs: supported params include `reasoning_effort`; Gemini 3 maps it to `thinking_level`; `minimal` is supported for Flash-family models, otherwise LiteLLM falls back to `low`
- LiteLLM streaming docs: repeated chunks raise `litellm.InternalServerError` so caller retry/handling logic can take over
- LiteLLM error itself recommends request-level `allowed_openai_params=["reasoning_effort"]` when the model support table does not include the param yet

## Verification
- `python3 -m py_compile src/api/flaskr/api/llm/__init__.py src/api/tests/test_llm.py`
- `git diff --check`
- extracted `_reload_gemini_params` via AST and verified gemini-3.1-flash-lite returns `reasoning_effort="minimal"` plus `allowed_openai_params=["reasoning_effort"]`
- CI is running on GitHub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Gemini model compatibility with optimized parameter configuration across different model versions.
  * Improved streaming reliability with graceful error recovery for LiteLLM responses, preventing interruptions in partial results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1763)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->