### PR TITLE
fix: credit notification SMS expiry time

### DIFF
--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -23,7 +23,7 @@ from flaskr.service.config import get_config
 from flaskr.service.config.funcs import add_config
 from flaskr.service.user.consts import USER_STATE_UNREGISTERED
 from flaskr.service.user.models import UserInfo as UserEntity
-from flaskr.util.timezone import serialize_with_app_timezone
+from flaskr.util.timezone import format_with_app_timezone
 from flaskr.util.uuid import generate_id
 
 from .consts import (
@@ -821,10 +821,33 @@ def _provider_response_payload(response: Any) -> dict[str, Any]:
     }
 
 
-def _serialize_dt(app: Flask, value: datetime | None) -> str:
+def _format_sms_datetime(app: Flask, value: Any) -> str:
     if value is None:
         return ""
-    return str(serialize_with_app_timezone(app, value) or "")
+    if isinstance(value, datetime):
+        resolved = value
+    else:
+        raw_value = str(value or "").strip()
+        if not raw_value:
+            return ""
+        try:
+            resolved = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+        except ValueError:
+            return raw_value
+    return str(format_with_app_timezone(app, resolved, "%Y-%m-%d %H:%M:%S") or "")
+
+
+def _serialize_dt(app: Flask, value: datetime | None) -> str:
+    return _format_sms_datetime(app, value)
+
+
+def _normalize_sms_template_params(
+    app: Flask, params: dict[str, Any]
+) -> dict[str, str]:
+    normalized = {str(key): str(value or "").strip() for key, value in params.items()}
+    if "expires_at" in normalized:
+        normalized["expires_at"] = _format_sms_datetime(app, normalized["expires_at"])
+    return normalized
 
 
 def _amount_text(value: Any) -> str:
@@ -2061,12 +2084,20 @@ def deliver_credit_notification(
                 "notification_status": notification.status,
             }
 
+        template_params = _normalize_sms_template_params(
+            app,
+            dict(notification.template_params_json or {}),
+        )
+        if template_params != dict(notification.template_params_json or {}):
+            notification.template_params_json = template_params
+            db.session.add(notification)
+
         try:
             response = send_sms_ali(
                 app,
                 mobile,
                 template_code=template_code,
-                template_params=dict(notification.template_params_json or {}),
+                template_params=template_params,
             )
         except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
             _finalize_notification(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -377,7 +377,7 @@ def test_credit_granted_notification_stages_once_and_delivers_sms(
             "template_code": "TPL-GRANT",
             "template_params": {
                 "credits": "12.50",
-                "expires_at": "2026-06-30T00:00:00+00:00",
+                "expires_at": "2026-06-30 00:00:00",
                 "source": "operator",
             },
         }
@@ -388,6 +388,71 @@ def test_credit_granted_notification_stages_once_and_delivers_sms(
         ).one()
         assert notification.status == CREDIT_NOTIFICATION_STATUS_SENT
         assert notification.mobile_snapshot == "13800000000"
+
+
+def test_credit_notification_delivery_normalizes_legacy_iso_expires_at(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    _seed_creator(app)
+    _enable_policy(app)
+    captured: list[dict[str, object]] = []
+
+    with app.app_context():
+        _seed_credit_ledger()
+
+    staged = stage_credit_granted_notification(
+        app,
+        ledger_bid="ledger-1",
+        enqueue=False,
+    )
+    with app.app_context():
+        notification = NotificationRecord.query.filter_by(
+            notification_bid=staged["notification_bid"]
+        ).one()
+        notification.template_params_json = {
+            "credits": "12.50",
+            "expires_at": "2026-06-30T00:00:00+00:00",
+            "source": "operator",
+        }
+        dao.db.session.commit()
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.send_sms_ali",
+        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+            captured.append(dict(template_params))
+            or SimpleNamespace(
+                body=SimpleNamespace(
+                    code="OK",
+                    message="accepted",
+                    request_id="req-legacy",
+                    biz_id="biz-legacy",
+                )
+            )
+        ),
+    )
+
+    delivered = deliver_credit_notification(
+        app,
+        notification_bid=str(staged["notification_bid"]),
+    )
+
+    assert delivered["status"] == CREDIT_NOTIFICATION_STATUS_SENT
+    assert captured == [
+        {
+            "credits": "12.50",
+            "expires_at": "2026-06-30 00:00:00",
+            "source": "operator",
+        }
+    ]
+    with app.app_context():
+        notification = NotificationRecord.query.filter_by(
+            notification_bid=staged["notification_bid"]
+        ).one()
+        assert notification.template_params_json["expires_at"] == (
+            "2026-06-30 00:00:00"
+        )
 
 
 def test_credit_notification_policy_rejects_invalid_windows(
@@ -973,6 +1038,14 @@ def test_expiring_and_low_balance_scans_stage_deduped_notifications(
 
     with app.app_context():
         assert NotificationRecord.query.count() == 2
+        expiring_notification = NotificationRecord.query.filter_by(
+            notification_type=CREDIT_NOTIFICATION_TYPE_EXPIRING
+        ).one()
+        assert expiring_notification.template_params_json == {
+            "credits": "5.00",
+            "expires_at": "2026-05-22 02:00:00",
+            "window": "1d",
+        }
 
 
 def test_low_balance_estimated_days_scan_uses_daily_ledger_summary(


### PR DESCRIPTION
## Summary
- format credit notification `expires_at` SMS template params as `YYYY-MM-DD HH:MM:SS` instead of ISO timestamps
- normalize persisted legacy ISO `expires_at` snapshots immediately before provider send, so existing `failed_provider` records can be requeued safely
- cover both newly staged notification params and legacy snapshot retry behavior in billing notification tests

## Root Cause
Aliyun SMS templates configured `expires_at` as a time variable. The notification center persisted ISO strings such as `2026-05-26T07:34:43+00:00`, which Aliyun rejects with `isv.TEMPLATE_PARAMS_ILLEGAL`.

## Validation
- `cd src/api && pytest tests/service/billing/test_credit_notifications.py -q`
- `python scripts/check_repo_harness.py`
- commit hook checks during `git commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS credit notification datetime formatting and parameter normalization to ensure dates display correctly, including proper handling of legacy ISO date formats.

* **Tests**
  * Updated and extended test coverage for SMS notification delivery and datetime parameter normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->