### PR TITLE
fix: stabilize billing admission repair test

### DIFF
--- a/src/api/tests/service/billing/test_billing_admission.py
+++ b/src/api/tests/service/billing/test_billing_admission.py
@@ -473,9 +473,10 @@ def test_admit_creator_usage_rejects_future_bucket_before_effective_time(
 def test_repair_subscription_cycle_mismatches_restores_admission_for_current_bucket(
     billing_admission_app: Flask,
 ) -> None:
-    paid_at = datetime(2026, 4, 15, 13, 10, 37)
-    cycle_end_at = datetime(2026, 5, 15, 13, 10, 37)
-    corrupted_start_at = datetime.now() + timedelta(hours=2)
+    reference_now = datetime.now().replace(microsecond=0)
+    paid_at = reference_now - timedelta(days=30)
+    cycle_end_at = reference_now + timedelta(days=1)
+    corrupted_start_at = reference_now + timedelta(hours=2)
     corrupted_end_at = corrupted_start_at + timedelta(days=1)
 
     with billing_admission_app.app_context():


### PR DESCRIPTION
Summary
- stabilize the billing admission repair test by replacing hard-coded April/May 2026 dates with relative timestamps around `datetime.now()`
- keep the subscription bucket in the current window before repair, while still forcing a future-dated corrupted subscription window
- prevent the test from flipping from `subscriptionInactive` to `creditInsufficient` as calendar time advances

Testing
- `cd src/api && pytest tests/service/billing/test_billing_admission.py -q`
- `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture setup for billing admission tests by using a unified timestamp reference for better consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->