### PR TITLE
fix: Extend mobile run stream timeout

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1510,6 +1510,50 @@ describe('useChatLogicHook stream cleanup', () => {
     jest.useRealTimers();
   });
 
+  it('uses the longer run stream idle timeout on mobile', async () => {
+    jest.useFakeTimers();
+
+    const { result } = renderHook(
+      () =>
+        useChatLogicHook({
+          ...buildBaseParams(),
+          isListenMode: true,
+        }),
+      {
+        wrapper: mobileWrapper,
+      },
+    );
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    act(() => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(
+      result.current.items.some(
+        item => item.type === ChatContentItemType.ERROR,
+      ),
+    ).toBe(false);
+    expect(activeRun?.source.close).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(45000);
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.some(
+          item => item.type === ChatContentItemType.ERROR,
+        ),
+      ).toBe(true),
+    );
+
+    expect(activeRun?.source.close).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
   it('does not auto-open lesson feedback popup for an already rated lesson', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -90,6 +90,7 @@ interface LessonFeedbackPopupState {
 
 const LESSON_FEEDBACK_DISMISS_CACHE_LIMIT = 200;
 const RUN_STREAM_IDLE_TIMEOUT_MS = 15000;
+const MOBILE_RUN_STREAM_IDLE_TIMEOUT_MS = 60000;
 const TTS_BACKFILL_IDLE_TIMEOUT_MS = 120000;
 const STREAM_TIMEOUT_ITEM_BID_PREFIX = 'stream-timeout-error';
 const DEFAULT_LISTEN_AUDIO_POSITION = 0;
@@ -1748,9 +1749,12 @@ function useChatLogicHook({
 
       const armRunStreamTimeout = () => {
         clearRunStreamTimeout();
+        const timeoutMs = mobileStyle
+          ? MOBILE_RUN_STREAM_IDLE_TIMEOUT_MS
+          : RUN_STREAM_IDLE_TIMEOUT_MS;
         runStreamTimeoutRef.current = setTimeout(() => {
           handleRunStreamTimeout();
-        }, RUN_STREAM_IDLE_TIMEOUT_MS);
+        }, timeoutMs);
       };
 
       // Track run start event


### PR DESCRIPTION
## Summary
- keep the learner run stream idle timeout at 15s for desktop
- extend the idle timeout to 60s only for mobile layouts
- add a focused hook test covering the mobile timeout behavior

## Why
A mobile WeChat learner hit a slow first generated block in the course "AI时代，如何做好长期赚钱的“一人公司”" and the frontend timed out before the SSE stream produced user-visible content. This preserves desktop behavior while giving mobile WebView sessions more time for heavy first-block generation.

## Validation
- `npm test -- useChatLogicHook.test.tsx --runInBand`
- `git diff --check`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mobile experience by extending the idle timeout during listening sessions, preventing premature stream disconnection on mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->