### PR TITLE
Refactor:optimize operator user request flow

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -244,6 +244,18 @@ OPERATOR_USER_REGISTRATION_SOURCE_GOOGLE = "google"
 OPERATOR_USER_REGISTRATION_SOURCE_WECHAT = "wechat"
 OPERATOR_USER_REGISTRATION_SOURCE_IMPORTED = "imported"
 OPERATOR_USER_REGISTRATION_SOURCE_UNKNOWN = "unknown"
+OPERATOR_USER_SUPPORTED_LOGIN_METHOD_PROVIDERS = {
+    "phone",
+    "email",
+    "google",
+    "wechat",
+}
+OPERATOR_USER_SUPPORTED_REGISTRATION_SOURCE_PROVIDERS = (
+    OPERATOR_USER_SUPPORTED_LOGIN_METHOD_PROVIDERS | {"manual", "import", "imported"}
+)
+OPERATOR_USER_PRELOADED_AUTH_CREDENTIAL_PROVIDERS = (
+    OPERATOR_USER_SUPPORTED_REGISTRATION_SOURCE_PROVIDERS | {"password"}
+)
 COURSE_FOLLOW_UP_LIST_MAX_PAGE_SIZE = 100
 COURSE_RATING_LIST_MAX_PAGE_SIZE = 100
 COURSE_CREDIT_USAGE_LIST_MAX_PAGE_SIZE = 100
@@ -1343,14 +1355,14 @@ def _normalize_login_method(provider_name: str) -> str:
     normalized = str(provider_name or "").strip().lower()
     if not normalized:
         return ""
-    if normalized in {"phone", "email", "google", "wechat"}:
+    if normalized in OPERATOR_USER_SUPPORTED_LOGIN_METHOD_PROVIDERS:
         return normalized
     return "unknown"
 
 
 def _normalize_registration_source(provider_name: str) -> str:
     normalized = str(provider_name or "").strip().lower()
-    if normalized in {"phone", "email", "google", "wechat"}:
+    if normalized in OPERATOR_USER_SUPPORTED_LOGIN_METHOD_PROVIDERS:
         return normalized
     if normalized in {"manual", "import", "imported"}:
         return OPERATOR_USER_REGISTRATION_SOURCE_IMPORTED
@@ -1368,6 +1380,9 @@ def _load_operator_user_auth_credentials(
 
     return AuthCredential.query.filter(
         AuthCredential.user_bid.in_(normalized_user_bids),
+        AuthCredential.provider_name.in_(
+            sorted(OPERATOR_USER_PRELOADED_AUTH_CREDENTIAL_PROVIDERS)
+        ),
         AuthCredential.deleted == 0,
     ).all()
 
@@ -1400,9 +1415,12 @@ def _load_operator_user_registration_source_map(
         user_bid = str(credential.user_bid or "").strip()
         if not user_bid or user_bid in registration_source_map:
             continue
-        registration_source_map[user_bid] = _normalize_registration_source(
+        registration_source = _normalize_registration_source(
             credential.provider_name or ""
         )
+        if registration_source == OPERATOR_USER_REGISTRATION_SOURCE_UNKNOWN:
+            continue
+        registration_source_map[user_bid] = registration_source
 
     if len(registration_source_map) == len(normalized_user_bids):
         return registration_source_map

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1407,8 +1407,7 @@ def _load_operator_user_registration_source_map(
     if len(registration_source_map) == len(normalized_user_bids):
         return registration_source_map
 
-    resolved_users = list(users) if users is not None else []
-    if not resolved_users:
+    if users is None:
         resolved_users = (
             UserEntity.query.filter(
                 UserEntity.user_bid.in_(normalized_user_bids),
@@ -1417,6 +1416,8 @@ def _load_operator_user_registration_source_map(
             .order_by(UserEntity.id.asc())
             .all()
         )
+    else:
+        resolved_users = list(users)
     for user in resolved_users:
         user_bid = str(user.user_bid or "").strip()
         if not user_bid or user_bid in registration_source_map:
@@ -1570,8 +1571,7 @@ def _load_operator_user_contact_map(
         ):
             resolved["email"] = credential.identifier
 
-    resolved_users = list(users) if users is not None else []
-    if not resolved_users:
+    if users is None:
         resolved_users = (
             UserEntity.query.filter(
                 UserEntity.user_bid.in_(list(user_bids)),
@@ -1580,6 +1580,8 @@ def _load_operator_user_contact_map(
             .order_by(UserEntity.id.asc())
             .all()
         )
+    else:
+        resolved_users = list(users)
     for user in resolved_users:
         resolved = contact_map.setdefault(
             user.user_bid or "",
@@ -1878,7 +1880,7 @@ def _load_latest_shifus(
     latest_rows = db.session.query(model).filter(
         model.id.in_(db.session.query(latest_subquery.c.max_id))
     )
-    if is_mapped_model:
+    if is_mapped_model and not lightweight:
         latest_rows = latest_rows.options(defer(model.llm_system_prompt))
     if course_name:
         latest_rows = latest_rows.filter(model.title.ilike(f"%{course_name}%"))

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
@@ -1356,8 +1357,29 @@ def _normalize_registration_source(provider_name: str) -> str:
     return OPERATOR_USER_REGISTRATION_SOURCE_UNKNOWN
 
 
+def _load_operator_user_auth_credentials(
+    user_bids: Sequence[str],
+) -> list[AuthCredential]:
+    normalized_user_bids = [
+        str(user_bid or "").strip() for user_bid in user_bids if user_bid
+    ]
+    if not normalized_user_bids:
+        return []
+
+    return (
+        AuthCredential.query.filter(
+            AuthCredential.user_bid.in_(normalized_user_bids),
+            AuthCredential.deleted == 0,
+        )
+        .all()
+    )
+
+
 def _load_operator_user_registration_source_map(
     user_bids: Sequence[str],
+    *,
+    users: Optional[Sequence[UserEntity]] = None,
+    credential_rows: Optional[Sequence[AuthCredential]] = None,
 ) -> Dict[str, str]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
@@ -1365,16 +1387,19 @@ def _load_operator_user_registration_source_map(
     if not normalized_user_bids:
         return {}
 
-    credential_rows = (
-        AuthCredential.query.filter(
-            AuthCredential.user_bid.in_(normalized_user_bids),
-            AuthCredential.deleted == 0,
-        )
-        .order_by(AuthCredential.created_at.asc(), AuthCredential.id.asc())
-        .all()
+    resolved_credential_rows = sorted(
+        list(
+            credential_rows
+            if credential_rows is not None
+            else _load_operator_user_auth_credentials(normalized_user_bids)
+        ),
+        key=lambda credential: (
+            getattr(credential, "created_at", None) or datetime.min,
+            int(getattr(credential, "id", 0) or 0),
+        ),
     )
     registration_source_map: Dict[str, str] = {}
-    for credential in credential_rows:
+    for credential in resolved_credential_rows:
         user_bid = str(credential.user_bid or "").strip()
         if not user_bid or user_bid in registration_source_map:
             continue
@@ -1385,15 +1410,17 @@ def _load_operator_user_registration_source_map(
     if len(registration_source_map) == len(normalized_user_bids):
         return registration_source_map
 
-    users = (
-        UserEntity.query.filter(
-            UserEntity.user_bid.in_(normalized_user_bids),
-            UserEntity.deleted == 0,
+    resolved_users = list(users) if users is not None else []
+    if not resolved_users:
+        resolved_users = (
+            UserEntity.query.filter(
+                UserEntity.user_bid.in_(normalized_user_bids),
+                UserEntity.deleted == 0,
+            )
+            .order_by(UserEntity.id.asc())
+            .all()
         )
-        .order_by(UserEntity.id.asc())
-        .all()
-    )
-    for user in users:
+    for user in resolved_users:
         user_bid = str(user.user_bid or "").strip()
         if not user_bid or user_bid in registration_source_map:
             continue
@@ -1500,23 +1527,27 @@ def _load_operator_user_last_learning_map(
 
 def _load_operator_user_contact_map(
     user_bids: Sequence[str],
+    *,
+    users: Optional[Sequence[UserEntity]] = None,
+    credential_rows: Optional[Sequence[AuthCredential]] = None,
 ) -> Dict[str, Dict[str, Any]]:
     if not user_bids:
         return {}
 
-    credential_rows = (
-        AuthCredential.query.filter(
-            AuthCredential.user_bid.in_(list(user_bids)),
-            AuthCredential.deleted == 0,
-        )
-        .order_by(AuthCredential.id.desc())
-        .all()
+    resolved_credential_rows = sorted(
+        list(
+            credential_rows
+            if credential_rows is not None
+            else _load_operator_user_auth_credentials(user_bids)
+        ),
+        key=lambda credential: int(getattr(credential, "id", 0) or 0),
+        reverse=True,
     )
     contact_map: Dict[str, Dict[str, Any]] = {
         user_bid: {"mobile": "", "email": "", "login_methods": []}
         for user_bid in user_bids
     }
-    for credential in credential_rows:
+    for credential in resolved_credential_rows:
         user_bid = str(credential.user_bid or "").strip()
         if not user_bid:
             continue
@@ -1542,15 +1573,17 @@ def _load_operator_user_contact_map(
         ):
             resolved["email"] = credential.identifier
 
-    users = (
-        UserEntity.query.filter(
-            UserEntity.user_bid.in_(list(user_bids)),
-            UserEntity.deleted == 0,
+    resolved_users = list(users) if users is not None else []
+    if not resolved_users:
+        resolved_users = (
+            UserEntity.query.filter(
+                UserEntity.user_bid.in_(list(user_bids)),
+                UserEntity.deleted == 0,
+            )
+            .order_by(UserEntity.id.asc())
+            .all()
         )
-        .order_by(UserEntity.id.asc())
-        .all()
-    )
-    for user in users:
+    for user in resolved_users:
         resolved = contact_map.setdefault(
             user.user_bid or "",
             {"mobile": "", "email": "", "login_methods": []},
@@ -1797,6 +1830,34 @@ def _assert_operator_user_grant_target_supported(user: UserEntity) -> None:
     raise_error("server.billing.adminPlanGrantRoleUnsupported")
 
 
+@dataclass
+class OperatorCourseListSeed:
+    id: int
+    shifu_bid: str
+    title: str
+    price: Any
+    llm: str
+    created_user_bid: str
+    updated_user_bid: str
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    has_course_prompt: Optional[bool] = None
+
+
+def _build_operator_course_list_seed(row) -> OperatorCourseListSeed:
+    return OperatorCourseListSeed(
+        id=int(row.id),
+        shifu_bid=str(row.shifu_bid or ""),
+        title=str(row.title or ""),
+        price=row.price,
+        llm=str(row.llm or ""),
+        created_user_bid=str(row.created_user_bid or ""),
+        updated_user_bid=str(row.updated_user_bid or ""),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
 def _load_latest_shifus(
     model,
     *,
@@ -1808,6 +1869,7 @@ def _load_latest_shifus(
     updated_start_time: Optional[datetime],
     updated_end_time: Optional[datetime],
     attach_prompt_flags: bool = False,
+    lightweight: bool = False,
 ):
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
@@ -1836,7 +1898,24 @@ def _load_latest_shifus(
     if updated_end_time:
         latest_rows = latest_rows.filter(model.updated_at <= updated_end_time)
 
-    rows = latest_rows.order_by(model.updated_at.desc(), model.id.desc()).all()
+    ordered_query = latest_rows.order_by(model.updated_at.desc(), model.id.desc())
+    if lightweight and is_mapped_model:
+        rows = (
+            ordered_query.with_entities(
+                model.id.label("id"),
+                model.shifu_bid.label("shifu_bid"),
+                model.title.label("title"),
+                model.price.label("price"),
+                model.llm.label("llm"),
+                model.created_user_bid.label("created_user_bid"),
+                model.updated_user_bid.label("updated_user_bid"),
+                model.created_at.label("created_at"),
+                model.updated_at.label("updated_at"),
+            ).all()
+        )
+        return [_build_operator_course_list_seed(row) for row in rows]
+
+    rows = ordered_query.all()
     if is_mapped_model and attach_prompt_flags:
         _attach_course_prompt_flags(model, rows)
     return rows
@@ -2590,6 +2669,8 @@ def _load_latest_course_versions(
 def _load_latest_courses_by_shifu_bids(
     model,
     shifu_bids: Sequence[str],
+    *,
+    lightweight: bool = False,
 ):
     normalized_shifu_bids = [
         str(shifu_bid or "").strip() for shifu_bid in shifu_bids if shifu_bid
@@ -2606,11 +2687,25 @@ def _load_latest_courses_by_shifu_bids(
         .group_by(model.shifu_bid)
         .subquery()
     )
-    return (
-        db.session.query(model)
-        .filter(model.id.in_(db.session.query(latest_subquery.c.max_id)))
-        .all()
+    query = db.session.query(model).filter(
+        model.id.in_(db.session.query(latest_subquery.c.max_id))
     )
+    if lightweight and hasattr(model, "__mapper__"):
+        rows = (
+            query.with_entities(
+                model.id.label("id"),
+                model.shifu_bid.label("shifu_bid"),
+                model.title.label("title"),
+                model.price.label("price"),
+                model.llm.label("llm"),
+                model.created_user_bid.label("created_user_bid"),
+                model.updated_user_bid.label("updated_user_bid"),
+                model.created_at.label("created_at"),
+                model.updated_at.label("updated_at"),
+            ).all()
+        )
+        return [_build_operator_course_list_seed(row) for row in rows]
+    return query.all()
 
 
 def _build_operator_user_course_summary(
@@ -2826,6 +2921,7 @@ def _load_operator_user_course_maps(
         end_time=None,
         updated_start_time=None,
         updated_end_time=None,
+        lightweight=True,
     )
     created_published = _load_latest_shifus(
         PublishedShifu,
@@ -2836,6 +2932,7 @@ def _load_operator_user_course_maps(
         end_time=None,
         updated_start_time=None,
         updated_end_time=None,
+        lightweight=True,
     )
     merged_created_courses, created_published_bids = _merge_courses(
         created_drafts,
@@ -2908,9 +3005,15 @@ def _load_operator_user_course_maps(
             if str(row.shifu_bid or "").strip()
         }
     )
-    learned_drafts = _load_latest_courses_by_shifu_bids(DraftShifu, learned_shifu_bids)
+    learned_drafts = _load_latest_courses_by_shifu_bids(
+        DraftShifu,
+        learned_shifu_bids,
+        lightweight=True,
+    )
     learned_published = _load_latest_courses_by_shifu_bids(
-        PublishedShifu, learned_shifu_bids
+        PublishedShifu,
+        learned_shifu_bids,
+        lightweight=True,
     )
     merged_learned_courses, learned_published_bids = _merge_courses(
         learned_drafts,
@@ -5406,12 +5509,21 @@ def list_operator_users(
         user_bids = [
             str(user.user_bid or "").strip() for user in page_items if user.user_bid
         ]
-        contact_map = _load_operator_user_contact_map(user_bids)
+        credential_rows = _load_operator_user_auth_credentials(user_bids)
+        contact_map = _load_operator_user_contact_map(
+            user_bids,
+            users=page_items,
+            credential_rows=credential_rows,
+        )
         created_course_count_map, learning_course_count_map = (
             _load_operator_user_course_count_maps(user_bids)
         )
         learner_user_bids = _load_learner_user_bids(user_bids)
-        registration_source_map = _load_operator_user_registration_source_map(user_bids)
+        registration_source_map = _load_operator_user_registration_source_map(
+            user_bids,
+            users=page_items,
+            credential_rows=credential_rows,
+        )
         last_login_map = _load_operator_user_last_login_map(user_bids)
         total_paid_amount_map = _load_operator_user_total_paid_amount_map(user_bids)
         last_learning_map = _load_operator_user_last_learning_map(user_bids)
@@ -5447,13 +5559,20 @@ def get_operator_user_detail(
         normalized_user_bid = str(user_bid or "").strip()
         user = _load_operator_user_or_raise(normalized_user_bid)
 
-        contact_map = _load_operator_user_contact_map([normalized_user_bid])
+        credential_rows = _load_operator_user_auth_credentials([normalized_user_bid])
+        contact_map = _load_operator_user_contact_map(
+            [normalized_user_bid],
+            users=[user],
+            credential_rows=credential_rows,
+        )
         created_courses_map, learning_courses_map = _load_operator_user_course_maps(
             [normalized_user_bid]
         )
         learner_user_bids = _load_learner_user_bids([normalized_user_bid])
         registration_source_map = _load_operator_user_registration_source_map(
-            [normalized_user_bid]
+            [normalized_user_bid],
+            users=[user],
+            credential_rows=credential_rows,
         )
         last_login_map = _load_operator_user_last_login_map([normalized_user_bid])
         total_paid_amount_map = _load_operator_user_total_paid_amount_map(

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1874,6 +1874,7 @@ def _build_operator_course_list_seed(row) -> OperatorCourseListSeed:
         updated_at=row.updated_at,
     )
 
+
 def _build_latest_shifus_query(
     model,
     *,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -1366,13 +1366,10 @@ def _load_operator_user_auth_credentials(
     if not normalized_user_bids:
         return []
 
-    return (
-        AuthCredential.query.filter(
-            AuthCredential.user_bid.in_(normalized_user_bids),
-            AuthCredential.deleted == 0,
-        )
-        .all()
-    )
+    return AuthCredential.query.filter(
+        AuthCredential.user_bid.in_(normalized_user_bids),
+        AuthCredential.deleted == 0,
+    ).all()
 
 
 def _load_operator_user_registration_source_map(
@@ -1900,19 +1897,17 @@ def _load_latest_shifus(
 
     ordered_query = latest_rows.order_by(model.updated_at.desc(), model.id.desc())
     if lightweight and is_mapped_model:
-        rows = (
-            ordered_query.with_entities(
-                model.id.label("id"),
-                model.shifu_bid.label("shifu_bid"),
-                model.title.label("title"),
-                model.price.label("price"),
-                model.llm.label("llm"),
-                model.created_user_bid.label("created_user_bid"),
-                model.updated_user_bid.label("updated_user_bid"),
-                model.created_at.label("created_at"),
-                model.updated_at.label("updated_at"),
-            ).all()
-        )
+        rows = ordered_query.with_entities(
+            model.id.label("id"),
+            model.shifu_bid.label("shifu_bid"),
+            model.title.label("title"),
+            model.price.label("price"),
+            model.llm.label("llm"),
+            model.created_user_bid.label("created_user_bid"),
+            model.updated_user_bid.label("updated_user_bid"),
+            model.created_at.label("created_at"),
+            model.updated_at.label("updated_at"),
+        ).all()
         return [_build_operator_course_list_seed(row) for row in rows]
 
     rows = ordered_query.all()
@@ -2691,19 +2686,17 @@ def _load_latest_courses_by_shifu_bids(
         model.id.in_(db.session.query(latest_subquery.c.max_id))
     )
     if lightweight and hasattr(model, "__mapper__"):
-        rows = (
-            query.with_entities(
-                model.id.label("id"),
-                model.shifu_bid.label("shifu_bid"),
-                model.title.label("title"),
-                model.price.label("price"),
-                model.llm.label("llm"),
-                model.created_user_bid.label("created_user_bid"),
-                model.updated_user_bid.label("updated_user_bid"),
-                model.created_at.label("created_at"),
-                model.updated_at.label("updated_at"),
-            ).all()
-        )
+        rows = query.with_entities(
+            model.id.label("id"),
+            model.shifu_bid.label("shifu_bid"),
+            model.title.label("title"),
+            model.price.label("price"),
+            model.llm.label("llm"),
+            model.created_user_bid.label("created_user_bid"),
+            model.updated_user_bid.label("updated_user_bid"),
+            model.created_at.label("created_at"),
+            model.updated_at.label("updated_at"),
+        ).all()
         return [_build_operator_course_list_seed(row) for row in rows]
     return query.all()
 

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from flask import Flask
@@ -1095,13 +1096,23 @@ class FakeOuterQuery:
         self.filters = []
         self.ordering = []
         self.result = result
+        self.options_calls = []
+        self.with_entities_calls = []
 
     def filter(self, *conditions):
         self.filters.extend(conditions)
         return self
 
+    def options(self, *options):
+        self.options_calls.extend(options)
+        return self
+
     def order_by(self, *ordering):
         self.ordering.extend(ordering)
+        return self
+
+    def with_entities(self, *columns):
+        self.with_entities_calls.append(columns)
         return self
 
     def all(self):
@@ -1117,7 +1128,7 @@ class FakeSession:
     def query(self, target):
         if target == ("max", "id", "max_id"):
             return self.latest_query
-        if target is FakeModel:
+        if isinstance(target, type) and issubclass(target, FakeModel):
             return self.outer_query
         id_query = FakeIdQuery(target)
         self.id_queries.append(id_query)
@@ -1144,6 +1155,14 @@ class FakeModel:
     created_user_bid = FakeColumn("created_user_bid")
     created_at = FakeColumn("created_at")
     updated_at = FakeColumn("updated_at")
+
+
+class FakeMappedModel(FakeModel):
+    __mapper__ = object()
+    llm_system_prompt = FakeColumn("llm_system_prompt")
+    price = FakeColumn("price")
+    llm = FakeColumn("llm")
+    updated_user_bid = FakeColumn("updated_user_bid")
 
 
 def test_load_latest_shifus_filters_on_latest_rows(monkeypatch):
@@ -1189,3 +1208,40 @@ def test_load_latest_shifus_filters_on_latest_rows(monkeypatch):
         ("desc", "updated_at"),
         ("desc", "id"),
     ]
+
+
+def test_load_latest_shifus_skips_loader_options_for_lightweight_queries(monkeypatch):
+    latest_query = FakeLatestQuery()
+    outer_query = FakeOuterQuery(
+        [
+            SimpleNamespace(
+                id=1,
+                shifu_bid="course-1",
+                title="Course 1",
+                price="19.00",
+                llm="gpt-4.1-mini",
+                created_user_bid="creator-1",
+                updated_user_bid="creator-1",
+                created_at=datetime(2025, 4, 1, 10, 0, 0),
+                updated_at=datetime(2025, 4, 2, 10, 0, 0),
+            )
+        ]
+    )
+    fake_db = FakeDB(latest_query, outer_query)
+    monkeypatch.setattr(admin_module, "db", fake_db)
+
+    result = _load_latest_shifus(
+        FakeMappedModel,
+        shifu_bid="",
+        course_name="",
+        creator_bids=None,
+        start_time=None,
+        end_time=None,
+        updated_start_time=None,
+        updated_end_time=None,
+        lightweight=True,
+    )
+
+    assert len(outer_query.options_calls) == 0
+    assert len(outer_query.with_entities_calls) == 1
+    assert result[0].shifu_bid == "course-1"

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -3407,6 +3407,30 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     assert result == {"user-1": "email"}
 
 
+def test_registration_source_map_skips_unknown_provider_when_supported_one_exists(app):
+    with app.app_context():
+        result = admin_module._load_operator_user_registration_source_map(
+            ["user-1"],
+            users=[],
+            credential_rows=[
+                SimpleNamespace(
+                    user_bid="user-1",
+                    provider_name="password",
+                    created_at=datetime(2026, 5, 1, 10, 0, 0),
+                    id=1,
+                ),
+                SimpleNamespace(
+                    user_bid="user-1",
+                    provider_name="email",
+                    created_at=datetime(2026, 5, 1, 10, 5, 0),
+                    id=2,
+                ),
+            ],
+        )
+
+    assert result == {"user-1": "email"}
+
+
 def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
     class ForbiddenUserQuery:
         def filter(self, *_args, **_kwargs):

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -3374,3 +3374,66 @@ def test_get_operator_user_detail_normalizes_unknown_login_methods(app):
 
     assert isinstance(result, AdminOperationUserSummaryDTO)
     assert result.login_methods == ["unknown", "email"]
+
+
+def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
+    app, monkeypatch
+):
+    class ForbiddenUserQuery:
+        def filter(self, *_args, **_kwargs):
+            raise AssertionError("expected no user query when users=[] is provided")
+
+    with app.app_context():
+        monkeypatch.setattr(
+            admin_module.UserEntity,
+            "query",
+            ForbiddenUserQuery(),
+            raising=False,
+        )
+
+        result = admin_module._load_operator_user_registration_source_map(
+            ["user-1", "user-2"],
+            users=[],
+            credential_rows=[
+                SimpleNamespace(
+                    user_bid="user-1",
+                    provider_name="email",
+                    created_at=datetime(2026, 5, 1, 10, 0, 0),
+                    id=1,
+                )
+            ],
+        )
+
+    assert result == {"user-1": "email"}
+
+
+def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
+    class ForbiddenUserQuery:
+        def filter(self, *_args, **_kwargs):
+            raise AssertionError("expected no user query when users=[] is provided")
+
+    with app.app_context():
+        monkeypatch.setattr(
+            admin_module.UserEntity,
+            "query",
+            ForbiddenUserQuery(),
+            raising=False,
+        )
+
+        result = admin_module._load_operator_user_contact_map(
+            ["user-1", "user-2"],
+            users=[],
+            credential_rows=[
+                SimpleNamespace(
+                    user_bid="user-1",
+                    provider_name="phone",
+                    state=CREDENTIAL_STATE_VERIFIED,
+                    identifier="13800000000",
+                    id=1,
+                )
+            ],
+        )
+
+    assert result["user-1"]["mobile"] == "13800000000"
+    assert result["user-1"]["login_methods"] == ["phone"]
+    assert result["user-2"] == {"mobile": "", "email": "", "login_methods": []}

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -284,6 +285,28 @@ const mockGetAdminOperationUsers = api.getAdminOperationUsers as jest.Mock;
 const mockGetAdminOperationUserDetail =
   api.getAdminOperationUserDetail as jest.Mock;
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const flushMicrotasks = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const renderResolvedPage = async () => {
+  render(<AdminOperationUsersPage />);
+  await screen.findByText('module.operationsUser.title');
+  await screen.findByText(String(DEFAULT_OVERVIEW.total_user_count));
+};
+
 describe('AdminOperationUsersPage', () => {
   beforeEach(() => {
     mockReplace.mockReset();
@@ -412,6 +435,10 @@ describe('AdminOperationUsersPage', () => {
     });
   });
 
+  afterEach(async () => {
+    await flushMicrotasks();
+  });
+
   afterAll(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -419,8 +446,55 @@ describe('AdminOperationUsersPage', () => {
     });
   });
 
+  test('loads user overview after the initial list request settles', async () => {
+    const listDeferred = createDeferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_count: number;
+      page_size: number;
+      total: number;
+    }>();
+    const overviewDeferred =
+      createDeferred<Record<string, number | undefined>>();
+    mockGetAdminOperationUsers.mockReturnValueOnce(listDeferred.promise);
+    mockGetAdminOperationUsersOverview.mockReturnValueOnce(
+      overviewDeferred.promise,
+    );
+
+    await act(async () => {
+      render(<AdminOperationUsersPage />);
+    });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetAdminOperationUsersOverview).not.toHaveBeenCalled();
+
+    await act(async () => {
+      listDeferred.resolve({
+        items: [],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsersOverview).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      overviewDeferred.resolve(DEFAULT_OVERVIEW);
+      await overviewDeferred.promise;
+    });
+  });
+
   test('loads and renders operator users', async () => {
-    render(<AdminOperationUsersPage />);
+    await act(async () => {
+      render(<AdminOperationUsersPage />);
+    });
+    await flushMicrotasks();
 
     await waitFor(() => {
       expect(mockGetAdminOperationUsers).toHaveBeenCalledWith({
@@ -434,6 +508,9 @@ describe('AdminOperationUsersPage', () => {
         start_time: '',
         end_time: '',
       });
+    });
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsersOverview).toHaveBeenCalled();
     });
 
     expect(
@@ -567,11 +644,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('opens the credit grant dialog from the action menu', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationUsers).toHaveBeenCalledTimes(1);
-    });
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -618,7 +691,7 @@ describe('AdminOperationUsersPage', () => {
       total: 1,
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     const actionButton = await screen.findByRole('button', {
       name: 'module.operationsUser.actions.grantCredits',
@@ -628,11 +701,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('revalidates billing overview after credits are granted successfully', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationUsers).toHaveBeenCalledTimes(1);
-    });
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -655,11 +724,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('submits search filters', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationUsers).toHaveBeenCalledTimes(1);
-    });
+    await renderResolvedPage();
 
     const identifierInput = screen.getAllByRole('textbox')[0];
     fireEvent.change(identifierInput, {
@@ -692,9 +757,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('clicking the paid users overview card syncs status and quick filter', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await screen.findByText('module.operationsUser.title');
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -719,9 +782,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('clicking the registered users overview card applies the registered quick filter', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await screen.findByText('module.operationsUser.title');
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -742,9 +803,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('clicking the active learning overview card applies and clears the quick filter chip', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await screen.findByText('module.operationsUser.title');
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -783,9 +842,7 @@ describe('AdminOperationUsersPage', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-05-06T10:00:00Z'));
 
     try {
-      render(<AdminOperationUsersPage />);
-
-      await screen.findByText('module.operationsUser.title');
+      await renderResolvedPage();
 
       fireEvent.click(
         screen.getByRole('button', {
@@ -808,9 +865,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('clicking the recent registered overview card applies the quick filter without overriding created-at range', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await screen.findByText('module.operationsUser.title');
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -831,8 +886,8 @@ describe('AdminOperationUsersPage', () => {
 
   test('reinitializing the page clears the stale quick filter state', async () => {
     const { rerender } = render(<AdminOperationUsersPage />);
-
     await screen.findByText('module.operationsUser.title');
+    await screen.findByText(String(DEFAULT_OVERVIEW.total_user_count));
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -849,11 +904,62 @@ describe('AdminOperationUsersPage', () => {
       );
     });
 
-    mockUserState.isInitialized = false;
-    rerender(<AdminOperationUsersPage />);
+    const refreshedListDeferred = createDeferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_count: number;
+      page_size: number;
+      total: number;
+    }>();
+    const refreshedOverviewDeferred =
+      createDeferred<Record<string, number | undefined>>();
 
+    mockUserState.isInitialized = false;
+    await act(async () => {
+      rerender(<AdminOperationUsersPage />);
+      await Promise.resolve();
+    });
+
+    mockGetAdminOperationUsers.mockReturnValueOnce(refreshedListDeferred.promise);
+    mockGetAdminOperationUsersOverview.mockReturnValueOnce(
+      refreshedOverviewDeferred.promise,
+    );
     mockUserState.isInitialized = true;
-    rerender(<AdminOperationUsersPage />);
+    await act(async () => {
+      rerender(<AdminOperationUsersPage />);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          page_index: 1,
+          page_size: 20,
+          quick_filter: '',
+          user_status: '',
+          user_role: '',
+          start_time: '',
+          end_time: '',
+        }),
+      );
+    });
+    await act(async () => {
+      refreshedListDeferred.resolve({
+        items: [],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 0,
+      });
+      await refreshedListDeferred.promise;
+    });
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsersOverview).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      refreshedOverviewDeferred.resolve(DEFAULT_OVERVIEW);
+      await refreshedOverviewDeferred.promise;
+    });
 
     await waitFor(() => {
       expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
@@ -866,6 +972,9 @@ describe('AdminOperationUsersPage', () => {
         }),
       );
     });
+    expect(
+      await screen.findByText(String(DEFAULT_OVERVIEW.total_user_count)),
+    ).toBeInTheDocument();
 
     expect(
       screen.queryByText('module.operationsUser.overview.activeFilter'),
@@ -877,14 +986,51 @@ describe('AdminOperationUsersPage', () => {
 
     expect(await screen.findByText('128')).toBeInTheDocument();
 
-    mockGetAdminOperationUsersOverview.mockRejectedValueOnce(
-      new Error('overview failed'),
-    );
-    mockUserState.isInitialized = false;
-    rerender(<AdminOperationUsersPage />);
+    const refreshedListDeferred = createDeferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_count: number;
+      page_size: number;
+      total: number;
+    }>();
+    const refreshedOverviewDeferred =
+      createDeferred<Record<string, number | undefined>>();
 
+    mockUserState.isInitialized = false;
+    await act(async () => {
+      rerender(<AdminOperationUsersPage />);
+      await Promise.resolve();
+    });
+
+    mockGetAdminOperationUsers.mockReturnValueOnce(refreshedListDeferred.promise);
+    mockGetAdminOperationUsersOverview.mockReturnValueOnce(
+      refreshedOverviewDeferred.promise,
+    );
     mockUserState.isInitialized = true;
-    rerender(<AdminOperationUsersPage />);
+    await act(async () => {
+      rerender(<AdminOperationUsersPage />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      refreshedListDeferred.resolve({
+        items: [],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 0,
+      });
+      await refreshedListDeferred.promise;
+    });
+    await waitFor(() => {
+      expect(mockGetAdminOperationUsersOverview).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      refreshedOverviewDeferred.reject(new Error('overview failed'));
+      try {
+        await refreshedOverviewDeferred.promise;
+      } catch {}
+    });
 
     expect(await screen.findByText('128')).toBeInTheDocument();
     expect(
@@ -893,9 +1039,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('keeps nickname visible when collapsed and shifts remaining filters forward when expanded', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await screen.findByText('module.operationsUser.title');
+    await renderResolvedPage();
 
     expect(screen.getAllByRole('textbox')).toHaveLength(2);
     expect(
@@ -930,11 +1074,7 @@ describe('AdminOperationUsersPage', () => {
   });
 
   test('opens course dialog from summary cells', async () => {
-    render(<AdminOperationUsersPage />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationUsers).toHaveBeenCalledTimes(1);
-    });
+    await renderResolvedPage();
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -996,7 +1136,7 @@ describe('AdminOperationUsersPage', () => {
       total: 1,
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     expect(
       await screen.findByRole('link', { name: 'user-no-contact' }),
@@ -1055,7 +1195,7 @@ describe('AdminOperationUsersPage', () => {
       total: 1,
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     const row = (
       await screen.findByRole('link', { name: 'user-phone-only' })
@@ -1153,7 +1293,7 @@ describe('AdminOperationUsersPage', () => {
       updated_at: '2026-04-14T11:00:00Z',
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     fireEvent.click(
       await screen.findByRole('button', {
@@ -1243,7 +1383,7 @@ describe('AdminOperationUsersPage', () => {
       updated_at: '2026-04-14T11:00:00Z',
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     expect(
       await screen.findByText(
@@ -1297,7 +1437,7 @@ describe('AdminOperationUsersPage', () => {
       total: 1,
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     expect(
       await screen.findByText('module.user.defaultUserName'),
@@ -1337,7 +1477,7 @@ describe('AdminOperationUsersPage', () => {
       total: 1,
     });
 
-    render(<AdminOperationUsersPage />);
+    await renderResolvedPage();
 
     expect(
       await screen.findByText('module.operationsUser.credits.longTerm'),
@@ -1384,16 +1524,7 @@ describe('AdminOperationUsersPage', () => {
       total: 21,
     });
 
-    render(<AdminOperationUsersPage />);
-
-    await waitFor(() => {
-      expect(mockGetAdminOperationUsers).toHaveBeenCalledWith(
-        expect.objectContaining({
-          page_index: 1,
-          page_size: 20,
-        }),
-      );
-    });
+    await renderResolvedPage();
 
     fireEvent.click(
       await screen.findByRole('link', {

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -920,7 +920,9 @@ describe('AdminOperationUsersPage', () => {
       await Promise.resolve();
     });
 
-    mockGetAdminOperationUsers.mockReturnValueOnce(refreshedListDeferred.promise);
+    mockGetAdminOperationUsers.mockReturnValueOnce(
+      refreshedListDeferred.promise,
+    );
     mockGetAdminOperationUsersOverview.mockReturnValueOnce(
       refreshedOverviewDeferred.promise,
     );
@@ -1002,7 +1004,9 @@ describe('AdminOperationUsersPage', () => {
       await Promise.resolve();
     });
 
-    mockGetAdminOperationUsers.mockReturnValueOnce(refreshedListDeferred.promise);
+    mockGetAdminOperationUsers.mockReturnValueOnce(
+      refreshedListDeferred.promise,
+    );
     mockGetAdminOperationUsersOverview.mockReturnValueOnce(
       refreshedOverviewDeferred.promise,
     );

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -621,8 +621,10 @@ export default function AdminOperationUsersPage() {
     setDraftFilters(initialFilters);
     setAppliedFilters(initialFilters);
     setQuickFilter('');
-    void fetchUserOverview();
-    void fetchUsers(1, initialFilters, '');
+    void (async () => {
+      await fetchUsers(1, initialFilters, '');
+      await fetchUserOverview();
+    })();
   }, [fetchUserOverview, fetchUsers, isReady]);
 
   const clearQuickFilterIfConflicted = useCallback(


### PR DESCRIPTION
## Summary
- optimize operator user list metadata loading by reusing credential queries and lightweight course seeds
- load the operator user overview after the initial list request so the page renders visible data sooner
- update focused operator user page tests to cover the new request ordering and refresh behavior

## Testing
- `cd src/api && pytest tests/service/shifu/test_admin_users.py -q`
- `cd src/cook-web && npm run lint -- --file src/app/admin/operations/users/page.tsx --file src/app/admin/operations/users/page.test.tsx`
- `cd src/cook-web && npm run test -- --runInBand --runTestsByPath src/app/admin/operations/users/page.test.tsx`
- `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured operator users page loads the user list before fetching overview data to avoid race conditions.

* **Performance**
  * Reduced payload for operator course and user listings via lightweight projections to speed listings and reduce load.

* **Improvements**
  * More consistent, deterministic operator user contact and registration resolution using preloaded credentials and provider allowlists.

* **Tests**
  * Strengthened and stabilized admin unit and page tests to cover lightweight queries and async page init.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->