### PR TITLE
fix: add missing shifu generate_id import

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -82,6 +82,7 @@ from flaskr.service.common.models import (
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
 from flaskr.service.profile.models import Variable
+from flaskr.util import generate_id
 from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseListDTO,
     AdminOperationCourseChapterDetailDTO,


### PR DESCRIPTION
Summary
- add the missing `generate_id` import in `src/api/flaskr/service/shifu/admin.py`
- unblock the backend `ruff-check` failure introduced by the course copy flow merge

Testing
- pre-commit run ruff-check --files src/api/flaskr/service/shifu/admin.py
- /Users/iris/.codex/bin/branch_context_manager.py pre-pr-review

Context
- this fixes the `F821 Undefined name `generate_id`` failure currently shown in `pre-commit.ci`
- the failing references were introduced in PR #1768 (`feat: add operator course copy flow`)
