### PR TITLE
fix: dashboard learner time serialization

### DIFF
--- a/src/api/flaskr/util/timezone.py
+++ b/src/api/flaskr/util/timezone.py
@@ -44,11 +44,41 @@ def get_app_timezone(app: Flask, tz_name: str | None = None) -> ZoneInfo:
     return ZoneInfo("UTC")
 
 
+def _coerce_datetime(app: Flask, value: datetime | str | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        if not stripped_value:
+            return None
+        normalized_value = (
+            f"{stripped_value[:-1]}+00:00"
+            if stripped_value.endswith("Z")
+            else stripped_value
+        )
+        try:
+            return datetime.fromisoformat(normalized_value)
+        except ValueError:
+            app.logger.warning(
+                "Failed to parse datetime string '%s' for timezone conversion",
+                stripped_value,
+            )
+            return None
+    app.logger.warning(
+        "Unexpected datetime value type '%s' for timezone conversion",
+        type(value).__name__,
+    )
+    return None
+
+
 def serialize_with_app_timezone(
     app: Flask,
-    dt: datetime | None,
+    dt: datetime | str | None,
     tz_name: str | None = None,
 ) -> str | None:
+    dt = _coerce_datetime(app, dt)
     if dt is None:
         return None
     app_tz = get_app_timezone(app, tz_name)
@@ -60,10 +90,11 @@ def serialize_with_app_timezone(
 
 def format_with_app_timezone(
     app: Flask,
-    dt: datetime | None,
+    dt: datetime | str | None,
     fmt: str,
     tz_name: str | None = None,
 ) -> str | None:
+    dt = _coerce_datetime(app, dt)
     if dt is None:
         return None
     app_tz = get_app_timezone(app, tz_name)

--- a/src/api/tests/common/test_timezone.py
+++ b/src/api/tests/common/test_timezone.py
@@ -1,0 +1,39 @@
+from flask import Flask
+
+from flaskr.util.timezone import (
+    format_with_app_timezone,
+    serialize_with_app_timezone,
+)
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["TZ"] = "Asia/Shanghai"
+    return app
+
+
+def test_serialize_with_app_timezone_accepts_mysql_datetime_string() -> None:
+    app = _make_app()
+
+    assert (
+        serialize_with_app_timezone(app, "2026-05-20 16:40:51", "UTC")
+        == "2026-05-20T08:40:51+00:00"
+    )
+    assert (
+        format_with_app_timezone(
+            app,
+            "2026-05-20 16:40:51",
+            "%Y-%m-%d %H:%M:%S",
+            "UTC",
+        )
+        == "2026-05-20 08:40:51"
+    )
+
+
+def test_serialize_with_app_timezone_accepts_offset_datetime_string() -> None:
+    app = _make_app()
+
+    assert (
+        serialize_with_app_timezone(app, "2026-05-20T08:40:51Z", "Asia/Shanghai")
+        == "2026-05-20T16:40:51+08:00"
+    )


### PR DESCRIPTION
## Summary
- Allow shared timezone serializers to accept datetime strings returned by SQL expressions.
- Cover MySQL-style datetime strings and UTC `Z` ISO strings with focused tests.

## Root cause
The optimized dashboard learner query can return `joined_at` from SQLAlchemy/MySQL as a string. `serialize_with_app_timezone()` and `format_with_app_timezone()` assumed every non-null value was a `datetime`, so `/api/dashboard/shifus/{shifu_bid}/learners` raised `AttributeError: 'str' object has no attribute 'tzinfo'` on current production image `20260520-7e1aa29`.

## Validation
- `python -m pytest tests/common/test_timezone.py -q`
- `python -m pytest tests/service/dashboard/test_dashboard_routes.py -q`
- `python -m ruff check flaskr/util/timezone.py tests/common/test_timezone.py`
- `python -m ruff format --check flaskr/util/timezone.py tests/common/test_timezone.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Timezone serialization and formatting functions now accept flexible input formats, including string datetime representations alongside date/time objects, improving usability and compatibility
* **Tests**
  * Added comprehensive timezone conversion tests to ensure reliability across different input formats and timezone scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->