### PR TITLE
feat:Optimize operator follow-up request loading

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5058,6 +5058,7 @@ def get_operator_course_follow_ups(
     page_index: int,
     page_size: int,
     filters: Optional[dict] = None,
+    include_summary: bool = True,
 ) -> AdminOperationCourseFollowUpListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -5124,28 +5125,32 @@ def get_operator_course_follow_ups(
             )
 
         filtered_follow_ups = filtered_query.subquery()
-        summary_row = db.session.query(
-            db.func.count(filtered_follow_ups.c.id).label("follow_up_count"),
-            db.func.count(
-                db.func.distinct(db.func.nullif(filtered_follow_ups.c.user_bid, ""))
-            ).label("user_count"),
-            db.func.count(
-                db.func.distinct(
-                    db.func.nullif(filtered_follow_ups.c.outline_item_bid, "")
-                )
-            ).label("lesson_count"),
-            db.func.max(filtered_follow_ups.c.created_at).label("latest_follow_up_at"),
-        ).one()
+        if include_summary:
+            summary_row = db.session.query(
+                db.func.count(filtered_follow_ups.c.id).label("follow_up_count"),
+                db.func.count(
+                    db.func.distinct(db.func.nullif(filtered_follow_ups.c.user_bid, ""))
+                ).label("user_count"),
+                db.func.count(
+                    db.func.distinct(
+                        db.func.nullif(filtered_follow_ups.c.outline_item_bid, "")
+                    )
+                ).label("lesson_count"),
+                db.func.max(filtered_follow_ups.c.created_at).label(
+                    "latest_follow_up_at"
+                ),
+            ).one()
+            total = int(getattr(summary_row, "follow_up_count", 0) or 0)
+        else:
+            summary_row = None
+            total = int(
+                db.session.query(db.func.count(filtered_follow_ups.c.id)).scalar()
+                or 0
+            )
 
-        total = int(getattr(summary_row, "follow_up_count", 0) or 0)
         if total == 0:
             return AdminOperationCourseFollowUpListDTO(
-                summary=AdminOperationCourseFollowUpSummaryDTO(
-                    follow_up_count=0,
-                    user_count=0,
-                    lesson_count=0,
-                    latest_follow_up_at="",
-                ),
+                summary=AdminOperationCourseFollowUpSummaryDTO(),
                 items=[],
                 page=safe_page_index,
                 page_size=safe_page_size,
@@ -5215,14 +5220,17 @@ def get_operator_course_follow_ups(
                     created_at=_format_operator_datetime(created_at),
                 )
             )
-        summary = AdminOperationCourseFollowUpSummaryDTO(
-            follow_up_count=total,
-            user_count=int(getattr(summary_row, "user_count", 0) or 0),
-            lesson_count=int(getattr(summary_row, "lesson_count", 0) or 0),
-            latest_follow_up_at=_format_operator_datetime(
-                getattr(summary_row, "latest_follow_up_at", None)
-            ),
-        )
+        if include_summary:
+            summary = AdminOperationCourseFollowUpSummaryDTO(
+                follow_up_count=total,
+                user_count=int(getattr(summary_row, "user_count", 0) or 0),
+                lesson_count=int(getattr(summary_row, "lesson_count", 0) or 0),
+                latest_follow_up_at=_format_operator_datetime(
+                    getattr(summary_row, "latest_follow_up_at", None)
+                ),
+            )
+        else:
+            summary = AdminOperationCourseFollowUpSummaryDTO()
         return AdminOperationCourseFollowUpListDTO(
             summary=summary,
             items=items,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5229,7 +5229,7 @@ def get_operator_course_follow_ups(
                 ),
             )
         else:
-            summary = AdminOperationCourseFollowUpSummaryDTO()
+            summary = AdminOperationCourseFollowUpSummaryDTO(follow_up_count=total)
         return AdminOperationCourseFollowUpListDTO(
             summary=summary,
             items=items,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5144,8 +5144,7 @@ def get_operator_course_follow_ups(
         else:
             summary_row = None
             total = int(
-                db.session.query(db.func.count(filtered_follow_ups.c.id)).scalar()
-                or 0
+                db.session.query(db.func.count(filtered_follow_ups.c.id)).scalar() or 0
             )
 
         if total == 0:

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1963,6 +1963,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
               type: string
               required: false
               description: Inclusive filter end time
+            - name: include_summary
+              in: query
+              type: boolean
+              required: false
+              description: Whether to include expensive summary metrics
         responses:
             200:
                 description: Operator course follow-up list
@@ -1990,6 +1995,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 is_end=True,
             ),
         }
+        include_summary = _parse_boolean_query_param(
+            request.args.get("include_summary", None),
+            field_name="include_summary",
+            default=True,
+        )
         return make_common_response(
             get_operator_course_follow_ups(
                 app,
@@ -1997,6 +2007,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 page_index=page_index,
                 page_size=page_size,
                 filters=filters,
+                include_summary=include_summary,
             )
         )
 

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2460,7 +2460,7 @@ def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(
     assert lightweight_filtered_response.status_code == 200
     assert lightweight_filtered_payload["code"] == 0
     assert lightweight_filtered_payload["data"]["summary"] == {
-        "follow_up_count": 0,
+        "follow_up_count": 1,
         "user_count": 0,
         "lesson_count": 0,
         "latest_follow_up_at": "",

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2449,6 +2449,28 @@ def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(
     }
     assert filtered_payload["data"]["items"][0]["generated_block_bid"] == "ask-3"
 
+    lightweight_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/follow-ups?page=1&page_size=20"
+        "&keyword=student2@example.com&chapter_keyword=Chapter 2"
+        "&start_time=2026-04-05&end_time=2026-04-05&include_summary=false",
+        headers={"Token": "test-token"},
+    )
+    lightweight_filtered_payload = lightweight_filtered_response.get_json(force=True)
+
+    assert lightweight_filtered_response.status_code == 200
+    assert lightweight_filtered_payload["code"] == 0
+    assert lightweight_filtered_payload["data"]["summary"] == {
+        "follow_up_count": 0,
+        "user_count": 0,
+        "lesson_count": 0,
+        "latest_follow_up_at": "",
+    }
+    assert lightweight_filtered_payload["data"]["total"] == 1
+    assert (
+        lightweight_filtered_payload["data"]["items"][0]["generated_block_bid"]
+        == "ask-3"
+    )
+
     lesson_filtered_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/follow-ups?page=1&page_size=20"
         "&chapter_keyword=Lesson 2",

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -292,6 +292,7 @@ describe('AdminOperationCourseFollowUpsPage', () => {
         shifu_bid: 'course-1',
         page: 1,
         page_size: 20,
+        include_summary: true,
         keyword: '',
         chapter_keyword: '',
         start_time: '',
@@ -338,6 +339,108 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     expect(screen.queryByText('12,000')).not.toBeInTheDocument();
   });
 
+  test('keeps summary cards scoped to all follow-ups when filters change', async () => {
+    mockGetAdminOperationCourseFollowUps
+      .mockResolvedValueOnce({
+        summary: {
+          follow_up_count: 42,
+          user_count: 7,
+          lesson_count: 5,
+          latest_follow_up_at: '2026-04-05T11:02:00Z',
+        },
+        items: [
+          {
+            generated_block_bid: 'ask-all',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-1',
+            mobile: '13900001235',
+            email: '',
+            nickname: 'Bob',
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            lesson_outline_item_bid: 'lesson-1',
+            lesson_title: 'Lesson 1',
+            follow_up_content: 'All follow-up question',
+            turn_index: 1,
+            created_at: '2026-04-05T11:02:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 42,
+        page_count: 3,
+      })
+      .mockResolvedValueOnce({
+        summary: {
+          follow_up_count: 0,
+          user_count: 0,
+          lesson_count: 0,
+          latest_follow_up_at: '',
+        },
+        items: [
+          {
+            generated_block_bid: 'ask-filtered',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-2',
+            mobile: '13900009999',
+            email: '',
+            nickname: 'Alice',
+            chapter_outline_item_bid: 'chapter-2',
+            chapter_title: 'Chapter 2',
+            lesson_outline_item_bid: 'lesson-2',
+            lesson_title: 'Lesson 2',
+            follow_up_content: 'Filtered follow-up question',
+            turn_index: 1,
+            created_at: '2026-04-06T11:02:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 1,
+        page_count: 1,
+      });
+
+    render(<AdminOperationCourseFollowUpsPage />);
+
+    expect(await screen.findByText('All follow-up question')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'module.operationsCourse.detail.followUps.filters.userKeywordPlaceholderPhone',
+      ),
+      {
+        target: { value: 'student-2' },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsCourse.detail.followUps.filters.search',
+      }),
+    );
+
+    expect(
+      await screen.findByText('Filtered follow-up question'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseFollowUps).toHaveBeenLastCalledWith({
+        shifu_bid: 'course-1',
+        page: 1,
+        page_size: 20,
+        include_summary: false,
+        keyword: 'student-2',
+        chapter_keyword: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
   test('submits filters and opens the detail drawer', async () => {
     render(<AdminOperationCourseFollowUpsPage />);
 
@@ -376,6 +479,7 @@ describe('AdminOperationCourseFollowUpsPage', () => {
         shifu_bid: 'course-1',
         page: 1,
         page_size: 20,
+        include_summary: false,
         keyword: 'student',
         chapter_keyword: 'Lesson 1',
         start_time: '2026-04-05',

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -529,6 +529,31 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     expect(screen.getAllByText('Lesson 1').length).toBeGreaterThan(0);
   });
 
+  test('clears draft filters on reset without refetching when applied filters are already default', async () => {
+    render(<AdminOperationCourseFollowUpsPage />);
+
+    await screen.findByText('Second follow-up question');
+    mockGetAdminOperationCourseFollowUps.mockClear();
+
+    const keywordInput = screen.getByPlaceholderText(
+      'module.operationsCourse.detail.followUps.filters.userKeywordPlaceholderPhone',
+    );
+    fireEvent.change(keywordInput, {
+      target: { value: 'unsaved draft' },
+    });
+
+    expect(keywordInput).toHaveValue('unsaved draft');
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsCourse.detail.followUps.filters.reset',
+      }),
+    );
+
+    expect(keywordInput).toHaveValue('');
+    expect(mockGetAdminOperationCourseFollowUps).not.toHaveBeenCalled();
+  });
+
   test('shows a descriptive source fallback when original output cannot be resolved', async () => {
     mockGetAdminOperationCourseFollowUpDetail.mockResolvedValueOnce({
       basic_info: {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -402,7 +402,9 @@ describe('AdminOperationCourseFollowUpsPage', () => {
 
     render(<AdminOperationCourseFollowUpsPage />);
 
-    expect(await screen.findByText('All follow-up question')).toBeInTheDocument();
+    expect(
+      await screen.findByText('All follow-up question'),
+    ).toBeInTheDocument();
     expect(screen.getByText('42')).toBeInTheDocument();
     expect(screen.getByText('7')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -120,7 +120,9 @@ const createFollowUpFilters = (): FollowUpFilters => ({
   endTime: '',
 });
 
-const normalizeFollowUpFilters = (filters: FollowUpFilters): FollowUpFilters => ({
+const normalizeFollowUpFilters = (
+  filters: FollowUpFilters,
+): FollowUpFilters => ({
   keyword: filters.keyword.trim(),
   chapterKeyword: filters.chapterKeyword.trim(),
   startTime: filters.startTime,
@@ -384,7 +386,8 @@ export default function AdminOperationCourseFollowUpsPage() {
       }
 
       const resolvedFilters = normalizeFollowUpFilters(nextFilters ?? filters);
-      const shouldRefreshFullSummary = isDefaultFollowUpFilters(resolvedFilters);
+      const shouldRefreshFullSummary =
+        isDefaultFollowUpFilters(resolvedFilters);
       const requestId = listRequestIdRef.current + 1;
       listRequestIdRef.current = requestId;
       setLoading(true);
@@ -405,7 +408,9 @@ export default function AdminOperationCourseFollowUpsPage() {
           return;
         }
         if (shouldRefreshFullSummary) {
-          setFullSummary(response?.summary || EMPTY_FOLLOW_UPS_RESPONSE.summary);
+          setFullSummary(
+            response?.summary || EMPTY_FOLLOW_UPS_RESPONSE.summary,
+          );
         }
         setFollowUps({
           summary: response?.summary || EMPTY_FOLLOW_UPS_RESPONSE.summary,
@@ -542,8 +547,7 @@ export default function AdminOperationCourseFollowUpsPage() {
         key: 'latestFollowUpAt',
         label: tOperations('detail.followUps.summary.latestFollowUpAt'),
         value:
-          formatAdminUtcDateTime(fullSummary.latest_follow_up_at) ||
-          emptyValue,
+          formatAdminUtcDateTime(fullSummary.latest_follow_up_at) || emptyValue,
         tone: 'timestamp' as const,
       },
     ],

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -120,6 +120,25 @@ const createFollowUpFilters = (): FollowUpFilters => ({
   endTime: '',
 });
 
+const normalizeFollowUpFilters = (filters: FollowUpFilters): FollowUpFilters => ({
+  keyword: filters.keyword.trim(),
+  chapterKeyword: filters.chapterKeyword.trim(),
+  startTime: filters.startTime,
+  endTime: filters.endTime,
+});
+
+const areFollowUpFiltersEqual = (
+  first: FollowUpFilters,
+  second: FollowUpFilters,
+) =>
+  first.keyword === second.keyword &&
+  first.chapterKeyword === second.chapterKeyword &&
+  first.startTime === second.startTime &&
+  first.endTime === second.endTime;
+
+const isDefaultFollowUpFilters = (filters: FollowUpFilters) =>
+  areFollowUpFiltersEqual(filters, createFollowUpFilters());
+
 const formatCount = (value: number, locale: string): string =>
   formatAdminCount(value, locale);
 
@@ -325,6 +344,9 @@ export default function AdminOperationCourseFollowUpsPage() {
     useState<AdminOperationCourseFollowUpListResponse>(
       EMPTY_FOLLOW_UPS_RESPONSE,
     );
+  const [fullSummary, setFullSummary] = useState(
+    EMPTY_FOLLOW_UPS_RESPONSE.summary,
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<ErrorState | null>(null);
   const [pageIndex, setPageIndex] = useState(1);
@@ -357,10 +379,12 @@ export default function AdminOperationCourseFollowUpsPage() {
       if (!shifuBid.trim()) {
         setError({ message: unknownErrorMessage });
         setFollowUps(EMPTY_FOLLOW_UPS_RESPONSE);
+        setFullSummary(EMPTY_FOLLOW_UPS_RESPONSE.summary);
         return;
       }
 
-      const resolvedFilters = nextFilters ?? filters;
+      const resolvedFilters = normalizeFollowUpFilters(nextFilters ?? filters);
+      const shouldRefreshFullSummary = isDefaultFollowUpFilters(resolvedFilters);
       const requestId = listRequestIdRef.current + 1;
       listRequestIdRef.current = requestId;
       setLoading(true);
@@ -371,13 +395,17 @@ export default function AdminOperationCourseFollowUpsPage() {
           shifu_bid: shifuBid,
           page: targetPage,
           page_size: PAGE_SIZE,
-          keyword: resolvedFilters.keyword.trim(),
-          chapter_keyword: resolvedFilters.chapterKeyword.trim(),
+          include_summary: shouldRefreshFullSummary,
+          keyword: resolvedFilters.keyword,
+          chapter_keyword: resolvedFilters.chapterKeyword,
           start_time: resolvedFilters.startTime,
           end_time: resolvedFilters.endTime,
         })) as AdminOperationCourseFollowUpListResponse;
         if (requestId !== listRequestIdRef.current) {
           return;
+        }
+        if (shouldRefreshFullSummary) {
+          setFullSummary(response?.summary || EMPTY_FOLLOW_UPS_RESPONSE.summary);
         }
         setFollowUps({
           summary: response?.summary || EMPTY_FOLLOW_UPS_RESPONSE.summary,
@@ -495,31 +523,31 @@ export default function AdminOperationCourseFollowUpsPage() {
       {
         key: 'followUpCount',
         label: tOperations('detail.followUps.summary.followUpCount'),
-        value: formatCount(followUps.summary.follow_up_count, i18n.language),
+        value: formatCount(fullSummary.follow_up_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'userCount',
         label: tOperations('detail.followUps.summary.userCount'),
-        value: formatCount(followUps.summary.user_count, i18n.language),
+        value: formatCount(fullSummary.user_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'lessonCount',
         label: tOperations('detail.followUps.summary.lessonCount'),
-        value: formatCount(followUps.summary.lesson_count, i18n.language),
+        value: formatCount(fullSummary.lesson_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'latestFollowUpAt',
         label: tOperations('detail.followUps.summary.latestFollowUpAt'),
         value:
-          formatAdminUtcDateTime(followUps.summary.latest_follow_up_at) ||
+          formatAdminUtcDateTime(fullSummary.latest_follow_up_at) ||
           emptyValue,
         tone: 'timestamp' as const,
       },
     ],
-    [emptyValue, followUps.summary, i18n.language, tOperations],
+    [emptyValue, fullSummary, i18n.language, tOperations],
   );
 
   const resolveUserSecondary = useCallback(
@@ -534,22 +562,27 @@ export default function AdminOperationCourseFollowUpsPage() {
   );
 
   const handleSearch = useCallback(() => {
-    const nextFilters = {
-      keyword: filtersDraft.keyword.trim(),
-      chapterKeyword: filtersDraft.chapterKeyword.trim(),
-      startTime: filtersDraft.startTime,
-      endTime: filtersDraft.endTime,
-    };
+    const nextFilters = normalizeFollowUpFilters(filtersDraft);
+    if (pageIndex === 1 && areFollowUpFiltersEqual(nextFilters, filters)) {
+      return;
+    }
     setFilters(nextFilters);
     setPageIndex(1);
-  }, [filtersDraft]);
+  }, [filters, filtersDraft, pageIndex]);
 
   const handleReset = useCallback(() => {
     const nextFilters = createFollowUpFilters();
+    if (
+      pageIndex === 1 &&
+      areFollowUpFiltersEqual(nextFilters, filters) &&
+      areFollowUpFiltersEqual(nextFilters, filtersDraft)
+    ) {
+      return;
+    }
     setFiltersDraft(nextFilters);
     setFilters(nextFilters);
     setPageIndex(1);
-  }, []);
+  }, [filters, filtersDraft, pageIndex]);
 
   const handlePageChange = useCallback(
     (nextPage: number) => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -584,6 +584,9 @@ export default function AdminOperationCourseFollowUpsPage() {
       return;
     }
     setFiltersDraft(nextFilters);
+    if (pageIndex === 1 && areFollowUpFiltersEqual(nextFilters, filters)) {
+      return;
+    }
     setFilters(nextFilters);
     setPageIndex(1);
   }, [filters, filtersDraft, pageIndex]);


### PR DESCRIPTION
Summary
- Keep the operator follow-up summary cards scoped to the full data set instead of filtered results.
- Add an include_summary flag so filtered list requests can skip expensive backend summary aggregation.
- Avoid duplicate search/reset requests when filters are unchanged.
- Add focused frontend and backend coverage for the optimized flow.

Tests
- cd src/cook-web && npm test -- --runInBand --runTestsByPath 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx'
- cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx' --file 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx'
- cd src/cook-web && npm run type-check\n- cd src/api && pytest -q tests/service/shifu/test_admin_course_detail.py -k 'follow_ups_route'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Summary metrics remain independent from filter selections so aggregate cards stay consistent while filtered results update separately.
  * Filter/search inputs are normalized and compared more strictly to avoid redundant updates and unnecessary reloads.
  * The page avoids fetching expensive summary data when not needed, improving responsiveness.

* **Tests**
  * Updated and added tests to cover summary inclusion behavior, filter/search interactions, and reset semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->