### PR TITLE
feat：Optimize user management course dialog requests

### DIFF
--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -1150,6 +1150,285 @@ describe('AdminOperationUsersPage', () => {
     expect(mockGetAdminOperationUserDetail).toHaveBeenCalledTimes(1);
   });
 
+  test('deduplicates in-flight detail requests for the same user while switching dialog tabs', async () => {
+    const deferredDetail =
+      createDeferred<
+        Parameters<typeof mockGetAdminOperationUserDetail>[0] extends never
+          ? never
+          : Awaited<ReturnType<typeof api.getAdminOperationUserDetail>>
+      >();
+    mockGetAdminOperationUserDetail.mockReturnValueOnce(deferredDetail.promise);
+
+    await renderResolvedPage();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.createdCourses (2)',
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.learningCourses (1)',
+      }),
+    );
+
+    expect(mockGetAdminOperationUserDetail).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferredDetail.resolve({
+        user_bid: 'user-1',
+        mobile: '13812345678',
+        email: 'user-1@example.com',
+        nickname: 'Nick',
+        user_status: 'paid',
+        user_role: 'operator',
+        user_roles: ['operator', 'creator', 'learner'],
+        login_methods: ['phone', 'google'],
+        registration_source: 'google',
+        language: 'zh-CN',
+        learning_course_count: 1,
+        learning_courses: [
+          {
+            shifu_bid: 'course-1',
+            course_name: 'Learned Course',
+            course_status: 'published',
+            completed_lesson_count: 1,
+            total_lesson_count: 4,
+          },
+        ],
+        created_course_count: 2,
+        created_courses: [
+          {
+            shifu_bid: 'course-2',
+            course_name: 'Created Course',
+            course_status: 'unpublished',
+            completed_lesson_count: 0,
+            total_lesson_count: 0,
+          },
+          {
+            shifu_bid: 'course-3',
+            course_name: 'Second Created Course',
+            course_status: 'published',
+            completed_lesson_count: 0,
+            total_lesson_count: 0,
+          },
+        ],
+        total_paid_amount: '88.50',
+        available_credits: '35.5',
+        subscription_credits: '27.5',
+        topup_credits: '8',
+        credits_expire_at: '2026-05-01T00:00:00Z',
+        has_active_subscription: false,
+        last_login_at: '2026-04-15T09:00:00Z',
+        last_learning_at: '2026-04-15T10:00:00Z',
+        created_at: '2026-04-14T10:00:00Z',
+        updated_at: '2026-04-14T11:00:00Z',
+      });
+      await deferredDetail.promise;
+    });
+
+    expect(
+      await screen.findByText(
+        'module.operationsUser.courseSummary.dialog.learningTitle',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Learned Course')).toBeInTheDocument();
+  });
+
+  test('keeps cached dialog state when an older request resolves later', async () => {
+    const deferredUserOneDetail =
+      createDeferred<
+        Awaited<ReturnType<typeof api.getAdminOperationUserDetail>>
+      >();
+    mockGetAdminOperationUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'user-1',
+          mobile: '13812345678',
+          email: 'user-1@example.com',
+          nickname: 'Nick',
+          user_status: 'paid',
+          user_role: 'operator',
+          user_roles: ['operator', 'creator', 'learner'],
+          login_methods: ['phone', 'google'],
+          registration_source: 'google',
+          language: 'zh-CN',
+          learning_course_count: 1,
+          learning_courses: [],
+          created_course_count: 2,
+          created_courses: [],
+          total_paid_amount: '88.50',
+          available_credits: '35.5',
+          subscription_credits: '27.5',
+          topup_credits: '8',
+          credits_expire_at: '2026-05-01T00:00:00Z',
+          last_login_at: '2026-04-15T09:00:00Z',
+          last_learning_at: '2026-04-15T10:00:00Z',
+          created_at: '2026-04-14T10:00:00Z',
+          updated_at: '2026-04-14T11:00:00Z',
+        },
+        {
+          user_bid: 'user-2',
+          mobile: '13912345678',
+          email: 'user-2@example.com',
+          nickname: 'Other User',
+          user_status: 'paid',
+          user_role: 'learner',
+          user_roles: ['learner'],
+          login_methods: ['phone'],
+          registration_source: 'phone',
+          language: 'zh-CN',
+          learning_course_count: 1,
+          learning_courses: [],
+          created_course_count: 1,
+          created_courses: [],
+          total_paid_amount: '12.00',
+          available_credits: '5',
+          subscription_credits: '5',
+          topup_credits: '0',
+          credits_expire_at: '2026-05-01T00:00:00Z',
+          last_login_at: '2026-04-15T09:00:00Z',
+          last_learning_at: '2026-04-15T10:00:00Z',
+          created_at: '2026-04-14T10:00:00Z',
+          updated_at: '2026-04-14T11:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 2,
+    });
+    mockGetAdminOperationUserDetail.mockImplementation(({ user_bid }) => {
+      if (user_bid === 'user-1') {
+        return deferredUserOneDetail.promise;
+      }
+      if (user_bid === 'user-2') {
+        return Promise.resolve({
+          user_bid: 'user-2',
+          mobile: '13912345678',
+          email: 'user-2@example.com',
+          nickname: 'Other User',
+          user_status: 'paid',
+          user_role: 'learner',
+          user_roles: ['learner'],
+          login_methods: ['phone'],
+          registration_source: 'phone',
+          language: 'zh-CN',
+          learning_course_count: 1,
+          learning_courses: [
+            {
+              shifu_bid: 'course-9',
+              course_name: 'Cached Learned Course',
+              course_status: 'published',
+              completed_lesson_count: 2,
+              total_lesson_count: 5,
+            },
+          ],
+          created_course_count: 1,
+          created_courses: [
+            {
+              shifu_bid: 'course-8',
+              course_name: 'Cached Created Course',
+              course_status: 'published',
+              completed_lesson_count: 0,
+              total_lesson_count: 0,
+            },
+          ],
+          total_paid_amount: '12.00',
+          available_credits: '5',
+          subscription_credits: '5',
+          topup_credits: '0',
+          credits_expire_at: '2026-05-01T00:00:00Z',
+          has_active_subscription: false,
+          last_login_at: '2026-04-15T09:00:00Z',
+          last_learning_at: '2026-04-15T10:00:00Z',
+          created_at: '2026-04-14T10:00:00Z',
+          updated_at: '2026-04-14T11:00:00Z',
+        });
+      }
+      return Promise.reject(new Error(`unexpected user ${user_bid}`));
+    });
+
+    await renderResolvedPage();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.createdCourses (1)',
+      }),
+    );
+
+    expect(await screen.findByText('Cached Created Course')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.createdCourses (2)',
+      }),
+    );
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.operationsUser.table.learningCourses (1)',
+      })[1],
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'module.operationsUser.courseSummary.dialog.learningTitle',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      deferredUserOneDetail.resolve({
+        user_bid: 'user-1',
+        mobile: '13812345678',
+        email: 'user-1@example.com',
+        nickname: 'Nick',
+        user_status: 'paid',
+        user_role: 'operator',
+        user_roles: ['operator', 'creator', 'learner'],
+        login_methods: ['phone', 'google'],
+        registration_source: 'google',
+        language: 'zh-CN',
+        learning_course_count: 1,
+        learning_courses: [
+          {
+            shifu_bid: 'course-1',
+            course_name: 'Learned Course',
+            course_status: 'published',
+            completed_lesson_count: 1,
+            total_lesson_count: 4,
+          },
+        ],
+        created_course_count: 2,
+        created_courses: [
+          {
+            shifu_bid: 'course-2',
+            course_name: 'Created Course',
+            course_status: 'unpublished',
+            completed_lesson_count: 0,
+            total_lesson_count: 0,
+          },
+        ],
+        total_paid_amount: '88.50',
+        available_credits: '35.5',
+        subscription_credits: '27.5',
+        topup_credits: '8',
+        credits_expire_at: '2026-05-01T00:00:00Z',
+        has_active_subscription: false,
+        last_login_at: '2026-04-15T09:00:00Z',
+        last_learning_at: '2026-04-15T10:00:00Z',
+        created_at: '2026-04-14T10:00:00Z',
+        updated_at: '2026-04-14T11:00:00Z',
+      });
+      await deferredUserOneDetail.promise;
+    });
+    await flushMicrotasks();
+
+    expect(screen.getByText('Cached Learned Course')).toBeInTheDocument();
+    expect(screen.queryByText('Learned Course')).not.toBeInTheDocument();
+  });
+
   test('links the user id cell when the primary contact is empty', async () => {
     mockGetAdminOperationUsers.mockResolvedValueOnce({
       items: [

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -1107,7 +1107,7 @@ describe('AdminOperationUsersPage', () => {
         'module.operationsUser.courseSummary.dialog.createdTitle',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText('Created Course')).toBeInTheDocument();
+    expect(await screen.findByText('Created Course')).toBeInTheDocument();
     expect(screen.getByText('course-2')).toBeInTheDocument();
     expect(
       screen.getByText('module.operationsCourse.statusLabels.unpublished'),
@@ -1115,6 +1115,39 @@ describe('AdminOperationUsersPage', () => {
     expect(
       screen.getByRole('link', { name: 'Created Course' }),
     ).toHaveAttribute('href', '/admin/operations/course-2');
+  });
+
+  test('reuses cached detail data when reopening course dialog for the same user', async () => {
+    await renderResolvedPage();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.createdCourses (2)',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUserDetail).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByText('Created Course')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.table.learningCourses (1)',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'module.operationsUser.courseSummary.dialog.learningTitle',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Learned Course')).toBeInTheDocument();
+    expect(mockGetAdminOperationUserDetail).toHaveBeenCalledTimes(1);
   });
 
   test('links the user id cell when the primary contact is empty', async () => {

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -1357,7 +1357,9 @@ describe('AdminOperationUsersPage', () => {
       }),
     );
 
-    expect(await screen.findByText('Cached Created Course')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Cached Created Course'),
+    ).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole('button', {

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -597,7 +597,8 @@ export default function AdminOperationUsersPage() {
       throw new Error('Missing user bid');
     }
 
-    const cachedDetail = courseDialogDetailCacheRef.current.get(normalizedUserBid);
+    const cachedDetail =
+      courseDialogDetailCacheRef.current.get(normalizedUserBid);
     if (cachedDetail) {
       return cachedDetail;
     }
@@ -608,9 +609,11 @@ export default function AdminOperationUsersPage() {
       return inFlightRequest;
     }
 
-    const request = (api.getAdminOperationUserDetail({
-      user_bid: normalizedUserBid,
-    }) as Promise<AdminOperationUserDetailResponse>)
+    const request = (
+      api.getAdminOperationUserDetail({
+        user_bid: normalizedUserBid,
+      }) as Promise<AdminOperationUserDetailResponse>
+    )
       .then(detail => {
         courseDialogDetailCacheRef.current.set(normalizedUserBid, detail);
         return detail;
@@ -625,9 +628,13 @@ export default function AdminOperationUsersPage() {
 
   const openCourseDialog = useCallback(
     async (user: AdminOperationUserItem, type: 'learning' | 'created') => {
-      const cachedDetail = courseDialogDetailCacheRef.current.get(user.user_bid);
+      const cachedDetail = courseDialogDetailCacheRef.current.get(
+        user.user_bid,
+      );
       if (cachedDetail) {
-        setCourseDialog(buildCourseDialogStateFromDetail(user, type, cachedDetail));
+        setCourseDialog(
+          buildCourseDialogStateFromDetail(user, type, cachedDetail),
+        );
         return;
       }
 

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -107,6 +107,7 @@ type UserQuickFilterKey =
 type ErrorState = { message: string; code?: number };
 
 const PAGE_SIZE = 20;
+const COURSE_DIALOG_DETAIL_CACHE_LIMIT = 50;
 const ALL_OPTION_VALUE = '__all__';
 const EMPTY_STATE_LABEL = '--';
 const USER_STATUS_UNREGISTERED = 'unregistered';
@@ -169,6 +170,41 @@ const createDefaultFilters = (): UserFilters => ({
   start_time: '',
   end_time: '',
 });
+
+const readCachedCourseDialogDetail = (
+  cache: Map<string, AdminOperationUserDetailResponse>,
+  userBid: string,
+) => {
+  const cachedDetail = cache.get(userBid);
+  if (!cachedDetail) {
+    return null;
+  }
+
+  // Refresh insertion order so the map behaves like a tiny LRU cache.
+  cache.delete(userBid);
+  cache.set(userBid, cachedDetail);
+  return cachedDetail;
+};
+
+const cacheCourseDialogDetail = (
+  cache: Map<string, AdminOperationUserDetailResponse>,
+  userBid: string,
+  detail: AdminOperationUserDetailResponse,
+) => {
+  if (cache.has(userBid)) {
+    cache.delete(userBid);
+  }
+  cache.set(userBid, detail);
+
+  if (cache.size <= COURSE_DIALOG_DETAIL_CACHE_LIMIT) {
+    return;
+  }
+
+  const oldestUserBid = cache.keys().next().value;
+  if (oldestUserBid) {
+    cache.delete(oldestUserBid);
+  }
+};
 
 const formatLocalDate = (date: Date): string => {
   const year = date.getFullYear();
@@ -591,45 +627,55 @@ export default function AdminOperationUsersPage() {
     [],
   );
 
-  const getCourseDialogDetail = useCallback(async (userBid: string) => {
-    const normalizedUserBid = userBid.trim();
-    if (!normalizedUserBid) {
-      throw new Error('Missing user bid');
-    }
+  const getCourseDialogDetail = useCallback(
+    async (userBid: string) => {
+      const normalizedUserBid = userBid.trim();
+      if (!normalizedUserBid) {
+        throw new Error(t('common.core.networkError'));
+      }
+      const cachedDetail = readCachedCourseDialogDetail(
+        courseDialogDetailCacheRef.current,
+        normalizedUserBid,
+      );
+      if (cachedDetail) {
+        return cachedDetail;
+      }
 
-    const cachedDetail =
-      courseDialogDetailCacheRef.current.get(normalizedUserBid);
-    if (cachedDetail) {
-      return cachedDetail;
-    }
-
-    const inFlightRequest =
-      courseDialogDetailRequestCacheRef.current.get(normalizedUserBid);
-    if (inFlightRequest) {
-      return inFlightRequest;
-    }
-
-    const request = (
-      api.getAdminOperationUserDetail({
+      const inFlightRequest =
+        courseDialogDetailRequestCacheRef.current.get(normalizedUserBid);
+      if (inFlightRequest) {
+        return inFlightRequest;
+      }
+      const request = (api.getAdminOperationUserDetail({
         user_bid: normalizedUserBid,
-      }) as Promise<AdminOperationUserDetailResponse>
-    )
-      .then(detail => {
-        courseDialogDetailCacheRef.current.set(normalizedUserBid, detail);
-        return detail;
-      })
-      .finally(() => {
-        courseDialogDetailRequestCacheRef.current.delete(normalizedUserBid);
-      });
+      }) as Promise<AdminOperationUserDetailResponse>)
+        .then(detail => {
+          cacheCourseDialogDetail(
+            courseDialogDetailCacheRef.current,
+            normalizedUserBid,
+            detail,
+          );
+          return detail;
+        })
+        .finally(() => {
+          courseDialogDetailRequestCacheRef.current.delete(normalizedUserBid);
+        });
 
-    courseDialogDetailRequestCacheRef.current.set(normalizedUserBid, request);
-    return request;
-  }, []);
+      courseDialogDetailRequestCacheRef.current.set(normalizedUserBid, request);
+      return request;
+    },
+    [t],
+  );
 
   const openCourseDialog = useCallback(
     async (user: AdminOperationUserItem, type: 'learning' | 'created') => {
-      const cachedDetail = courseDialogDetailCacheRef.current.get(
-        user.user_bid,
+      const requestId = courseDialogRequestIdRef.current + 1;
+      courseDialogRequestIdRef.current = requestId;
+
+      const normalizedUserBid = user.user_bid.trim();
+      const cachedDetail = readCachedCourseDialogDetail(
+        courseDialogDetailCacheRef.current,
+        normalizedUserBid,
       );
       if (cachedDetail) {
         setCourseDialog(
@@ -638,8 +684,6 @@ export default function AdminOperationUsersPage() {
         return;
       }
 
-      const requestId = courseDialogRequestIdRef.current + 1;
-      courseDialogRequestIdRef.current = requestId;
       setCourseDialog({
         user,
         type,

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -403,6 +403,12 @@ export default function AdminOperationUsersPage() {
   const [quickFilter, setQuickFilter] = useState<UserQuickFilterKey>('');
   const requestIdRef = useRef(0);
   const courseDialogRequestIdRef = useRef(0);
+  const courseDialogDetailCacheRef = useRef(
+    new Map<string, AdminOperationUserDetailResponse>(),
+  );
+  const courseDialogDetailRequestCacheRef = useRef(
+    new Map<string, Promise<AdminOperationUserDetailResponse>>(),
+  );
   const { mutate } = useSWRConfig();
   const lastRequestedPageRef = useRef(1);
   const { getColumnStyle, getResizeHandleProps } =
@@ -567,8 +573,64 @@ export default function AdminOperationUsersPage() {
     [t],
   );
 
+  const buildCourseDialogStateFromDetail = useCallback(
+    (
+      user: AdminOperationUserItem,
+      type: 'learning' | 'created',
+      detail: AdminOperationUserDetailResponse,
+    ): CourseDialogState => ({
+      user,
+      type,
+      courses:
+        type === 'learning'
+          ? detail.learning_courses || []
+          : detail.created_courses || [],
+      loading: false,
+      error: '',
+    }),
+    [],
+  );
+
+  const getCourseDialogDetail = useCallback(async (userBid: string) => {
+    const normalizedUserBid = userBid.trim();
+    if (!normalizedUserBid) {
+      throw new Error('Missing user bid');
+    }
+
+    const cachedDetail = courseDialogDetailCacheRef.current.get(normalizedUserBid);
+    if (cachedDetail) {
+      return cachedDetail;
+    }
+
+    const inFlightRequest =
+      courseDialogDetailRequestCacheRef.current.get(normalizedUserBid);
+    if (inFlightRequest) {
+      return inFlightRequest;
+    }
+
+    const request = (api.getAdminOperationUserDetail({
+      user_bid: normalizedUserBid,
+    }) as Promise<AdminOperationUserDetailResponse>)
+      .then(detail => {
+        courseDialogDetailCacheRef.current.set(normalizedUserBid, detail);
+        return detail;
+      })
+      .finally(() => {
+        courseDialogDetailRequestCacheRef.current.delete(normalizedUserBid);
+      });
+
+    courseDialogDetailRequestCacheRef.current.set(normalizedUserBid, request);
+    return request;
+  }, []);
+
   const openCourseDialog = useCallback(
     async (user: AdminOperationUserItem, type: 'learning' | 'created') => {
+      const cachedDetail = courseDialogDetailCacheRef.current.get(user.user_bid);
+      if (cachedDetail) {
+        setCourseDialog(buildCourseDialogStateFromDetail(user, type, cachedDetail));
+        return;
+      }
+
       const requestId = courseDialogRequestIdRef.current + 1;
       courseDialogRequestIdRef.current = requestId;
       setCourseDialog({
@@ -580,22 +642,11 @@ export default function AdminOperationUsersPage() {
       });
 
       try {
-        const detail = (await api.getAdminOperationUserDetail({
-          user_bid: user.user_bid,
-        })) as AdminOperationUserDetailResponse;
+        const detail = await getCourseDialogDetail(user.user_bid);
         if (requestId !== courseDialogRequestIdRef.current) {
           return;
         }
-        setCourseDialog({
-          user,
-          type,
-          courses:
-            type === 'learning'
-              ? detail.learning_courses || []
-              : detail.created_courses || [],
-          loading: false,
-          error: '',
-        });
+        setCourseDialog(buildCourseDialogStateFromDetail(user, type, detail));
       } catch (requestError) {
         if (requestId !== courseDialogRequestIdRef.current) {
           return;
@@ -610,7 +661,7 @@ export default function AdminOperationUsersPage() {
         });
       }
     },
-    [t],
+    [buildCourseDialogStateFromDetail, getCourseDialogDetail, t],
   );
 
   React.useEffect(() => {

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -646,9 +646,11 @@ export default function AdminOperationUsersPage() {
       if (inFlightRequest) {
         return inFlightRequest;
       }
-      const request = (api.getAdminOperationUserDetail({
-        user_bid: normalizedUserBid,
-      }) as Promise<AdminOperationUserDetailResponse>)
+      const request = (
+        api.getAdminOperationUserDetail({
+          user_bid: normalizedUserBid,
+        }) as Promise<AdminOperationUserDetailResponse>
+      )
         .then(detail => {
           cacheCourseDialogDetail(
             courseDialogDetailCacheRef.current,


### PR DESCRIPTION
Summary
- cache user detail responses in the operator user management page so reopening course dialogs for the same user does not refetch the same payload
- deduplicate in-flight user detail requests to avoid parallel duplicate calls while the first dialog request is still loading
- add regression coverage for reopening created/learning course dialogs from the same user row

Testing
- npx jest --runTestsByPath src/app/admin/operations/users/page.test.tsx
- npm run type-check
- npx eslint src/app/admin/operations/users/page.tsx src/app/admin/operations/users/page.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Course detail loading in the admin operations user page now caches recent results and deduplicates in-flight requests, reducing redundant network calls when reopening dialogs for the same user.

* **Stability**
  * Dialog now handles overlapping requests so newer data isn’t overwritten by older responses.

* **Tests**
  * Added/updated tests to verify caching, request deduplication, and improved async dialog assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->