### PR TITLE
[codex] Fix generated-block listen TTS element lookup

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1000,6 +1000,25 @@ def _build_tts_done_message(
     )
 
 
+def _log_generated_block_tts_noop(
+    app: Flask,
+    *,
+    shifu_bid: str,
+    generated_block_bid: str,
+    user_bid: str,
+    listen: bool,
+) -> None:
+    app.logger.info(
+        "No speakable text for generated block TTS; skipping synthesis",
+        extra={
+            "shifu_bid": shifu_bid,
+            "generated_block_bid": generated_block_bid,
+            "user_bid": user_bid,
+            "listen": listen,
+        },
+    )
+
+
 def _subtitle_cues_from_audio_record(
     audio_record: LearnGeneratedAudio | None,
 ) -> list[dict]:
@@ -1226,6 +1245,7 @@ def stream_generated_block_audio(
             final_elements = get_final_elements_for_generated_block(
                 generated_block_bid=generated_block_bid,
                 user_bid=user_bid,
+                progress_record_bid=generated_block.progress_record_bid or "",
                 shifu_bid=shifu_bid,
             )
             speakable_elements = get_speakable_text_elements(final_elements)
@@ -1233,10 +1253,18 @@ def stream_generated_block_audio(
                 str(element.content_text or "") for element in speakable_elements
             ]
             if not speakable_segments:
-                raise_error_with_args(
-                    "server.common.paramsError",
-                    param_message="No speakable text elements available for TTS synthesis",
+                _log_generated_block_tts_noop(
+                    app,
+                    shifu_bid=shifu_bid,
+                    generated_block_bid=generated_block_bid,
+                    user_bid=user_bid,
+                    listen=True,
                 )
+                yield _build_tts_done_message(
+                    outline_bid=generated_block.outline_item_bid or "",
+                    generated_block_bid=generated_block_bid,
+                )
+                return
 
             expected_segment_count = len(speakable_segments)
             existing_by_position: dict[int, LearnGeneratedAudio] = {}
@@ -1342,10 +1370,18 @@ def stream_generated_block_audio(
 
         cleaned_text = preprocess_for_tts(raw_text)
         if not cleaned_text or len(cleaned_text.strip()) < 2:
-            raise_error_with_args(
-                "server.common.paramsError",
-                param_message="No speakable text available for TTS synthesis",
+            _log_generated_block_tts_noop(
+                app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                listen=False,
             )
+            yield _build_tts_done_message(
+                outline_bid=generated_block.outline_item_bid or "",
+                generated_block_bid=generated_block_bid,
+            )
+            return
 
         def _generate_single_audio():
             yield from _yield_run_tts_audio_events(

--- a/src/api/flaskr/service/learn/listen_element_history.py
+++ b/src/api/flaskr/service/learn/listen_element_history.py
@@ -413,6 +413,7 @@ def get_final_elements_for_generated_block(
     *,
     generated_block_bid: str,
     user_bid: str = "",
+    progress_record_bid: str = "",
     shifu_bid: str = "",
     include_non_navigable: bool = False,
 ) -> list[ElementDTO]:
@@ -425,7 +426,9 @@ def get_final_elements_for_generated_block(
         LearnGeneratedElement.deleted == 0,
         LearnGeneratedElement.status == 1,
     ]
-    if user_bid:
+    if progress_record_bid:
+        filters.append(LearnGeneratedElement.progress_record_bid == progress_record_bid)
+    elif user_bid:
         filters.append(LearnGeneratedElement.user_bid == user_bid)
     if shifu_bid:
         filters.append(LearnGeneratedElement.shifu_bid == shifu_bid)

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -503,6 +503,284 @@ class TestGeneratedBlockListenTtsElementFirst:
             assert records[0].subtitle_cues[0]["text"] == "First."
             assert records[1].subtitle_cues[0]["text"] == "Second."
 
+    def test_stream_generated_block_audio_listen_uses_block_progress_for_elements(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "owner-user-1"
+        element_user_bid = "runtime-user-1"
+        shifu_bid = "shifu-progress-scope-1"
+        generated_block_bid = "gen-progress-scope-1"
+        progress_record_bid = "progress-scope-1"
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid=progress_record_bid,
+                    user_bid=user_bid,
+                    block_bid="block-progress-scope-1",
+                    outline_item_bid="outline-progress-scope-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content="Persisted listen text.",
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.add_all(
+                [
+                    self.LearnGeneratedElement(
+                        element_bid="el-progress-scope-1",
+                        progress_record_bid=progress_record_bid,
+                        user_bid=element_user_bid,
+                        generated_block_bid=generated_block_bid,
+                        outline_item_bid="outline-progress-scope-1",
+                        shifu_bid=shifu_bid,
+                        run_session_bid="run-progress-scope-1",
+                        run_event_seq=1,
+                        event_type="element",
+                        role="teacher",
+                        element_index=0,
+                        element_type="text",
+                        change_type="render",
+                        is_renderable=0,
+                        is_new=1,
+                        is_marker=0,
+                        sequence_number=1,
+                        is_speakable=1,
+                        is_navigable=1,
+                        is_final=1,
+                        content_text="Persisted listen text.",
+                        payload="",
+                        status=1,
+                        deleted=0,
+                    ),
+                    self.LearnGeneratedElement(
+                        element_bid="el-progress-scope-decoy-1",
+                        progress_record_bid="other-progress-scope-1",
+                        user_bid=user_bid,
+                        generated_block_bid=generated_block_bid,
+                        outline_item_bid="outline-progress-scope-1",
+                        shifu_bid=shifu_bid,
+                        run_session_bid="run-progress-scope-1",
+                        run_event_seq=2,
+                        event_type="element",
+                        role="teacher",
+                        element_index=1,
+                        element_type="text",
+                        change_type="render",
+                        is_renderable=0,
+                        is_new=1,
+                        is_marker=0,
+                        sequence_number=2,
+                        is_speakable=1,
+                        is_navigable=1,
+                        is_final=1,
+                        content_text="Wrong progress text.",
+                        payload="",
+                        status=1,
+                        deleted=0,
+                    ),
+                ]
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=False,
+                listen=True,
+            )
+        )
+
+        assert synthesized_texts == ["Persisted listen text."]
+        assert [event.type for event in events] == [
+            GeneratedType.AUDIO_SEGMENT,
+            GeneratedType.AUDIO_COMPLETE,
+            GeneratedType.DONE,
+        ]
+
+        with self.app.app_context():
+            records = self.LearnGeneratedAudio.query.filter(
+                self.LearnGeneratedAudio.generated_block_bid == generated_block_bid,
+                self.LearnGeneratedAudio.deleted == 0,
+            ).all()
+            assert len(records) == 1
+            assert records[0].user_bid == user_bid
+            assert records[0].progress_record_bid == progress_record_bid
+
+    def test_stream_generated_block_audio_listen_no_speakable_finishes_stream(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "user-no-speakable-1"
+        shifu_bid = "shifu-no-speakable-1"
+        generated_block_bid = "gen-no-speakable-1"
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-no-speakable-1",
+                    user_bid=user_bid,
+                    block_bid="block-no-speakable-1",
+                    outline_item_bid="outline-no-speakable-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content="<svg><text>chart</text></svg>",
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.add(
+                self.LearnGeneratedElement(
+                    element_bid="el-no-speakable-1",
+                    progress_record_bid="progress-no-speakable-1",
+                    user_bid=user_bid,
+                    generated_block_bid=generated_block_bid,
+                    outline_item_bid="outline-no-speakable-1",
+                    shifu_bid=shifu_bid,
+                    run_session_bid="run-no-speakable-1",
+                    run_event_seq=1,
+                    event_type="element",
+                    role="teacher",
+                    element_index=0,
+                    element_type="svg",
+                    change_type="render",
+                    is_renderable=1,
+                    is_new=1,
+                    is_marker=0,
+                    sequence_number=1,
+                    is_speakable=0,
+                    is_navigable=1,
+                    is_final=1,
+                    content_text="",
+                    payload="",
+                    status=1,
+                    deleted=0,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=False,
+                listen=True,
+            )
+        )
+
+        assert synthesized_texts == []
+        assert [event.type for event in events] == [GeneratedType.DONE]
+
+        with self.app.app_context():
+            records = (
+                self.LearnGeneratedAudio.query.filter(
+                    self.LearnGeneratedAudio.generated_block_bid == generated_block_bid,
+                    self.LearnGeneratedAudio.user_bid == user_bid,
+                    self.LearnGeneratedAudio.shifu_bid == shifu_bid,
+                    self.LearnGeneratedAudio.deleted == 0,
+                )
+                .order_by(self.LearnGeneratedAudio.position.asc())
+                .all()
+            )
+            assert records == []
+
+    def test_stream_generated_block_audio_non_listen_no_speakable_finishes_stream(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "user-no-speakable-single-1"
+        shifu_bid = "shifu-no-speakable-single-1"
+        generated_block_bid = "gen-no-speakable-single-1"
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-no-speakable-single-1",
+                    user_bid=user_bid,
+                    block_bid="block-no-speakable-single-1",
+                    outline_item_bid="outline-no-speakable-single-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content="<svg><text>chart</text></svg>",
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=False,
+                listen=False,
+            )
+        )
+
+        assert synthesized_texts == []
+        assert [event.type for event in events] == [GeneratedType.DONE]
+
+        with self.app.app_context():
+            records = (
+                self.LearnGeneratedAudio.query.filter(
+                    self.LearnGeneratedAudio.generated_block_bid == generated_block_bid,
+                    self.LearnGeneratedAudio.user_bid == user_bid,
+                    self.LearnGeneratedAudio.shifu_bid == shifu_bid,
+                    self.LearnGeneratedAudio.deleted == 0,
+                )
+                .order_by(self.LearnGeneratedAudio.position.asc())
+                .all()
+            )
+            assert records == []
+
     def test_stream_generated_block_audio_listen_preserves_position_after_short_text(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- Scope listen-mode generated-block TTS element lookup by the verified block's `progress_record_bid`, with `user_bid` as fallback for older rows without progress metadata.
- Keep genuinely visual-only/no-speakable generated blocks as a no-op that emits terminal `done` instead of raising a params error.
- Add regression coverage for the production shape where `learn_generated_blocks.user_bid` differs from `learn_generated_elements.user_bid` but both rows share the same progress record.

## Root cause
Production logs for the reported block showed `AppException: No speakable text elements available for TTS synthesis`. The block and progress record are owned by the authenticated request user, but the persisted listen element rows for the same `generated_block_bid` were written under a runtime learner/user alias. The old TTS path passed `user_bid` into `get_final_elements_for_generated_block`, so the ORM query returned no element rows even though the block had an active speakable text element.

## Validation
- `pytest tests/service/learn/test_generated_block_tts_av_mode.py -q`
- `pre-commit run ruff-check --files src/api/flaskr/service/learn/learn_funcs.py src/api/flaskr/service/learn/listen_element_history.py src/api/tests/service/learn/test_generated_block_tts_av_mode.py`
- `pre-commit run ruff-format --files src/api/flaskr/service/learn/learn_funcs.py src/api/flaskr/service/learn/listen_element_history.py src/api/tests/service/learn/test_generated_block_tts_av_mode.py`
- `git diff --check`
