### PR TITLE
feat: sort creator course cards by updated time

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -115,6 +115,7 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserCourseSummaryDTO,
     AdminOperationUserSummaryDTO,
 )
+from flaskr.service.shifu.course_activity import load_course_activity_map
 from flaskr.service.shifu.consts import (
     BLOCK_TYPE_MDASK_VALUE,
     BLOCK_TYPE_MDANSWER_VALUE,
@@ -1881,122 +1882,11 @@ def _resolve_created_last_7d_window(
     return start, end
 
 
-def _record_course_activity(
-    activity_map: Dict[str, Dict[str, Any]],
-    *,
-    shifu_bid: str,
-    updated_at: Optional[datetime],
-    updated_user_bid: str,
-    prefer_on_equal: bool = False,
-) -> None:
-    if not shifu_bid:
-        return
-    current = activity_map.get(shifu_bid)
-    candidate_time = updated_at or datetime.min
-    current_time = (
-        current.get("updated_at")
-        if current and current.get("updated_at")
-        else datetime.min
-    )
-    should_replace = current is None or candidate_time > current_time
-    if (
-        not should_replace
-        and prefer_on_equal
-        and current is not None
-        and candidate_time == current_time
-    ):
-        should_replace = True
-    if should_replace:
-        activity_map[shifu_bid] = {
-            "updated_at": updated_at,
-            "updated_user_bid": str(updated_user_bid or "").strip(),
-        }
-
-
 def _load_course_activity_map(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
 ) -> Dict[str, Dict[str, Any]]:
-    activity_map: Dict[str, Dict[str, Any]] = {}
-    shifu_bids: Set[str] = set()
-
-    for course in list(drafts) + list(published):
-        shifu_bid = str(course.shifu_bid or "").strip()
-        if not shifu_bid:
-            continue
-        shifu_bids.add(shifu_bid)
-        _record_course_activity(
-            activity_map,
-            shifu_bid=shifu_bid,
-            updated_at=course.updated_at,
-            updated_user_bid=course.updated_user_bid or "",
-        )
-
-    if not shifu_bids:
-        return activity_map
-
-    ordered_shifu_bids = sorted(shifu_bids)
-    outline_models = [DraftOutlineItem, PublishedOutlineItem]
-    for model in outline_models:
-        latest_updated_subquery = (
-            db.session.query(
-                model.shifu_bid.label("shifu_bid"),
-                db.func.max(model.updated_at).label("max_updated_at"),
-            )
-            .filter(
-                model.deleted == 0,
-                model.shifu_bid.in_(ordered_shifu_bids),
-            )
-            .group_by(model.shifu_bid)
-            .subquery()
-        )
-        latest_id_subquery = (
-            db.session.query(
-                model.shifu_bid.label("shifu_bid"),
-                db.func.max(model.id).label("max_id"),
-            )
-            .join(
-                latest_updated_subquery,
-                and_(
-                    model.shifu_bid == latest_updated_subquery.c.shifu_bid,
-                    or_(
-                        model.updated_at == latest_updated_subquery.c.max_updated_at,
-                        and_(
-                            model.updated_at.is_(None),
-                            latest_updated_subquery.c.max_updated_at.is_(None),
-                        ),
-                    ),
-                ),
-            )
-            .filter(
-                model.deleted == 0,
-                model.shifu_bid.in_(ordered_shifu_bids),
-            )
-            .group_by(model.shifu_bid)
-            .subquery()
-        )
-        rows = (
-            db.session.query(
-                model.shifu_bid,
-                model.updated_at,
-                model.updated_user_bid,
-            )
-            .join(latest_id_subquery, model.id == latest_id_subquery.c.max_id)
-            .all()
-        )
-        for shifu_bid, updated_at, updated_user_bid in rows:
-            normalized_shifu_bid = str(shifu_bid or "").strip()
-            if not normalized_shifu_bid:
-                continue
-            _record_course_activity(
-                activity_map,
-                shifu_bid=normalized_shifu_bid,
-                updated_at=updated_at,
-                updated_user_bid=updated_user_bid or "",
-                prefer_on_equal=True,
-            )
-
-    return activity_map
+    return load_course_activity_map(drafts, published)
 
 
 def _load_latest_course_for_transfer(shifu_bid: str):

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -45,6 +45,8 @@ def _record_course_activity(
 def load_course_activity_map(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
+    *,
+    include_published_outline: bool = True,
 ) -> Dict[str, Dict[str, Any]]:
     activity_map: Dict[str, Dict[str, Any]] = {}
     shifu_bids: Set[str] = set()
@@ -65,7 +67,9 @@ def load_course_activity_map(
         return activity_map
 
     ordered_shifu_bids = sorted(shifu_bids)
-    outline_models = [DraftOutlineItem, PublishedOutlineItem]
+    outline_models = [DraftOutlineItem]
+    if include_published_outline:
+        outline_models.append(PublishedOutlineItem)
     for model in outline_models:
         latest_updated_subquery = (
             db.session.query(

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional, Set
+
+from sqlalchemy import and_, or_
+
+from flaskr.dao import db
+
+from .models import DraftOutlineItem, DraftShifu, PublishedOutlineItem, PublishedShifu
+
+
+def _record_course_activity(
+    activity_map: Dict[str, Dict[str, Any]],
+    *,
+    shifu_bid: str,
+    updated_at: Optional[datetime],
+    updated_user_bid: str,
+    prefer_on_equal: bool = False,
+) -> None:
+    if not shifu_bid:
+        return
+    current = activity_map.get(shifu_bid)
+    candidate_time = updated_at or datetime.min
+    current_time = (
+        current.get("updated_at")
+        if current and current.get("updated_at")
+        else datetime.min
+    )
+    should_replace = current is None or candidate_time > current_time
+    if (
+        not should_replace
+        and prefer_on_equal
+        and current is not None
+        and candidate_time == current_time
+    ):
+        should_replace = True
+    if should_replace:
+        activity_map[shifu_bid] = {
+            "updated_at": updated_at,
+            "updated_user_bid": str(updated_user_bid or "").strip(),
+        }
+
+
+def load_course_activity_map(
+    drafts: Iterable[DraftShifu],
+    published: Iterable[PublishedShifu],
+) -> Dict[str, Dict[str, Any]]:
+    activity_map: Dict[str, Dict[str, Any]] = {}
+    shifu_bids: Set[str] = set()
+
+    for course in list(drafts) + list(published):
+        shifu_bid = str(course.shifu_bid or "").strip()
+        if not shifu_bid:
+            continue
+        shifu_bids.add(shifu_bid)
+        _record_course_activity(
+            activity_map,
+            shifu_bid=shifu_bid,
+            updated_at=course.updated_at,
+            updated_user_bid=course.updated_user_bid or "",
+        )
+
+    if not shifu_bids:
+        return activity_map
+
+    ordered_shifu_bids = sorted(shifu_bids)
+    outline_models = [DraftOutlineItem, PublishedOutlineItem]
+    for model in outline_models:
+        latest_updated_subquery = (
+            db.session.query(
+                model.shifu_bid.label("shifu_bid"),
+                db.func.max(model.updated_at).label("max_updated_at"),
+            )
+            .filter(
+                model.deleted == 0,
+                model.shifu_bid.in_(ordered_shifu_bids),
+            )
+            .group_by(model.shifu_bid)
+            .subquery()
+        )
+        latest_id_subquery = (
+            db.session.query(
+                model.shifu_bid.label("shifu_bid"),
+                db.func.max(model.id).label("max_id"),
+            )
+            .join(
+                latest_updated_subquery,
+                and_(
+                    model.shifu_bid == latest_updated_subquery.c.shifu_bid,
+                    or_(
+                        model.updated_at == latest_updated_subquery.c.max_updated_at,
+                        and_(
+                            model.updated_at.is_(None),
+                            latest_updated_subquery.c.max_updated_at.is_(None),
+                        ),
+                    ),
+                ),
+            )
+            .filter(
+                model.deleted == 0,
+                model.shifu_bid.in_(ordered_shifu_bids),
+            )
+            .group_by(model.shifu_bid)
+            .subquery()
+        )
+        rows = (
+            db.session.query(
+                model.shifu_bid,
+                model.updated_at,
+                model.updated_user_bid,
+            )
+            .join(latest_id_subquery, model.id == latest_id_subquery.c.max_id)
+            .all()
+        )
+        for shifu_bid, updated_at, updated_user_bid in rows:
+            normalized_shifu_bid = str(shifu_bid or "").strip()
+            if not normalized_shifu_bid:
+                continue
+            _record_course_activity(
+                activity_map,
+                shifu_bid=normalized_shifu_bid,
+                updated_at=updated_at,
+                updated_user_bid=updated_user_bid or "",
+                prefer_on_equal=True,
+            )
+
+    return activity_map

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -652,7 +652,11 @@ def get_shifu_draft_list(
             .all()
         )
 
-        activity_map = load_course_activity_map(shifu_drafts, [])
+        activity_map = load_course_activity_map(
+            shifu_drafts,
+            [],
+            include_published_outline=False,
+        )
 
         def resolve_updated_at(draft: DraftShifu) -> datetime:
             activity = activity_map.get(str(draft.shifu_bid or "").strip(), {})

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -35,6 +35,7 @@ from .utils import (
 )
 from .models import DraftShifu, FavoriteScenario, ShifuUserArchive, PublishedShifu
 from .permissions import get_user_shifu_permissions
+from .course_activity import load_course_activity_map
 from .shifu_history_manager import save_shifu_history
 from ..common.dtos import PageNationDTO
 from ...service.config import get_config
@@ -648,8 +649,22 @@ def get_shifu_draft_list(
         shifu_drafts: list[DraftShifu] = (
             db.session.query(DraftShifu)
             .filter(DraftShifu.id.in_(latest_subquery))
-            .order_by(DraftShifu.updated_at.desc(), DraftShifu.id.desc())
             .all()
+        )
+
+        activity_map = load_course_activity_map(shifu_drafts, [])
+
+        def resolve_updated_at(draft: DraftShifu) -> datetime:
+            activity = activity_map.get(str(draft.shifu_bid or "").strip(), {})
+            return activity.get("updated_at") or draft.updated_at or datetime.min
+
+        shifu_drafts.sort(
+            key=lambda draft: (
+                resolve_updated_at(draft),
+                draft.updated_at or datetime.min,
+                int(draft.id or 0),
+            ),
+            reverse=True,
         )
 
         if is_favorite:

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -648,7 +648,7 @@ def get_shifu_draft_list(
         shifu_drafts: list[DraftShifu] = (
             db.session.query(DraftShifu)
             .filter(DraftShifu.id.in_(latest_subquery))
-            .order_by(DraftShifu.title.asc(), DraftShifu.shifu_bid.asc())
+            .order_by(DraftShifu.updated_at.desc(), DraftShifu.id.desc())
             .all()
         )
 

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -11,11 +11,11 @@ from flaskr.dao import db
 from flaskr.service.common.models import AppException
 from flaskr.service.shifu import admin as admin_module
 from flaskr.service.shifu.admin import (
-    _load_course_activity_map,
     _load_latest_shifus,
     _build_operator_course_overview,
     list_operator_courses,
 )
+from flaskr.service.shifu.course_activity import load_course_activity_map
 from flaskr.service.learn.const import LEARN_STATUS_COMPLETED
 from flaskr.service.learn.models import LearnProgressRecord
 from flaskr.service.order.consts import ORDER_STATUS_INIT, ORDER_STATUS_SUCCESS
@@ -394,7 +394,7 @@ def test_load_course_activity_map_prefers_latest_outline_activity_row(app):
         )
         db.session.commit()
 
-        activity_map = _load_course_activity_map([draft_course], [])
+        activity_map = load_course_activity_map([draft_course], [])
 
     assert activity_map[shifu_bid]["updated_user_bid"] == "editor-2"
     assert activity_map[shifu_bid]["updated_at"] == datetime(2025, 4, 5, 10, 0, 0)
@@ -437,7 +437,7 @@ def test_load_course_activity_map_prefers_outline_when_timestamp_ties_course(app
         )
         db.session.commit()
 
-        activity_map = _load_course_activity_map([draft_course], [])
+        activity_map = load_course_activity_map([draft_course], [])
 
     assert activity_map[shifu_bid]["updated_user_bid"] == "outline-editor"
     assert activity_map[shifu_bid]["updated_at"] == shared_updated_at

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+import flaskr.dao as dao
+from flaskr.service.shifu.models import DraftShifu
+from flaskr.service.shifu.shifu_draft_funcs import get_shifu_draft_list
+
+
+def _seed_draft(
+    *,
+    shifu_bid: str,
+    title: str,
+    owner_bid: str,
+    created_at: datetime,
+    updated_at: datetime,
+) -> None:
+    draft = DraftShifu(
+        shifu_bid=shifu_bid,
+        title=title,
+        description="desc",
+        avatar_res_bid="res",
+        keywords="test",
+        llm="gpt",
+        llm_temperature=Decimal("0"),
+        llm_system_prompt="",
+        price=Decimal("0"),
+        created_user_bid=owner_bid,
+        updated_user_bid=owner_bid,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    dao.db.session.add(draft)
+
+
+def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
+    owner_bid = "draft-list-owner"
+    with app.app_context():
+        DraftShifu.query.filter(
+            DraftShifu.created_user_bid == owner_bid,
+            DraftShifu.shifu_bid.in_(
+                ["draft-sort-older", "draft-sort-newer", "draft-sort-same-time-a"]
+            ),
+        ).delete(synchronize_session=False)
+
+        same_updated_at = datetime(2026, 5, 15, 12, 0, 0)
+        _seed_draft(
+            shifu_bid="draft-sort-older",
+            title="AAA Older Title",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 10, 10, 0, 0),
+            updated_at=datetime(2026, 5, 14, 9, 0, 0),
+        )
+        _seed_draft(
+            shifu_bid="draft-sort-newer",
+            title="ZZZ Newer Title",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 11, 10, 0, 0),
+            updated_at=datetime(2026, 5, 15, 13, 0, 0),
+        )
+        _seed_draft(
+            shifu_bid="draft-sort-same-time-a",
+            title="MMM Same Time Title",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 12, 10, 0, 0),
+            updated_at=same_updated_at,
+        )
+        _seed_draft(
+            shifu_bid="draft-sort-same-time-a",
+            title="MMM Same Time Title",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 12, 10, 0, 0),
+            updated_at=same_updated_at,
+        )
+        dao.db.session.commit()
+
+        result = get_shifu_draft_list(
+            app,
+            owner_bid,
+            page_index=1,
+            page_size=10,
+            is_favorite=False,
+            archived=False,
+            creator_only=True,
+        )
+
+    assert [item.bid for item in result.data[:3]] == [
+        "draft-sort-newer",
+        "draft-sort-same-time-a",
+        "draft-sort-older",
+    ]

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -4,7 +4,11 @@ from datetime import datetime
 from decimal import Decimal
 
 import flaskr.dao as dao
-from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
+from flaskr.service.shifu.models import (
+    DraftOutlineItem,
+    DraftShifu,
+    PublishedOutlineItem,
+)
 from flaskr.service.shifu.shifu_draft_funcs import get_shifu_draft_list
 
 
@@ -169,4 +173,76 @@ def test_get_shifu_draft_list_prefers_latest_outline_activity(app):
     assert [item.bid for item in result.data[:2]] == [
         "draft-activity-course",
         "draft-activity-reference",
+    ]
+
+
+def test_get_shifu_draft_list_ignores_published_outline_activity(app):
+    owner_bid = "draft-list-published-outline-owner"
+    with app.app_context():
+        PublishedOutlineItem.query.filter(
+            PublishedOutlineItem.shifu_bid == "draft-published-outline-course"
+        ).delete(synchronize_session=False)
+        DraftShifu.query.filter(
+            DraftShifu.created_user_bid == owner_bid,
+            DraftShifu.shifu_bid.in_(
+                ["draft-published-outline-course", "draft-published-outline-reference"]
+            ),
+        ).delete(synchronize_session=False)
+
+        _seed_draft(
+            shifu_bid="draft-published-outline-course",
+            title="Course With Published Activity",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 10, 10, 0, 0),
+            updated_at=datetime(2026, 5, 10, 10, 0, 0),
+        )
+        _seed_draft(
+            shifu_bid="draft-published-outline-reference",
+            title="Reference Draft Course",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 11, 10, 0, 0),
+            updated_at=datetime(2026, 5, 12, 10, 0, 0),
+        )
+        dao.db.session.flush()
+
+        dao.db.session.add(
+            PublishedOutlineItem(
+                outline_item_bid="published-outline-activity",
+                shifu_bid="draft-published-outline-course",
+                title="Published Lesson",
+                parent_bid="",
+                position="01",
+                prerequisite_item_bids="",
+                llm="",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                ask_enabled_status=5101,
+                ask_llm="",
+                ask_llm_temperature=Decimal("0"),
+                ask_llm_system_prompt="",
+                content="",
+                type=0,
+                hidden=0,
+                deleted=0,
+                created_at=datetime(2026, 5, 13, 10, 0, 0),
+                updated_at=datetime(2026, 5, 13, 10, 0, 0),
+                created_user_bid=owner_bid,
+                updated_user_bid=owner_bid,
+            )
+        )
+        dao.db.session.commit()
+
+        result = get_shifu_draft_list(
+            app,
+            owner_bid,
+            page_index=1,
+            page_size=10,
+            is_favorite=False,
+            archived=False,
+            creator_only=True,
+        )
+
+    assert [item.bid for item in result.data[:2]] == [
+        "draft-published-outline-reference",
+        "draft-published-outline-course",
     ]

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 
 import flaskr.dao as dao
-from flaskr.service.shifu.models import DraftShifu
+from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 from flaskr.service.shifu.shifu_draft_funcs import get_shifu_draft_list
 
 
@@ -89,4 +89,78 @@ def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
         "draft-sort-newer",
         "draft-sort-same-time-a",
         "draft-sort-older",
+    ]
+
+
+def test_get_shifu_draft_list_prefers_latest_outline_activity(app):
+    owner_bid = "draft-list-activity-owner"
+    with app.app_context():
+        DraftOutlineItem.query.filter(
+            DraftOutlineItem.shifu_bid.in_(
+                ["draft-activity-course", "draft-activity-reference"]
+            )
+        ).delete(synchronize_session=False)
+        DraftShifu.query.filter(
+            DraftShifu.created_user_bid == owner_bid,
+            DraftShifu.shifu_bid.in_(
+                ["draft-activity-course", "draft-activity-reference"]
+            ),
+        ).delete(synchronize_session=False)
+
+        _seed_draft(
+            shifu_bid="draft-activity-course",
+            title="Outline Activity",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 10, 10, 0, 0),
+            updated_at=datetime(2026, 5, 10, 10, 0, 0),
+        )
+        _seed_draft(
+            shifu_bid="draft-activity-reference",
+            title="Reference Course",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 11, 10, 0, 0),
+            updated_at=datetime(2026, 5, 12, 10, 0, 0),
+        )
+        dao.db.session.flush()
+
+        dao.db.session.add(
+            DraftOutlineItem(
+                outline_item_bid="draft-activity-outline",
+                shifu_bid="draft-activity-course",
+                title="Fresh Lesson",
+                parent_bid="",
+                position="01",
+                prerequisite_item_bids="",
+                llm="",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                ask_enabled_status=5101,
+                ask_llm="",
+                ask_llm_temperature=Decimal("0"),
+                ask_llm_system_prompt="",
+                content="",
+                type=0,
+                hidden=0,
+                deleted=0,
+                created_at=datetime(2026, 5, 13, 10, 0, 0),
+                updated_at=datetime(2026, 5, 13, 10, 0, 0),
+                created_user_bid=owner_bid,
+                updated_user_bid=owner_bid,
+            )
+        )
+        dao.db.session.commit()
+
+        result = get_shifu_draft_list(
+            app,
+            owner_bid,
+            page_index=1,
+            page_size=10,
+            is_favorite=False,
+            archived=False,
+            creator_only=True,
+        )
+
+    assert [item.bid for item in result.data[:2]] == [
+        "draft-activity-course",
+        "draft-activity-reference",
     ]

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -40,7 +40,12 @@ def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
         DraftShifu.query.filter(
             DraftShifu.created_user_bid == owner_bid,
             DraftShifu.shifu_bid.in_(
-                ["draft-sort-older", "draft-sort-newer", "draft-sort-same-time-a"]
+                [
+                    "draft-sort-older",
+                    "draft-sort-newer",
+                    "draft-sort-same-time-a",
+                    "draft-sort-same-time-b",
+                ]
             ),
         ).delete(synchronize_session=False)
 
@@ -61,14 +66,14 @@ def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
         )
         _seed_draft(
             shifu_bid="draft-sort-same-time-a",
-            title="MMM Same Time Title",
+            title="MMM Same Time Title A",
             owner_bid=owner_bid,
             created_at=datetime(2026, 5, 12, 10, 0, 0),
             updated_at=same_updated_at,
         )
         _seed_draft(
-            shifu_bid="draft-sort-same-time-a",
-            title="MMM Same Time Title",
+            shifu_bid="draft-sort-same-time-b",
+            title="MMM Same Time Title B",
             owner_bid=owner_bid,
             created_at=datetime(2026, 5, 12, 10, 0, 0),
             updated_at=same_updated_at,
@@ -85,8 +90,9 @@ def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
             creator_only=True,
         )
 
-    assert [item.bid for item in result.data[:3]] == [
+    assert [item.bid for item in result.data[:4]] == [
         "draft-sort-newer",
+        "draft-sort-same-time-b",
         "draft-sort-same-time-a",
         "draft-sort-older",
     ]


### PR DESCRIPTION
Summary
- sort creator course cards by draft `updated_at` descending instead of title order
- use draft record `id` descending as the stable tie-breaker when update times are equal
- add targeted coverage for the updated ordering behavior

Tests
- `cd src/api && pytest tests/service/shifu/test_shifu_draft_list.py tests/service/shifu/test_archive.py -q`
- `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Draft course listings now prioritize courses with recent content activity, considering both draft-level and outline-level updates to ensure the most recently modified courses appear first.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1767)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->