### PR TITLE
feat(billing): add operator credit grant cli

### DIFF
--- a/src/api/flaskr/service/billing/api.py
+++ b/src/api/flaskr/service/billing/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from flaskr.service.billing.manual_credit_grants import grant_manual_credits_to_user
 from flaskr.service.billing.manual_plan_grants import grant_manual_plan_to_user
 from flaskr.service.billing.read_models import (
     build_billing_catalog,
@@ -12,6 +13,7 @@ __all__ = [
     "build_billing_catalog",
     "build_operator_credit_orders_overview",
     "build_operator_credit_orders_page",
+    "grant_manual_credits_to_user",
     "grant_manual_plan_to_user",
     "get_operator_credit_order_detail",
 ]

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+import hashlib
 import json
 from datetime import datetime
 from decimal import Decimal
@@ -55,6 +56,12 @@ from .consts import (
 from .daily_aggregates import (
     detect_daily_aggregate_rebuild_range,
     rebuild_daily_aggregates,
+)
+from .manual_credit_grants import (
+    MANUAL_CREDIT_GRANT_SOURCES,
+    MANUAL_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION,
+    MANUAL_CREDIT_VALIDITY_PRESETS,
+    grant_manual_credits_to_user,
 )
 from .models import (
     BillingOrder,
@@ -116,6 +123,8 @@ _PRODUCT_STATUS_LABELS = {
     "active": BILLING_PRODUCT_STATUS_ACTIVE,
     "inactive": BILLING_PRODUCT_STATUS_INACTIVE,
 }
+
+_DEFAULT_CLI_OPERATOR_USER_BID = "billing-cli"
 
 
 def _normalize_cli_bid(value: object) -> str:
@@ -480,6 +489,70 @@ def register_billing_commands(console) -> None:
             product_code=product_code,
             effective_to=effective_to,
             note=note,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="grant-credits")
+    @click.option(
+        "--identify",
+        default="",
+        help="User identify value, usually phone or email.",
+    )
+    @click.option("--user-bid", default="", help="Target user business identifier.")
+    @click.option("--amount", required=True, help="Granted credits amount.")
+    @click.option(
+        "--request-id",
+        default="",
+        help=(
+            "Optional idempotency request id. When omitted, the CLI derives one "
+            "from the grant inputs and the current date."
+        ),
+    )
+    @click.option(
+        "--grant-source",
+        type=click.Choice(MANUAL_CREDIT_GRANT_SOURCES),
+        default="compensation",
+        show_default=True,
+        help="Operator grant source.",
+    )
+    @click.option(
+        "--validity-preset",
+        type=click.Choice(MANUAL_CREDIT_VALIDITY_PRESETS),
+        default=MANUAL_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION,
+        show_default=True,
+        help="Grant validity preset. Defaults to the current subscription period.",
+    )
+    @click.option("--name", "display_name", default="", help="User-visible name.")
+    @click.option("--note", default="", help="User-visible note.")
+    @click.option(
+        "--operator-user-bid",
+        default="",
+        help="Optional operator user bid for audit metadata.",
+    )
+    @with_appcontext
+    def grant_credits_command(
+        identify: str,
+        user_bid: str,
+        amount: str,
+        request_id: str,
+        grant_source: str,
+        validity_preset: str,
+        display_name: str,
+        note: str,
+        operator_user_bid: str,
+    ) -> None:
+        """Grant manual credits through the operator credit grant service."""
+
+        payload = grant_operator_credits_by_cli(
+            identify=identify,
+            user_bid=user_bid,
+            amount=amount,
+            request_id=request_id,
+            grant_source=grant_source,
+            validity_preset=validity_preset,
+            display_name=display_name,
+            note=note,
+            operator_user_bid=operator_user_bid,
         )
         _echo_payload(payload)
 
@@ -1218,6 +1291,110 @@ def grant_billing_plan_by_identify(
     except Exception:
         db.session.rollback()
         raise
+
+
+def grant_operator_credits_by_cli(
+    *,
+    identify: str = "",
+    user_bid: str = "",
+    amount: str,
+    request_id: str,
+    grant_source: str = "compensation",
+    validity_preset: str,
+    display_name: str = "",
+    note: str = "",
+    operator_user_bid: str = "",
+) -> dict[str, Any]:
+    normalized_identify = str(identify or "").strip()
+    normalized_user_bid = str(user_bid or "").strip()
+    if bool(normalized_identify) == bool(normalized_user_bid):
+        raise click.ClickException("Pass exactly one of --identify or --user-bid.")
+
+    normalized_request_id = str(request_id or "").strip()
+    if len(normalized_request_id) > 100:
+        raise click.ClickException("--request-id must be 100 characters or fewer.")
+
+    normalized_display_name = str(display_name or "").strip()
+    if len(normalized_display_name) > 128:
+        raise click.ClickException("--name must be 128 characters or fewer.")
+
+    normalized_note = str(note or "").strip()
+    if len(normalized_note) > 255:
+        raise click.ClickException("--note must be 255 characters or fewer.")
+
+    normalized_operator_user_bid = (
+        str(operator_user_bid or "").strip() or _DEFAULT_CLI_OPERATOR_USER_BID
+    )
+
+    try:
+        aggregate = (
+            load_user_aggregate(normalized_user_bid)
+            if normalized_user_bid
+            else load_user_aggregate_by_identifier(normalized_identify)
+        )
+        if aggregate is None:
+            target = normalized_user_bid or normalized_identify
+            raise click.ClickException(f"No user found for target: {target}")
+        if not normalized_request_id:
+            normalized_request_id = _build_cli_credit_grant_request_id(
+                user_bid=aggregate.user_bid,
+                amount=amount,
+                grant_source=grant_source,
+                validity_preset=validity_preset,
+                display_name=normalized_display_name,
+                note=normalized_note,
+            )
+
+        grant_result = grant_manual_credits_to_user(
+            current_app,
+            user_bid=aggregate.user_bid,
+            operator_user_bid=normalized_operator_user_bid,
+            request_id=normalized_request_id,
+            amount=str(amount or "").strip(),
+            grant_source=str(grant_source or "").strip(),
+            validity_preset=str(validity_preset or "").strip(),
+            display_name=normalized_display_name,
+            note=normalized_note,
+            grant_channel="operator_cli",
+        )
+        payload = dict(_serialize_cli_payload(grant_result))
+        payload.update(
+            {
+                "identify": normalized_identify,
+                "creator_bid": aggregate.user_bid,
+                "operator_user_bid": normalized_operator_user_bid,
+                "request_id": normalized_request_id,
+                "email": getattr(aggregate, "email", ""),
+                "mobile": getattr(aggregate, "mobile", ""),
+            }
+        )
+        return payload
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def _build_cli_credit_grant_request_id(
+    *,
+    user_bid: str,
+    amount: str,
+    grant_source: str,
+    validity_preset: str,
+    display_name: str,
+    note: str,
+) -> str:
+    fingerprint_payload = "|".join(
+        [
+            str(user_bid or "").strip(),
+            str(amount or "").strip(),
+            str(grant_source or "").strip().lower(),
+            str(validity_preset or "").strip().lower(),
+            str(display_name or "").strip(),
+            str(note or "").strip(),
+        ]
+    )
+    fingerprint = hashlib.sha256(fingerprint_payload.encode("utf-8")).hexdigest()[:16]
+    return f"cli:{datetime.now():%Y%m%d}:{fingerprint}"
 
 
 def _upsert_bootstrap_rows(

--- a/src/api/flaskr/service/billing/manual_credit_grants.py
+++ b/src/api/flaskr/service/billing/manual_credit_grants.py
@@ -1,0 +1,216 @@
+"""Manual operator/admin credit grant helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from flask import Flask
+
+from flaskr.service.common.models import raise_error, raise_param_error
+from flaskr.util.uuid import generate_id
+
+from .primitives import (
+    credit_decimal_to_number as _credit_decimal_to_number,
+    normalize_bid as _normalize_bid,
+    quantize_credit_amount as _quantize_credit_amount,
+)
+from .queries import add_months as _add_months
+from .queries import add_years as _add_years
+from .queries import load_primary_active_subscription
+from .wallets import grant_manual_credit_wallet_balance
+
+MANUAL_CREDIT_GRANT_SOURCE_REWARD = "reward"
+MANUAL_CREDIT_GRANT_SOURCE_COMPENSATION = "compensation"
+MANUAL_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION = "align_subscription"
+MANUAL_CREDIT_VALIDITY_1D = "1d"
+MANUAL_CREDIT_VALIDITY_7D = "7d"
+MANUAL_CREDIT_VALIDITY_1M = "1m"
+MANUAL_CREDIT_VALIDITY_3M = "3m"
+MANUAL_CREDIT_VALIDITY_1Y = "1y"
+
+MANUAL_CREDIT_GRANT_SOURCES = (
+    MANUAL_CREDIT_GRANT_SOURCE_REWARD,
+    MANUAL_CREDIT_GRANT_SOURCE_COMPENSATION,
+)
+MANUAL_CREDIT_VALIDITY_PRESETS = (
+    MANUAL_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION,
+    MANUAL_CREDIT_VALIDITY_1D,
+    MANUAL_CREDIT_VALIDITY_7D,
+    MANUAL_CREDIT_VALIDITY_1M,
+    MANUAL_CREDIT_VALIDITY_3M,
+    MANUAL_CREDIT_VALIDITY_1Y,
+)
+
+
+@dataclass(slots=True, frozen=True)
+class ManualCreditGrantResult:
+    """Resolved state for one manual credit grant request."""
+
+    status: str
+    user_bid: str
+    amount: int | float
+    grant_source: str
+    validity_preset: str
+    expires_at: datetime | None
+    wallet_bucket_bid: str
+    ledger_bid: str
+    display_name: str = ""
+    note: str = ""
+    metadata_json: dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "user_bid": self.user_bid,
+            "amount": self.amount,
+            "grant_source": self.grant_source,
+            "validity_preset": self.validity_preset,
+            "expires_at": self.expires_at,
+            "display_name": self.display_name,
+            "note": self.note,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "ledger_bid": self.ledger_bid,
+            "metadata_json": self.metadata_json,
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_payload()[key]
+
+
+def _normalize_credit_amount(value: Any) -> Decimal:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise_param_error("amount")
+    try:
+        parsed = _quantize_credit_amount(Decimal(normalized))
+    except (InvalidOperation, TypeError, ValueError, ArithmeticError):
+        raise_param_error("amount")
+    if not parsed.is_finite() or parsed <= Decimal("0"):
+        raise_param_error("amount")
+    return parsed
+
+
+def _resolve_manual_credit_grant_expiry(
+    *,
+    creator_bid: str,
+    validity_preset: str,
+    granted_at: datetime,
+) -> datetime | None:
+    normalized_preset = _normalize_bid(validity_preset)
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION:
+        subscription = load_primary_active_subscription(
+            creator_bid,
+            as_of=granted_at,
+        )
+        if (
+            subscription is None
+            or subscription.current_period_end_at is None
+            or subscription.current_period_end_at <= granted_at
+        ):
+            raise_error("server.billing.subscriptionInactive")
+        return subscription.current_period_end_at
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_1D:
+        return granted_at + timedelta(days=1)
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_7D:
+        return granted_at + timedelta(days=7)
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_1M:
+        return _add_months(granted_at, 1)
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_3M:
+        return _add_months(granted_at, 3)
+    if normalized_preset == MANUAL_CREDIT_VALIDITY_1Y:
+        return _add_years(granted_at, 1)
+    raise_param_error("validity_preset")
+
+
+def grant_manual_credits_to_user(
+    app: Flask,
+    *,
+    user_bid: str,
+    operator_user_bid: str,
+    request_id: str,
+    amount: str,
+    grant_source: str,
+    validity_preset: str,
+    display_name: str = "",
+    note: str = "",
+    grant_channel: str = "operator_user_management",
+) -> ManualCreditGrantResult:
+    """Grant manual credits to one user through the shared operator semantics."""
+
+    with app.app_context():
+        normalized_user_bid = _normalize_bid(user_bid)
+        normalized_operator_user_bid = _normalize_bid(operator_user_bid)
+        normalized_request_id = _normalize_bid(request_id)
+        normalized_grant_source = _normalize_bid(grant_source).lower()
+        normalized_validity_preset = _normalize_bid(validity_preset).lower()
+        normalized_display_name = str(display_name or "").strip()
+        normalized_note = str(note or "").strip()
+
+        if not normalized_user_bid:
+            raise_param_error("user_bid")
+        if not normalized_operator_user_bid:
+            raise_param_error("operator_user_bid")
+        if not normalized_request_id:
+            raise_param_error("request_id")
+        if normalized_grant_source not in MANUAL_CREDIT_GRANT_SOURCES:
+            raise_param_error("grant_source")
+        if normalized_validity_preset not in MANUAL_CREDIT_VALIDITY_PRESETS:
+            raise_param_error("validity_preset")
+        if len(normalized_display_name) > 128:
+            raise_param_error("display_name")
+        if len(normalized_note) > 255:
+            raise_param_error("note")
+
+        granted_amount = _normalize_credit_amount(amount)
+        granted_at = datetime.now()
+        expires_at = _resolve_manual_credit_grant_expiry(
+            creator_bid=normalized_user_bid,
+            validity_preset=normalized_validity_preset,
+            granted_at=granted_at,
+        )
+        grant_result = grant_manual_credit_wallet_balance(
+            app,
+            creator_bid=normalized_user_bid,
+            amount=granted_amount,
+            source_bid=generate_id(app),
+            effective_from=granted_at,
+            effective_to=expires_at,
+            idempotency_key=f"operator_manual_grant:{normalized_request_id}",
+            metadata={
+                "checkout_type": "manual_grant",
+                "grant_type": "manual_grant",
+                "grant_source": normalized_grant_source,
+                "validity_preset": normalized_validity_preset,
+                "operator_user_bid": normalized_operator_user_bid,
+                "grant_channel": grant_channel,
+            },
+            ledger_metadata={
+                "display_name": normalized_display_name,
+                "name": normalized_display_name,
+                "note": normalized_note,
+            },
+        )
+        if grant_result.status not in {"granted", "noop_existing"}:
+            raise_error("server.common.systemError")
+
+        persisted_metadata = dict(grant_result.metadata_json or {})
+        return ManualCreditGrantResult(
+            status=str(grant_result.status or "granted"),
+            user_bid=normalized_user_bid,
+            amount=_credit_decimal_to_number(grant_result.amount),
+            grant_source=str(
+                persisted_metadata.get("grant_source") or normalized_grant_source
+            ).strip(),
+            validity_preset=str(
+                persisted_metadata.get("validity_preset") or normalized_validity_preset
+            ).strip(),
+            expires_at=grant_result.expires_at,
+            display_name=str(persisted_metadata.get("display_name") or "").strip(),
+            note=str(persisted_metadata.get("note") or "").strip(),
+            wallet_bucket_bid=str(grant_result.wallet_bucket_bid or "").strip(),
+            ledger_bid=str(grant_result.ledger_bid or "").strip(),
+            metadata_json=persisted_metadata,
+        )

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -829,6 +829,7 @@ def grant_manual_credit_wallet_balance(
     effective_from: datetime | None = None,
     effective_to: datetime | None = None,
     metadata: dict[str, Any] | None = None,
+    ledger_metadata: dict[str, Any] | None = None,
     idempotency_key: str = "",
 ) -> ManualCreditGrantResult:
     """Create a dedicated manual-grant bucket and matching ledger row."""
@@ -864,6 +865,10 @@ def grant_manual_credit_wallet_balance(
             return existing_result
 
         normalized_metadata = dict(metadata or {})
+        normalized_ledger_metadata = {
+            **normalized_metadata,
+            **dict(ledger_metadata or {}),
+        }
         bucket = CreditWalletBucket(
             wallet_bucket_bid=generate_id(app),
             wallet_bid=wallet.wallet_bid,
@@ -905,7 +910,7 @@ def grant_manual_credit_wallet_balance(
             balance_after=balance_after,
             expires_at=effective_to,
             consumable_from=granted_at,
-            metadata_json=normalized_metadata,
+            metadata_json=normalized_ledger_metadata,
         )
         wallet.available_credits = balance_after
         persist_credit_wallet_snapshot(
@@ -935,7 +940,7 @@ def grant_manual_credit_wallet_balance(
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             ledger_bid=ledger_entry.ledger_bid,
             expires_at=effective_to,
-            metadata_json=normalized_metadata,
+            metadata_json=normalized_ledger_metadata,
         )
 
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
 from flask import Flask, current_app
@@ -42,18 +42,14 @@ from flaskr.service.billing.models import (
 )
 from flaskr.service.billing.api import (
     build_billing_catalog,
+    grant_manual_credits_to_user,
     grant_manual_plan_to_user,
 )
 from flaskr.service.billing.primitives import (
     credit_decimal_to_number,
     quantize_credit_amount as _quantize_credit_amount,
 )
-from flaskr.service.billing.queries import (
-    add_months as _add_months,
-    add_years as _add_years,
-    load_primary_active_subscription,
-)
-from flaskr.service.billing.wallets import grant_manual_credit_wallet_balance
+from flaskr.service.billing.queries import load_primary_active_subscription
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
@@ -151,7 +147,6 @@ from flaskr.service.user.repository import (
     upsert_credential,
 )
 from flaskr.util.timezone import serialize_with_app_timezone
-from flaskr.util.uuid import generate_id
 from flaskr.service.user.utils import (
     ensure_demo_course_permissions,
     load_existing_demo_shifu_ids,
@@ -482,51 +477,6 @@ def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}
-
-
-def _normalize_credit_amount(value: Any) -> Decimal:
-    normalized = str(value or "").strip()
-    if not normalized:
-        raise_param_error("amount")
-    try:
-        parsed = _quantize_credit_amount(Decimal(normalized))
-    except (InvalidOperation, TypeError, ValueError, ArithmeticError):
-        raise_param_error("amount")
-    if not parsed.is_finite() or parsed <= Decimal("0"):
-        raise_param_error("amount")
-    return parsed
-
-
-def _resolve_operator_credit_grant_expiry(
-    *,
-    creator_bid: str,
-    validity_preset: str,
-    granted_at: datetime,
-) -> datetime | None:
-    normalized_preset = str(validity_preset or "").strip()
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_ALIGN_SUBSCRIPTION:
-        subscription = load_primary_active_subscription(
-            creator_bid,
-            as_of=granted_at,
-        )
-        if (
-            subscription is None
-            or subscription.current_period_end_at is None
-            or subscription.current_period_end_at <= granted_at
-        ):
-            raise_error("server.billing.subscriptionInactive")
-        return subscription.current_period_end_at
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_1D:
-        return granted_at + timedelta(days=1)
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_7D:
-        return granted_at + timedelta(days=7)
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_1M:
-        return _add_months(granted_at, 1)
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_3M:
-        return _add_months(granted_at, 3)
-    if normalized_preset == OPERATOR_USER_CREDIT_VALIDITY_1Y:
-        return _add_years(granted_at, 1)
-    raise_param_error("validity_preset")
 
 
 def _load_active_subscription_end_map(
@@ -5171,38 +5121,22 @@ def grant_operator_user_credits(
         if normalized_validity_preset not in OPERATOR_USER_CREDIT_VALIDITY_PRESETS:
             raise_param_error("validity_preset")
 
-        granted_amount = _normalize_credit_amount(payload.amount)
         normalized_request_id = str(payload.request_id or "").strip()
         if not normalized_request_id:
             raise_param_error("request_id")
+        normalized_display_name = str(payload.display_name or "").strip()
         normalized_note = str(payload.note or "").strip()
-        granted_at = datetime.now()
-        expires_at = _resolve_operator_credit_grant_expiry(
-            creator_bid=normalized_user_bid,
-            validity_preset=normalized_validity_preset,
-            granted_at=granted_at,
-        )
-        grant_bid = generate_id(app)
-        grant_result = grant_manual_credit_wallet_balance(
+        grant_result = grant_manual_credits_to_user(
             app,
-            creator_bid=normalized_user_bid,
-            amount=granted_amount,
-            source_bid=grant_bid,
-            effective_from=granted_at,
-            effective_to=expires_at,
-            idempotency_key=f"operator_manual_grant:{normalized_request_id}",
-            metadata={
-                "checkout_type": "manual_grant",
-                "grant_type": "manual_grant",
-                "grant_source": normalized_grant_source,
-                "validity_preset": normalized_validity_preset,
-                "operator_user_bid": normalized_operator_user_bid,
-                "grant_channel": "operator_user_management",
-                "note": normalized_note,
-            },
+            user_bid=normalized_user_bid,
+            operator_user_bid=normalized_operator_user_bid,
+            request_id=normalized_request_id,
+            amount=payload.amount,
+            grant_source=normalized_grant_source,
+            validity_preset=normalized_validity_preset,
+            display_name=normalized_display_name,
+            note=normalized_note,
         )
-        if grant_result.status not in {"granted", "noop_existing"}:
-            raise_error("server.common.systemError")
 
         persisted_metadata = _normalize_metadata_json(grant_result.metadata_json)
         resolved_grant_source = str(
@@ -5222,11 +5156,14 @@ def grant_operator_user_credits(
             credit_summary_map=credit_summary_map,
         )
         return AdminOperationUserCreditGrantResultDTO(
+            status=str(grant_result.status or "granted"),
             user_bid=normalized_user_bid,
             amount=resolved_amount,
             grant_source=resolved_grant_source,
             validity_preset=resolved_validity_preset,
             expires_at=_format_operator_datetime(grant_result.expires_at),
+            display_name=str(persisted_metadata.get("display_name") or "").strip(),
+            note=str(persisted_metadata.get("note") or "").strip(),
             wallet_bucket_bid=str(grant_result.wallet_bucket_bid or "").strip(),
             ledger_bid=str(grant_result.ledger_bid or "").strip(),
             summary=summary,

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -416,6 +416,11 @@ class AdminOperationUserCreditGrantRequestDTO(BaseModel):
     validity_preset: str = Field(
         ..., description="Grant validity preset", required=True
     )
+    display_name: str = Field(
+        default="",
+        description="Optional user-visible grant display name",
+        required=False,
+    )
     note: str = Field(default="", description="Optional operator note", required=False)
 
     def __json__(self) -> dict[str, Any]:
@@ -426,6 +431,7 @@ class AdminOperationUserCreditGrantRequestDTO(BaseModel):
 class AdminOperationUserCreditGrantResultDTO(BaseModel):
     """Operator credits grant response payload."""
 
+    status: str = Field(default="granted", description="Grant result status")
     user_bid: str = Field(..., description="Target user business identifier")
     amount: str = Field(..., description="Granted credits amount", required=False)
     grant_source: str = Field(
@@ -436,6 +442,16 @@ class AdminOperationUserCreditGrantResultDTO(BaseModel):
     )
     expires_at: str = Field(
         default="", description="Resolved expiry timestamp", required=False
+    )
+    display_name: str = Field(
+        default="",
+        description="User-visible grant display name",
+        required=False,
+    )
+    note: str = Field(
+        default="",
+        description="User-visible grant note",
+        required=False,
     )
     wallet_bucket_bid: str = Field(
         ..., description="Created wallet bucket identifier", required=False

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -27,7 +27,9 @@ from flaskr.service.billing.models import (
     BillingRenewalEvent,
     BillingSubscription,
     CreditUsageRate,
+    CreditLedgerEntry,
     CreditWallet,
+    CreditWalletBucket,
 )
 from flaskr.service.billing.queries import calculate_self_managed_billing_cycle_end
 from flaskr.service.config.models import Config
@@ -676,6 +678,155 @@ def test_billing_grant_plan_cli_grants_manual_plan_by_phone_identify(
         assert len(pending_events) == 1
         assert pending_events[0].event_type == BILLING_RENEWAL_EVENT_TYPE_EXPIRE
         assert pending_events[0].scheduled_at == expected_period_end_at
+
+
+def test_billing_grant_credits_cli_grants_visible_manual_credits(
+    billing_cli_db_app: Flask,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+
+    with billing_cli_db_app.app_context():
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-credit",
+            identify="creator-cli-credit",
+            phone="13800138001",
+            is_creator=True,
+        )
+        dao.db.session.add(
+            BillingSubscription(
+                subscription_bid="sub-cli-credit-active",
+                creator_bid="creator-cli-credit",
+                product_bid="bill-product-plan-monthly",
+                status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                billing_provider="manual",
+                provider_subscription_id="",
+                provider_customer_id="",
+                current_period_start_at=datetime.now() - timedelta(days=1),
+                current_period_end_at=datetime.now() + timedelta(days=30),
+                cancel_at_period_end=0,
+                next_product_bid="",
+                metadata_json={},
+            )
+        )
+        dao.db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "grant-credits",
+            "--identify",
+            "13800138001",
+            "--amount",
+            "12.5",
+            "--grant-source",
+            "compensation",
+            "--name",
+            "模型扣费补偿",
+            "--note",
+            "DeepSeek 费率补偿",
+            "--operator-user-bid",
+            "operator-cli-1",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "granted"
+    assert payload["creator_bid"] == "creator-cli-credit"
+    assert payload["mobile"] == "13800138001"
+    assert payload["amount"] == 12.5
+    assert payload["grant_source"] == "compensation"
+    assert payload["validity_preset"] == "align_subscription"
+    assert payload["display_name"] == "模型扣费补偿"
+    assert payload["note"] == "DeepSeek 费率补偿"
+    assert payload["operator_user_bid"] == "operator-cli-1"
+    assert payload["request_id"].startswith("cli:")
+
+    with billing_cli_db_app.app_context():
+        wallet = CreditWallet.query.filter_by(creator_bid="creator-cli-credit").one()
+        bucket = CreditWalletBucket.query.filter_by(
+            creator_bid="creator-cli-credit"
+        ).one()
+        ledger = CreditLedgerEntry.query.filter_by(
+            creator_bid="creator-cli-credit"
+        ).one()
+
+        assert wallet.available_credits == Decimal("12.5000000000")
+        assert bucket.available_credits == Decimal("12.5000000000")
+        assert bucket.metadata_json["grant_source"] == "compensation"
+        assert bucket.metadata_json["validity_preset"] == "align_subscription"
+        assert "display_name" not in bucket.metadata_json
+        assert "note" not in bucket.metadata_json
+        assert ledger.wallet_bucket_bid == bucket.wallet_bucket_bid
+        assert ledger.amount == Decimal("12.5000000000")
+        assert ledger.metadata_json["grant_source"] == "compensation"
+        assert ledger.metadata_json["display_name"] == "模型扣费补偿"
+        assert ledger.metadata_json["name"] == "模型扣费补偿"
+        assert ledger.metadata_json["note"] == "DeepSeek 费率补偿"
+        assert ledger.metadata_json["operator_user_bid"] == "operator-cli-1"
+        assert ledger.metadata_json["grant_channel"] == "operator_cli"
+        assert (
+            ledger.idempotency_key == f"operator_manual_grant:{payload['request_id']}"
+        )
+
+
+def test_billing_grant_credits_cli_reuses_request_id(
+    billing_cli_db_app: Flask,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+
+    with billing_cli_db_app.app_context():
+        _seed_billing_cli_user(
+            billing_cli_db_app,
+            user_bid="creator-cli-credit-idempotent",
+            identify="creator-cli-credit-idempotent@example.com",
+            email="creator-cli-credit-idempotent@example.com",
+            is_creator=True,
+        )
+        dao.db.session.commit()
+
+    args = [
+        "console",
+        "billing",
+        "grant-credits",
+        "--user-bid",
+        "creator-cli-credit-idempotent",
+        "--amount",
+        "3",
+        "--grant-source",
+        "reward",
+        "--validity-preset",
+        "1d",
+        "--name",
+        "运营奖励",
+        "--note",
+        "活动奖励",
+    ]
+    first = runner.invoke(args=args)
+    second = runner.invoke(args=args)
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    first_payload = json.loads(first.output)
+    second_payload = json.loads(second.output)
+    assert first_payload["status"] == "granted"
+    assert second_payload["status"] == "noop_existing"
+    assert second_payload["request_id"] == first_payload["request_id"]
+    assert second_payload["ledger_bid"] == first_payload["ledger_bid"]
+
+    with billing_cli_db_app.app_context():
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-cli-credit-idempotent"
+        ).one()
+        assert wallet.available_credits == Decimal("3.0000000000")
+        assert (
+            CreditLedgerEntry.query.filter_by(
+                creator_bid="creator-cli-credit-idempotent"
+            ).count()
+            == 1
+        )
 
 
 def test_billing_backfill_trial_plans_cli_grants_missing_trials_for_creators(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1658,6 +1658,7 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
                 amount="5",
                 grant_source="compensation",
                 validity_preset="7d",
+                display_name="模型扣费补偿",
                 note="ops support",
             ),
         )
@@ -1682,6 +1683,8 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
     assert result.grant_source == "compensation"
     assert result.validity_preset == "7d"
     assert result.expires_at.endswith("Z")
+    assert result.display_name == "模型扣费补偿"
+    assert result.note == "ops support"
     assert result.summary.available_credits == "5"
     assert result.summary.subscription_credits == "5"
     assert result.summary.topup_credits == "0"
@@ -1690,11 +1693,15 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
     assert bucket.source_type == CREDIT_SOURCE_TYPE_MANUAL
     assert bucket.metadata_json["grant_source"] == "compensation"
     assert bucket.metadata_json["validity_preset"] == "7d"
+    assert "display_name" not in bucket.metadata_json
+    assert "note" not in bucket.metadata_json
     assert ledger is not None
     assert ledger.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT
     assert ledger.source_type == CREDIT_SOURCE_TYPE_MANUAL
     assert ledger.metadata_json["grant_type"] == "manual_grant"
     assert ledger.metadata_json["grant_channel"] == "operator_user_management"
+    assert ledger.metadata_json["display_name"] == "模型扣费补偿"
+    assert ledger.metadata_json["note"] == "ops support"
 
 
 def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app):
@@ -1763,6 +1770,7 @@ def test_grant_operator_user_credits_returns_persisted_payload_for_reused_reques
             amount="5",
             grant_source="reward",
             validity_preset="1d",
+            display_name="first display",
             note="first grant",
         )
         second_payload = AdminOperationUserCreditGrantRequestDTO(
@@ -1770,6 +1778,7 @@ def test_grant_operator_user_credits_returns_persisted_payload_for_reused_reques
             amount="9",
             grant_source="compensation",
             validity_preset="7d",
+            display_name="second display",
             note="second grant",
         )
         first_result = grant_operator_user_credits(
@@ -1791,6 +1800,8 @@ def test_grant_operator_user_credits_returns_persisted_payload_for_reused_reques
     assert second_result.grant_source == "reward"
     assert second_result.validity_preset == "1d"
     assert second_result.expires_at == first_result.expires_at
+    assert second_result.display_name == "first display"
+    assert second_result.note == "first grant"
 
 
 def test_grant_operator_user_credits_rejects_regular_user_targets(app):


### PR DESCRIPTION
## Summary
- add a billing CLI command to grant manual credits by identify or user bid without passing API tokens
- share manual credit grant semantics between operator API and CLI, keeping user-visible name/note on ledger metadata rather than bucket display
- show manual grant name/note in creator billing recent activity

## Validation
- pytest tests/service/billing/test_billing_cli.py tests/service/shifu/test_admin_users.py -q
- NODE_PATH=/Users/geyunfei/dev/yfge/ai-shifu/src/cook-web/node_modules /Users/geyunfei/dev/yfge/ai-shifu/src/cook-web/node_modules/.bin/jest BillingRecentActivitySection.test.tsx --runInBand
- python3 scripts/check_architecture_boundaries.py
- pre-commit hooks during commit

Note: full tsc --noEmit still reports an existing unrelated ShifuEdit.tsx fr-FR type issue at src/components/shifu-edit/ShifuEdit.tsx:1429.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Operators can now grant manual credits to users with customizable display names and explanatory notes for transparency
  * Billing activity ledger displays credit grant details including display names and notes
  * New CLI command enables offline manual credit granting with idempotency protection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->