### PR TITLE
fix: correct package purchase dialog payment state

### DIFF
--- a/src/cook-web/src/components/billing/BillingCheckoutDialog.tsx
+++ b/src/cook-web/src/components/billing/BillingCheckoutDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { getPaymentAgreementUrl } from '@/c-utils/urlUtils';
 import { Checkbox } from '@/components/ui/Checkbox';
@@ -23,7 +23,9 @@ type BillingCheckoutDialogProps = {
   priceLabel: string;
   productName: string;
   providerLabel: string;
+  agreed: boolean;
   onConfirm: () => void;
+  onAgreedChange: (agreed: boolean) => void;
   onOpenChange: (open: boolean) => void;
   onPingxxChannelChange?: (channel: BillingPingxxChannel) => void;
 };
@@ -37,17 +39,14 @@ export function BillingCheckoutDialog({
   priceLabel,
   productName,
   providerLabel,
+  agreed,
   onConfirm,
+  onAgreedChange,
   onOpenChange,
   onPingxxChannelChange,
 }: BillingCheckoutDialogProps) {
   const { t } = useTranslation();
-  const [agreed, setAgreed] = useState(false);
   const agreementUrl = getPaymentAgreementUrl();
-
-  useEffect(() => {
-    if (!open) setAgreed(false);
-  }, [open]);
 
   return (
     <Dialog
@@ -109,7 +108,7 @@ export function BillingCheckoutDialog({
             <Checkbox
               id='billing-checkout-agreement'
               checked={agreed}
-              onCheckedChange={checked => setAgreed(checked === true)}
+              onCheckedChange={checked => onAgreedChange(checked === true)}
             />
             <label
               htmlFor='billing-checkout-agreement'

--- a/src/cook-web/src/components/billing/BillingOverviewTab.test.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewTab.test.tsx
@@ -36,6 +36,13 @@ jest.mock('react-i18next', () => ({
       ) {
         return `${key}:${options.count}`;
       }
+      if (
+        key === 'module.billing.catalog.labels.providerWithChannel' &&
+        typeof options?.provider === 'string' &&
+        typeof options?.channel === 'string'
+      ) {
+        return `${options.provider} / ${options.channel}`;
+      }
       return key;
     },
     i18n: {
@@ -946,7 +953,9 @@ describe('BillingOverviewTab', () => {
 
     expect(
       screen.getByText(
-        'module.billing.catalog.labels.providerPingxx / module.pay.wechatPay',
+        (_content, element) =>
+          element?.textContent ===
+          'module.billing.catalog.labels.providerPingxx / module.pay.wechatPay',
       ),
     ).toBeInTheDocument();
 

--- a/src/cook-web/src/components/billing/BillingOverviewTab.test.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewTab.test.tsx
@@ -944,6 +944,12 @@ describe('BillingOverviewTab', () => {
       );
     });
 
+    expect(
+      screen.getByText(
+        'module.billing.catalog.labels.providerPingxx / module.pay.wechatPay',
+      ),
+    ).toBeInTheDocument();
+
     await acceptBillingAgreement(user);
 
     await act(async () => {
@@ -965,6 +971,12 @@ describe('BillingOverviewTab', () => {
     });
 
     expect(screen.getByTestId('billing-pingxx-qr-code')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(
+      screen.getByRole('button', {
+        name: 'module.pay.clickRefresh',
+      }),
+    ).toBeEnabled();
 
     await act(async () => {
       await user.click(screen.getByTestId('billing-pingxx-channel-alipay_qr'));

--- a/src/cook-web/src/components/billing/BillingOverviewTab.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewTab.tsx
@@ -127,7 +127,10 @@ function resolveCheckoutChannelLabel(
   }
 
   if (target.provider === 'pingxx') {
-    return `${resolveBillingProviderLabel(t, target.provider)} / ${resolveBillingPingxxChannelLabel(t, selectedPingxxChannel)}`;
+    return t('module.billing.catalog.labels.providerWithChannel', {
+      provider: resolveBillingProviderLabel(t, target.provider),
+      channel: resolveBillingPingxxChannelLabel(t, selectedPingxxChannel),
+    });
   }
 
   if (target.provider === 'alipay') {

--- a/src/cook-web/src/components/billing/BillingOverviewTab.tsx
+++ b/src/cook-web/src/components/billing/BillingOverviewTab.tsx
@@ -29,6 +29,7 @@ import {
   formatBillingPrice,
   openBillingCheckoutUrl,
   registerBillingTranslationUsage,
+  resolveBillingPingxxChannelLabel,
   resolveBillingProductTitle,
   resolveBillingProviderLabel,
   withBillingTimezone,
@@ -116,6 +117,30 @@ function resolveFirstBillingProvider(
   return null;
 }
 
+function resolveCheckoutChannelLabel(
+  t: ReturnType<typeof useTranslation>['t'],
+  target: CheckoutTarget,
+  selectedPingxxChannel: BillingPingxxChannel,
+): string {
+  if (!target) {
+    return '';
+  }
+
+  if (target.provider === 'pingxx') {
+    return `${resolveBillingProviderLabel(t, target.provider)} / ${resolveBillingPingxxChannelLabel(t, selectedPingxxChannel)}`;
+  }
+
+  if (target.provider === 'alipay') {
+    return resolveBillingPingxxChannelLabel(t, 'alipay_qr');
+  }
+
+  if (target.provider === 'wechatpay') {
+    return resolveBillingPingxxChannelLabel(t, 'wx_pub_qr');
+  }
+
+  return resolveBillingProviderLabel(t, target.provider);
+}
+
 export function BillingOverviewTab({
   onOpenOrdersTab,
 }: BillingOverviewTabProps = {}) {
@@ -158,6 +183,7 @@ export function BillingOverviewTab({
     useState<PingxxCheckoutState | null>(null);
   const [selectedPingxxChannel, setSelectedPingxxChannel] =
     useState<BillingPingxxChannel>('wx_pub_qr');
+  const [checkoutAgreed, setCheckoutAgreed] = useState(false);
   const [subscriptionActionLoading, setSubscriptionActionLoading] = useState<
     'cancel' | 'resume' | ''
   >('');
@@ -174,6 +200,7 @@ export function BillingOverviewTab({
       ]);
       if (result.status !== 'pending') {
         setPingxxCheckout(null);
+        setCheckoutAgreed(false);
       }
     },
   });
@@ -256,6 +283,7 @@ export function BillingOverviewTab({
           variant: 'destructive',
         });
         setCheckoutTarget(null);
+        setCheckoutAgreed(false);
         return;
       }
 
@@ -267,6 +295,7 @@ export function BillingOverviewTab({
           );
         }
         setCheckoutTarget(null);
+        setCheckoutAgreed(false);
         openBillingCheckoutUrl(result.redirect_url);
         return;
       }
@@ -400,6 +429,7 @@ export function BillingOverviewTab({
             resolveDefaultBillingQrChannel(firstAvailableTopup.provider),
           );
         }
+        setCheckoutAgreed(false);
         setCheckoutTarget({
           kind: 'topup',
           product: firstAvailableTopup.product,
@@ -430,7 +460,7 @@ export function BillingOverviewTab({
     ? formatBillingCredits(checkoutTarget.product.credit_amount, i18n.language)
     : '';
   const dialogProviderLabel = checkoutTarget
-    ? resolveBillingProviderLabel(t, checkoutTarget.provider)
+    ? resolveCheckoutChannelLabel(t, checkoutTarget, selectedPingxxChannel)
     : '';
   const loadError = overviewError || catalogError;
   // Trial column hidden in the comparison table; keep trial data wiring so the
@@ -491,6 +521,7 @@ export function BillingOverviewTab({
           if (isQrBillingProvider(provider)) {
             setSelectedPingxxChannel(resolveDefaultBillingQrChannel(provider));
           }
+          setCheckoutAgreed(false);
           setCheckoutTarget({
             kind: 'plan',
             product: plan,
@@ -501,6 +532,7 @@ export function BillingOverviewTab({
           if (isQrBillingProvider(provider)) {
             setSelectedPingxxChannel(resolveDefaultBillingQrChannel(provider));
           }
+          setCheckoutAgreed(false);
           setCheckoutTarget({
             kind: 'topup',
             product,
@@ -529,10 +561,13 @@ export function BillingOverviewTab({
             : t('module.billing.checkout.productLabel')
         }
         providerLabel={dialogProviderLabel}
+        agreed={checkoutAgreed}
         onConfirm={() => void handleCheckout()}
+        onAgreedChange={setCheckoutAgreed}
         onOpenChange={open => {
           if (!open) {
             setCheckoutTarget(null);
+            setCheckoutAgreed(false);
           }
         }}
         onPingxxChannelChange={setSelectedPingxxChannel}
@@ -548,10 +583,13 @@ export function BillingOverviewTab({
         provider={pingxxCheckout?.provider || 'pingxx'}
         qrUrl={pingxxCheckout?.qrUrl || ''}
         selectedChannel={pingxxCheckout?.selectedChannel || 'wx_pub_qr'}
+        agreed={checkoutAgreed}
         onChannelChange={channel => void handlePingxxQrChannelChange(channel)}
+        onAgreedChange={setCheckoutAgreed}
         onOpenChange={open => {
           if (!open) {
             setPingxxCheckout(null);
+            setCheckoutAgreed(false);
           }
         }}
       />

--- a/src/cook-web/src/components/billing/BillingPingxxQrDialog.tsx
+++ b/src/cook-web/src/components/billing/BillingPingxxQrDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { LoaderIcon } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +35,9 @@ type BillingPingxxQrDialogProps = {
   provider?: BillingProvider;
   qrUrl: string;
   selectedChannel: BillingPingxxChannel;
+  agreed: boolean;
   onChannelChange: (channel: BillingPingxxChannel) => void;
+  onAgreedChange: (agreed: boolean) => void;
   onOpenChange: (open: boolean) => void;
 };
 
@@ -49,11 +51,12 @@ export function BillingPingxxQrDialog({
   provider = 'pingxx',
   qrUrl,
   selectedChannel,
+  agreed,
   onChannelChange,
+  onAgreedChange,
   onOpenChange,
 }: BillingPingxxQrDialogProps) {
   const { t, i18n } = useTranslation();
-  const [agreed, setAgreed] = useState(false);
   const agreementUrl = getPaymentAgreementUrl();
   const availableChannels =
     provider === 'alipay'
@@ -61,10 +64,6 @@ export function BillingPingxxQrDialog({
       : provider === 'wechatpay'
         ? (['wx_pub_qr'] as BillingPingxxChannel[])
         : BILLING_PINGXX_CHANNELS;
-
-  useEffect(() => {
-    if (!open) setAgreed(false);
-  }, [open]);
 
   return (
     <Dialog
@@ -138,7 +137,7 @@ export function BillingPingxxQrDialog({
             <Checkbox
               id='billing-pingxx-agreement'
               checked={agreed}
-              onCheckedChange={checked => setAgreed(checked === true)}
+              onCheckedChange={checked => onAgreedChange(checked === true)}
             />
             <label
               htmlFor='billing-pingxx-agreement'

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -873,6 +873,10 @@ export function registerBillingTranslationUsage(t: BillingTranslator): void {
     t('module.billing.catalog.labels.providerAlipay'),
     t('module.billing.catalog.labels.providerManual'),
     t('module.billing.catalog.labels.providerPingxx'),
+    t('module.billing.catalog.labels.providerWithChannel', {
+      provider: t('module.billing.catalog.labels.providerPingxx'),
+      channel: t('module.pay.wechatPay'),
+    }),
     t('module.billing.catalog.labels.providerStripe'),
     t('module.billing.catalog.labels.providerWechatpay'),
     t('module.billing.catalog.plans.creatorMonthly.description'),

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -370,6 +370,7 @@ export type I18nKey =
   | 'module.billing.catalog.labels.providerAlipay'
   | 'module.billing.catalog.labels.providerManual'
   | 'module.billing.catalog.labels.providerPingxx'
+  | 'module.billing.catalog.labels.providerWithChannel'
   | 'module.billing.catalog.labels.providerStripe'
   | 'module.billing.catalog.labels.providerWechatpay'
   | 'module.billing.catalog.plans.creatorMonthly.description'

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -277,6 +277,7 @@
       "providerAlipay": "Alipay",
       "providerManual": "Manual",
       "providerPingxx": "Pingxx",
+      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
       "providerWechatpay": "WeChat Pay"
     },

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -277,9 +277,9 @@
       "providerAlipay": "Alipay",
       "providerManual": "Manual",
       "providerPingxx": "Pingxx",
-      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
-      "providerWechatpay": "WeChat Pay"
+      "providerWechatpay": "WeChat Pay",
+      "providerWithChannel": "{provider} / {channel}"
     },
     "plans": {
       "creatorMonthly": {

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -276,7 +276,7 @@
       "perYear": "yearly",
       "providerAlipay": "Alipay",
       "providerManual": "Manual",
-      "providerPingxx": "Pingxx / Alipay QR",
+      "providerPingxx": "Pingxx",
       "providerStripe": "Stripe",
       "providerWechatpay": "WeChat Pay"
     },

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -277,6 +277,7 @@
       "providerAlipay": "Alipay",
       "providerManual": "Manuel",
       "providerPingxx": "Pingxx",
+      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
       "providerWechatpay": "WeChat Pay"
     },

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -277,9 +277,9 @@
       "providerAlipay": "Alipay",
       "providerManual": "Manuel",
       "providerPingxx": "Pingxx",
-      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
-      "providerWechatpay": "WeChat Pay"
+      "providerWechatpay": "WeChat Pay",
+      "providerWithChannel": "{provider} / {channel}"
     },
     "plans": {
       "creatorMonthly": {

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -276,7 +276,7 @@
       "perYear": "annuel",
       "providerAlipay": "Alipay",
       "providerManual": "Manuel",
-      "providerPingxx": "Pingxx / Alipay QR",
+      "providerPingxx": "Pingxx",
       "providerStripe": "Stripe",
       "providerWechatpay": "WeChat Pay"
     },

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -277,9 +277,9 @@
       "providerAlipay": "支付宝",
       "providerManual": "人工开通",
       "providerPingxx": "Pingxx",
-      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
-      "providerWechatpay": "微信支付"
+      "providerWechatpay": "微信支付",
+      "providerWithChannel": "{provider} / {channel}"
     },
     "plans": {
       "creatorMonthly": {

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -276,7 +276,7 @@
       "perYear": "每年",
       "providerAlipay": "支付宝",
       "providerManual": "人工开通",
-      "providerPingxx": "Pingxx / 支付宝二维码",
+      "providerPingxx": "Pingxx",
       "providerStripe": "Stripe",
       "providerWechatpay": "微信支付"
     },

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -277,6 +277,7 @@
       "providerAlipay": "支付宝",
       "providerManual": "人工开通",
       "providerPingxx": "Pingxx",
+      "providerWithChannel": "{provider} / {channel}",
       "providerStripe": "Stripe",
       "providerWechatpay": "微信支付"
     },


### PR DESCRIPTION
Summary
- fix the package purchase confirm dialog payment channel label so Pingxx only shows the selected QR channel once
- persist the billing agreement checkbox state when moving from the confirm step into the QR payment step
- update billing checkout tests and billing locale labels to cover the corrected payment-channel copy

Testing
- cd src/cook-web && npm test -- --runInBand --runTestsByPath src/components/billing/BillingOverviewTab.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/components/billing/BillingCheckoutDialog.tsx --file src/components/billing/BillingPingxxQrDialog.tsx --file src/components/billing/BillingOverviewTab.tsx --file src/components/billing/BillingOverviewTab.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing checkout agreement state now reliably resets when dialogs close and checkout flows complete.

* **Refactor**
  * Checkout dialogs converted to controlled agreement props to improve UI consistency and enable external state control.

* **Localization**
  * Simplified Pingxx provider labels across supported languages for clearer channel labeling.

* **Tests**
  * Expanded billing subscription tests and i18n mocks to assert provider/channel labels and agreement-driven UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->