### PR TITLE
feat: optimize shifu history page layout

### DIFF
--- a/src/cook-web/src/app/shifu/[id]/history/page.test.tsx
+++ b/src/cook-web/src/app/shifu/[id]/history/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import ShifuPage from './page';
+import ShifuHistoryPage from './page';
 
 jest.mock('react', () => {
   const actual = jest.requireActual('react');
@@ -21,9 +21,7 @@ jest.mock('next/dynamic', () => ({
     }) {
       return (
         <div data-testid='mock-shifu-root'>
-          {`${props.id}:${props.initialLessonId}:${
-            props.initialViewMode || 'edit'
-          }`}
+          {`${props.id}:${props.initialLessonId}:${props.initialViewMode}`}
         </div>
       );
     },
@@ -48,17 +46,16 @@ jest.mock('@/c-utils/urlUtils', () => ({
   getLessonIdFromQuery: jest.fn(() => 'lesson-42'),
 }));
 
-describe('ShifuPage', () => {
-  test('passes shifu params through without rendering the shared contact side rail', () => {
+describe('ShifuHistoryPage', () => {
+  test('passes history view mode into shifu root', () => {
     render(
-      <ShifuPage
+      <ShifuHistoryPage
         params={{ id: 'shifu-1' } as unknown as Promise<{ id: string }>}
       />,
     );
 
     expect(screen.getByTestId('mock-shifu-root')).toHaveTextContent(
-      'shifu-1:lesson-42:edit',
+      'shifu-1:lesson-42:history',
     );
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/shifu/[id]/history/page.tsx
+++ b/src/cook-web/src/app/shifu/[id]/history/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { use } from 'react';
+import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
+import Loading from '@/components/loading';
+import MobileUnsupportedDialog from '@/components/MobileUnsupportedDialog';
+import { getLessonIdFromQuery } from '@/c-utils/urlUtils';
+
+const ShifuRoot = dynamic(() => import('@/components/shifu-root'), {
+  ssr: false,
+  loading: () => (
+    <div className='flex h-screen w-full items-center justify-center'>
+      <Loading />
+    </div>
+  ),
+});
+
+type ShifuHistoryPageParams = { id: string };
+
+export default function Page({
+  params,
+}: {
+  params: Promise<ShifuHistoryPageParams>;
+}) {
+  const { id } = use(params);
+  const searchParams = useSearchParams();
+  const initialLessonId = getLessonIdFromQuery(searchParams);
+
+  return (
+    <>
+      <MobileUnsupportedDialog />
+      <div className='h-screen w-full'>
+        <ShifuRoot
+          id={id}
+          initialLessonId={initialLessonId}
+          initialViewMode='history'
+        />
+      </div>
+    </>
+  );
+}

--- a/src/cook-web/src/components/main-root/MainRoot.tsx
+++ b/src/cook-web/src/components/main-root/MainRoot.tsx
@@ -6,14 +6,20 @@ import ShifuEdit from '../shifu-edit';
 type MainRootProps = {
   id: string;
   initialLessonId?: string;
+  initialViewMode?: 'edit' | 'history';
 };
 
-export default function ShifuRoot({ id, initialLessonId }: MainRootProps) {
+export default function ShifuRoot({
+  id,
+  initialLessonId,
+  initialViewMode,
+}: MainRootProps) {
   return (
     <UserProvider>
       <ShifuEdit
         id={id}
         initialLessonId={initialLessonId}
+        initialViewMode={initialViewMode}
       />
     </UserProvider>
   );

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -470,9 +470,7 @@ describe('ShifuEdit draft conflict checks', () => {
   });
 
   test('opens the history page in a new tab for the current lesson', async () => {
-    const openSpy = jest
-      .spyOn(window, 'open')
-      .mockImplementation(() => null);
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
     setLessonNode();
 
     render(<ScriptEditor id='shifu-1' />);

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import ScriptEditor from './ShifuEdit';
 
 const refreshLabel = 'refresh';
@@ -26,10 +20,33 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
-jest.mock('@/components/ui/Button', () => ({
-  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
-    <button {...props}>{children}</button>
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.ComponentProps<'a'> & { href: string }) => (
+    <a
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
   ),
+}));
+
+jest.mock('@/components/ui/Button', () => ({
+  Button: ({
+    children,
+    asChild,
+    ...props
+  }: React.ComponentProps<'button'> & { asChild?: boolean }) => {
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, props);
+    }
+    return <button {...props}>{children}</button>;
+  },
 }));
 
 jest.mock('@/components/outline-tree', () => {
@@ -469,19 +486,20 @@ describe('ShifuEdit draft conflict checks', () => {
     });
   });
 
-  test('opens the history page in a new tab for the current lesson', async () => {
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  test('renders the history entry as a native link for the current lesson', async () => {
     setLessonNode();
 
     render(<ScriptEditor id='shifu-1' />);
 
-    fireEvent.click(screen.getByTitle('module.shifu.history.title'));
+    const historyLink = screen.getByTitle(
+      'module.shifu.history.title',
+    ) as HTMLAnchorElement;
 
-    expect(openSpy).toHaveBeenCalledWith(
+    expect(historyLink.getAttribute('href')).toBe(
       '/shifu/shifu-1/history?lessonid=lesson-1',
-      '_blank',
-      'noopener,noreferrer',
     );
+    expect(historyLink.getAttribute('target')).toBe('_blank');
+    expect(historyLink.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   test('renders the dedicated history layout in history mode', async () => {
@@ -531,5 +549,8 @@ describe('ShifuEdit draft conflict checks', () => {
     expect(
       screen.getByText('module.shifu.history.backToDocument'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText('module.shifu.history.backToDocument'),
+    ).toHaveAttribute('href', '/shifu/shifu-1?lessonid=lesson-1');
   });
 });

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import ScriptEditor from './ShifuEdit';
 
 const refreshLabel = 'refresh';
@@ -75,9 +81,13 @@ jest.mock('@/components/ui/Sheet', () => ({
   ),
 }));
 jest.mock('@/components/ui/Dialog', () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  Dialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+  }) => (open ? <div>{children}</div> : null),
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -111,6 +121,9 @@ jest.mock('@/c-common/hooks/useTracking', () => ({
   useTracking: () => ({ trackEvent: jest.fn() }),
 }));
 jest.mock('@/c-utils/urlUtils', () => ({
+  buildUrlWithLessonId: jest.fn((url: string, lessonId: string) =>
+    lessonId ? `${url}?lessonid=${lessonId}` : url,
+  ),
   replaceCurrentUrlWithLessonId: jest.fn(),
 }));
 jest.mock('@/components/lesson-preview/usePreviewChat', () => ({
@@ -275,6 +288,7 @@ describe('ShifuEdit draft conflict checks', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   test('does not start draft conflict checks when a chapter node is selected', async () => {
@@ -453,5 +467,71 @@ describe('ShifuEdit draft conflict checks', () => {
     await waitFor(() => {
       expect(getLatestEditorProps().content).toBe('remote synced content');
     });
+  });
+
+  test('opens the history page in a new tab for the current lesson', async () => {
+    const openSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => null);
+    setLessonNode();
+
+    render(<ScriptEditor id='shifu-1' />);
+
+    fireEvent.click(screen.getByTitle('module.shifu.history.title'));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      '/shifu/shifu-1/history?lessonid=lesson-1',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  test('renders the dedicated history layout in history mode', async () => {
+    setLessonNode();
+    baseActions.loadMdflowHistory.mockResolvedValue([
+      {
+        version_id: 11,
+        updated_at: '2026-05-19 10:00:00',
+        updated_at_display: '05-19 10:00:00',
+        updated_user_name: 'Operator',
+        updated_user_bid: 'user-1',
+      },
+    ]);
+    baseActions.loadMdflowHistoryVersionDetail.mockResolvedValue({
+      version_id: 11,
+      content: 'history body',
+      updated_at: '2026-05-19 10:00:00',
+      updated_at_display: '05-19 10:00:00',
+      updated_user_name: 'Operator',
+      updated_user_bid: 'user-1',
+      restored: false,
+    });
+
+    render(
+      <ScriptEditor
+        id='shifu-1'
+        initialViewMode='history'
+      />,
+    );
+
+    expect(
+      screen.getByText('module.shifu.history.backToDocument'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(baseActions.loadMdflowHistory).toHaveBeenCalledWith(
+        'shifu-1',
+        'lesson-1',
+      );
+    });
+    await waitFor(() => {
+      expect(baseActions.loadMdflowHistoryVersionDetail).toHaveBeenCalledWith(
+        'shifu-1',
+        'lesson-1',
+        11,
+      );
+    });
+    expect(
+      screen.getByText('module.shifu.history.backToDocument'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -1396,7 +1396,9 @@ const ScriptEditor = ({
         >
           <DialogContent className='sm:max-w-[440px]'>
             <DialogHeader>
-              <DialogTitle>{t('module.shifu.history.confirmTitle')}</DialogTitle>
+              <DialogTitle>
+                {t('module.shifu.history.confirmTitle')}
+              </DialogTitle>
             </DialogHeader>
             <div className='text-sm leading-6 text-muted-foreground'>
               {t('module.shifu.history.confirmDescription')}

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { Button } from '@/components/ui/Button';
 import {
+  ChevronLeft,
   Columns2,
   History,
   Info,
@@ -27,12 +28,6 @@ import Header from '../header';
 import { UploadProps, EditMode } from 'markdown-flow-ui/editor';
 import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/Sheet';
 import {
   Dialog,
   DialogContent,
@@ -60,7 +55,10 @@ const MarkdownFlowEditor = dynamic(
 import i18n, { normalizeLanguage } from '@/i18n';
 import { useEnvStore } from '@/c-store';
 import { EnvStoreState } from '@/c-types/store';
-import { replaceCurrentUrlWithLessonId } from '@/c-utils/urlUtils';
+import {
+  buildUrlWithLessonId,
+  replaceCurrentUrlWithLessonId,
+} from '@/c-utils/urlUtils';
 import LessonPreview from '@/components/lesson-preview';
 import { usePreviewChat } from '@/components/lesson-preview/usePreviewChat';
 import { Rnd } from 'react-rnd';
@@ -80,7 +78,6 @@ const OUTLINE_STORAGE_KEY = 'shifu-outline-panel-width';
 const TOOLBAR_ICON_SIZE = 18; // Match markdown-flow-ui toolbar icon size
 
 const VARIABLE_NAME_REGEXP = /\{\{([\p{L}\p{N}_]+)\}\}/gu;
-const HISTORY_CONTENT_PREVIEW_LINES = 6;
 type MarkdownFlowEditorLocale = 'en-US' | 'zh-CN';
 
 const resolveMarkdownFlowEditorLocale = (
@@ -113,6 +110,7 @@ const extractVariableNames = (text?: string | null) => {
 type ScriptEditorProps = {
   id: string;
   initialLessonId?: string;
+  initialViewMode?: 'edit' | 'history';
 };
 
 type DraftConflictMode = 'other-user' | 'same-user';
@@ -120,7 +118,11 @@ type DraftConflictMode = 'other-user' | 'same-user';
 const getDraftSyncTargetKey = (shifuBid: string, outlineBid: string) =>
   `${shifuBid}:${outlineBid}`;
 
-const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
+const ScriptEditor = ({
+  id,
+  initialLessonId = '',
+  initialViewMode = 'edit',
+}: ScriptEditorProps) => {
   const { t } = useTranslation();
   const { trackEvent } = useTracking();
   const profile = useUserStore(state => state.userInfo);
@@ -139,7 +141,6 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
   const [draftConflictMode, setDraftConflictMode] =
     useState<DraftConflictMode>('other-user');
   const [remoteSyncNotice, setRemoteSyncNotice] = useState<string | null>(null);
-  const [isHistoryPanelOpen, setIsHistoryPanelOpen] = useState(false);
   const [historyItems, setHistoryItems] = useState<MdflowHistoryItem[]>([]);
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [isHistoryRestoring, setIsHistoryRestoring] = useState(false);
@@ -155,8 +156,6 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
   const [historyVersionLoadError, setHistoryVersionLoadError] = useState<
     string | null
   >(null);
-  const [isHistoryContentExpanded, setIsHistoryContentExpanded] =
-    useState(false);
   const historyRequestIdRef = useRef(0);
   const historyDetailRequestIdRef = useRef(0);
   const selectedHistoryVersionIdRef = useRef<number | null>(null);
@@ -252,6 +251,7 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
     if (!profile) return '';
     return profile.user_bid || profile.user_id || '';
   }, [profile]);
+  const isHistoryPage = initialViewMode === 'history';
   const actionsRef = useRef(actions);
   const baseRevisionRef = useRef<number | null>(null);
   const conflictStateRef = useRef({
@@ -875,22 +875,19 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
   }, [currentNode?.bid, currentShifu?.bid]);
 
   const resetHistoryRestoreDialog = useCallback(() => {
-    historyDetailRequestIdRef.current += 1;
     setIsHistoryRestoreDialogOpen(false);
-    setIsHistoryVersionDetailLoading(false);
-    setHistoryVersionDetail(null);
-    setHistoryVersionLoadError(null);
-    setIsHistoryContentExpanded(false);
   }, []);
 
-  const handleOpenHistoryRestoreDialog = useCallback(async () => {
+  const loadSelectedHistoryVersionDetail = useCallback(async () => {
     if (
       !currentShifu?.bid ||
       !currentNode?.bid ||
-      selectedHistoryVersionId == null ||
-      isHistoryRestoring ||
-      currentShifu?.readonly
+      selectedHistoryVersionId == null
     ) {
+      historyDetailRequestIdRef.current += 1;
+      setHistoryVersionDetail(null);
+      setHistoryVersionLoadError(null);
+      setIsHistoryVersionDetailLoading(false);
       return;
     }
     const targetShifuBid = currentShifu.bid;
@@ -900,8 +897,6 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
     historyDetailRequestIdRef.current = requestId;
     setHistoryVersionDetail(null);
     setHistoryVersionLoadError(null);
-    setIsHistoryContentExpanded(false);
-    setIsHistoryRestoreDialogOpen(true);
     setIsHistoryVersionDetailLoading(true);
     try {
       const detail = await actions.loadMdflowHistoryVersionDetail(
@@ -931,10 +926,31 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
     actions,
     currentNode?.bid,
     currentShifu?.bid,
-    currentShifu?.readonly,
-    isHistoryRestoring,
     selectedHistoryVersionId,
     t,
+  ]);
+
+  const handleOpenHistoryRestoreDialog = useCallback(() => {
+    if (
+      !currentShifu?.bid ||
+      !currentNode?.bid ||
+      selectedHistoryVersionId == null ||
+      isHistoryRestoring ||
+      currentShifu?.readonly ||
+      !historyVersionDetail ||
+      !!historyVersionLoadError
+    ) {
+      return;
+    }
+    setIsHistoryRestoreDialogOpen(true);
+  }, [
+    currentNode?.bid,
+    currentShifu?.bid,
+    currentShifu?.readonly,
+    historyVersionDetail,
+    historyVersionLoadError,
+    isHistoryRestoring,
+    selectedHistoryVersionId,
   ]);
 
   const handleConfirmRestoreMdflowHistory = useCallback(async () => {
@@ -963,14 +979,18 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
           title: t('module.shifu.history.restoreLessonDeleted'),
           variant: 'destructive',
         });
-        await actions.loadChapters(currentShifu.bid, {
-          autoSelectFirstLesson: false,
-        });
-        setIsHistoryPanelOpen(false);
+        if (isHistoryPage && typeof window !== 'undefined') {
+          window.location.assign(`/shifu/${id}`);
+          return;
+        }
         return;
       }
       await actions.loadMdflow(currentNode.bid, currentShifu.bid);
-      setIsHistoryPanelOpen(false);
+      if (isHistoryPage && typeof window !== 'undefined') {
+        window.location.assign(
+          buildUrlWithLessonId(`/shifu/${id}`, currentNode.bid),
+        );
+      }
     } catch (error) {
       console.error(error);
     } finally {
@@ -980,45 +1000,29 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
     actions,
     currentNode?.bid,
     currentShifu?.bid,
+    id,
     historyVersionDetail?.version_id,
+    isHistoryPage,
     isHistoryRestoring,
     resetHistoryRestoreDialog,
     t,
   ]);
 
   useEffect(() => {
-    if (!isHistoryPanelOpen) {
+    if (!isHistoryPage) {
       return;
     }
     void loadCurrentMdflowHistory();
-  }, [isHistoryPanelOpen, loadCurrentMdflowHistory]);
+  }, [isHistoryPage, loadCurrentMdflowHistory]);
 
   const historyVersionContent = historyVersionDetail?.content || '';
-  const historyVersionContentLines = useMemo(() => {
-    if (!historyVersionContent) {
-      return [] as string[];
+
+  useEffect(() => {
+    if (!isHistoryPage) {
+      return;
     }
-    return historyVersionContent.split('\n');
-  }, [historyVersionContent]);
-  const shouldTruncateHistoryContent =
-    historyVersionContentLines.length > HISTORY_CONTENT_PREVIEW_LINES;
-  const displayedHistoryVersionContent = useMemo(() => {
-    if (
-      !shouldTruncateHistoryContent ||
-      isHistoryContentExpanded ||
-      !historyVersionContentLines.length
-    ) {
-      return historyVersionContent;
-    }
-    return historyVersionContentLines
-      .slice(0, HISTORY_CONTENT_PREVIEW_LINES)
-      .join('\n');
-  }, [
-    historyVersionContent,
-    historyVersionContentLines,
-    isHistoryContentExpanded,
-    shouldTruncateHistoryContent,
-  ]);
+    void loadSelectedHistoryVersionDetail();
+  }, [isHistoryPage, loadSelectedHistoryVersionDetail]);
 
   const mdflowVariableNames = useMemo(
     () => extractVariableNames(mdflow),
@@ -1180,6 +1184,29 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
     : t('module.shifu.previewArea.open');
 
   const previewDisabledReason = t('module.shifu.previewArea.disabled');
+  const historyPageUrl = useMemo(() => {
+    return buildUrlWithLessonId(`/shifu/${id}/history`, currentNode?.bid || '');
+  }, [currentNode?.bid, id]);
+  const documentPageUrl = useMemo(() => {
+    return buildUrlWithLessonId(
+      `/shifu/${id}`,
+      currentNode?.bid || initialLessonId,
+    );
+  }, [currentNode?.bid, id, initialLessonId]);
+
+  const handleOpenHistoryPage = useCallback(() => {
+    if (typeof window === 'undefined' || !currentNode?.bid) {
+      return;
+    }
+    window.open(historyPageUrl, '_blank', 'noopener,noreferrer');
+  }, [currentNode?.bid, historyPageUrl]);
+
+  const handleReturnToDocument = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.location.assign(documentPageUrl);
+  }, [documentPageUrl]);
 
   const persistOutlineWidth = useCallback((width: number) => {
     if (typeof window === 'undefined') {
@@ -1235,6 +1262,175 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
       return next;
     });
   };
+
+  if (isHistoryPage) {
+    return (
+      <div className='flex h-screen flex-col bg-gray-50'>
+        <div className='flex flex-1 overflow-hidden p-6'>
+          <div className='flex min-h-0 w-full flex-1 flex-col rounded-2xl border bg-white shadow-sm'>
+            <div className='relative flex items-center border-b px-4 py-3'>
+              <Button
+                type='button'
+                variant='ghost'
+                className='h-9 gap-2 px-3 text-sm font-medium text-foreground hover:bg-muted/60'
+                onClick={handleReturnToDocument}
+              >
+                <ChevronLeft className='h-4 w-4' />
+                {t('module.shifu.history.backToDocument')}
+              </Button>
+              <div className='pointer-events-none absolute inset-x-0 flex justify-center'>
+                <div className='pointer-events-auto'>
+                  <Button
+                    type='button'
+                    className='h-9 px-4 text-sm font-semibold'
+                    disabled={
+                      currentShifu?.readonly ||
+                      isHistoryLoading ||
+                      isHistoryRestoring ||
+                      isHistoryVersionDetailLoading ||
+                      !selectedHistoryVersionId ||
+                      !historyVersionDetail ||
+                      !!historyVersionLoadError
+                    }
+                    onClick={handleOpenHistoryRestoreDialog}
+                  >
+                    {isHistoryRestoring
+                      ? t('module.shifu.history.restoring')
+                      : t('module.shifu.history.restore')}
+                  </Button>
+                </div>
+              </div>
+            </div>
+            <div className='flex min-h-0 flex-1 gap-6 p-6'>
+              <div className='flex min-w-0 flex-1 flex-col'>
+                <div className='flex min-w-0 items-baseline gap-2 pb-4'>
+                  <h2 className='shrink-0 whitespace-nowrap text-base font-semibold text-foreground'>
+                    {t('module.shifu.creationArea.title')}
+                  </h2>
+                  <p className='min-w-0 flex-1 truncate text-xs leading-5 text-[rgba(0,0,0,0.45)]'>
+                    <MarkdownFlowLink
+                      prefix={t('module.shifu.creationArea.descriptionPrefix')}
+                      suffix={t('module.shifu.creationArea.descriptionSuffix')}
+                      linkText='MarkdownFlow'
+                      title={`${t('module.shifu.creationArea.descriptionPrefix')} MarkdownFlow ${t('module.shifu.creationArea.descriptionSuffix')}`}
+                      targetUrl='https://markdownflow.ai/docs'
+                    />
+                  </p>
+                </div>
+                <div className='min-h-0 flex-1 overflow-hidden rounded-2xl border bg-white'>
+                  {isHistoryVersionDetailLoading ? (
+                    <div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
+                      {t('module.shifu.history.loading')}
+                    </div>
+                  ) : historyVersionLoadError ? (
+                    <div className='flex h-full items-center justify-center px-6 text-center text-sm text-destructive'>
+                      {historyVersionLoadError}
+                    </div>
+                  ) : (
+                    <div className='h-full overflow-auto p-6 whitespace-pre-wrap break-words text-sm leading-7 text-foreground'>
+                      {historyVersionContent ||
+                        t('module.shifu.history.contentEmpty')}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <aside className='flex min-h-0 w-[320px] shrink-0 flex-col border-l pl-6'>
+                <div className='pb-4 text-sm font-semibold text-foreground'>
+                  {t('module.shifu.history.title')}
+                </div>
+                <div className='min-h-0 flex-1 overflow-y-auto'>
+                  {isHistoryLoading ? (
+                    <div className='py-8 text-center text-sm text-muted-foreground'>
+                      {t('module.shifu.history.loading')}
+                    </div>
+                  ) : !historyItems.length ? (
+                    <div className='py-8 text-center text-sm text-muted-foreground'>
+                      {t('module.shifu.history.empty')}
+                    </div>
+                  ) : (
+                    <div className='divide-y divide-border'>
+                      {historyItems.map(item => {
+                        const selected =
+                          selectedHistoryVersionId === item.version_id;
+                        const timeLabel =
+                          item.updated_at_display || item.updated_at || '--';
+                        const userName =
+                          item.updated_user_name ||
+                          item.updated_user_bid ||
+                          t('module.shifu.history.unknownUser');
+                        return (
+                          <button
+                            key={item.version_id}
+                            type='button'
+                            className={cn(
+                              'w-full rounded-xl px-4 py-4 text-left transition-colors',
+                              selected
+                                ? 'bg-muted text-foreground'
+                                : 'text-foreground hover:bg-muted/40',
+                            )}
+                            onClick={() =>
+                              setSelectedHistoryVersionId(item.version_id)
+                            }
+                          >
+                            <div className='text-sm leading-6'>{timeLabel}</div>
+                            <div className='mt-1 text-sm text-[rgba(0,0,0,0.65)]'>
+                              {userName}
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </aside>
+            </div>
+          </div>
+        </div>
+        <Dialog
+          open={isHistoryRestoreDialogOpen}
+          onOpenChange={nextOpen => {
+            if (!nextOpen) {
+              resetHistoryRestoreDialog();
+            }
+          }}
+        >
+          <DialogContent className='sm:max-w-[440px]'>
+            <DialogHeader>
+              <DialogTitle>{t('module.shifu.history.confirmTitle')}</DialogTitle>
+            </DialogHeader>
+            <div className='text-sm leading-6 text-muted-foreground'>
+              {t('module.shifu.history.confirmDescription')}
+            </div>
+            <DialogFooter>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={resetHistoryRestoreDialog}
+                disabled={isHistoryRestoring}
+              >
+                {t('common.core.cancel')}
+              </Button>
+              <Button
+                type='button'
+                onClick={handleConfirmRestoreMdflowHistory}
+                disabled={
+                  currentShifu?.readonly ||
+                  isHistoryRestoring ||
+                  isHistoryVersionDetailLoading ||
+                  !historyVersionDetail ||
+                  !!historyVersionLoadError
+                }
+              >
+                {isHistoryRestoring
+                  ? t('module.shifu.history.restoring')
+                  : t('module.shifu.history.restore')}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  }
 
   return (
     <div className='flex flex-col h-screen bg-gray-50'>
@@ -1373,7 +1569,7 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
                         variant='ghost'
                         size='icon'
                         className='h-8 w-8 rounded-full text-[rgba(0,0,0,0.65)] hover:bg-muted/50 hover:text-foreground shrink-0'
-                        onClick={() => setIsHistoryPanelOpen(true)}
+                        onClick={handleOpenHistoryPage}
                         aria-label={t('module.shifu.history.title')}
                         title={t('module.shifu.history.title')}
                       >
@@ -1516,162 +1712,6 @@ const ScriptEditor = ({ id, initialLessonId = '' }: ScriptEditorProps) => {
           phone={latestDraftMeta?.updated_user?.phone}
           onRefresh={handleDraftConflictRefresh}
         />
-        <Sheet
-          open={isHistoryPanelOpen}
-          onOpenChange={setIsHistoryPanelOpen}
-        >
-          <SheetContent
-            side='right'
-            className='w-full sm:w-[420px] md:w-[480px] h-full flex flex-col p-0 font-sans'
-          >
-            <SheetHeader className='px-6 pt-[19px] pb-4'>
-              <SheetTitle className='text-lg font-medium'>
-                {t('module.shifu.history.title')}
-              </SheetTitle>
-            </SheetHeader>
-            <div className='h-px w-full bg-border' />
-            <div className='flex-1 overflow-y-auto px-4 py-4'>
-              {isHistoryLoading ? (
-                <div className='py-8 text-center text-sm text-muted-foreground'>
-                  {t('module.shifu.history.loading')}
-                </div>
-              ) : !historyItems.length ? (
-                <div className='py-8 text-center text-sm text-muted-foreground'>
-                  {t('module.shifu.history.empty')}
-                </div>
-              ) : (
-                <div className='divide-y divide-[#E5E5E5]'>
-                  {historyItems.map(item => {
-                    const selected =
-                      selectedHistoryVersionId === item.version_id;
-                    const timeLabel =
-                      item.updated_at_display || item.updated_at || '--';
-                    const userName =
-                      item.updated_user_name ||
-                      item.updated_user_bid ||
-                      t('module.shifu.history.unknownUser');
-                    return (
-                      <button
-                        key={item.version_id}
-                        type='button'
-                        className={cn(
-                          'w-full h-[72px] px-2 text-left flex items-center transition-colors',
-                          selected ? 'bg-[#F5F5F5]' : 'hover:bg-muted/30',
-                        )}
-                        onClick={() =>
-                          setSelectedHistoryVersionId(item.version_id)
-                        }
-                      >
-                        <div className='w-full font-sans text-base font-normal text-foreground leading-5 flex items-center'>
-                          <span>{timeLabel}</span>
-                          <span className='ml-4'>{userName}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-            <div className='h-[68px] border-t border-[#E5E5E5] px-4 flex items-center justify-end'>
-              <Button
-                type='button'
-                variant='outline'
-                className='h-9 px-4 rounded-[10px] text-red-500 border-red-500 hover:bg-red-50 text-sm font-medium'
-                disabled={
-                  currentShifu?.readonly ||
-                  isHistoryLoading ||
-                  isHistoryRestoring ||
-                  !selectedHistoryVersionId
-                }
-                onClick={handleOpenHistoryRestoreDialog}
-              >
-                {isHistoryRestoring
-                  ? t('module.shifu.history.restoring')
-                  : t('module.shifu.history.restore')}
-              </Button>
-            </div>
-          </SheetContent>
-        </Sheet>
-        <Dialog
-          open={isHistoryRestoreDialogOpen}
-          onOpenChange={nextOpen => {
-            if (!nextOpen) {
-              resetHistoryRestoreDialog();
-            }
-          }}
-        >
-          <DialogContent className='sm:max-w-[520px] max-h-[76vh] overflow-hidden flex flex-col'>
-            <DialogHeader>
-              <DialogTitle>
-                {t('module.shifu.history.confirmTitle')}
-              </DialogTitle>
-            </DialogHeader>
-            <div className='flex-1 min-h-0 overflow-y-auto space-y-4 pr-1'>
-              <div className='text-sm text-muted-foreground'>
-                {t('module.shifu.history.confirmDescription')}
-              </div>
-              <div>
-                {isHistoryVersionDetailLoading ? (
-                  <div className='h-24 text-sm text-muted-foreground'>
-                    {t('module.shifu.history.loading')}
-                  </div>
-                ) : historyVersionLoadError ? (
-                  <div className='h-24 text-sm text-destructive'>
-                    {historyVersionLoadError}
-                  </div>
-                ) : (
-                  <>
-                    <div className='max-h-[240px] overflow-y-auto whitespace-pre-wrap break-words text-sm leading-6 text-foreground'>
-                      {displayedHistoryVersionContent ||
-                        t('module.shifu.history.contentEmpty')}
-                    </div>
-                    {shouldTruncateHistoryContent ? (
-                      <div className='mt-1 flex items-center gap-1 text-sm text-muted-foreground'>
-                        <Button
-                          type='button'
-                          variant='link'
-                          className='h-auto p-0 text-sm'
-                          onClick={() =>
-                            setIsHistoryContentExpanded(prev => !prev)
-                          }
-                        >
-                          {isHistoryContentExpanded
-                            ? t('module.shifu.history.collapse')
-                            : t('module.shifu.history.expand')}
-                        </Button>
-                      </div>
-                    ) : null}
-                  </>
-                )}
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                type='button'
-                variant='outline'
-                onClick={resetHistoryRestoreDialog}
-                disabled={isHistoryRestoring}
-              >
-                {t('common.core.cancel')}
-              </Button>
-              <Button
-                type='button'
-                onClick={handleConfirmRestoreMdflowHistory}
-                disabled={
-                  currentShifu?.readonly ||
-                  isHistoryRestoring ||
-                  isHistoryVersionDetailLoading ||
-                  !historyVersionDetail ||
-                  !!historyVersionLoadError
-                }
-              >
-                {isHistoryRestoring
-                  ? t('module.shifu.history.restoring')
-                  : t('module.shifu.history.restore')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </div>
     </div>
   );

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -1275,7 +1275,7 @@ const ScriptEditor = ({
                       isHistoryLoading ||
                       isHistoryRestoring ||
                       isHistoryVersionDetailLoading ||
-                      !selectedHistoryVersionId ||
+                      selectedHistoryVersionId == null ||
                       !historyVersionDetail ||
                       !!historyVersionLoadError
                     }

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -6,7 +6,11 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
-import { Button } from '@/components/ui/Button';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { UploadProps, EditMode } from 'markdown-flow-ui/editor';
+import { Rnd } from 'react-rnd';
+import { useTranslation } from 'react-i18next';
 import {
   ChevronLeft,
   Columns2,
@@ -18,16 +22,33 @@ import {
   Sparkles,
   X,
 } from 'lucide-react';
-import { useShifu } from '@/store';
-import { useUserStore } from '@/store';
-import OutlineTree from '@/components/outline-tree';
-import ChapterSettingsDialog from '@/components/chapter-setting';
-import { MdfConvertDialog } from '@/components/mdf-convert';
-import Header from '../header';
-// import MarkdownFlowEditor from '../../../../../../markdown-flow-ui/src/components/MarkdownFlowEditor';
-import { UploadProps, EditMode } from 'markdown-flow-ui/editor';
-import dynamic from 'next/dynamic';
+import { useEnvStore } from '@/c-store';
+import { useTracking } from '@/c-common/hooks/useTracking';
+import { EnvStoreState } from '@/c-types/store';
+import {
+  buildUrlWithLessonId,
+  replaceCurrentUrlWithLessonId,
+} from '@/c-utils/urlUtils';
+import { toast } from '@/hooks/useToast';
+import i18n, { normalizeLanguage } from '@/i18n';
 import { cn } from '@/lib/utils';
+import { useShifu, useUserStore } from '@/store';
+import {
+  DraftMeta,
+  LessonCreationSettings,
+  MdflowHistoryItem,
+  MdflowHistoryVersionDetail,
+} from '@/types/shifu';
+import ChapterSettingsDialog from '@/components/chapter-setting';
+import LessonPreview from '@/components/lesson-preview';
+import { usePreviewChat } from '@/components/lesson-preview/usePreviewChat';
+import { MdfConvertDialog } from '@/components/mdf-convert';
+import OutlineTree from '@/components/outline-tree';
+import DraftConflictDialog from './DraftConflictDialog';
+import Loading from '../loading';
+import Header from '../header';
+import MarkdownFlowLink from '@/components/ui/MarkdownFlowLink';
+import { Button } from '@/components/ui/Button';
 import {
   Dialog,
   DialogContent,
@@ -37,9 +58,6 @@ import {
 } from '@/components/ui/Dialog';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import './shifuEdit.scss';
-import Loading from '../loading';
-import { useTranslation } from 'react-i18next';
-import { toast } from '@/hooks/useToast';
 
 const MarkdownFlowEditor = dynamic(
   () => import('markdown-flow-ui/editor').then(mod => mod.MarkdownFlowEditor),
@@ -52,25 +70,6 @@ const MarkdownFlowEditor = dynamic(
     ),
   },
 );
-import i18n, { normalizeLanguage } from '@/i18n';
-import { useEnvStore } from '@/c-store';
-import { EnvStoreState } from '@/c-types/store';
-import {
-  buildUrlWithLessonId,
-  replaceCurrentUrlWithLessonId,
-} from '@/c-utils/urlUtils';
-import LessonPreview from '@/components/lesson-preview';
-import { usePreviewChat } from '@/components/lesson-preview/usePreviewChat';
-import { Rnd } from 'react-rnd';
-import { useTracking } from '@/c-common/hooks/useTracking';
-import MarkdownFlowLink from '@/components/ui/MarkdownFlowLink';
-import {
-  DraftMeta,
-  LessonCreationSettings,
-  MdflowHistoryItem,
-  MdflowHistoryVersionDetail,
-} from '@/types/shifu';
-import DraftConflictDialog from './DraftConflictDialog';
 
 const OUTLINE_DEFAULT_WIDTH = 256;
 const OUTLINE_COLLAPSED_WIDTH = 60;
@@ -985,12 +984,13 @@ const ScriptEditor = ({
         }
         return;
       }
-      await actions.loadMdflow(currentNode.bid, currentShifu.bid);
       if (isHistoryPage && typeof window !== 'undefined') {
         window.location.assign(
           buildUrlWithLessonId(`/shifu/${id}`, currentNode.bid),
         );
+        return;
       }
+      await actions.loadMdflow(currentNode.bid, currentShifu.bid);
     } catch (error) {
       console.error(error);
     } finally {
@@ -1194,20 +1194,6 @@ const ScriptEditor = ({
     );
   }, [currentNode?.bid, id, initialLessonId]);
 
-  const handleOpenHistoryPage = useCallback(() => {
-    if (typeof window === 'undefined' || !currentNode?.bid) {
-      return;
-    }
-    window.open(historyPageUrl, '_blank', 'noopener,noreferrer');
-  }, [currentNode?.bid, historyPageUrl]);
-
-  const handleReturnToDocument = useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    window.location.assign(documentPageUrl);
-  }, [documentPageUrl]);
-
   const persistOutlineWidth = useCallback((width: number) => {
     if (typeof window === 'undefined') {
       return;
@@ -1270,13 +1256,14 @@ const ScriptEditor = ({
           <div className='flex min-h-0 w-full flex-1 flex-col rounded-2xl border bg-white shadow-sm'>
             <div className='relative flex items-center border-b px-4 py-3'>
               <Button
-                type='button'
+                asChild
                 variant='ghost'
                 className='h-9 gap-2 px-3 text-sm font-medium text-foreground hover:bg-muted/60'
-                onClick={handleReturnToDocument}
               >
-                <ChevronLeft className='h-4 w-4' />
-                {t('module.shifu.history.backToDocument')}
+                <Link href={documentPageUrl}>
+                  <ChevronLeft className='h-4 w-4' />
+                  {t('module.shifu.history.backToDocument')}
+                </Link>
               </Button>
               <div className='pointer-events-none absolute inset-x-0 flex justify-center'>
                 <div className='pointer-events-auto'>
@@ -1566,17 +1553,36 @@ const ScriptEditor = ({
                           ))}
                         </TabsList>
                       </Tabs>
-                      <Button
-                        type='button'
-                        variant='ghost'
-                        size='icon'
-                        className='h-8 w-8 rounded-full text-[rgba(0,0,0,0.65)] hover:bg-muted/50 hover:text-foreground shrink-0'
-                        onClick={handleOpenHistoryPage}
-                        aria-label={t('module.shifu.history.title')}
-                        title={t('module.shifu.history.title')}
-                      >
-                        <History className='h-4 w-4' />
-                      </Button>
+                      {currentNode?.bid ? (
+                        <Button
+                          asChild
+                          variant='ghost'
+                          size='icon'
+                          className='h-8 w-8 rounded-full text-[rgba(0,0,0,0.65)] hover:bg-muted/50 hover:text-foreground shrink-0'
+                        >
+                          <Link
+                            href={historyPageUrl}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            aria-label={t('module.shifu.history.title')}
+                            title={t('module.shifu.history.title')}
+                          >
+                            <History className='h-4 w-4' />
+                          </Link>
+                        </Button>
+                      ) : (
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='icon'
+                          className='h-8 w-8 rounded-full text-[rgba(0,0,0,0.65)] hover:bg-muted/50 hover:text-foreground shrink-0'
+                          aria-label={t('module.shifu.history.title')}
+                          title={t('module.shifu.history.title')}
+                          disabled
+                        >
+                          <History className='h-4 w-4' />
+                        </Button>
+                      )}
                       <Button
                         type='button'
                         size='sm'

--- a/src/cook-web/src/components/shifu-root/ShifuRoot.tsx
+++ b/src/cook-web/src/components/shifu-root/ShifuRoot.tsx
@@ -7,15 +7,21 @@ import ShifuEdit from '../shifu-edit';
 type ShifuRootProps = {
   id: string;
   initialLessonId?: string;
+  initialViewMode?: 'edit' | 'history';
 };
 
-export default function ShifuRoot({ id, initialLessonId }: ShifuRootProps) {
+export default function ShifuRoot({
+  id,
+  initialLessonId,
+  initialViewMode,
+}: ShifuRootProps) {
   return (
     <UserProvider>
       <ShifuProvider>
         <ShifuEdit
           id={id}
           initialLessonId={initialLessonId}
+          initialViewMode={initialViewMode}
         />
       </ShifuProvider>
     </UserProvider>

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -1847,6 +1847,7 @@ export type I18nKey =
   | 'module.shifu.creationArea.modeCode'
   | 'module.shifu.creationArea.modeText'
   | 'module.shifu.creationArea.title'
+  | 'module.shifu.history.backToDocument'
   | 'module.shifu.history.collapse'
   | 'module.shifu.history.confirmDescription'
   | 'module.shifu.history.confirmLoadFailed'

--- a/src/i18n/en-US/modules/shifu.json
+++ b/src/i18n/en-US/modules/shifu.json
@@ -8,6 +8,7 @@
     "title": "Teaching Prompts"
   },
   "history": {
+    "backToDocument": "Back to document",
     "collapse": "Collapse",
     "confirmDescription": "After confirmation, the current lesson content will be fully replaced by this version.",
     "confirmLoadFailed": "Failed to load this version content. Please try again later.",

--- a/src/i18n/fr-FR/modules/shifu.json
+++ b/src/i18n/fr-FR/modules/shifu.json
@@ -8,6 +8,7 @@
     "title": "Prompts pédagogiques"
   },
   "history": {
+    "backToDocument": "Retour au document",
     "collapse": "Réduire",
     "confirmDescription": "Après confirmation, le contenu actuel de la leçon sera entièrement remplacé par cette version.",
     "confirmLoadFailed": "Échec du chargement du contenu de cette version. Veuillez réessayer plus tard.",

--- a/src/i18n/zh-CN/modules/shifu.json
+++ b/src/i18n/zh-CN/modules/shifu.json
@@ -8,6 +8,7 @@
     "title": "授课提示词"
   },
   "history": {
+    "backToDocument": "返回文档",
     "collapse": "收起",
     "confirmDescription": "确认恢复后，当前节内容将被该版本完整覆盖。",
     "confirmLoadFailed": "加载版本内容失败，请稍后重试",


### PR DESCRIPTION
## Summary
- move shifu lesson history from the editor-side sheet into a dedicated history page opened in a new tab
- render the history content and history list side by side on the same page with the restore action centered in the top bar
- remove the extra course-title header from the history page and add the back-to-document i18n entry plus route coverage

## Validation
- `cd src/cook-web && npm test -- --runInBand src/components/shifu-edit/ShifuEdit.test.tsx`
- `cd src/cook-web && npm test -- --runInBand src/app/shifu/`
- `cd src/cook-web && npm run type-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a dedicated full-page history view for documents, providing a cleaner interface to review document changes
  * Added "Back to Document" navigation link to quickly return from history view
  * Enhanced view mode support across the editor with edit and history options

* **Documentation**
  * Added multilingual support with localization strings for history UI in English, French, and Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->