### PR TITLE
feat:Optimize operator rating request loading

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5283,28 +5283,17 @@ def get_operator_course_ratings(
             LearnLessonFeedback.updated_at,
             LearnLessonFeedback.created_at,
         )
-        rating_base_query = db.session.query(
-            LearnLessonFeedback.id.label("id"),
-            LearnLessonFeedback.lesson_feedback_bid.label("lesson_feedback_bid"),
-            LearnLessonFeedback.progress_record_bid.label("progress_record_bid"),
-            LearnLessonFeedback.user_bid.label("user_bid"),
-            LearnLessonFeedback.outline_item_bid.label("outline_item_bid"),
-            LearnLessonFeedback.score.label("score"),
-            LearnLessonFeedback.comment.label("comment"),
-            LearnLessonFeedback.mode.label("mode"),
-            rated_at_expression.label("rated_at"),
-        ).filter(
+        base_filters = [
             LearnLessonFeedback.shifu_bid == normalized_shifu_bid,
             LearnLessonFeedback.deleted == 0,
-        )
+        ]
 
-        filtered_query = rating_base_query
         user_keyword_filter = _build_follow_up_user_keyword_filter(
             LearnLessonFeedback.user_bid,
             keyword,
         )
         if user_keyword_filter is not None:
-            filtered_query = filtered_query.filter(user_keyword_filter)
+            base_filters.append(user_keyword_filter)
 
         matching_outline_item_bids = _resolve_follow_up_matching_outline_bids(
             outline_context_map,
@@ -5320,44 +5309,49 @@ def get_operator_course_ratings(
                     total=0,
                     page_count=0,
                 )
-            filtered_query = filtered_query.filter(
+            base_filters.append(
                 LearnLessonFeedback.outline_item_bid.in_(
                     sorted(matching_outline_item_bids)
                 )
             )
 
         if normalized_score_filter is not None:
-            filtered_query = filtered_query.filter(
-                LearnLessonFeedback.score == normalized_score_filter
-            )
+            base_filters.append(LearnLessonFeedback.score == normalized_score_filter)
         if mode_filter:
-            filtered_query = filtered_query.filter(
-                LearnLessonFeedback.mode == mode_filter
-            )
+            base_filters.append(LearnLessonFeedback.mode == mode_filter)
         if has_comment_filter == "true":
-            filtered_query = filtered_query.filter(
+            base_filters.append(
                 db.func.trim(db.func.coalesce(LearnLessonFeedback.comment, "")) != ""
             )
         if start_time:
-            filtered_query = filtered_query.filter(rated_at_expression >= start_time)
+            base_filters.append(rated_at_expression >= start_time)
         if end_time:
-            filtered_query = filtered_query.filter(rated_at_expression <= end_time)
+            base_filters.append(rated_at_expression <= end_time)
 
-        filtered_ratings = filtered_query.subquery()
+        summary_source = (
+            db.session.query(
+                LearnLessonFeedback.id.label("id"),
+                LearnLessonFeedback.score.label("score"),
+                LearnLessonFeedback.user_bid.label("user_bid"),
+                rated_at_expression.label("rated_at"),
+            )
+            .filter(*base_filters)
+            .subquery()
+        )
         if include_summary:
             summary_row = db.session.query(
-                db.func.avg(filtered_ratings.c.score).label("average_score"),
-                db.func.count(filtered_ratings.c.id).label("rating_count"),
+                db.func.avg(summary_source.c.score).label("average_score"),
+                db.func.count(summary_source.c.id).label("rating_count"),
                 db.func.count(
-                    db.func.distinct(db.func.nullif(filtered_ratings.c.user_bid, ""))
+                    db.func.distinct(db.func.nullif(summary_source.c.user_bid, ""))
                 ).label("user_count"),
-                db.func.max(filtered_ratings.c.rated_at).label("latest_rated_at"),
+                db.func.max(summary_source.c.rated_at).label("latest_rated_at"),
             ).one()
             total = int(getattr(summary_row, "rating_count", 0) or 0)
         else:
             summary_row = None
             total = int(
-                db.session.query(db.func.count(filtered_ratings.c.id)).scalar() or 0
+                db.session.query(db.func.count(summary_source.c.id)).scalar() or 0
             )
 
         if total == 0:
@@ -5371,15 +5365,26 @@ def get_operator_course_ratings(
             )
 
         start = (safe_page_index - 1) * safe_page_size
-        ordered_query = db.session.query(filtered_ratings).order_by(
-            filtered_ratings.c.rated_at.desc(),
-            filtered_ratings.c.id.desc(),
+        page_query = db.session.query(
+            LearnLessonFeedback.id.label("id"),
+            LearnLessonFeedback.lesson_feedback_bid.label("lesson_feedback_bid"),
+            LearnLessonFeedback.progress_record_bid.label("progress_record_bid"),
+            LearnLessonFeedback.user_bid.label("user_bid"),
+            LearnLessonFeedback.outline_item_bid.label("outline_item_bid"),
+            LearnLessonFeedback.score.label("score"),
+            LearnLessonFeedback.comment.label("comment"),
+            LearnLessonFeedback.mode.label("mode"),
+            rated_at_expression.label("rated_at"),
+        ).filter(*base_filters)
+        ordered_query = page_query.order_by(
+            rated_at_expression.desc(),
+            LearnLessonFeedback.id.desc(),
         )
         if sort_by == "score_asc":
-            ordered_query = db.session.query(filtered_ratings).order_by(
-                filtered_ratings.c.score.asc(),
-                filtered_ratings.c.rated_at.desc(),
-                filtered_ratings.c.id.desc(),
+            ordered_query = page_query.order_by(
+                LearnLessonFeedback.score.asc(),
+                rated_at_expression.desc(),
+                LearnLessonFeedback.id.desc(),
             )
         page_rows = ordered_query.offset(start).limit(safe_page_size).all()
         user_map = _load_user_map(

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5240,6 +5240,7 @@ def get_operator_course_ratings(
     page_index: int,
     page_size: int,
     filters: Optional[dict] = None,
+    include_summary: bool = True,
 ) -> AdminOperationCourseRatingListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -5257,26 +5258,6 @@ def get_operator_course_ratings(
             normalized_shifu_bid
         )
         outline_context_map = _build_course_outline_context_map(outline_items)
-        rating_rows = (
-            LearnLessonFeedback.query.filter(
-                LearnLessonFeedback.shifu_bid == normalized_shifu_bid,
-                LearnLessonFeedback.deleted == 0,
-            )
-            .order_by(
-                LearnLessonFeedback.updated_at.desc(),
-                LearnLessonFeedback.id.desc(),
-            )
-            .all()
-        )
-        user_bids = sorted(
-            {
-                str(getattr(row, "user_bid", "") or "").strip()
-                for row in rating_rows
-                if str(getattr(row, "user_bid", "") or "").strip()
-            }
-        )
-        user_map = _load_user_map(user_bids)
-
         keyword = _normalize_identifier(str(filters.get("keyword", "") or "")).lower()
         chapter_keyword = str(filters.get("chapter_keyword", "") or "").strip().lower()
         score_filter = str(filters.get("score", "") or "").strip()
@@ -5298,20 +5279,123 @@ def get_operator_course_ratings(
         if str(filters.get("sort_by", "") or "").strip() and not sort_by:
             raise_param_error("sort_by")
 
-        filtered_items: list[
-            tuple[datetime, int, AdminOperationCourseRatingItemDTO]
-        ] = []
-        total_score = 0
-        latest_rated_at: Optional[datetime] = None
-        for row in rating_rows:
+        rated_at_expression = db.func.coalesce(
+            LearnLessonFeedback.updated_at,
+            LearnLessonFeedback.created_at,
+        )
+        rating_base_query = db.session.query(
+            LearnLessonFeedback.id.label("id"),
+            LearnLessonFeedback.lesson_feedback_bid.label("lesson_feedback_bid"),
+            LearnLessonFeedback.progress_record_bid.label("progress_record_bid"),
+            LearnLessonFeedback.user_bid.label("user_bid"),
+            LearnLessonFeedback.outline_item_bid.label("outline_item_bid"),
+            LearnLessonFeedback.score.label("score"),
+            LearnLessonFeedback.comment.label("comment"),
+            LearnLessonFeedback.mode.label("mode"),
+            rated_at_expression.label("rated_at"),
+        ).filter(
+            LearnLessonFeedback.shifu_bid == normalized_shifu_bid,
+            LearnLessonFeedback.deleted == 0,
+        )
+
+        filtered_query = rating_base_query
+        user_keyword_filter = _build_follow_up_user_keyword_filter(
+            LearnLessonFeedback.user_bid,
+            keyword,
+        )
+        if user_keyword_filter is not None:
+            filtered_query = filtered_query.filter(user_keyword_filter)
+
+        matching_outline_item_bids = _resolve_follow_up_matching_outline_bids(
+            outline_context_map,
+            chapter_keyword,
+        )
+        if matching_outline_item_bids is not None:
+            if not matching_outline_item_bids:
+                return AdminOperationCourseRatingListDTO(
+                    summary=AdminOperationCourseRatingSummaryDTO(),
+                    items=[],
+                    page=safe_page_index,
+                    page_size=safe_page_size,
+                    total=0,
+                    page_count=0,
+                )
+            filtered_query = filtered_query.filter(
+                LearnLessonFeedback.outline_item_bid.in_(
+                    sorted(matching_outline_item_bids)
+                )
+            )
+
+        if normalized_score_filter is not None:
+            filtered_query = filtered_query.filter(
+                LearnLessonFeedback.score == normalized_score_filter
+            )
+        if mode_filter:
+            filtered_query = filtered_query.filter(
+                LearnLessonFeedback.mode == mode_filter
+            )
+        if has_comment_filter == "true":
+            filtered_query = filtered_query.filter(
+                db.func.trim(db.func.coalesce(LearnLessonFeedback.comment, "")) != ""
+            )
+        if start_time:
+            filtered_query = filtered_query.filter(rated_at_expression >= start_time)
+        if end_time:
+            filtered_query = filtered_query.filter(rated_at_expression <= end_time)
+
+        filtered_ratings = filtered_query.subquery()
+        if include_summary:
+            summary_row = db.session.query(
+                db.func.avg(filtered_ratings.c.score).label("average_score"),
+                db.func.count(filtered_ratings.c.id).label("rating_count"),
+                db.func.count(
+                    db.func.distinct(db.func.nullif(filtered_ratings.c.user_bid, ""))
+                ).label("user_count"),
+                db.func.max(filtered_ratings.c.rated_at).label("latest_rated_at"),
+            ).one()
+            total = int(getattr(summary_row, "rating_count", 0) or 0)
+        else:
+            summary_row = None
+            total = int(
+                db.session.query(db.func.count(filtered_ratings.c.id)).scalar() or 0
+            )
+
+        if total == 0:
+            return AdminOperationCourseRatingListDTO(
+                summary=AdminOperationCourseRatingSummaryDTO(),
+                items=[],
+                page=safe_page_index,
+                page_size=safe_page_size,
+                total=0,
+                page_count=0,
+            )
+
+        start = (safe_page_index - 1) * safe_page_size
+        ordered_query = db.session.query(filtered_ratings).order_by(
+            filtered_ratings.c.rated_at.desc(),
+            filtered_ratings.c.id.desc(),
+        )
+        if sort_by == "score_asc":
+            ordered_query = db.session.query(filtered_ratings).order_by(
+                filtered_ratings.c.score.asc(),
+                filtered_ratings.c.rated_at.desc(),
+                filtered_ratings.c.id.desc(),
+            )
+        page_rows = ordered_query.offset(start).limit(safe_page_size).all()
+        user_map = _load_user_map(
+            sorted(
+                {
+                    str(getattr(row, "user_bid", "") or "").strip()
+                    for row in page_rows
+                    if str(getattr(row, "user_bid", "") or "").strip()
+                }
+            )
+        )
+
+        items: list[AdminOperationCourseRatingItemDTO] = []
+        for row in page_rows:
             user_bid = str(getattr(row, "user_bid", "") or "").strip()
             outline_item_bid = str(getattr(row, "outline_item_bid", "") or "").strip()
-            score = int(getattr(row, "score", 0) or 0)
-            comment = str(getattr(row, "comment", "") or "")
-            mode = _resolve_course_rating_mode(str(getattr(row, "mode", "") or ""))
-            rated_at = getattr(row, "updated_at", None) or getattr(
-                row, "created_at", None
-            )
             context = outline_context_map.get(
                 outline_item_bid,
                 {
@@ -5322,95 +5406,51 @@ def get_operator_course_ratings(
                 },
             )
             user = user_map.get(user_bid, {})
-
-            if keyword:
-                haystack = [
-                    str(user.get("mobile", "") or "").lower(),
-                    str(user.get("email", "") or "").lower(),
-                    str(user.get("nickname", "") or "").lower(),
-                ]
-                if not any(keyword in value for value in haystack if value):
-                    continue
-
-            if chapter_keyword:
-                chapter_haystack = [
-                    str(context.get("chapter_title", "") or "").lower(),
-                    str(context.get("lesson_title", "") or "").lower(),
-                ]
-                if not any(
-                    chapter_keyword in value for value in chapter_haystack if value
-                ):
-                    continue
-
-            if normalized_score_filter is not None and score != normalized_score_filter:
-                continue
-            if mode_filter and mode != mode_filter:
-                continue
-            if has_comment_filter == "true" and not comment.strip():
-                continue
-            if start_time and (rated_at is None or rated_at < start_time):
-                continue
-            if end_time and (rated_at is None or rated_at > end_time):
-                continue
-
-            if rated_at is not None and (
-                latest_rated_at is None or rated_at > latest_rated_at
-            ):
-                latest_rated_at = rated_at
-            filtered_items.append(
-                (
-                    rated_at or datetime.min,
-                    int(getattr(row, "id", 0) or 0),
-                    AdminOperationCourseRatingItemDTO(
-                        lesson_feedback_bid=str(
-                            getattr(row, "lesson_feedback_bid", "") or ""
-                        ),
-                        progress_record_bid=str(
-                            getattr(row, "progress_record_bid", "") or ""
-                        ),
-                        user_bid=user_bid,
-                        mobile=str(user.get("mobile", "") or ""),
-                        email=str(user.get("email", "") or ""),
-                        nickname=str(user.get("nickname", "") or ""),
-                        chapter_outline_item_bid=str(
-                            context.get("chapter_outline_item_bid", "") or ""
-                        ),
-                        chapter_title=str(context.get("chapter_title", "") or ""),
-                        lesson_outline_item_bid=str(
-                            context.get("lesson_outline_item_bid", "") or ""
-                        ),
-                        lesson_title=str(context.get("lesson_title", "") or ""),
-                        score=score,
-                        comment=comment,
-                        mode=mode,
-                        rated_at=_format_operator_datetime(rated_at),
+            items.append(
+                AdminOperationCourseRatingItemDTO(
+                    lesson_feedback_bid=str(
+                        getattr(row, "lesson_feedback_bid", "") or ""
                     ),
+                    progress_record_bid=str(
+                        getattr(row, "progress_record_bid", "") or ""
+                    ),
+                    user_bid=user_bid,
+                    mobile=str(user.get("mobile", "") or ""),
+                    email=str(user.get("email", "") or ""),
+                    nickname=str(user.get("nickname", "") or ""),
+                    chapter_outline_item_bid=str(
+                        context.get("chapter_outline_item_bid", "") or ""
+                    ),
+                    chapter_title=str(context.get("chapter_title", "") or ""),
+                    lesson_outline_item_bid=str(
+                        context.get("lesson_outline_item_bid", "") or ""
+                    ),
+                    lesson_title=str(context.get("lesson_title", "") or ""),
+                    score=int(getattr(row, "score", 0) or 0),
+                    comment=str(getattr(row, "comment", "") or ""),
+                    mode=_resolve_course_rating_mode(
+                        str(getattr(row, "mode", "") or "")
+                    ),
+                    rated_at=_format_operator_datetime(getattr(row, "rated_at", None)),
                 )
             )
-            total_score += score
 
-        filtered_items.sort(key=lambda item: (item[0], item[1]), reverse=True)
-        if sort_by == "score_asc":
-            filtered_items.sort(key=lambda item: item[2].score)
-
-        rows = [item for _, _, item in filtered_items]
-        total = len(rows)
-        start = (safe_page_index - 1) * safe_page_size
-        end = start + safe_page_size
-        average_score = (
-            _format_average_score(Decimal(total_score) / Decimal(total))
-            if total
-            else ""
-        )
-        summary = AdminOperationCourseRatingSummaryDTO(
-            average_score=average_score,
-            rating_count=total,
-            user_count=len({item.user_bid for item in rows if item.user_bid}),
-            latest_rated_at=_format_operator_datetime(latest_rated_at),
-        )
+        if include_summary:
+            summary = AdminOperationCourseRatingSummaryDTO(
+                average_score=_format_average_score(
+                    getattr(summary_row, "average_score", None)
+                ),
+                rating_count=total,
+                user_count=int(getattr(summary_row, "user_count", 0) or 0),
+                latest_rated_at=_format_operator_datetime(
+                    getattr(summary_row, "latest_rated_at", None)
+                ),
+            )
+        else:
+            summary = AdminOperationCourseRatingSummaryDTO()
         return AdminOperationCourseRatingListDTO(
             summary=summary,
-            items=rows[start:end],
+            items=items,
             page=safe_page_index,
             page_size=safe_page_size,
             total=total,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1876,6 +1876,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
               type: string
               required: false
               description: Inclusive filter end time
+            - name: include_summary
+              in: query
+              type: boolean
+              required: false
+              description: Whether to include expensive summary metrics
         responses:
             200:
                 description: Operator course rating list
@@ -1907,6 +1912,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 is_end=True,
             ),
         }
+        include_summary = _parse_boolean_query_param(
+            request.args.get("include_summary", None),
+            field_name="include_summary",
+            default=True,
+        )
         return make_common_response(
             get_operator_course_ratings(
                 app,
@@ -1914,6 +1924,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 page_index=page_index,
                 page_size=page_size,
                 filters=filters,
+                include_summary=include_summary,
             )
         )
 

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1880,7 +1880,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
               in: query
               type: boolean
               required: false
-              description: Whether to include expensive summary metrics
+              description: Whether to include expensive summary metrics. Defaults to true. When false, summary fields are returned as defaults while total and page_count still reflect the filtered result.
         responses:
             200:
                 description: Operator course rating list

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2744,6 +2744,29 @@ def test_admin_operation_course_ratings_route_returns_summary_and_filters(
     }
     assert filtered_payload["data"]["items"][0]["lesson_feedback_bid"] == "feedback-2"
 
+    lightweight_filtered_response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/ratings?page=1&page_size=20"
+        "&keyword=student2@example.com&chapter_keyword=Chapter 2"
+        "&score=3&mode=listen&start_time=2026-04-05&end_time=2026-04-05"
+        "&include_summary=false",
+        headers={"Token": "test-token"},
+    )
+    lightweight_filtered_payload = lightweight_filtered_response.get_json(force=True)
+
+    assert lightweight_filtered_response.status_code == 200
+    assert lightweight_filtered_payload["code"] == 0
+    assert lightweight_filtered_payload["data"]["summary"] == {
+        "average_score": "",
+        "rating_count": 0,
+        "user_count": 0,
+        "latest_rated_at": "",
+    }
+    assert lightweight_filtered_payload["data"]["total"] == 1
+    assert (
+        lightweight_filtered_payload["data"]["items"][0]["lesson_feedback_bid"]
+        == "feedback-2"
+    )
+
     commented_low_score_response = test_client.get(
         "/api/shifu/admin/operations/courses/course-detail/ratings?page=1&page_size=20"
         "&has_comment=true&sort_by=score_asc",

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -244,6 +244,7 @@ describe('AdminOperationCourseRatingsPage', () => {
         shifu_bid: 'course-1',
         page: 1,
         page_size: 20,
+        include_summary: true,
         keyword: '',
         chapter_keyword: '',
         score: '',
@@ -296,6 +297,114 @@ describe('AdminOperationCourseRatingsPage', () => {
     expect(screen.getByText('12000')).toBeInTheDocument();
     expect(screen.queryByText('76,384')).not.toBeInTheDocument();
     expect(screen.queryByText('12,000')).not.toBeInTheDocument();
+  });
+
+  test('keeps summary cards scoped to all ratings when filters change', async () => {
+    mockGetAdminOperationCourseRatings
+      .mockResolvedValueOnce({
+        summary: {
+          average_score: '4.2',
+          rating_count: 42,
+          user_count: 7,
+          latest_rated_at: '2026-04-05T11:02:00Z',
+        },
+        items: [
+          {
+            lesson_feedback_bid: 'feedback-all',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-1',
+            mobile: '13900001235',
+            email: '',
+            nickname: 'Bob',
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            lesson_outline_item_bid: 'lesson-1',
+            lesson_title: 'Lesson 1',
+            score: 5,
+            comment: 'All rating comment',
+            mode: 'read',
+            rated_at: '2026-04-05T11:02:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 42,
+        page_count: 3,
+      })
+      .mockResolvedValueOnce({
+        summary: {
+          average_score: '',
+          rating_count: 0,
+          user_count: 0,
+          latest_rated_at: '',
+        },
+        items: [
+          {
+            lesson_feedback_bid: 'feedback-filtered',
+            progress_record_bid: 'progress-2',
+            user_bid: 'student-2',
+            mobile: '13900009999',
+            email: '',
+            nickname: 'Alice',
+            chapter_outline_item_bid: 'chapter-2',
+            chapter_title: 'Chapter 2',
+            lesson_outline_item_bid: 'lesson-2',
+            lesson_title: 'Lesson 2',
+            score: 3,
+            comment: 'Filtered rating comment',
+            mode: 'listen',
+            rated_at: '2026-04-06T11:02:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 1,
+        page_count: 1,
+      });
+
+    render(<AdminOperationCourseRatingsPage />);
+
+    expect(await screen.findByText('All rating comment')).toBeInTheDocument();
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'module.operationsCourse.detail.ratings.filters.userKeywordPlaceholderPhone',
+      ),
+      {
+        target: { value: 'student-2' },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsCourse.detail.ratings.filters.search',
+      }),
+    );
+
+    expect(
+      await screen.findByText('Filtered rating comment'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseRatings).toHaveBeenLastCalledWith({
+        shifu_bid: 'course-1',
+        page: 1,
+        page_size: 20,
+        include_summary: false,
+        keyword: 'student-2',
+        chapter_keyword: '',
+        score: '',
+        mode: '',
+        has_comment: '',
+        sort_by: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
   });
 
   test('submits search filters including score, mode, comment filter, sort, and rating time', async () => {
@@ -355,6 +464,7 @@ describe('AdminOperationCourseRatingsPage', () => {
         shifu_bid: 'course-1',
         page: 1,
         page_size: 20,
+        include_summary: false,
         keyword: '13900001235',
         chapter_keyword: 'Chapter 1',
         score: '5',

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -407,6 +407,106 @@ describe('AdminOperationCourseRatingsPage', () => {
     expect(screen.getByText('7')).toBeInTheDocument();
   });
 
+  test('skips summary refresh when paging through unfiltered ratings', async () => {
+    mockGetAdminOperationCourseRatings
+      .mockResolvedValueOnce({
+        summary: {
+          average_score: '4.2',
+          rating_count: 42,
+          user_count: 7,
+          latest_rated_at: '2026-04-05T11:02:00Z',
+        },
+        items: [
+          {
+            lesson_feedback_bid: 'feedback-page-1',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-1',
+            mobile: '13900001235',
+            email: '',
+            nickname: 'Bob',
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            lesson_outline_item_bid: 'lesson-1',
+            lesson_title: 'Lesson 1',
+            score: 5,
+            comment: 'First page rating comment',
+            mode: 'read',
+            rated_at: '2026-04-05T11:02:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 42,
+        page_count: 3,
+      })
+      .mockResolvedValueOnce({
+        summary: {
+          average_score: '',
+          rating_count: 0,
+          user_count: 0,
+          latest_rated_at: '',
+        },
+        items: [
+          {
+            lesson_feedback_bid: 'feedback-page-2',
+            progress_record_bid: 'progress-2',
+            user_bid: 'student-2',
+            mobile: '13900009999',
+            email: '',
+            nickname: 'Alice',
+            chapter_outline_item_bid: 'chapter-2',
+            chapter_title: 'Chapter 2',
+            lesson_outline_item_bid: 'lesson-2',
+            lesson_title: 'Lesson 2',
+            score: 4,
+            comment: 'Second page rating comment',
+            mode: 'listen',
+            rated_at: '2026-04-06T11:02:00Z',
+          },
+        ],
+        page: 2,
+        page_size: 20,
+        total: 42,
+        page_count: 3,
+      });
+
+    render(<AdminOperationCourseRatingsPage />);
+
+    expect(
+      await screen.findByText('First page rating comment'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('link', {
+        name: 'module.order.paginationNextAriaLabel',
+      }),
+    );
+
+    expect(
+      await screen.findByText('Second page rating comment'),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseRatings).toHaveBeenLastCalledWith({
+        shifu_bid: 'course-1',
+        page: 2,
+        page_size: 20,
+        include_summary: false,
+        keyword: '',
+        chapter_keyword: '',
+        score: '',
+        mode: '',
+        has_comment: '',
+        sort_by: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
   test('submits search filters including score, mode, comment filter, sort, and rating time', async () => {
     render(<AdminOperationCourseRatingsPage />);
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -110,6 +110,30 @@ const createRatingFilters = (): RatingFilters => ({
   endTime: '',
 });
 
+const normalizeRatingFilters = (filters: RatingFilters): RatingFilters => ({
+  keyword: filters.keyword.trim(),
+  chapterKeyword: filters.chapterKeyword.trim(),
+  score: filters.score,
+  mode: filters.mode,
+  commentFilter: filters.commentFilter,
+  sortBy: filters.sortBy,
+  startTime: filters.startTime,
+  endTime: filters.endTime,
+});
+
+const areRatingFiltersEqual = (first: RatingFilters, second: RatingFilters) =>
+  first.keyword === second.keyword &&
+  first.chapterKeyword === second.chapterKeyword &&
+  first.score === second.score &&
+  first.mode === second.mode &&
+  first.commentFilter === second.commentFilter &&
+  first.sortBy === second.sortBy &&
+  first.startTime === second.startTime &&
+  first.endTime === second.endTime;
+
+const isDefaultRatingFilters = (filters: RatingFilters) =>
+  areRatingFiltersEqual(filters, createRatingFilters());
+
 const formatCount = (value: number, locale: string): string =>
   formatAdminCount(value, locale);
 
@@ -298,6 +322,9 @@ export default function AdminOperationCourseRatingsPage() {
 
   const [ratings, setRatings] =
     useState<AdminOperationCourseRatingListResponse>(EMPTY_RATINGS_RESPONSE);
+  const [fullSummary, setFullSummary] = useState(
+    EMPTY_RATINGS_RESPONSE.summary,
+  );
   const [pageIndex, setPageIndex] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<ErrorState | null>(null);
@@ -327,11 +354,14 @@ export default function AdminOperationCourseRatingsPage() {
     async (nextPage: number, nextFilters: RatingFilters) => {
       if (!shifuBid) {
         setRatings(EMPTY_RATINGS_RESPONSE);
+        setFullSummary(EMPTY_RATINGS_RESPONSE.summary);
         setError({ message: unknownErrorMessage });
         setLoading(false);
         return;
       }
 
+      const resolvedFilters = normalizeRatingFilters(nextFilters);
+      const shouldRefreshFullSummary = isDefaultRatingFilters(resolvedFilters);
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       setLoading(true);
@@ -341,24 +371,33 @@ export default function AdminOperationCourseRatingsPage() {
           shifu_bid: shifuBid,
           page: nextPage,
           page_size: PAGE_SIZE,
-          keyword: nextFilters.keyword,
-          chapter_keyword: nextFilters.chapterKeyword,
+          include_summary: shouldRefreshFullSummary,
+          keyword: resolvedFilters.keyword,
+          chapter_keyword: resolvedFilters.chapterKeyword,
           score:
-            nextFilters.score === FILTER_ALL_OPTION ? '' : nextFilters.score,
-          mode: nextFilters.mode === FILTER_ALL_OPTION ? '' : nextFilters.mode,
+            resolvedFilters.score === FILTER_ALL_OPTION
+              ? ''
+              : resolvedFilters.score,
+          mode:
+            resolvedFilters.mode === FILTER_ALL_OPTION
+              ? ''
+              : resolvedFilters.mode,
           has_comment:
-            nextFilters.commentFilter === COMMENT_FILTER_COMMENTED_OPTION
+            resolvedFilters.commentFilter === COMMENT_FILTER_COMMENTED_OPTION
               ? 'true'
               : '',
           sort_by:
-            nextFilters.sortBy === SORT_BY_LATEST_OPTION
+            resolvedFilters.sortBy === SORT_BY_LATEST_OPTION
               ? ''
-              : nextFilters.sortBy,
-          start_time: nextFilters.startTime,
-          end_time: nextFilters.endTime,
+              : resolvedFilters.sortBy,
+          start_time: resolvedFilters.startTime,
+          end_time: resolvedFilters.endTime,
         });
         if (requestId !== requestIdRef.current) {
           return;
+        }
+        if (shouldRefreshFullSummary) {
+          setFullSummary(response?.summary || EMPTY_RATINGS_RESPONSE.summary);
         }
         setRatings(response || EMPTY_RATINGS_RESPONSE);
       } catch (err) {
@@ -427,30 +466,30 @@ export default function AdminOperationCourseRatingsPage() {
       {
         key: 'averageScore',
         label: tOperations('detail.ratings.summary.averageScore'),
-        value: ratings.summary.average_score || emptyValue,
+        value: fullSummary.average_score || emptyValue,
         tone: 'number' as const,
       },
       {
         key: 'ratingCount',
         label: tOperations('detail.ratings.summary.ratingCount'),
-        value: formatCount(ratings.summary.rating_count, i18n.language),
+        value: formatCount(fullSummary.rating_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'userCount',
         label: tOperations('detail.ratings.summary.userCount'),
-        value: formatCount(ratings.summary.user_count, i18n.language),
+        value: formatCount(fullSummary.user_count, i18n.language),
         tone: 'number' as const,
       },
       {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminUtcDateTime(ratings.summary.latest_rated_at) || emptyValue,
+          formatAdminUtcDateTime(fullSummary.latest_rated_at) || emptyValue,
         tone: 'timestamp' as const,
       },
     ],
-    [emptyValue, i18n.language, ratings.summary, tOperations],
+    [emptyValue, fullSummary, i18n.language, tOperations],
   );
 
   const resolveUserSecondary = useCallback(
@@ -478,26 +517,27 @@ export default function AdminOperationCourseRatingsPage() {
   );
 
   const handleSearch = useCallback(() => {
-    const nextFilters = {
-      keyword: filtersDraft.keyword.trim(),
-      chapterKeyword: filtersDraft.chapterKeyword.trim(),
-      score: filtersDraft.score,
-      mode: filtersDraft.mode,
-      commentFilter: filtersDraft.commentFilter,
-      sortBy: filtersDraft.sortBy,
-      startTime: filtersDraft.startTime,
-      endTime: filtersDraft.endTime,
-    };
+    const nextFilters = normalizeRatingFilters(filtersDraft);
+    if (pageIndex === 1 && areRatingFiltersEqual(nextFilters, filters)) {
+      return;
+    }
     setFilters(nextFilters);
     setPageIndex(1);
-  }, [filtersDraft]);
+  }, [filters, filtersDraft, pageIndex]);
 
   const handleReset = useCallback(() => {
     const nextFilters = createRatingFilters();
+    if (
+      pageIndex === 1 &&
+      areRatingFiltersEqual(nextFilters, filters) &&
+      areRatingFiltersEqual(nextFilters, filtersDraft)
+    ) {
+      return;
+    }
     setFiltersDraft(nextFilters);
     setFilters(nextFilters);
     setPageIndex(1);
-  }, []);
+  }, [filters, filtersDraft, pageIndex]);
 
   const handlePageChange = useCallback(
     (nextPage: number) => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -333,6 +333,7 @@ export default function AdminOperationCourseRatingsPage() {
   const [filtersDraft, setFiltersDraft] =
     useState<RatingFilters>(createRatingFilters);
   const requestIdRef = useRef(0);
+  const fullSummaryLoadedRef = useRef(false);
 
   const detailPageUrl = useMemo(
     () => buildAdminOperationsCourseDetailUrl(shifuBid),
@@ -355,13 +356,16 @@ export default function AdminOperationCourseRatingsPage() {
       if (!shifuBid) {
         setRatings(EMPTY_RATINGS_RESPONSE);
         setFullSummary(EMPTY_RATINGS_RESPONSE.summary);
+        fullSummaryLoadedRef.current = false;
         setError({ message: unknownErrorMessage });
         setLoading(false);
         return;
       }
 
       const resolvedFilters = normalizeRatingFilters(nextFilters);
-      const shouldRefreshFullSummary = isDefaultRatingFilters(resolvedFilters);
+      const shouldRefreshFullSummary =
+        isDefaultRatingFilters(resolvedFilters) &&
+        !fullSummaryLoadedRef.current;
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       setLoading(true);
@@ -398,6 +402,7 @@ export default function AdminOperationCourseRatingsPage() {
         }
         if (shouldRefreshFullSummary) {
           setFullSummary(response?.summary || EMPTY_RATINGS_RESPONSE.summary);
+          fullSummaryLoadedRef.current = true;
         }
         setRatings(response || EMPTY_RATINGS_RESPONSE);
       } catch (err) {
@@ -521,6 +526,12 @@ export default function AdminOperationCourseRatingsPage() {
     if (pageIndex === 1 && areRatingFiltersEqual(nextFilters, filters)) {
       return;
     }
+    if (
+      isDefaultRatingFilters(nextFilters) &&
+      !isDefaultRatingFilters(filters)
+    ) {
+      fullSummaryLoadedRef.current = false;
+    }
     setFilters(nextFilters);
     setPageIndex(1);
   }, [filters, filtersDraft, pageIndex]);
@@ -535,6 +546,9 @@ export default function AdminOperationCourseRatingsPage() {
       return;
     }
     setFiltersDraft(nextFilters);
+    if (!areRatingFiltersEqual(nextFilters, filters)) {
+      fullSummaryLoadedRef.current = false;
+    }
     setFilters(nextFilters);
     setPageIndex(1);
   }, [filters, filtersDraft, pageIndex]);


### PR DESCRIPTION
Summary
- Keep the operator rating summary cards scoped to the full data set instead of filtered results.
- Add an include_summary flag so filtered rating list requests can skip expensive backend summary aggregation.
- Move rating filtering, sorting, and pagination into the database query path to avoid loading all rating rows and users.
- Avoid duplicate search/reset requests when filters are unchanged.
- Add focused frontend and backend coverage for the optimized flow.

Tests
- cd src/cook-web && npm test -- --runInBand --runTestsByPath 'src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx'
- cd src/api && pytest -q tests/service/shifu/test_admin_course_detail.py -k 'ratings_route'
- cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/[shifu_bid]/ratings/page.tsx' --file 'src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx'- cd src/cook-web && npm run type-check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin course ratings can return a lightweight, faster response that omits expensive summary metrics when viewing filtered results; full summary remains available for the unfiltered view.
  * Summary cards now persist overall (unfiltered) statistics while list results reflect applied filters.

* **Tests**
  * Updated tests to cover both full-summary and lightweight filtered response behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->