### PR TITLE
fix: delay lesson rating popup until playback completes

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2045,7 +2045,7 @@ class RunScriptContextV2:
                 return True
         return False
 
-    def _maybe_emit_feedback_before_access_gate(
+    def _maybe_emit_feedback_after_access_gate(
         self,
         *,
         parsed_interaction: dict,
@@ -2138,10 +2138,10 @@ class RunScriptContextV2:
         current_outline_completed: bool,
         has_next_outline_item: bool,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
-        if current_outline_completed:
-            yield from self._emit_lesson_feedback_interaction(progress_record)
         if has_next_outline_item:
             yield from self._emit_next_chapter_interaction(progress_record)
+        if current_outline_completed:
+            yield from self._emit_lesson_feedback_interaction(progress_record)
 
     def _get_default_llm_settings(self) -> LLMSettings:
         return LLMSettings(
@@ -2547,12 +2547,6 @@ class RunScriptContextV2:
                 for button in parsed_interaction.get("buttons"):
                     if button.get("value") == "_sys_pay":
                         if not self._is_paid:
-                            yield from self._maybe_emit_feedback_before_access_gate(
-                                parsed_interaction=parsed_interaction,
-                                progress_record=run_script_info.attend,
-                                is_tail_gate=run_script_info.block_position
-                                >= len(block_list) - 1,
-                            )
                             # Use translated content from database if available
                             interaction_content = (
                                 generated_block.block_content_conf
@@ -2581,6 +2575,12 @@ class RunScriptContextV2:
                                 generated_block_bid=generated_block.generated_block_bid,
                                 type=GeneratedType.INTERACTION,
                                 content=interaction_content,
+                            )
+                            yield from self._maybe_emit_feedback_after_access_gate(
+                                parsed_interaction=parsed_interaction,
+                                progress_record=run_script_info.attend,
+                                is_tail_gate=run_script_info.block_position
+                                >= len(block_list) - 1,
                             )
                             self._can_continue = False
                             db.session.flush()
@@ -2599,12 +2599,6 @@ class RunScriptContextV2:
                             db.session.flush()
                             return
                         else:
-                            yield from self._maybe_emit_feedback_before_access_gate(
-                                parsed_interaction=parsed_interaction,
-                                progress_record=run_script_info.attend,
-                                is_tail_gate=run_script_info.block_position
-                                >= len(block_list) - 1,
-                            )
                             # Use translated content from database if available
                             interaction_content = (
                                 generated_block.block_content_conf
@@ -2633,6 +2627,12 @@ class RunScriptContextV2:
                                 generated_block_bid=generated_block.generated_block_bid,
                                 type=GeneratedType.INTERACTION,
                                 content=interaction_content,
+                            )
+                            yield from self._maybe_emit_feedback_after_access_gate(
+                                parsed_interaction=parsed_interaction,
+                                progress_record=run_script_info.attend,
+                                is_tail_gate=run_script_info.block_position
+                                >= len(block_list) - 1,
                             )
                             self._can_continue = False
                             db.session.flush()
@@ -2962,11 +2962,6 @@ class RunScriptContextV2:
             if block.block_type == BlockType.INTERACTION:
                 interaction_parser: InteractionParser = InteractionParser()
                 parsed_interaction = interaction_parser.parse(block.content)
-                yield from self._maybe_emit_feedback_before_access_gate(
-                    parsed_interaction=parsed_interaction,
-                    progress_record=run_script_info.attend,
-                    is_tail_gate=run_script_info.block_position >= len(block_list) - 1,
-                )
                 if (
                     parsed_interaction.get("buttons")
                     and len(parsed_interaction.get("buttons")) > 0
@@ -3019,6 +3014,11 @@ class RunScriptContextV2:
                     generated_block_bid=generated_block.generated_block_bid,
                     type=GeneratedType.INTERACTION,
                     content=rendered_content,
+                )
+                yield from self._maybe_emit_feedback_after_access_gate(
+                    parsed_interaction=parsed_interaction,
+                    progress_record=run_script_info.attend,
+                    is_tail_gate=run_script_info.block_position >= len(block_list) - 1,
                 )
                 self._can_continue = False
                 self._current_attend.status = LEARN_STATUS_IN_PROGRESS
@@ -3313,17 +3313,17 @@ class RunScriptContextV2:
         except PaidException:
             app.logger.info("PaidException")
             self._can_continue = False
-            yield from self._emit_feedback_before_exception_gate()
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.order.checkout')}//_sys_pay]"
             )
+            yield from self._emit_feedback_before_exception_gate()
         except UserNotLoginException:
             app.logger.info("UserNotLoginException")
             self._can_continue = False
-            yield from self._emit_feedback_before_exception_gate()
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.user.login')}//_sys_login]"
             )
+            yield from self._emit_feedback_before_exception_gate()
 
     def has_next(self) -> bool:
         return self._can_continue

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2058,7 +2058,7 @@ class RunScriptContextV2:
             return
         yield from self._emit_lesson_feedback_interaction(progress_record)
 
-    def _emit_feedback_before_exception_gate(
+    def _emit_feedback_after_exception_gate(
         self,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         if not self._outline_item_info:
@@ -2097,26 +2097,63 @@ class RunScriptContextV2:
             return
         yield from self._emit_lesson_feedback_interaction(latest_completed_progress)
 
+    def _ensure_current_attend_for_gate_interaction(self) -> LearnProgressRecord | None:
+        if self._current_attend:
+            return self._current_attend
+        if not self._outline_item_info:
+            return None
+
+        outline_bid = getattr(self._outline_item_info, "bid", "")
+        shifu_bid = getattr(self._outline_item_info, "shifu_bid", "")
+        user_bid = getattr(self._user_info, "user_id", "")
+        if not outline_bid or not shifu_bid or not user_bid:
+            return None
+
+        current_attend = (
+            LearnProgressRecord.query.filter(
+                LearnProgressRecord.outline_item_bid == outline_bid,
+                LearnProgressRecord.user_bid == user_bid,
+                LearnProgressRecord.status != LEARN_STATUS_RESET,
+            )
+            .order_by(LearnProgressRecord.id.desc())
+            .first()
+        )
+        if current_attend is None:
+            current_attend = LearnProgressRecord(
+                progress_record_bid=generate_id(self.app),
+                shifu_bid=shifu_bid,
+                outline_item_bid=outline_bid,
+                user_bid=user_bid,
+                status=LEARN_STATUS_NOT_STARTED,
+                block_position=0,
+            )
+            db.session.add(current_attend)
+            db.session.flush()
+
+        self._current_attend = current_attend
+        return current_attend
+
     def _emit_current_progress_gate_interaction(
         self,
         content: str,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
-        if not self._current_attend:
+        current_attend = self._ensure_current_attend_for_gate_interaction()
+        if not current_attend:
             return
-        outline_bid = self._current_attend.outline_item_bid or getattr(
+        outline_bid = current_attend.outline_item_bid or getattr(
             self._outline_item_info, "bid", ""
         )
         if not outline_bid:
             return
         generated_block: LearnGeneratedBlock = init_generated_block(
             self.app,
-            shifu_bid=self._current_attend.shifu_bid,
+            shifu_bid=current_attend.shifu_bid,
             outline_item_bid=outline_bid,
-            progress_record_bid=self._current_attend.progress_record_bid,
+            progress_record_bid=current_attend.progress_record_bid,
             user_bid=self._user_info.user_id,
             block_type=BLOCK_TYPE_MDINTERACTION_VALUE,
             mdflow=content,
-            block_index=self._current_attend.block_position,
+            block_index=current_attend.block_position,
         )
         generated_block.role = ROLE_TEACHER
         generated_block.block_content_conf = content
@@ -3316,14 +3353,14 @@ class RunScriptContextV2:
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.order.checkout')}//_sys_pay]"
             )
-            yield from self._emit_feedback_before_exception_gate()
+            yield from self._emit_feedback_after_exception_gate()
         except UserNotLoginException:
             app.logger.info("UserNotLoginException")
             self._can_continue = False
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.user.login')}//_sys_login]"
             )
-            yield from self._emit_feedback_before_exception_gate()
+            yield from self._emit_feedback_after_exception_gate()
 
     def has_next(self) -> bool:
         return self._can_continue

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -132,6 +132,39 @@ def _is_access_gate_interaction(
     return False
 
 
+def _find_feedback_interaction_index(
+    records: list[LegacyGeneratedBlockRecord],
+) -> int:
+    for index, record in enumerate(records):
+        if (
+            record.block_type == BlockType.INTERACTION
+            and is_lesson_feedback_interaction(record.content)
+        ):
+            return index
+    return -1
+
+
+def _insert_record_before_feedback_tail(
+    records: list[LegacyGeneratedBlockRecord],
+    record: LegacyGeneratedBlockRecord,
+) -> None:
+    feedback_index = _find_feedback_interaction_index(records)
+    if feedback_index < 0:
+        records.append(record)
+        return
+    records.insert(feedback_index, record)
+
+
+def _move_feedback_interaction_to_tail(
+    records: list[LegacyGeneratedBlockRecord],
+) -> None:
+    feedback_index = _find_feedback_interaction_index(records)
+    if feedback_index < 0 or feedback_index == len(records) - 1:
+        return
+    feedback_record = records.pop(feedback_index)
+    records.append(feedback_record)
+
+
 def _collect_outline_bids(struct: HistoryItem) -> list[str]:
     outline_bids = []
     q = queue.Queue()
@@ -473,14 +506,15 @@ def get_learn_record(
         ):
             button_label = _("server.learn.nextChapterButton")
             fallback_content = f"?[{button_label}//{CONTEXT_INTERACTION_NEXT}]"
-            records.append(
+            _insert_record_before_feedback_tail(
+                records,
                 LegacyGeneratedBlockRecord(
                     generated_block_bid=generate_id(app),
                     content=fallback_content,
                     like_status=LikeStatus.NONE,
                     block_type=BlockType.INTERACTION,
                     user_input="",
-                )
+                ),
             )
 
         if (
@@ -514,6 +548,7 @@ def get_learn_record(
                 user_input=feedback_generated_content,
             )
             records.append(feedback_record)
+        _move_feedback_interaction_to_tail(records)
         return LegacyLearnRecord(
             records=records,
         )

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -466,6 +466,24 @@ def get_learn_record(
             )
         )
         if (
+            progress_record.status == LEARN_STATUS_COMPLETED
+            and has_next_outline
+            and not has_tail_access_gate
+            and not has_next_chapter_button
+        ):
+            button_label = _("server.learn.nextChapterButton")
+            fallback_content = f"?[{button_label}//{CONTEXT_INTERACTION_NEXT}]"
+            records.append(
+                LegacyGeneratedBlockRecord(
+                    generated_block_bid=generate_id(app),
+                    content=fallback_content,
+                    like_status=LikeStatus.NONE,
+                    block_type=BlockType.INTERACTION,
+                    user_input="",
+                )
+            )
+
+        if (
             progress_record.status == LEARN_STATUS_COMPLETED or has_tail_access_gate
         ) and not has_feedback_interaction:
             saved_feedback = (
@@ -495,37 +513,7 @@ def get_learn_record(
                 block_type=BlockType.INTERACTION,
                 user_input=feedback_generated_content,
             )
-            next_button_index = next(
-                (
-                    index
-                    for index, record in enumerate(records)
-                    if record.block_type == BlockType.INTERACTION
-                    and CONTEXT_INTERACTION_NEXT in record.content
-                ),
-                len(records),
-            )
-            insert_index = next_button_index
-            if has_tail_access_gate:
-                insert_index = min(insert_index, len(records) - 1)
-            records.insert(insert_index, feedback_record)
-
-        if (
-            progress_record.status == LEARN_STATUS_COMPLETED
-            and has_next_outline
-            and not has_tail_access_gate
-            and not has_next_chapter_button
-        ):
-            button_label = _("server.learn.nextChapterButton")
-            fallback_content = f"?[{button_label}//{CONTEXT_INTERACTION_NEXT}]"
-            records.append(
-                LegacyGeneratedBlockRecord(
-                    generated_block_bid=generate_id(app),
-                    content=fallback_content,
-                    like_status=LikeStatus.NONE,
-                    block_type=BlockType.INTERACTION,
-                    user_input="",
-                )
-            )
+            records.append(feedback_record)
         return LegacyLearnRecord(
             records=records,
         )

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -127,6 +127,7 @@ from flaskr.service.learn.preview_elements import PreviewElementRunAdapter
 from flaskr.service.order.consts import (
     LEARN_STATUS_COMPLETED,
     LEARN_STATUS_IN_PROGRESS,
+    LEARN_STATUS_NOT_STARTED,
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
@@ -575,13 +576,13 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
                 )
             )
             dao.db.session.commit()
-            events = list(self.ctx._emit_feedback_before_exception_gate())
+            events = list(self.ctx._emit_feedback_after_exception_gate())
             self.assertEqual(len(events), 1)
             self.assertEqual(events[0].type, GeneratedType.INTERACTION)
 
     def test_skips_when_no_completed_progress(self):
         with self.app.app_context():
-            events = list(self.ctx._emit_feedback_before_exception_gate())
+            events = list(self.ctx._emit_feedback_after_exception_gate())
             self.assertEqual(events, [])
 
     def test_skips_completed_progress_without_generated_blocks(self):
@@ -596,8 +597,57 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
                 )
             )
             dao.db.session.commit()
-            events = list(self.ctx._emit_feedback_before_exception_gate())
+            events = list(self.ctx._emit_feedback_after_exception_gate())
             self.assertEqual(events, [])
+
+
+class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = Flask("exception-gate-interaction-persistence")
+        cls.app.config.update(
+            SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+            SQLALCHEMY_BINDS={
+                "ai_shifu_saas": "sqlite:///:memory:",
+                "ai_shifu_admin": "sqlite:///:memory:",
+            },
+            SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        )
+        dao.db.init_app(cls.app)
+        with cls.app.app_context():
+            dao.db.create_all()
+
+    def setUp(self):
+        self.app = self.__class__.app
+        self.ctx = _make_context()
+        self.ctx.app = self.app
+        self.ctx._outline_item_info = types.SimpleNamespace(
+            bid="outline-locked",
+            shifu_bid="shifu-1",
+        )
+        self.ctx._user_info = types.SimpleNamespace(user_id="user-1")
+        self.ctx._current_attend = None
+        with self.app.app_context():
+            LearnGeneratedBlock.query.delete()
+            LearnProgressRecord.query.delete()
+            dao.db.session.commit()
+
+    def test_emits_gate_interaction_without_existing_progress(self):
+        with self.app.app_context():
+            events = list(
+                self.ctx._emit_current_progress_gate_interaction(
+                    "?[server.order.checkout//_sys_pay]"
+                )
+            )
+
+            progress = LearnProgressRecord.query.one()
+            block = LearnGeneratedBlock.query.one()
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(progress.status, LEARN_STATUS_NOT_STARTED)
+        self.assertEqual(block.progress_record_bid, progress.progress_record_bid)
+        self.assertEqual(block.outline_item_bid, "outline-locked")
+        self.assertEqual(block.block_content_conf, "?[server.order.checkout//_sys_pay]")
 
 
 class StreamTtsGateTests(unittest.TestCase):
@@ -1667,7 +1717,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
             raise PaidException()
 
         ctx.run_inner = _raise_paid
-        ctx._emit_feedback_before_exception_gate = lambda: iter(["feedback"])
+        ctx._emit_feedback_after_exception_gate = lambda: iter(["feedback"])
         ctx._emit_current_progress_gate_interaction = lambda content: iter([content])
 
         with patch("flaskr.service.learn.context_v2._", lambda key: key):

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -341,8 +341,8 @@ class CompletionTailInteractionTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["feedback", "next"])
-        self.assertEqual(events, ["feedback-event", "next-event"])
+        self.assertEqual(calls, ["next", "feedback"])
+        self.assertEqual(events, ["next-event", "feedback-event"])
 
     def test_skips_next_when_no_next_outline(self):
         ctx = _make_context()
@@ -1673,7 +1673,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         with patch("flaskr.service.learn.context_v2._", lambda key: key):
             outputs = list(ctx.run(app))
 
-        self.assertEqual(outputs, ["feedback", "?[server.order.checkout//_sys_pay]"])
+        self.assertEqual(outputs, ["?[server.order.checkout//_sys_pay]", "feedback"])
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -149,9 +149,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
             )
 
         self.assertEqual(len(result.records), 2)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
-        self.assertEqual(result.records[1].block_type, BlockType.INTERACTION)
-        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[1].content)
+        self.assertEqual(result.records[0].block_type, BlockType.INTERACTION)
+        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
     def test_uses_persisted_button_when_present(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -186,10 +186,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
             )
 
         self.assertEqual(len(result.records), 2)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
-        record = result.records[1]
+        record = result.records[0]
         self.assertEqual(record.generated_block_bid, block.generated_block_bid)
         self.assertIn(CONTEXT_INTERACTION_NEXT, record.content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
     def test_no_button_when_not_completed(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -224,7 +224,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         self.assertEqual(len(result.records), 1)
         self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
 
-    def test_feedback_before_pay_gate_when_in_progress(self):
+    def test_feedback_after_pay_gate_when_in_progress(self):
         self._seed_struct(["outline-1"])
         progress = self._create_progress(LEARN_STATUS_IN_PROGRESS)
         self._add_interaction_block(progress, "?[去支付//_sys_pay]")
@@ -240,10 +240,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
             )
 
         self.assertEqual(len(result.records), 2)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
-        self.assertIn("_sys_pay", result.records[1].content)
+        self.assertIn("_sys_pay", result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
-    def test_feedback_before_login_gate_when_in_progress(self):
+    def test_feedback_after_login_gate_when_in_progress(self):
         self._seed_struct(["outline-1"])
         progress = self._create_progress(LEARN_STATUS_IN_PROGRESS)
         self._add_interaction_block(progress, "?[去登录//_sys_login]")
@@ -259,8 +259,8 @@ class LearnRecordFallbackTests(unittest.TestCase):
             )
 
         self.assertEqual(len(result.records), 2)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
-        self.assertIn("_sys_login", result.records[1].content)
+        self.assertIn("_sys_login", result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
     def test_no_next_button_when_completed_with_pay_gate(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -278,9 +278,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
             )
 
         self.assertEqual(len(result.records), 2)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
-        self.assertIn("_sys_pay", result.records[1].content)
-        self.assertNotIn(CONTEXT_INTERACTION_NEXT, result.records[1].content)
+        self.assertIn("_sys_pay", result.records[0].content)
+        self.assertNotIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -23,7 +23,10 @@ if dao.db is None:
 from flaskr.i18n import _
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.learn_dtos import BlockType
-from flaskr.service.learn.lesson_feedback import is_lesson_feedback_interaction
+from flaskr.service.learn.lesson_feedback import (
+    build_lesson_feedback_interaction_md,
+    is_lesson_feedback_interaction,
+)
 from flaskr.service.learn.learn_funcs import get_learn_record
 from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 from flaskr.service.order.consts import (
@@ -280,6 +283,58 @@ class LearnRecordFallbackTests(unittest.TestCase):
         self.assertEqual(len(result.records), 2)
         self.assertIn("_sys_pay", result.records[0].content)
         self.assertNotIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+
+    def test_inserts_fallback_next_before_existing_feedback(self):
+        self._seed_struct(["outline-1", "outline-2"])
+        progress = self._create_progress(LEARN_STATUS_COMPLETED)
+        self._add_interaction_block(
+            progress,
+            build_lesson_feedback_interaction_md(),
+            position=0,
+        )
+
+        with self.app.test_request_context():
+            self._set_request_user()
+            result = get_learn_record(
+                self.app,
+                progress.shifu_bid,
+                progress.outline_item_bid,
+                progress.user_bid,
+                False,
+            )
+
+        self.assertEqual(len(result.records), 2)
+        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
+        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+
+    def test_moves_existing_feedback_to_tail_when_next_already_persisted(self):
+        self._seed_struct(["outline-1", "outline-2"])
+        progress = self._create_progress(LEARN_STATUS_COMPLETED)
+        button_label = _("server.learn.nextChapterButton")
+        self._add_interaction_block(
+            progress,
+            build_lesson_feedback_interaction_md(),
+            position=0,
+        )
+        self._add_interaction_block(
+            progress,
+            f"?[{button_label}//{CONTEXT_INTERACTION_NEXT}]",
+            position=1,
+        )
+
+        with self.app.test_request_context():
+            self._set_request_user()
+            result = get_learn_record(
+                self.app,
+                progress.shifu_bid,
+                progress.outline_item_bid,
+                progress.user_bid,
+                False,
+            )
+
+        self.assertEqual(len(result.records), 2)
+        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
         self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
 
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -6,6 +6,10 @@ import {
   shouldDelayListenFeedbackPromptForTailInteraction,
 } from './lessonFeedbackPromptState';
 
+const mockIsLessonFeedbackInteractionContent = jest.fn(
+  (content?: string) => content?.includes('lesson_feedback') ?? false,
+);
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -218,6 +222,3 @@ describe('ListenModeSlideRenderer', () => {
     ).toBe(true);
   });
 });
-const mockIsLessonFeedbackInteractionContent = jest.fn(
-  (content?: string) => content?.includes('lesson_feedback') ?? false,
-);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import type React from 'react';
 import ListenModeSlideRenderer from './ListenModeSlideRenderer';
+import {
+  isListenLessonFeedbackPromptReady,
+  shouldDelayListenFeedbackPromptForTailInteraction,
+} from './lessonFeedbackPromptState';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -43,7 +47,8 @@ jest.mock('@/c-utils/lesson-feedback-interaction-defaults', () => ({
 }));
 
 jest.mock('@/c-utils/lesson-feedback-interaction', () => ({
-  isLessonFeedbackInteractionContent: () => false,
+  isLessonFeedbackInteractionContent: (content?: string) =>
+    mockIsLessonFeedbackInteractionContent(content),
 }));
 
 jest.mock('@/c-utils/system-interaction', () => ({
@@ -65,6 +70,7 @@ const getMockSlide = () =>
 describe('ListenModeSlideRenderer', () => {
   beforeEach(() => {
     getMockSlide().mockClear();
+    mockIsLessonFeedbackInteractionContent.mockClear();
   });
 
   it('does not show the audio preparation text for normal loading', () => {
@@ -178,4 +184,40 @@ describe('ListenModeSlideRenderer', () => {
       }),
     );
   });
+
+  it('keeps lesson feedback pending until the trailing visible interaction settles', () => {
+    expect(
+      shouldDelayListenFeedbackPromptForTailInteraction({
+        lastItemIsLessonFeedbackInteraction: true,
+        markerStepCount: 3,
+        currentStepIndex: 2,
+        currentStepHasAudio: false,
+        currentStepHasBlockingInteraction: false,
+        currentStepElementType: 'interaction',
+      }),
+    ).toBe(true);
+
+    expect(
+      isListenLessonFeedbackPromptReady({
+        lastItemIsLessonFeedbackInteraction: true,
+        markerStepCount: 3,
+        currentStepIndex: 2,
+        isPlaybackSequenceActive: false,
+        hasSettledTailInteraction: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isListenLessonFeedbackPromptReady({
+        lastItemIsLessonFeedbackInteraction: true,
+        markerStepCount: 3,
+        currentStepIndex: 2,
+        isPlaybackSequenceActive: false,
+        hasSettledTailInteraction: true,
+      }),
+    ).toBe(true);
+  });
 });
+const mockIsLessonFeedbackInteractionContent = jest.fn(
+  (content?: string) => content?.includes('lesson_feedback') ?? false,
+);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -86,6 +86,7 @@ interface ListenModeSlideRendererProps {
     isAudioPlaying: boolean;
     isAudioSequenceActive: boolean;
   }) => void;
+  onLessonFeedbackPromptStateChange?: (ready: boolean) => void;
   onMobileViewModeChange?: (viewMode: MobileViewMode) => void;
 }
 
@@ -410,6 +411,7 @@ const ListenModeSlideRenderer = ({
   onSend,
   onPlayerVisibilityChange,
   onPlaybackStateChange,
+  onLessonFeedbackPromptStateChange,
   onMobileViewModeChange,
 }: ListenModeSlideRendererProps) => {
   const { t } = useTranslation();
@@ -458,8 +460,12 @@ const ListenModeSlideRenderer = ({
   const storedAskListByAnchorElementBid = useAskStateStore(
     state => state.askListByAnchorElementBid,
   );
-  const { lastInteractionBid, lastItemIsInteraction, firstContentItem } =
-    useListenContentData(items);
+  const {
+    lastInteractionBid,
+    lastItemIsInteraction,
+    lastItemIsLessonFeedbackInteraction,
+    firstContentItem,
+  } = useListenContentData(items);
   const baseAskListByAnchorElementBid = useMemo(
     () => buildAskListByAnchorElementBid(items),
     [items],
@@ -1112,6 +1118,25 @@ const ListenModeSlideRenderer = ({
     });
   }, [onPlaybackStateChange, playbackState]);
 
+  const isLessonFeedbackPromptReady = useMemo(() => {
+    if (!lastItemIsLessonFeedbackInteraction) {
+      return false;
+    }
+
+    if (markerStepCount <= 0) {
+      return false;
+    }
+
+    return (
+      playbackState.currentStepIndex === markerStepCount - 1 &&
+      !getListenPlaybackSequenceActive(playbackState)
+    );
+  }, [lastItemIsLessonFeedbackInteraction, markerStepCount, playbackState]);
+
+  useEffect(() => {
+    onLessonFeedbackPromptStateChange?.(isLessonFeedbackPromptReady);
+  }, [isLessonFeedbackPromptReady, onLessonFeedbackPromptStateChange]);
+
   useEffect(() => {
     previousMarkerStepKeyRef.current = '';
     setPlaybackState({
@@ -1137,8 +1162,9 @@ const ListenModeSlideRenderer = ({
         isAudioPlaying: false,
         isAudioSequenceActive: false,
       });
+      onLessonFeedbackPromptStateChange?.(false);
     },
-    [onPlaybackStateChange],
+    [onLessonFeedbackPromptStateChange, onPlaybackStateChange],
   );
 
   const playerCustomActions = useCallback(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -40,6 +40,11 @@ import { useListenContentData } from './useListenMode';
 import { buildAskListByAnchorElementBid } from './askState';
 import { useAskStateStore } from './useAskStateStore';
 import { DEFAULT_LISTEN_MOBILE_VIEW_MODE } from './listenModeTypes';
+import {
+  isListenLessonFeedbackPromptReady,
+  LESSON_FEEDBACK_TAIL_INTERACTION_SETTLE_DELAY_MS,
+  shouldDelayListenFeedbackPromptForTailInteraction,
+} from './lessonFeedbackPromptState';
 
 type ListenSlideElement = SlideElement & {
   blockBid?: string;
@@ -434,6 +439,8 @@ const ListenModeSlideRenderer = ({
     isAudioPlaying: false,
     isAudioWaiting: false,
   });
+  const [hasSettledTailInteraction, setHasSettledTailInteraction] =
+    useState(false);
   const [isMobileAskOpen, setIsMobileAskOpen] = useState(false);
   const [isPlayerVisible, setIsPlayerVisible] = useState(true);
   const [mobileViewMode, setMobileViewMode] = useState<MobileViewMode>(
@@ -1118,20 +1125,57 @@ const ListenModeSlideRenderer = ({
     });
   }, [onPlaybackStateChange, playbackState]);
 
+  const shouldDelayTailInteractionFeedbackPrompt = useMemo(
+    () =>
+      shouldDelayListenFeedbackPromptForTailInteraction({
+        lastItemIsLessonFeedbackInteraction,
+        markerStepCount,
+        currentStepIndex: playbackState.currentStepIndex,
+        currentStepHasAudio: playbackState.currentStepHasAudio,
+        currentStepHasBlockingInteraction:
+          playbackState.currentStepHasBlockingInteraction,
+        currentStepElementType: currentMarkerStepElement?.type,
+      }),
+    [
+      currentMarkerStepElement?.type,
+      lastItemIsLessonFeedbackInteraction,
+      markerStepCount,
+      playbackState.currentStepHasAudio,
+      playbackState.currentStepHasBlockingInteraction,
+      playbackState.currentStepIndex,
+    ],
+  );
+
+  useEffect(() => {
+    if (!shouldDelayTailInteractionFeedbackPrompt) {
+      setHasSettledTailInteraction(true);
+      return;
+    }
+
+    setHasSettledTailInteraction(false);
+    const timer = window.setTimeout(() => {
+      setHasSettledTailInteraction(true);
+    }, LESSON_FEEDBACK_TAIL_INTERACTION_SETTLE_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [currentMarkerStepKey, shouldDelayTailInteractionFeedbackPrompt]);
+
   const isLessonFeedbackPromptReady = useMemo(() => {
-    if (!lastItemIsLessonFeedbackInteraction) {
-      return false;
-    }
-
-    if (markerStepCount <= 0) {
-      return false;
-    }
-
-    return (
-      playbackState.currentStepIndex === markerStepCount - 1 &&
-      !getListenPlaybackSequenceActive(playbackState)
-    );
-  }, [lastItemIsLessonFeedbackInteraction, markerStepCount, playbackState]);
+    return isListenLessonFeedbackPromptReady({
+      lastItemIsLessonFeedbackInteraction,
+      markerStepCount,
+      currentStepIndex: playbackState.currentStepIndex,
+      isPlaybackSequenceActive: getListenPlaybackSequenceActive(playbackState),
+      hasSettledTailInteraction,
+    });
+  }, [
+    hasSettledTailInteraction,
+    lastItemIsLessonFeedbackInteraction,
+    markerStepCount,
+    playbackState,
+  ]);
 
   useEffect(() => {
     onLessonFeedbackPromptStateChange?.(isLessonFeedbackPromptReady);
@@ -1148,7 +1192,8 @@ const ListenModeSlideRenderer = ({
       isAudioPlaying: false,
       isAudioWaiting: false,
     });
-  }, [lessonId, markerSequenceKey]);
+    setHasSettledTailInteraction(false);
+  }, [lessonId, markerSequenceKey, markerStepCount]);
 
   useEffect(() => {
     setPlaybackState(prevState =>

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import Image from 'next/image';
 import { createPortal } from 'react-dom';
@@ -1146,7 +1154,7 @@ const ListenModeSlideRenderer = ({
     ],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldDelayTailInteractionFeedbackPrompt) {
       setHasSettledTailInteraction(true);
       return;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.test.tsx
@@ -3,7 +3,13 @@ import {
   projectListenModeItems,
   projectReadModeItems,
 } from './chatUiModeProjection';
+import { findLastVisibleLessonFeedbackElementBid } from './lessonFeedbackPromptState';
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
+
+jest.mock('@/c-utils/lesson-feedback-interaction', () => ({
+  isLessonFeedbackInteractionContent: (content?: string) =>
+    content?.includes('sys_lesson_feedback_score') ?? false,
+}));
 
 describe('NewChatComp read mode loading gate', () => {
   it('keeps existing read content visible while a run is still loading', () => {
@@ -244,5 +250,27 @@ describe('NewChatComp mode projections', () => {
         shouldUseTypewriter: false,
       }),
     );
+  });
+
+  it('tracks the latest visible lesson feedback interaction anchor', () => {
+    expect(
+      findLastVisibleLessonFeedbackElementBid([
+        {
+          element_bid: 'feedback-old',
+          content: '%{{sys_lesson_feedback_score}}1|2|3|4|5|...comment',
+          type: ChatContentItemType.INTERACTION,
+        },
+        {
+          element_bid: 'content-1',
+          content: 'Lesson content',
+          type: ChatContentItemType.CONTENT,
+        },
+        {
+          element_bid: 'feedback-new',
+          content: '%{{sys_lesson_feedback_score}}1|2|3|4|5|...comment',
+          type: ChatContentItemType.INTERACTION,
+        },
+      ]),
+    ).toBe('feedback-new');
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -777,7 +777,11 @@ export const NewChatComponents = ({
       return;
     }
 
-    if (isLoading || isOutputInProgress || Boolean(currentTypewriterElementBid)) {
+    if (
+      isLoading ||
+      isOutputInProgress ||
+      Boolean(currentTypewriterElementBid)
+    ) {
       setIsReadFeedbackReady(false);
       return;
     }
@@ -1085,7 +1089,13 @@ export const NewChatComponents = ({
       });
       resizeObserver.disconnect();
     };
-  }, [checkScroll, isListenModeActive, isScrollableElement, items, mobileStyle]);
+  }, [
+    checkScroll,
+    isListenModeActive,
+    isScrollableElement,
+    items,
+    mobileStyle,
+  ]);
 
   useEffect(() => {
     if (mobileStyle) {
@@ -1424,7 +1434,7 @@ export const NewChatComponents = ({
                         padding: getReadModeElementPadding(idx === 0),
                       }}
                     >
-                        {isLongPressed && mobileStyle && (
+                      {isLongPressed && mobileStyle && (
                         <div className='long-press-overlay' />
                       )}
                       {item.element_bid === readModeFeedbackElementBid ? (

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -24,7 +24,6 @@ import { useCourseStore } from '@/c-store/useCourseStore';
 import { fail, toast } from '@/hooks/useToast';
 import useExclusiveAudio from '@/hooks/useExclusiveAudio';
 import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
-import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import InteractionBlock from './InteractionBlock';
 import useChatLogicHook, { ChatContentItemType } from './useChatLogicHook';
 import type { ChatContentItem } from './useChatLogicHook';
@@ -76,6 +75,7 @@ import {
   projectListenModeItems,
   projectReadModeItems,
 } from './chatUiModeProjection';
+import { findLastVisibleLessonFeedbackElementBid } from './lessonFeedbackPromptState';
 
 const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
 
@@ -504,12 +504,7 @@ export const NewChatComponents = ({
     [visibleReadModeItems],
   );
   const readModeFeedbackElementBid = useMemo(
-    () =>
-      visibleReadModeItems.find(
-        item =>
-          item.type === ChatContentItemType.INTERACTION &&
-          isLessonFeedbackInteractionContent(item.content),
-      )?.element_bid || '',
+    () => findLastVisibleLessonFeedbackElementBid(visibleReadModeItems),
     [visibleReadModeItems],
   );
   const isTrailingVisibleReadModeItemText = useMemo(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -24,6 +24,7 @@ import { useCourseStore } from '@/c-store/useCourseStore';
 import { fail, toast } from '@/hooks/useToast';
 import useExclusiveAudio from '@/hooks/useExclusiveAudio';
 import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
+import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import InteractionBlock from './InteractionBlock';
 import useChatLogicHook, { ChatContentItemType } from './useChatLogicHook';
 import type { ChatContentItem } from './useChatLogicHook';
@@ -172,13 +173,12 @@ export const NewChatComponents = ({
   // });
 
   const [showScrollDown, setShowScrollDown] = useState(false);
-  const [isAtBottom, setIsAtBottom] = useState(false);
+  const [isReadFeedbackReady, setIsReadFeedbackReady] = useState(false);
+  const [isReadFeedbackAnchorVisible, setIsReadFeedbackAnchorVisible] =
+    useState(false);
+  const [readFeedbackTriggerElement, setReadFeedbackTriggerElement] =
+    useState<HTMLDivElement | null>(null);
   const listenTtsToastShownRef = useRef(false);
-  const listenFeedbackReadyTimerRef = useRef<number | null>(null);
-  const [listenPlaybackState, setListenPlaybackState] = useState({
-    isAudioPlaying: false,
-    isAudioSequenceActive: false,
-  });
   const [isListenFeedbackReady, setIsListenFeedbackReady] = useState(false);
   const listenAudioBackfillInFlightRef = useRef<Record<string, Promise<any>>>(
     {},
@@ -213,26 +213,60 @@ export const NewChatComponents = ({
     [],
   );
 
+  const isScrollableElement = useCallback((element?: HTMLElement | null) => {
+    if (!element) {
+      return false;
+    }
+
+    return element.scrollHeight > element.clientHeight + 1;
+  }, []);
+
+  const resolveScrollPresentation = useCallback(() => {
+    const localContainers: HTMLElement[] = [];
+
+    if (chatRef.current) {
+      localContainers.push(chatRef.current);
+      if (chatRef.current.parentElement) {
+        localContainers.push(chatRef.current.parentElement);
+      }
+    }
+
+    const containers: Array<HTMLElement | Document> = [...localContainers];
+    const shouldUseDocumentScroll =
+      mobileStyle || !localContainers.some(isScrollableElement);
+
+    // Desktop read mode sometimes scrolls on the page instead of the chat body.
+    // Fall back to the document scroll position so lesson feedback does not open early.
+    if (shouldUseDocumentScroll) {
+      containers.push(document);
+    }
+
+    const shouldShow = containers.some(container => !isNearBottom(container));
+    return {
+      shouldShow,
+    };
+  }, [isNearBottom, isScrollableElement, mobileStyle]);
+
+  const resolveReadFeedbackObserverRoot = useCallback(() => {
+    const chatContainer = chatRef.current;
+    if (chatContainer && isScrollableElement(chatContainer)) {
+      return chatContainer;
+    }
+
+    const parentContainer = chatContainer?.parentElement;
+    if (parentContainer && isScrollableElement(parentContainer)) {
+      return parentContainer;
+    }
+
+    return null;
+  }, [isScrollableElement]);
+
   const checkScroll = useCallback(() => {
     requestAnimationFrame(() => {
-      const containers: Array<HTMLElement | Document> = [];
-
-      if (chatRef.current) {
-        containers.push(chatRef.current);
-        if (chatRef.current.parentElement) {
-          containers.push(chatRef.current.parentElement);
-        }
-      }
-
-      if (mobileStyle) {
-        containers.push(document);
-      }
-
-      const shouldShow = containers.some(container => !isNearBottom(container));
-      setIsAtBottom(!shouldShow);
-      setShowScrollDown(shouldShow);
+      const nextPresentation = resolveScrollPresentation();
+      setShowScrollDown(nextPresentation.shouldShow);
     });
-  }, [isNearBottom, mobileStyle]);
+  }, [resolveScrollPresentation]);
 
   const { openPayModal, payModalResult, resetedLessonId, resettingLessonId } =
     useCourseStore(
@@ -270,9 +304,6 @@ export const NewChatComponents = ({
     useState(promptContextKey);
   const shouldShowAudioAction = previewMode || isListenModeActive;
   const { requestExclusive, releaseExclusive } = useExclusiveAudio();
-  const isListenPlaybackBusy =
-    listenPlaybackState.isAudioPlaying ||
-    listenPlaybackState.isAudioSequenceActive;
   const isPromptContextSettled = settledPromptContextKey === promptContextKey;
   const ensureLessonScope = useAskStateStore(state => state.ensureLessonScope);
   const hydrateAskListMap = useAskStateStore(state => state.hydrateAskListMap);
@@ -387,7 +418,9 @@ export const NewChatComponents = ({
     listenRequestEnabled: isListenModeActive,
     shouldPromptLessonFeedback:
       isPromptContextSettled &&
-      (isListenModeActive ? isListenFeedbackReady : isAtBottom),
+      (isListenModeActive
+        ? isListenFeedbackReady
+        : isReadFeedbackReady && isReadFeedbackAnchorVisible),
     // scrollToBottom,
     showOutputInProgressToast,
     onPayModalOpen,
@@ -468,6 +501,15 @@ export const NewChatComponents = ({
       [...visibleReadModeItems]
         .reverse()
         .find(item => isReadModeTextContentItem(item))?.element_bid || '',
+    [visibleReadModeItems],
+  );
+  const readModeFeedbackElementBid = useMemo(
+    () =>
+      visibleReadModeItems.find(
+        item =>
+          item.type === ChatContentItemType.INTERACTION &&
+          isLessonFeedbackInteractionContent(item.content),
+      )?.element_bid || '',
     [visibleReadModeItems],
   );
   const isTrailingVisibleReadModeItemText = useMemo(
@@ -553,9 +595,44 @@ export const NewChatComponents = ({
   }, [isListenModeActive, isLoading, onListenPlayerVisibilityChange]);
 
   useEffect(() => {
-    setIsAtBottom(false);
     setShowScrollDown(false);
   }, [isListenModeActive, lessonId]);
+
+  useEffect(() => {
+    if (isListenModeActive) {
+      setIsReadFeedbackAnchorVisible(false);
+      setReadFeedbackTriggerElement(null);
+      return;
+    }
+
+    if (!readFeedbackTriggerElement) {
+      setIsReadFeedbackAnchorVisible(false);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const [entry] = entries;
+        setIsReadFeedbackAnchorVisible(Boolean(entry?.isIntersecting));
+      },
+      {
+        root: resolveReadFeedbackObserverRoot(),
+        threshold: 0.98,
+      },
+    );
+
+    observer.observe(readFeedbackTriggerElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    isListenModeActive,
+    lessonId,
+    mobileStyle,
+    readFeedbackTriggerElement,
+    resolveReadFeedbackObserverRoot,
+  ]);
 
   useEffect(() => {
     setReadModeTypewriterCache(prevCache =>
@@ -678,37 +755,53 @@ export const NewChatComponents = ({
 
   useEffect(() => {
     setIsListenFeedbackReady(false);
+    setIsReadFeedbackReady(false);
     setSettledPromptContextKey(promptContextKey);
   }, [promptContextKey]);
 
   useEffect(() => {
-    if (listenFeedbackReadyTimerRef.current !== null) {
-      window.clearTimeout(listenFeedbackReadyTimerRef.current);
-      listenFeedbackReadyTimerRef.current = null;
-    }
-
     if (!isListenModeActive) {
-      setIsListenFeedbackReady(true);
-      return;
-    }
-
-    if (isLoading || isListenPlaybackBusy) {
       setIsListenFeedbackReady(false);
       return;
     }
 
-    listenFeedbackReadyTimerRef.current = window.setTimeout(() => {
-      setIsListenFeedbackReady(true);
-      listenFeedbackReadyTimerRef.current = null;
-    }, 1200);
+    if (isLoading) {
+      setIsListenFeedbackReady(false);
+      return;
+    }
+  }, [isListenModeActive, isLoading, lessonId]);
+
+  useEffect(() => {
+    if (isListenModeActive) {
+      setIsReadFeedbackReady(false);
+      return;
+    }
+
+    if (isLoading || isOutputInProgress || Boolean(currentTypewriterElementBid)) {
+      setIsReadFeedbackReady(false);
+      return;
+    }
+
+    setIsReadFeedbackReady(false);
+
+    const rafId = window.requestAnimationFrame(() => {
+      const nextPresentation = resolveScrollPresentation();
+      setShowScrollDown(nextPresentation.shouldShow);
+      setIsReadFeedbackReady(true);
+    });
 
     return () => {
-      if (listenFeedbackReadyTimerRef.current !== null) {
-        window.clearTimeout(listenFeedbackReadyTimerRef.current);
-        listenFeedbackReadyTimerRef.current = null;
-      }
+      window.cancelAnimationFrame(rafId);
     };
-  }, [isListenModeActive, isLoading, isListenPlaybackBusy, lessonId]);
+  }, [
+    currentTypewriterElementBid,
+    isListenModeActive,
+    isLoading,
+    isOutputInProgress,
+    items.length,
+    promptContextKey,
+    resolveScrollPresentation,
+  ]);
 
   const listenModeItems = useMemo(
     () =>
@@ -949,6 +1042,11 @@ export const NewChatComponents = ({
     const container = chatRef.current;
     const parentContainer = container?.parentElement;
     const listeners: Array<{ element: EventTarget; handler: () => void }> = [];
+    const shouldTrackWindowScroll =
+      mobileStyle ||
+      ![container, parentContainer].some(
+        element => element && isScrollableElement(element),
+      );
 
     if (container) {
       container.addEventListener('scroll', checkScroll, { passive: true });
@@ -962,7 +1060,7 @@ export const NewChatComponents = ({
       listeners.push({ element: parentContainer, handler: checkScroll });
     }
 
-    if (mobileStyle) {
+    if (shouldTrackWindowScroll) {
       window.addEventListener('scroll', checkScroll, { passive: true });
       listeners.push({ element: window, handler: checkScroll });
     }
@@ -987,7 +1085,7 @@ export const NewChatComponents = ({
       });
       resizeObserver.disconnect();
     };
-  }, [checkScroll, isListenModeActive, items, mobileStyle]);
+  }, [checkScroll, isListenModeActive, isScrollableElement, items, mobileStyle]);
 
   useEffect(() => {
     if (mobileStyle) {
@@ -1117,7 +1215,7 @@ export const NewChatComponents = ({
             onMobileViewModeChange={onListenMobileViewModeChange}
             onSend={memoizedOnSend}
             onPlayerVisibilityChange={onListenPlayerVisibilityChange}
-            onPlaybackStateChange={setListenPlaybackState}
+            onLessonFeedbackPromptStateChange={setIsListenFeedbackReady}
           />
         ) : (
           <div
@@ -1326,9 +1424,16 @@ export const NewChatComponents = ({
                         padding: getReadModeElementPadding(idx === 0),
                       }}
                     >
-                      {isLongPressed && mobileStyle && (
+                        {isLongPressed && mobileStyle && (
                         <div className='long-press-overlay' />
                       )}
+                      {item.element_bid === readModeFeedbackElementBid ? (
+                        <div
+                          ref={setReadFeedbackTriggerElement}
+                          aria-hidden='true'
+                          className='h-px w-full'
+                        />
+                      ) : null}
                       {/*
                         Keep typewriter enabled when the current element content
                         has already grown beyond the finished cache snapshot.

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/lessonFeedbackPromptState.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/lessonFeedbackPromptState.ts
@@ -1,0 +1,70 @@
+import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
+
+type FeedbackPromptContentItem = {
+  type?: string;
+  content?: string | null;
+  element_bid?: string | null;
+};
+
+type ListenFeedbackPromptDelayOptions = {
+  lastItemIsLessonFeedbackInteraction: boolean;
+  markerStepCount: number;
+  currentStepIndex: number;
+  currentStepHasAudio: boolean;
+  currentStepHasBlockingInteraction: boolean;
+  currentStepElementType?: string;
+};
+
+type ListenFeedbackPromptReadyOptions = {
+  lastItemIsLessonFeedbackInteraction: boolean;
+  markerStepCount: number;
+  currentStepIndex: number;
+  isPlaybackSequenceActive: boolean;
+  hasSettledTailInteraction: boolean;
+};
+
+export const LESSON_FEEDBACK_TAIL_INTERACTION_SETTLE_DELAY_MS = 2000;
+
+export const findLastVisibleLessonFeedbackElementBid = (
+  items: FeedbackPromptContentItem[],
+) => {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i];
+    if (
+      item?.type === 'interaction' &&
+      isLessonFeedbackInteractionContent(item.content || '')
+    ) {
+      return item.element_bid || '';
+    }
+  }
+
+  return '';
+};
+
+export const shouldDelayListenFeedbackPromptForTailInteraction = ({
+  lastItemIsLessonFeedbackInteraction,
+  markerStepCount,
+  currentStepIndex,
+  currentStepHasAudio,
+  currentStepHasBlockingInteraction,
+  currentStepElementType,
+}: ListenFeedbackPromptDelayOptions) =>
+  lastItemIsLessonFeedbackInteraction &&
+  markerStepCount > 0 &&
+  currentStepIndex === markerStepCount - 1 &&
+  currentStepElementType === 'interaction' &&
+  !currentStepHasAudio &&
+  !currentStepHasBlockingInteraction;
+
+export const isListenLessonFeedbackPromptReady = ({
+  lastItemIsLessonFeedbackInteraction,
+  markerStepCount,
+  currentStepIndex,
+  isPlaybackSequenceActive,
+  hasSettledTailInteraction,
+}: ListenFeedbackPromptReadyOptions) =>
+  lastItemIsLessonFeedbackInteraction &&
+  markerStepCount > 0 &&
+  currentStepIndex === markerStepCount - 1 &&
+  !isPlaybackSequenceActive &&
+  hasSettledTailInteraction;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
@@ -198,6 +198,10 @@ export const useListenContentData = (items: ChatContentItem[]) => {
       lastItemIsInteraction: lastItem?.type === ChatContentItemType.INTERACTION,
     };
   }, [audioAndInteractionList]);
+  const lastItemIsLessonFeedbackInteraction = useMemo(
+    () => isLessonFeedbackInteractionItem(audioAndInteractionList.at(-1)),
+    [audioAndInteractionList],
+  );
 
   const contentByBid = useMemo(() => {
     const mapping = new Map<string, ChatContentItem>();
@@ -257,6 +261,7 @@ export const useListenContentData = (items: ChatContentItem[]) => {
     ttsReadyElementBids,
     lastInteractionBid,
     lastItemIsInteraction,
+    lastItemIsLessonFeedbackInteraction,
     firstContentItem,
   };
 };


### PR DESCRIPTION
Summary
- move lesson feedback behind next/login/pay tail interactions on the backend
- gate read mode feedback on the actual feedback node becoming visible
- gate listen mode feedback on the listen sequence reaching the final feedback node after playback settles

Tests
- cd src/api && pytest tests/service/learn/test_learn_record.py tests/service/learn/test_context_v2.py -q
- cd src/cook-web && npx jest --runTestsByPath "src/app/c/[[...id]]/Components/ChatUi/NewChatComp.test.tsx" "src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx" "src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx" "src/app/c/[[...id]]/Components/ChatUi/useListenMode.test.tsx"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lesson feedback is now emitted after access and exception gate checks; next-chapter prompts appear before lesson feedback when both apply.
  * Gate-interaction sequencing during paid/login exceptions and progress-gate emission has been corrected.

* **Improvements**
  * Read/listen mode feedback prompting refined: delayed tail-feedback settling, visibility anchoring, and more reliable scroll/anchor behavior for prompting.
  * Listen-mode readiness is now reported via a dedicated callback so UI can react to prompt availability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->