### PR TITLE
fix: Enable daily ledger summary finalization

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -292,6 +292,10 @@ WECHAT_APP_SECRET=""
 # (Optional - default: * * * * *)
 BILLING_BUCKET_EXPIRE_CRON="* * * * *"
 
+# Cron expression for finalizing the previous day's billing ledger summary.
+# (Optional - default: 30 1 * * *)
+BILLING_DAILY_LEDGER_SUMMARY_CRON="30 1 * * *"
+
 # Cron expression for scanning billing low-balance alerts.
 # (Optional - default: 0 * * * *)
 BILLING_LOW_BALANCE_CRON="0 * * * *"

--- a/docs/billing-subscription-design.md
+++ b/docs/billing-subscription-design.md
@@ -735,7 +735,7 @@ v1 的改造要求：
 - 当前实现中，`src/api/flaskr/common/celery_app.py` 已提供共享 Celery app factory，`src/api/celery_app.py` 作为 worker / beat 入口统一复用 `app.py:create_app()`
 - 当前实现中，`src/api/flaskr/common/config.py` 已注册 `CELERY_BROKER_URL`、`CELERY_RESULT_BACKEND`、`CELERY_TASK_ALWAYS_EAGER`，并同步刷新 `docker/.env.example.full`
 - 当前实现中，`docker/docker-compose.yml`、`docker/docker-compose.latest.yml`、`docker/docker-compose.dev.yml` 已补 `ai-shifu-redis`、Celery worker、Celery beat 三类服务，并统一为 API / worker / beat 注入容器内 Redis/Celery 地址
-- 当前实现中，`src/api/flaskr/service/billing/tasks.py` 已注册 `billing.settle_usage`、`billing.replay_usage_settlement`、`billing.expire_wallet_buckets`、`billing.reconcile_provider_reference`、`billing.send_low_balance_alert`、`billing.run_renewal_event`、`billing.retry_failed_renewal` 以及 v1.1 的 `billing.aggregate_daily_usage_metrics`、`billing.aggregate_daily_ledger_summary`、`billing.rebuild_daily_aggregates`、`billing.verify_domain_binding`
+- 当前实现中，`src/api/flaskr/service/billing/tasks.py` 已注册 `billing.settle_usage`、`billing.replay_usage_settlement`、`billing.expire_wallet_buckets`、`billing.reconcile_provider_reference`、`billing.send_low_balance_alert`、`billing.run_renewal_event`、`billing.retry_failed_renewal` 以及 v1.1 的 `billing.aggregate_daily_usage_metrics`、`billing.aggregate_daily_ledger_summary`、`billing.finalize_daily_ledger_summary`、`billing.rebuild_daily_aggregates`、`billing.verify_domain_binding`
 - 当前实现中，`billing.expire_wallet_buckets` 会直接复用 `src/api/flaskr/service/billing/wallets.py:expire_credit_wallet_buckets`，扫描到期 bucket 并落 `credit_ledger_entries.entry_type=expire`
 - 当前实现中，`src/api/flaskr/service/billing/cli.py` 已提供 `flask console billing backfill-settlement`、`rebuild-wallets`、`rebuild-daily-aggregates`、`reconcile-order`、`run-renewal-event`、`retry-renewal` 六个离线运维入口，统一复用 service helper，不再单独实现一套 CLI 专属账务逻辑
 - 当前实现中，billing v1.1 的所有表结构已统一收敛到 `src/api/migrations/versions/b114d7f5e2c1_add_billing_core_phase.py`
@@ -746,7 +746,7 @@ v1 的改造要求：
 - 当前实现中，`billing.verify_domain_binding` task 已复用 `src/api/flaskr/service/billing/domains.py` 的既有 verify flow：可按 `domain_binding_bid` 或 `host` 加载 binding，并在未显式传 `verification_token` 时回退到绑定上已有 token 做后台刷新
 - 当前实现中，`src/api/flaskr/common/shifu_context.py` 已开始在缺少 `shifu_bid` 时回退按 `Host` / `X-Forwarded-Host` 解析 `bill_domain_bindings.host`，但只认可 `status=verified` 且 creator 仍具备 `custom_domain_enabled` 权益的域名
 - 当前实现中，`/api/runtime-config` 已开始返回 `entitlements`、`branding`、`domain` 三个 v1.1 扩展字段；当 creator 启用 branding 且 feature payload 提供 logo/home 配置时，会覆盖顶层 `logoWideUrl`、`logoSquareUrl`、`faviconUrl`、`homeUrl`
-- 当前实现中，`bill_daily_usage_metrics`、`bill_daily_ledger_summary` 已由 `src/api/flaskr/service/billing/models.py` 和 `src/api/migrations/versions/b114d7f5e2c1_add_billing_core_phase.py` 落地；其中 usage / ledger 两条日报表都已由 `src/api/flaskr/service/billing/daily_aggregates.py` 和 `src/api/flaskr/service/billing/tasks.py` 补齐 `stat_date + creator_bid` 维度的重算任务，增量窗口按 `day_start -> min(now, day_end)` 回填，`finalize=true` 时会重算整天窗口；同时 `rebuild_daily_aggregates` 已支持按 `creator_bid + date window` 全量重算 usage / ledger 报表，若再传 `shifu_bid`，则只重算 usage 报表并跳过 ledger summary，因为 `bill_daily_ledger_summary` 本身不含 `shifu_bid` 维度
+- 当前实现中，`bill_daily_usage_metrics`、`bill_daily_ledger_summary` 已由 `src/api/flaskr/service/billing/models.py` 和 `src/api/migrations/versions/b114d7f5e2c1_add_billing_core_phase.py` 落地；其中 usage / ledger 两条日报表都已由 `src/api/flaskr/service/billing/daily_aggregates.py` 和 `src/api/flaskr/service/billing/tasks.py` 补齐 `stat_date + creator_bid` 维度的重算任务，增量窗口按 `day_start -> min(now, day_end)` 回填，`finalize=true` 时会重算整天窗口；`billing.finalize_daily_ledger_summary` 已通过 Celery beat 默认每天 01:30 finalize 前一自然日 ledger summary；同时 `rebuild_daily_aggregates` 已支持按 `creator_bid + date window` 全量重算 usage / ledger 报表，若再传 `shifu_bid`，则只重算 usage 报表并跳过 ledger summary，因为 `bill_daily_ledger_summary` 本身不含 `shifu_bid` 维度
 - 当前实现中，`src/api/flaskr/service/billing/renewal.py` 已落地 renewal executor：`bill_renewal_events` 通过 `pending/failed -> processing` compare-and-set 抢占；未来排期会释放回 `pending`；`cancel_effective`、`downgrade_effective`、`expire` 会直接推进 `bill_subscriptions` 并把事件标记为 `succeeded`
 - 当前实现中，`renewal/retry/reconcile` 已复用同一条 renewal order 补偿链路：`subscription_renewal` 订单会写入 `bill_orders.metadata.provider_reference_type=subscription` 与 `renewal_cycle_*` 周期快照，`POST /billing/orders/{bill_order_bid}/sync`、`billing.retry_failed_renewal` 和 Stripe `customer.subscription.updated` webhook 都会围绕这笔 renewal order 做 paid/failed 状态推进与幂等 grant
 - 当前实现中，billing checkout / webhook / sync 编排已分别落在 `src/api/flaskr/service/billing/checkout.py`、`src/api/flaskr/service/billing/webhooks.py`、`src/api/flaskr/service/billing/provider_state.py`，并且只通过 shared `src/api/flaskr/service/order/payment_providers/` adapter 暴露的接口访问 Stripe / Pingxx；`src/api/flaskr/service/billing/funcs.py` 仅保留兼容导出层
@@ -895,7 +895,7 @@ v1 需要补充以下环境变量和配置项：
 | `BILLING_RECONCILE_CRON` | provider reconcile 调度表达式 |
 | `BILLING_BUCKET_EXPIRE_CRON` | 余额桶过期扫描调度表达式 |
 | `BILLING_LOW_BALANCE_CRON` | 低余额扫描调度表达式 |
-| `BILLING_DAILY_AGGREGATE_CRON` | 日汇总调度表达式，v1.1 才启用 |
+| `BILLING_DAILY_LEDGER_SUMMARY_CRON` | 前一自然日 ledger 日汇总 finalize 调度表达式 |
 
 同时在 `sys_configs` 预置以下 billing bootstrap 配置：
 

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -14,6 +14,7 @@ _DEFAULT_BROKER_URL = "redis://localhost:6379/0"
 _DEFAULT_BILLING_RENEWAL_CRON = "* * * * *"
 _DEFAULT_BILLING_BUCKET_EXPIRE_CRON = "* * * * *"
 _DEFAULT_BILLING_LOW_BALANCE_CRON = "0 * * * *"
+_DEFAULT_BILLING_DAILY_LEDGER_SUMMARY_CRON = "30 1 * * *"
 
 __CELERY_APP__: Celery | None = None
 
@@ -104,6 +105,14 @@ def _build_billing_beat_schedule(flask_app: Flask) -> dict[str, Any]:
                 flask_app,
                 "BILLING_LOW_BALANCE_CRON",
                 _DEFAULT_BILLING_LOW_BALANCE_CRON,
+            ),
+        },
+        "billing.finalize_daily_ledger_summary.schedule": {
+            "task": "billing.finalize_daily_ledger_summary",
+            "schedule": _resolve_billing_crontab(
+                flask_app,
+                "BILLING_DAILY_LEDGER_SUMMARY_CRON",
+                _DEFAULT_BILLING_DAILY_LEDGER_SUMMARY_CRON,
             ),
         },
     }

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -675,6 +675,14 @@ Example: mysql://username:password@hostname:3306/database_name?charset=utf8mb4""
         description="Cron expression for scanning billing low-balance alerts.",
         group="celery",
     ),
+    "BILLING_DAILY_LEDGER_SUMMARY_CRON": EnvVar(
+        name="BILLING_DAILY_LEDGER_SUMMARY_CRON",
+        default="30 1 * * *",
+        description=(
+            "Cron expression for finalizing the previous day's billing ledger summary."
+        ),
+        group="celery",
+    ),
     # Authentication Configuration
     "SECRET_KEY": EnvVar(
         name="SECRET_KEY",

--- a/src/api/flaskr/service/billing/capabilities.py
+++ b/src/api/flaskr/service/billing/capabilities.py
@@ -222,6 +222,7 @@ _CAPABILITIES: tuple[BillingCapabilityDefinition, ...] = (
         task_entries=(
             "billing.aggregate_daily_usage_metrics",
             "billing.aggregate_daily_ledger_summary",
+            "billing.finalize_daily_ledger_summary",
             "billing.rebuild_daily_aggregates",
         ),
         cli_entries=("flask console billing rebuild-daily-aggregates",),

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -18,6 +18,7 @@ from .consts import (
 from .daily_aggregates import (
     aggregate_daily_ledger_summary,
     aggregate_daily_usage_metrics,
+    finalize_daily_ledger_summary,
     rebuild_daily_aggregates,
 )
 from .domains import verify_domain_binding
@@ -555,6 +556,28 @@ def aggregate_daily_ledger_summary_task(
     )
     payload = _serialize_task_payload(payload)
     payload["task_name"] = "billing.aggregate_daily_ledger_summary"
+    return payload
+
+
+@shared_task(name="billing.finalize_daily_ledger_summary")
+def finalize_daily_ledger_summary_task(
+    *,
+    stat_date: str = "",
+    creator_bid: str = "",
+) -> dict[str, Any]:
+    """Finalize one complete ledger-summary day, defaulting to yesterday."""
+
+    app = _create_task_app()
+    normalized_stat_date = _normalize_bid(stat_date)
+    if not normalized_stat_date:
+        normalized_stat_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    payload = finalize_daily_ledger_summary(
+        app,
+        stat_date=normalized_stat_date,
+        creator_bid=_normalize_bid(creator_bid),
+    )
+    payload = _serialize_task_payload(payload)
+    payload["task_name"] = "billing.finalize_daily_ledger_summary"
     return payload
 
 

--- a/src/api/tests/common/test_celery_app.py
+++ b/src/api/tests/common/test_celery_app.py
@@ -34,6 +34,7 @@ def test_create_celery_app_reuses_flask_config() -> None:
         BILLING_RENEWAL_CRON="*/2 * * * *",
         BILLING_BUCKET_EXPIRE_CRON="*/15 * * * *",
         BILLING_LOW_BALANCE_CRON="30 * * * *",
+        BILLING_DAILY_LEDGER_SUMMARY_CRON="45 1 * * *",
     )
 
     celery_app = celery_app_module.create_celery_app(flask_app=flask_app)
@@ -54,6 +55,7 @@ def test_create_celery_app_reuses_flask_config() -> None:
     assert "billing.retry_failed_renewal" in celery_app.tasks
     assert "billing.aggregate_daily_usage_metrics" in celery_app.tasks
     assert "billing.aggregate_daily_ledger_summary" in celery_app.tasks
+    assert "billing.finalize_daily_ledger_summary" in celery_app.tasks
     assert "billing.rebuild_daily_aggregates" in celery_app.tasks
     assert "billing.verify_domain_binding" in celery_app.tasks
 
@@ -66,6 +68,9 @@ def test_create_celery_app_reuses_flask_config() -> None:
     )
     assert beat_schedule["billing.send_low_balance_alert.schedule"]["task"] == (
         "billing.send_low_balance_alert"
+    )
+    assert beat_schedule["billing.finalize_daily_ledger_summary.schedule"]["task"] == (
+        "billing.finalize_daily_ledger_summary"
     )
     _assert_cron_schedule(
         beat_schedule["billing.dispatch_due_renewal_events.schedule"]["schedule"],
@@ -81,6 +86,11 @@ def test_create_celery_app_reuses_flask_config() -> None:
         beat_schedule["billing.send_low_balance_alert.schedule"]["schedule"],
         minute="30",
         hour="*",
+    )
+    _assert_cron_schedule(
+        beat_schedule["billing.finalize_daily_ledger_summary.schedule"]["schedule"],
+        minute="45",
+        hour="1",
     )
 
 
@@ -306,4 +316,9 @@ def test_create_celery_app_uses_default_billing_beat_crons() -> None:
         beat_schedule["billing.send_low_balance_alert.schedule"]["schedule"],
         minute="0",
         hour="*",
+    )
+    _assert_cron_schedule(
+        beat_schedule["billing.finalize_daily_ledger_summary.schedule"]["schedule"],
+        minute="30",
+        hour="1",
     )

--- a/src/api/tests/common/test_celery_config.py
+++ b/src/api/tests/common/test_celery_config.py
@@ -11,6 +11,7 @@ def test_env_registry_includes_celery_runtime_variables() -> None:
     assert ENV_VARS["BILLING_RENEWAL_CRON"].group == "celery"
     assert ENV_VARS["BILLING_BUCKET_EXPIRE_CRON"].group == "celery"
     assert ENV_VARS["BILLING_LOW_BALANCE_CRON"].group == "celery"
+    assert ENV_VARS["BILLING_DAILY_LEDGER_SUMMARY_CRON"].group == "celery"
 
 
 def test_env_example_exports_celery_variables() -> None:
@@ -22,3 +23,4 @@ def test_env_example_exports_celery_variables() -> None:
     assert 'BILLING_RENEWAL_CRON="* * * * *"' in output
     assert 'BILLING_BUCKET_EXPIRE_CRON="* * * * *"' in output
     assert 'BILLING_LOW_BALANCE_CRON="0 * * * *"' in output
+    assert 'BILLING_DAILY_LEDGER_SUMMARY_CRON="30 1 * * *"' in output

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -40,6 +40,7 @@ from flaskr.service.billing.tasks import (
     aggregate_daily_usage_metrics_task,
     dispatch_due_renewal_events_task,
     expire_wallet_buckets_task,
+    finalize_daily_ledger_summary_task,
     reconcile_provider_reference_task,
     replay_usage_settlement_task,
     rebuild_daily_aggregates_task,
@@ -235,6 +236,95 @@ def test_aggregate_daily_ledger_summary_task_calls_helper(
     }
     assert payload["status"] == "finalized"
     assert payload["task_name"] == "billing.aggregate_daily_ledger_summary"
+
+
+def test_finalize_daily_ledger_summary_task_defaults_to_previous_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_app = object()
+    _install_fake_app_module(monkeypatch, fake_app)
+
+    captured: dict[str, object] = {}
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 5, 22, 2, 0, 0, tzinfo=tz)
+
+    def _fake_finalize_daily_ledger_summary(
+        app,
+        *,
+        stat_date: str = "",
+        creator_bid: str = "",
+    ):
+        captured["app"] = app
+        captured["stat_date"] = stat_date
+        captured["creator_bid"] = creator_bid
+        return {
+            "status": "finalized",
+            "stat_date": stat_date,
+            "creator_bid": creator_bid or None,
+            "finalize": True,
+        }
+
+    monkeypatch.setattr("flaskr.service.billing.tasks.datetime", FixedDateTime)
+    monkeypatch.setattr(
+        "flaskr.service.billing.tasks.finalize_daily_ledger_summary",
+        _fake_finalize_daily_ledger_summary,
+    )
+
+    payload = finalize_daily_ledger_summary_task(creator_bid=" creator-task-3 ")
+
+    assert captured == {
+        "app": fake_app,
+        "stat_date": "2026-05-21",
+        "creator_bid": "creator-task-3",
+    }
+    assert payload["status"] == "finalized"
+    assert payload["task_name"] == "billing.finalize_daily_ledger_summary"
+
+
+def test_finalize_daily_ledger_summary_task_accepts_explicit_stat_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_app = object()
+    _install_fake_app_module(monkeypatch, fake_app)
+
+    captured: dict[str, object] = {}
+
+    def _fake_finalize_daily_ledger_summary(
+        app,
+        *,
+        stat_date: str = "",
+        creator_bid: str = "",
+    ):
+        captured["app"] = app
+        captured["stat_date"] = stat_date
+        captured["creator_bid"] = creator_bid
+        return {
+            "status": "finalized",
+            "stat_date": stat_date,
+            "creator_bid": creator_bid or None,
+            "finalize": True,
+        }
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.tasks.finalize_daily_ledger_summary",
+        _fake_finalize_daily_ledger_summary,
+    )
+
+    payload = finalize_daily_ledger_summary_task(
+        stat_date=" 2026-05-20 ",
+        creator_bid=" creator-task-4 ",
+    )
+
+    assert captured == {
+        "app": fake_app,
+        "stat_date": "2026-05-20",
+        "creator_bid": "creator-task-4",
+    }
+    assert payload["status"] == "finalized"
+    assert payload["task_name"] == "billing.finalize_daily_ledger_summary"
 
 
 def test_rebuild_daily_aggregates_task_calls_helper(


### PR DESCRIPTION
## Summary
- Add a scheduled `billing.finalize_daily_ledger_summary` Celery task that finalizes the previous natural day.
- Register `BILLING_DAILY_LEDGER_SUMMARY_CRON` with a default `30 1 * * *` schedule and expose it in generated env examples.
- Keep billing capability/docs/tests aligned with the new scheduled ledger summary task.

## Why
The `bill_daily_ledger_summary` table and rebuild helpers existed, but Celery beat did not schedule ledger-summary finalization. Low-balance estimated-days notifications need complete prior-day consume summaries, so the scheduled task must populate yesterday before later scans run.

## Validation
- `cd src/api && pytest tests/common/test_celery_app.py tests/common/test_celery_config.py tests/service/billing/test_billing_tasks.py tests/service/billing/test_billing_daily_ledger_aggregates.py -q`
- `python scripts/check_repo_harness.py`
- commit hooks: ruff, repository harness, architecture boundaries, translation checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily billing ledger summary finalization, scheduled to run at 01:30 UTC to process the previous day's ledger data.

* **Documentation**
  * Updated billing and subscription design documentation with implementation details for the ledger summary finalization feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->