### PR TITLE
feat(creator_analytics): add /credit-detail endpoint for joined credit consumption

### DIFF
--- a/docs/generated/architecture-boundary-baseline.json
+++ b/docs/generated/architecture-boundary-baseline.json
@@ -7,7 +7,7 @@
       "source": "flaskr/service/billing/auth_hooks.py",
       "target": "flaskr.service.user.post_auth",
       "message": "flaskr/service/billing/auth_hooks.py imports cross-service module flaskr.service.user.post_auth outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/checkout.py|flaskr.service.order.payment_channel_resolution",
@@ -15,7 +15,7 @@
       "source": "flaskr/service/billing/checkout.py",
       "target": "flaskr.service.order.payment_channel_resolution",
       "message": "flaskr/service/billing/checkout.py imports cross-service module flaskr.service.order.payment_channel_resolution outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/checkout.py|flaskr.service.order.payment_providers",
@@ -23,7 +23,7 @@
       "source": "flaskr/service/billing/checkout.py",
       "target": "flaskr.service.order.payment_providers",
       "message": "flaskr/service/billing/checkout.py imports cross-service module flaskr.service.order.payment_providers outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/checkout.py|flaskr.service.order.raw_snapshots",
@@ -31,7 +31,7 @@
       "source": "flaskr/service/billing/checkout.py",
       "target": "flaskr.service.order.raw_snapshots",
       "message": "flaskr/service/billing/checkout.py imports cross-service module flaskr.service.order.raw_snapshots outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/checkout.py|flaskr.service.user.repository",
@@ -39,7 +39,7 @@
       "source": "flaskr/service/billing/checkout.py",
       "target": "flaskr.service.user.repository",
       "message": "flaskr/service/billing/checkout.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/cli.py|flaskr.service.user.repository",
@@ -47,7 +47,7 @@
       "source": "flaskr/service/billing/cli.py",
       "target": "flaskr.service.user.repository",
       "message": "flaskr/service/billing/cli.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/notifications.py|flaskr.service.user.repository",
@@ -55,7 +55,7 @@
       "source": "flaskr/service/billing/notifications.py",
       "target": "flaskr.service.user.repository",
       "message": "flaskr/service/billing/notifications.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/ownership.py|flaskr.service.shifu.utils",
@@ -63,7 +63,7 @@
       "source": "flaskr/service/billing/ownership.py",
       "target": "flaskr.service.shifu.utils",
       "message": "flaskr/service/billing/ownership.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/subscriptions.py|flaskr.service.order.payment_providers",
@@ -71,7 +71,7 @@
       "source": "flaskr/service/billing/subscriptions.py",
       "target": "flaskr.service.order.payment_providers",
       "message": "flaskr/service/billing/subscriptions.py imports cross-service module flaskr.service.order.payment_providers outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/trials.py|flaskr.service.user.repository",
@@ -79,7 +79,7 @@
       "source": "flaskr/service/billing/trials.py",
       "target": "flaskr.service.user.repository",
       "message": "flaskr/service/billing/trials.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/billing/webhooks.py|flaskr.service.order.payment_providers",
@@ -87,855 +87,15 @@
       "source": "flaskr/service/billing/webhooks.py",
       "target": "flaskr.service.order.payment_providers",
       "message": "flaskr/service/billing/webhooks.py imports cross-service module flaskr.service.order.payment_providers outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
-      "key": "backend.cross_service_import|flaskr/service/dashboard/funcs.py|flaskr.service.learn.const",
+      "key": "backend.cross_service_import|flaskr/service/creator_analytics/credit_detail.py|flaskr.service.shifu.permissions",
       "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/dashboard/funcs.py",
-      "target": "flaskr.service.learn.const",
-      "message": "flaskr/service/dashboard/funcs.py imports cross-service module flaskr.service.learn.const outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/dashboard/funcs.py|flaskr.service.shifu.demo_courses",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/dashboard/funcs.py",
-      "target": "flaskr.service.shifu.demo_courses",
-      "message": "flaskr/service/dashboard/funcs.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/feedback/funs.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/feedback/funs.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/feedback/funs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/coze_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/coze_adapter.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/coze_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/dify_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/dify_adapter.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/dify_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/llm_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/llm_adapter.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/llm_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/registry.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/registry.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/registry.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.check_risk",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/check_text.py",
-      "target": "flaskr.service.check_risk",
-      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.check_risk outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/check_text.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/check_text.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.constants",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.profile.constants",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.constants outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.profile.funcs",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.profile_manage",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.profile.profile_manage",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.profile_manage outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.shifu_history_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.shifu.shifu_history_manager",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.shifu_struct_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.shifu.shifu_struct_manager",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.struct_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.shifu.struct_utils",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.tts.streaming_tts",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.tts.streaming_tts",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.tts.streaming_tts outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.tts.validation",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.tts.validation",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.user.exceptions",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.user.exceptions",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.user.exceptions outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/context_v2.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/handle_input_ask.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.ask_provider_registry",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/handle_input_ask.py",
-      "target": "flaskr.service.shifu.ask_provider_registry",
-      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.ask_provider_registry outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/handle_input_ask.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.shifu_struct_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/handle_input_ask.py",
-      "target": "flaskr.service.shifu.shifu_struct_manager",
-      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/handle_input_ask.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.shifu_history_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.shifu.shifu_history_manager",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.struct_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.shifu.struct_utils",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.shifu.utils",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.audio_record_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.audio_record_utils",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.audio_record_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.audio_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.audio_utils",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.audio_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.pipeline",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.pipeline",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.subtitle_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.subtitle_utils",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.tts_handler",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.tts_handler",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.tts_handler outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.validation",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/learn_funcs.py",
-      "target": "flaskr.service.tts.validation",
-      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/legacy_record_builder.py|flaskr.service.tts.subtitle_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/legacy_record_builder.py",
-      "target": "flaskr.service.tts.subtitle_utils",
-      "message": "flaskr/service/learn/legacy_record_builder.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_history.py|flaskr.service.tts.subtitle_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/listen_element_history.py",
-      "target": "flaskr.service.tts.subtitle_utils",
-      "message": "flaskr/service/learn/listen_element_history.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_legacy.py|flaskr.service.tts.pipeline",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/listen_element_legacy.py",
-      "target": "flaskr.service.tts.pipeline",
-      "message": "flaskr/service/learn/listen_element_legacy.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_payloads.py|flaskr.service.tts.subtitle_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/listen_element_payloads.py",
-      "target": "flaskr.service.tts.subtitle_utils",
-      "message": "flaskr/service/learn/listen_element_payloads.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_rows.py|flaskr.service.tts.subtitle_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/listen_element_rows.py",
-      "target": "flaskr.service.tts.subtitle_utils",
-      "message": "flaskr/service/learn/listen_element_rows.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.billing.admission",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/routes.py",
-      "target": "flaskr.service.billing.admission",
-      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.billing.admission outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.shifu.demo_courses",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/routes.py",
-      "target": "flaskr.service.shifu.demo_courses",
-      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.shifu.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/routes.py",
-      "target": "flaskr.service.shifu.utils",
-      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.shifu.shifu_history_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/runscript_v2.py",
-      "target": "flaskr.service.shifu.shifu_history_manager",
-      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.shifu.shifu_struct_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/runscript_v2.py",
-      "target": "flaskr.service.shifu.shifu_struct_manager",
-      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/runscript_v2.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.profile.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/utils_v2.py",
-      "target": "flaskr.service.profile.funcs",
-      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/utils_v2.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.shifu_struct_manager",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/utils_v2.py",
-      "target": "flaskr.service.shifu.shifu_struct_manager",
-      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.struct_utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/learn/utils_v2.py",
-      "target": "flaskr.service.shifu.struct_utils",
-      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/metering/recorder.py|flaskr.service.shifu.demo_courses",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/metering/recorder.py",
-      "target": "flaskr.service.shifu.demo_courses",
-      "message": "flaskr/service/metering/recorder.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.shifu.shifu_draft_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/admin.py",
-      "target": "flaskr.service.shifu.shifu_draft_funcs",
-      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.shifu.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/admin.py",
-      "target": "flaskr.service.shifu.utils",
-      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/admin.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.user.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/admin.py",
-      "target": "flaskr.service.user.utils",
-      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/coupon_funcs.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/coupon_funcs.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/order/coupon_funcs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.billing.webhooks",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.billing.webhooks",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.billing.webhooks outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.learn.learn_dtos",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.learn.learn_dtos",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.learn.learn_funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.learn.learn_funcs",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.learn.learn_funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.promo.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.promo.funcs",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.promo.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.shifu.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.shifu.utils",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/funs.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/open_api.py|flaskr.service.shifu.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/open_api.py",
-      "target": "flaskr.service.shifu.utils",
-      "message": "flaskr/service/order/open_api.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/order/open_api.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/order/open_api.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/order/open_api.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/profile/funcs.py|flaskr.service.check_risk.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/profile/funcs.py",
-      "target": "flaskr.service.check_risk.funcs",
-      "message": "flaskr/service/profile/funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/profile/funcs.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/profile/funcs.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/profile/funcs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.bucket_categories",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.billing.bucket_categories",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.bucket_categories outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.primitives",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.billing.primitives",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.primitives outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.queries",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.billing.queries",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.queries outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.wallets",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.billing.wallets",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.wallets outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.const",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.learn.const",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.const outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.learn_dtos",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.learn.learn_dtos",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.listen_element_payloads",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.learn.listen_element_payloads",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.listen_element_payloads outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.user.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/admin.py",
-      "target": "flaskr.service.user.utils",
-      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.billing.admission",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.billing.admission",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.billing.admission outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.ask_provider_adapters",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.learn.ask_provider_adapters",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.ask_provider_adapters outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.ask_provider_langfuse",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.learn.ask_provider_langfuse",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.ask_provider_langfuse outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.langfuse_naming",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.learn.langfuse_naming",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.langfuse_naming outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.common",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.user.common",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.common outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.repository",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.user.repository",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.utils",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/route.py",
-      "target": "flaskr.service.user.utils",
-      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_draft_funcs.py|flaskr.service.check_risk.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_draft_funcs.py",
-      "target": "flaskr.service.check_risk.funcs",
-      "message": "flaskr/service/shifu/shifu_draft_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_draft_funcs.py|flaskr.service.tts.validation",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_draft_funcs.py",
-      "target": "flaskr.service.tts.validation",
-      "message": "flaskr/service/shifu/shifu_draft_funcs.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_import_export_funcs.py|flaskr.service.check_risk.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_import_export_funcs.py",
-      "target": "flaskr.service.check_risk.funcs",
-      "message": "flaskr/service/shifu/shifu_import_export_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_mdflow_funcs.py|flaskr.service.check_risk.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_mdflow_funcs.py",
-      "target": "flaskr.service.check_risk.funcs",
-      "message": "flaskr/service/shifu/shifu_mdflow_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_mdflow_funcs.py|flaskr.service.profile.profile_manage",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_mdflow_funcs.py",
-      "target": "flaskr.service.profile.profile_manage",
-      "message": "flaskr/service/shifu/shifu_mdflow_funcs.py imports cross-service module flaskr.service.profile.profile_manage outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_outline_funcs.py|flaskr.service.check_risk.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_outline_funcs.py",
-      "target": "flaskr.service.check_risk.funcs",
-      "message": "flaskr/service/shifu/shifu_outline_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_publish_funcs.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/shifu_publish_funcs.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/shifu/shifu_publish_funcs.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/tts_preview.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/tts_preview.py",
-      "target": "flaskr.service.tts",
-      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts.pipeline",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/tts_preview.py",
-      "target": "flaskr.service.tts.pipeline",
-      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts.validation",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/shifu/tts_preview.py",
-      "target": "flaskr.service.tts.validation",
-      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/tts/pipeline.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/tts/pipeline.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/tts/pipeline.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.learn.learn_dtos",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/tts/streaming_tts.py",
-      "target": "flaskr.service.learn.learn_dtos",
-      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.learn.listen_slide_builder",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/tts/streaming_tts.py",
-      "target": "flaskr.service.learn.listen_slide_builder",
-      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.learn.listen_slide_builder outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/tts/streaming_tts.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/tts/tts_usage_recorder.py|flaskr.service.metering",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/tts/tts_usage_recorder.py",
-      "target": "flaskr.service.metering",
-      "message": "flaskr/service/tts/tts_usage_recorder.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/user/common.py|flaskr.service.profile.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/user/common.py",
-      "target": "flaskr.service.profile.funcs",
-      "message": "flaskr/service/user/common.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/user/email_flow.py|flaskr.service.profile.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/user/email_flow.py",
-      "target": "flaskr.service.profile.funcs",
-      "message": "flaskr/service/user/email_flow.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
-    },
-    {
-      "key": "backend.cross_service_import|flaskr/service/user/phone_flow.py|flaskr.service.profile.funcs",
-      "rule_id": "backend.cross_service_import",
-      "source": "flaskr/service/user/phone_flow.py",
-      "target": "flaskr.service.profile.funcs",
-      "message": "flaskr/service/user/phone_flow.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
-      "remediation": "Prefer shared common/config utilities, stable DTO/model/const modules, or a deliberate service API boundary."
+      "source": "flaskr/service/creator_analytics/credit_detail.py",
+      "target": "flaskr.service.shifu.permissions",
+      "message": "flaskr/service/creator_analytics/credit_detail.py imports cross-service module flaskr.service.shifu.permissions outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     },
     {
       "key": "backend.cross_service_import|flaskr/service/creator_analytics/funcs.py|flaskr.service.shifu.permissions",
@@ -943,6 +103,854 @@
       "source": "flaskr/service/creator_analytics/funcs.py",
       "target": "flaskr.service.shifu.permissions",
       "message": "flaskr/service/creator_analytics/funcs.py imports cross-service module flaskr.service.shifu.permissions outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/dashboard/funcs.py|flaskr.service.learn.const",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/dashboard/funcs.py",
+      "target": "flaskr.service.learn.const",
+      "message": "flaskr/service/dashboard/funcs.py imports cross-service module flaskr.service.learn.const outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/dashboard/funcs.py|flaskr.service.shifu.demo_courses",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/dashboard/funcs.py",
+      "target": "flaskr.service.shifu.demo_courses",
+      "message": "flaskr/service/dashboard/funcs.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/feedback/funs.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/feedback/funs.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/feedback/funs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/coze_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/coze_adapter.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/coze_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/dify_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/dify_adapter.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/dify_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/llm_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/llm_adapter.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/llm_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/registry.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/registry.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/registry.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.check_risk",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/check_text.py",
+      "target": "flaskr.service.check_risk",
+      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.check_risk outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/check_text.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/check_text.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/check_text.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/learn/check_text.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.constants",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.profile.constants",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.constants outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.profile.funcs",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.profile.profile_manage",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.profile.profile_manage",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.profile.profile_manage outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.shifu_history_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.shifu.shifu_history_manager",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.shifu_struct_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.shifu.shifu_struct_manager",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.shifu.struct_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.shifu.struct_utils",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.tts.streaming_tts",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.tts.streaming_tts",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.tts.streaming_tts outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.tts.validation",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.tts.validation",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.user.exceptions",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.user.exceptions",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.user.exceptions outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/context_v2.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/context_v2.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/learn/context_v2.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/handle_input_ask.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.ask_provider_registry",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/handle_input_ask.py",
+      "target": "flaskr.service.shifu.ask_provider_registry",
+      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.ask_provider_registry outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/handle_input_ask.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.shifu.shifu_struct_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/handle_input_ask.py",
+      "target": "flaskr.service.shifu.shifu_struct_manager",
+      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/handle_input_ask.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/handle_input_ask.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/learn/handle_input_ask.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.shifu_history_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.shifu.shifu_history_manager",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.struct_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.shifu.struct_utils",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.shifu.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.shifu.utils",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.audio_record_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.audio_record_utils",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.audio_record_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.audio_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.audio_utils",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.audio_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.pipeline",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.pipeline",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.subtitle_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.subtitle_utils",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.tts_handler",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.tts_handler",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.tts_handler outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/learn_funcs.py|flaskr.service.tts.validation",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/learn_funcs.py",
+      "target": "flaskr.service.tts.validation",
+      "message": "flaskr/service/learn/learn_funcs.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/legacy_record_builder.py|flaskr.service.tts.subtitle_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/legacy_record_builder.py",
+      "target": "flaskr.service.tts.subtitle_utils",
+      "message": "flaskr/service/learn/legacy_record_builder.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_history.py|flaskr.service.tts.subtitle_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/listen_element_history.py",
+      "target": "flaskr.service.tts.subtitle_utils",
+      "message": "flaskr/service/learn/listen_element_history.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_legacy.py|flaskr.service.tts.pipeline",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/listen_element_legacy.py",
+      "target": "flaskr.service.tts.pipeline",
+      "message": "flaskr/service/learn/listen_element_legacy.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_payloads.py|flaskr.service.tts.subtitle_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/listen_element_payloads.py",
+      "target": "flaskr.service.tts.subtitle_utils",
+      "message": "flaskr/service/learn/listen_element_payloads.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/listen_element_rows.py|flaskr.service.tts.subtitle_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/listen_element_rows.py",
+      "target": "flaskr.service.tts.subtitle_utils",
+      "message": "flaskr/service/learn/listen_element_rows.py imports cross-service module flaskr.service.tts.subtitle_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.billing.admission",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/routes.py",
+      "target": "flaskr.service.billing.admission",
+      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.billing.admission outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.shifu.demo_courses",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/routes.py",
+      "target": "flaskr.service.shifu.demo_courses",
+      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/routes.py|flaskr.service.shifu.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/routes.py",
+      "target": "flaskr.service.shifu.utils",
+      "message": "flaskr/service/learn/routes.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.shifu.shifu_history_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/runscript_v2.py",
+      "target": "flaskr.service.shifu.shifu_history_manager",
+      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.shifu.shifu_history_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.shifu.shifu_struct_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/runscript_v2.py",
+      "target": "flaskr.service.shifu.shifu_struct_manager",
+      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/runscript_v2.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/runscript_v2.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/learn/runscript_v2.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.profile.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/utils_v2.py",
+      "target": "flaskr.service.profile.funcs",
+      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/utils_v2.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.shifu_struct_manager",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/utils_v2.py",
+      "target": "flaskr.service.shifu.shifu_struct_manager",
+      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.shifu_struct_manager outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/learn/utils_v2.py|flaskr.service.shifu.struct_utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/learn/utils_v2.py",
+      "target": "flaskr.service.shifu.struct_utils",
+      "message": "flaskr/service/learn/utils_v2.py imports cross-service module flaskr.service.shifu.struct_utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/metering/recorder.py|flaskr.service.shifu.demo_courses",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/metering/recorder.py",
+      "target": "flaskr.service.shifu.demo_courses",
+      "message": "flaskr/service/metering/recorder.py imports cross-service module flaskr.service.shifu.demo_courses outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.shifu.shifu_draft_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/admin.py",
+      "target": "flaskr.service.shifu.shifu_draft_funcs",
+      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.shifu.shifu_draft_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.shifu.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/admin.py",
+      "target": "flaskr.service.shifu.utils",
+      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/admin.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/admin.py|flaskr.service.user.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/admin.py",
+      "target": "flaskr.service.user.utils",
+      "message": "flaskr/service/order/admin.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/coupon_funcs.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/coupon_funcs.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/order/coupon_funcs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.billing.webhooks",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.billing.webhooks",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.billing.webhooks outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.learn.learn_dtos",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.learn.learn_dtos",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.learn.learn_funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.learn.learn_funcs",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.learn.learn_funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.promo.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.promo.funcs",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.promo.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.shifu.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.shifu.utils",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/funs.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/funs.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/order/funs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/open_api.py|flaskr.service.shifu.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/open_api.py",
+      "target": "flaskr.service.shifu.utils",
+      "message": "flaskr/service/order/open_api.py imports cross-service module flaskr.service.shifu.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/order/open_api.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/order/open_api.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/order/open_api.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/profile/funcs.py|flaskr.service.check_risk.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/profile/funcs.py",
+      "target": "flaskr.service.check_risk.funcs",
+      "message": "flaskr/service/profile/funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/profile/funcs.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/profile/funcs.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/profile/funcs.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.bucket_categories",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.billing.bucket_categories",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.bucket_categories outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.primitives",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.billing.primitives",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.primitives outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.queries",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.billing.queries",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.queries outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.billing.wallets",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.billing.wallets",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.billing.wallets outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.const",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.learn.const",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.const outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.learn_dtos",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.learn.learn_dtos",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.learn.listen_element_payloads",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.learn.listen_element_payloads",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.learn.listen_element_payloads outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/admin.py|flaskr.service.user.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/admin.py",
+      "target": "flaskr.service.user.utils",
+      "message": "flaskr/service/shifu/admin.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.billing.admission",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.billing.admission",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.billing.admission outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.ask_provider_adapters",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.learn.ask_provider_adapters",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.ask_provider_adapters outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.ask_provider_langfuse",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.learn.ask_provider_langfuse",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.ask_provider_langfuse outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.learn.langfuse_naming",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.learn.langfuse_naming",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.learn.langfuse_naming outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.common",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.user.common",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.common outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.repository",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.user.repository",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.repository outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/route.py|flaskr.service.user.utils",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/route.py",
+      "target": "flaskr.service.user.utils",
+      "message": "flaskr/service/shifu/route.py imports cross-service module flaskr.service.user.utils outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_draft_funcs.py|flaskr.service.check_risk.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_draft_funcs.py",
+      "target": "flaskr.service.check_risk.funcs",
+      "message": "flaskr/service/shifu/shifu_draft_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_draft_funcs.py|flaskr.service.tts.validation",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_draft_funcs.py",
+      "target": "flaskr.service.tts.validation",
+      "message": "flaskr/service/shifu/shifu_draft_funcs.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_import_export_funcs.py|flaskr.service.check_risk.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_import_export_funcs.py",
+      "target": "flaskr.service.check_risk.funcs",
+      "message": "flaskr/service/shifu/shifu_import_export_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_mdflow_funcs.py|flaskr.service.check_risk.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_mdflow_funcs.py",
+      "target": "flaskr.service.check_risk.funcs",
+      "message": "flaskr/service/shifu/shifu_mdflow_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_mdflow_funcs.py|flaskr.service.profile.profile_manage",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_mdflow_funcs.py",
+      "target": "flaskr.service.profile.profile_manage",
+      "message": "flaskr/service/shifu/shifu_mdflow_funcs.py imports cross-service module flaskr.service.profile.profile_manage outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_outline_funcs.py|flaskr.service.check_risk.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_outline_funcs.py",
+      "target": "flaskr.service.check_risk.funcs",
+      "message": "flaskr/service/shifu/shifu_outline_funcs.py imports cross-service module flaskr.service.check_risk.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/shifu_publish_funcs.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/shifu_publish_funcs.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/shifu/shifu_publish_funcs.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/tts_preview.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/tts_preview.py",
+      "target": "flaskr.service.tts",
+      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts.pipeline",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/tts_preview.py",
+      "target": "flaskr.service.tts.pipeline",
+      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts.pipeline outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/shifu/tts_preview.py|flaskr.service.tts.validation",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/shifu/tts_preview.py",
+      "target": "flaskr.service.tts.validation",
+      "message": "flaskr/service/shifu/tts_preview.py imports cross-service module flaskr.service.tts.validation outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/tts/pipeline.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/tts/pipeline.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/tts/pipeline.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.learn.learn_dtos",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/tts/streaming_tts.py",
+      "target": "flaskr.service.learn.learn_dtos",
+      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.learn.learn_dtos outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.learn.listen_slide_builder",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/tts/streaming_tts.py",
+      "target": "flaskr.service.learn.listen_slide_builder",
+      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.learn.listen_slide_builder outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/tts/streaming_tts.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/tts/streaming_tts.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/tts/streaming_tts.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/tts/tts_usage_recorder.py|flaskr.service.metering",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/tts/tts_usage_recorder.py",
+      "target": "flaskr.service.metering",
+      "message": "flaskr/service/tts/tts_usage_recorder.py imports cross-service module flaskr.service.metering outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/user/common.py|flaskr.service.profile.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/user/common.py",
+      "target": "flaskr.service.profile.funcs",
+      "message": "flaskr/service/user/common.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/user/email_flow.py|flaskr.service.profile.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/user/email_flow.py",
+      "target": "flaskr.service.profile.funcs",
+      "message": "flaskr/service/user/email_flow.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
+      "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
+    },
+    {
+      "key": "backend.cross_service_import|flaskr/service/user/phone_flow.py|flaskr.service.profile.funcs",
+      "rule_id": "backend.cross_service_import",
+      "source": "flaskr/service/user/phone_flow.py",
+      "target": "flaskr.service.profile.funcs",
+      "message": "flaskr/service/user/phone_flow.py imports cross-service module flaskr.service.profile.funcs outside the shared/common stable entry points.",
       "remediation": "Prefer shared common/config utilities, stable API/DTO/model/const modules, or a deliberate service boundary."
     }
   ]

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -14,8 +14,8 @@ This generated report summarizes the repository harness control plane.
 
 ## Boundary Baseline
 
-- Baseline entries: `118`
-- `backend.cross_service_import`: `118`
+- Baseline entries: `119`
+- `backend.cross_service_import`: `119`
 
 ## Critical Assets
 

--- a/src/api/flaskr/route/creator_analytics.py
+++ b/src/api/flaskr/route/creator_analytics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from flask import Flask, request
 
 from flaskr.route.common import make_common_response
+from flaskr.service.creator_analytics.credit_detail import run as run_credit_detail
 from flaskr.service.creator_analytics.funcs import run_dsl
 
 
@@ -84,6 +85,84 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
         user_id = request.user.user_id
         payload = request.get_json(silent=True) or {}
         result = run_dsl(app, user_id, payload)
+        return make_common_response(result)
+
+    @app.route(path_prefix + "/credit-detail", methods=["POST"])
+    def creator_analytics_credit_detail():
+        """
+        Fetch joined credit consumption detail for one shifu.
+
+        Server-side joins ``bill_usage`` and ``credit_ledger_entries`` on
+        ``source_bid = usage_bid AND source_type = USAGE``, then returns
+        a paginated row list together with a summary block (total records,
+        total credits, distinct users / progress records, wallet creator,
+        time range). The DSL surface is deliberately untouched —
+        ``credit_ledger_entries`` is not in the whitelist; this endpoint is
+        the only way creators can read real credit-deduction amounts until
+        the daily aggregation cron is enabled and
+        ``bill_daily_usage_metrics`` carries data again.
+        ---
+        tags:
+            - creator-analytics
+        parameters:
+            - in: body
+              name: body
+              required: true
+              schema:
+                type: object
+                properties:
+                    shifu_bid:
+                        type: string
+                        description: Course id the caller must have view permission on.
+                    start_date:
+                        type: string
+                        description: Optional ISO date (YYYY-MM-DD). Inclusive lower bound.
+                    end_date:
+                        type: string
+                        description: Optional ISO date (YYYY-MM-DD). Inclusive upper bound.
+                    usage_scene:
+                        type: array
+                        items:
+                            type: integer
+                        description: Optional list, subset of [1201, 1202, 1203].
+                    usage_type:
+                        type: array
+                        items:
+                            type: integer
+                        description: Optional list, subset of [1101, 1102].
+                    limit:
+                        type: integer
+                    offset:
+                        type: integer
+        responses:
+            200:
+                description: Joined credit consumption detail.
+                content:
+                    application/json:
+                        schema:
+                            properties:
+                                code:
+                                    type: integer
+                                message:
+                                    type: string
+                                data:
+                                    type: object
+                                    properties:
+                                        summary:
+                                            type: object
+                                        rows:
+                                            type: array
+                                            items:
+                                                type: object
+                                        limit:
+                                            type: integer
+                                        offset:
+                                            type: integer
+        """
+
+        user_id = request.user.user_id
+        payload = request.get_json(silent=True) or {}
+        result = run_credit_detail(app, user_id, payload)
         return make_common_response(result)
 
     return app

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -1,0 +1,453 @@
+"""Credit-detail endpoint — server-side join of bill_usage × credit_ledger_entries.
+
+The DSL path (``funcs.run_dsl``) intentionally does not expose
+``credit_ledger_entries`` and (since 2026-05-15) does not expose
+``bill_usage`` either. The motivation was that ``bill_daily_usage_metrics``
+would carry an aggregated ``consumed_credits`` figure that creators could
+query directly. In practice that table is empty in production because the
+daily aggregation Celery beat schedule never registered the
+``billing.aggregate_daily_usage_metrics`` task (see
+``flaskr.common.celery_app._build_billing_beat_schedule``), so creators have
+no way to see actual credit consumption through the DSL.
+
+This module fills that gap with a single purpose-built endpoint. It joins
+``bill_usage`` to ``credit_ledger_entries`` on
+``source_bid = usage_bid AND source_type = USAGE`` and returns one row per
+real credit deduction tied to the requested shifu. The DSL surface is
+left untouched — ``credit_ledger_entries`` still does not appear in the
+whitelist.
+
+Security model:
+
+* Permission check uses :func:`get_user_shifu_permissions` exactly like the
+  DSL path; callers must hold ``"view"`` on the requested ``shifu_bid``.
+* The join is anchored on ``bill_usage.shifu_bid``, so rows for other
+  courses cannot leak even though ``credit_ledger_entries`` itself has no
+  ``shifu_bid`` column.
+* ``source_type = CREDIT_SOURCE_TYPE_USAGE`` is asserted as a join condition
+  to keep subscription / top-up / gift / refund / manual adjustments out of
+  the result — those are wallet-level ledger entries unrelated to the
+  course's runtime spend.
+* The response exposes only the fields creators need (``usage_bid``,
+  ``created_at``, ``user_bid``, ``progress_record_bid``, ``outline_item_bid``,
+  ``usage_type``, ``usage_scene``, ``provider``, ``model``, ``credits``,
+  ``wallet_creator_bid``). Internal ledger fields (``wallet_bid``,
+  ``wallet_bucket_bid``, ``idempotency_key``, ``balance_after``,
+  ``metadata_json``) are not selected.
+* ``amount`` is stored as a negative number for deductions; the API returns
+  ``ABS(amount)`` so creators see a positive credit-consumption figure.
+
+A separate aggregate query computes the summary (total records, total
+credits, distinct users / progress records, wallet creator id, time range)
+over the full filtered set — independent of the pagination on the row
+result so the summary is stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from datetime import date, datetime
+from flask import Flask
+from sqlalchemy import and_, bindparam, func, select
+from sqlalchemy.sql import Select
+
+from flaskr.service.billing.consts import CREDIT_SOURCE_TYPE_USAGE
+from flaskr.service.billing.models import CreditLedgerEntry
+from flaskr.service.common.models import AppException, ERROR_CODE
+from flaskr.service.metering.models import BillUsageRecord
+from flaskr.service.shifu.permissions import get_user_shifu_permissions
+from flaskr.i18n import _
+
+from .engine import get_analytics_engine
+
+
+# Reuse the DSL-path error names so the HTTP wrapper maps them consistently
+# (the error name → HTTP code mapping lives in error_codes.json).
+ERR_NO_PERMISSION = "server.creatorAnalytics.noPermission"
+ERR_INVALID_DSL = "server.creatorAnalytics.invalidDsl"
+ERR_INVALID_LIMIT = "server.creatorAnalytics.invalidLimit"
+
+
+# Allowed enum values for the optional filters. Anything outside these sets
+# is rejected with ERR_INVALID_DSL so the caller learns about typos quickly
+# rather than getting a silently empty result set.
+_ALLOWED_USAGE_SCENES = frozenset({1201, 1202, 1203})
+_ALLOWED_USAGE_TYPES = frozenset({1101, 1102})
+
+_DEFAULT_LIMIT = 100
+
+
+def run(app: Flask, user_id: str, payload: Any) -> Dict[str, Any]:
+    """Execute the credit-detail query for ``user_id``.
+
+    Validates the payload, enforces the per-shifu permission check, then
+    issues two SQL statements against the analytics engine: one paginated
+    detail query and one aggregate summary query.
+    """
+
+    limit_max = int(app.config.get("ANALYTICS_QUERY_LIMIT_MAX") or 1000)
+
+    params = _parse_payload(payload, limit_max=limit_max)
+
+    permissions = get_user_shifu_permissions(app, user_id)
+    allowed_perms = permissions.get(params.shifu_bid, set())
+    if "view" not in allowed_perms:
+        _raise(ERR_NO_PERMISSION)
+
+    detail_stmt = _build_detail_statement(params)
+    summary_stmt = _build_summary_statement(params)
+
+    engine = get_analytics_engine(app)
+    with engine.connect() as connection:
+        detail_result = connection.execute(detail_stmt)
+        detail_columns = list(detail_result.keys())
+        detail_rows = [list(row) for row in detail_result.fetchall()]
+
+        summary_result = connection.execute(summary_stmt)
+        summary_row = summary_result.first()
+
+    rows = [_row_to_dict(detail_columns, r) for r in detail_rows]
+    summary = _summary_row_to_dict(summary_row)
+
+    # Audit: who hit credit-detail for which shifu with which filters. The
+    # row count plus the resolved time window is enough for retroactive
+    # auditing without dumping the (potentially large) row payload itself.
+    app.logger.info(
+        "creator_analytics.credit_detail user_id=%s shifu_bid=%s "
+        "rows=%d total_credits=%s scene=%s usage_type=%s "
+        "start_date=%s end_date=%s limit=%s offset=%s",
+        user_id,
+        params.shifu_bid,
+        len(rows),
+        summary.get("total_credits"),
+        sorted(params.usage_scene) if params.usage_scene else None,
+        sorted(params.usage_type) if params.usage_type else None,
+        params.start_date.isoformat() if params.start_date else None,
+        params.end_date.isoformat() if params.end_date else None,
+        params.limit,
+        params.offset,
+    )
+
+    return {
+        "summary": summary,
+        "rows": rows,
+        "limit": params.limit,
+        "offset": params.offset,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parameter parsing
+# ---------------------------------------------------------------------------
+
+
+class _Params:
+    """Parsed and validated request payload — internal type only."""
+
+    __slots__ = (
+        "shifu_bid",
+        "start_date",
+        "end_date",
+        "usage_scene",
+        "usage_type",
+        "limit",
+        "offset",
+    )
+
+    def __init__(
+        self,
+        *,
+        shifu_bid: str,
+        start_date: Optional[date],
+        end_date: Optional[date],
+        usage_scene: Optional[Tuple[int, ...]],
+        usage_type: Optional[Tuple[int, ...]],
+        limit: int,
+        offset: int,
+    ) -> None:
+        self.shifu_bid = shifu_bid
+        self.start_date = start_date
+        self.end_date = end_date
+        self.usage_scene = usage_scene
+        self.usage_type = usage_type
+        self.limit = limit
+        self.offset = offset
+
+
+def _parse_payload(payload: Any, limit_max: int) -> _Params:
+    if not isinstance(payload, dict):
+        _raise(ERR_INVALID_DSL, "payload must be a JSON object")
+
+    shifu_bid = payload.get("shifu_bid")
+    if not isinstance(shifu_bid, str) or not shifu_bid:
+        _raise(ERR_INVALID_DSL, "shifu_bid is required and must be a non-empty string")
+
+    start_date = _parse_optional_date(payload.get("start_date"), "start_date")
+    end_date = _parse_optional_date(payload.get("end_date"), "end_date")
+    if start_date and end_date and end_date < start_date:
+        _raise(ERR_INVALID_DSL, "end_date must be on or after start_date")
+
+    usage_scene = _parse_int_set(
+        payload.get("usage_scene"), "usage_scene", _ALLOWED_USAGE_SCENES
+    )
+    usage_type = _parse_int_set(
+        payload.get("usage_type"), "usage_type", _ALLOWED_USAGE_TYPES
+    )
+
+    limit = _parse_int(payload.get("limit"), "limit", default=_DEFAULT_LIMIT)
+    if limit < 1 or limit > limit_max:
+        _raise(ERR_INVALID_LIMIT, f"'limit' must be in [1, {limit_max}]")
+
+    offset = _parse_int(payload.get("offset"), "offset", default=0)
+    if offset < 0:
+        _raise(ERR_INVALID_LIMIT, "'offset' must be >= 0")
+
+    return _Params(
+        shifu_bid=shifu_bid,
+        start_date=start_date,
+        end_date=end_date,
+        usage_scene=usage_scene,
+        usage_type=usage_type,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _parse_optional_date(raw: Any, field_name: str) -> Optional[date]:
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str):
+        _raise(
+            ERR_INVALID_DSL, f"'{field_name}' must be an ISO date string (YYYY-MM-DD)"
+        )
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        _raise(
+            ERR_INVALID_DSL, f"'{field_name}' must be an ISO date string (YYYY-MM-DD)"
+        )
+        return None  # unreachable — _raise raises
+
+
+def _parse_int_set(
+    raw: Any, field_name: str, allowed: Iterable[int]
+) -> Optional[Tuple[int, ...]]:
+    if raw is None:
+        return None
+    if not isinstance(raw, list) or not raw:
+        _raise(ERR_INVALID_DSL, f"'{field_name}' must be a non-empty list of integers")
+    allowed_set = set(allowed)
+    out: List[int] = []
+    seen: set[int] = set()
+    for item in raw:
+        if isinstance(item, bool) or not isinstance(item, int):
+            _raise(ERR_INVALID_DSL, f"'{field_name}' values must be integers")
+        if item not in allowed_set:
+            _raise(
+                ERR_INVALID_DSL,
+                f"'{field_name}' value {item} is not in the allowed set "
+                f"{sorted(allowed_set)}",
+            )
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return tuple(out)
+
+
+def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
+    if raw is None:
+        return default
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        _raise(ERR_INVALID_LIMIT, f"'{field_name}' must be an integer")
+    return int(raw)
+
+
+# ---------------------------------------------------------------------------
+# SQL construction
+# ---------------------------------------------------------------------------
+
+
+def _join_conditions(params: _Params):
+    """Build the bill_usage × credit_ledger_entries ON clause.
+
+    ``source_type = USAGE`` is part of the JOIN (not the WHERE) so the
+    optimizer can use the
+    ``ix_credit_ledger_entries_source_type_source_bid`` composite index
+    rather than scanning every ledger row tied to the matching usage_bid.
+    """
+
+    bu = BillUsageRecord.__table__
+    cle = CreditLedgerEntry.__table__
+    return cle.join(
+        bu,
+        and_(
+            cle.c.source_bid == bu.c.usage_bid,
+            cle.c.source_type
+            == bindparam("__source_type", value=CREDIT_SOURCE_TYPE_USAGE),
+            cle.c.deleted == 0,
+            bu.c.deleted == 0,
+        ),
+    )
+
+
+def _where_clauses(params: _Params):
+    """Common WHERE predicates shared by detail + summary queries."""
+
+    bu = BillUsageRecord.__table__
+    clauses = [bu.c.shifu_bid == bindparam("__shifu_bid", value=params.shifu_bid)]
+    if params.start_date is not None:
+        clauses.append(
+            bu.c.created_at
+            >= bindparam(
+                "__start_at",
+                value=datetime.combine(params.start_date, datetime.min.time()),
+            )
+        )
+    if params.end_date is not None:
+        # end_date is inclusive in the user-facing API; convert to an
+        # exclusive upper bound at midnight of the *next* day so the
+        # comparison stays consistent regardless of how the underlying
+        # `created_at` carries fractional seconds.
+        next_day = datetime.combine(params.end_date, datetime.min.time())
+        # Pull in timedelta locally to avoid a top-level import for one use.
+        from datetime import timedelta
+
+        next_day = next_day + timedelta(days=1)
+        clauses.append(bu.c.created_at < bindparam("__end_at", value=next_day))
+    if params.usage_scene:
+        clauses.append(bu.c.usage_scene.in_(list(params.usage_scene)))
+    if params.usage_type:
+        clauses.append(bu.c.usage_type.in_(list(params.usage_type)))
+    return clauses
+
+
+def _build_detail_statement(params: _Params) -> Select:
+    bu = BillUsageRecord.__table__
+    cle = CreditLedgerEntry.__table__
+
+    stmt = (
+        select(
+            bu.c.usage_bid,
+            bu.c.created_at,
+            bu.c.user_bid,
+            bu.c.progress_record_bid,
+            bu.c.outline_item_bid,
+            bu.c.usage_type,
+            bu.c.usage_scene,
+            bu.c.provider,
+            bu.c.model,
+            func.abs(cle.c.amount).label("credits"),
+            cle.c.creator_bid.label("wallet_creator_bid"),
+        )
+        .select_from(_join_conditions(params))
+        .where(and_(*_where_clauses(params)))
+        .order_by(bu.c.created_at.desc())
+        .limit(params.limit)
+        .offset(params.offset)
+    )
+    return stmt
+
+
+def _build_summary_statement(params: _Params) -> Select:
+    bu = BillUsageRecord.__table__
+    cle = CreditLedgerEntry.__table__
+
+    stmt = (
+        select(
+            func.count().label("total_records"),
+            func.coalesce(func.sum(func.abs(cle.c.amount)), 0).label("total_credits"),
+            func.count(func.distinct(bu.c.user_bid)).label("unique_users"),
+            func.count(func.distinct(bu.c.progress_record_bid)).label(
+                "unique_progress"
+            ),
+            func.min(bu.c.created_at).label("first_at"),
+            func.max(bu.c.created_at).label("last_at"),
+            # The result is shifu-scoped so creator_bid is constant. MIN
+            # picks one deterministically without an extra GROUP BY.
+            func.min(cle.c.creator_bid).label("wallet_creator_bid"),
+        )
+        .select_from(_join_conditions(params))
+        .where(and_(*_where_clauses(params)))
+    )
+    return stmt
+
+
+# ---------------------------------------------------------------------------
+# Result shaping
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(columns: Sequence[str], values: Sequence[Any]) -> Dict[str, Any]:
+    row: Dict[str, Any] = {}
+    for col, val in zip(columns, values):
+        row[col] = _coerce_value(val)
+    return row
+
+
+def _summary_row_to_dict(summary_row: Any) -> Dict[str, Any]:
+    if summary_row is None:
+        return {
+            "total_records": 0,
+            "total_credits": 0,
+            "unique_users": 0,
+            "unique_progress": 0,
+            "wallet_creator_bid": None,
+            "time_range": [None, None],
+        }
+    mapping = summary_row._mapping  # noqa: SLF001 — SQLAlchemy public-ish API
+    total_records = int(mapping.get("total_records") or 0)
+    total_credits = _coerce_value(mapping.get("total_credits") or 0)
+    unique_users = int(mapping.get("unique_users") or 0)
+    unique_progress = int(mapping.get("unique_progress") or 0)
+    wallet_creator_bid = mapping.get("wallet_creator_bid") if total_records else None
+    first_at = _coerce_value(mapping.get("first_at"))
+    last_at = _coerce_value(mapping.get("last_at"))
+    return {
+        "total_records": total_records,
+        "total_credits": total_credits,
+        "unique_users": unique_users,
+        "unique_progress": unique_progress,
+        "wallet_creator_bid": wallet_creator_bid,
+        "time_range": [first_at, last_at],
+    }
+
+
+def _coerce_value(value: Any) -> Any:
+    """Coerce non-JSON-friendly values (Decimal, datetime) to strings.
+
+    The HTTP response wrapper turns the dict into JSON; SQLAlchemy returns
+    ``Decimal`` for ``CREDIT_NUMERIC`` columns and ``datetime`` for timestamp
+    columns. JSON serialization on either would raise; rendering as strings
+    keeps the response stable and lets the CLI / frontend parse on demand.
+    """
+
+    if isinstance(value, datetime):
+        return value.isoformat(sep=" ", timespec="seconds")
+    # Decimal carries arbitrary precision; str() keeps the exact value the
+    # billing ledger stored (avoids float rounding).
+    try:
+        from decimal import Decimal
+
+        if isinstance(value, Decimal):
+            return str(value)
+    except ImportError:  # pragma: no cover - stdlib
+        pass
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Error raising — keep the shape identical to dsl._raise
+# ---------------------------------------------------------------------------
+
+
+def _raise(error_name: str, detail: Optional[str] = None) -> None:
+    message = _(error_name)
+    if detail:
+        message = f"{message} ({detail})"
+    code = ERROR_CODE.get(error_name, ERROR_CODE.get("server.common.unknownError"))
+    raise AppException(message, code)
+
+
+__all__ = ["run", "ERR_NO_PERMISSION", "ERR_INVALID_DSL", "ERR_INVALID_LIMIT"]

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -1,4 +1,4 @@
-"""Credit-detail endpoint — server-side join of bill_usage × credit_ledger_entries.
+"""Credit-detail endpoint — server-side join of bill_usage x credit_ledger_entries.
 
 The DSL path (``funcs.run_dsl``) intentionally does not expose
 ``credit_ledger_entries`` and (since 2026-05-15) does not expose
@@ -102,12 +102,16 @@ def run(app: Flask, user_id: str, payload: Any) -> Dict[str, Any]:
     with engine.connect() as connection:
         detail_result = connection.execute(detail_stmt)
         detail_columns = list(detail_result.keys())
-        detail_rows = [list(row) for row in detail_result.fetchall()]
+        # Iterate the result proxy directly instead of fetchall() + list comp:
+        # avoids materialising an intermediate per-row list copy. The page
+        # size is already capped at `limit` (≤ 1000) so memory is bounded
+        # either way, but the shorter form is the conventional SQLAlchemy
+        # pattern and was flagged by review on PR #1771.
+        rows = [_row_to_dict(detail_columns, row) for row in detail_result]
 
         summary_result = connection.execute(summary_stmt)
         summary_row = summary_result.first()
 
-    rows = [_row_to_dict(detail_columns, r) for r in detail_rows]
     summary = _summary_row_to_dict(summary_row)
 
     # Audit: who hit credit-detail for which shifu with which filters. The
@@ -270,7 +274,7 @@ def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
 
 
 def _join_conditions(params: _Params):
-    """Build the bill_usage × credit_ledger_entries ON clause.
+    """Build the bill_usage x credit_ledger_entries ON clause.
 
     ``source_type = USAGE`` is part of the JOIN (not the WHERE) so the
     optimizer can use the
@@ -362,11 +366,17 @@ def _build_summary_statement(params: _Params) -> Select:
             func.count(func.distinct(bu.c.progress_record_bid)).label(
                 "unique_progress"
             ),
+            # unique_wallets counts how many distinct wallets paid for this
+            # shifu's runtime. Normally 1 (the course author's own wallet),
+            # but subscription / sponsor / proxy-payment scenarios can split
+            # it across multiple wallets. Per-row `wallet_creator_bid` shows
+            # which wallet absorbed each charge; the summary intentionally
+            # exposes only the count so callers do not treat a single
+            # ``min(creator_bid)`` value as "the" wallet for the course
+            # (raised on PR #1771 review).
+            func.count(func.distinct(cle.c.creator_bid)).label("unique_wallets"),
             func.min(bu.c.created_at).label("first_at"),
             func.max(bu.c.created_at).label("last_at"),
-            # The result is shifu-scoped so creator_bid is constant. MIN
-            # picks one deterministically without an extra GROUP BY.
-            func.min(cle.c.creator_bid).label("wallet_creator_bid"),
         )
         .select_from(_join_conditions(params))
         .where(and_(*_where_clauses(params)))
@@ -393,7 +403,7 @@ def _summary_row_to_dict(summary_row: Any) -> Dict[str, Any]:
             "total_credits": 0,
             "unique_users": 0,
             "unique_progress": 0,
-            "wallet_creator_bid": None,
+            "unique_wallets": 0,
             "time_range": [None, None],
         }
     mapping = summary_row._mapping  # noqa: SLF001 — SQLAlchemy public-ish API
@@ -401,7 +411,7 @@ def _summary_row_to_dict(summary_row: Any) -> Dict[str, Any]:
     total_credits = _coerce_value(mapping.get("total_credits") or 0)
     unique_users = int(mapping.get("unique_users") or 0)
     unique_progress = int(mapping.get("unique_progress") or 0)
-    wallet_creator_bid = mapping.get("wallet_creator_bid") if total_records else None
+    unique_wallets = int(mapping.get("unique_wallets") or 0)
     first_at = _coerce_value(mapping.get("first_at"))
     last_at = _coerce_value(mapping.get("last_at"))
     return {
@@ -409,7 +419,7 @@ def _summary_row_to_dict(summary_row: Any) -> Dict[str, Any]:
         "total_credits": total_credits,
         "unique_users": unique_users,
         "unique_progress": unique_progress,
-        "wallet_creator_bid": wallet_creator_bid,
+        "unique_wallets": unique_wallets,
         "time_range": [first_at, last_at],
     }
 

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -7,12 +7,17 @@ from typing import Optional
 import pytest
 
 from flaskr.dao import db
-from flaskr.service.billing.models import BillingDailyUsageMetric
+from flaskr.service.billing.consts import (
+    CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+    CREDIT_SOURCE_TYPE_USAGE,
+)
+from flaskr.service.billing.models import BillingDailyUsageMetric, CreditLedgerEntry
 from flaskr.service.learn.models import (
     LearnGeneratedBlock,
     LearnLessonFeedback,
     LearnProgressRecord,
 )
+from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.order.models import Order
 from flaskr.service.profile.models import VariableValue
 from flaskr.service.shifu.models import (
@@ -26,6 +31,8 @@ from flaskr.service.user.models import UserInfo
 
 def _clear_tables() -> None:
     for model in (
+        CreditLedgerEntry,
+        BillUsageRecord,
         BillingDailyUsageMetric,
         VariableValue,
         LearnLessonFeedback,
@@ -244,6 +251,88 @@ def seed_user_info(
         )
     )
     db.session.commit()
+
+
+def seed_bill_usage_record(
+    *,
+    usage_bid: str,
+    shifu_bid: str,
+    user_bid: str = "",
+    progress_record_bid: str = "",
+    outline_item_bid: str = "",
+    usage_type: int = 1101,
+    usage_scene: int = 1203,
+    provider: str = "deepseek",
+    model: str = "deepseek-v4-flash",
+    created_at: Optional[datetime] = None,
+    deleted: int = 0,
+) -> str:
+    """Seed one BillUsageRecord row for credit-detail E2E tests.
+
+    Mirrors the production schema's defaults (all string fields default to
+    empty, numeric fields to zero) so callers only have to set what the
+    test cares about.
+    """
+
+    db.session.add(
+        BillUsageRecord(
+            usage_bid=usage_bid,
+            shifu_bid=shifu_bid,
+            user_bid=user_bid,
+            progress_record_bid=progress_record_bid,
+            outline_item_bid=outline_item_bid,
+            usage_type=usage_type,
+            usage_scene=usage_scene,
+            provider=provider,
+            model=model,
+            created_at=created_at or datetime.utcnow(),
+            deleted=deleted,
+        )
+    )
+    db.session.commit()
+    return usage_bid
+
+
+def seed_credit_ledger_entry(
+    *,
+    ledger_bid: str,
+    creator_bid: str,
+    source_bid: str,
+    amount: float,
+    source_type: int = CREDIT_SOURCE_TYPE_USAGE,
+    entry_type: int = CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+    wallet_bid: str = "",
+    wallet_bucket_bid: str = "",
+    idempotency_key: Optional[str] = None,
+    created_at: Optional[datetime] = None,
+    deleted: int = 0,
+) -> str:
+    """Seed one CreditLedgerEntry row.
+
+    ``amount`` is stored verbatim — for credit consumption tests, pass the
+    actual negative value (the production code writes negatives for
+    deductions). ``idempotency_key`` defaults to a per-source-bid value to
+    satisfy the (creator_bid, idempotency_key) unique constraint.
+    """
+
+    db.session.add(
+        CreditLedgerEntry(
+            ledger_bid=ledger_bid,
+            creator_bid=creator_bid,
+            wallet_bid=wallet_bid,
+            wallet_bucket_bid=wallet_bucket_bid,
+            entry_type=entry_type,
+            source_type=source_type,
+            source_bid=source_bid,
+            idempotency_key=idempotency_key or f"usage:{source_bid}:consume",
+            amount=amount,
+            balance_after=0,
+            created_at=created_at or datetime.utcnow(),
+            deleted=deleted,
+        )
+    )
+    db.session.commit()
+    return ledger_bid
 
 
 def seed_bill_daily_metric(

--- a/src/api/tests/service/creator_analytics/test_credit_detail.py
+++ b/src/api/tests/service/creator_analytics/test_credit_detail.py
@@ -1,0 +1,477 @@
+"""End-to-end tests for POST /api/creator-analytics/credit-detail.
+
+The endpoint joins bill_usage × credit_ledger_entries server-side and
+returns the actual credit deduction per usage row, scoped to the caller's
+shifu permission. These tests cover the happy path, the
+``source_type = USAGE`` security filter, scope enforcement, optional
+filters (scene / type / date range), pagination, absolute-value rendering,
+audit logging, and the empty-result fall-through when no ledger entry
+matches a usage record.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from flaskr.service.billing.consts import (
+    CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+)
+from flaskr.service.creator_analytics import engine as analytics_engine
+
+from .conftest import (
+    seed_bill_usage_record,
+    seed_credit_ledger_entry,
+    seed_owned_course,
+)
+
+
+ENDPOINT = "/api/creator-analytics/credit-detail"
+
+
+@pytest.fixture(autouse=True)
+def _reset_analytics_engine_singleton():
+    analytics_engine.reset_for_tests()
+    yield
+    analytics_engine.reset_for_tests()
+
+
+def _post(test_client, body):
+    return test_client.post(ENDPOINT, json=body)
+
+
+def _seed_usage_with_ledger(
+    *,
+    shifu_bid: str,
+    user_bid: str,
+    creator_bid: str,
+    suffix: str,
+    amount: float,
+    usage_scene: int = 1203,
+    usage_type: int = 1101,
+    provider: str = "deepseek",
+    model: str = "deepseek-v4-flash",
+    created_at=None,
+) -> str:
+    """Seed a paired (BillUsageRecord, CreditLedgerEntry) for one charge."""
+
+    usage_bid = f"u-{shifu_bid}-{suffix}"
+    seed_bill_usage_record(
+        usage_bid=usage_bid,
+        shifu_bid=shifu_bid,
+        user_bid=user_bid,
+        progress_record_bid=f"pr-{suffix}",
+        outline_item_bid=f"ol-{suffix}",
+        usage_type=usage_type,
+        usage_scene=usage_scene,
+        provider=provider,
+        model=model,
+        created_at=created_at,
+    )
+    seed_credit_ledger_entry(
+        ledger_bid=f"l-{shifu_bid}-{suffix}",
+        creator_bid=creator_bid,
+        source_bid=usage_bid,
+        amount=amount,
+        created_at=created_at,
+    )
+    return usage_bid
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_returns_summary_and_rows(mock_request_user, test_client, app):
+    """3 paired usage / ledger rows → summary aggregates them and rows
+    list each charge. amount stored as a negative number; API returns
+    the absolute value as `credits`."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="1",
+            amount=-0.51,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="2",
+            amount=-0.32,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u2",
+            creator_bid="teacher-1",
+            suffix="3",
+            amount=-1.10,
+            usage_scene=1202,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    assert response.status_code == 200, response.get_data(as_text=True)
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+
+    data = payload["data"]
+    assert data["summary"]["total_records"] == 3
+    assert float(data["summary"]["total_credits"]) == pytest.approx(1.93)
+    assert data["summary"]["unique_users"] == 2
+    assert data["summary"]["unique_progress"] == 3
+    assert data["summary"]["wallet_creator_bid"] == "teacher-1"
+    assert len(data["rows"]) == 3
+    for row in data["rows"]:
+        assert float(row["credits"]) >= 0  # ABS applied
+        assert row["wallet_creator_bid"] == "teacher-1"
+
+
+# ---------------------------------------------------------------------------
+# source_type = USAGE security filter (key security guard)
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_excludes_non_usage_ledger_entries(
+    mock_request_user, test_client, app
+):
+    """A ledger entry with source_type != USAGE (e.g. subscription / topup)
+    must never appear in the result, even if its source_bid happens to
+    match an existing bill_usage.usage_bid (which would not happen in
+    production, but the filter must be defensive)."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        # Legitimate USAGE row — must appear
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="legit",
+            amount=-0.5,
+        )
+        # Plant a SUBSCRIPTION ledger row pointing at the same usage_bid;
+        # the join must filter it out via source_type clause.
+        seed_credit_ledger_entry(
+            ledger_bid="l-poison",
+            creator_bid="teacher-1",
+            source_bid="u-shifu-a-legit",
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            amount=100.00,  # would massively skew summary if leaked
+            idempotency_key="poison-1",
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    data = response.get_json(force=True)["data"]
+    # Only the legitimate USAGE row contributes — total credits stays at 0.5
+    assert data["summary"]["total_records"] == 1
+    assert float(data["summary"]["total_credits"]) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Permission / scope enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_user_cannot_query_other_shifu(
+    mock_request_user, test_client, app
+):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-mine", user_id="teacher-1")
+        seed_owned_course(shifu_bid="shifu-other", user_id="teacher-2")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-other",
+            user_bid="u1",
+            creator_bid="teacher-2",
+            suffix="1",
+            amount=-9.99,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-other"})
+    payload = response.get_json(force=True)
+    assert payload["code"] == 11001  # server.creatorAnalytics.noPermission
+
+
+def test_credit_detail_results_are_scoped_to_requested_shifu(
+    mock_request_user, test_client, app
+):
+    """Even when the caller owns multiple shifu, only the requested one's
+    rows surface — the join is anchored on bill_usage.shifu_bid."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_owned_course(shifu_bid="shifu-b", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="a1",
+            amount=-1.0,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-b",
+            user_bid="u2",
+            creator_bid="teacher-1",
+            suffix="b1",
+            amount=-2.0,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 1
+    assert float(data["summary"]["total_credits"]) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_filters_by_usage_scene(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="prod",
+            amount=-1.0,
+            usage_scene=1203,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="prev",
+            amount=-2.0,
+            usage_scene=1202,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a", "usage_scene": [1203]})
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 1
+    assert all(row["usage_scene"] == 1203 for row in data["rows"])
+
+
+def test_credit_detail_filters_by_usage_type(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="llm",
+            amount=-1.0,
+            usage_type=1101,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="tts",
+            amount=-2.0,
+            usage_type=1102,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a", "usage_type": [1101]})
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 1
+    assert all(row["usage_type"] == 1101 for row in data["rows"])
+
+
+def test_credit_detail_filters_by_date_range(mock_request_user, test_client, app):
+    """start_date and end_date are inclusive bounds on bill_usage.created_at."""
+
+    mock_request_user(user_id="teacher-1")
+    today = datetime(2026, 5, 16, 10, 0, 0)
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="d-15",
+            amount=-1.0,
+            created_at=today - timedelta(days=1),
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="d-16",
+            amount=-2.0,
+            created_at=today,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="d-17",
+            amount=-4.0,
+            created_at=today + timedelta(days=1),
+        )
+
+    response = _post(
+        test_client,
+        {"shifu_bid": "shifu-a", "start_date": "2026-05-16", "end_date": "2026-05-16"},
+    )
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 1
+    assert float(data["summary"]["total_credits"]) == pytest.approx(2.0)
+
+
+def test_credit_detail_rejects_invalid_scene_value(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+
+    response = _post(test_client, {"shifu_bid": "shifu-a", "usage_scene": [9999]})
+    payload = response.get_json(force=True)
+    assert payload["code"] == 11002  # invalidDsl
+
+
+def test_credit_detail_rejects_end_before_start(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+
+    response = _post(
+        test_client,
+        {
+            "shifu_bid": "shifu-a",
+            "start_date": "2026-05-16",
+            "end_date": "2026-05-15",
+        },
+    )
+    assert response.get_json(force=True)["code"] == 11002
+
+
+# ---------------------------------------------------------------------------
+# Pagination + empty edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_pagination(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        for i in range(5):
+            _seed_usage_with_ledger(
+                shifu_bid="shifu-a",
+                user_bid=f"u{i}",
+                creator_bid="teacher-1",
+                suffix=str(i),
+                amount=-(i + 1) * 0.5,
+            )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a", "limit": 2, "offset": 1})
+    data = response.get_json(force=True)["data"]
+    # Summary aggregates over the full filtered set, not the paginated rows
+    assert data["summary"]["total_records"] == 5
+    assert len(data["rows"]) == 2
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+
+
+def test_credit_detail_empty_when_bill_usage_has_no_ledger_entries(
+    mock_request_user, test_client, app
+):
+    """If settlement failed for every usage row (no ledger entry exists),
+    the join collapses to zero rows — surfaces as empty summary."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        seed_bill_usage_record(
+            usage_bid="u-lonely",
+            shifu_bid="shifu-a",
+            user_bid="u1",
+        )
+        # NB: no seed_credit_ledger_entry call — usage exists, but no
+        # corresponding ledger row.
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 0
+    assert float(data["summary"]["total_credits"]) == pytest.approx(0.0)
+    assert data["summary"]["wallet_creator_bid"] is None
+    assert data["rows"] == []
+
+
+def test_credit_detail_rejects_limit_above_max(mock_request_user, test_client, app):
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+
+    # ANALYTICS_QUERY_LIMIT_MAX defaults to 1000; 1001 must reject.
+    response = _post(test_client, {"shifu_bid": "shifu-a", "limit": 1001})
+    assert response.get_json(force=True)["code"] == 11007  # invalidLimit
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_emits_audit_log(
+    mock_request_user, test_client, app, monkeypatch
+):
+    """Each call must log user_id + shifu_bid + row count + filter summary
+    so retroactive auditing can reconstruct who hit credit-detail.
+
+    Uses the same `monkeypatch app.logger.info` capture pattern as the
+    user_users lookup audit test (see test_query.py) — pytest's caplog
+    fixture does not see Flask's per-app logger by default.
+    """
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="1",
+            amount=-0.5,
+        )
+
+    info_calls: list[tuple] = []
+    real_info = app.logger.info
+    monkeypatch.setattr(
+        app.logger,
+        "info",
+        lambda *args, **kwargs: (
+            info_calls.append((args, kwargs)),
+            real_info(*args, **kwargs),
+        )[1],
+    )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    assert response.status_code == 200
+
+    audit_entries = [
+        args
+        for args, _ in info_calls
+        if args
+        and isinstance(args[0], str)
+        and "creator_analytics.credit_detail" in args[0]
+    ]
+    assert audit_entries, "Expected a credit_detail audit log entry"
+    # The first positional arg is the fmt string; subsequent args are the
+    # values logger.info substitutes in. user_id / shifu_bid appear as
+    # substitution args, not in the fmt string itself.
+    first = audit_entries[0]
+    assert "teacher-1" in first, f"user_id missing from audit log: {first}"
+    assert "shifu-a" in first, f"shifu_bid missing from audit log: {first}"

--- a/src/api/tests/service/creator_analytics/test_credit_detail.py
+++ b/src/api/tests/service/creator_analytics/test_credit_detail.py
@@ -1,6 +1,6 @@
 """End-to-end tests for POST /api/creator-analytics/credit-detail.
 
-The endpoint joins bill_usage × credit_ledger_entries server-side and
+The endpoint joins bill_usage x credit_ledger_entries server-side and
 returns the actual credit deduction per usage row, scoped to the caller's
 shifu permission. These tests cover the happy path, the
 ``source_type = USAGE`` security filter, scope enforcement, optional
@@ -126,7 +126,12 @@ def test_credit_detail_returns_summary_and_rows(mock_request_user, test_client, 
     assert float(data["summary"]["total_credits"]) == pytest.approx(1.93)
     assert data["summary"]["unique_users"] == 2
     assert data["summary"]["unique_progress"] == 3
-    assert data["summary"]["wallet_creator_bid"] == "teacher-1"
+    # Single wallet absorbed every charge: the course owner. The summary
+    # exposes the count, callers must look at per-row wallet_creator_bid
+    # if they care which wallet it was (or which wallets, in the rare
+    # subscription / proxy-payment split case).
+    assert data["summary"]["unique_wallets"] == 1
+    assert "wallet_creator_bid" not in data["summary"]
     assert len(data["rows"]) == 3
     for row in data["rows"]:
         assert float(row["credits"]) >= 0  # ABS applied
@@ -174,6 +179,58 @@ def test_credit_detail_excludes_non_usage_ledger_entries(
     # Only the legitimate USAGE row contributes — total credits stays at 0.5
     assert data["summary"]["total_records"] == 1
     assert float(data["summary"]["total_credits"]) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# unique_wallets — multi-wallet corner case
+# ---------------------------------------------------------------------------
+
+
+def test_credit_detail_summary_unique_wallets_counts_distinct_creators(
+    mock_request_user, test_client, app
+):
+    """Most courses bill against a single wallet (the author's), but
+    subscription / proxy-payment / sponsorship scenarios can split charges
+    across multiple wallets for the same shifu. The summary must surface
+    this as a distinct count so a caller does not treat the per-row
+    wallet_creator_bid as "the" wallet for the course (raised on PR #1771
+    review of the original `min(creator_bid)` aggregate)."""
+
+    mock_request_user(user_id="teacher-1")
+    with app.app_context():
+        seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
+        # Two charges hit teacher-1's own wallet (the normal case)
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u1",
+            creator_bid="teacher-1",
+            suffix="own1",
+            amount=-0.5,
+        )
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u2",
+            creator_bid="teacher-1",
+            suffix="own2",
+            amount=-0.3,
+        )
+        # One charge hit a different wallet (e.g. a platform-credit grant)
+        _seed_usage_with_ledger(
+            shifu_bid="shifu-a",
+            user_bid="u3",
+            creator_bid="sponsor-x",
+            suffix="sponsor",
+            amount=-1.0,
+        )
+
+    response = _post(test_client, {"shifu_bid": "shifu-a"})
+    data = response.get_json(force=True)["data"]
+    assert data["summary"]["total_records"] == 3
+    assert data["summary"]["unique_wallets"] == 2
+    # Per-row wallet_creator_bid is preserved so callers can see which
+    # wallets paid for which charges.
+    row_wallets = {row["wallet_creator_bid"] for row in data["rows"]}
+    assert row_wallets == {"teacher-1", "sponsor-x"}
 
 
 # ---------------------------------------------------------------------------
@@ -406,7 +463,7 @@ def test_credit_detail_empty_when_bill_usage_has_no_ledger_entries(
     data = response.get_json(force=True)["data"]
     assert data["summary"]["total_records"] == 0
     assert float(data["summary"]["total_credits"]) == pytest.approx(0.0)
-    assert data["summary"]["wallet_creator_bid"] is None
+    assert data["summary"]["unique_wallets"] == 0
     assert data["rows"] == []
 
 


### PR DESCRIPTION
## Summary

Add `POST /api/creator-analytics/credit-detail` that joins `bill_usage` × `credit_ledger_entries` server-side and returns the **actual credit deduction** for one shifu, scoped to the caller's permission.

## Motivation

`bill_daily_usage_metrics` is empty in production because the `billing.aggregate_daily_usage_metrics` Celery task is not registered in `flaskr/common/celery_app.py:_build_billing_beat_schedule` — the 2026-05-15 design (PR #1764) that routed creators to that table left them with **no way at all** to see credit consumption. Investigation matches `plan/AI-Shifu积分消耗明细查询避坑经验.md` §坑2 (whole table = 0 rows confirmed on live).

The PDF also documents that the **only** working path to "how many credits did this course consume" is `bill_usage JOIN credit_ledger_entries ON source_bid = usage_bid AND source_type = USAGE`. Reopening the DSL whitelist to `credit_ledger_entries` would require sub-query verification to prevent cross-creator access (since the table has no `shifu_bid` column). This PR instead does the join server-side in a single purpose-built endpoint.

## Implementation

- `flaskr/service/creator_analytics/credit_detail.py` — join + summary logic, validation, audit log
- `flaskr/route/creator_analytics.py` — `POST /credit-detail` handler alongside the existing `/query` DSL handler
- `tests/service/creator_analytics/test_credit_detail.py` — 13 new cases (happy path, security guards, scope, filters, date range, pagination, empty result, audit log)
- `tests/service/creator_analytics/conftest.py` — `seed_bill_usage_record` / `seed_credit_ledger_entry` helpers + `CreditLedgerEntry` / `BillUsageRecord` added to `_clear_tables`
- `docs/generated/architecture-boundary-baseline.json` + `harness-health.md` regenerated (the new file uses the same cross-service permission import as `funcs.run_dsl`; no new pattern, just a second call site)

## Security model

- Permission goes through the existing `get_user_shifu_permissions(app, user_id)` — caller must have `view` on the requested `shifu_bid`
- The join is anchored on `bill_usage.shifu_bid` so rows for other courses cannot leak even though `credit_ledger_entries` itself has no `shifu_bid` column
- `source_type = CREDIT_SOURCE_TYPE_USAGE` is asserted as a JOIN predicate (not just WHERE), so subscription / topup / gift / refund / manual ledger entries cannot leak even if their `source_bid` happens to collide with a usage_bid
- Response exposes only the fields the creator needs (`usage_bid`, `created_at`, `user_bid`, `progress_record_bid`, `outline_item_bid`, `usage_type`, `usage_scene`, `provider`, `model`, `credits`, `wallet_creator_bid`). Internal ledger fields (`wallet_bid`, `wallet_bucket_bid`, `idempotency_key`, `balance_after`, `metadata_json`) are not selected
- `amount` is stored as a negative number for deductions; the API returns `ABS(amount)` as `credits`

## Out of scope (deliberate non-changes)

- DSL whitelist unchanged: `credit_ledger_entries` does **not** enter the whitelist; `bill_usage` stays out (token-vs-credit boundary)
- `bill_daily_usage_metrics` stays in the whitelist as a no-op for now. When the daily aggregation cron is enabled (separate work item), it will start returning data and DSL recipes around it will work again; `credit-detail` remains the real-time path
- Token fields (`bill_usage.input` / `output` / `input_cache` / `total`) remain non-exposed

## Companion PR

CLI subcommand `shifu-cli.py credit-detail` and skill documentation update lives in [ai-shifu/skills#TBD](https://github.com/ai-shifu/skills/pulls).

## Test plan

- [x] `conda activate aishifu && cd src/api && pytest tests/service/creator_analytics/ -q` → **258 passed** (245 baseline + 13 new)
- [x] `python scripts/check_architecture_boundaries.py` passes (baseline updated)
- [x] `pre-commit run` passes locally (ruff, harness validation, translation parity, locales metadata, hardcoded-CJK)
- [ ] Manual: `curl -X POST /api/creator-analytics/credit-detail` with real shifu_bid → confirm `summary.total_credits` matches the PDF's manual SQL result on the same shifu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a credit detail analytics endpoint providing per-usage credit deductions and aggregate summaries, including total credits consumed, record counts, and distinct user metrics.
  * Supports filtering by date range, usage type, and scene with pagination capabilities.
  * Enforces creator-level access permissions on credit data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->