### PR TITLE
feat: add security query restrictions for author metadata tables

### DIFF
--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -77,6 +77,17 @@ _GENERATED_CONTENT_LIMIT_MAX = 100
 # DSL query, and may resolve at most this many per call.
 _USER_USERS_LIMIT_MAX = 50
 
+# Querying the shifu metadata tables (shifu_published_shifus /
+# shifu_draft_shifus) is restricted to "look up the current title for the
+# shifu I own / list courses I created that match a substring". Aggregates
+# and group_by are blocked (would let a caller probe permission edges via
+# count_distinct(shifu_bid) etc.), the limit is hard-capped, and a
+# `title like` value must include at least _LIKE_MIN_NON_WILDCARD_CHARS
+# non-wildcard characters so a caller cannot scan with `like "a%"`.
+_SHIFU_META_LIMIT_MAX = 50
+_SHIFU_META_TABLES = frozenset({"shifu_published_shifus", "shifu_draft_shifus"})
+_LIKE_MIN_NON_WILDCARD_CHARS = 2
+
 
 def _raise(error_name: str, detail: Optional[str] = None) -> None:
     """Raise an :class:`AppException` with a stable error name.
@@ -127,6 +138,10 @@ class QueryDSL:
     offset: int
 
     output_columns: Tuple[str, ...] = field(default_factory=tuple)
+    # Caller's authenticated user_id, threaded from funcs.run_dsl. Consumed
+    # by sql_builder when the target TableSpec declares a
+    # `creator_scoped_column` (currently the shifu metadata tables).
+    caller_user_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -134,11 +149,18 @@ class QueryDSL:
 # ---------------------------------------------------------------------------
 
 
-def parse_dsl(payload: Any, limit_max: int) -> QueryDSL:
+def parse_dsl(payload: Any, limit_max: int, user_id: str = "") -> QueryDSL:
     """Validate ``payload`` and return a :class:`QueryDSL`.
 
     ``limit_max`` is the upper bound for the DSL ``limit`` field (typically
     ``ANALYTICS_QUERY_LIMIT_MAX``).
+
+    ``user_id`` is the caller's authenticated user_id. It is threaded into
+    :attr:`QueryDSL.caller_user_id` so :mod:`sql_builder` can inject the
+    ``creator_scoped_column = :__user_id`` predicate for tables that opt
+    into row-ownership enforcement. The default empty string is allowed
+    for legacy call sites that never hit a creator-scoped table (the SQL
+    builder still validates this combination).
     """
 
     if not isinstance(payload, Mapping):
@@ -168,9 +190,12 @@ def parse_dsl(payload: Any, limit_max: int) -> QueryDSL:
     filters = _parse_filters(payload.get("where"), spec)
     _enforce_generated_content_type_filter(select, filters)
     _enforce_user_users_requires_user_bid_filter(table_key, filters)
+    _enforce_shifu_meta_table_constraints(table_key, aggregates, group_by, filters)
     order_by = _parse_order_by(payload.get("order_by"), select, aggregates, group_by)
     if table_key == "user_users":
         effective_limit_max = _USER_USERS_LIMIT_MAX
+    elif table_key in _SHIFU_META_TABLES:
+        effective_limit_max = _SHIFU_META_LIMIT_MAX
     elif "generated_content" in select:
         effective_limit_max = _GENERATED_CONTENT_LIMIT_MAX
     else:
@@ -197,6 +222,7 @@ def parse_dsl(payload: Any, limit_max: int) -> QueryDSL:
         limit=limit,
         offset=offset,
         output_columns=output_columns,
+        caller_user_id=user_id,
     )
 
 
@@ -579,6 +605,52 @@ def _enforce_user_users_requires_user_bid_filter(
                 f"(got '{filt.op}'); 'in', 'like', and ranges are not allowed "
                 "(batch enumeration of registered phone/email is not permitted)",
             )
+
+
+def _enforce_shifu_meta_table_constraints(
+    table_key: str,
+    aggregates: Sequence[Aggregate],
+    group_by: Sequence[str],
+    filters: Sequence[Filter],
+) -> None:
+    """Block aggregate / group_by on metadata tables and tighten title like.
+
+    The metadata tables are for "what is this course currently called" / "list
+    courses I own that match this substring" — pure row lookups. Allowing
+    aggregate or group_by would let a caller probe permission edges (e.g.
+    ``count_distinct(shifu_bid)`` returns the size of the caller's owned set,
+    which is a side channel even without revealing the individual bids).
+
+    The ``title`` column is the only free-text filter target. ``like`` is
+    already gated to trailing-% only in :func:`_validate_filter_value`; here
+    we require at least :data:`_LIKE_MIN_NON_WILDCARD_CHARS` non-wildcard
+    characters so a caller cannot enumerate with ``like "a%"``.
+    """
+
+    if table_key not in _SHIFU_META_TABLES:
+        return
+    if aggregates:
+        _raise(
+            ERR_INVALID_DSL,
+            f"'{table_key}' does not support 'aggregate' "
+            "(metadata tables are row-lookup only)",
+        )
+    if group_by:
+        _raise(
+            ERR_INVALID_DSL,
+            f"'{table_key}' does not support 'group_by' "
+            "(metadata tables are row-lookup only)",
+        )
+    for filt in filters:
+        if filt.field == "title" and filt.op == "like":
+            non_wildcard = filt.value.rstrip("%")
+            if len(non_wildcard) < _LIKE_MIN_NON_WILDCARD_CHARS:
+                _raise(
+                    ERR_INVALID_DSL,
+                    f"'title' 'like' requires at least "
+                    f"{_LIKE_MIN_NON_WILDCARD_CHARS} non-wildcard characters "
+                    "(anti-enumeration guard)",
+                )
 
 
 def _default_alias(fn: str, field_name: Optional[str]) -> str:

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -621,10 +621,13 @@ def _enforce_shifu_meta_table_constraints(
     ``count_distinct(shifu_bid)`` returns the size of the caller's owned set,
     which is a side channel even without revealing the individual bids).
 
-    The ``title`` column is the only free-text filter target. ``like`` is
-    already gated to trailing-% only in :func:`_validate_filter_value`; here
-    we require at least :data:`_LIKE_MIN_NON_WILDCARD_CHARS` non-wildcard
-    characters so a caller cannot enumerate with ``like "a%"``.
+    The ``title`` column is the only free-text filter target. The generic
+    :func:`_validate_filter_value` only blocks leading ``%``; that is too
+    permissive for metadata lookups, where the design contract is strict
+    prefix matching. Here we additionally reject any ``_`` (SQL single-char
+    wildcard) and any ``%`` other than a single trailing one, then require
+    at least :data:`_LIKE_MIN_NON_WILDCARD_CHARS` literal characters so a
+    caller cannot enumerate with ``like "__%"`` / ``like "a%b"`` / etc.
     """
 
     if table_key not in _SHIFU_META_TABLES:
@@ -643,7 +646,19 @@ def _enforce_shifu_meta_table_constraints(
         )
     for filt in filters:
         if filt.field == "title" and filt.op == "like":
-            non_wildcard = filt.value.rstrip("%")
+            value = filt.value
+            # Metadata-table title lookup is strict prefix matching:
+            # only an optional trailing '%' wildcard is allowed. Reject any
+            # '_' (SQL single-char wildcard) and any '%' that is not the
+            # final character, so patterns like "__%" / "a%b" cannot bypass
+            # the non-wildcard length floor below.
+            if "_" in value or "%" in value[:-1]:
+                _raise(
+                    ERR_INVALID_DSL,
+                    "'title' 'like' only supports an optional trailing '%' "
+                    "wildcard (no '_' / no internal '%')",
+                )
+            non_wildcard = value[:-1] if value.endswith("%") else value
             if len(non_wildcard) < _LIKE_MIN_NON_WILDCARD_CHARS:
                 _raise(
                     ERR_INVALID_DSL,

--- a/src/api/flaskr/service/creator_analytics/funcs.py
+++ b/src/api/flaskr/service/creator_analytics/funcs.py
@@ -34,7 +34,7 @@ def run_dsl(app: Flask, user_id: str, payload: Any) -> Dict[str, Any]:
     limit_max = int(app.config.get("ANALYTICS_QUERY_LIMIT_MAX") or 1000)
     query_timeout = int(app.config.get("ANALYTICS_QUERY_TIMEOUT_SECONDS") or 15)
 
-    dsl = parse_dsl(payload, limit_max=limit_max)
+    dsl = parse_dsl(payload, limit_max=limit_max, user_id=user_id)
 
     permissions = get_user_shifu_permissions(app, user_id)
     allowed_perms = permissions.get(dsl.shifu_bid, set())

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -3,13 +3,20 @@
 The builder never accepts raw user strings into the SQL text — every column
 and operator passes through the whitelist enforced by
 :mod:`flaskr.service.creator_analytics.dsl`, and every value is bound via
-SQLAlchemy bindparam. Two cross-cutting rules are applied regardless of what
-the caller sent:
+SQLAlchemy bindparam. Four cross-cutting predicates are applied automatically,
+driven by :class:`flaskr.service.creator_analytics.whitelist.TableSpec` flags:
 
-1. ``WHERE shifu_bid = :shifu_bid`` is always appended so callers cannot
-   widen the scope to courses they do not own.
-2. ``AND deleted = 0`` is appended for tables whose :class:`TableSpec` has
-   ``has_deleted=True`` (i.e. all tables except ``shifu_user_archives``).
+1. ``WHERE shifu_bid = :shifu_bid`` when ``has_shifu_bid`` is True — callers
+   cannot widen the scope to courses they do not own.
+2. ``AND deleted = 0`` when ``has_deleted`` is True — soft-deleted rows stay
+   hidden.
+3. ``AND <creator_scoped_column> = :__user_id`` when ``creator_scoped_column``
+   is non-None — row ownership is enforced on top of the shifu-scope check.
+   Used by the shifu metadata tables so co-authors cannot read author-only
+   title rows even when they have query permission for the shifu.
+4. ``AND status = 1`` when ``auto_filter_status_active`` is True — used by
+   ``learn_generated_blocks`` to drop rerolled history (``status = 0``) from
+   every result, so creator counts reflect the current learner experience.
 
 The MySQL ``MAX_EXECUTION_TIME`` optimizer hint is injected only when the
 target dialect is MySQL — under SQLite (tests) the hint would not parse.
@@ -66,6 +73,23 @@ def build_statement(
         )
     if dsl.spec.has_deleted:
         where_clauses.append(table.c.deleted == 0)
+    if dsl.spec.creator_scoped_column:
+        # Row-ownership enforcement on top of the shifu permission check in
+        # funcs.run_dsl. The caller_user_id must be threaded through by the
+        # entry point; if it is missing here we refuse to compile rather than
+        # silently emit a WHERE col = '' clause that would always match
+        # legacy rows whose creator field is empty.
+        if not dsl.caller_user_id:
+            raise ValueError(
+                f"caller_user_id is required for creator-scoped table "
+                f"'{dsl.spec.table_key}'"
+            )
+        where_clauses.append(
+            table.c[dsl.spec.creator_scoped_column]
+            == bindparam("__user_id", value=dsl.caller_user_id)
+        )
+    if dsl.spec.auto_filter_status_active:
+        where_clauses.append(table.c.status == 1)
 
     for index, filt in enumerate(dsl.filters):
         where_clauses.append(_compile_filter(table.c[filt.field], filt, index))

--- a/src/api/flaskr/service/creator_analytics/whitelist.py
+++ b/src/api/flaskr/service/creator_analytics/whitelist.py
@@ -2,16 +2,24 @@
 
 Every DSL request is constrained by :data:`WHITELIST`. The set of tables, the
 columns that may appear in ``select`` / ``where`` / ``group_by``, and the
-aggregations allowed per column are declared here. ``shifu_bid`` and ``deleted``
-are not exposed in the DSL surface — they are injected by the SQL builder
-based on :attr:`TableSpec.has_deleted` and the authenticated user's
-permissions.
+aggregations allowed per column are declared here. Several columns are not
+exposed in the DSL surface and are instead injected automatically by the SQL
+builder, driven by :class:`TableSpec` flags:
+
+* ``shifu_bid`` — injected when :attr:`TableSpec.has_shifu_bid` is True.
+* ``deleted = 0`` — injected when :attr:`TableSpec.has_deleted` is True.
+* ``<creator_scoped_column> = caller_user_id`` — injected when
+  :attr:`TableSpec.creator_scoped_column` is non-None (used by the metadata
+  tables ``shifu_published_shifus`` / ``shifu_draft_shifus`` to enforce row
+  ownership in addition to the shifu-scope check).
+* ``status = 1`` — injected when :attr:`TableSpec.auto_filter_status_active`
+  is True (used by ``learn_generated_blocks`` to exclude rerolled history).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet, Mapping, Type
+from typing import FrozenSet, Mapping, Optional, Type
 
 from flaskr.service.learn.models import (
     LearnGeneratedBlock,
@@ -21,7 +29,7 @@ from flaskr.service.learn.models import (
 from flaskr.service.billing.models import BillingDailyUsageMetric
 from flaskr.service.order.models import Order
 from flaskr.service.profile.models import VariableValue
-from flaskr.service.shifu.models import ShifuUserArchive
+from flaskr.service.shifu.models import DraftShifu, PublishedShifu, ShifuUserArchive
 from flaskr.service.user.models import UserInfo
 
 
@@ -63,6 +71,15 @@ class TableSpec:
     # by funcs.run_dsl using get_user_shifu_permissions, but the SQL cannot
     # filter by a column the table does not have.
     has_shifu_bid: bool = True
+    # When non-None, sql_builder injects WHERE <col> = :__user_id (the caller).
+    # Used for creator-owned metadata tables (shifu_published_shifus /
+    # shifu_draft_shifus) so the row's creator must match the caller. Pairs
+    # with has_shifu_bid for a double-gate: shifu permission AND row ownership.
+    creator_scoped_column: Optional[str] = None
+    # When True, sql_builder injects AND status = 1 to exclude rerolled /
+    # superseded history rows. Only enabled where status semantics are
+    # "1 = current, 0 = history" (e.g. learn_generated_blocks).
+    auto_filter_status_active: bool = False
 
 
 _DIMENSION_AGGS: FrozenSet[str] = frozenset({"count", "count_distinct"})
@@ -115,8 +132,11 @@ WHITELIST: Mapping[str, TableSpec] = {
                 "generated_block_bid",
                 "user_bid",
                 "progress_record_bid",
+                "outline_item_bid",
                 "type",
                 "role",
+                "status",
+                "position",
                 "liked",
                 "created_at",
                 "generated_content",
@@ -126,20 +146,27 @@ WHITELIST: Mapping[str, TableSpec] = {
             {
                 "user_bid",
                 "progress_record_bid",
+                "outline_item_bid",
                 "type",
                 "role",
+                "status",
+                "position",
                 "liked",
                 "created_at",
             }
         ),
-        groupable=frozenset({"user_bid", "type", "role", "liked"}),
+        groupable=frozenset(
+            {"user_bid", "outline_item_bid", "type", "role", "status", "liked"}
+        ),
         aggregatable={
             "generated_block_bid": _DIMENSION_AGGS,
             "user_bid": _DIMENSION_AGGS,
+            "outline_item_bid": _DIMENSION_AGGS,
             "liked": _NUMERIC_AGGS,
             "created_at": _TIMESTAMP_AGGS,
         },
         has_deleted=True,
+        auto_filter_status_active=True,
     ),
     "learn_lesson_feedbacks": TableSpec(
         table_key="learn_lesson_feedbacks",
@@ -251,6 +278,7 @@ WHITELIST: Mapping[str, TableSpec] = {
         selectable=frozenset(
             {
                 "stat_date",
+                "creator_bid",
                 "usage_scene",
                 "usage_type",
                 "provider",
@@ -273,6 +301,7 @@ WHITELIST: Mapping[str, TableSpec] = {
         groupable=frozenset(
             {
                 "stat_date",
+                "creator_bid",
                 "usage_scene",
                 "usage_type",
                 "provider",
@@ -315,6 +344,62 @@ WHITELIST: Mapping[str, TableSpec] = {
         aggregatable={},
         has_deleted=True,
         has_shifu_bid=False,
+    ),
+    # ------------------------------------------------------------------
+    # Course metadata tables — answer "what is shifu_bid X currently
+    # called", "did I rename it", "which of my courses match this title".
+    # Two-table layout: published_shifus is the live learner-facing title;
+    # draft_shifus is the in-progress editor title. They can diverge after
+    # rename (draft updated, not yet republished).
+    # Security model — double-gate:
+    #   1. funcs.run_dsl checks get_user_shifu_permissions for view access
+    #      on dsl.shifu_bid (caller is owner or co-author).
+    #   2. sql_builder injects WHERE created_user_bid = :__user_id so the
+    #      row must belong to the caller. Co-authors with view permission
+    #      can run analytics queries on shared courses but cannot read the
+    #      title metadata — that stays scoped to the original author per
+    #      PDF §7.2 "current course attribution = published.created_user_bid".
+    # Hard restrictions:
+    #   - aggregatable={} / groupable=frozenset(): no aggregate / group_by;
+    #     prevents using count_distinct(shifu_bid) as a permission-probe
+    #     side channel.
+    #   - selectable / filterable expose only the minimum fields needed
+    #     for title lookup. Sensitive author secrets (llm_system_prompt,
+    #     ask_llm_system_prompt, ask_provider_config, etc.) are NEVER on
+    #     this list — those are creator IP and must not flow through the
+    #     analytics DSL even to the owner.
+    #   - title supports op=like, but dsl.py enforces a minimum
+    #     non-wildcard length (>= 2) on top of the existing leading-%
+    #     guard, so callers cannot scan with `like "a%"`.
+    #   - limit hard-capped to 50 (see dsl._SHIFU_META_LIMIT_MAX).
+    # ------------------------------------------------------------------
+    "shifu_published_shifus": TableSpec(
+        table_key="shifu_published_shifus",
+        model=PublishedShifu,
+        # shifu_bid is intentionally NOT exposed — the sql_builder injects it
+        # from the CLI's positional argument; selecting / filtering it again
+        # would be pure echo and breaks the global "shifu_bid stays out of the
+        # DSL surface" invariant (see test_shifu_bid_and_deleted_are_never_
+        # user_addressable). created_user_bid is exposed so the caller can
+        # confirm ownership in the response payload.
+        selectable=frozenset({"title", "created_user_bid", "created_at", "updated_at"}),
+        filterable=frozenset({"title", "created_user_bid", "created_at", "updated_at"}),
+        groupable=frozenset(),
+        aggregatable={},
+        has_deleted=True,
+        has_shifu_bid=True,
+        creator_scoped_column="created_user_bid",
+    ),
+    "shifu_draft_shifus": TableSpec(
+        table_key="shifu_draft_shifus",
+        model=DraftShifu,
+        selectable=frozenset({"title", "created_user_bid", "created_at", "updated_at"}),
+        filterable=frozenset({"title", "created_user_bid", "created_at", "updated_at"}),
+        groupable=frozenset(),
+        aggregatable={},
+        has_deleted=True,
+        has_shifu_bid=True,
+        creator_scoped_column="created_user_bid",
     ),
 }
 

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -79,6 +79,7 @@ def seed_owned_course(
     shifu_bid: str,
     user_id: str = "teacher-1",
     title: str = "Untitled",
+    deleted: int = 0,
 ) -> None:
     now = datetime.utcnow()
     db.session.add(
@@ -97,7 +98,45 @@ def seed_owned_course(
             ask_llm_system_prompt="",
             ask_provider_config="{}",
             price=0,
-            deleted=0,
+            deleted=deleted,
+            created_at=now,
+            created_user_bid=user_id,
+            updated_at=now,
+            updated_user_bid=user_id,
+        )
+    )
+    db.session.commit()
+
+
+def seed_published_shifu(
+    *,
+    shifu_bid: str,
+    user_id: str = "teacher-1",
+    title: str = "Untitled",
+    deleted: int = 0,
+) -> None:
+    """Seed one PublishedShifu row. Pair with seed_owned_course when the test
+    needs both the draft and the published version of a course (e.g. to cover
+    the "draft title diverges from published title after rename" scenario)."""
+
+    now = datetime.utcnow()
+    db.session.add(
+        PublishedShifu(
+            shifu_bid=shifu_bid,
+            title=title,
+            keywords="",
+            description="",
+            avatar_res_bid="",
+            llm="",
+            llm_temperature=0,
+            llm_system_prompt="",
+            ask_enabled_status=0,
+            ask_llm="",
+            ask_llm_temperature=0,
+            ask_llm_system_prompt="",
+            ask_provider_config="{}",
+            price=0,
+            deleted=deleted,
             created_at=now,
             created_user_bid=user_id,
             updated_at=now,
@@ -162,6 +201,9 @@ def seed_generated_block(
     content: str,
     progress_record_bid: str = "pr-default",
     generated_block_bid: Optional[str] = None,
+    outline_item_bid: str = "",
+    position: int = 0,
+    status: int = 1,
 ) -> str:
     bid = generated_block_bid or f"gb-{shifu_bid}-{user_bid}-{type}-{content[:8]}"
     now = datetime.utcnow()
@@ -171,8 +213,11 @@ def seed_generated_block(
             shifu_bid=shifu_bid,
             user_bid=user_bid,
             progress_record_bid=progress_record_bid,
+            outline_item_bid=outline_item_bid,
+            position=position,
             type=type,
             role=role,
+            status=status,
             generated_content=content,
             deleted=0,
             created_at=now,

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -656,3 +656,232 @@ def test_bill_usage_table_rejected() -> None:
         "limit": 1,
     }
     _assert_error(payload, ERR_INVALID_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# learn_generated_blocks — new fields (status / position / outline_item_bid)
+# ---------------------------------------------------------------------------
+
+
+def _generated_blocks_payload(**overrides):
+    base = {
+        "shifu_bid": "shifu-abc",
+        "table": "learn_generated_blocks",
+        "where": [{"field": "type", "op": "=", "value": 321}],
+        "aggregate": [{"fn": "count", "alias": "asks"}],
+        "limit": 10,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_learn_generated_blocks_status_filterable() -> None:
+    """status is filterable even though sql_builder auto-injects status=1.
+    Allowing explicit filtering lets a caller debug `status=0` history rows
+    in tests / one-off audits if the auto-injection is ever relaxed."""
+
+    payload = _generated_blocks_payload(
+        where=[
+            {"field": "type", "op": "=", "value": 321},
+            {"field": "status", "op": "=", "value": 1},
+        ],
+    )
+    dsl = _parse(payload)
+    assert any(f.field == "status" for f in dsl.filters)
+
+
+def test_learn_generated_blocks_outline_item_bid_groupable() -> None:
+    """Group by outline_item_bid answers "follow-up questions per lesson"."""
+
+    payload = _generated_blocks_payload(
+        select=["outline_item_bid"],
+        where=[{"field": "type", "op": "=", "value": 321}],
+        aggregate=[{"fn": "count_distinct", "field": "user_bid", "alias": "askers"}],
+        group_by=["outline_item_bid"],
+    )
+    dsl = _parse(payload)
+    assert "outline_item_bid" in dsl.group_by
+
+
+def test_learn_generated_blocks_position_selectable() -> None:
+    """position is needed for the four-key follow-up pairing
+    (progress_record_bid + shifu_bid + outline_item_bid + position).
+    The conversation-replay path (generated_content in select) exempts
+    user_bid from the group-by guard, so list mode is the right test."""
+
+    payload = {
+        "shifu_bid": "shifu-abc",
+        "table": "learn_generated_blocks",
+        "select": [
+            "user_bid",
+            "progress_record_bid",
+            "outline_item_bid",
+            "position",
+            "generated_content",
+            "created_at",
+        ],
+        "where": [{"field": "type", "op": "=", "value": 321}],
+        "limit": 10,
+    }
+    dsl = _parse(payload)
+    assert "position" in dsl.select
+    assert "outline_item_bid" in dsl.select
+
+
+def test_learn_generated_blocks_position_not_groupable() -> None:
+    """position is row-ordering, not a dimension; grouping on it would
+    multiply rows. Reject `group_by=["position"]`."""
+
+    payload = _generated_blocks_payload(
+        select=["position"],
+        group_by=["position"],
+        aggregate=[{"fn": "count", "alias": "n"}],
+    )
+    _assert_error(payload, ERR_INVALID_COLUMN)
+
+
+# ---------------------------------------------------------------------------
+# bill_daily_usage_metrics.creator_bid — selectable + groupable, not filterable
+# ---------------------------------------------------------------------------
+
+
+def test_bill_daily_creator_bid_groupable() -> None:
+    """creator_bid lets the author see which wallet absorbed the course's
+    credit cost — shifu_bid isolation guarantees the value is the caller's
+    own bid, but exposing it confirms that explicitly in the result."""
+
+    payload = _daily_metric_payload(
+        select=["creator_bid", "stat_date"],
+        aggregate=[{"fn": "sum", "field": "consumed_credits", "alias": "credits"}],
+        group_by=["creator_bid", "stat_date"],
+        where=[{"field": "usage_scene", "op": "=", "value": 1203}],
+    )
+    dsl = _parse(payload)
+    assert "creator_bid" in dsl.group_by
+
+
+def test_bill_daily_creator_bid_filter_rejected() -> None:
+    """Filtering by creator_bid is intentionally blocked — shifu_bid scope
+    already binds the value, so an explicit filter is either redundant
+    (same caller) or an attempt to look at someone else's wallet."""
+
+    payload = _daily_metric_payload(
+        where=[
+            {"field": "usage_scene", "op": "=", "value": 1203},
+            {"field": "creator_bid", "op": "=", "value": "someone-else"},
+        ],
+    )
+    _assert_error(payload, ERR_INVALID_COLUMN)
+
+
+# ---------------------------------------------------------------------------
+# shifu metadata tables — strict row-lookup surface
+# ---------------------------------------------------------------------------
+
+
+def _shifu_meta_payload(table_key="shifu_published_shifus", **overrides):
+    base = {
+        "shifu_bid": "shifu-abc",
+        "table": table_key,
+        # shifu_bid is intentionally not in select — the CLI already injected
+        # it and exposing it on the metadata table would re-introduce the
+        # column to the user-addressable surface.
+        "select": ["title", "updated_at"],
+        "limit": 10,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_shifu_published_select_parses() -> None:
+    """Baseline: select-only query on the published metadata table."""
+
+    dsl = _parse(_shifu_meta_payload())
+    assert dsl.table == "shifu_published_shifus"
+    assert "title" in dsl.select
+
+
+def test_shifu_draft_select_parses() -> None:
+    """Baseline: select-only query on the draft metadata table."""
+
+    dsl = _parse(_shifu_meta_payload(table_key="shifu_draft_shifus"))
+    assert dsl.table == "shifu_draft_shifus"
+
+
+def test_shifu_meta_aggregate_rejected() -> None:
+    """count / count_distinct on metadata tables would leak permission
+    edges (e.g. count_distinct(shifu_bid) reveals "how many courses do I
+    own that match this filter")."""
+
+    payload = {
+        "shifu_bid": "shifu-abc",
+        "table": "shifu_published_shifus",
+        "aggregate": [{"fn": "count", "alias": "n"}],
+        "limit": 10,
+    }
+    _assert_error(payload, ERR_INVALID_DSL)
+
+
+def test_shifu_meta_group_by_rejected() -> None:
+    """group_by has no row-lookup use. With groupable=frozenset(), the
+    parser actually rejects at the column-membership check (column not
+    groupable) before reaching the per-table guard; either rejection
+    satisfies the security goal."""
+
+    payload = _shifu_meta_payload(
+        select=["title"],
+        group_by=["title"],
+    )
+    _assert_error(payload, ERR_INVALID_COLUMN)
+
+
+def test_shifu_meta_title_like_too_short_rejected() -> None:
+    """`title like 'a%'` is rejected — 1 non-wildcard char approaches full
+    enumeration. Minimum is 2 non-wildcard chars."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "a%"}],
+    )
+    _assert_error(payload, ERR_INVALID_DSL)
+
+
+def test_shifu_meta_title_like_minimum_accepted() -> None:
+    """`title like 'ai%'` (2 non-wildcard chars) is accepted."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "ai%"}],
+    )
+    dsl = _parse(payload)
+    assert dsl.filters[0].op == "like"
+
+
+def test_shifu_meta_limit_capped_at_50() -> None:
+    """Hard cap at 50 even when the global limit_max is 1000."""
+
+    payload = _shifu_meta_payload(limit=51)
+    _assert_error(payload, ERR_INVALID_LIMIT)
+
+
+def test_shifu_meta_limit_50_accepted() -> None:
+    """Exactly 50 is accepted (cap is inclusive)."""
+
+    payload = _shifu_meta_payload(limit=50)
+    dsl = _parse(payload)
+    assert dsl.limit == 50
+
+
+def test_shifu_meta_caller_user_id_threaded() -> None:
+    """parse_dsl propagates user_id into QueryDSL.caller_user_id; the SQL
+    builder reads it to inject WHERE created_user_bid = :__user_id."""
+
+    payload = _shifu_meta_payload()
+    dsl = parse_dsl(payload, limit_max=DEFAULT_LIMIT_MAX, user_id="teacher-1")
+    assert dsl.caller_user_id == "teacher-1"
+
+
+def test_shifu_meta_select_forbidden_field_rejected() -> None:
+    """Author-secret fields like `llm_system_prompt` must not be selectable
+    even on the caller's own course."""
+
+    payload = _shifu_meta_payload(select=["title", "llm_system_prompt"])
+    _assert_error(payload, ERR_INVALID_COLUMN)

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -664,6 +664,7 @@ def test_bill_usage_table_rejected() -> None:
 
 
 def _generated_blocks_payload(**overrides):
+    """Build a baseline DSL payload for learn_generated_blocks tests."""
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_generated_blocks",
@@ -780,6 +781,7 @@ def test_bill_daily_creator_bid_filter_rejected() -> None:
 
 
 def _shifu_meta_payload(table_key="shifu_published_shifus", **overrides):
+    """Build a baseline DSL payload for shifu metadata-table tests."""
     base = {
         "shifu_bid": "shifu-abc",
         "table": table_key,
@@ -853,6 +855,49 @@ def test_shifu_meta_title_like_minimum_accepted() -> None:
     )
     dsl = _parse(payload)
     assert dsl.filters[0].op == "like"
+
+
+def test_shifu_meta_title_like_underscore_rejected() -> None:
+    """SQL `_` single-char wildcard would let a caller scan with `'a_%'`
+    (one literal char + a wildcard floor). The metadata contract is strict
+    prefix matching — reject any `_` regardless of position."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "a_%"}],
+    )
+    _assert_error(payload, ERR_INVALID_DSL)
+
+
+def test_shifu_meta_title_like_double_underscore_rejected() -> None:
+    """Original bypass case raised in PR #1769 review: `'__%'` passes the
+    `rstrip('%')` length check (2 chars) but is wildcard-only. Must reject."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "__%"}],
+    )
+    _assert_error(payload, ERR_INVALID_DSL)
+
+
+def test_shifu_meta_title_like_internal_percent_rejected() -> None:
+    """`'a%b'` would be 3 non-wildcard chars under naive counting, but the
+    middle `%` violates the prefix-only contract — reject."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "a%b"}],
+    )
+    _assert_error(payload, ERR_INVALID_DSL)
+
+
+def test_shifu_meta_title_like_exact_match_accepted() -> None:
+    """A `like` value without any wildcard is just an exact match;
+    accepting it preserves the "look up this exact title" use case."""
+
+    payload = _shifu_meta_payload(
+        where=[{"field": "title", "op": "like", "value": "AI"}],
+    )
+    dsl = _parse(payload)
+    assert dsl.filters[0].op == "like"
+    assert dsl.filters[0].value == "AI"
 
 
 def test_shifu_meta_limit_capped_at_50() -> None:

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -17,6 +17,7 @@ from .conftest import (
     seed_generated_block,
     seed_owned_course,
     seed_progress,
+    seed_published_shifu,
     seed_user_info,
 )
 
@@ -780,3 +781,342 @@ def test_bill_daily_split_by_usage_type(mock_request_user, test_client, app):
     rows_by_type = {row[0]: float(row[1]) for row in data["rows"]}
     assert rows_by_type[1101] == pytest.approx(8.0)
     assert rows_by_type[1102] == pytest.approx(2.0)
+
+
+def test_bill_daily_creator_bid_grouping_shows_callers_own_wallet(
+    mock_request_user, test_client, app
+):
+    """The author can now group by creator_bid to confirm which wallet is
+    being deducted for the course; shifu_bid isolation guarantees the
+    grouping only returns the caller's own bid."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_bill_daily_metric(
+            shifu_bid="shifu-a",
+            stat_date="2026-05-01",
+            creator_bid="teacher-1",
+            consumed_credits=12.0,
+        )
+        # Row for a different course owned by someone else — shifu_bid
+        # isolation must keep it out of the result.
+        seed_owned_course(shifu_bid="shifu-other", user_id="teacher-2")
+        seed_bill_daily_metric(
+            shifu_bid="shifu-other",
+            stat_date="2026-05-01",
+            creator_bid="teacher-2",
+            consumed_credits=99.0,
+            daily_usage_metric_bid="dm-other",
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "table": "bill_daily_usage_metrics",
+            "select": ["creator_bid"],
+            "aggregate": [
+                {"fn": "sum", "field": "consumed_credits", "alias": "credits"}
+            ],
+            "group_by": ["creator_bid"],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    # consumed_credits is a NUMERIC column, so SQLite returns it as a string;
+    # the public Order test (test_bill_daily_sum_credits_for_production_usage)
+    # does the same float() conversion.
+    assert len(data["rows"]) == 1
+    row = data["rows"][0]
+    assert row[0] == "teacher-1"
+    assert float(row[1]) == pytest.approx(12.0)
+
+
+# ---------------------------------------------------------------------------
+# learn_generated_blocks — status auto-filter (reroll history excluded)
+# ---------------------------------------------------------------------------
+
+
+def test_followup_count_excludes_rerolled_history(mock_request_user, test_client, app):
+    """A learner can re-roll a follow-up question; the old block flips to
+    status=0. The PDF §6 trap is "status=0 history rows must not be
+    counted as live follow-ups". sql_builder auto-injects status=1, so
+    the count should stay at 2 even with a status=0 row present."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        # Two live follow-ups
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            type=321,
+            role=2,
+            content="question 1",
+            generated_block_bid="gb-live-1",
+            status=1,
+        )
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u2",
+            type=321,
+            role=2,
+            content="question 2",
+            generated_block_bid="gb-live-2",
+            status=1,
+        )
+        # One historical (rerolled) row — must be excluded
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            type=321,
+            role=2,
+            content="rerolled",
+            generated_block_bid="gb-history-1",
+            status=0,
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "table": "learn_generated_blocks",
+            "where": [{"field": "type", "op": "=", "value": 321}],
+            "aggregate": [{"fn": "count", "alias": "asks"}],
+            "limit": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    assert data["rows"] == [[2]]
+
+
+def test_followup_count_per_lesson_by_outline(mock_request_user, test_client, app):
+    """Group by outline_item_bid answers "follow-up questions per lesson".
+    Requires both `outline_item_bid` selectable / filterable / groupable
+    AND aggregate count_distinct support — added in this round."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            type=321,
+            role=2,
+            content="q for lesson 1",
+            generated_block_bid="gb-l1-u1",
+            outline_item_bid="outline-1",
+        )
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u2",
+            type=321,
+            role=2,
+            content="q2 for lesson 1",
+            generated_block_bid="gb-l1-u2",
+            outline_item_bid="outline-1",
+        )
+        seed_generated_block(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            type=321,
+            role=2,
+            content="q for lesson 2",
+            generated_block_bid="gb-l2-u1",
+            outline_item_bid="outline-2",
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "table": "learn_generated_blocks",
+            "where": [{"field": "type", "op": "=", "value": 321}],
+            "select": ["outline_item_bid"],
+            "group_by": ["outline_item_bid"],
+            "aggregate": [
+                {"fn": "count", "alias": "asks"},
+                {"fn": "count_distinct", "field": "user_bid", "alias": "askers"},
+            ],
+            "order_by": [{"field": "asks", "dir": "desc"}],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    rows_by_lesson = {row[0]: (row[1], row[2]) for row in data["rows"]}
+    assert rows_by_lesson["outline-1"] == (2, 2)
+    assert rows_by_lesson["outline-2"] == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Shifu metadata tables — current title + creator-scoped filtering
+# ---------------------------------------------------------------------------
+
+
+def test_shifu_published_returns_current_title_excluding_history(
+    mock_request_user, test_client, app
+):
+    """Rename scenario: the same shifu_bid has historical PublishedShifu
+    rows (deleted=1) plus the current row (deleted=0). The query must
+    return only the current row — historical titles must not be presented
+    as the course's "current name" (PDF §1 + §7 rules)."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_published_shifu(
+            shifu_bid="shifu-a",
+            user_id="teacher-1",
+            title="历史标题 A",
+            deleted=1,
+        )
+        seed_published_shifu(
+            shifu_bid="shifu-a",
+            user_id="teacher-1",
+            title="历史标题 B",
+            deleted=1,
+        )
+        seed_published_shifu(
+            shifu_bid="shifu-a",
+            user_id="teacher-1",
+            title="当前标题",
+            deleted=0,
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "table": "shifu_published_shifus",
+            "select": ["title"],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    titles = [row[0] for row in data["rows"]]
+    assert titles == ["当前标题"]
+
+
+def test_shifu_published_excludes_other_creators_rows(
+    mock_request_user, test_client, app
+):
+    """Even if a co-author / shared user had view permission on the same
+    shifu_bid, the creator_scoped_column injection (created_user_bid =
+    :caller) ensures only the caller's own rows surface. Here we model
+    the simpler "two creators with the same shifu_bid title prefix" case
+    — caller can see their own row and never the other creator's."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-mine", user_id="teacher-1")
+        seed_published_shifu(
+            shifu_bid="shifu-mine",
+            user_id="teacher-1",
+            title="跟 AI 学 AI 通识",
+        )
+        # Different shifu_bid, different creator, different title:
+        seed_owned_course(shifu_bid="shifu-other", user_id="teacher-2")
+        seed_published_shifu(
+            shifu_bid="shifu-other",
+            user_id="teacher-2",
+            title="李卓:K12 AI 教育产品的一线实践",
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-mine",
+            "table": "shifu_published_shifus",
+            "select": ["title", "created_user_bid"],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    assert data["rows"] == [
+        ["跟 AI 学 AI 通识", "teacher-1"],
+    ]
+
+
+def test_shifu_meta_aggregate_rejected_at_http_layer(
+    mock_request_user, test_client, app
+):
+    """The DSL validator must reject aggregate on metadata tables before
+    SQL is built. Verifies the HTTP error code is the standard invalidDsl."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "table": "shifu_published_shifus",
+            "aggregate": [{"fn": "count", "alias": "n"}],
+            "limit": 1,
+        },
+    )
+
+    payload = response.get_json(force=True)
+    assert payload["code"] == 11002  # server.creatorAnalytics.invalidDsl
+
+
+def test_shifu_meta_title_like_searches_callers_courses(
+    mock_request_user, test_client, app
+):
+    """title `like` with trailing-% is the canonical "find my course by
+    name" path. Combined with creator_scoped filtering, the caller only
+    sees their own matches."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_owned_course(shifu_bid="shifu-b", user_id="teacher-1")
+        seed_published_shifu(
+            shifu_bid="shifu-a",
+            user_id="teacher-1",
+            title="AI 通识入门",
+        )
+        seed_published_shifu(
+            shifu_bid="shifu-b",
+            user_id="teacher-1",
+            title="AI 通识进阶",
+        )
+        # A course owned by teacher-2 with matching title — must not leak
+        seed_owned_course(shifu_bid="shifu-c", user_id="teacher-2")
+        seed_published_shifu(
+            shifu_bid="shifu-c",
+            user_id="teacher-2",
+            title="AI 通识 (其他作者)",
+        )
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",  # CLI must inject this; metadata query
+            #                       # is per-shifu in this single call,
+            #                       # broader fan-out happens client-side
+            "table": "shifu_published_shifus",
+            "where": [{"field": "title", "op": "like", "value": "AI 通识%"}],
+            "select": ["title"],
+            "limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json(force=True)["data"]
+    # Only the caller's own shifu-a row matches both the shifu_bid scope
+    # AND the title like; shifu-b has the same creator but is filtered
+    # out by shifu_bid scope; shifu-c is filtered out by both.
+    assert data["rows"] == [["AI 通识入门"]]

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -296,6 +296,7 @@ def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> Non
 
 
 def _meta_payload(table_key="shifu_published_shifus", **overrides):
+    """Build a baseline DSL payload for shifu metadata-table compile tests."""
     base = {
         "shifu_bid": "shifu-abc",
         "table": table_key,

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -16,8 +16,8 @@ from flaskr.service.creator_analytics.sql_builder import build_statement
 LIMIT_MAX = 1000
 
 
-def _compile_for(dialect, payload, dialect_name):
-    dsl = parse_dsl(payload, limit_max=LIMIT_MAX)
+def _compile_for(dialect, payload, dialect_name, user_id=""):
+    dsl = parse_dsl(payload, limit_max=LIMIT_MAX, user_id=user_id)
     stmt = build_statement(dsl, dialect_name=dialect_name)
     return str(
         stmt.compile(
@@ -27,12 +27,12 @@ def _compile_for(dialect, payload, dialect_name):
     )
 
 
-def _compile_mysql(payload):
-    return _compile_for(mysql.dialect(), payload, "mysql")
+def _compile_mysql(payload, user_id=""):
+    return _compile_for(mysql.dialect(), payload, "mysql", user_id=user_id)
 
 
-def _compile_sqlite(payload):
-    return _compile_for(sqlite.dialect(), payload, "sqlite")
+def _compile_sqlite(payload, user_id=""):
+    return _compile_for(sqlite.dialect(), payload, "sqlite", user_id=user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -244,3 +244,108 @@ def test_limit_and_offset_present() -> None:
     assert "25" in sql
     assert "OFFSET" in sql.upper()
     assert "5" in sql
+
+
+# ---------------------------------------------------------------------------
+# learn_generated_blocks status auto-filter
+# ---------------------------------------------------------------------------
+
+
+def test_generated_blocks_status_auto_injected() -> None:
+    """auto_filter_status_active=True on the spec must emit AND status = 1
+    even when the DSL has no status clause. Rerolled-history rows
+    (status=0) must never leak into a creator's follow-up count."""
+
+    sql = _compile_sqlite(
+        {
+            "shifu_bid": "shifu-abc",
+            "table": "learn_generated_blocks",
+            "where": [{"field": "type", "op": "=", "value": 321}],
+            "aggregate": [{"fn": "count", "alias": "asks"}],
+            "limit": 10,
+        }
+    )
+    assert "status = 1" in sql
+
+
+def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> None:
+    """If the caller explicitly filters status=1, the auto-injected predicate
+    is still present (idempotent — SQL would simply have two `status = 1`
+    clauses; AND-of-two-identical predicates is fine)."""
+
+    sql = _compile_sqlite(
+        {
+            "shifu_bid": "shifu-abc",
+            "table": "learn_generated_blocks",
+            "where": [
+                {"field": "type", "op": "=", "value": 321},
+                {"field": "status", "op": "=", "value": 1},
+            ],
+            "aggregate": [{"fn": "count", "alias": "asks"}],
+            "limit": 10,
+        }
+    )
+    # Both injected and explicit status=1 should appear; count them by
+    # checking SQL contains the predicate.
+    assert sql.count("status = 1") >= 1
+
+
+# ---------------------------------------------------------------------------
+# shifu metadata tables — creator_scoped_column injection + double-gate
+# ---------------------------------------------------------------------------
+
+
+def _meta_payload(table_key="shifu_published_shifus", **overrides):
+    base = {
+        "shifu_bid": "shifu-abc",
+        "table": table_key,
+        "select": ["title", "updated_at"],
+        "limit": 10,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_shifu_meta_injects_created_user_bid_predicate() -> None:
+    """Metadata tables require WHERE created_user_bid = :__user_id in
+    addition to shifu_bid scope — row ownership enforcement on top of
+    the funcs.run_dsl permission check."""
+
+    sql = _compile_sqlite(_meta_payload(), user_id="teacher-1")
+    assert "created_user_bid = 'teacher-1'" in sql
+    assert "shifu_bid = 'shifu-abc'" in sql
+    assert "deleted = 0" in sql
+
+
+def test_shifu_draft_injects_created_user_bid_predicate() -> None:
+    """Both metadata tables share the same double-gate."""
+
+    sql = _compile_sqlite(
+        _meta_payload(table_key="shifu_draft_shifus"), user_id="teacher-2"
+    )
+    assert "created_user_bid = 'teacher-2'" in sql
+
+
+def test_shifu_meta_without_caller_user_id_fails_compile() -> None:
+    """Missing caller_user_id is a hard error — sql_builder refuses rather
+    than emitting `WHERE created_user_bid = ''` which would accidentally
+    match legacy rows."""
+
+    with pytest.raises(ValueError, match="caller_user_id is required"):
+        _compile_sqlite(_meta_payload())  # user_id defaults to ""
+
+
+def test_non_meta_table_does_not_inject_created_user_bid() -> None:
+    """The created_user_bid predicate must only appear for tables that
+    opt into it via creator_scoped_column."""
+
+    sql = _compile_sqlite(
+        {
+            "shifu_bid": "shifu-abc",
+            "table": "learn_progress_records",
+            "select": ["outline_item_bid"],
+            "limit": 10,
+        },
+        user_id="teacher-1",
+    )
+    assert "created_user_bid" not in sql

--- a/src/api/tests/service/creator_analytics/test_whitelist.py
+++ b/src/api/tests/service/creator_analytics/test_whitelist.py
@@ -25,15 +25,24 @@ EXPECTED_TABLE_KEYS = {
     "bill_daily_usage_metrics",
     "shifu_user_archives",
     "user_users",
+    "shifu_published_shifus",
+    "shifu_draft_shifus",
 }
 
 # Tables whose rows are shifu-scoped (sql_builder injects WHERE shifu_bid=:sb).
 # user_users is global and gated by funcs.run_dsl permission check instead.
 SHIFU_SCOPED_TABLE_KEYS = EXPECTED_TABLE_KEYS - {"user_users"}
 
+# Course metadata tables — answer "what is this course currently called".
+# Aggregates and group_by are blocked here to prevent permission-edge probes.
+SHIFU_META_TABLE_KEYS = {"shifu_published_shifus", "shifu_draft_shifus"}
+
 # Learner-grained tables that expose user_bid — bill_daily_usage_metrics is a
-# daily summary table without user_bid.
-USER_BID_GROUPABLE_TABLE_KEYS = SHIFU_SCOPED_TABLE_KEYS - {"bill_daily_usage_metrics"}
+# daily summary table without user_bid; shifu metadata tables describe the
+# course, not learner activity.
+USER_BID_GROUPABLE_TABLE_KEYS = (
+    SHIFU_SCOPED_TABLE_KEYS - {"bill_daily_usage_metrics"} - SHIFU_META_TABLE_KEYS
+)
 
 
 def test_whitelist_covers_expected_tables() -> None:
@@ -164,3 +173,135 @@ def test_bill_usage_is_not_whitelisted() -> None:
     """Creators cannot query raw token usage; only credit aggregates are exposed."""
 
     assert "bill_usage" not in WHITELIST
+
+
+# ---------------------------------------------------------------------------
+# learn_generated_blocks — new field coverage + status auto-filter
+# ---------------------------------------------------------------------------
+
+
+def test_learn_generated_blocks_exposes_new_followup_fields() -> None:
+    """status / position / outline_item_bid are needed for follow-up pairing
+    (per the 2026-05-15 follow-up query handbook PDF §6)."""
+
+    spec = WHITELIST["learn_generated_blocks"]
+    for col in ("status", "position", "outline_item_bid"):
+        assert col in spec.selectable, (
+            f"learn_generated_blocks.{col} must be selectable"
+        )
+        assert col in spec.filterable, (
+            f"learn_generated_blocks.{col} must be filterable"
+        )
+    assert "outline_item_bid" in spec.groupable
+    assert "status" in spec.groupable
+    # position is not group-able — it is a within-row ordering index, not a
+    # dimension; grouping on it would explode the row count and is rarely
+    # what an author intends.
+    assert "position" not in spec.groupable
+    assert "outline_item_bid" in spec.aggregatable
+
+
+def test_learn_generated_blocks_auto_filters_active_status() -> None:
+    """Rerolled history rows (status=0) must be excluded from creator views.
+
+    This pairs with sql_builder which injects AND status = 1; the spec flag
+    is the source of truth for that injection.
+    """
+
+    spec = WHITELIST["learn_generated_blocks"]
+    assert spec.auto_filter_status_active is True
+
+
+@pytest.mark.parametrize(
+    "table_key",
+    sorted(EXPECTED_TABLE_KEYS - {"learn_generated_blocks"}),
+)
+def test_other_tables_do_not_auto_filter_status(table_key: str) -> None:
+    """Only learn_generated_blocks opts into status=1 auto-injection."""
+
+    spec = WHITELIST[table_key]
+    assert spec.auto_filter_status_active is False
+
+
+# ---------------------------------------------------------------------------
+# bill_daily_usage_metrics — creator_bid surface
+# ---------------------------------------------------------------------------
+
+
+def test_bill_daily_usage_metrics_exposes_creator_bid() -> None:
+    """creator_bid lets the author see which wallet the course's credits hit;
+    shifu_bid isolation already constrains the value to the caller's own bid."""
+
+    spec = WHITELIST["bill_daily_usage_metrics"]
+    assert "creator_bid" in spec.selectable
+    assert "creator_bid" in spec.groupable
+    # Deliberately NOT in filterable / aggregatable: the SQL builder already
+    # restricts rows via shifu_bid, so a creator_bid filter would be
+    # redundant; keeping it out blocks "where creator_bid = 'someone-else'"
+    # attempts even though shifu_bid isolation would still defeat them.
+    assert "creator_bid" not in spec.filterable
+    assert "creator_bid" not in spec.aggregatable
+
+
+# ---------------------------------------------------------------------------
+# shifu metadata tables — double-gate + no-aggregate side channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("table_key", sorted(SHIFU_META_TABLE_KEYS))
+def test_shifu_meta_tables_are_creator_scoped(table_key: str) -> None:
+    """Both metadata tables enforce row ownership via created_user_bid in
+    addition to the funcs.run_dsl shifu permission check."""
+
+    spec = WHITELIST[table_key]
+    assert spec.creator_scoped_column == "created_user_bid"
+    assert spec.has_shifu_bid is True  # double-gate: shifu scope + row owner
+    assert spec.has_deleted is True
+
+
+@pytest.mark.parametrize("table_key", sorted(SHIFU_META_TABLE_KEYS))
+def test_shifu_meta_tables_block_aggregate_and_group_by(table_key: str) -> None:
+    """count_distinct(shifu_bid) etc. would leak the size of the caller's
+    owned set; keep these tables strictly row-lookup only."""
+
+    spec = WHITELIST[table_key]
+    assert spec.aggregatable == {}
+    assert spec.groupable == frozenset()
+
+
+@pytest.mark.parametrize("table_key", sorted(SHIFU_META_TABLE_KEYS))
+def test_shifu_meta_tables_minimum_select_surface(table_key: str) -> None:
+    """Author-secret prompt fields (llm_system_prompt, ask_*) must never be
+    selectable — they are creator IP and stay out of the analytics surface
+    even for the owner. shifu_bid is also intentionally not selectable here
+    (covered by test_shifu_bid_and_deleted_are_never_user_addressable)."""
+
+    spec = WHITELIST[table_key]
+    assert spec.selectable == frozenset(
+        {"title", "created_user_bid", "created_at", "updated_at"}
+    )
+    for forbidden in (
+        "llm",
+        "llm_system_prompt",
+        "ask_llm",
+        "ask_llm_system_prompt",
+        "ask_provider_config",
+        "keywords",
+        "description",
+        "avatar_res_bid",
+        "price",
+    ):
+        assert forbidden not in spec.selectable
+        assert forbidden not in spec.filterable
+
+
+@pytest.mark.parametrize(
+    "table_key",
+    sorted(EXPECTED_TABLE_KEYS - SHIFU_META_TABLE_KEYS),
+)
+def test_other_tables_have_no_creator_scoped_column(table_key: str) -> None:
+    """Only the metadata tables opt into the created_user_bid auto-injection;
+    every other table goes through the standard shifu_bid scope path."""
+
+    spec = WHITELIST[table_key]
+    assert spec.creator_scoped_column is None


### PR DESCRIPTION
## Summary

- Add `shifu_published_shifus` / `shifu_draft_shifus` to the creator-analytics whitelist so authors can resolve current vs. historical course titles via DSL — PDF §1 / §7 root-cause for "查不到 / 查错".
- Extend `learn_generated_blocks` with `status` / `position` / `outline_item_bid` and auto-inject `status = 1` so reroll history never inflates follow-up counts (PDF §6).
- Expose `bill_daily_usage_metrics.creator_bid` so authors can confirm which wallet absorbed a course's credit deduction.
- Tighten DSL plumbing: thread `caller_user_id` through `parse_dsl` → `sql_builder`; metadata tables hard-cap `limit = 50`, reject `aggregate` / `group_by`, and (after the in-review fixup) require `title like` patterns to be strict prefix matches with ≥ 2 literal characters — no `_`, no internal `%`.
- Skill repository (`/Users/aichy/work/aishifu/skills/skills/ai-shifu-course-creator/`): tables / recipes / dsl / overview / privacy docs + main SKILL.md updated; Recipe 22 rewritten for four-key follow-up pairing; new Course Metadata recipes 0a/0b/0c and `find-title` CLI subcommand.


## Out of scope (deliberate non-changes)

- `credit_ledger_entries` / `credit_usage_rates` remain unavailable to creators (cross-creator surface; full-DB tool only).
- `bill_usage` stays off the whitelist (token vs. credit boundary set in PR #1764 / earlier same-day work).
- Metadata tables remain owner-only; co-authors with view permission still cannot read title / rename history.
- Author-secret prompt fields (`llm_system_prompt`, `ask_*`, `keywords`, `description`, etc.) are never selectable through the analytics surface, even for the owner.

## Test plan

- [x] `conda activate aishifu && cd src/api && pytest tests/service/creator_analytics/ -q` → **245 passed** (176 baseline + 65 new + 4 added in AI-review fixup commit).
- [x] `python3 skills/skills/ai-shifu-course-creator/scripts/shifu-cli.py --help` and `find-title --help` parse cleanly.
- [x] Skill repo residue scan `grep -RnE "8 tables |8 张|bill_usage[^_]|token cost|raw token"` → 0 hits.
- [ ] Manual: run `find-title <keyword>` on a real account that has a renamed course, confirm `(same)` / `(draft only)` / divergence column behaves as documented.

## Review fix-up (commit 7b97e4c8)

CodeRabbit and Gemini independently flagged that the previous `rstrip("%")` floor on `title like` did not stop SQL `_` single-char wildcards or non-trailing `%`. The fix-up commit replaces it with strict prefix matching (reject any `_`, reject `%` anywhere except the final position, then enforce the existing 2-char literal floor) and adds 4 targeted tests covering the bypass cases plus one exact-match acceptance.