### PR TITLE
fix: unblock cook-web build lint check

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminTooltipText.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTooltipText.test.tsx
@@ -34,6 +34,9 @@ jest.mock('@/components/ui/tooltip', () => ({
 
 describe('AdminTooltipText', () => {
   let mutationObserver: MockMutationObserver | null = null;
+  const registerMutationObserver = (observer: MockMutationObserver) => {
+    mutationObserver = observer;
+  };
 
   beforeEach(() => {
     mutationObserver = null;
@@ -48,22 +51,20 @@ describe('AdminTooltipText', () => {
       value: class extends MockMutationObserver {
         constructor(callback: MutationCallback) {
           super(callback);
-          mutationObserver = this;
+          registerMutationObserver(this);
         }
       },
     });
     Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
       configurable: true,
       get() {
-        const text = this.textContent?.trim() ?? '';
-        return text === 'Long content value' ? 80 : 120;
+        return this.textContent?.trim() === 'Long content value' ? 80 : 120;
       },
     });
     Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
       configurable: true,
       get() {
-        const text = this.textContent?.trim() ?? '';
-        return text === 'Long content value' ? 160 : 120;
+        return this.textContent?.trim() === 'Long content value' ? 160 : 120;
       },
     });
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', {


### PR DESCRIPTION
## Summary
- fix the `no-this-alias` lint error in `AdminTooltipText` test setup
- unblock `src/cook-web` Docker/Next build in CI

## Testing
- `cd src/cook-web && npx eslint src/app/admin/components/AdminTooltipText.test.tsx`
- `cd src/cook-web && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for the AdminTooltipText component with enhanced test utilities and mock setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->