### PR TITLE
fix: correct operator timestamp display

### DIFF
--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
@@ -50,7 +50,7 @@ type CourseChaptersTabProps = {
     secondary: string;
   };
   formatCount: (value: number, locale: string) => string;
-  formatAdminNaiveDateTime: (value?: string) => string;
+  formatAdminUtcDateTime: (value?: string) => string;
   getColumnStyle: (key: ChapterColumnKey) => {
     width: number;
     minWidth: number;
@@ -73,7 +73,7 @@ export default function CourseChaptersTab({
   resolveContentStatusLabel,
   resolveModifierDisplay,
   formatCount,
-  formatAdminNaiveDateTime,
+  formatAdminUtcDateTime,
   getColumnStyle,
   getResizeHandleProps,
   tOperations,
@@ -307,7 +307,7 @@ export default function CourseChaptersTab({
                       >
                         <AdminTooltipText
                           text={
-                            formatAdminNaiveDateTime(chapter.updated_at) ||
+                            formatAdminUtcDateTime(chapter.updated_at) ||
                             emptyValue
                           }
                           emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -12,7 +12,7 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { ClearableTextInput } from '@/app/admin/operations/orders/orderUiShared';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
@@ -532,7 +532,7 @@ export default function CourseCreditUsageTab({
                           style={getColumnStyle('createdAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminNaiveDateTime(row.created_at)}
+                            text={formatAdminUtcDateTime(row.created_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -536,9 +536,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLearnedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminUtcDateTime(
-                              row.last_learning_at,
-                            )}
+                            text={formatAdminUtcDateTime(row.last_learning_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -11,7 +11,7 @@ import {
   getAdminStickyRightCellClass,
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
@@ -536,7 +536,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLearnedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminNaiveDateTime(
+                            text={formatAdminUtcDateTime(
                               row.last_learning_at,
                             )}
                             emptyValue={emptyValue}
@@ -548,7 +548,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLoginAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminNaiveDateTime(row.last_login_at)}
+                            text={formatAdminUtcDateTime(row.last_login_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />
@@ -558,7 +558,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('joinedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminNaiveDateTime(row.joined_at)}
+                            text={formatAdminUtcDateTime(row.joined_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -17,7 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/Sheet';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { cn } from '@/lib/utils';
 import type { AdminOperationCourseFollowUpDetailResponse } from '../../operation-course-types';
 
@@ -300,7 +300,7 @@ export default function FollowUpDetailSheet({
                 <DetailRow
                   label={t('detail.followUps.drawer.fields.followUpTime')}
                   value={
-                    formatAdminNaiveDateTime(basicInfo?.created_at) ||
+                    formatAdminUtcDateTime(basicInfo?.created_at) ||
                     emptyValue
                   }
                 />
@@ -371,7 +371,7 @@ export default function FollowUpDetailSheet({
                             ) : null}
                           </div>
                           <span className='text-xs text-muted-foreground'>
-                            {formatAdminNaiveDateTime(item.created_at) ||
+                            {formatAdminUtcDateTime(item.created_at) ||
                               emptyValue}
                           </span>
                         </div>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -300,8 +300,7 @@ export default function FollowUpDetailSheet({
                 <DetailRow
                   label={t('detail.followUps.drawer.fields.followUpTime')}
                   value={
-                    formatAdminUtcDateTime(basicInfo?.created_at) ||
-                    emptyValue
+                    formatAdminUtcDateTime(basicInfo?.created_at) || emptyValue
                   }
                 />
                 <DetailRow

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -17,7 +17,7 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -516,7 +516,7 @@ export default function AdminOperationCourseFollowUpsPage() {
         key: 'latestFollowUpAt',
         label: tOperations('detail.followUps.summary.latestFollowUpAt'),
         value:
-          formatAdminNaiveDateTime(followUps.summary.latest_follow_up_at) ||
+          formatAdminUtcDateTime(followUps.summary.latest_follow_up_at) ||
           emptyValue,
         tone: 'timestamp' as const,
       },
@@ -922,7 +922,7 @@ export default function AdminOperationCourseFollowUpsPage() {
                                       style={getColumnStyle('createdAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminNaiveDateTime(
+                                        text={formatAdminUtcDateTime(
                                           item.created_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
@@ -1320,12 +1320,12 @@ export default function AdminOperationCourseDetailPage() {
       {
         label: tOperations('detail.fields.createdAt'),
         value:
-          formatAdminNaiveDateTime(detail.basic_info.created_at) || emptyValue,
+          formatAdminUtcDateTime(detail.basic_info.created_at) || emptyValue,
       },
       {
         label: tOperations('detail.fields.updatedAt'),
         value:
-          formatAdminNaiveDateTime(detail.basic_info.updated_at) || emptyValue,
+          formatAdminUtcDateTime(detail.basic_info.updated_at) || emptyValue,
       },
     ],
     [
@@ -1434,7 +1434,7 @@ export default function AdminOperationCourseDetailPage() {
                   resolveContentStatusLabel={resolveContentStatusLabel}
                   resolveModifierDisplay={resolveModifierDisplay}
                   formatCount={formatCount}
-                  formatAdminNaiveDateTime={formatAdminNaiveDateTime}
+                  formatAdminUtcDateTime={formatAdminUtcDateTime}
                   getColumnStyle={getChapterColumnStyle}
                   getResizeHandleProps={getChapterResizeHandleProps}
                   tOperations={tOperations}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -448,8 +448,7 @@ export default function AdminOperationCourseRatingsPage() {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminUtcDateTime(ratings.summary.latest_rated_at) ||
-          emptyValue,
+          formatAdminUtcDateTime(ratings.summary.latest_rated_at) || emptyValue,
         tone: 'timestamp' as const,
       },
     ],

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -14,7 +14,7 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -448,7 +448,7 @@ export default function AdminOperationCourseRatingsPage() {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminNaiveDateTime(ratings.summary.latest_rated_at) ||
+          formatAdminUtcDateTime(ratings.summary.latest_rated_at) ||
           emptyValue,
         tone: 'timestamp' as const,
       },
@@ -994,7 +994,7 @@ export default function AdminOperationCourseRatingsPage() {
                                       style={getColumnStyle('ratedAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminNaiveDateTime(
+                                        text={formatAdminUtcDateTime(
                                           item.rated_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -255,9 +255,7 @@ export default function CreditOrderDetailDialog({
                 />
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
-                  value={
-                    formatAdminUtcDateTime(order.created_at) || emptyValue
-                  }
+                  value={formatAdminUtcDateTime(order.created_at) || emptyValue}
                 />
                 <DetailRow
                   label={tOperationsOrder('creditOrders.detail.labels.paidAt')}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
   formatAdminCredits,
   formatAdminPrice,
@@ -256,12 +256,12 @@ export default function CreditOrderDetailDialog({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatAdminNaiveDateTime(order.created_at) || emptyValue
+                    formatAdminUtcDateTime(order.created_at) || emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('creditOrders.detail.labels.paidAt')}
-                  value={formatAdminNaiveDateTime(order.paid_at) || emptyValue}
+                  value={formatAdminUtcDateTime(order.paid_at) || emptyValue}
                 />
                 {order.failed_at ? (
                   <DetailRow
@@ -269,7 +269,7 @@ export default function CreditOrderDetailDialog({
                       'creditOrders.detail.labels.failedAt',
                     )}
                     value={
-                      formatAdminNaiveDateTime(order.failed_at) || emptyValue
+                      formatAdminUtcDateTime(order.failed_at) || emptyValue
                     }
                   />
                 ) : null}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -8,7 +8,7 @@ import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -988,7 +988,7 @@ export default function CreditOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatAdminNaiveDateTime(order.created_at) ||
+                            formatAdminUtcDateTime(order.created_at) ||
                               EMPTY_STATE_LABEL,
                           )}
                         </TableCell>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -9,7 +9,7 @@ import api from '@/api';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
   formatAdminCount,
   formatAdminNumber,
@@ -928,7 +928,7 @@ export default function LearnOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatAdminNaiveDateTime(order.created_at),
+                            formatAdminUtcDateTime(order.created_at),
                           )}
                         </TableCell>
                         <TableCell

--- a/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import api from '@/api';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Badge } from '@/components/ui/Badge';
@@ -209,13 +209,13 @@ const OperatorOrderDetailSheet = ({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatAdminNaiveDateTime(summary.created_at) || emptyValue
+                    formatAdminUtcDateTime(summary.created_at) || emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('table.updatedAt')}
                   value={
-                    formatAdminNaiveDateTime(summary.updated_at) || emptyValue
+                    formatAdminUtcDateTime(summary.updated_at) || emptyValue
                   }
                 />
               </Section>

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -17,7 +17,7 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
-import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { TITLE_MAX_LENGTH } from '@/c-constants/uiConstants';
 import {
@@ -1897,7 +1897,7 @@ const OperationsPage = () => {
                         style={getColumnStyle('updatedAt')}
                       >
                         {renderTooltipText(
-                          formatAdminNaiveDateTime(course.updated_at),
+                          formatAdminUtcDateTime(course.updated_at),
                           'mx-auto block',
                         )}
                       </TableCell>
@@ -1906,7 +1906,7 @@ const OperationsPage = () => {
                         style={getColumnStyle('createdAt')}
                       >
                         {renderTooltipText(
-                          formatAdminNaiveDateTime(course.created_at),
+                          formatAdminUtcDateTime(course.created_at),
                           'mx-auto block',
                         )}
                       </TableCell>

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -39,7 +39,7 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
-import { formatOperatorNaiveDateTime } from './dateTime';
+import { formatOperatorUtcDateTime } from './dateTime';
 import type {
   AdminOperationUserBenefitGrantResponse,
   AdminOperationUserCreditGrantRequest,
@@ -115,7 +115,7 @@ const resolveCurrentExpiry = (
     return '--';
   }
   if (user.credits_expire_at) {
-    return formatOperatorNaiveDateTime(user.credits_expire_at);
+    return formatOperatorUtcDateTime(user.credits_expire_at);
   }
   if (Number(user.available_credits || 0) > 0) {
     return longTermLabel;

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
@@ -39,7 +39,7 @@ import {
   FILTER_ALL_OPTION,
   sanitizeCreditFiltersByType,
 } from './creditFilterUtils';
-import { formatOperatorNaiveDateTime } from '../dateTime';
+import { formatOperatorUtcDateTime } from '../dateTime';
 
 type ErrorState = { message: string; code?: number };
 
@@ -480,7 +480,7 @@ export default function UserCreditLedgerTab({
                     <TableRow key={item.ledger_bid}>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={formatOperatorNaiveDateTime(item.created_at)}
+                          text={formatOperatorUtcDateTime(item.created_at)}
                           emptyValue={emptyValue}
                         />
                       </TableCell>
@@ -540,7 +540,7 @@ export default function UserCreditLedgerTab({
                       </TableCell>
                       <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
                         <AdminTooltipText
-                          text={formatOperatorNaiveDateTime(item.expires_at)}
+                          text={formatOperatorUtcDateTime(item.expires_at)}
                           emptyValue={emptyValue}
                         />
                       </TableCell>

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/tooltip';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
-import { formatOperatorNaiveDateTime } from '../dateTime';
+import { formatOperatorUtcDateTime } from '../dateTime';
 import type {
   AdminOperationUserCourseItem,
   AdminOperationUserCreditFilters,
@@ -554,7 +554,7 @@ export default function AdminOperationUserDetailPage() {
   };
   const resolveCreditsExpireAt = useCallback(() => {
     if (creditSummary.credits_expire_at) {
-      return formatOperatorNaiveDateTime(creditSummary.credits_expire_at);
+      return formatOperatorUtcDateTime(creditSummary.credits_expire_at);
     }
     if (Number(creditSummary.available_credits || 0) > 0) {
       return tOperationsUsers('credits.longTerm');
@@ -619,12 +619,12 @@ export default function AdminOperationUserDetailPage() {
       {
         key: 'lastLoginAt',
         label: tOperationsUsers('table.lastLoginAt'),
-        value: formatOperatorNaiveDateTime(detail.last_login_at),
+        value: formatOperatorUtcDateTime(detail.last_login_at),
       },
       {
         key: 'createdAt',
         label: tOperationsUsers('table.createdAt'),
-        value: formatOperatorNaiveDateTime(detail.created_at),
+        value: formatOperatorUtcDateTime(detail.created_at),
       },
     ],
     [
@@ -677,7 +677,7 @@ export default function AdminOperationUserDetailPage() {
       {
         key: 'lastLearningAt',
         label: tOperationsUsers('table.lastLearningAt'),
-        value: formatOperatorNaiveDateTime(detail.last_learning_at),
+        value: formatOperatorUtcDateTime(detail.last_learning_at),
       },
     ],
     [

--- a/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
+++ b/src/cook-web/src/app/admin/operations/users/dateTime.test.ts
@@ -4,13 +4,13 @@ import {
 } from './dateTime';
 
 jest.mock('@/lib/browser-timezone', () => ({
-  getBrowserTimeZone: () => 'UTC',
+  getBrowserTimeZone: () => 'Asia/Shanghai',
 }));
 
 describe('formatOperatorUtcDateTime', () => {
   test('formats ISO datetimes with timezone', () => {
     expect(formatOperatorUtcDateTime('2026-05-01T00:00:00Z')).toBe(
-      '2026-05-01 00:00:00',
+      '2026-05-01 08:00:00',
     );
   });
 

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -71,7 +71,7 @@ import { cn } from '@/lib/utils';
 import { ErrorWithCode } from '@/lib/request';
 import { buildAdminOperationsCourseDetailUrl } from '../operation-course-routes';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
-import { formatOperatorNaiveDateTime } from './dateTime';
+import { formatOperatorUtcDateTime } from './dateTime';
 import { normalizeLoginMethodLabelKey } from './loginMethodUtils';
 import UserCreditGrantDialog from './UserCreditGrantDialog';
 import useOperatorGuard from '../useOperatorGuard';
@@ -492,7 +492,7 @@ export default function AdminOperationUsersPage() {
   const resolveCreditsExpireAtLabel = React.useCallback(
     (user: AdminOperationUserItem) => {
       if (user.credits_expire_at) {
-        return formatOperatorNaiveDateTime(user.credits_expire_at);
+        return formatOperatorUtcDateTime(user.credits_expire_at);
       }
       if (Number(user.available_credits || 0) > 0) {
         return tOperationsUsers('credits.longTerm');
@@ -1504,7 +1504,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLoginAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorNaiveDateTime(user.last_login_at),
+                            formatOperatorUtcDateTime(user.last_login_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1512,7 +1512,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLearningAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorNaiveDateTime(user.last_learning_at),
+                            formatOperatorUtcDateTime(user.last_learning_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1520,7 +1520,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorNaiveDateTime(user.created_at),
+                            formatOperatorUtcDateTime(user.created_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1528,7 +1528,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('updatedAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorNaiveDateTime(user.updated_at),
+                            formatOperatorUtcDateTime(user.updated_at),
                           )}
                         </TableCell>
                         <TableCell


### PR DESCRIPTION
## Summary

Fix operator-management time display so UTC timestamps are rendered in the viewer timezone instead of being shown as naive local wall-clock values.

## Updates

- switch affected operator-management pages from naive datetime formatters to UTC-aware formatters
- align operator-management time rendering with the dashboard behavior
- add/update timestamp formatting coverage for the 8-hour offset case

## Validation

- `cd src/cook-web && npx jest --runTestsByPath 'src/app/admin/operations/users/dateTime.test.ts' 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx' --runInBand`\n- `cd src/cook-web && npm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated timestamp displays across the admin dashboard to use UTC formatting for:
    - Course management (chapters, credit usage, user activity)
    - Order management (credit and learn orders)
    - User accounts and credit tracking
    - Ratings and follow-up records
  * Adjusted test validations for datetime formatting changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->