### PR TITLE
feat(cook-web): include shifu and outline ids in last learning mode tracking

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -115,6 +115,7 @@ export default function ChatLayout({
   const params = parseUrlParams() as Record<string, string>;
   const routeCourseId = Array.isArray(routeParams?.id) ? routeParams.id[0] : '';
   const storageCourseId = routeCourseId || params.courseId || courseId;
+  const outlineBid = params.lessonid || '';
   const currChannel = params.channel || '';
   const isPreviewMode = parseBooleanQueryParam(params.preview) ?? false;
   const isSkipMode = parseBooleanQueryParam(params.skip) ?? false;
@@ -222,9 +223,17 @@ export default function ChatLayout({
       return;
     }
     void trackEvent('learner_last_learning_mode', {
+      shifu_bid: storageCourseId,
+      outline_bid: outlineBid,
       learning_mode: storedLearningMode,
     });
-  }, [hasListenModeOverride, listenModeParam, storageCourseId, trackEvent]);
+  }, [
+    hasListenModeOverride,
+    listenModeParam,
+    outlineBid,
+    storageCourseId,
+    trackEvent,
+  ]);
 
   useEffect(() => {
     const storedLearningMode = readLearningModeFromStorage(storageCourseId);


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of learning mode tracking by including lesson outline information in telemetry data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->