### PR TITLE
fix: prevent duplicate credit notification sends

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -153,7 +153,7 @@ services:
       - ./observability/otel-collector-config.yml:/etc/otel-collector-config.yml
 
   ai-shifu-prometheus:
-    image: prom/prometheus:v2.2.0
+    image: prom/prometheus:v2.54.1
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -788,6 +788,15 @@ def build_credit_expiring_dedupe_key(wallet_bucket_bid: str, window: str) -> str
     return f"{CREDIT_NOTIFICATION_TYPE_EXPIRING}:{_normalize_bid(wallet_bucket_bid)}:{_normalize_bid(window)}"
 
 
+def build_credit_expiring_creator_dedupe_key(
+    creator_bid: str, window: str, day: date
+) -> str:
+    return (
+        f"{CREDIT_NOTIFICATION_TYPE_EXPIRING}:"
+        f"{_normalize_bid(creator_bid)}:{_normalize_bid(window)}:{day.isoformat()}"
+    )
+
+
 def build_low_balance_dedupe_key(creator_bid: str, threshold: str, day: date) -> str:
     return (
         f"{CREDIT_NOTIFICATION_TYPE_LOW_BALANCE}:"
@@ -855,6 +864,43 @@ def _amount_text(value: Any) -> str:
         return str(_quantize_credit_amount(value))
     except Exception:
         return str(value or "").strip()
+
+
+def _template_placeholders(template_code: str) -> tuple[str, ...]:
+    normalized_template_code = str(template_code or "").strip()
+    if not normalized_template_code:
+        return ()
+    template = (
+        NotificationTemplate.query.filter(
+            NotificationTemplate.deleted == 0,
+            NotificationTemplate.channel == CREDIT_NOTIFICATION_CHANNEL_SMS,
+            NotificationTemplate.provider == NOTIFICATION_TEMPLATE_PROVIDER_ALIYUN,
+            NotificationTemplate.template_code == normalized_template_code,
+        )
+        .order_by(NotificationTemplate.id.desc())
+        .first()
+    )
+    if template is None:
+        return ()
+    placeholders = template.placeholders_json
+    if not isinstance(placeholders, list):
+        return ()
+    return tuple(
+        str(item or "").strip() for item in placeholders if str(item or "").strip()
+    )
+
+
+def _missing_template_params(
+    *,
+    template_code: str,
+    template_params: dict[str, Any] | None,
+) -> list[str]:
+    params = template_params or {}
+    missing: list[str] = []
+    for placeholder in _template_placeholders(template_code):
+        if not str(params.get(placeholder) or "").strip():
+            missing.append(placeholder)
+    return missing
 
 
 def _is_valid_sms_mobile(mobile: str) -> bool:
@@ -1164,6 +1210,53 @@ def _parse_window_days(window: Any) -> int | None:
     return days if days >= 0 else None
 
 
+def _suppressed_duplicate_result(
+    existing: NotificationRecord,
+) -> CreditNotificationStageResult:
+    record_credit_notification_event(
+        "stage",
+        notification_type=existing.notification_type,
+        channel=existing.channel,
+        status="suppressed_duplicate",
+    )
+    return CreditNotificationStageResult(
+        status="suppressed_duplicate",
+        notification_bid=existing.notification_bid,
+        notification_type=existing.notification_type,
+        creator_bid=existing.creator_bid,
+        source_type=existing.source_type,
+        source_bid=existing.source_bid,
+        dedupe_key=existing.dedupe_key,
+    )
+
+
+def _find_credit_expiring_creator_window_record(
+    *,
+    creator_bid: str,
+    window: str,
+    now: datetime,
+) -> NotificationRecord | None:
+    day_start, day_end = _today_bounds(now)
+    records = (
+        NotificationRecord.query.filter(
+            NotificationRecord.deleted == 0,
+            NotificationRecord.notification_type == CREDIT_NOTIFICATION_TYPE_EXPIRING,
+            NotificationRecord.creator_bid == _normalize_bid(creator_bid),
+            NotificationRecord.requested_at >= day_start,
+            NotificationRecord.requested_at < day_end,
+        )
+        .order_by(NotificationRecord.id.desc())
+        .all()
+    )
+    for record in records:
+        metadata = (
+            record.metadata_json if isinstance(record.metadata_json, dict) else {}
+        )
+        if str(metadata.get("window") or "").strip() == window:
+            return record
+    return None
+
+
 def scan_credit_expiring_notifications(
     app: Flask,
     *,
@@ -1184,9 +1277,11 @@ def scan_credit_expiring_notifications(
                 "dry_run": dry_run,
                 "notifications": [],
             }
-        windows = _type_policy(policy, CREDIT_NOTIFICATION_TYPE_EXPIRING).get("windows")
+        type_policy = _type_policy(policy, CREDIT_NOTIFICATION_TYPE_EXPIRING)
+        windows = type_policy.get("windows")
         if not isinstance(windows, list):
             windows = ["7d", "3d", "1d", "0d"]
+        merge_same_creator = _coerce_bool(type_policy.get("merge_same_creator", True))
 
         notifications: list[dict[str, Any]] = []
         creator_eligibility_cache: dict[str, bool] = {}
@@ -1217,6 +1312,96 @@ def scan_credit_expiring_notifications(
                 .limit(500)
                 .all()
             )
+            if merge_same_creator:
+                grouped: dict[str, dict[str, Any]] = {}
+                for bucket in buckets:
+                    if not _is_notification_eligible_creator_cached(
+                        bucket.creator_bid,
+                        creator_eligibility_cache,
+                    ):
+                        continue
+                    group = grouped.setdefault(
+                        bucket.creator_bid,
+                        {
+                            "creator_bid": bucket.creator_bid,
+                            "source_bid": bucket.wallet_bucket_bid,
+                            "wallet_bid": bucket.wallet_bid,
+                            "bucket_bids": [],
+                            "wallet_bids": set(),
+                            "available_credits": _ZERO,
+                            "effective_to": bucket.effective_to,
+                        },
+                    )
+                    group["bucket_bids"].append(bucket.wallet_bucket_bid)
+                    group["wallet_bids"].add(bucket.wallet_bid)
+                    group["available_credits"] = _to_decimal(
+                        group["available_credits"]
+                    ) + _to_decimal(bucket.available_credits)
+                    if bucket.effective_to is not None and (
+                        group.get("effective_to") is None
+                        or bucket.effective_to < group["effective_to"]
+                    ):
+                        group["effective_to"] = bucket.effective_to
+                        group["source_bid"] = bucket.wallet_bucket_bid
+                        group["wallet_bid"] = bucket.wallet_bid
+
+                for group in grouped.values():
+                    dedupe_key = build_credit_expiring_creator_dedupe_key(
+                        str(group.get("creator_bid") or ""),
+                        window,
+                        scan_now.date(),
+                    )
+                    existing = _find_credit_expiring_creator_window_record(
+                        creator_bid=str(group.get("creator_bid") or ""),
+                        window=window,
+                        now=scan_now,
+                    )
+                    if existing is not None:
+                        notifications.append(
+                            _suppressed_duplicate_result(existing).to_payload()
+                        )
+                        continue
+                    if dry_run:
+                        notifications.append(
+                            {
+                                "status": "candidate",
+                                "notification_type": (
+                                    CREDIT_NOTIFICATION_TYPE_EXPIRING
+                                ),
+                                "creator_bid": group["creator_bid"],
+                                "source_bid": group["source_bid"],
+                                "dedupe_key": dedupe_key,
+                            }
+                        )
+                        continue
+                    result = _stage_notification_record(
+                        app,
+                        notification_type=CREDIT_NOTIFICATION_TYPE_EXPIRING,
+                        creator_bid=group["creator_bid"],
+                        source_type=SOURCE_TYPE_WALLET_BUCKET,
+                        source_bid=group["source_bid"],
+                        dedupe_key=dedupe_key,
+                        template_params={
+                            "credits": _amount_text(group["available_credits"]),
+                            "expires_at": _serialize_dt(
+                                app,
+                                group.get("effective_to"),
+                            ),
+                            "window": window,
+                        },
+                        metadata={
+                            "wallet_bid": group["wallet_bid"],
+                            "wallet_bids": sorted(group["wallet_bids"]),
+                            "wallet_bucket_bid": group["source_bid"],
+                            "wallet_bucket_bids": group["bucket_bids"],
+                            "merged_bucket_count": len(group["bucket_bids"]),
+                            "window": window,
+                        },
+                        policy=policy,
+                    )
+                    notifications.append(result.to_payload())
+                continue
+
             for bucket in buckets:
                 if not _is_notification_eligible_creator_cached(
                     bucket.creator_bid,
@@ -1696,6 +1881,28 @@ def scan_low_balance_notifications(
                 else:
                     continue
 
+                missing_template_params = _missing_template_params(
+                    template_code=_template_code(
+                        policy,
+                        CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
+                    ),
+                    template_params=template_params,
+                )
+                if missing_template_params:
+                    if dry_run:
+                        notifications.append(
+                            _low_balance_dry_run_payload(
+                                status="skipped",
+                                creator_bid=wallet.creator_bid,
+                                source_bid=wallet.creator_bid,
+                                dedupe_key=dedupe_key,
+                                template_params=template_params,
+                                reason="missing_template_params",
+                            )
+                            | {"missing_template_params": missing_template_params}
+                        )
+                    continue
+
                 if _should_skip_low_balance_zero_without_remaining_days(
                     CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
                     template_params,
@@ -2091,6 +2298,33 @@ def deliver_credit_notification(
         if template_params != dict(notification.template_params_json or {}):
             notification.template_params_json = template_params
             db.session.add(notification)
+
+        if notification.notification_type == CREDIT_NOTIFICATION_TYPE_LOW_BALANCE:
+            missing_template_params = _missing_template_params(
+                template_code=template_code,
+                template_params=template_params,
+            )
+            if missing_template_params:
+                reason = "missing_template_params"
+                _finalize_notification(
+                    notification,
+                    status=CREDIT_NOTIFICATION_STATUS_SKIPPED_OPT_OUT,
+                    now=now,
+                    mobile=mobile,
+                    error_code=reason,
+                    error_message=(
+                        "Notification template requires empty params: "
+                        f"{','.join(missing_template_params)}."
+                    ),
+                )
+                db.session.commit()
+                return {
+                    "status": CREDIT_NOTIFICATION_STATUS_SKIPPED_OPT_OUT,
+                    "notification_bid": notification.notification_bid,
+                    "notification_status": notification.status,
+                    "reason": reason,
+                    "missing_template_params": missing_template_params,
+                }
 
         try:
             response = send_sms_ali(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -213,15 +213,17 @@ def _seed_bucket(
     creator_bid: str = "creator-1",
     effective_to: datetime,
     available_credits: str = "5",
+    wallet_bucket_bid: str | None = None,
 ) -> None:
+    resolved_wallet_bucket_bid = wallet_bucket_bid or f"bucket-{creator_bid}"
     dao.db.session.add(
         CreditWalletBucket(
-            wallet_bucket_bid=f"bucket-{creator_bid}",
+            wallet_bucket_bid=resolved_wallet_bucket_bid,
             wallet_bid=f"wallet-{creator_bid}",
             creator_bid=creator_bid,
             bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
             source_type=CREDIT_SOURCE_TYPE_MANUAL,
-            source_bid=f"source-{creator_bid}",
+            source_bid=f"source-{resolved_wallet_bucket_bid}",
             priority=10,
             original_credits=Decimal(available_credits),
             available_credits=Decimal(available_credits),
@@ -314,7 +316,7 @@ def _seed_default_notification_templates(app: Flask) -> None:
     _seed_notification_template(
         app,
         template_code="TPL-LOW",
-        placeholders=["available_credits", "threshold"],
+        placeholders=["available_credits"],
     )
 
 
@@ -1028,7 +1030,7 @@ def test_expiring_and_low_balance_scans_stage_deduped_notifications(
     assert expiring_first["created_count"] == 1
     assert expiring_first["enqueued_count"] == 1
     assert expiring_first["notifications"][0]["dedupe_key"] == (
-        "credit_expiring:bucket-creator-1:1d"
+        "credit_expiring:creator-1:1d:2026-05-21"
     )
     assert expiring_second["created_count"] == 0
     assert expiring_second["notifications"][0]["status"] == "suppressed_duplicate"
@@ -1046,6 +1048,124 @@ def test_expiring_and_low_balance_scans_stage_deduped_notifications(
             "expires_at": "2026-05-22 02:00:00",
             "window": "1d",
         }
+
+
+def test_expiring_scan_merges_same_creator_buckets(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    now = datetime(2026, 5, 21, 0, 0, 0)
+    _seed_creator(app)
+    _enable_policy(app)
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
+        lambda app, *, notification_bid: {
+            "status": "enqueued",
+            "notification_bid": notification_bid,
+            "enqueued": True,
+        },
+    )
+
+    with app.app_context():
+        _seed_wallet()
+        _seed_bucket(
+            wallet_bucket_bid="bucket-creator-1-a",
+            effective_to=now + timedelta(days=1, hours=2),
+            available_credits="2",
+        )
+        _seed_bucket(
+            wallet_bucket_bid="bucket-creator-1-b",
+            effective_to=now + timedelta(days=1, hours=2),
+            available_credits="3.5",
+        )
+        dao.db.session.commit()
+
+    payload = scan_credit_expiring_notifications(app, now=now)
+    second_payload = scan_credit_expiring_notifications(app, now=now)
+
+    assert payload["created_count"] == 1
+    assert payload["enqueued_count"] == 1
+    assert payload["notifications"][0]["dedupe_key"] == (
+        "credit_expiring:creator-1:1d:2026-05-21"
+    )
+    assert second_payload["created_count"] == 0
+    assert second_payload["notifications"][0]["status"] == "suppressed_duplicate"
+    with app.app_context():
+        notification = NotificationRecord.query.filter_by(
+            notification_type=CREDIT_NOTIFICATION_TYPE_EXPIRING
+        ).one()
+        assert notification.template_params_json == {
+            "credits": "5.50",
+            "expires_at": "2026-05-22 02:00:00",
+            "window": "1d",
+        }
+        assert notification.metadata_json["merged_bucket_count"] == 2
+        assert notification.metadata_json["wallet_bucket_bids"] == [
+            "bucket-creator-1-a",
+            "bucket-creator-1-b",
+        ]
+
+
+def test_expiring_merge_suppresses_existing_bucket_level_record(
+    credit_notifications_app: Flask,
+) -> None:
+    app = credit_notifications_app
+    now = datetime(2026, 5, 21, 0, 0, 0)
+    _seed_creator(app)
+    _enable_policy(app)
+
+    with app.app_context():
+        _seed_wallet()
+        _seed_bucket(
+            wallet_bucket_bid="bucket-creator-1-a",
+            effective_to=now + timedelta(days=1, hours=2),
+            available_credits="2",
+        )
+        _seed_bucket(
+            wallet_bucket_bid="bucket-creator-1-b",
+            effective_to=now + timedelta(days=1, hours=2),
+            available_credits="3.5",
+        )
+        dao.db.session.add(
+            NotificationRecord(
+                notification_bid="legacy-expiring-record",
+                notification_type=CREDIT_NOTIFICATION_TYPE_EXPIRING,
+                channel="sms",
+                creator_bid="creator-1",
+                target_user_bid="creator-1",
+                mobile_snapshot="13800000000",
+                source_type="wallet_bucket",
+                source_bid="bucket-creator-1-a",
+                dedupe_key="credit_expiring:bucket-creator-1-a:1d",
+                status=CREDIT_NOTIFICATION_STATUS_SENT,
+                template_code="TPL-EXPIRING",
+                template_params_json={
+                    "credits": "2.00",
+                    "expires_at": "2026-05-22 02:00:00",
+                    "window": "1d",
+                },
+                policy_snapshot_json={},
+                provider_response_json={},
+                requested_at=now,
+                attempted_at=now,
+                sent_at=now,
+                metadata_json={
+                    "wallet_bucket_bid": "bucket-creator-1-a",
+                    "window": "1d",
+                },
+                deleted=0,
+            )
+        )
+        dao.db.session.commit()
+
+    payload = scan_credit_expiring_notifications(app, now=now)
+
+    assert payload["created_count"] == 0
+    assert payload["notifications"][0]["status"] == "suppressed_duplicate"
+    assert payload["notifications"][0]["notification_bid"] == "legacy-expiring-record"
+    with app.app_context():
+        assert NotificationRecord.query.count() == 1
 
 
 def test_low_balance_estimated_days_scan_uses_daily_ledger_summary(
@@ -1273,6 +1393,49 @@ def test_low_balance_scan_skips_zero_balance_without_estimated_remaining_days(
         assert NotificationRecord.query.count() == 0
 
 
+def test_low_balance_scan_skips_template_params_missing_for_mode(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    now = datetime(2026, 5, 21, 8, 0, 0)
+    _seed_creator(app)
+    _enable_policy(
+        app,
+        low_balance_thresholds=[{"kind": "fixed", "value": "5"}],
+    )
+    _seed_notification_template(
+        app,
+        template_code="TPL-LOW",
+        placeholders=["available_credits", "estimated_remaining_days"],
+    )
+    enqueue_calls: list[str] = []
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
+        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+    )
+
+    with app.app_context():
+        _seed_wallet(available_credits="2")
+        dao.db.session.commit()
+
+    payload = scan_low_balance_notifications(app, now=now)
+    dry_run_payload = scan_low_balance_notifications(app, now=now, dry_run=True)
+
+    assert payload["candidate_count"] == 0
+    assert payload["created_count"] == 0
+    assert payload["enqueued_count"] == 0
+    assert payload["notifications"] == []
+    assert enqueue_calls == []
+    assert dry_run_payload["candidate_count"] == 0
+    assert dry_run_payload["notifications"][0]["reason"] == "missing_template_params"
+    assert dry_run_payload["notifications"][0]["missing_template_params"] == [
+        "estimated_remaining_days"
+    ]
+    with app.app_context():
+        assert NotificationRecord.query.count() == 0
+
+
 def test_low_balance_delivery_skips_zero_balance_without_estimated_remaining_days(
     credit_notifications_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
@@ -1343,6 +1506,82 @@ def test_low_balance_delivery_skips_zero_balance_without_estimated_remaining_day
         assert notification.error_code == (
             "zero_balance_missing_estimated_remaining_days"
         )
+
+
+def test_low_balance_delivery_skips_template_params_missing_for_mode(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    _seed_creator(app)
+    _enable_policy(app)
+    _seed_notification_template(
+        app,
+        template_code="TPL-LOW",
+        placeholders=["available_credits", "estimated_remaining_days"],
+    )
+    send_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.send_sms_ali",
+        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+            send_calls.append(
+                {
+                    "mobile": mobile,
+                    "template_code": template_code,
+                    "template_params": dict(template_params),
+                }
+            )
+            or SimpleNamespace(body=SimpleNamespace(code="OK"))
+        ),
+    )
+
+    with app.app_context():
+        notification = NotificationRecord(
+            notification_bid="notification-missing-template-param",
+            notification_type=CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
+            channel="sms",
+            creator_bid="creator-1",
+            target_user_bid="creator-1",
+            mobile_snapshot="13800000000",
+            source_type="wallet",
+            source_bid="creator-1",
+            dedupe_key="low_balance:creator-1:5.00:2026-05-21",
+            status=CREDIT_NOTIFICATION_STATUS_PENDING,
+            template_code="TPL-LOW",
+            template_params_json={
+                "available_credits": "2.00",
+                "threshold": "5.00",
+                "threshold_kind": "fixed",
+                "trigger_days": "",
+                "lookback_days": "",
+                "avg_daily_consumption": "",
+                "estimated_remaining_days": "",
+            },
+            policy_snapshot_json={},
+            provider_response_json={},
+            metadata_json={},
+            deleted=0,
+            created_at=datetime(2026, 5, 21, 8, 0, 0),
+            updated_at=datetime(2026, 5, 21, 8, 0, 0),
+        )
+        dao.db.session.add(notification)
+        dao.db.session.commit()
+
+    delivered = deliver_credit_notification(
+        app,
+        notification_bid="notification-missing-template-param",
+    )
+
+    assert delivered["status"] == CREDIT_NOTIFICATION_STATUS_SKIPPED_OPT_OUT
+    assert delivered["reason"] == "missing_template_params"
+    assert delivered["missing_template_params"] == ["estimated_remaining_days"]
+    assert send_calls == []
+    with app.app_context():
+        notification = NotificationRecord.query.filter_by(
+            notification_bid="notification-missing-template-param"
+        ).one()
+        assert notification.status == CREDIT_NOTIFICATION_STATUS_SKIPPED_OPT_OUT
+        assert notification.error_code == "missing_template_params"
 
 
 def test_failed_provider_notification_can_be_requeued(


### PR DESCRIPTION
## Summary
- merge expiring credit notification buckets by creator/window/day when `merge_same_creator` is enabled
- suppress creator/window expiring records if an earlier bucket-level record already exists for the same day
- skip low-balance SMS delivery when the synced Aliyun template uses placeholders that are empty for the current trigger path

## Production Evidence
- production image `20260524-169fd8d` is sending successfully after the expiry-time format fix
- today still has duplicate `credit_expiring` sent records for the same creator/mobile/window because staging used bucket-level dedupe keys
- yesterday had one low-balance sent record whose template used `estimated_remaining_days` while the fixed-threshold path populated it as empty

## Tests
- `cd src/api && pytest tests/service/billing/test_credit_notifications.py -q`
- `python scripts/check_repo_harness.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expiring-credit notifications can now merge multiple bucket credits into a single per-creator notification.
  * SMS templates are introspected and required placeholders are validated before staging/delivery.

* **Bug Fixes**
  * Improved duplicate suppression for expiring notifications; legacy per-bucket duplicates are suppressed when merged.
  * Low-balance notifications are skipped if required template params are missing and recorded with skip reasons.

* **Tests**
  * Updated tests covering merged notifications, deduplication, and template validation.

* **Chores**
  * Development Prometheus image updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->