### PR TITLE
feat(cook-web): persist default read learning mode on first load

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -9,7 +9,7 @@
 
 ## Project-Wide Constraints
 
-- Treat URL parameters as explicit overrides: use `lessonid` for lesson targeting, let `listen` query override learner mode when present, and fall back to course-level `tts_enabled` to decide whether listen mode is available while keeping read mode as the default.
+- Treat URL parameters as explicit overrides: use `lessonid` for lesson targeting, let `listen` query override learner mode when present, and fall back to course-level `tts_enabled` to decide whether listen mode is available while keeping `read` as the default. When no course-scoped `course_learning_mode:*` storage exists yet and there is no explicit URL override, persist the resolved default mode immediately so first-load behavior and local storage stay in sync.
 - 当 `listen=true` 先以听课模式初始化、后续又因为旧课兼容或能力检查回退到阅读模式时，要基于当前模式重新同步移动端正文里的追问按钮，不要只依赖首轮数据装配结果。
 - Streaming chat must use `element_bid` as the stable render key, with compatibility fields backfilled in the shared normalization entry point.
 - When the same logic is reused by more than two files, extract it into shared `utils/constants/hooks` instead of duplicating it.

--- a/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.test.ts
@@ -1,0 +1,58 @@
+import { resolveCourseLearningMode } from './learningModePreference';
+
+describe('resolveCourseLearningMode', () => {
+  it('keeps read when the course supports listen mode and no storage exists yet', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: true,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+
+  it('keeps read when the course listen capability is still unknown', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: null,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+
+  it('keeps read when the course does not support listen mode', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: false,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+
+  it('respects an explicit stored read preference', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: true,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: 'read',
+      }),
+    ).toBe('read');
+  });
+
+  it('keeps url override higher priority than the auto default', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: true,
+        hasListenModeOverride: true,
+        listenModeParam: false,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.ts
@@ -1,0 +1,35 @@
+import type { LearningMode } from './learningModeOptions';
+
+type ResolveCourseLearningModeArgs = {
+  courseTtsEnabled: boolean | null;
+  hasListenModeOverride: boolean;
+  listenModeParam: boolean | null;
+  storedLearningMode: LearningMode | null;
+};
+
+export const resolveCourseLearningMode = ({
+  courseTtsEnabled,
+  hasListenModeOverride,
+  listenModeParam,
+  storedLearningMode,
+}: ResolveCourseLearningModeArgs): LearningMode => {
+  if (hasListenModeOverride) {
+    if (courseTtsEnabled === null) {
+      return listenModeParam === true ? 'listen' : 'read';
+    }
+
+    return listenModeParam === true && courseTtsEnabled === true
+      ? 'listen'
+      : 'read';
+  }
+
+  if (storedLearningMode === 'listen' && courseTtsEnabled !== false) {
+    return 'listen';
+  }
+
+  if (storedLearningMode === 'read') {
+    return 'read';
+  }
+
+  return 'read';
+};

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -7,7 +7,6 @@ import { parseUrlParams } from '@/c-utils/urlUtils';
 // import { ConfigProvider } from 'antd';
 import { useSystemStore } from '@/c-store/useSystemStore';
 import { useTranslation } from 'react-i18next';
-import type { LearningMode } from './Components/learningModeOptions';
 import { debugError, debugInfo } from '@/c-utils/debugConsole';
 
 import { useShallow } from 'zustand/react/shallow';
@@ -32,6 +31,7 @@ import {
   readLearningModeFromStorage,
   writeLearningModeToStorage,
 } from './Components/learningModeStorage';
+import { resolveCourseLearningMode } from './Components/learningModePreference';
 
 const parseBooleanQueryParam = (value?: string) => {
   if (typeof value !== 'string') {
@@ -39,34 +39,6 @@ const parseBooleanQueryParam = (value?: string) => {
   }
 
   return value.trim().toLowerCase() === 'true';
-};
-
-const resolveLearningMode = ({
-  courseTtsEnabled,
-  hasListenModeOverride,
-  listenModeParam,
-  storedLearningMode,
-}: {
-  courseTtsEnabled: boolean | null;
-  hasListenModeOverride: boolean;
-  listenModeParam: boolean | null;
-  storedLearningMode: LearningMode | null;
-}): LearningMode => {
-  if (hasListenModeOverride) {
-    if (courseTtsEnabled === null) {
-      return listenModeParam === true ? 'listen' : 'read';
-    }
-
-    return listenModeParam === true && courseTtsEnabled === true
-      ? 'listen'
-      : 'read';
-  }
-
-  if (storedLearningMode === 'listen' && courseTtsEnabled !== false) {
-    return 'listen';
-  }
-
-  return 'read';
 };
 
 export default function ChatLayout({
@@ -227,7 +199,7 @@ export default function ChatLayout({
 
   useEffect(() => {
     const storedLearningMode = readLearningModeFromStorage(storageCourseId);
-    const nextLearningMode = resolveLearningMode({
+    const nextLearningMode = resolveCourseLearningMode({
       courseTtsEnabled,
       hasListenModeOverride,
       listenModeParam,
@@ -259,11 +231,7 @@ export default function ChatLayout({
       return;
     }
 
-    if (storedLearningMode === null && learningMode === 'read') {
-      return;
-    }
-
-    // Keep the course-scoped preference synced after user toggles mode.
+    // Keep the course-scoped preference synced after auto resolution or manual toggles.
     writeLearningModeToStorage(storageCourseId, learningMode);
   }, [hasListenModeOverride, learningMode, storageCourseId]);
 


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced learning mode preference synchronization to ensure local storage and initial default behavior remain properly synchronized when no explicit URL parameter override is specified, eliminating potential inconsistencies.

* **Tests**
  * Added comprehensive tests for learning mode resolution, validating behavior across various scenarios including storage states, course capabilities, preference overrides, and default fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->