### PR TITLE
feat: add operator course credit usage details

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2768,6 +2768,9 @@ class RunScriptContextV2:
             generated_block.position = run_script_info.block_position
             # For STUDENT records, also store translated interaction block
             # (in case this record is returned instead of TEACHER record)
+            llm_provider.set_usage_generated_block_bid(
+                generated_block.generated_block_bid
+            )
             interaction_result = mdflow_context.process(
                 block_index=run_script_info.block_position,
                 mode=ProcessMode.COMPLETE,
@@ -2779,9 +2782,6 @@ class RunScriptContextV2:
             )
             generated_block.status = 1
             db.session.flush()
-            llm_provider.set_usage_generated_block_bid(
-                generated_block.generated_block_bid
-            )
             trace_metadata = self._trace_args.get("metadata") or {}
             if not isinstance(trace_metadata, dict):
                 trace_metadata = {}

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -4,6 +4,7 @@ import json
 import queue
 import threading
 import contextlib
+from dataclasses import replace
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Callable, Generator, Iterable, Optional, Union
@@ -230,6 +231,12 @@ class RUNLLMProvider(LLMProvider):
         self.trace_args = trace_args
         self.usage_context = usage_context
         self.usage_scene = usage_scene
+
+    def set_usage_generated_block_bid(self, generated_block_bid: str) -> None:
+        self.usage_context = replace(
+            self.usage_context,
+            generated_block_bid=str(generated_block_bid or ""),
+        )
 
     def _log_preview_output(
         self,
@@ -2483,18 +2490,19 @@ class RunScriptContextV2:
             progress_record_bid=self._current_attend.progress_record_bid,
             usage_scene=usage_scene,
         )
+        llm_provider = RUNLLMProvider(
+            app,
+            llm_settings,
+            self._trace,
+            self._trace_root_span,
+            self._trace_args,
+            usage_context,
+            usage_scene,
+        )
         mdflow_context = MdflowContextV2(
             document=run_script_info.mdflow,
             document_prompt=system_prompt,
-            llm_provider=RUNLLMProvider(
-                app,
-                llm_settings,
-                self._trace,
-                self._trace_root_span,
-                self._trace_args,
-                usage_context,
-                usage_scene,
-            ),
+            llm_provider=llm_provider,
             use_learner_language=self._shifu_info.use_learner_language,
             visual_mode=True,
         )
@@ -2700,6 +2708,9 @@ class RunScriptContextV2:
 
                 # Render interaction content with translation (INPUT mode, no cached block)
                 # Note: Do NOT pass variables here - we only want translation, not variable replacement
+                llm_provider.set_usage_generated_block_bid(
+                    generated_block.generated_block_bid
+                )
                 interaction_result = mdflow_context.process(
                     block_index=run_script_info.block_position,
                     mode=ProcessMode.COMPLETE,
@@ -2768,6 +2779,9 @@ class RunScriptContextV2:
             )
             generated_block.status = 1
             db.session.flush()
+            llm_provider.set_usage_generated_block_bid(
+                generated_block.generated_block_bid
+            )
             trace_metadata = self._trace_args.get("metadata") or {}
             if not isinstance(trace_metadata, dict):
                 trace_metadata = {}
@@ -2788,7 +2802,10 @@ class RunScriptContextV2:
                 llm_settings=llm_settings,
                 attend_id=self._current_attend.progress_record_bid,
                 fmt_prompt="",
-                usage_context=usage_context,
+                usage_context=replace(
+                    usage_context,
+                    generated_block_bid=generated_block.generated_block_bid,
+                ),
                 chapter_title=chapter_title,
                 scene=f"{trace_scene}_interaction",
             )
@@ -2970,6 +2987,9 @@ class RunScriptContextV2:
 
                 # Render interaction content with translation after validation error
                 # Note: Do NOT pass variables here - we only want translation, not variable replacement
+                llm_provider.set_usage_generated_block_bid(
+                    generated_block.generated_block_bid
+                )
                 interaction_result = mdflow_context.process(
                     block_index=run_script_info.block_position,
                     mode=ProcessMode.COMPLETE,
@@ -3035,6 +3055,9 @@ class RunScriptContextV2:
                 # Call process() without user_input to trigger interaction rendering
                 # Note: Do NOT pass variables here - we only want translation, not variable replacement
                 app.logger.info(f"render_interaction: {run_script_info.block_position}")
+                llm_provider.set_usage_generated_block_bid(
+                    generated_block.generated_block_bid
+                )
 
                 interaction_result = mdflow_context.process(
                     block_index=run_script_info.block_position,
@@ -3108,6 +3131,9 @@ class RunScriptContextV2:
                         return
                 generated_block.type = BLOCK_TYPE_MDCONTENT_VALUE
                 _persist_generated_block_for_events(generated_block)
+                llm_provider.set_usage_generated_block_bid(
+                    generated_block.generated_block_bid
+                )
                 generated_content = ""
                 tts_processor = None
                 tts_enabled = bool(self._should_stream_tts())

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
@@ -348,6 +348,8 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
     if value is None:
         return None
     if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(timezone.utc).replace(tzinfo=None)
         return value
     if isinstance(value, str):
         normalized = value.strip()
@@ -363,7 +365,9 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
                 value,
             )
             return None
-        return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+        if parsed.tzinfo is not None:
+            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
     current_app.logger.warning(
         "Unexpected operator datetime value type '%s'",
         type(value).__name__,
@@ -600,7 +604,11 @@ def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
     )
 
 
-def _build_operator_course_credit_usage_base_query(shifu_bid: str):
+def _build_operator_course_credit_usage_base_query(
+    shifu_bid: str,
+    *,
+    outline_item_bids: Optional[Sequence[str]] = None,
+):
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -611,7 +619,7 @@ def _build_operator_course_credit_usage_base_query(shifu_bid: str):
         ledger_totals,
         ledger_totals.c.usage_bid == BillUsageRecord.usage_bid,
     )
-    return query.filter(
+    query = query.filter(
         BillUsageRecord.shifu_bid == shifu_bid,
         BillUsageRecord.deleted == 0,
         BillUsageRecord.billable == 1,
@@ -620,6 +628,16 @@ def _build_operator_course_credit_usage_base_query(shifu_bid: str):
         BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
         ledger_totals.c.ledger_amount < 0,
     )
+    if outline_item_bids is not None:
+        normalized_outline_item_bids = [
+            str(outline_item_bid or "").strip()
+            for outline_item_bid in outline_item_bids
+            if str(outline_item_bid or "").strip()
+        ]
+        query = query.filter(
+            BillUsageRecord.outline_item_bid.in_(normalized_outline_item_bids)
+        )
+    return query
 
 
 def _resolve_course_credit_usage_output_summary(
@@ -728,8 +746,7 @@ def _load_course_credit_usage_output_summary_map(
     if not generated_block_bids:
         return {}
 
-    element_summary_map: dict[str, str] = {}
-    element_count_map: dict[str, int] = {}
+    element_parts_map: dict[str, list[str]] = {}
     element_rows = (
         LearnGeneratedElement.query.filter(
             LearnGeneratedElement.generated_block_bid.in_(generated_block_bids),
@@ -747,7 +764,7 @@ def _load_course_credit_usage_output_summary_map(
             LearnGeneratedElement.run_event_seq.asc(),
             LearnGeneratedElement.id.asc(),
         )
-        .all()
+        .yield_per(100)
     )
     for element in element_rows:
         generated_block_bid = str(
@@ -755,19 +772,18 @@ def _load_course_credit_usage_output_summary_map(
         ).strip()
         if not generated_block_bid:
             continue
-        if element_count_map.get(generated_block_bid, 0) >= 20:
+        parts = element_parts_map.setdefault(generated_block_bid, [])
+        if len(parts) >= 20:
             continue
         content = str(getattr(element, "content_text", "") or "").strip()
-        if not content:
-            continue
-        element_summary_map[generated_block_bid] = "\n".join(
-            part
-            for part in [element_summary_map.get(generated_block_bid, ""), content]
-            if part
-        )
-        element_count_map[generated_block_bid] = (
-            element_count_map.get(generated_block_bid, 0) + 1
-        )
+        if content:
+            parts.append(content)
+
+    element_summary_map = {
+        generated_block_bid: "\n".join(parts)
+        for generated_block_bid, parts in element_parts_map.items()
+        if parts
+    }
 
     missing_block_bids = [
         generated_block_bid
@@ -930,7 +946,10 @@ def _build_operator_course_credit_metrics(
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
 ) -> Dict[str, Any]:
-    base_query = _build_operator_course_credit_usage_base_query(shifu_bid)
+    base_query = _build_operator_course_credit_usage_base_query(
+        shifu_bid,
+        outline_item_bids=leaf_outline_bids,
+    )
     usage_rows = base_query.subquery("operator_course_credit_metric_usages")
     aggregate_row = db.session.query(
         db.func.coalesce(
@@ -5286,16 +5305,11 @@ def get_operator_course_credit_usages(
         )
         filters = filters or {}
 
-        detail_source = _load_operator_course_detail_source(normalized_shifu_bid)
-        outline_items = (
-            _load_latest_outline_items(
-                detail_source["outline_model"],
-                normalized_shifu_bid,
-            )
-            if detail_source is not None
-            else []
+        _detail_source, outline_items = _load_operator_course_outline_items(
+            normalized_shifu_bid
         )
         outline_context_map = _build_course_outline_context_map(outline_items)
+        visible_leaf_outline_bids = _resolve_visible_leaf_outline_bids(outline_items)
 
         mode_filter = _resolve_course_credit_usage_mode_filter(
             str(filters.get("mode", "") or "")
@@ -5307,7 +5321,10 @@ def get_operator_course_credit_usages(
         if str(filters.get("view", "") or "").strip() and not view:
             raise_param_error("view")
 
-        query = _build_operator_course_credit_usage_base_query(normalized_shifu_bid)
+        query = _build_operator_course_credit_usage_base_query(
+            normalized_shifu_bid,
+            outline_item_bids=visible_leaf_outline_bids,
+        )
         query = _apply_course_credit_usage_filters(query, filters)
 
         if view == COURSE_CREDIT_USAGE_VIEW_RAW:
@@ -5378,37 +5395,30 @@ def get_operator_course_credit_usages(
             ),
             else_=COURSE_CREDIT_USAGE_MODE_LEARN,
         ).label("usage_mode")
-        group_key_expr = (
-            usage_rows.c.user_bid
-            + literal(":")
-            + usage_rows.c.outline_item_bid
-            + literal(":")
-            + usage_mode_expr
+        group_key_expr = db.func.concat(
+            usage_rows.c.user_bid,
+            literal(":"),
+            usage_rows.c.outline_item_bid,
+            literal(":"),
+            usage_mode_expr,
         ).label("group_key")
 
         grouped_query = (
             db.session.query(
-                db.func.max(group_key_expr).label("group_key"),
-                db.func.max(usage_rows.c.usage_bid).label("usage_bid"),
-                db.func.max(usage_rows.c.progress_record_bid).label(
-                    "progress_record_bid"
-                ),
-                db.func.max(usage_rows.c.generated_block_bid).label(
-                    "generated_block_bid"
-                ),
+                group_key_expr,
                 usage_rows.c.user_bid.label("user_bid"),
                 usage_rows.c.outline_item_bid.label("outline_item_bid"),
                 usage_mode_expr,
-                db.func.max(usage_rows.c.provider).label("provider"),
-                db.func.max(usage_rows.c.model).label("model"),
                 db.func.count(db.func.distinct(usage_rows.c.usage_bid)).label(
                     "usage_count"
                 ),
                 db.func.count(
                     db.func.distinct(
-                        db.func.coalesce(usage_rows.c.provider, "")
-                        + literal("/")
-                        + db.func.coalesce(usage_rows.c.model, "")
+                        db.func.concat(
+                            db.func.coalesce(usage_rows.c.provider, ""),
+                            literal("/"),
+                            db.func.coalesce(usage_rows.c.model, ""),
+                        )
                     )
                 ).label("model_variant_count"),
                 db.func.coalesce(
@@ -5423,14 +5433,56 @@ def get_operator_course_credit_usages(
                 usage_mode_expr,
             )
         )
+        latest_usage_query = db.session.query(
+            group_key_expr,
+            usage_rows.c.usage_bid.label("usage_bid"),
+            usage_rows.c.progress_record_bid.label("progress_record_bid"),
+            usage_rows.c.generated_block_bid.label("generated_block_bid"),
+            usage_rows.c.provider.label("provider"),
+            usage_rows.c.model.label("model"),
+            db.func.row_number()
+            .over(
+                partition_by=[
+                    usage_rows.c.user_bid,
+                    usage_rows.c.outline_item_bid,
+                    usage_mode_expr,
+                ],
+                order_by=[usage_rows.c.created_at.desc(), usage_rows.c.id.desc()],
+            )
+            .label("row_number"),
+        ).select_from(usage_rows)
 
         grouped_subquery = grouped_query.subquery("operator_course_credit_usage_groups")
+        latest_usage_subquery = latest_usage_query.subquery(
+            "operator_course_credit_usage_latest_rows"
+        )
         total = (
             db.session.query(db.func.count()).select_from(grouped_subquery).scalar()
             or 0
         )
         grouped_rows = (
-            db.session.query(grouped_subquery)
+            db.session.query(
+                grouped_subquery.c.group_key,
+                latest_usage_subquery.c.usage_bid,
+                latest_usage_subquery.c.progress_record_bid,
+                latest_usage_subquery.c.generated_block_bid,
+                grouped_subquery.c.user_bid,
+                grouped_subquery.c.outline_item_bid,
+                grouped_subquery.c.usage_mode,
+                latest_usage_subquery.c.provider,
+                latest_usage_subquery.c.model,
+                grouped_subquery.c.usage_count,
+                grouped_subquery.c.model_variant_count,
+                grouped_subquery.c.consumed_credits,
+                grouped_subquery.c.created_at,
+            )
+            .join(
+                latest_usage_subquery,
+                and_(
+                    latest_usage_subquery.c.group_key == grouped_subquery.c.group_key,
+                    latest_usage_subquery.c.row_number == 1,
+                ),
+            )
             .order_by(
                 grouped_subquery.c.created_at.desc(), grouped_subquery.c.group_key.asc()
             )
@@ -5541,7 +5593,14 @@ def get_operator_course_credit_usage_details(
         if str(filters.get("mode", "") or "").strip() and not mode_filter:
             raise_param_error("mode")
 
-        query = _build_operator_course_credit_usage_base_query(normalized_shifu_bid)
+        _detail_source, outline_items = _load_operator_course_outline_items(
+            normalized_shifu_bid
+        )
+        visible_leaf_outline_bids = _resolve_visible_leaf_outline_bids(outline_items)
+        query = _build_operator_course_credit_usage_base_query(
+            normalized_shifu_bid,
+            outline_item_bids=visible_leaf_outline_bids,
+        )
         query = query.filter(
             BillUsageRecord.user_bid == user_bid,
             BillUsageRecord.outline_item_bid == outline_item_bid,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -746,10 +746,26 @@ def _load_course_credit_usage_output_summary_map(
     if not generated_block_bids:
         return {}
 
-    element_parts_map: dict[str, list[str]] = {}
+    def context_key(row: Any) -> tuple[str, str, str, str]:
+        return (
+            str(getattr(row, "generated_block_bid", "") or "").strip(),
+            str(getattr(row, "shifu_bid", "") or "").strip(),
+            str(getattr(row, "user_bid", "") or "").strip(),
+            str(getattr(row, "outline_item_bid", "") or "").strip(),
+        )
+
+    usage_context_keys = {context_key(usage_row) for usage_row in normalized_rows}
+    shifu_bids = sorted({key[1] for key in usage_context_keys if key[1]})
+    user_bids = sorted({key[2] for key in usage_context_keys if key[2]})
+    outline_item_bids = sorted({key[3] for key in usage_context_keys if key[3]})
+
+    element_parts_map: dict[tuple[str, str, str, str], list[str]] = {}
     element_rows = (
         LearnGeneratedElement.query.filter(
             LearnGeneratedElement.generated_block_bid.in_(generated_block_bids),
+            LearnGeneratedElement.shifu_bid.in_(shifu_bids),
+            LearnGeneratedElement.user_bid.in_(user_bids),
+            LearnGeneratedElement.outline_item_bid.in_(outline_item_bids),
             LearnGeneratedElement.event_type == "element",
             LearnGeneratedElement.role == "teacher",
             LearnGeneratedElement.is_final == 1,
@@ -772,7 +788,10 @@ def _load_course_credit_usage_output_summary_map(
         ).strip()
         if not generated_block_bid:
             continue
-        parts = element_parts_map.setdefault(generated_block_bid, [])
+        key = context_key(element)
+        if key not in usage_context_keys:
+            continue
+        parts = element_parts_map.setdefault(key, [])
         if len(parts) >= 20:
             continue
         content = str(getattr(element, "content_text", "") or "").strip()
@@ -780,21 +799,22 @@ def _load_course_credit_usage_output_summary_map(
             parts.append(content)
 
     element_summary_map = {
-        generated_block_bid: "\n".join(parts)
-        for generated_block_bid, parts in element_parts_map.items()
-        if parts
+        key: "\n".join(parts) for key, parts in element_parts_map.items() if parts
     }
 
-    missing_block_bids = [
-        generated_block_bid
-        for generated_block_bid in generated_block_bids
-        if not element_summary_map.get(generated_block_bid)
+    missing_context_keys = [
+        key for key in usage_context_keys if not element_summary_map.get(key)
     ]
-    block_summary_map: dict[str, str] = {}
+    missing_context_key_set = set(missing_context_keys)
+    missing_block_bids = sorted({key[0] for key in missing_context_keys if key[0]})
+    block_summary_map: dict[tuple[str, str, str, str], str] = {}
     if missing_block_bids:
         block_rows = (
             LearnGeneratedBlock.query.filter(
                 LearnGeneratedBlock.generated_block_bid.in_(missing_block_bids),
+                LearnGeneratedBlock.shifu_bid.in_(shifu_bids),
+                LearnGeneratedBlock.user_bid.in_(user_bids),
+                LearnGeneratedBlock.outline_item_bid.in_(outline_item_bids),
                 LearnGeneratedBlock.deleted == 0,
                 LearnGeneratedBlock.status == 1,
                 LearnGeneratedBlock.type.in_(
@@ -815,16 +835,21 @@ def _load_course_credit_usage_output_summary_map(
             generated_block_bid = str(
                 getattr(block, "generated_block_bid", "") or ""
             ).strip()
-            if not generated_block_bid or generated_block_bid in block_summary_map:
+            key = context_key(block)
+            if (
+                not generated_block_bid
+                or key not in missing_context_key_set
+                or key in block_summary_map
+            ):
                 continue
             generated_content = str(
                 getattr(block, "generated_content", "") or ""
             ).strip()
             if generated_content:
-                block_summary_map[generated_block_bid] = generated_content
+                block_summary_map[key] = generated_content
                 continue
             if int(getattr(block, "type", 0) or 0) == BLOCK_TYPE_MDINTERACTION_VALUE:
-                block_summary_map[generated_block_bid] = str(
+                block_summary_map[key] = str(
                     getattr(block, "block_content_conf", "") or ""
                 ).strip()
 
@@ -834,9 +859,8 @@ def _load_course_credit_usage_output_summary_map(
         generated_block_bid = str(
             getattr(usage_row, "generated_block_bid", "") or ""
         ).strip()
-        summary = element_summary_map.get(generated_block_bid) or block_summary_map.get(
-            generated_block_bid, ""
-        )
+        key = context_key(usage_row)
+        summary = element_summary_map.get(key) or block_summary_map.get(key, "")
         if summary:
             summary_by_usage_bid[usage_bid] = summary
 
@@ -916,20 +940,44 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     if not normalized_leaf_outline_bids:
         return None
 
-    completed_lesson_counts = (
+    latest_progress_rows = (
         db.session.query(
             LearnProgressRecord.user_bid.label("user_bid"),
-            db.func.count(db.func.distinct(LearnProgressRecord.outline_item_bid)).label(
-                "learned_lesson_count"
-            ),
+            LearnProgressRecord.outline_item_bid.label("outline_item_bid"),
+            LearnProgressRecord.status.label("status"),
+            db.func.row_number()
+            .over(
+                partition_by=[
+                    LearnProgressRecord.user_bid,
+                    LearnProgressRecord.outline_item_bid,
+                ],
+                order_by=[
+                    LearnProgressRecord.updated_at.desc(),
+                    LearnProgressRecord.id.desc(),
+                ],
+            )
+            .label("row_index"),
         )
         .filter(
             LearnProgressRecord.shifu_bid == shifu_bid,
             LearnProgressRecord.outline_item_bid.in_(normalized_leaf_outline_bids),
             LearnProgressRecord.deleted == 0,
-            LearnProgressRecord.status != LEARN_STATUS_RESET,
         )
-        .group_by(LearnProgressRecord.user_bid)
+        .subquery()
+    )
+
+    completed_lesson_counts = (
+        db.session.query(
+            latest_progress_rows.c.user_bid.label("user_bid"),
+            db.func.count(
+                db.func.distinct(latest_progress_rows.c.outline_item_bid)
+            ).label("learned_lesson_count"),
+        )
+        .filter(
+            latest_progress_rows.c.row_index == 1,
+            latest_progress_rows.c.status == LEARN_STATUS_COMPLETED,
+        )
+        .group_by(latest_progress_rows.c.user_bid)
         .subquery()
     )
     return (

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -90,6 +90,8 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseDetailBasicInfoDTO,
     AdminOperationCourseDetailChapterDTO,
     AdminOperationCourseDetailDTO,
+    AdminOperationCourseCreditUsageDetailItemDTO,
+    AdminOperationCourseCreditUsageDetailListDTO,
     AdminOperationCourseCreditUsageItemDTO,
     AdminOperationCourseCreditUsageListDTO,
     AdminOperationCourseFollowUpCurrentRecordDTO,
@@ -342,12 +344,40 @@ def _format_decimal(value: Optional[Decimal]) -> str:
     return normalized
 
 
-def _format_operator_datetime(value: Optional[datetime]) -> str:
-    if not value:
+def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            current_app.logger.warning(
+                "Failed to parse operator datetime value '%s'",
+                value,
+            )
+            return None
+        return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+    current_app.logger.warning(
+        "Unexpected operator datetime value type '%s'",
+        type(value).__name__,
+    )
+    return None
+
+
+def _format_operator_datetime(value: Any) -> str:
+    normalized_value = _coerce_operator_datetime(value)
+    if not normalized_value:
         return ""
     serialized_value = serialize_with_app_timezone(
         current_app._get_current_object(),
-        value,
+        normalized_value,
         tz_name="UTC",
     )
     return str(serialized_value or "").replace("+00:00", "Z")
@@ -536,6 +566,433 @@ def _build_course_credit_usage_learn_filter(
         generation_name == "",
         not_(_build_course_credit_usage_ask_filter(generation_name)),
     )
+
+
+def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
+    course_usage_bids = (
+        db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
+        .filter(
+            BillUsageRecord.shifu_bid == shifu_bid,
+            BillUsageRecord.deleted == 0,
+            BillUsageRecord.billable == 1,
+            BillUsageRecord.status == 0,
+            BillUsageRecord.record_level == 0,
+            BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
+        )
+        .subquery()
+    )
+    return (
+        db.session.query(
+            CreditLedgerEntry.source_bid.label("usage_bid"),
+            db.func.sum(CreditLedgerEntry.amount).label("ledger_amount"),
+        )
+        .join(
+            course_usage_bids,
+            course_usage_bids.c.usage_bid == CreditLedgerEntry.source_bid,
+        )
+        .filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
+            CreditLedgerEntry.source_type == CREDIT_SOURCE_TYPE_USAGE,
+        )
+        .group_by(CreditLedgerEntry.source_bid)
+        .subquery()
+    )
+
+
+def _build_operator_course_credit_usage_base_query(shifu_bid: str):
+    ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
+        shifu_bid
+    )
+    query = db.session.query(
+        BillUsageRecord,
+        ledger_totals.c.ledger_amount,
+    ).join(
+        ledger_totals,
+        ledger_totals.c.usage_bid == BillUsageRecord.usage_bid,
+    )
+    return query.filter(
+        BillUsageRecord.shifu_bid == shifu_bid,
+        BillUsageRecord.deleted == 0,
+        BillUsageRecord.billable == 1,
+        BillUsageRecord.status == 0,
+        BillUsageRecord.record_level == 0,
+        BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
+        ledger_totals.c.ledger_amount < 0,
+    )
+
+
+def _resolve_course_credit_usage_output_summary(
+    usage_row: BillUsageRecord,
+) -> str:
+    normalized_generated_block_bid = str(
+        getattr(usage_row, "generated_block_bid", "") or ""
+    ).strip()
+    shifu_bid = str(getattr(usage_row, "shifu_bid", "") or "")
+    user_bid = str(getattr(usage_row, "user_bid", "") or "")
+    outline_item_bid = str(getattr(usage_row, "outline_item_bid", "") or "")
+
+    def resolve_element_summary(generated_block_bid: str) -> str:
+        normalized_block_bid = str(generated_block_bid or "").strip()
+        if not normalized_block_bid:
+            return ""
+        element_rows = (
+            LearnGeneratedElement.query.filter(
+                LearnGeneratedElement.generated_block_bid == normalized_block_bid,
+                LearnGeneratedElement.shifu_bid == shifu_bid,
+                LearnGeneratedElement.user_bid == user_bid,
+                LearnGeneratedElement.outline_item_bid == outline_item_bid,
+                LearnGeneratedElement.event_type == "element",
+                LearnGeneratedElement.role == "teacher",
+                LearnGeneratedElement.is_final == 1,
+                LearnGeneratedElement.is_renderable == 1,
+                LearnGeneratedElement.deleted == 0,
+                LearnGeneratedElement.status == 1,
+                LearnGeneratedElement.content_text != "",
+            )
+            .order_by(
+                LearnGeneratedElement.sequence_number.asc(),
+                LearnGeneratedElement.run_event_seq.asc(),
+                LearnGeneratedElement.id.asc(),
+            )
+            .limit(20)
+            .all()
+        )
+        return "\n".join(
+            str(getattr(row, "content_text", "") or "").strip()
+            for row in element_rows
+            if str(getattr(row, "content_text", "") or "").strip()
+        ).strip()
+
+    def resolve_block_generated_content(generated_block_bid: str) -> str:
+        normalized_block_bid = str(generated_block_bid or "").strip()
+        if not normalized_block_bid:
+            return ""
+        block = (
+            LearnGeneratedBlock.query.filter(
+                LearnGeneratedBlock.generated_block_bid == normalized_block_bid,
+                LearnGeneratedBlock.shifu_bid == shifu_bid,
+                LearnGeneratedBlock.user_bid == user_bid,
+                LearnGeneratedBlock.outline_item_bid == outline_item_bid,
+                LearnGeneratedBlock.deleted == 0,
+                LearnGeneratedBlock.status == 1,
+                LearnGeneratedBlock.type.in_(
+                    [
+                        BLOCK_TYPE_MDANSWER_VALUE,
+                        BLOCK_TYPE_MDCONTENT_VALUE,
+                        BLOCK_TYPE_MDINTERACTION_VALUE,
+                    ]
+                ),
+            )
+            .order_by(LearnGeneratedBlock.id.desc())
+            .first()
+        )
+        if not block:
+            return ""
+        generated_content = str(getattr(block, "generated_content", "") or "").strip()
+        if generated_content:
+            return generated_content
+        if int(getattr(block, "type", 0) or 0) == BLOCK_TYPE_MDINTERACTION_VALUE:
+            return str(getattr(block, "block_content_conf", "") or "").strip()
+        return ""
+
+    if normalized_generated_block_bid:
+        exact_content = resolve_element_summary(
+            normalized_generated_block_bid
+        ) or resolve_block_generated_content(normalized_generated_block_bid)
+        if exact_content:
+            return exact_content
+
+    return ""
+
+
+def _load_course_credit_usage_output_summary_map(
+    usage_rows: Sequence[BillUsageRecord],
+) -> dict[str, str]:
+    normalized_rows = [
+        usage_row
+        for usage_row in usage_rows
+        if str(getattr(usage_row, "usage_bid", "") or "").strip()
+        and str(getattr(usage_row, "generated_block_bid", "") or "").strip()
+    ]
+    if not normalized_rows:
+        return {}
+
+    generated_block_bids = sorted(
+        {
+            str(getattr(usage_row, "generated_block_bid", "") or "").strip()
+            for usage_row in normalized_rows
+            if str(getattr(usage_row, "generated_block_bid", "") or "").strip()
+        }
+    )
+    if not generated_block_bids:
+        return {}
+
+    element_summary_map: dict[str, str] = {}
+    element_count_map: dict[str, int] = {}
+    element_rows = (
+        LearnGeneratedElement.query.filter(
+            LearnGeneratedElement.generated_block_bid.in_(generated_block_bids),
+            LearnGeneratedElement.event_type == "element",
+            LearnGeneratedElement.role == "teacher",
+            LearnGeneratedElement.is_final == 1,
+            LearnGeneratedElement.is_renderable == 1,
+            LearnGeneratedElement.deleted == 0,
+            LearnGeneratedElement.status == 1,
+            LearnGeneratedElement.content_text != "",
+        )
+        .order_by(
+            LearnGeneratedElement.generated_block_bid.asc(),
+            LearnGeneratedElement.sequence_number.asc(),
+            LearnGeneratedElement.run_event_seq.asc(),
+            LearnGeneratedElement.id.asc(),
+        )
+        .all()
+    )
+    for element in element_rows:
+        generated_block_bid = str(
+            getattr(element, "generated_block_bid", "") or ""
+        ).strip()
+        if not generated_block_bid:
+            continue
+        if element_count_map.get(generated_block_bid, 0) >= 20:
+            continue
+        content = str(getattr(element, "content_text", "") or "").strip()
+        if not content:
+            continue
+        element_summary_map[generated_block_bid] = "\n".join(
+            part
+            for part in [element_summary_map.get(generated_block_bid, ""), content]
+            if part
+        )
+        element_count_map[generated_block_bid] = (
+            element_count_map.get(generated_block_bid, 0) + 1
+        )
+
+    missing_block_bids = [
+        generated_block_bid
+        for generated_block_bid in generated_block_bids
+        if not element_summary_map.get(generated_block_bid)
+    ]
+    block_summary_map: dict[str, str] = {}
+    if missing_block_bids:
+        block_rows = (
+            LearnGeneratedBlock.query.filter(
+                LearnGeneratedBlock.generated_block_bid.in_(missing_block_bids),
+                LearnGeneratedBlock.deleted == 0,
+                LearnGeneratedBlock.status == 1,
+                LearnGeneratedBlock.type.in_(
+                    [
+                        BLOCK_TYPE_MDANSWER_VALUE,
+                        BLOCK_TYPE_MDCONTENT_VALUE,
+                        BLOCK_TYPE_MDINTERACTION_VALUE,
+                    ]
+                ),
+            )
+            .order_by(
+                LearnGeneratedBlock.generated_block_bid.asc(),
+                LearnGeneratedBlock.id.desc(),
+            )
+            .all()
+        )
+        for block in block_rows:
+            generated_block_bid = str(
+                getattr(block, "generated_block_bid", "") or ""
+            ).strip()
+            if not generated_block_bid or generated_block_bid in block_summary_map:
+                continue
+            generated_content = str(
+                getattr(block, "generated_content", "") or ""
+            ).strip()
+            if generated_content:
+                block_summary_map[generated_block_bid] = generated_content
+                continue
+            if int(getattr(block, "type", 0) or 0) == BLOCK_TYPE_MDINTERACTION_VALUE:
+                block_summary_map[generated_block_bid] = str(
+                    getattr(block, "block_content_conf", "") or ""
+                ).strip()
+
+    summary_by_usage_bid: dict[str, str] = {}
+    for usage_row in normalized_rows:
+        usage_bid = str(getattr(usage_row, "usage_bid", "") or "").strip()
+        generated_block_bid = str(
+            getattr(usage_row, "generated_block_bid", "") or ""
+        ).strip()
+        summary = element_summary_map.get(generated_block_bid) or block_summary_map.get(
+            generated_block_bid, ""
+        )
+        if summary:
+            summary_by_usage_bid[usage_bid] = summary
+
+    return summary_by_usage_bid
+
+
+def _build_operator_course_credit_usage_detail_item(
+    usage_row: BillUsageRecord,
+    ledger_amount: Any,
+    output_summary: Optional[str] = None,
+) -> AdminOperationCourseCreditUsageDetailItemDTO:
+    return AdminOperationCourseCreditUsageDetailItemDTO(
+        usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
+        consumed_credits=credit_decimal_to_number(
+            abs(Decimal(str(ledger_amount or 0)))
+        ),
+        input_tokens=int(getattr(usage_row, "input", 0) or 0),
+        output_tokens=int(getattr(usage_row, "output", 0) or 0),
+        word_count=int(getattr(usage_row, "word_count", 0) or 0),
+        duration_ms=int(getattr(usage_row, "duration_ms", 0) or 0),
+        segment_count=int(getattr(usage_row, "segment_count", 0) or 0),
+        output_summary=(
+            output_summary
+            if output_summary is not None
+            else _resolve_course_credit_usage_output_summary(usage_row)
+        ),
+        created_at=_format_operator_datetime(getattr(usage_row, "created_at", None)),
+    )
+
+
+def _apply_course_credit_usage_filters(query: Any, filters: dict) -> Any:
+    keyword = str(filters.get("keyword", "") or "").strip()
+    mode_filter = _resolve_course_credit_usage_mode_filter(
+        str(filters.get("mode", "") or "")
+    )
+    start_time = filters.get("start_time")
+    end_time = filters.get("end_time")
+
+    user_keyword_filter = _build_credit_usage_user_keyword_filter(
+        BillUsageRecord.user_bid,
+        keyword,
+    )
+    if user_keyword_filter is not None:
+        query = query.filter(user_keyword_filter)
+    if start_time:
+        query = query.filter(BillUsageRecord.created_at >= start_time)
+    if end_time:
+        query = query.filter(BillUsageRecord.created_at <= end_time)
+
+    generation_name_expr = _build_course_credit_usage_generation_name_expr()
+    if mode_filter == COURSE_CREDIT_USAGE_MODE_LISTEN:
+        query = query.filter(BillUsageRecord.usage_type == BILL_USAGE_TYPE_TTS)
+    elif mode_filter == COURSE_CREDIT_USAGE_MODE_ASK:
+        query = query.filter(
+            BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
+            _build_course_credit_usage_ask_filter(generation_name_expr),
+        )
+    elif mode_filter == COURSE_CREDIT_USAGE_MODE_LEARN:
+        query = query.filter(
+            BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
+            _build_course_credit_usage_learn_filter(generation_name_expr),
+        )
+
+    return query
+
+
+def _build_course_credit_usage_covered_completed_user_subquery(
+    *,
+    shifu_bid: str,
+    leaf_outline_bids: Sequence[str],
+):
+    normalized_leaf_outline_bids = [
+        str(outline_item_bid or "").strip()
+        for outline_item_bid in leaf_outline_bids
+        if str(outline_item_bid or "").strip()
+    ]
+    if not normalized_leaf_outline_bids:
+        return None
+
+    completed_lesson_counts = (
+        db.session.query(
+            LearnProgressRecord.user_bid.label("user_bid"),
+            db.func.count(
+                db.func.distinct(LearnProgressRecord.outline_item_bid)
+            ).label("learned_lesson_count"),
+        )
+        .filter(
+            LearnProgressRecord.shifu_bid == shifu_bid,
+            LearnProgressRecord.outline_item_bid.in_(normalized_leaf_outline_bids),
+            LearnProgressRecord.deleted == 0,
+            LearnProgressRecord.status != LEARN_STATUS_RESET,
+        )
+        .group_by(LearnProgressRecord.user_bid)
+        .subquery()
+    )
+    return (
+        db.session.query(completed_lesson_counts.c.user_bid.label("user_bid"))
+        .filter(
+            completed_lesson_counts.c.learned_lesson_count
+            >= len(normalized_leaf_outline_bids)
+        )
+        .subquery()
+    )
+
+
+def _build_operator_course_credit_metrics(
+    shifu_bid: str,
+    leaf_outline_bids: Sequence[str],
+) -> Dict[str, Any]:
+    base_query = _build_operator_course_credit_usage_base_query(shifu_bid)
+    usage_rows = base_query.subquery("operator_course_credit_metric_usages")
+    aggregate_row = db.session.query(
+        db.func.coalesce(
+            db.func.sum(db.func.abs(usage_rows.c.ledger_amount)),
+            0,
+        ).label("credit_consumed_total"),
+        db.func.count(db.func.distinct(usage_rows.c.usage_bid)).label(
+            "credit_usage_count"
+        ),
+        db.func.count(db.func.distinct(usage_rows.c.user_bid)).label(
+            "credit_user_count"
+        ),
+    ).one()
+
+    completed_user_subquery = _build_course_credit_usage_covered_completed_user_subquery(
+        shifu_bid=shifu_bid,
+        leaf_outline_bids=leaf_outline_bids,
+    )
+    completed_credit_user_count = 0
+    completed_credit_total = Decimal("0")
+    if completed_user_subquery is not None:
+        completed_row = (
+            db.session.query(
+                db.func.count(db.func.distinct(usage_rows.c.user_bid)).label(
+                    "completed_credit_user_count"
+                ),
+                db.func.coalesce(
+                    db.func.sum(db.func.abs(usage_rows.c.ledger_amount)),
+                    0,
+                ).label("completed_credit_total"),
+            )
+            .select_from(usage_rows)
+            .join(
+                completed_user_subquery,
+                completed_user_subquery.c.user_bid == usage_rows.c.user_bid,
+            )
+            .one()
+        )
+        completed_credit_user_count = int(
+            getattr(completed_row, "completed_credit_user_count", 0) or 0
+        )
+        completed_credit_total = Decimal(
+            str(getattr(completed_row, "completed_credit_total", 0) or 0)
+        )
+
+    completed_user_avg_credits = None
+    if completed_credit_user_count > 0:
+        completed_user_avg_credits = credit_decimal_to_number(
+            completed_credit_total / Decimal(completed_credit_user_count)
+        )
+
+    return {
+        "credit_consumed_total": credit_decimal_to_number(
+            abs(Decimal(str(getattr(aggregate_row, "credit_consumed_total", 0) or 0)))
+        ),
+        "credit_usage_count": int(
+            getattr(aggregate_row, "credit_usage_count", 0) or 0
+        ),
+        "credit_user_count": int(getattr(aggregate_row, "credit_user_count", 0) or 0),
+        "completed_credit_user_count": completed_credit_user_count,
+        "completed_user_avg_credits": completed_user_avg_credits,
+    }
 
 
 def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
@@ -4387,14 +4844,15 @@ def _load_course_user_joined_at_map(
 
     joined_at_map: Dict[str, datetime] = {}
 
-    def _merge_rows(rows: Sequence[tuple[str, Optional[datetime]]]) -> None:
+    def _merge_rows(rows: Sequence[tuple[str, Any]]) -> None:
         for user_bid, joined_at in rows:
             normalized_user_bid = str(user_bid or "").strip()
-            if not normalized_user_bid or not joined_at:
+            normalized_joined_at = _coerce_operator_datetime(joined_at)
+            if not normalized_user_bid or normalized_joined_at is None:
                 continue
             current = joined_at_map.get(normalized_user_bid)
-            if current is None or joined_at < current:
-                joined_at_map[normalized_user_bid] = joined_at
+            if current is None or normalized_joined_at < current:
+                joined_at_map[normalized_user_bid] = normalized_joined_at
 
     _merge_rows(
         db.session.query(
@@ -4441,10 +4899,11 @@ def _load_course_user_joined_at_map(
     )
 
     normalized_creator_user_bid = str(creator_user_bid or "").strip()
-    if normalized_creator_user_bid and course_created_at:
+    normalized_course_created_at = _coerce_operator_datetime(course_created_at)
+    if normalized_creator_user_bid and normalized_course_created_at:
         current = joined_at_map.get(normalized_creator_user_bid)
-        if current is None or course_created_at < current:
-            joined_at_map[normalized_creator_user_bid] = course_created_at
+        if current is None or normalized_course_created_at < current:
+            joined_at_map[normalized_creator_user_bid] = normalized_course_created_at
 
     return joined_at_map
 
@@ -4573,6 +5032,11 @@ def get_operator_course_detail(
             ],
         )
         follow_up_count_map, rating_count_map, rating_score_map = outline_learning_stats
+        visible_leaf_outline_bids = _resolve_visible_leaf_outline_bids(outline_items)
+        credit_metrics = _build_operator_course_credit_metrics(
+            normalized_shifu_bid,
+            visible_leaf_outline_bids,
+        )
 
         return AdminOperationCourseDetailDTO(
             basic_info=AdminOperationCourseDetailBasicInfoDTO(
@@ -4595,6 +5059,15 @@ def get_operator_course_detail(
                 ),
                 follow_up_count=int(follow_up_count),
                 rating_score=_format_average_score(rating_score),
+                credit_consumed_total=credit_metrics["credit_consumed_total"],
+                credit_usage_count=credit_metrics["credit_usage_count"],
+                credit_user_count=credit_metrics["credit_user_count"],
+                completed_credit_user_count=credit_metrics[
+                    "completed_credit_user_count"
+                ],
+                completed_user_avg_credits=credit_metrics[
+                    "completed_user_avg_credits"
+                ],
             ),
             chapters=_build_chapter_tree(
                 outline_items,
@@ -4815,235 +5288,252 @@ def get_operator_course_credit_usages(
         )
         filters = filters or {}
 
-        _detail_source, outline_items = _load_operator_course_outline_items(
-            normalized_shifu_bid
+        detail_source = _load_operator_course_detail_source(normalized_shifu_bid)
+        outline_items = (
+            _load_latest_outline_items(
+                detail_source["outline_model"],
+                normalized_shifu_bid,
+            )
+            if detail_source is not None
+            else []
         )
         outline_context_map = _build_course_outline_context_map(outline_items)
 
-        keyword = str(filters.get("keyword", "") or "").strip()
         mode_filter = _resolve_course_credit_usage_mode_filter(
             str(filters.get("mode", "") or "")
         )
         view = _resolve_course_credit_usage_view(str(filters.get("view", "") or ""))
-        start_time = filters.get("start_time")
-        end_time = filters.get("end_time")
 
         if str(filters.get("mode", "") or "").strip() and not mode_filter:
             raise_param_error("mode")
         if str(filters.get("view", "") or "").strip() and not view:
             raise_param_error("view")
 
-        # Limit ledger aggregation to this course's production usage rows first.
-        course_credit_usage_bids = (
-            db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
-            .filter(
-                BillUsageRecord.shifu_bid == normalized_shifu_bid,
-                BillUsageRecord.deleted == 0,
-                BillUsageRecord.billable == 1,
-                BillUsageRecord.status == 0,
-                BillUsageRecord.record_level == 0,
-                BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
-            )
-            .subquery()
-        )
+        query = _build_operator_course_credit_usage_base_query(normalized_shifu_bid)
+        query = _apply_course_credit_usage_filters(query, filters)
 
-        credit_usage_ledger_totals = (
-            db.session.query(
-                CreditLedgerEntry.source_bid.label("usage_bid"),
-                db.func.sum(CreditLedgerEntry.amount).label("ledger_amount"),
+        if view == COURSE_CREDIT_USAGE_VIEW_RAW:
+            total = query.count()
+            rows = (
+                query.order_by(BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc())
+                .offset((safe_page_index - 1) * safe_page_size)
+                .limit(safe_page_size)
+                .all()
             )
-            .join(
-                course_credit_usage_bids,
-                course_credit_usage_bids.c.usage_bid == CreditLedgerEntry.source_bid,
-            )
-            .filter(
-                CreditLedgerEntry.deleted == 0,
-                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
-                CreditLedgerEntry.source_type == CREDIT_SOURCE_TYPE_USAGE,
-            )
-            .group_by(CreditLedgerEntry.source_bid)
-            .subquery()
-        )
-
-        query = db.session.query(
-            BillUsageRecord,
-            credit_usage_ledger_totals.c.ledger_amount,
-        ).join(
-            credit_usage_ledger_totals,
-            credit_usage_ledger_totals.c.usage_bid == BillUsageRecord.usage_bid,
-        )
-
-        query = query.filter(
-            BillUsageRecord.shifu_bid == normalized_shifu_bid,
-            BillUsageRecord.deleted == 0,
-            BillUsageRecord.billable == 1,
-            BillUsageRecord.status == 0,
-            BillUsageRecord.record_level == 0,
-            BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD,
-            credit_usage_ledger_totals.c.ledger_amount < 0,
-        )
-
-        user_keyword_filter = _build_credit_usage_user_keyword_filter(
-            BillUsageRecord.user_bid,
-            keyword,
-        )
-        if user_keyword_filter is not None:
-            query = query.filter(user_keyword_filter)
-        if start_time:
-            query = query.filter(BillUsageRecord.created_at >= start_time)
-        if end_time:
-            query = query.filter(BillUsageRecord.created_at <= end_time)
-
-        generation_name_expr = _build_course_credit_usage_generation_name_expr()
-        if mode_filter == COURSE_CREDIT_USAGE_MODE_LISTEN:
-            query = query.filter(BillUsageRecord.usage_type == BILL_USAGE_TYPE_TTS)
-        elif mode_filter == COURSE_CREDIT_USAGE_MODE_ASK:
-            query = query.filter(
-                BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
-                _build_course_credit_usage_ask_filter(generation_name_expr),
-            )
-        elif mode_filter == COURSE_CREDIT_USAGE_MODE_LEARN:
-            query = query.filter(
-                BillUsageRecord.usage_type != BILL_USAGE_TYPE_TTS,
-                _build_course_credit_usage_learn_filter(generation_name_expr),
-            )
-
-        rows = query.order_by(
-            BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc()
-        ).all()
-
-        if not rows:
-            return AdminOperationCourseCreditUsageListDTO(
-                view=view or COURSE_CREDIT_USAGE_VIEW_GROUPED,
-                items=[],
-                page=safe_page_index,
-                page_size=safe_page_size,
-                total=0,
-                page_count=0,
-            )
-
-        user_map = _load_user_map(
-            sorted(
-                {
-                    str(getattr(usage_row, "user_bid", "") or "").strip()
-                    for usage_row, _ledger_amount in rows
-                    if str(getattr(usage_row, "user_bid", "") or "").strip()
-                }
-            )
-        )
-
-        raw_items: list[AdminOperationCourseCreditUsageItemDTO] = []
-        for usage_row, ledger_amount in rows:
-            model_display = _build_course_credit_usage_model_display(
-                str(getattr(usage_row, "provider", "") or ""),
-                str(getattr(usage_row, "model", "") or ""),
-            )
-            raw_items.append(
-                _build_operator_course_credit_usage_item(
-                    usage_row=usage_row,
-                    ledger_amount=ledger_amount,
-                    user_map=user_map,
-                    outline_context_map=outline_context_map,
-                    group_key=str(getattr(usage_row, "usage_bid", "") or ""),
-                    usage_count=1,
-                    usage_mode=_resolve_course_credit_usage_mode(usage_row),
-                    model_variant_count=1 if model_display else 0,
+            user_map = _load_user_map(
+                sorted(
+                    {
+                        str(getattr(usage_row, "user_bid", "") or "").strip()
+                        for usage_row, _ledger_amount in rows
+                        if str(getattr(usage_row, "user_bid", "") or "").strip()
+                    }
                 )
             )
-        if view == COURSE_CREDIT_USAGE_VIEW_RAW:
-            total = len(raw_items)
-            start = (safe_page_index - 1) * safe_page_size
-            paged_items = raw_items[start : start + safe_page_size]
+            raw_items: list[AdminOperationCourseCreditUsageItemDTO] = []
+            for usage_row, ledger_amount in rows:
+                model_display = _build_course_credit_usage_model_display(
+                    str(getattr(usage_row, "provider", "") or ""),
+                    str(getattr(usage_row, "model", "") or ""),
+                )
+                raw_items.append(
+                    _build_operator_course_credit_usage_item(
+                        usage_row=usage_row,
+                        ledger_amount=ledger_amount,
+                        user_map=user_map,
+                        outline_context_map=outline_context_map,
+                        group_key=str(getattr(usage_row, "usage_bid", "") or ""),
+                        usage_count=1,
+                        usage_mode=_resolve_course_credit_usage_mode(usage_row),
+                        model_variant_count=1 if model_display else 0,
+                    )
+                )
             return AdminOperationCourseCreditUsageListDTO(
                 view=COURSE_CREDIT_USAGE_VIEW_RAW,
-                items=paged_items,
+                items=raw_items,
                 page=safe_page_index,
                 page_size=safe_page_size,
                 total=total,
                 page_count=math.ceil(total / safe_page_size) if safe_page_size else 0,
             )
 
-        grouped_payloads: Dict[str, Dict[str, Any]] = {}
-        grouped_order: list[str] = []
-        for item in raw_items:
-            progress_record_bid = str(item.progress_record_bid or "").strip()
-            usage_mode = str(item.usage_mode or "").strip()
-            group_key = _build_course_credit_usage_group_key(
-                progress_record_bid=progress_record_bid,
-                usage_mode=usage_mode,
-                usage_bid=str(item.usage_bid or "").strip(),
-            )
-            if not group_key:
-                continue
+        usage_rows = query.subquery("operator_course_credit_usage_filtered")
+        generation_name_expr = db.func.lower(usage_rows.c.extra["generation_name"].as_string())
+        usage_mode_expr = case(
+            (usage_rows.c.usage_type == BILL_USAGE_TYPE_TTS, COURSE_CREDIT_USAGE_MODE_LISTEN),
+            (
+                and_(
+                    usage_rows.c.usage_type != BILL_USAGE_TYPE_TTS,
+                    or_(
+                        generation_name_expr.contains("/user_follow_ask/"),
+                        generation_name_expr.startswith("lesson_ask/"),
+                        generation_name_expr.startswith("lesson_preview_ask/"),
+                    ),
+                ),
+                COURSE_CREDIT_USAGE_MODE_ASK,
+            ),
+            else_=COURSE_CREDIT_USAGE_MODE_LEARN,
+        ).label("usage_mode")
+        group_key_expr = (
+            usage_rows.c.user_bid
+            + literal(":")
+            + usage_rows.c.outline_item_bid
+            + literal(":")
+            + usage_mode_expr
+        ).label("group_key")
 
-            payload = grouped_payloads.get(group_key)
-            if payload is None:
-                model_entries: Dict[str, tuple[str, str]] = {}
-                model_display = _build_course_credit_usage_model_display(
-                    item.provider,
-                    item.model,
+        grouped_query = db.session.query(
+            db.func.max(group_key_expr).label("group_key"),
+            db.func.max(usage_rows.c.usage_bid).label("usage_bid"),
+            db.func.max(usage_rows.c.progress_record_bid).label("progress_record_bid"),
+            db.func.max(usage_rows.c.generated_block_bid).label("generated_block_bid"),
+            usage_rows.c.user_bid.label("user_bid"),
+            usage_rows.c.outline_item_bid.label("outline_item_bid"),
+            usage_mode_expr,
+            db.func.max(usage_rows.c.provider).label("provider"),
+            db.func.max(usage_rows.c.model).label("model"),
+            db.func.count(db.func.distinct(usage_rows.c.usage_bid)).label("usage_count"),
+            db.func.count(
+                db.func.distinct(
+                    db.func.coalesce(usage_rows.c.provider, "")
+                    + literal("/")
+                    + db.func.coalesce(usage_rows.c.model, "")
                 )
-                if model_display:
-                    model_entries[model_display] = (item.provider, item.model)
-                grouped_payloads[group_key] = {
-                    "base_item": item,
-                    "usage_count": 1,
-                    "consumed_credits": Decimal(str(item.consumed_credits or 0)),
-                    "model_entries": model_entries,
-                }
-                grouped_order.append(group_key)
-                continue
+            ).label("model_variant_count"),
+            db.func.coalesce(db.func.sum(db.func.abs(usage_rows.c.ledger_amount)), 0).label(
+                "consumed_credits"
+            ),
+            db.func.max(usage_rows.c.created_at).label("created_at"),
+        ).select_from(usage_rows).group_by(
+            usage_rows.c.user_bid,
+            usage_rows.c.outline_item_bid,
+            usage_mode_expr,
+        )
 
-            payload["usage_count"] += 1
-            payload["consumed_credits"] += Decimal(str(item.consumed_credits or 0))
-            model_display = _build_course_credit_usage_model_display(
-                item.provider,
-                item.model,
+        grouped_subquery = grouped_query.subquery("operator_course_credit_usage_groups")
+        total = db.session.query(db.func.count()).select_from(grouped_subquery).scalar() or 0
+        grouped_rows = (
+            db.session.query(grouped_subquery)
+            .order_by(grouped_subquery.c.created_at.desc(), grouped_subquery.c.group_key.asc())
+            .offset((safe_page_index - 1) * safe_page_size)
+            .limit(safe_page_size)
+            .all()
+        )
+        user_map = _load_user_map(
+            sorted(
+                {
+                    str(getattr(row, "user_bid", "") or "").strip()
+                    for row in grouped_rows
+                    if str(getattr(row, "user_bid", "") or "").strip()
+                }
             )
-            if model_display and model_display not in payload["model_entries"]:
-                payload["model_entries"][model_display] = (item.provider, item.model)
+        )
 
         grouped_items: list[AdminOperationCourseCreditUsageItemDTO] = []
-        for group_key in grouped_order:
-            payload = grouped_payloads[group_key]
-            base_item = payload["base_item"]
-            model_entries = payload["model_entries"]
-            primary_provider = ""
-            primary_model = ""
-            if model_entries:
-                primary_provider, primary_model = next(iter(model_entries.values()))
+        for row in grouped_rows:
+            context = outline_context_map.get(
+                str(getattr(row, "outline_item_bid", "") or "").strip(),
+                {
+                    "chapter_outline_item_bid": "",
+                    "chapter_title": "",
+                    "lesson_outline_item_bid": str(getattr(row, "outline_item_bid", "") or ""),
+                    "lesson_title": "",
+                },
+            )
+            user_bid = str(getattr(row, "user_bid", "") or "").strip()
+            user = user_map.get(user_bid, {})
             grouped_items.append(
                 AdminOperationCourseCreditUsageItemDTO(
-                    group_key=group_key,
-                    usage_bid=base_item.usage_bid,
-                    progress_record_bid=base_item.progress_record_bid,
-                    generated_block_bid=base_item.generated_block_bid,
-                    user_bid=base_item.user_bid,
-                    mobile=base_item.mobile,
-                    email=base_item.email,
-                    nickname=base_item.nickname,
-                    chapter_outline_item_bid=base_item.chapter_outline_item_bid,
-                    chapter_title=base_item.chapter_title,
-                    lesson_outline_item_bid=base_item.lesson_outline_item_bid,
-                    lesson_title=base_item.lesson_title,
-                    usage_mode=base_item.usage_mode,
-                    provider=primary_provider,
-                    model=primary_model,
-                    usage_count=payload["usage_count"],
-                    model_variant_count=len(model_entries),
+                    group_key=str(getattr(row, "group_key", "") or ""),
+                    usage_bid=str(getattr(row, "usage_bid", "") or ""),
+                    progress_record_bid=str(getattr(row, "progress_record_bid", "") or ""),
+                    generated_block_bid=str(getattr(row, "generated_block_bid", "") or ""),
+                    user_bid=user_bid,
+                    mobile=str(user.get("mobile", "") or ""),
+                    email=str(user.get("email", "") or ""),
+                    nickname=str(user.get("nickname", "") or ""),
+                    chapter_outline_item_bid=str(context.get("chapter_outline_item_bid", "") or ""),
+                    chapter_title=str(context.get("chapter_title", "") or ""),
+                    lesson_outline_item_bid=str(context.get("lesson_outline_item_bid", "") or ""),
+                    lesson_title=str(context.get("lesson_title", "") or ""),
+                    usage_mode=str(getattr(row, "usage_mode", "") or ""),
+                    provider=str(getattr(row, "provider", "") or ""),
+                    model=str(getattr(row, "model", "") or ""),
+                    usage_count=int(getattr(row, "usage_count", 0) or 0),
+                    model_variant_count=int(getattr(row, "model_variant_count", 0) or 0),
                     consumed_credits=credit_decimal_to_number(
-                        payload["consumed_credits"]
+                        Decimal(str(getattr(row, "consumed_credits", 0) or 0))
                     ),
-                    created_at=base_item.created_at,
+                    created_at=_format_operator_datetime(getattr(row, "created_at", None)),
                 )
             )
 
-        total = len(grouped_items)
-        start = (safe_page_index - 1) * safe_page_size
-        paged_items = grouped_items[start : start + safe_page_size]
         return AdminOperationCourseCreditUsageListDTO(
             view=COURSE_CREDIT_USAGE_VIEW_GROUPED,
-            items=paged_items,
+            items=grouped_items,
+            page=safe_page_index,
+            page_size=safe_page_size,
+            total=int(total or 0),
+            page_count=math.ceil(int(total or 0) / safe_page_size) if safe_page_size else 0,
+        )
+
+
+def get_operator_course_credit_usage_details(
+    app: Flask,
+    *,
+    shifu_bid: str,
+    page_index: int,
+    page_size: int,
+    filters: Optional[dict] = None,
+) -> AdminOperationCourseCreditUsageDetailListDTO:
+    with app.app_context():
+        normalized_shifu_bid = str(shifu_bid or "").strip()
+        if not normalized_shifu_bid:
+            raise_param_error("shifu_bid is required")
+
+        safe_page_index = max(int(page_index or 1), 1)
+        safe_page_size = min(max(int(page_size or 10), 1), 50)
+        filters = filters or {}
+        user_bid = str(filters.get("user_bid", "") or "").strip()
+        outline_item_bid = str(filters.get("outline_item_bid", "") or "").strip()
+        mode_filter = _resolve_course_credit_usage_mode_filter(
+            str(filters.get("mode", "") or "")
+        )
+        if not user_bid:
+            raise_param_error("user_bid")
+        if not outline_item_bid:
+            raise_param_error("outline_item_bid")
+        if str(filters.get("mode", "") or "").strip() and not mode_filter:
+            raise_param_error("mode")
+
+        query = _build_operator_course_credit_usage_base_query(normalized_shifu_bid)
+        query = query.filter(
+            BillUsageRecord.user_bid == user_bid,
+            BillUsageRecord.outline_item_bid == outline_item_bid,
+        )
+        query = _apply_course_credit_usage_filters(query, {"mode": mode_filter})
+
+        total = query.count()
+        rows = (
+            query.order_by(BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc())
+            .offset((safe_page_index - 1) * safe_page_size)
+            .limit(safe_page_size)
+            .all()
+        )
+        output_summary_map = _load_course_credit_usage_output_summary_map(
+            [usage_row for usage_row, _ledger_amount in rows]
+        )
+        return AdminOperationCourseCreditUsageDetailListDTO(
+            items=[
+                _build_operator_course_credit_usage_detail_item(
+                    usage_row=usage_row,
+                    ledger_amount=ledger_amount,
+                    output_summary=output_summary_map.get(
+                        str(getattr(usage_row, "usage_bid", "") or "").strip(),
+                        "",
+                    ),
+                )
+                for usage_row, ledger_amount in rows
+            ],
             page=safe_page_index,
             page_size=safe_page_size,
             total=total,

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5414,10 +5414,13 @@ def get_operator_course_credit_usages(
                 ),
                 db.func.count(
                     db.func.distinct(
-                        db.func.concat(
-                            db.func.coalesce(usage_rows.c.provider, ""),
-                            literal("/"),
-                            db.func.coalesce(usage_rows.c.model, ""),
+                        db.func.nullif(
+                            db.func.concat(
+                                db.func.coalesce(usage_rows.c.provider, ""),
+                                literal("/"),
+                                db.func.coalesce(usage_rows.c.model, ""),
+                            ),
+                            "/",
                         )
                     )
                 ).label("model_variant_count"),

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -903,9 +903,9 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     completed_lesson_counts = (
         db.session.query(
             LearnProgressRecord.user_bid.label("user_bid"),
-            db.func.count(
-                db.func.distinct(LearnProgressRecord.outline_item_bid)
-            ).label("learned_lesson_count"),
+            db.func.count(db.func.distinct(LearnProgressRecord.outline_item_bid)).label(
+                "learned_lesson_count"
+            ),
         )
         .filter(
             LearnProgressRecord.shifu_bid == shifu_bid,
@@ -945,9 +945,11 @@ def _build_operator_course_credit_metrics(
         ),
     ).one()
 
-    completed_user_subquery = _build_course_credit_usage_covered_completed_user_subquery(
-        shifu_bid=shifu_bid,
-        leaf_outline_bids=leaf_outline_bids,
+    completed_user_subquery = (
+        _build_course_credit_usage_covered_completed_user_subquery(
+            shifu_bid=shifu_bid,
+            leaf_outline_bids=leaf_outline_bids,
+        )
     )
     completed_credit_user_count = 0
     completed_credit_total = Decimal("0")
@@ -986,9 +988,7 @@ def _build_operator_course_credit_metrics(
         "credit_consumed_total": credit_decimal_to_number(
             abs(Decimal(str(getattr(aggregate_row, "credit_consumed_total", 0) or 0)))
         ),
-        "credit_usage_count": int(
-            getattr(aggregate_row, "credit_usage_count", 0) or 0
-        ),
+        "credit_usage_count": int(getattr(aggregate_row, "credit_usage_count", 0) or 0),
         "credit_user_count": int(getattr(aggregate_row, "credit_user_count", 0) or 0),
         "completed_credit_user_count": completed_credit_user_count,
         "completed_user_avg_credits": completed_user_avg_credits,
@@ -5065,9 +5065,7 @@ def get_operator_course_detail(
                 completed_credit_user_count=credit_metrics[
                     "completed_credit_user_count"
                 ],
-                completed_user_avg_credits=credit_metrics[
-                    "completed_user_avg_credits"
-                ],
+                completed_user_avg_credits=credit_metrics["completed_user_avg_credits"],
             ),
             chapters=_build_chapter_tree(
                 outline_items,
@@ -5315,7 +5313,9 @@ def get_operator_course_credit_usages(
         if view == COURSE_CREDIT_USAGE_VIEW_RAW:
             total = query.count()
             rows = (
-                query.order_by(BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc())
+                query.order_by(
+                    BillUsageRecord.created_at.desc(), BillUsageRecord.id.desc()
+                )
                 .offset((safe_page_index - 1) * safe_page_size)
                 .limit(safe_page_size)
                 .all()
@@ -5357,9 +5357,14 @@ def get_operator_course_credit_usages(
             )
 
         usage_rows = query.subquery("operator_course_credit_usage_filtered")
-        generation_name_expr = db.func.lower(usage_rows.c.extra["generation_name"].as_string())
+        generation_name_expr = db.func.lower(
+            usage_rows.c.extra["generation_name"].as_string()
+        )
         usage_mode_expr = case(
-            (usage_rows.c.usage_type == BILL_USAGE_TYPE_TTS, COURSE_CREDIT_USAGE_MODE_LISTEN),
+            (
+                usage_rows.c.usage_type == BILL_USAGE_TYPE_TTS,
+                COURSE_CREDIT_USAGE_MODE_LISTEN,
+            ),
             (
                 and_(
                     usage_rows.c.usage_type != BILL_USAGE_TYPE_TTS,
@@ -5381,39 +5386,54 @@ def get_operator_course_credit_usages(
             + usage_mode_expr
         ).label("group_key")
 
-        grouped_query = db.session.query(
-            db.func.max(group_key_expr).label("group_key"),
-            db.func.max(usage_rows.c.usage_bid).label("usage_bid"),
-            db.func.max(usage_rows.c.progress_record_bid).label("progress_record_bid"),
-            db.func.max(usage_rows.c.generated_block_bid).label("generated_block_bid"),
-            usage_rows.c.user_bid.label("user_bid"),
-            usage_rows.c.outline_item_bid.label("outline_item_bid"),
-            usage_mode_expr,
-            db.func.max(usage_rows.c.provider).label("provider"),
-            db.func.max(usage_rows.c.model).label("model"),
-            db.func.count(db.func.distinct(usage_rows.c.usage_bid)).label("usage_count"),
-            db.func.count(
-                db.func.distinct(
-                    db.func.coalesce(usage_rows.c.provider, "")
-                    + literal("/")
-                    + db.func.coalesce(usage_rows.c.model, "")
-                )
-            ).label("model_variant_count"),
-            db.func.coalesce(db.func.sum(db.func.abs(usage_rows.c.ledger_amount)), 0).label(
-                "consumed_credits"
-            ),
-            db.func.max(usage_rows.c.created_at).label("created_at"),
-        ).select_from(usage_rows).group_by(
-            usage_rows.c.user_bid,
-            usage_rows.c.outline_item_bid,
-            usage_mode_expr,
+        grouped_query = (
+            db.session.query(
+                db.func.max(group_key_expr).label("group_key"),
+                db.func.max(usage_rows.c.usage_bid).label("usage_bid"),
+                db.func.max(usage_rows.c.progress_record_bid).label(
+                    "progress_record_bid"
+                ),
+                db.func.max(usage_rows.c.generated_block_bid).label(
+                    "generated_block_bid"
+                ),
+                usage_rows.c.user_bid.label("user_bid"),
+                usage_rows.c.outline_item_bid.label("outline_item_bid"),
+                usage_mode_expr,
+                db.func.max(usage_rows.c.provider).label("provider"),
+                db.func.max(usage_rows.c.model).label("model"),
+                db.func.count(db.func.distinct(usage_rows.c.usage_bid)).label(
+                    "usage_count"
+                ),
+                db.func.count(
+                    db.func.distinct(
+                        db.func.coalesce(usage_rows.c.provider, "")
+                        + literal("/")
+                        + db.func.coalesce(usage_rows.c.model, "")
+                    )
+                ).label("model_variant_count"),
+                db.func.coalesce(
+                    db.func.sum(db.func.abs(usage_rows.c.ledger_amount)), 0
+                ).label("consumed_credits"),
+                db.func.max(usage_rows.c.created_at).label("created_at"),
+            )
+            .select_from(usage_rows)
+            .group_by(
+                usage_rows.c.user_bid,
+                usage_rows.c.outline_item_bid,
+                usage_mode_expr,
+            )
         )
 
         grouped_subquery = grouped_query.subquery("operator_course_credit_usage_groups")
-        total = db.session.query(db.func.count()).select_from(grouped_subquery).scalar() or 0
+        total = (
+            db.session.query(db.func.count()).select_from(grouped_subquery).scalar()
+            or 0
+        )
         grouped_rows = (
             db.session.query(grouped_subquery)
-            .order_by(grouped_subquery.c.created_at.desc(), grouped_subquery.c.group_key.asc())
+            .order_by(
+                grouped_subquery.c.created_at.desc(), grouped_subquery.c.group_key.asc()
+            )
             .offset((safe_page_index - 1) * safe_page_size)
             .limit(safe_page_size)
             .all()
@@ -5435,7 +5455,9 @@ def get_operator_course_credit_usages(
                 {
                     "chapter_outline_item_bid": "",
                     "chapter_title": "",
-                    "lesson_outline_item_bid": str(getattr(row, "outline_item_bid", "") or ""),
+                    "lesson_outline_item_bid": str(
+                        getattr(row, "outline_item_bid", "") or ""
+                    ),
                     "lesson_title": "",
                 },
             )
@@ -5445,25 +5467,37 @@ def get_operator_course_credit_usages(
                 AdminOperationCourseCreditUsageItemDTO(
                     group_key=str(getattr(row, "group_key", "") or ""),
                     usage_bid=str(getattr(row, "usage_bid", "") or ""),
-                    progress_record_bid=str(getattr(row, "progress_record_bid", "") or ""),
-                    generated_block_bid=str(getattr(row, "generated_block_bid", "") or ""),
+                    progress_record_bid=str(
+                        getattr(row, "progress_record_bid", "") or ""
+                    ),
+                    generated_block_bid=str(
+                        getattr(row, "generated_block_bid", "") or ""
+                    ),
                     user_bid=user_bid,
                     mobile=str(user.get("mobile", "") or ""),
                     email=str(user.get("email", "") or ""),
                     nickname=str(user.get("nickname", "") or ""),
-                    chapter_outline_item_bid=str(context.get("chapter_outline_item_bid", "") or ""),
+                    chapter_outline_item_bid=str(
+                        context.get("chapter_outline_item_bid", "") or ""
+                    ),
                     chapter_title=str(context.get("chapter_title", "") or ""),
-                    lesson_outline_item_bid=str(context.get("lesson_outline_item_bid", "") or ""),
+                    lesson_outline_item_bid=str(
+                        context.get("lesson_outline_item_bid", "") or ""
+                    ),
                     lesson_title=str(context.get("lesson_title", "") or ""),
                     usage_mode=str(getattr(row, "usage_mode", "") or ""),
                     provider=str(getattr(row, "provider", "") or ""),
                     model=str(getattr(row, "model", "") or ""),
                     usage_count=int(getattr(row, "usage_count", 0) or 0),
-                    model_variant_count=int(getattr(row, "model_variant_count", 0) or 0),
+                    model_variant_count=int(
+                        getattr(row, "model_variant_count", 0) or 0
+                    ),
                     consumed_credits=credit_decimal_to_number(
                         Decimal(str(getattr(row, "consumed_credits", 0) or 0))
                     ),
-                    created_at=_format_operator_datetime(getattr(row, "created_at", None)),
+                    created_at=_format_operator_datetime(
+                        getattr(row, "created_at", None)
+                    ),
                 )
             )
 
@@ -5473,7 +5507,9 @@ def get_operator_course_credit_usages(
             page=safe_page_index,
             page_size=safe_page_size,
             total=int(total or 0),
-            page_count=math.ceil(int(total or 0) / safe_page_size) if safe_page_size else 0,
+            page_count=math.ceil(int(total or 0) / safe_page_size)
+            if safe_page_size
+            else 0,
         )
 
 

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -662,7 +662,9 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
         default=0, description="Total consumed credits for this course", required=False
     )
     credit_usage_count: int = Field(
-        default=0, description="Distinct billed usage count for this course", required=False
+        default=0,
+        description="Distinct billed usage count for this course",
+        required=False,
     )
     credit_user_count: int = Field(
         default=0, description="Distinct users with billed credit usage", required=False
@@ -1079,7 +1081,9 @@ class AdminOperationCourseCreditUsageDetailItemDTO(BaseModel):
         description="Consumed credits",
         required=False,
     )
-    input_tokens: int = Field(default=0, description="Input token count", required=False)
+    input_tokens: int = Field(
+        default=0, description="Input token count", required=False
+    )
     output_tokens: int = Field(
         default=0, description="Output token count", required=False
     )

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -658,6 +658,25 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     rating_score: str = Field(
         ..., description="Average lesson rating score", required=False
     )
+    credit_consumed_total: int | float = Field(
+        default=0, description="Total consumed credits for this course", required=False
+    )
+    credit_usage_count: int = Field(
+        default=0, description="Distinct billed usage count for this course", required=False
+    )
+    credit_user_count: int = Field(
+        default=0, description="Distinct users with billed credit usage", required=False
+    )
+    completed_credit_user_count: int = Field(
+        default=0,
+        description="Completed users with billed credit usage coverage",
+        required=False,
+    )
+    completed_user_avg_credits: int | float | None = Field(
+        default=None,
+        description="Average consumed credits among completed users with credit usage",
+        required=False,
+    )
 
     def __json__(self) -> dict[str, Any]:
         return self.model_dump()
@@ -1051,6 +1070,36 @@ class AdminOperationCourseCreditUsageItemDTO(BaseModel):
 
 
 @register_schema_to_swagger
+class AdminOperationCourseCreditUsageDetailItemDTO(BaseModel):
+    """Operator-facing single credit usage detail row."""
+
+    usage_bid: str = Field(..., description="Usage business identifier", required=False)
+    consumed_credits: int | float = Field(
+        default=0,
+        description="Consumed credits",
+        required=False,
+    )
+    input_tokens: int = Field(default=0, description="Input token count", required=False)
+    output_tokens: int = Field(
+        default=0, description="Output token count", required=False
+    )
+    word_count: int = Field(default=0, description="TTS word count", required=False)
+    duration_ms: int = Field(
+        default=0, description="TTS audio duration in milliseconds", required=False
+    )
+    segment_count: int = Field(
+        default=0, description="TTS synthesized segment count", required=False
+    )
+    output_summary: str = Field(
+        default="", description="Generated output summary", required=False
+    )
+    created_at: str = Field(default="", description="Created at", required=False)
+
+    def __json__(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
+@register_schema_to_swagger
 class AdminOperationCourseCreditUsageListDTO(BaseModel):
     """Operator-facing course credit usage list payload."""
 
@@ -1072,6 +1121,30 @@ class AdminOperationCourseCreditUsageListDTO(BaseModel):
     def __json__(self) -> dict[str, Any]:
         return {
             "view": self.view,
+            "items": [item.__json__() for item in self.items],
+            "page": self.page,
+            "page_size": self.page_size,
+            "total": self.total,
+            "page_count": self.page_count,
+        }
+
+
+@register_schema_to_swagger
+class AdminOperationCourseCreditUsageDetailListDTO(BaseModel):
+    """Operator-facing paginated single credit usage details."""
+
+    items: list[AdminOperationCourseCreditUsageDetailItemDTO] = Field(
+        default_factory=list,
+        description="Paginated credit usage detail rows",
+        required=False,
+    )
+    page: int = Field(..., description="Page index", required=False)
+    page_size: int = Field(..., description="Page size", required=False)
+    total: int = Field(..., description="Total row count", required=False)
+    page_count: int = Field(..., description="Page count", required=False)
+
+    def __json__(self) -> dict[str, Any]:
+        return {
             "items": [item.__json__() for item in self.items],
             "page": self.page,
             "page_size": self.page_size,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -113,6 +113,7 @@ from flaskr.service.shifu.shifu_draft_funcs import (
 )
 from flaskr.service.shifu.admin import (
     OPERATOR_ORDER_LIST_MAX_PAGE_SIZE,
+    get_operator_course_credit_usage_details,
     get_operator_course_credit_usages,
     get_operator_course_overview,
     get_operator_course_follow_up_detail,
@@ -1807,6 +1808,42 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 page_index=page_index,
                 page_size=page_size,
                 filters=filters,
+            )
+        )
+
+    @app.route(
+        path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages/details",
+        methods=["GET"],
+    )
+    def admin_operation_course_credit_usage_details(shifu_bid: str):
+        """
+        Get operator course credit usage detail list
+        ---
+        tags:
+            - Shifu
+        """
+        _require_operator()
+        page_index = _parse_positive_query_int(
+            request.args.get("page"),
+            field_name="page",
+            default=1,
+        )
+        page_size = _parse_positive_query_int(
+            request.args.get("page_size"),
+            field_name="page_size",
+            default=10,
+        )
+        return make_common_response(
+            get_operator_course_credit_usage_details(
+                app,
+                shifu_bid=shifu_bid,
+                page_index=page_index,
+                page_size=page_size,
+                filters={
+                    "user_bid": request.args.get("user_bid", ""),
+                    "outline_item_bid": request.args.get("outline_item_bid", ""),
+                    "mode": request.args.get("mode", ""),
+                },
             )
         )
 

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -1855,6 +1855,14 @@ def test_admin_operation_course_detail_metrics_include_credit_usage_and_complete
             created_at=created_at,
             updated_at=created_at,
         )
+        _seed_progress(
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-2",
+            user_bid="student-learning",
+            status=LEARN_STATUS_IN_PROGRESS,
+            created_at=created_at,
+            updated_at=created_at,
+        )
         _seed_credit_usage(
             usage_bid="usage-completed",
             user_bid="student-completed",
@@ -2358,6 +2366,16 @@ def test_admin_operation_course_credit_usage_details_route_returns_rows_and_summ
             consumed_credits=Decimal("5"),
             created_at=datetime(2026, 4, 4, 10, 0, 0),
             extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        _seed_generated_element(
+            element_bid="element-detail-collision",
+            progress_record_bid="progress-other",
+            user_bid="student-other",
+            generated_block_bid="block-detail-1",
+            outline_item_bid="lesson-other",
+            shifu_bid="other-course",
+            created_at=datetime(2026, 4, 4, 10, 0, 1),
+            content_text="Wrong course output",
         )
         _seed_generated_element(
             element_bid="element-detail-1",

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2167,6 +2167,74 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert raw_payload["data"]["items"][0]["usage_mode"] == "listen"
 
 
+def test_admin_operation_course_credit_usages_ignores_blank_model_variant(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(
+            app,
+            user_bid="student-1",
+            phone="13900001235",
+            email="student1@example.com",
+        )
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            parent_bid="chapter-1",
+            title="Lesson 1",
+            position="1.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_credit_usage(
+            usage_bid="usage-blank-model",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="",
+            model="",
+            consumed_credits=Decimal("5"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages?page=1&page_size=20",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["total"] == 1
+    assert payload["data"]["items"][0]["model_variant_count"] == 0
+
+
 def test_admin_operation_course_credit_usages_route_rejects_invalid_mode(
     app,
     test_client,

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -60,8 +60,10 @@ from flaskr.service.shifu.models import (
     PublishedShifu,
 )
 from flaskr.service.shifu.admin import (
+    _coerce_operator_datetime,
     get_operator_course_chapter_detail,
     get_operator_course_detail,
+    get_operator_course_credit_usages,
 )
 from flaskr.service.user.models import (
     AuthCredential,
@@ -704,6 +706,13 @@ def _seed_outline(
     )
 
 
+def test_coerce_operator_datetime_accepts_mysql_string_values(app):
+    with app.app_context():
+        assert _coerce_operator_datetime("2026-05-20 16:40:51") == datetime(
+            2026, 5, 20, 16, 40, 51
+        )
+
+
 def test_admin_operation_course_detail_route_returns_latest_detail(
     app,
     test_client,
@@ -945,6 +954,11 @@ def test_admin_operation_course_detail_route_returns_latest_detail(
         "order_amount": "88",
         "follow_up_count": 1,
         "rating_score": "4.0",
+        "credit_consumed_total": 0,
+        "credit_usage_count": 0,
+        "credit_user_count": 0,
+        "completed_credit_user_count": 0,
+        "completed_user_avg_credits": None,
     }
     assert payload["data"]["chapters"] == [
         {
@@ -1773,6 +1787,108 @@ def test_admin_operation_course_users_route_marks_redeem_orders_as_paid(
     assert paid_only_payload["data"]["items"][0]["user_bid"] == "redeem-user"
 
 
+def test_admin_operation_course_detail_metrics_include_credit_usage_and_completed_average(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    monkeypatch.setattr(
+        "flaskr.service.shifu.admin.get_course_visit_count_30d",
+        lambda _app, _shifu_bid: 0,
+    )
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(app, user_bid="student-completed", phone="13900001235")
+        _seed_user(app, user_bid="student-learning", phone="13900001236")
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        for lesson_bid, position in [("lesson-1", "1.1"), ("lesson-2", "1.2")]:
+            _seed_outline(
+                shifu_bid="course-detail",
+                model=DraftOutlineItem,
+                outline_item_bid=lesson_bid,
+                parent_bid="chapter-1",
+                title=lesson_bid,
+                position=position,
+                item_type=UNIT_TYPE_VALUE_NORMAL,
+                updated_at=created_at,
+            )
+            _seed_progress(
+                shifu_bid="course-detail",
+                outline_item_bid=lesson_bid,
+                user_bid="student-completed",
+                status=LEARN_STATUS_COMPLETED,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        _seed_progress(
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            user_bid="student-learning",
+            status=LEARN_STATUS_COMPLETED,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_credit_usage(
+            usage_bid="usage-completed",
+            user_bid="student-completed",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-completed",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("12"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        _seed_credit_usage(
+            usage_bid="usage-learning",
+            user_bid="student-learning",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-learning",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("8"),
+            created_at=datetime(2026, 4, 4, 11, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/detail",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["metrics"]["credit_consumed_total"] == 20
+    assert payload["data"]["metrics"]["credit_usage_count"] == 2
+    assert payload["data"]["metrics"]["credit_user_count"] == 2
+    assert payload["data"]["metrics"]["completed_credit_user_count"] == 1
+    assert payload["data"]["metrics"]["completed_user_avg_credits"] == 12
+
+
 def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_filters(
     app,
     test_client,
@@ -1921,10 +2037,10 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert payload["data"]["view"] == "grouped"
     assert payload["data"]["total"] == 4
     assert [item["group_key"] for item in payload["data"]["items"]] == [
-        "progress-1:listen",
-        "progress-2:ask",
-        "progress-1:learn",
-        "progress-3:learn",
+        "student-1:lesson-1:listen",
+        "student-2:lesson-2:ask",
+        "student-1:lesson-1:learn",
+        "student-2:lesson-2:learn",
     ]
     assert payload["data"]["items"][0]["usage_bid"] == "usage-listen-1"
     assert payload["data"]["items"][0]["usage_mode"] == "listen"
@@ -1947,7 +2063,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert filtered_response.status_code == 200
     assert filtered_payload["code"] == 0
     assert filtered_payload["data"]["total"] == 1
-    assert filtered_payload["data"]["items"][0]["group_key"] == "progress-2:ask"
+    assert filtered_payload["data"]["items"][0]["group_key"] == "student-2:lesson-2:ask"
     assert filtered_payload["data"]["items"][0]["usage_bid"] == "usage-ask-1"
 
     phone_filtered_response = test_client.get(
@@ -1961,7 +2077,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert phone_filtered_payload["code"] == 0
     assert phone_filtered_payload["data"]["total"] == 1
     assert (
-        phone_filtered_payload["data"]["items"][0]["group_key"] == "progress-1:listen"
+        phone_filtered_payload["data"]["items"][0]["group_key"] == "student-1:lesson-1:listen"
     )
     assert phone_filtered_payload["data"]["items"][0]["usage_count"] == 1
     assert phone_filtered_payload["data"]["items"][0]["consumed_credits"] == 12
@@ -1977,8 +2093,8 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert learn_filtered_payload["code"] == 0
     assert learn_filtered_payload["data"]["total"] == 2
     assert [item["group_key"] for item in learn_filtered_payload["data"]["items"]] == [
-        "progress-1:learn",
-        "progress-3:learn",
+        "student-1:lesson-1:learn",
+        "student-2:lesson-2:learn",
     ]
     assert learn_filtered_payload["data"]["items"][0]["usage_mode"] == "learn"
     assert learn_filtered_payload["data"]["items"][0]["consumed_credits"] == 5
@@ -1993,8 +2109,8 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert paged_payload["code"] == 0
     assert paged_payload["data"]["total"] == 4
     assert [item["group_key"] for item in paged_payload["data"]["items"]] == [
-        "progress-1:learn",
-        "progress-3:learn",
+        "student-1:lesson-1:learn",
+        "student-2:lesson-2:learn",
     ]
 
     partial_phone_filtered_response = test_client.get(
@@ -2097,6 +2213,27 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_view(
     assert payload["message"] == "Params Error view"
 
 
+def test_admin_operation_course_credit_usages_route_returns_empty_for_missing_course(
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/missing-course/credit-usages?page=1&page_size=20"
+        "&view=grouped&keyword=&mode=&start_time=&end_time=",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["view"] == "grouped"
+    assert payload["data"]["items"] == []
+    assert payload["data"]["total"] == 0
+    assert payload["data"]["page_count"] == 0
+
+
 def test_admin_operation_course_credit_usages_grouped_view_keeps_rows_without_progress_separate(
     app,
     test_client,
@@ -2171,13 +2308,12 @@ def test_admin_operation_course_credit_usages_grouped_view_keeps_rows_without_pr
     assert response.status_code == 200
     assert payload["code"] == 0
     assert payload["data"]["view"] == "grouped"
-    assert payload["data"]["total"] == 2
+    assert payload["data"]["total"] == 1
     assert [item["group_key"] for item in payload["data"]["items"]] == [
-        "usage-no-progress-2",
-        "usage-no-progress-1",
+        "student-1:lesson-1:learn",
     ]
-    assert payload["data"]["items"][0]["usage_count"] == 1
-    assert payload["data"]["items"][1]["usage_count"] == 1
+    assert payload["data"]["items"][0]["usage_count"] == 2
+    assert payload["data"]["items"][0]["consumed_credits"] == 5
 
 
 def test_admin_operation_course_credit_usages_route_aggregates_split_ledgers(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -63,7 +63,6 @@ from flaskr.service.shifu.admin import (
     _coerce_operator_datetime,
     get_operator_course_chapter_detail,
     get_operator_course_detail,
-    get_operator_course_credit_usages,
 )
 from flaskr.service.user.models import (
     AuthCredential,
@@ -2077,7 +2076,8 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     assert phone_filtered_payload["code"] == 0
     assert phone_filtered_payload["data"]["total"] == 1
     assert (
-        phone_filtered_payload["data"]["items"][0]["group_key"] == "student-1:lesson-1:listen"
+        phone_filtered_payload["data"]["items"][0]["group_key"]
+        == "student-1:lesson-1:listen"
     )
     assert phone_filtered_payload["data"]["items"][0]["usage_count"] == 1
     assert phone_filtered_payload["data"]["items"][0]["consumed_credits"] == 12

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sys
 from types import SimpleNamespace
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
@@ -710,6 +710,16 @@ def test_coerce_operator_datetime_accepts_mysql_string_values(app):
         assert _coerce_operator_datetime("2026-05-20 16:40:51") == datetime(
             2026, 5, 20, 16, 40, 51
         )
+
+
+def test_coerce_operator_datetime_normalizes_offset_values_to_utc(app):
+    with app.app_context():
+        assert _coerce_operator_datetime("2026-05-22T10:00:00+08:00") == datetime(
+            2026, 5, 22, 2, 0, 0
+        )
+        assert _coerce_operator_datetime(
+            datetime(2026, 5, 22, 10, 0, 0, tzinfo=timezone.utc)
+        ) == datetime(2026, 5, 22, 10, 0, 0)
 
 
 def test_admin_operation_course_detail_route_returns_latest_detail(
@@ -2213,7 +2223,7 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_view(
     assert payload["message"] == "Params Error view"
 
 
-def test_admin_operation_course_credit_usages_route_returns_empty_for_missing_course(
+def test_admin_operation_course_credit_usages_route_rejects_missing_course(
     test_client,
     monkeypatch,
 ):
@@ -2227,11 +2237,161 @@ def test_admin_operation_course_credit_usages_route_returns_empty_for_missing_co
     payload = response.get_json(force=True)
 
     assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.shifu.shifuNotFound"]
+
+
+def test_admin_operation_course_credit_usage_details_route_returns_rows_and_summary(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(app, user_bid="student-1", phone="13900001235")
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="chapter-1",
+            title="Chapter 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            parent_bid="chapter-1",
+            title="Lesson 1",
+            position="1.1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        _seed_credit_usage(
+            usage_bid="usage-detail-1",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            progress_record_bid="progress-1",
+            generated_block_bid="block-detail-1",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="openai",
+            model="gpt-4.1",
+            consumed_credits=Decimal("5"),
+            created_at=datetime(2026, 4, 4, 10, 0, 0),
+            extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+        )
+        _seed_generated_element(
+            element_bid="element-detail-1",
+            progress_record_bid="progress-1",
+            user_bid="student-1",
+            generated_block_bid="block-detail-1",
+            outline_item_bid="lesson-1",
+            shifu_bid="course-detail",
+            created_at=datetime(2026, 4, 4, 10, 0, 1),
+            content_text="Generated answer",
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages/details"
+        "?page=1&page_size=10&user_bid=student-1&outline_item_bid=lesson-1&mode=learn",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
     assert payload["code"] == 0
-    assert payload["data"]["view"] == "grouped"
-    assert payload["data"]["items"] == []
-    assert payload["data"]["total"] == 0
-    assert payload["data"]["page_count"] == 0
+    assert payload["data"]["page"] == 1
+    assert payload["data"]["page_size"] == 10
+    assert payload["data"]["total"] == 1
+    assert payload["data"]["page_count"] == 1
+    item = payload["data"]["items"][0]
+    assert item["usage_bid"] == "usage-detail-1"
+    assert item["consumed_credits"] == 5
+    assert item["input_tokens"] == 100
+    assert item["output_tokens"] == 200
+    assert item["output_summary"] == "Generated answer"
+
+
+def test_admin_operation_course_credit_usage_details_route_paginates_and_filters_mode(
+    app,
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+    created_at = datetime(2026, 4, 1, 9, 0, 0)
+
+    with app.app_context():
+        _seed_user(app, user_bid="creator-1", phone="13800001234")
+        _seed_user(app, user_bid="student-1", phone="13900001235")
+        _set_user_flags(user_bid="creator-1", is_creator=1)
+        _seed_course(
+            shifu_bid="course-detail",
+            creator_user_bid="creator-1",
+            created_at=created_at,
+            updated_at=created_at,
+        )
+        _seed_outline(
+            shifu_bid="course-detail",
+            model=DraftOutlineItem,
+            outline_item_bid="lesson-1",
+            title="Lesson 1",
+            position="1",
+            item_type=UNIT_TYPE_VALUE_NORMAL,
+            updated_at=created_at,
+        )
+        for index in range(3):
+            _seed_credit_usage(
+                usage_bid=f"usage-detail-{index}",
+                user_bid="student-1",
+                shifu_bid="course-detail",
+                outline_item_bid="lesson-1",
+                usage_type=BILL_USAGE_TYPE_LLM,
+                provider="openai",
+                model="gpt-4.1",
+                consumed_credits=Decimal("1"),
+                created_at=datetime(2026, 4, 4, 10, index, 0),
+                extra={"generation_name": "lesson_runtime/run_llm/Lesson 1"},
+            )
+        _seed_credit_usage(
+            usage_bid="usage-detail-listen",
+            user_bid="student-1",
+            shifu_bid="course-detail",
+            outline_item_bid="lesson-1",
+            usage_type=BILL_USAGE_TYPE_TTS,
+            provider="volcengine",
+            model="cancan-2.0",
+            consumed_credits=Decimal("2"),
+            created_at=datetime(2026, 4, 4, 11, 0, 0),
+        )
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/credit-usages/details"
+        "?page=2&page_size=2&user_bid=student-1&outline_item_bid=lesson-1&mode=learn",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["total"] == 3
+    assert payload["data"]["page_count"] == 2
+    assert [item["usage_bid"] for item in payload["data"]["items"]] == [
+        "usage-detail-0"
+    ]
+    assert payload["data"]["items"][0]["output_summary"] == ""
 
 
 def test_admin_operation_course_credit_usages_grouped_view_keeps_rows_without_progress_separate(

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -161,6 +161,8 @@ const api = {
     'GET /shifu/admin/operations/courses/{shifu_bid}/users',
   getAdminOperationCourseCreditUsages:
     'GET /shifu/admin/operations/courses/{shifu_bid}/credit-usages',
+  getAdminOperationCourseCreditUsageDetails:
+    'GET /shifu/admin/operations/courses/{shifu_bid}/credit-usages/details',
   getAdminOperationCourseRatings:
     'GET /shifu/admin/operations/courses/{shifu_bid}/ratings',
   getAdminOperationCourseFollowUps:

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import { AdminPagination } from '@/app/admin/components/AdminPagination';
@@ -17,6 +17,12 @@ import { ClearableTextInput } from '@/app/admin/operations/orders/orderUiShared'
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
 import { Label } from '@/components/ui/Label';
 import {
   Select,
@@ -36,6 +42,8 @@ import {
 import { ContactMode } from '@/lib/resolve-contact-mode';
 import { cn } from '@/lib/utils';
 import type {
+  AdminOperationCourseCreditUsageDetailItem,
+  AdminOperationCourseCreditUsageDetailListResponse,
   AdminOperationCourseCreditUsageFilters,
   AdminOperationCourseCreditUsageItem,
   AdminOperationCourseCreditUsageListResponse,
@@ -51,6 +59,7 @@ type CreditUsageColumnKey =
   | 'mode'
   | 'chapter'
   | 'lesson'
+  | 'usageCount'
   | 'credits'
   | 'model';
 
@@ -65,6 +74,7 @@ const CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS = {
   mode: 110,
   chapter: 160,
   lesson: 160,
+  usageCount: 110,
   credits: 120,
   model: 220,
 } as const;
@@ -72,6 +82,14 @@ const CREDIT_USAGE_COLUMN_KEYS = Object.keys(
   CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS,
 ) as CreditUsageColumnKey[];
 const FILTER_ALL_OPTION = 'all';
+const EMPTY_CREDIT_USAGE_DETAIL_RESPONSE: AdminOperationCourseCreditUsageDetailListResponse =
+  {
+    items: [],
+    page: 1,
+    page_count: 0,
+    page_size: 10,
+    total: 0,
+  };
 
 function formatUnknownEnumLabel(label: string, rawValue?: string) {
   const normalizedValue = (rawValue || '').trim();
@@ -106,6 +124,7 @@ export default function CourseCreditUsageTab({
   onSearch,
   onReset,
   onPageChange,
+  onFetchDetails,
 }: {
   filtersDraft: AdminOperationCourseCreditUsageFilters;
   data: AdminOperationCourseCreditUsageListResponse;
@@ -120,6 +139,10 @@ export default function CourseCreditUsageTab({
   onSearch: () => void;
   onReset: () => void;
   onPageChange: (page: number) => void;
+  onFetchDetails: (
+    row: AdminOperationCourseCreditUsageItem,
+    page: number,
+  ) => Promise<AdminOperationCourseCreditUsageDetailListResponse>;
 }) {
   const { t } = useTranslation();
   const { t: tOperations } = useTranslation('module.operationsCourse');
@@ -139,6 +162,18 @@ export default function CourseCreditUsageTab({
   const clearLabel = useMemo(
     () => t('module.chat.lessonFeedbackClearInput'),
     [t],
+  );
+  const [detailRow, setDetailRow] =
+    useState<AdminOperationCourseCreditUsageItem | null>(null);
+  const [detailPage, setDetailPage] = useState(1);
+  const [detailData, setDetailData] =
+    useState<AdminOperationCourseCreditUsageDetailListResponse>(
+      EMPTY_CREDIT_USAGE_DETAIL_RESPONSE,
+    );
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<ErrorState | null>(null);
+  const [expandedUsageBids, setExpandedUsageBids] = useState<Set<string>>(
+    () => new Set(),
   );
   const rows = useMemo(() => data.items || [], [data.items]);
   const currentPage = data.page || 1;
@@ -205,6 +240,86 @@ export default function CourseCreditUsageTab({
     [emptyValue, tOperations],
   );
 
+  const handleOpenDetails = useCallback(
+    (row: AdminOperationCourseCreditUsageItem) => {
+      setDetailRow(row);
+      setDetailPage(1);
+      setDetailData(EMPTY_CREDIT_USAGE_DETAIL_RESPONSE);
+      setDetailError(null);
+      setExpandedUsageBids(new Set());
+    },
+    [],
+  );
+
+  const handleDetailOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      return;
+    }
+    setDetailRow(null);
+    setDetailPage(1);
+    setDetailData(EMPTY_CREDIT_USAGE_DETAIL_RESPONSE);
+    setDetailError(null);
+    setExpandedUsageBids(new Set());
+  }, []);
+
+  const toggleOutputExpanded = useCallback((usageBid: string) => {
+    setExpandedUsageBids(prev => {
+      const next = new Set(prev);
+      if (next.has(usageBid)) {
+        next.delete(usageBid);
+      } else {
+        next.add(usageBid);
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!detailRow) {
+      return;
+    }
+
+    let isActive = true;
+    setDetailLoading(true);
+    setDetailError(null);
+    onFetchDetails(detailRow, detailPage)
+      .then(response => {
+        if (!isActive) {
+          return;
+        }
+        setDetailData({
+          items: (response?.items || []).map(item => ({
+            ...item,
+            word_count: item.word_count || 0,
+            duration_ms: item.duration_ms || 0,
+            segment_count: item.segment_count || 0,
+          })),
+          page: response?.page || detailPage,
+          page_count: response?.page_count || 0,
+          page_size: response?.page_size || 10,
+          total: response?.total || 0,
+        });
+      })
+      .catch(err => {
+        if (!isActive) {
+          return;
+        }
+        setDetailData(EMPTY_CREDIT_USAGE_DETAIL_RESPONSE);
+        setDetailError({
+          message: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        if (isActive) {
+          setDetailLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [detailPage, detailRow, onFetchDetails]);
+
   useEffect(() => {
     if (!rows.length) {
       setColumnWidths(prev => {
@@ -230,6 +345,7 @@ export default function CourseCreditUsageTab({
       mode: row => [resolveModeLabel(row.usage_mode)],
       chapter: row => [row.chapter_title || emptyValue],
       lesson: row => [row.lesson_title || emptyValue],
+      usageCount: row => [String(row.usage_count || 0)],
       credits: row => [String(row.consumed_credits || 0)],
       model: row => [resolveModelDisplay(row)],
     };
@@ -240,6 +356,7 @@ export default function CourseCreditUsageTab({
       mode: 5.5,
       chapter: 6,
       lesson: 6,
+      usageCount: 5.5,
       credits: 5.5,
       model: 6,
     };
@@ -297,9 +414,66 @@ export default function CourseCreditUsageTab({
     />
   );
 
+  const renderOutputSummary = (
+    detail: AdminOperationCourseCreditUsageDetailItem,
+  ) => {
+    const outputSummary = detail.output_summary?.trim() || '';
+    if (!outputSummary) {
+      return <span className='text-muted-foreground'>{emptyValue}</span>;
+    }
+    const isExpanded = expandedUsageBids.has(detail.usage_bid);
+    return (
+      <div className='min-w-0 text-left'>
+        <span
+          className={cn(
+            'align-middle text-foreground',
+            isExpanded
+              ? 'whitespace-pre-wrap break-words'
+              : 'inline-block max-w-[360px] truncate align-bottom',
+          )}
+        >
+          {outputSummary}
+        </span>
+        <button
+          type='button'
+          className='ml-1 align-middle text-xs font-medium text-primary hover:underline'
+          onClick={() => toggleOutputExpanded(detail.usage_bid)}
+        >
+          {isExpanded
+            ? tOperations('detail.creditUsage.details.collapse')
+            : tOperations('detail.creditUsage.details.expand')}
+        </button>
+      </div>
+    );
+  };
+  const isListenDetail = detailRow?.usage_mode === 'listen';
+  const detailFirstMetricLabel = isListenDetail
+    ? tOperations('detail.creditUsage.details.table.ttsWordCount')
+    : tOperations('detail.creditUsage.details.table.inputTokens');
+  const detailSecondMetricLabel = isListenDetail
+    ? tOperations('detail.creditUsage.details.table.ttsDuration')
+    : tOperations('detail.creditUsage.details.table.outputTokens');
+  const detailSummaryLabel = isListenDetail
+    ? tOperations('detail.creditUsage.details.table.ttsContent')
+    : tOperations('detail.creditUsage.details.table.outputSummary');
+  const formatDuration = (durationMs: number) => {
+    const safeDuration = Math.max(Number(durationMs || 0), 0);
+    if (!safeDuration) {
+      return emptyValue;
+    }
+    const totalSeconds = Math.round(safeDuration / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (!minutes) {
+      return `${seconds}s`;
+    }
+    return `${minutes}m ${String(seconds).padStart(2, '0')}s`;
+  };
+
   return (
-    <Card className='overflow-hidden border-border/80 shadow-sm ring-1 ring-border/40'>
-      <CardContent className='space-y-3 px-6 py-6'>
+    <>
+      <Card className='overflow-hidden border-border/80 shadow-sm ring-1 ring-border/40'>
+        <CardContent className='space-y-3 px-6 py-6'>
         <form
           className='rounded-xl border border-border bg-muted/20 p-3'
           onSubmit={event => {
@@ -398,7 +572,7 @@ export default function CourseCreditUsageTab({
           loading={loading}
           isEmpty={!error && rows.length === 0}
           emptyContent={tOperations('detail.creditUsage.table.empty')}
-          emptyColSpan={8}
+          emptyColSpan={9}
           withTooltipProvider={!error}
           tableWrapperClassName='overflow-auto'
           loadingClassName='min-h-[240px]'
@@ -506,6 +680,16 @@ export default function CourseCreditUsageTab({
                           ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
                           'h-10 whitespace-nowrap bg-muted/80 text-xs',
                         )}
+                        style={getColumnStyle('usageCount')}
+                      >
+                        {tOperations('detail.creditUsage.table.usageCount')}
+                        {renderResizeHandle('usageCount')}
+                      </TableHead>
+                      <TableHead
+                        className={cn(
+                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                        )}
                         style={getColumnStyle('credits')}
                       >
                         {tOperations('detail.creditUsage.table.credits')}
@@ -590,6 +774,19 @@ export default function CourseCreditUsageTab({
                         </TableCell>
                         <TableCell
                           className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          style={getColumnStyle('usageCount')}
+                        >
+                          <button
+                            type='button'
+                            className='tabular-nums text-primary hover:underline disabled:pointer-events-none disabled:text-foreground'
+                            disabled={!row.usage_count}
+                            onClick={() => handleOpenDetails(row)}
+                          >
+                            {row.usage_count}
+                          </button>
+                        </TableCell>
+                        <TableCell
+                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
                           style={getColumnStyle('credits')}
                         >
                           <span className='font-medium tabular-nums text-foreground'>
@@ -614,7 +811,128 @@ export default function CourseCreditUsageTab({
             )
           }
         />
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={Boolean(detailRow)}
+        onOpenChange={handleDetailOpenChange}
+      >
+        <DialogContent className='max-h-[82vh] max-w-5xl overflow-hidden p-0'>
+          <DialogHeader className='border-b px-6 py-4'>
+            <DialogTitle>
+              {tOperations('detail.creditUsage.details.title')}
+            </DialogTitle>
+          </DialogHeader>
+          <div className='space-y-3 overflow-auto px-6 pb-5'>
+            <AdminTableShell
+              loading={detailLoading}
+              isEmpty={!detailError && detailData.items.length === 0}
+              emptyContent={tOperations('detail.creditUsage.details.empty')}
+              emptyColSpan={isListenDetail ? 6 : 5}
+              withTooltipProvider={false}
+              tableWrapperClassName='max-h-[52vh] overflow-auto'
+              loadingClassName='min-h-[220px]'
+              footer={
+                Math.max(detailData.page_count || 0, 1) > 1 ? (
+                  <AdminPagination
+                    pageIndex={detailData.page || 1}
+                    pageCount={Math.max(detailData.page_count || 0, 1)}
+                    onPageChange={setDetailPage}
+                    prevLabel={t('module.order.paginationPrev', 'Previous')}
+                    nextLabel={t('module.order.paginationNext', 'Next')}
+                    prevAriaLabel={t(
+                      'module.order.paginationPrevAriaLabel',
+                      'Go to previous page',
+                    )}
+                    nextAriaLabel={t(
+                      'module.order.paginationNextAriaLabel',
+                      'Go to next page',
+                    )}
+                    className='mx-0 w-auto justify-end'
+                  />
+                ) : null
+              }
+              table={
+                detailError ? (
+                  <div className='flex min-h-[220px] items-center justify-center p-6 text-center'>
+                    <div className='text-sm font-medium text-destructive'>
+                      {detailError.message}
+                    </div>
+                  </div>
+                ) : (
+                  emptyRow => (
+                    <Table className='table-auto'>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className='h-10 w-[170px] whitespace-nowrap bg-muted/80 text-center text-xs'>
+                            {tOperations(
+                              'detail.creditUsage.details.table.createdAt',
+                            )}
+                          </TableHead>
+                          <TableHead className='h-10 w-[120px] whitespace-nowrap bg-muted/80 text-center text-xs'>
+                            {tOperations(
+                              'detail.creditUsage.details.table.credits',
+                            )}
+                          </TableHead>
+                          <TableHead className='h-10 w-[120px] whitespace-nowrap bg-muted/80 text-center text-xs'>
+                            {detailFirstMetricLabel}
+                          </TableHead>
+                          <TableHead className='h-10 w-[120px] whitespace-nowrap bg-muted/80 text-center text-xs'>
+                            {detailSecondMetricLabel}
+                          </TableHead>
+                          {isListenDetail ? (
+                            <TableHead className='h-10 w-[120px] whitespace-nowrap bg-muted/80 text-center text-xs'>
+                              {tOperations(
+                                'detail.creditUsage.details.table.ttsSegmentCount',
+                              )}
+                            </TableHead>
+                          ) : null}
+                          <TableHead className='h-10 min-w-[360px] whitespace-nowrap bg-muted/80 text-left text-xs'>
+                            {detailSummaryLabel}
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {emptyRow}
+                        {detailData.items.map(detail => (
+                          <TableRow key={detail.usage_bid}>
+                            <TableCell className='border-r border-border py-2.5 text-center text-xs text-muted-foreground/70'>
+                              {formatAdminUtcDateTime(detail.created_at) ||
+                                emptyValue}
+                            </TableCell>
+                            <TableCell className='border-r border-border py-2.5 text-center text-sm font-medium tabular-nums text-foreground'>
+                              {detail.consumed_credits}
+                            </TableCell>
+                            <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
+                              {isListenDetail
+                                ? detail.word_count || emptyValue
+                                : detail.input_tokens}
+                            </TableCell>
+                            <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
+                              {isListenDetail
+                                ? formatDuration(detail.duration_ms)
+                                : detail.output_tokens}
+                            </TableCell>
+                            {isListenDetail ? (
+                              <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
+                                {detail.segment_count || emptyValue}
+                              </TableCell>
+                            ) : null}
+                            <TableCell className='py-2.5 text-sm text-foreground'>
+                              {renderOutputSummary(detail)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  )
+                )
+              }
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -418,7 +418,7 @@ export default function CourseCreditUsageTab({
     detail: AdminOperationCourseCreditUsageDetailItem,
   ) => {
     const outputSummary = detail.output_summary?.trim() || '';
-    if (!outputSummary) {
+    if (!outputSummary || outputSummary === emptyValue) {
       return <span className='text-muted-foreground'>{emptyValue}</span>;
     }
     const isExpanded = expandedUsageBids.has(detail.usage_bid);
@@ -465,9 +465,14 @@ export default function CourseCreditUsageTab({
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
     if (!minutes) {
-      return `${seconds}s`;
+      return tOperations('detail.creditUsage.details.durationSeconds', {
+        seconds,
+      });
     }
-    return `${minutes}m ${String(seconds).padStart(2, '0')}s`;
+    return tOperations('detail.creditUsage.details.durationMinutesSeconds', {
+      minutes,
+      seconds: String(seconds).padStart(2, '0'),
+    });
   };
 
   return (
@@ -584,16 +589,10 @@ export default function CourseCreditUsageTab({
                   pageIndex={currentPage}
                   pageCount={pageCount}
                   onPageChange={onPageChange}
-                  prevLabel={t('module.order.paginationPrev', 'Previous')}
-                  nextLabel={t('module.order.paginationNext', 'Next')}
-                  prevAriaLabel={t(
-                    'module.order.paginationPrevAriaLabel',
-                    'Go to previous page',
-                  )}
-                  nextAriaLabel={t(
-                    'module.order.paginationNextAriaLabel',
-                    'Go to next page',
-                  )}
+                  prevLabel={t('module.order.paginationPrev')}
+                  nextLabel={t('module.order.paginationNext')}
+                  prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
+                  nextAriaLabel={t('module.order.paginationNextAriaLabel')}
                   className='mx-0 w-auto justify-end'
                 />
               ) : null
@@ -782,6 +781,10 @@ export default function CourseCreditUsageTab({
                               type='button'
                               className='tabular-nums text-primary hover:underline disabled:pointer-events-none disabled:text-foreground'
                               disabled={!row.usage_count}
+                              aria-label={tOperations(
+                                'detail.creditUsage.details.openUsageDetails',
+                                { count: row.usage_count || 0 },
+                              )}
                               onClick={() => handleOpenDetails(row)}
                             >
                               {row.usage_count}
@@ -841,16 +844,10 @@ export default function CourseCreditUsageTab({
                     pageIndex={detailData.page || 1}
                     pageCount={Math.max(detailData.page_count || 0, 1)}
                     onPageChange={setDetailPage}
-                    prevLabel={t('module.order.paginationPrev', 'Previous')}
-                    nextLabel={t('module.order.paginationNext', 'Next')}
-                    prevAriaLabel={t(
-                      'module.order.paginationPrevAriaLabel',
-                      'Go to previous page',
-                    )}
-                    nextAriaLabel={t(
-                      'module.order.paginationNextAriaLabel',
-                      'Go to next page',
-                    )}
+                    prevLabel={t('module.order.paginationPrev')}
+                    nextLabel={t('module.order.paginationNext')}
+                    prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
+                    nextAriaLabel={t('module.order.paginationNextAriaLabel')}
                     className='mx-0 w-auto justify-end'
                   />
                 ) : null

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -905,7 +905,7 @@ export default function CourseCreditUsageTab({
                             </TableCell>
                             <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
                               {isListenDetail
-                                ? detail.word_count || emptyValue
+                                ? (detail.word_count ?? emptyValue)
                                 : detail.input_tokens}
                             </TableCell>
                             <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
@@ -915,7 +915,7 @@ export default function CourseCreditUsageTab({
                             </TableCell>
                             {isListenDetail ? (
                               <TableCell className='border-r border-border py-2.5 text-center text-sm tabular-nums text-foreground'>
-                                {detail.segment_count || emptyValue}
+                                {detail.segment_count ?? emptyValue}
                               </TableCell>
                             ) : null}
                             <TableCell className='py-2.5 text-sm text-foreground'>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -474,343 +474,345 @@ export default function CourseCreditUsageTab({
     <>
       <Card className='overflow-hidden border-border/80 shadow-sm ring-1 ring-border/40'>
         <CardContent className='space-y-3 px-6 py-6'>
-        <form
-          className='rounded-xl border border-border bg-muted/20 p-3'
-          onSubmit={event => {
-            event.preventDefault();
-            onSearch();
-          }}
-        >
-          <div className='flex flex-col gap-3 xl:flex-row xl:items-end'>
-            <div className='flex flex-1 flex-col gap-2'>
-              <Label className='text-xs font-medium text-muted-foreground'>
-                {tOperations('detail.creditUsage.filters.userKeyword')}
-              </Label>
-              <ClearableTextInput
-                value={filtersDraft.keyword}
-                placeholder={keywordPlaceholder}
-                clearLabel={t('module.chat.lessonFeedbackClearInput')}
-                onChange={onKeywordChange}
-              />
-            </div>
-            <div className='flex flex-1 flex-col gap-2'>
-              <Label className='text-xs font-medium text-muted-foreground'>
-                {tOperations('detail.creditUsage.filters.mode')}
-              </Label>
-              <Select
-                value={filtersDraft.mode}
-                onValueChange={value =>
-                  onModeChange(
-                    value as AdminOperationCourseCreditUsageModeFilter,
-                  )
-                }
-              >
-                <SelectTrigger className='h-9'>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={FILTER_ALL_OPTION}>
-                    {tOperations('detail.creditUsage.filters.modeAll')}
-                  </SelectItem>
-                  <SelectItem value='learn'>
-                    {tOperations('detail.creditUsage.modes.learn')}
-                  </SelectItem>
-                  <SelectItem value='listen'>
-                    {tOperations('detail.creditUsage.modes.listen')}
-                  </SelectItem>
-                  <SelectItem value='ask'>
-                    {tOperations('detail.creditUsage.modes.ask')}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className='flex flex-1 flex-col gap-2'>
-              <Label className='text-xs font-medium text-muted-foreground'>
-                {tOperations('detail.creditUsage.filters.time')}
-              </Label>
-              <AdminDateRangeFilter
-                startValue={filtersDraft.startTime}
-                endValue={filtersDraft.endTime}
-                triggerAriaLabel={tOperations(
-                  'detail.creditUsage.filters.time',
-                )}
-                placeholder={tOperations(
-                  'detail.creditUsage.filters.timePlaceholder',
-                )}
-                resetLabel={tOperations('detail.creditUsage.filters.reset')}
-                clearLabel={clearLabel}
-                onChange={({ start, end }) => onDateRangeChange({ start, end })}
-              />
-            </div>
-            <div className='flex min-h-9 shrink-0 items-center justify-start gap-2 xl:justify-end'>
-              <Button
-                type='button'
-                variant='outline'
-                className='h-9 px-4'
-                onClick={onReset}
-                disabled={loading}
-              >
-                {t('module.order.filters.reset')}
-              </Button>
-              <Button
-                type='submit'
-                className='h-9 px-4'
-                disabled={loading}
-              >
-                {t('module.order.filters.search')}
-              </Button>
-            </div>
-          </div>
-          <div className='mt-3 pl-3 text-sm text-muted-foreground'>
-            {tOperations('detail.creditUsage.count', {
-              count: data.total,
-            })}
-          </div>
-        </form>
-
-        <AdminTableShell
-          loading={loading}
-          isEmpty={!error && rows.length === 0}
-          emptyContent={tOperations('detail.creditUsage.table.empty')}
-          emptyColSpan={9}
-          withTooltipProvider={!error}
-          tableWrapperClassName='overflow-auto'
-          loadingClassName='min-h-[240px]'
-          footer={
-            pageCount > 1 ? (
-              <AdminPagination
-                pageIndex={currentPage}
-                pageCount={pageCount}
-                onPageChange={onPageChange}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-              />
-            ) : null
-          }
-          table={
-            error ? (
-              <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
-                <div className='space-y-2'>
-                  <div className='text-sm font-medium text-destructive'>
-                    {error.message}
-                  </div>
-                  {typeof error.code === 'number' ? (
-                    <div className='text-xs text-muted-foreground'>
-                      {error.code}
-                    </div>
-                  ) : null}
-                </div>
+          <form
+            className='rounded-xl border border-border bg-muted/20 p-3'
+            onSubmit={event => {
+              event.preventDefault();
+              onSearch();
+            }}
+          >
+            <div className='flex flex-col gap-3 xl:flex-row xl:items-end'>
+              <div className='flex flex-1 flex-col gap-2'>
+                <Label className='text-xs font-medium text-muted-foreground'>
+                  {tOperations('detail.creditUsage.filters.userKeyword')}
+                </Label>
+                <ClearableTextInput
+                  value={filtersDraft.keyword}
+                  placeholder={keywordPlaceholder}
+                  clearLabel={t('module.chat.lessonFeedbackClearInput')}
+                  onChange={onKeywordChange}
+                />
               </div>
-            ) : (
-              emptyRow => (
-                <Table className='table-auto'>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('createdAt')}
-                      >
-                        {tOperations('detail.creditUsage.table.createdAt')}
-                        {renderResizeHandle('createdAt')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('account')}
-                      >
-                        {accountLabel}
-                        {renderResizeHandle('account')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('nickname')}
-                      >
-                        {tOperations('detail.creditUsage.table.nickname')}
-                        {renderResizeHandle('nickname')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('mode')}
-                      >
-                        {tOperations('detail.creditUsage.table.mode')}
-                        {renderResizeHandle('mode')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('chapter')}
-                      >
-                        {tOperations('detail.creditUsage.table.chapter')}
-                        {renderResizeHandle('chapter')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('lesson')}
-                      >
-                        {tOperations('detail.creditUsage.table.lesson')}
-                        {renderResizeHandle('lesson')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('usageCount')}
-                      >
-                        {tOperations('detail.creditUsage.table.usageCount')}
-                        {renderResizeHandle('usageCount')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('credits')}
-                      >
-                        {tOperations('detail.creditUsage.table.credits')}
-                        {renderResizeHandle('credits')}
-                      </TableHead>
-                      <TableHead
-                        className={cn(
-                          ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
-                          'h-10 whitespace-nowrap bg-muted/80 text-xs',
-                        )}
-                        style={getColumnStyle('model')}
-                      >
-                        {tOperations('detail.creditUsage.table.model')}
-                        {renderResizeHandle('model')}
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {emptyRow}
-                    {rows.map(row => (
-                      <TableRow key={row.group_key || row.usage_bid}>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-xs text-muted-foreground/65 last:border-r-0'
+              <div className='flex flex-1 flex-col gap-2'>
+                <Label className='text-xs font-medium text-muted-foreground'>
+                  {tOperations('detail.creditUsage.filters.mode')}
+                </Label>
+                <Select
+                  value={filtersDraft.mode}
+                  onValueChange={value =>
+                    onModeChange(
+                      value as AdminOperationCourseCreditUsageModeFilter,
+                    )
+                  }
+                >
+                  <SelectTrigger className='h-9'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={FILTER_ALL_OPTION}>
+                      {tOperations('detail.creditUsage.filters.modeAll')}
+                    </SelectItem>
+                    <SelectItem value='learn'>
+                      {tOperations('detail.creditUsage.modes.learn')}
+                    </SelectItem>
+                    <SelectItem value='listen'>
+                      {tOperations('detail.creditUsage.modes.listen')}
+                    </SelectItem>
+                    <SelectItem value='ask'>
+                      {tOperations('detail.creditUsage.modes.ask')}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className='flex flex-1 flex-col gap-2'>
+                <Label className='text-xs font-medium text-muted-foreground'>
+                  {tOperations('detail.creditUsage.filters.time')}
+                </Label>
+                <AdminDateRangeFilter
+                  startValue={filtersDraft.startTime}
+                  endValue={filtersDraft.endTime}
+                  triggerAriaLabel={tOperations(
+                    'detail.creditUsage.filters.time',
+                  )}
+                  placeholder={tOperations(
+                    'detail.creditUsage.filters.timePlaceholder',
+                  )}
+                  resetLabel={tOperations('detail.creditUsage.filters.reset')}
+                  clearLabel={clearLabel}
+                  onChange={({ start, end }) =>
+                    onDateRangeChange({ start, end })
+                  }
+                />
+              </div>
+              <div className='flex min-h-9 shrink-0 items-center justify-start gap-2 xl:justify-end'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  className='h-9 px-4'
+                  onClick={onReset}
+                  disabled={loading}
+                >
+                  {t('module.order.filters.reset')}
+                </Button>
+                <Button
+                  type='submit'
+                  className='h-9 px-4'
+                  disabled={loading}
+                >
+                  {t('module.order.filters.search')}
+                </Button>
+              </div>
+            </div>
+            <div className='mt-3 pl-3 text-sm text-muted-foreground'>
+              {tOperations('detail.creditUsage.count', {
+                count: data.total,
+              })}
+            </div>
+          </form>
+
+          <AdminTableShell
+            loading={loading}
+            isEmpty={!error && rows.length === 0}
+            emptyContent={tOperations('detail.creditUsage.table.empty')}
+            emptyColSpan={9}
+            withTooltipProvider={!error}
+            tableWrapperClassName='overflow-auto'
+            loadingClassName='min-h-[240px]'
+            footer={
+              pageCount > 1 ? (
+                <AdminPagination
+                  pageIndex={currentPage}
+                  pageCount={pageCount}
+                  onPageChange={onPageChange}
+                  prevLabel={t('module.order.paginationPrev', 'Previous')}
+                  nextLabel={t('module.order.paginationNext', 'Next')}
+                  prevAriaLabel={t(
+                    'module.order.paginationPrevAriaLabel',
+                    'Go to previous page',
+                  )}
+                  nextAriaLabel={t(
+                    'module.order.paginationNextAriaLabel',
+                    'Go to next page',
+                  )}
+                  className='mx-0 w-auto justify-end'
+                />
+              ) : null
+            }
+            table={
+              error ? (
+                <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
+                  <div className='space-y-2'>
+                    <div className='text-sm font-medium text-destructive'>
+                      {error.message}
+                    </div>
+                    {typeof error.code === 'number' ? (
+                      <div className='text-xs text-muted-foreground'>
+                        {error.code}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : (
+                emptyRow => (
+                  <Table className='table-auto'>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('createdAt')}
                         >
-                          <AdminTooltipText
-                            text={formatAdminUtcDateTime(row.created_at)}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-full tabular-nums'
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {tOperations('detail.creditUsage.table.createdAt')}
+                          {renderResizeHandle('createdAt')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('account')}
                         >
-                          <AdminTooltipText
-                            text={resolveAccount(row)}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-[180px] text-foreground'
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {accountLabel}
+                          {renderResizeHandle('account')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('nickname')}
                         >
-                          <AdminTooltipText
-                            text={row.nickname || defaultUserName}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-[140px]'
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center last:border-r-0'
+                          {tOperations('detail.creditUsage.table.nickname')}
+                          {renderResizeHandle('nickname')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('mode')}
                         >
-                          <Badge
-                            variant='outline'
-                            className='border-0 bg-transparent px-0 py-0 text-xs font-medium text-foreground shadow-none'
-                          >
-                            {resolveModeLabel(row.usage_mode)}
-                          </Badge>
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {tOperations('detail.creditUsage.table.mode')}
+                          {renderResizeHandle('mode')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('chapter')}
                         >
-                          <AdminTooltipText
-                            text={row.chapter_title}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-[180px]'
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {tOperations('detail.creditUsage.table.chapter')}
+                          {renderResizeHandle('chapter')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('lesson')}
                         >
-                          <AdminTooltipText
-                            text={row.lesson_title}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-[180px]'
-                          />
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {tOperations('detail.creditUsage.table.lesson')}
+                          {renderResizeHandle('lesson')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('usageCount')}
                         >
-                          <button
-                            type='button'
-                            className='tabular-nums text-primary hover:underline disabled:pointer-events-none disabled:text-foreground'
-                            disabled={!row.usage_count}
-                            onClick={() => handleOpenDetails(row)}
-                          >
-                            {row.usage_count}
-                          </button>
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                          {tOperations('detail.creditUsage.table.usageCount')}
+                          {renderResizeHandle('usageCount')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('credits')}
                         >
-                          <span className='font-medium tabular-nums text-foreground'>
-                            {row.consumed_credits}
-                          </span>
-                        </TableCell>
-                        <TableCell
-                          className='py-2.5 text-center text-sm text-foreground'
+                          {tOperations('detail.creditUsage.table.credits')}
+                          {renderResizeHandle('credits')}
+                        </TableHead>
+                        <TableHead
+                          className={cn(
+                            ADMIN_TABLE_HEADER_LAST_CELL_CENTER_CLASS,
+                            'h-10 whitespace-nowrap bg-muted/80 text-xs',
+                          )}
                           style={getColumnStyle('model')}
                         >
-                          <AdminTooltipText
-                            text={resolveModelDisplay(row)}
-                            emptyValue={emptyValue}
-                            className='mx-auto block max-w-[220px]'
-                          />
-                        </TableCell>
+                          {tOperations('detail.creditUsage.table.model')}
+                          {renderResizeHandle('model')}
+                        </TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {emptyRow}
+                      {rows.map(row => (
+                        <TableRow key={row.group_key || row.usage_bid}>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-xs text-muted-foreground/65 last:border-r-0'
+                            style={getColumnStyle('createdAt')}
+                          >
+                            <AdminTooltipText
+                              text={formatAdminUtcDateTime(row.created_at)}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-full tabular-nums'
+                            />
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('account')}
+                          >
+                            <AdminTooltipText
+                              text={resolveAccount(row)}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-[180px] text-foreground'
+                            />
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('nickname')}
+                          >
+                            <AdminTooltipText
+                              text={row.nickname || defaultUserName}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-[140px]'
+                            />
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center last:border-r-0'
+                            style={getColumnStyle('mode')}
+                          >
+                            <Badge
+                              variant='outline'
+                              className='border-0 bg-transparent px-0 py-0 text-xs font-medium text-foreground shadow-none'
+                            >
+                              {resolveModeLabel(row.usage_mode)}
+                            </Badge>
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('chapter')}
+                          >
+                            <AdminTooltipText
+                              text={row.chapter_title}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-[180px]'
+                            />
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('lesson')}
+                          >
+                            <AdminTooltipText
+                              text={row.lesson_title}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-[180px]'
+                            />
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('usageCount')}
+                          >
+                            <button
+                              type='button'
+                              className='tabular-nums text-primary hover:underline disabled:pointer-events-none disabled:text-foreground'
+                              disabled={!row.usage_count}
+                              onClick={() => handleOpenDetails(row)}
+                            >
+                              {row.usage_count}
+                            </button>
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 border-r border-border text-center text-sm text-foreground last:border-r-0'
+                            style={getColumnStyle('credits')}
+                          >
+                            <span className='font-medium tabular-nums text-foreground'>
+                              {row.consumed_credits}
+                            </span>
+                          </TableCell>
+                          <TableCell
+                            className='py-2.5 text-center text-sm text-foreground'
+                            style={getColumnStyle('model')}
+                          >
+                            <AdminTooltipText
+                              text={resolveModelDisplay(row)}
+                              emptyValue={emptyValue}
+                              className='mx-auto block max-w-[220px]'
+                            />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )
               )
-            )
-          }
-        />
+            }
+          />
         </CardContent>
       </Card>
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -610,6 +610,56 @@ describe('AdminOperationCourseDetailPage', () => {
     });
   });
 
+  test('keeps zero values visible in listen usage details', async () => {
+    mockGetAdminOperationCourseCreditUsages.mockResolvedValueOnce({
+      view: 'grouped',
+      items: [
+        {
+          group_key: 'progress-1:listen',
+          usage_bid: 'usage-listen',
+          progress_record_bid: 'progress-1',
+          generated_block_bid: '',
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          chapter_outline_item_bid: 'chapter-1',
+          chapter_title: 'Chapter 1',
+          lesson_outline_item_bid: 'lesson-1',
+          lesson_title: 'Lesson 1',
+          usage_mode: 'listen',
+          provider: 'volcengine',
+          model: 'cancan-2.0',
+          usage_count: 1,
+          model_variant_count: 1,
+          consumed_credits: 2,
+          created_at: '2026-04-08T12:30:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+
+    render(<AdminOperationCourseDetailPage />);
+
+    await openCreditUsageTab();
+
+    const usageRow = (await screen.findByText('Lesson 1')).closest('tr');
+    expect(usageRow).not.toBeNull();
+    fireEvent.click(
+      within(usageRow as HTMLElement).getByRole('button', {
+        name: 'module.operationsCourse.detail.creditUsage.details.openUsageDetails',
+      }),
+    );
+
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(within(dialog).getAllByText('0').length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   test('formats course metrics and learning progress without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';
     mockGetAdminOperationCourseUsers.mockResolvedValueOnce({

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -579,16 +579,16 @@ describe('AdminOperationCourseDetailPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: '2' }));
 
     await waitFor(() => {
-      expect(mockGetAdminOperationCourseCreditUsageDetails).toHaveBeenCalledWith(
-        {
-          shifu_bid: 'course-1',
-          page: 1,
-          page_size: 10,
-          user_bid: 'student-1',
-          outline_item_bid: 'lesson-1',
-          mode: 'learn',
-        },
-      );
+      expect(
+        mockGetAdminOperationCourseCreditUsageDetails,
+      ).toHaveBeenCalledWith({
+        shifu_bid: 'course-1',
+        page: 1,
+        page_size: 10,
+        user_bid: 'student-1',
+        outline_item_bid: 'lesson-1',
+        mode: 'learn',
+      });
     });
 
     const dialog = screen.getByRole('dialog');

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -14,6 +14,7 @@ const mockPush = jest.fn();
 const mockGetAdminOperationCourseDetail = jest.fn();
 const mockGetAdminOperationCourseUsers = jest.fn();
 const mockGetAdminOperationCourseCreditUsages = jest.fn();
+const mockGetAdminOperationCourseCreditUsageDetails = jest.fn();
 const mockGetAdminOperationCourseChapterDetail = jest.fn();
 const mockCopyText = jest.fn();
 const mockToastShow = jest.fn();
@@ -69,6 +70,8 @@ jest.mock('@/api', () => ({
       mockGetAdminOperationCourseUsers(...args),
     getAdminOperationCourseCreditUsages: (...args: unknown[]) =>
       mockGetAdminOperationCourseCreditUsages(...args),
+    getAdminOperationCourseCreditUsageDetails: (...args: unknown[]) =>
+      mockGetAdminOperationCourseCreditUsageDetails(...args),
     getAdminOperationCourseChapterDetail: (...args: unknown[]) =>
       mockGetAdminOperationCourseChapterDetail(...args),
   },
@@ -289,6 +292,7 @@ describe('AdminOperationCourseDetailPage', () => {
     mockGetAdminOperationCourseDetail.mockReset();
     mockGetAdminOperationCourseUsers.mockReset();
     mockGetAdminOperationCourseCreditUsages.mockReset();
+    mockGetAdminOperationCourseCreditUsageDetails.mockReset();
     mockGetAdminOperationCourseChapterDetail.mockReset();
     mockCopyText.mockReset();
     mockToastShow.mockReset();
@@ -363,6 +367,25 @@ describe('AdminOperationCourseDetailPage', () => {
       page_size: 20,
       total: 1,
     });
+    mockGetAdminOperationCourseCreditUsageDetails.mockResolvedValue({
+      items: [
+        {
+          usage_bid: 'usage-1',
+          consumed_credits: 7,
+          input_tokens: 1200,
+          output_tokens: 80,
+          word_count: 0,
+          duration_ms: 0,
+          segment_count: 0,
+          output_summary: 'First generated output summary',
+          created_at: '2026-04-08T12:20:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 10,
+      total: 1,
+    });
     mockGetAdminOperationCourseDetail.mockResolvedValue({
       basic_info: {
         shifu_bid: 'course-1',
@@ -382,6 +405,11 @@ describe('AdminOperationCourseDetailPage', () => {
         order_amount: '88',
         follow_up_count: 9,
         rating_score: '4.2',
+        credit_consumed_total: 120,
+        credit_usage_count: 18,
+        credit_user_count: 6,
+        completed_credit_user_count: 3,
+        completed_user_avg_credits: 20,
       },
       chapters: [
         {
@@ -444,12 +472,19 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.getByText('Course One')).toBeInTheDocument();
     expect(screen.getAllByText('13800001234').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Alice').length).toBeGreaterThan(0);
-    const visitorsMetricCard = screen
-      .getByText('module.operationsCourse.detail.metricsLabels.visitCount30d')
-      .closest('.rounded-lg');
-    expect(visitorsMetricCard).not.toBeNull();
     expect(
-      within(visitorsMetricCard as HTMLElement).getByText('34'),
+      screen.queryByText(
+        'module.operationsCourse.detail.metricsLabels.visitCount30d',
+      ),
+    ).not.toBeInTheDocument();
+    const creditsMetricCard = screen
+      .getByText(
+        'module.operationsCourse.detail.metricsLabels.creditConsumedTotal',
+      )
+      .closest('.rounded-lg');
+    expect(creditsMetricCard).not.toBeNull();
+    expect(
+      within(creditsMetricCard as HTMLElement).getByText('120'),
     ).toBeInTheDocument();
     expect(screen.getByText('¥88')).toBeInTheDocument();
     expect(screen.getByText('4.2')).toBeInTheDocument();
@@ -529,11 +564,44 @@ describe('AdminOperationCourseDetailPage', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(
+      screen.getByText(
         'module.operationsCourse.detail.creditUsage.table.usageCount',
       ),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(screen.getByText('17')).toBeInTheDocument();
+  });
+
+  test('opens credit usage detail dialog from usage count', async () => {
+    render(<AdminOperationCourseDetailPage />);
+
+    await openCreditUsageTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: '2' }));
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationCourseCreditUsageDetails).toHaveBeenCalledWith(
+        {
+          shifu_bid: 'course-1',
+          page: 1,
+          page_size: 10,
+          user_bid: 'student-1',
+          outline_item_bid: 'lesson-1',
+          mode: 'learn',
+        },
+      );
+    });
+
+    const dialog = screen.getByRole('dialog');
+    expect(
+      within(dialog).getByText(
+        'module.operationsCourse.detail.creditUsage.details.title',
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        within(dialog).getByText('First generated output summary'),
+      ).toBeInTheDocument();
+    });
   });
 
   test('formats course metrics and learning progress without grouping in Chinese locale', async () => {
@@ -580,14 +648,20 @@ describe('AdminOperationCourseDetailPage', () => {
         order_amount: '88',
         follow_up_count: 9000,
         rating_score: '4.2',
+        credit_consumed_total: 11000,
+        credit_usage_count: 8000,
+        credit_user_count: 3000,
+        completed_credit_user_count: 2000,
+        completed_user_avg_credits: 5.5,
       },
       chapters: [],
     });
 
     render(<AdminOperationCourseDetailPage />);
 
-    expect(await screen.findByText('76384')).toBeInTheDocument();
-    expect(screen.queryByText('76,384')).not.toBeInTheDocument();
+    expect(await screen.findByText('12000')).toBeInTheDocument();
+    expect(screen.getByText('11000')).toBeInTheDocument();
+    expect(screen.queryByText('12,000')).not.toBeInTheDocument();
 
     await openUsersTab();
     expect(screen.getByText('1000 / 2000')).toBeInTheDocument();
@@ -646,9 +720,9 @@ describe('AdminOperationCourseDetailPage', () => {
     await screen.findByText('Course One');
 
     expect(
-      screen.queryByRole('button', {
-        name: 'module.operationsCourse.detail.metricsLabels.visitCount30d',
-      }),
+      screen.queryByText(
+        'module.operationsCourse.detail.metricsLabels.visitCount30d',
+      ),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
@@ -773,6 +847,11 @@ describe('AdminOperationCourseDetailPage', () => {
         order_amount: '88',
         follow_up_count: 9,
         rating_score: '4.2',
+        credit_consumed_total: 120,
+        credit_usage_count: 18,
+        credit_user_count: 6,
+        completed_credit_user_count: 3,
+        completed_user_avg_credits: 20,
       },
       chapters: [
         {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -576,7 +576,13 @@ describe('AdminOperationCourseDetailPage', () => {
 
     await openCreditUsageTab();
 
-    fireEvent.click(await screen.findByRole('button', { name: '2' }));
+    const usageRow = (await screen.findByText('Lesson 1')).closest('tr');
+    expect(usageRow).not.toBeNull();
+    fireEvent.click(
+      within(usageRow as HTMLElement).getByRole('button', {
+        name: 'module.operationsCourse.detail.creditUsage.details.openUsageDetails',
+      }),
+    );
 
     await waitFor(() => {
       expect(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -22,7 +22,9 @@ import {
   buildAdminOperationsCourseRatingsUrl,
 } from '../operation-course-routes';
 import type {
+  AdminOperationCourseCreditUsageDetailListResponse,
   AdminOperationCourseCreditUsageFilters,
+  AdminOperationCourseCreditUsageItem,
   AdminOperationCourseCreditUsageListResponse,
   AdminOperationCourseChapterDetailResponse,
   AdminOperationCourseDetailChapter,
@@ -106,6 +108,8 @@ const EMPTY_COURSE_CREDIT_USAGE_RESPONSE: AdminOperationCourseCreditUsageListRes
     total: 0,
   };
 
+const COURSE_CREDIT_USAGE_DETAIL_PAGE_SIZE = 10;
+
 const EMPTY_DETAIL: AdminOperationCourseDetailResponse = {
   basic_info: {
     shifu_bid: '',
@@ -125,6 +129,11 @@ const EMPTY_DETAIL: AdminOperationCourseDetailResponse = {
     order_amount: '0',
     follow_up_count: 0,
     rating_score: '',
+    credit_consumed_total: 0,
+    credit_usage_count: 0,
+    credit_user_count: 0,
+    completed_credit_user_count: 0,
+    completed_user_avg_credits: null,
   },
   chapters: [],
 };
@@ -177,6 +186,10 @@ const createCourseCreditUsageFilters =
  * t('module.operationsCourse.detail.metricsLabels.orderAmount')
  * t('module.operationsCourse.detail.metricsLabels.followUpCount')
  * t('module.operationsCourse.detail.metricsLabels.ratingScore')
+ * t('module.operationsCourse.detail.metricsLabels.creditConsumedTotal')
+ * t('module.operationsCourse.detail.metricsLabels.creditUsageCount')
+ * t('module.operationsCourse.detail.metricsLabels.creditUserCount')
+ * t('module.operationsCourse.detail.metricsLabels.completedUserAvgCredits')
  * t('module.operationsCourse.detail.orders.openMetric')
  * t('module.operationsCourse.detail.followUps.openMetric')
  * t('module.operationsCourse.detail.ratings.openMetric')
@@ -537,6 +550,23 @@ export default function AdminOperationCourseDetailPage() {
     [courseCreditUsageFilters, shifuBid, unknownErrorMessage],
   );
 
+  const fetchCourseCreditUsageDetails = useCallback(
+    async (row: AdminOperationCourseCreditUsageItem, page: number) => {
+      if (!shifuBid.trim()) {
+        throw new Error(unknownErrorMessage);
+      }
+      return (await api.getAdminOperationCourseCreditUsageDetails({
+        shifu_bid: shifuBid,
+        page,
+        page_size: COURSE_CREDIT_USAGE_DETAIL_PAGE_SIZE,
+        user_bid: row.user_bid,
+        outline_item_bid: row.lesson_outline_item_bid,
+        mode: row.usage_mode === 'mixed' ? '' : row.usage_mode,
+      })) as AdminOperationCourseCreditUsageDetailListResponse;
+    },
+    [shifuBid, unknownErrorMessage],
+  );
+
   useEffect(() => {
     if (!isReady) {
       return;
@@ -687,10 +717,6 @@ export default function AdminOperationCourseDetailPage() {
   const metricCards = useMemo(
     () => [
       {
-        label: tOperations('detail.metricsLabels.visitCount30d'),
-        value: formatCount(detail.metrics.visit_count_30d, i18n.language),
-      },
-      {
         label: tOperations('detail.metricsLabels.learnerCount'),
         value: formatCount(detail.metrics.learner_count, i18n.language),
       },
@@ -717,6 +743,29 @@ export default function AdminOperationCourseDetailPage() {
         value: detail.metrics.rating_score || emptyValue,
         onClick: ratingsPageUrl ? () => router.push(ratingsPageUrl) : undefined,
         actionLabel: tOperations('detail.ratings.openMetric'),
+      },
+      {
+        label: tOperations('detail.metricsLabels.creditConsumedTotal'),
+        value: formatCount(detail.metrics.credit_consumed_total || 0, i18n.language),
+      },
+      {
+        label: tOperations('detail.metricsLabels.creditUsageCount'),
+        value: formatCount(detail.metrics.credit_usage_count || 0, i18n.language),
+      },
+      {
+        label: tOperations('detail.metricsLabels.creditUserCount'),
+        value: formatCount(detail.metrics.credit_user_count || 0, i18n.language),
+      },
+      {
+        label: tOperations('detail.metricsLabels.completedUserAvgCredits'),
+        value:
+          detail.metrics.completed_user_avg_credits === null ||
+          detail.metrics.completed_user_avg_credits === undefined
+            ? emptyValue
+            : formatCount(
+                detail.metrics.completed_user_avg_credits,
+                i18n.language,
+              ),
       },
     ],
     [
@@ -1527,6 +1576,7 @@ export default function AdminOperationCourseDetailPage() {
                   onSearch={handleCourseCreditUsageSearch}
                   onReset={handleCourseCreditUsageReset}
                   onPageChange={handleCourseCreditUsagePageChange}
+                  onFetchDetails={fetchCourseCreditUsageDetails}
                 />
               </TabsContent>
             </Tabs>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -746,15 +746,24 @@ export default function AdminOperationCourseDetailPage() {
       },
       {
         label: tOperations('detail.metricsLabels.creditConsumedTotal'),
-        value: formatCount(detail.metrics.credit_consumed_total || 0, i18n.language),
+        value: formatCount(
+          detail.metrics.credit_consumed_total || 0,
+          i18n.language,
+        ),
       },
       {
         label: tOperations('detail.metricsLabels.creditUsageCount'),
-        value: formatCount(detail.metrics.credit_usage_count || 0, i18n.language),
+        value: formatCount(
+          detail.metrics.credit_usage_count || 0,
+          i18n.language,
+        ),
       },
       {
         label: tOperations('detail.metricsLabels.creditUserCount'),
-        value: formatCount(detail.metrics.credit_user_count || 0, i18n.language),
+        value: formatCount(
+          detail.metrics.credit_user_count || 0,
+          i18n.language,
+        ),
       },
       {
         label: tOperations('detail.metricsLabels.completedUserAvgCredits'),

--- a/src/cook-web/src/app/admin/operations/operation-course-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-course-types.ts
@@ -68,6 +68,11 @@ export type AdminOperationCourseDetailMetrics = {
   order_amount: string;
   follow_up_count: number;
   rating_score: string;
+  credit_consumed_total: number;
+  credit_usage_count: number;
+  credit_user_count: number;
+  completed_credit_user_count: number;
+  completed_user_avg_credits: number | null;
 };
 
 export type AdminOperationCourseDetailChapter = {
@@ -188,6 +193,26 @@ export type AdminOperationCourseCreditUsageItem = {
 export type AdminOperationCourseCreditUsageListResponse = {
   view: AdminOperationCourseCreditUsageView;
   items: AdminOperationCourseCreditUsageItem[];
+  page: number;
+  page_count: number;
+  page_size: number;
+  total: number;
+};
+
+export type AdminOperationCourseCreditUsageDetailItem = {
+  usage_bid: string;
+  consumed_credits: number;
+  input_tokens: number;
+  output_tokens: number;
+  word_count: number;
+  duration_ms: number;
+  segment_count: number;
+  output_summary: string;
+  created_at: string;
+};
+
+export type AdminOperationCourseCreditUsageDetailListResponse = {
+  items: AdminOperationCourseCreditUsageDetailItem[];
   page: number;
   page_count: number;
   page_size: number;

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -95,6 +95,23 @@
       "modelSummary": {
         "multiple": "{model} and {count} models"
       },
+      "details": {
+        "collapse": "Collapse",
+        "empty": "No usage details",
+        "expand": "...",
+        "table": {
+          "createdAt": "Consumed At",
+          "credits": "Credits",
+          "inputTokens": "Input Tokens",
+          "outputSummary": "Output Summary",
+          "outputTokens": "Output Tokens",
+          "ttsWordCount": "Synthesized Words",
+          "ttsDuration": "Audio Duration",
+          "ttsSegmentCount": "Segments",
+          "ttsContent": "Synthesized Content"
+        },
+        "title": "Credit Usage Details"
+      },
       "modes": {
         "ask": "Follow-up",
         "learn": "Read",
@@ -104,7 +121,7 @@
       },
       "table": {
         "chapter": "Chapter",
-        "createdAt": "Consumed At",
+        "createdAt": "Latest Consumed At",
         "credits": "Total Credits Consumed",
         "empty": "No credit usage records",
         "lesson": "Lesson",
@@ -203,7 +220,11 @@
       "orderAmount": "Collected Revenue (Incl. Coupon Codes)",
       "orderCount": "Orders",
       "ratingScore": "Rating",
-      "visitCount30d": "Visitors (30d)"
+      "visitCount30d": "Visitors (30d)",
+      "creditConsumedTotal": "Total Credits Consumed",
+      "creditUsageCount": "Credit Usage Count",
+      "creditUserCount": "Credit Usage Users",
+      "completedUserAvgCredits": "Avg Credits Consumed per Completed User"
     },
     "orders": {
       "openMetric": "Open order data"

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -82,6 +82,23 @@
     "creditUsage": {
       "count": "{count} records",
       "description": "Review credit consumption records for this course.",
+      "details": {
+        "collapse": "Collapse",
+        "empty": "No usage details",
+        "expand": "...",
+        "table": {
+          "createdAt": "Consumed At",
+          "credits": "Credits",
+          "inputTokens": "Input Tokens",
+          "outputSummary": "Output Summary",
+          "outputTokens": "Output Tokens",
+          "ttsContent": "Synthesized Content",
+          "ttsDuration": "Audio Duration",
+          "ttsSegmentCount": "Segments",
+          "ttsWordCount": "Synthesized Words"
+        },
+        "title": "Credit Usage Details"
+      },
       "filters": {
         "mode": "Usage mode",
         "modeAll": "All",
@@ -94,23 +111,6 @@
       },
       "modelSummary": {
         "multiple": "{model} and {count} models"
-      },
-      "details": {
-        "collapse": "Collapse",
-        "empty": "No usage details",
-        "expand": "...",
-        "table": {
-          "createdAt": "Consumed At",
-          "credits": "Credits",
-          "inputTokens": "Input Tokens",
-          "outputSummary": "Output Summary",
-          "outputTokens": "Output Tokens",
-          "ttsWordCount": "Synthesized Words",
-          "ttsDuration": "Audio Duration",
-          "ttsSegmentCount": "Segments",
-          "ttsContent": "Synthesized Content"
-        },
-        "title": "Credit Usage Details"
       },
       "modes": {
         "ask": "Follow-up",
@@ -215,16 +215,16 @@
     },
     "metrics": "Metrics",
     "metricsLabels": {
+      "completedUserAvgCredits": "Avg Credits Consumed per Completed User",
+      "creditConsumedTotal": "Total Credits Consumed",
+      "creditUsageCount": "Credit Usage Count",
+      "creditUserCount": "Credit Usage Users",
       "followUpCount": "Ask",
       "learnerCount": "Learners",
       "orderAmount": "Collected Revenue (Incl. Coupon Codes)",
       "orderCount": "Orders",
       "ratingScore": "Rating",
-      "visitCount30d": "Visitors (30d)",
-      "creditConsumedTotal": "Total Credits Consumed",
-      "creditUsageCount": "Credit Usage Count",
-      "creditUserCount": "Credit Usage Users",
-      "completedUserAvgCredits": "Avg Credits Consumed per Completed User"
+      "visitCount30d": "Visitors (30d)"
     },
     "orders": {
       "openMetric": "Open order data"

--- a/src/i18n/en-US/modules/operations-course.json
+++ b/src/i18n/en-US/modules/operations-course.json
@@ -84,8 +84,11 @@
       "description": "Review credit consumption records for this course.",
       "details": {
         "collapse": "Collapse",
+        "durationMinutesSeconds": "{minutes}m {seconds}s",
+        "durationSeconds": "{seconds}s",
         "empty": "No usage details",
-        "expand": "...",
+        "expand": "Expand",
+        "openUsageDetails": "Open {count} credit usage details",
         "table": {
           "createdAt": "Consumed At",
           "credits": "Credits",

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -95,6 +95,23 @@
       "modelSummary": {
         "multiple": "{model} et {count} modèles"
       },
+      "details": {
+        "collapse": "Réduire",
+        "empty": "Aucun détail de consommation",
+        "expand": "...",
+        "table": {
+          "createdAt": "Consommé le",
+          "credits": "Crédits",
+          "inputTokens": "Tokens d'entrée",
+          "outputSummary": "Résumé de sortie",
+          "outputTokens": "Tokens de sortie",
+          "ttsWordCount": "Mots synthétisés",
+          "ttsDuration": "Durée audio",
+          "ttsSegmentCount": "Segments",
+          "ttsContent": "Contenu synthétisé"
+        },
+        "title": "Détails de consommation des crédits"
+      },
       "modes": {
         "ask": "Relance",
         "learn": "Lecture",
@@ -104,7 +121,7 @@
       },
       "table": {
         "chapter": "Chapitre",
-        "createdAt": "Heure de consommation",
+        "createdAt": "Dernière consommation",
         "credits": "Total des crédits consommés",
         "empty": "Aucun enregistrement de consommation de crédits",
         "lesson": "Leçon",
@@ -203,7 +220,11 @@
       "orderAmount": "Revenus collectés (codes coupon inclus)",
       "orderCount": "Commandes",
       "ratingScore": "Note",
-      "visitCount30d": "Visiteurs (30 j)"
+      "visitCount30d": "Visiteurs (30 j)",
+      "creditConsumedTotal": "Crédits consommés",
+      "creditUsageCount": "Nombre de consommations de crédits",
+      "creditUserCount": "Utilisateurs consommateurs de crédits",
+      "completedUserAvgCredits": "Moy. crédits consommés par utilisateur terminé"
     },
     "orders": {
       "openMetric": "Ouvrir les données de commande"

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -82,6 +82,23 @@
     "creditUsage": {
       "count": "{count} enregistrements",
       "description": "Consulter les enregistrements de consommation de crédits de ce cours.",
+      "details": {
+        "collapse": "Réduire",
+        "empty": "Aucun détail de consommation",
+        "expand": "...",
+        "table": {
+          "createdAt": "Consommé le",
+          "credits": "Crédits",
+          "inputTokens": "Tokens d'entrée",
+          "outputSummary": "Résumé de sortie",
+          "outputTokens": "Tokens de sortie",
+          "ttsContent": "Contenu synthétisé",
+          "ttsDuration": "Durée audio",
+          "ttsSegmentCount": "Segments",
+          "ttsWordCount": "Mots synthétisés"
+        },
+        "title": "Détails de consommation des crédits"
+      },
       "filters": {
         "mode": "Scène d'utilisation",
         "modeAll": "Tous",
@@ -94,23 +111,6 @@
       },
       "modelSummary": {
         "multiple": "{model} et {count} modèles"
-      },
-      "details": {
-        "collapse": "Réduire",
-        "empty": "Aucun détail de consommation",
-        "expand": "...",
-        "table": {
-          "createdAt": "Consommé le",
-          "credits": "Crédits",
-          "inputTokens": "Tokens d'entrée",
-          "outputSummary": "Résumé de sortie",
-          "outputTokens": "Tokens de sortie",
-          "ttsWordCount": "Mots synthétisés",
-          "ttsDuration": "Durée audio",
-          "ttsSegmentCount": "Segments",
-          "ttsContent": "Contenu synthétisé"
-        },
-        "title": "Détails de consommation des crédits"
       },
       "modes": {
         "ask": "Relance",
@@ -215,16 +215,16 @@
     },
     "metrics": "Métriques",
     "metricsLabels": {
+      "completedUserAvgCredits": "Moy. crédits consommés par utilisateur terminé",
+      "creditConsumedTotal": "Crédits consommés",
+      "creditUsageCount": "Nombre de consommations de crédits",
+      "creditUserCount": "Utilisateurs consommateurs de crédits",
       "followUpCount": "Questions",
       "learnerCount": "Apprenants",
       "orderAmount": "Revenus collectés (codes coupon inclus)",
       "orderCount": "Commandes",
       "ratingScore": "Note",
-      "visitCount30d": "Visiteurs (30 j)",
-      "creditConsumedTotal": "Crédits consommés",
-      "creditUsageCount": "Nombre de consommations de crédits",
-      "creditUserCount": "Utilisateurs consommateurs de crédits",
-      "completedUserAvgCredits": "Moy. crédits consommés par utilisateur terminé"
+      "visitCount30d": "Visiteurs (30 j)"
     },
     "orders": {
       "openMetric": "Ouvrir les données de commande"

--- a/src/i18n/fr-FR/modules/operations-course.json
+++ b/src/i18n/fr-FR/modules/operations-course.json
@@ -84,8 +84,11 @@
       "description": "Consulter les enregistrements de consommation de crédits de ce cours.",
       "details": {
         "collapse": "Réduire",
+        "durationMinutesSeconds": "{minutes} min {seconds} s",
+        "durationSeconds": "{seconds} s",
         "empty": "Aucun détail de consommation",
-        "expand": "...",
+        "expand": "Développer",
+        "openUsageDetails": "Ouvrir les détails des {count} consommations",
         "table": {
           "createdAt": "Consommé le",
           "credits": "Crédits",

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -95,6 +95,23 @@
       "modelSummary": {
         "multiple": "{model} 等 {count} 个"
       },
+      "details": {
+        "collapse": "收起",
+        "empty": "暂无消耗明细",
+        "expand": "...",
+        "table": {
+          "createdAt": "消耗时间",
+          "credits": "消耗积分",
+          "inputTokens": "输入 Tokens",
+          "outputSummary": "输出摘要",
+          "outputTokens": "输出 Tokens",
+          "ttsWordCount": "合成字数",
+          "ttsDuration": "音频时长",
+          "ttsSegmentCount": "分段数",
+          "ttsContent": "合成内容"
+        },
+        "title": "积分消耗明细"
+      },
       "modes": {
         "ask": "追问",
         "learn": "阅读",
@@ -104,7 +121,7 @@
       },
       "table": {
         "chapter": "章节",
-        "createdAt": "消耗时间",
+        "createdAt": "最近消耗时间",
         "credits": "总消耗积分",
         "empty": "暂无积分消耗记录",
         "lesson": "小节",
@@ -203,7 +220,11 @@
       "orderAmount": "实收总额（含兑换码）",
       "orderCount": "订单数",
       "ratingScore": "评分",
-      "visitCount30d": "近30天访问人数"
+      "visitCount30d": "近30天访问人数",
+      "creditConsumedTotal": "总消耗积分",
+      "creditUsageCount": "积分消耗次数",
+      "creditUserCount": "积分消耗用户数",
+      "completedUserAvgCredits": "完课用户平均积分消耗"
     },
     "orders": {
       "openMetric": "查看订单数据"

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -82,6 +82,23 @@
     "creditUsage": {
       "count": "{count} 条记录",
       "description": "查看该课程的积分消耗记录。",
+      "details": {
+        "collapse": "收起",
+        "empty": "暂无消耗明细",
+        "expand": "...",
+        "table": {
+          "createdAt": "消耗时间",
+          "credits": "消耗积分",
+          "inputTokens": "输入 Tokens",
+          "outputSummary": "输出摘要",
+          "outputTokens": "输出 Tokens",
+          "ttsContent": "合成内容",
+          "ttsDuration": "音频时长",
+          "ttsSegmentCount": "分段数",
+          "ttsWordCount": "合成字数"
+        },
+        "title": "积分消耗明细"
+      },
       "filters": {
         "mode": "消耗场景",
         "modeAll": "全部",
@@ -94,23 +111,6 @@
       },
       "modelSummary": {
         "multiple": "{model} 等 {count} 个"
-      },
-      "details": {
-        "collapse": "收起",
-        "empty": "暂无消耗明细",
-        "expand": "...",
-        "table": {
-          "createdAt": "消耗时间",
-          "credits": "消耗积分",
-          "inputTokens": "输入 Tokens",
-          "outputSummary": "输出摘要",
-          "outputTokens": "输出 Tokens",
-          "ttsWordCount": "合成字数",
-          "ttsDuration": "音频时长",
-          "ttsSegmentCount": "分段数",
-          "ttsContent": "合成内容"
-        },
-        "title": "积分消耗明细"
       },
       "modes": {
         "ask": "追问",
@@ -215,16 +215,16 @@
     },
     "metrics": "数据概览",
     "metricsLabels": {
+      "completedUserAvgCredits": "完课用户平均积分消耗",
+      "creditConsumedTotal": "总消耗积分",
+      "creditUsageCount": "积分消耗次数",
+      "creditUserCount": "积分消耗用户数",
       "followUpCount": "追问数",
       "learnerCount": "学习人数",
       "orderAmount": "实收总额（含兑换码）",
       "orderCount": "订单数",
       "ratingScore": "评分",
-      "visitCount30d": "近30天访问人数",
-      "creditConsumedTotal": "总消耗积分",
-      "creditUsageCount": "积分消耗次数",
-      "creditUserCount": "积分消耗用户数",
-      "completedUserAvgCredits": "完课用户平均积分消耗"
+      "visitCount30d": "近30天访问人数"
     },
     "orders": {
       "openMetric": "查看订单数据"

--- a/src/i18n/zh-CN/modules/operations-course.json
+++ b/src/i18n/zh-CN/modules/operations-course.json
@@ -84,8 +84,11 @@
       "description": "查看该课程的积分消耗记录。",
       "details": {
         "collapse": "收起",
+        "durationMinutesSeconds": "{minutes}分{seconds}秒",
+        "durationSeconds": "{seconds}秒",
         "empty": "暂无消耗明细",
-        "expand": "...",
+        "expand": "展开",
+        "openUsageDetails": "查看{count}次消耗明细",
         "table": {
           "createdAt": "消耗时间",
           "credits": "消耗积分",


### PR DESCRIPTION
## Summary
- add operator course detail credit metrics and hide the temporary 30-day visit card
- optimize the credit usage tab with grouped usage rows and a details dialog from usage count
- add backend credit usage detail API, precise generated output summaries, and TTS/listen detail fields

## Verification
- `git diff --check`
- `python scripts/check_translation_usage.py --fail-on-unused`
- `cd src/api && pytest tests/service/shifu/test_admin_course_detail.py -q`
- `cd src/cook-web && npm test -- --runTestsByPath 'src/app/admin/operations/[shifu_bid]/page.test.tsx' --runInBand`
- `cd src/cook-web && npm run type-check`

## Notes
- Existing historical usage rows without `generated_block_bid` will show `--` for output summary.
- TTS/listen detail behavior needs test-environment validation where TTS is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credit usage details dialog with expandable output summaries, per-usage pagination, token/TTS/duration/segment stats, and per-row detail loading
  * Dashboard adds credit-consumption cards: total consumed, usage count, user count, and completed-user average; visit-count metric removed
  * Filters by user, lesson, and operation mode for credit usage reports

* **Bug Fixes**
  * Robust normalization of heterogeneous operator datetimes
  * Grouped credit-usage view returns not-found for missing courses

* **Tests**
  * Added tests for datetime coercion, credit metrics, grouped views, and details pagination

* **Documentation**
  * Updated EN/FR/ZH translations for credit metrics and detail views

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->