### PR TITLE
refactor:optimize operator course request time

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -6238,8 +6238,7 @@ def list_operator_courses(
         published_page_items = [
             course
             for course in page_items
-            if selected_sources.get(str(course.shifu_bid or "").strip())
-            == "published"
+            if selected_sources.get(str(course.shifu_bid or "").strip()) == "published"
         ]
         _attach_course_prompt_flags(DraftShifu, draft_page_items)
         _attach_course_prompt_flags(PublishedShifu, published_page_items)

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1812,7 +1812,21 @@ class OperatorCourseListSeed:
     has_course_prompt: Optional[bool] = None
 
 
-def _load_latest_shifus(
+def _build_operator_course_list_seed(row) -> OperatorCourseListSeed:
+    return OperatorCourseListSeed(
+        id=int(row.id),
+        shifu_bid=str(row.shifu_bid or ""),
+        title=str(row.title or ""),
+        price=row.price,
+        llm=str(row.llm or ""),
+        created_user_bid=str(row.created_user_bid or ""),
+        updated_user_bid=str(row.updated_user_bid or ""),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _build_latest_shifus_query(
     model,
     *,
     shifu_bid: str,
@@ -1822,8 +1836,6 @@ def _load_latest_shifus(
     end_time: Optional[datetime],
     updated_start_time: Optional[datetime],
     updated_end_time: Optional[datetime],
-    attach_prompt_flags: bool = False,
-    lightweight: bool = False,
 ):
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
@@ -1851,39 +1863,76 @@ def _load_latest_shifus(
         latest_rows = latest_rows.filter(model.updated_at >= updated_start_time)
     if updated_end_time:
         latest_rows = latest_rows.filter(model.updated_at <= updated_end_time)
+    return latest_rows.order_by(model.updated_at.desc(), model.id.desc())
 
-    ordered_query = latest_rows.order_by(model.updated_at.desc(), model.id.desc())
-    if lightweight and is_mapped_model:
-        rows = ordered_query.with_entities(
-            model.id.label("id"),
-            model.shifu_bid.label("shifu_bid"),
-            model.title.label("title"),
-            model.price.label("price"),
-            model.llm.label("llm"),
-            model.created_user_bid.label("created_user_bid"),
-            model.updated_user_bid.label("updated_user_bid"),
-            model.created_at.label("created_at"),
-            model.updated_at.label("updated_at"),
-        ).all()
-        return [
-            OperatorCourseListSeed(
-                id=int(row.id),
-                shifu_bid=str(row.shifu_bid or ""),
-                title=str(row.title or ""),
-                price=row.price,
-                llm=str(row.llm or ""),
-                created_user_bid=str(row.created_user_bid or ""),
-                updated_user_bid=str(row.updated_user_bid or ""),
-                created_at=row.created_at,
-                updated_at=row.updated_at,
-            )
-            for row in rows
-        ]
+
+def _load_latest_shifus(
+    model,
+    *,
+    shifu_bid: str,
+    course_name: str,
+    creator_bids: Optional[Set[str]],
+    start_time: Optional[datetime],
+    end_time: Optional[datetime],
+    updated_start_time: Optional[datetime],
+    updated_end_time: Optional[datetime],
+    attach_prompt_flags: bool = False,
+):
+    ordered_query = _build_latest_shifus_query(
+        model,
+        shifu_bid=shifu_bid,
+        course_name=course_name,
+        creator_bids=creator_bids,
+        start_time=start_time,
+        end_time=end_time,
+        updated_start_time=updated_start_time,
+        updated_end_time=updated_end_time,
+    )
+    if isinstance(ordered_query, list):
+        return []
 
     rows = ordered_query.all()
-    if is_mapped_model and attach_prompt_flags:
+    if hasattr(model, "__mapper__") and attach_prompt_flags:
         _attach_course_prompt_flags(model, rows)
     return rows
+
+
+def _load_latest_shifu_seeds(
+    model,
+    *,
+    shifu_bid: str,
+    course_name: str,
+    creator_bids: Optional[Set[str]],
+    start_time: Optional[datetime],
+    end_time: Optional[datetime],
+    updated_start_time: Optional[datetime],
+    updated_end_time: Optional[datetime],
+) -> list[OperatorCourseListSeed]:
+    ordered_query = _build_latest_shifus_query(
+        model,
+        shifu_bid=shifu_bid,
+        course_name=course_name,
+        creator_bids=creator_bids,
+        start_time=start_time,
+        end_time=end_time,
+        updated_start_time=updated_start_time,
+        updated_end_time=updated_end_time,
+    )
+    if isinstance(ordered_query, list):
+        return []
+
+    rows = ordered_query.with_entities(
+        model.id.label("id"),
+        model.shifu_bid.label("shifu_bid"),
+        model.title.label("title"),
+        model.price.label("price"),
+        model.llm.label("llm"),
+        model.created_user_bid.label("created_user_bid"),
+        model.updated_user_bid.label("updated_user_bid"),
+        model.created_at.label("created_at"),
+        model.updated_at.label("updated_at"),
+    ).all()
+    return [_build_operator_course_list_seed(row) for row in rows]
 
 
 def _attach_course_prompt_flags(model, rows) -> None:
@@ -2585,16 +2634,19 @@ def _merge_courses(
 ):
     course_map = {}
     published_bids: Set[str] = set()
+    selected_sources: Dict[str, str] = {}
     for course in drafts:
         visible = _is_operator_visible_course(course)
         if visible:
             course_map[course.shifu_bid] = course
+            selected_sources[course.shifu_bid] = "draft"
     for course in published:
         visible = _is_operator_visible_course(course)
         if visible:
             published_bids.add(course.shifu_bid)
         if visible and course.shifu_bid not in course_map:
             course_map[course.shifu_bid] = course
+            selected_sources[course.shifu_bid] = "published"
     return (
         sorted(
             course_map.values(),
@@ -2606,6 +2658,7 @@ def _merge_courses(
             reverse=True,
         ),
         published_bids,
+        selected_sources,
     )
 
 
@@ -2881,7 +2934,7 @@ def _load_operator_user_course_maps(
         updated_start_time=None,
         updated_end_time=None,
     )
-    merged_created_courses, created_published_bids = _merge_courses(
+    merged_created_courses, created_published_bids, _ = _merge_courses(
         created_drafts,
         created_published,
     )
@@ -2956,7 +3009,7 @@ def _load_operator_user_course_maps(
     learned_published = _load_latest_courses_by_shifu_bids(
         PublishedShifu, learned_shifu_bids
     )
-    merged_learned_courses, learned_published_bids = _merge_courses(
+    merged_learned_courses, learned_published_bids, _ = _merge_courses(
         learned_drafts,
         learned_published,
     )
@@ -3033,7 +3086,7 @@ def _load_operator_user_course_count_maps(
         updated_start_time=None,
         updated_end_time=None,
     )
-    merged_created_courses, _ = _merge_courses(created_drafts, created_published)
+    merged_created_courses, _, _ = _merge_courses(created_drafts, created_published)
     for course in merged_created_courses:
         creator_user_bid = str(course.created_user_bid or "").strip()
         if creator_user_bid not in created_course_count_map:
@@ -3100,7 +3153,7 @@ def _load_operator_user_course_count_maps(
     learned_published = _load_latest_courses_by_shifu_bids(
         PublishedShifu, learned_shifu_bids
     )
-    merged_learned_courses, _ = _merge_courses(learned_drafts, learned_published)
+    merged_learned_courses, _, _ = _merge_courses(learned_drafts, learned_published)
     visible_learned_shifu_bids = {
         str(course.shifu_bid or "").strip()
         for course in merged_learned_courses
@@ -5989,7 +6042,7 @@ def _build_operator_course_overview(app: Flask) -> AdminOperationCourseOverviewD
         updated_start_time=None,
         updated_end_time=None,
     )
-    merged_courses, published_bids = _merge_courses(draft_rows, published_rows)
+    merged_courses, published_bids, _ = _merge_courses(draft_rows, published_rows)
     total_course_count = len(merged_courses)
     if total_course_count == 0:
         return AdminOperationCourseOverviewDTO()
@@ -6067,7 +6120,7 @@ def list_operator_courses(
         updated_end_time = filters.get("updated_end_time")
 
         creator_bids = _find_matching_creator_bids(creator_keyword)
-        draft_rows = _load_latest_shifus(
+        draft_rows = _load_latest_shifu_seeds(
             DraftShifu,
             shifu_bid=shifu_bid,
             course_name=course_name,
@@ -6076,9 +6129,8 @@ def list_operator_courses(
             end_time=end_time,
             updated_start_time=None,
             updated_end_time=None,
-            lightweight=True,
         )
-        published_rows = _load_latest_shifus(
+        published_rows = _load_latest_shifu_seeds(
             PublishedShifu,
             shifu_bid=shifu_bid,
             course_name=course_name,
@@ -6087,13 +6139,12 @@ def list_operator_courses(
             end_time=end_time,
             updated_start_time=None,
             updated_end_time=None,
-            lightweight=True,
         )
 
-        merged_courses, published_bids = _merge_courses(draft_rows, published_rows)
+        merged_courses, published_bids, selected_sources = _merge_courses(
+            draft_rows, published_rows
+        )
         activity_map = _load_course_activity_map(draft_rows, published_rows)
-        draft_row_refs = {id(course) for course in draft_rows}
-        published_row_refs = {id(course) for course in published_rows}
 
         def resolve_activity(course) -> Dict[str, Any]:
             return activity_map.get(str(course.shifu_bid or "").strip(), {})
@@ -6180,10 +6231,15 @@ def list_operator_courses(
         page_offset = (safe_page_index - 1) * safe_page_size
         page_items = merged_courses[page_offset : page_offset + safe_page_size]
         draft_page_items = [
-            course for course in page_items if id(course) in draft_row_refs
+            course
+            for course in page_items
+            if selected_sources.get(str(course.shifu_bid or "").strip()) == "draft"
         ]
         published_page_items = [
-            course for course in page_items if id(course) in published_row_refs
+            course
+            for course in page_items
+            if selected_sources.get(str(course.shifu_bid or "").strip())
+            == "published"
         ]
         _attach_course_prompt_flags(DraftShifu, draft_page_items)
         _attach_course_prompt_flags(PublishedShifu, published_page_items)

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1854,19 +1854,17 @@ def _load_latest_shifus(
 
     ordered_query = latest_rows.order_by(model.updated_at.desc(), model.id.desc())
     if lightweight and is_mapped_model:
-        rows = (
-            ordered_query.with_entities(
-                model.id.label("id"),
-                model.shifu_bid.label("shifu_bid"),
-                model.title.label("title"),
-                model.price.label("price"),
-                model.llm.label("llm"),
-                model.created_user_bid.label("created_user_bid"),
-                model.updated_user_bid.label("updated_user_bid"),
-                model.created_at.label("created_at"),
-                model.updated_at.label("updated_at"),
-            ).all()
-        )
+        rows = ordered_query.with_entities(
+            model.id.label("id"),
+            model.shifu_bid.label("shifu_bid"),
+            model.title.label("title"),
+            model.price.label("price"),
+            model.llm.label("llm"),
+            model.created_user_bid.label("created_user_bid"),
+            model.updated_user_bid.label("updated_user_bid"),
+            model.created_at.label("created_at"),
+            model.updated_at.label("updated_at"),
+        ).all()
         return [
             OperatorCourseListSeed(
                 id=int(row.id),

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
@@ -1797,6 +1798,20 @@ def _assert_operator_user_grant_target_supported(user: UserEntity) -> None:
     raise_error("server.billing.adminPlanGrantRoleUnsupported")
 
 
+@dataclass
+class OperatorCourseListSeed:
+    id: int
+    shifu_bid: str
+    title: str
+    price: Any
+    llm: str
+    created_user_bid: str
+    updated_user_bid: str
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    has_course_prompt: Optional[bool] = None
+
+
 def _load_latest_shifus(
     model,
     *,
@@ -1808,6 +1823,7 @@ def _load_latest_shifus(
     updated_start_time: Optional[datetime],
     updated_end_time: Optional[datetime],
     attach_prompt_flags: bool = False,
+    lightweight: bool = False,
 ):
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
@@ -1836,7 +1852,37 @@ def _load_latest_shifus(
     if updated_end_time:
         latest_rows = latest_rows.filter(model.updated_at <= updated_end_time)
 
-    rows = latest_rows.order_by(model.updated_at.desc(), model.id.desc()).all()
+    ordered_query = latest_rows.order_by(model.updated_at.desc(), model.id.desc())
+    if lightweight and is_mapped_model:
+        rows = (
+            ordered_query.with_entities(
+                model.id.label("id"),
+                model.shifu_bid.label("shifu_bid"),
+                model.title.label("title"),
+                model.price.label("price"),
+                model.llm.label("llm"),
+                model.created_user_bid.label("created_user_bid"),
+                model.updated_user_bid.label("updated_user_bid"),
+                model.created_at.label("created_at"),
+                model.updated_at.label("updated_at"),
+            ).all()
+        )
+        return [
+            OperatorCourseListSeed(
+                id=int(row.id),
+                shifu_bid=str(row.shifu_bid or ""),
+                title=str(row.title or ""),
+                price=row.price,
+                llm=str(row.llm or ""),
+                created_user_bid=str(row.created_user_bid or ""),
+                updated_user_bid=str(row.updated_user_bid or ""),
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+            )
+            for row in rows
+        ]
+
+    rows = ordered_query.all()
     if is_mapped_model and attach_prompt_flags:
         _attach_course_prompt_flags(model, rows)
     return rows
@@ -6032,6 +6078,7 @@ def list_operator_courses(
             end_time=end_time,
             updated_start_time=None,
             updated_end_time=None,
+            lightweight=True,
         )
         published_rows = _load_latest_shifus(
             PublishedShifu,
@@ -6042,10 +6089,13 @@ def list_operator_courses(
             end_time=end_time,
             updated_start_time=None,
             updated_end_time=None,
+            lightweight=True,
         )
 
         merged_courses, published_bids = _merge_courses(draft_rows, published_rows)
         activity_map = _load_course_activity_map(draft_rows, published_rows)
+        draft_row_refs = {id(course) for course in draft_rows}
+        published_row_refs = {id(course) for course in published_rows}
 
         def resolve_activity(course) -> Dict[str, Any]:
             return activity_map.get(str(course.shifu_bid or "").strip(), {})
@@ -6132,10 +6182,10 @@ def list_operator_courses(
         page_offset = (safe_page_index - 1) * safe_page_size
         page_items = merged_courses[page_offset : page_offset + safe_page_size]
         draft_page_items = [
-            course for course in page_items if isinstance(course, DraftShifu)
+            course for course in page_items if id(course) in draft_row_refs
         ]
         published_page_items = [
-            course for course in page_items if isinstance(course, PublishedShifu)
+            course for course in page_items if id(course) in published_row_refs
         ]
         _attach_course_prompt_flags(DraftShifu, draft_page_items)
         _attach_course_prompt_flags(PublishedShifu, published_page_items)

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -13,6 +13,7 @@ from flaskr.service.shifu import admin as admin_module
 from flaskr.service.shifu.admin import (
     _load_latest_shifus,
     _build_operator_course_overview,
+    OperatorCourseListSeed,
     list_operator_courses,
 )
 from flaskr.service.shifu.course_activity import load_course_activity_map
@@ -143,8 +144,10 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     assert item.updater_nickname == "Editor Venus"
     assert latest_mock.call_args_list[0].kwargs["updated_start_time"] is None
     assert latest_mock.call_args_list[0].kwargs["updated_end_time"] is None
+    assert latest_mock.call_args_list[0].kwargs["lightweight"] is True
     assert latest_mock.call_args_list[1].kwargs["updated_start_time"] is None
     assert latest_mock.call_args_list[1].kwargs["updated_end_time"] is None
+    assert latest_mock.call_args_list[1].kwargs["lightweight"] is True
 
 
 def test_list_operator_courses_paginates_merged_results():
@@ -206,6 +209,77 @@ def test_list_operator_courses_paginates_merged_results():
     assert result.total == 2
     assert len(result.items) == 1
     assert result.items[0].shifu_bid == "course-1"
+
+
+def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items():
+    app = Flask(__name__)
+    draft_seed = OperatorCourseListSeed(
+        id=11,
+        shifu_bid="course-draft",
+        title="Draft Seed",
+        price="29.00",
+        llm="gpt-4.1-mini",
+        created_user_bid="creator-1",
+        updated_user_bid="creator-1",
+        created_at=datetime(2025, 4, 2, 10, 0, 0),
+        updated_at=datetime(2025, 4, 4, 10, 0, 0),
+    )
+    published_seed = OperatorCourseListSeed(
+        id=12,
+        shifu_bid="course-published",
+        title="Published Seed",
+        price="59.00",
+        llm="gpt-4.1",
+        created_user_bid="creator-2",
+        updated_user_bid="creator-2",
+        created_at=datetime(2025, 4, 1, 10, 0, 0),
+        updated_at=datetime(2025, 4, 3, 10, 0, 0),
+    )
+
+    def attach_prompt_flags(model, rows):
+        for row in rows:
+            row.has_course_prompt = model is PublishedShifu
+
+    with patch(
+        "flaskr.service.shifu.admin._find_matching_creator_bids"
+    ) as creator_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+            with patch(
+                "flaskr.service.shifu.admin._load_course_activity_map"
+            ) as activity_mock:
+                with patch(
+                    "flaskr.service.shifu.admin._attach_course_prompt_flags",
+                    side_effect=attach_prompt_flags,
+                ):
+                    with patch(
+                        "flaskr.service.shifu.admin._load_user_map"
+                    ) as user_map_mock:
+                        with patch(
+                            "flaskr.service.shifu.admin._build_operator_course_overview",
+                            return_value=EMPTY_COURSE_OVERVIEW,
+                        ):
+                            creator_mock.return_value = None
+                            latest_mock.side_effect = [[draft_seed], [published_seed]]
+                            activity_mock.return_value = {}
+                            user_map_mock.return_value = {
+                                "creator-1": {
+                                    "mobile": "",
+                                    "email": "creator-1@example.com",
+                                    "nickname": "",
+                                },
+                                "creator-2": {
+                                    "mobile": "",
+                                    "email": "creator-2@example.com",
+                                    "nickname": "",
+                                },
+                            }
+
+                            result = list_operator_courses(app, 2, 1, {})
+
+    assert result.total == 2
+    assert len(result.items) == 1
+    assert result.items[0].shifu_bid == "course-published"
+    assert result.items[0].has_course_prompt is True
 
 
 def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at():

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -87,7 +87,7 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -144,10 +144,8 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     assert item.updater_nickname == "Editor Venus"
     assert latest_mock.call_args_list[0].kwargs["updated_start_time"] is None
     assert latest_mock.call_args_list[0].kwargs["updated_end_time"] is None
-    assert latest_mock.call_args_list[0].kwargs["lightweight"] is True
     assert latest_mock.call_args_list[1].kwargs["updated_start_time"] is None
     assert latest_mock.call_args_list[1].kwargs["updated_end_time"] is None
-    assert latest_mock.call_args_list[1].kwargs["lightweight"] is True
 
 
 def test_list_operator_courses_paginates_merged_results():
@@ -174,7 +172,7 @@ def test_list_operator_courses_paginates_merged_results():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -243,7 +241,7 @@ def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items(
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -306,7 +304,7 @@ def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at()
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -370,7 +368,7 @@ def test_list_operator_courses_filters_by_latest_activity_updated_range():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -550,7 +548,7 @@ def test_list_operator_courses_filters_out_builtin_demo_courses_only():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -614,7 +612,7 @@ def test_list_operator_courses_skips_system_user_lookup():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -671,7 +669,7 @@ def test_list_operator_courses_filters_by_course_status():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -766,7 +764,7 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -841,7 +839,7 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
     with patch(
         "flaskr.service.shifu.admin._build_operator_course_overview"
     ) as overview_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifus") as latest_mock:
+        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
             try:
                 list_operator_courses(app, 1, 20, {"quick_filter": "invalid"})
             except AppException as exc:
@@ -1090,7 +1088,7 @@ def test_merge_courses_checks_published_visibility_once():
         "flaskr.service.shifu.admin._is_operator_visible_course",
         side_effect=[True, True],
     ) as visible_mock:
-        merged_courses, published_bids = admin_module._merge_courses(
+        merged_courses, published_bids, _ = admin_module._merge_courses(
             [draft_course], [published_course]
         )
 

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -87,7 +87,9 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -172,7 +174,9 @@ def test_list_operator_courses_paginates_merged_results():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -241,7 +245,9 @@ def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items(
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -304,7 +310,9 @@ def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at()
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -368,7 +376,9 @@ def test_list_operator_courses_filters_by_latest_activity_updated_range():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -548,7 +558,9 @@ def test_list_operator_courses_filters_out_builtin_demo_courses_only():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -612,7 +624,9 @@ def test_list_operator_courses_skips_system_user_lookup():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -669,7 +683,9 @@ def test_list_operator_courses_filters_by_course_status():
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -764,7 +780,9 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
     with patch(
         "flaskr.service.shifu.admin._find_matching_creator_bids"
     ) as creator_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             with patch(
                 "flaskr.service.shifu.admin._load_course_activity_map"
             ) as activity_mock:
@@ -839,7 +857,9 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
     with patch(
         "flaskr.service.shifu.admin._build_operator_course_overview"
     ) as overview_mock:
-        with patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock:
+        with patch(
+            "flaskr.service.shifu.admin._load_latest_shifu_seeds"
+        ) as latest_mock:
             try:
                 list_operator_courses(app, 1, 20, {"quick_filter": "invalid"})
             except AppException as exc:

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -436,7 +437,9 @@ const createDeferred = <T,>() => {
 
 describe('OperationsPage', () => {
   const renderAndWaitForLoadedPage = async () => {
-    render(<OperationsPage />);
+    await act(async () => {
+      render(<OperationsPage />);
+    });
 
     await waitFor(() => {
       expect(mockGetAdminOperationCourses).toHaveBeenCalled();
@@ -445,7 +448,54 @@ describe('OperationsPage', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCoursesOverview).toHaveBeenCalled();
+    });
   };
+
+  test('loads course overview after the initial list request settles', async () => {
+    const listDeferred = createDeferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_count: number;
+      page_size: number;
+      total: number;
+    }>();
+    const overviewDeferred =
+      createDeferred<Record<string, number | undefined>>();
+    mockGetAdminOperationCourses.mockReturnValueOnce(listDeferred.promise);
+    mockGetAdminOperationCoursesOverview.mockReturnValueOnce(
+      overviewDeferred.promise,
+    );
+
+    await act(async () => {
+      render(<OperationsPage />);
+    });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourses).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetAdminOperationCoursesOverview).not.toHaveBeenCalled();
+
+    await act(async () => {
+      listDeferred.resolve({
+        items: [],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCoursesOverview).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      overviewDeferred.resolve(DEFAULT_OVERVIEW);
+    });
+  });
 
   beforeAll(() => {
     Object.defineProperty(window, 'location', {

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -639,8 +639,10 @@ const OperationsPage = () => {
     if (!isInitialized || isGuest || !isReady) {
       return;
     }
-    void fetchCourseOverview();
-    fetchCoursesRef.current?.(1, createDefaultFilters(), '');
+    void (async () => {
+      await fetchCoursesRef.current?.(1, createDefaultFilters(), '');
+      void fetchCourseOverview();
+    })();
   }, [fetchCourseOverview, isGuest, isInitialized, isReady]);
 
   const clearQuickFilterIfConflicted = useCallback(


### PR DESCRIPTION
Summary
- optimize the operator course list request path by loading lightweight course seeds before pagination
- defer the operator course overview request until the initial course list request settles
- add backend and frontend regression coverage for lightweight pagination and delayed overview loading

Testing
- cd src/api && pytest tests/service/shifu/test_admin_courses.py -q
- cd src/cook-web && npm run test -- --runInBand --runTestsByPath src/app/admin/operations/page.test.tsx
- cd src/cook-web && npm run lint -- --file src/app/admin/operations/page.tsx --file src/app/admin/operations/page.test.tsx
- pre-commit run -a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed loading order of course data on the admin operations page to ensure the course list loads before the course overview, improving data consistency and loading reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->