### PR TITLE
fix: MiniMax TTS usage character billing

### DIFF
--- a/src/api/flaskr/api/tts/base.py
+++ b/src/api/flaskr/api/tts/base.py
@@ -77,6 +77,7 @@ class TTSResult:
     sample_rate: int
     format: str
     word_count: int = 0
+    usage_characters: int = 0
     subtitle_cues: List[Dict[str, Any]] = field(default_factory=list)
 
 

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -144,6 +144,7 @@ class MinimaxHTTPStreamChunk:
     sample_rate: int = 24000
     format: str = "mp3"
     word_count: int = 0
+    usage_characters: int = 0
     subtitles: List[Dict[str, Any]] = field(default_factory=list)
     extra_info: Dict[str, Any] = field(default_factory=dict)
     trace_id: str = ""
@@ -341,11 +342,12 @@ class MinimaxTTSProvider(BaseTTSProvider):
         duration_ms = extra_info.get("audio_length", 0)
         sample_rate = extra_info.get("audio_sample_rate", 24000)
         audio_format = extra_info.get("audio_format", "mp3")
-        word_count = extra_info.get("usage_characters", 0)
+        word_count = int(extra_info.get("word_count") or 0)
+        usage_characters = int(extra_info.get("usage_characters") or 0)
 
         logger.info(
             f"Minimax TTS synthesis completed: duration={duration_ms}ms, "
-            f"size={len(audio_data)} bytes, usage_characters={word_count}, extra_info={extra_info}"
+            f"size={len(audio_data)} bytes, usage_characters={usage_characters}, extra_info={extra_info}"
         )
 
         return TTSResult(
@@ -354,6 +356,7 @@ class MinimaxTTSProvider(BaseTTSProvider):
             sample_rate=sample_rate,
             format=audio_format,
             word_count=word_count,
+            usage_characters=usage_characters,
         )
 
     def stream_synthesize(
@@ -465,7 +468,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
                 format=str(
                     extra_info.get("audio_format") or audio_settings.format or "mp3"
                 ),
-                word_count=int(extra_info.get("usage_characters") or 0),
+                word_count=int(extra_info.get("word_count") or 0),
+                usage_characters=int(extra_info.get("usage_characters") or 0),
                 subtitles=subtitles,
                 extra_info=extra_info,
                 trace_id=str(message.get("trace_id") or ""),

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -42,16 +42,14 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_SCENE_PROD,
 )
-from flaskr.service.tts.pipeline import (
-    split_text_for_tts,
-)
+from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
+from flaskr.service.tts.pipeline import split_text_for_tts
 from flaskr.api.tts import (
     get_default_audio_settings,
     get_default_voice_settings,
     synthesize_text,
     is_tts_configured,
 )
-from flaskr.service.tts import preprocess_for_tts
 from flaskr.service.tts.api import create_streaming_tts_processor
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
@@ -732,6 +730,7 @@ def _yield_tts_segments(
             int(result.duration_ms or 0),
             segment_text,
             int(result.word_count or 0),
+            int(getattr(result, "usage_characters", 0) or 0),
             latency_ms,
         )
 
@@ -848,6 +847,7 @@ def _record_stream_segment_usage(
     tts_model: str,
     segment_text: str,
     word_count: int,
+    usage_characters: int,
     duration_ms: int,
     latency_ms: int,
     parent_usage_bid: str,
@@ -855,6 +855,7 @@ def _record_stream_segment_usage(
     usage_metadata: dict,
 ):
     segment_length = len(segment_text or "")
+    output_chars = resolve_tts_billable_chars(segment_text, usage_characters)
     record_tts_usage(
         app,
         usage_context,
@@ -862,8 +863,8 @@ def _record_stream_segment_usage(
         model=tts_model or "",
         is_stream=True,
         input=segment_length,
-        output=segment_length,
-        total=segment_length,
+        output=output_chars,
+        total=output_chars,
         word_count=int(word_count or 0),
         duration_ms=int(duration_ms or 0),
         latency_ms=int(latency_ms or 0),
@@ -885,12 +886,14 @@ def _record_stream_summary_usage(
     raw_text: str,
     cleaned_text: str,
     total_word_count: int,
+    total_output_chars: int,
     duration_ms: int,
     segment_count: int,
     usage_metadata: dict,
 ):
     raw_length = len(raw_text or "")
     cleaned_length = len(cleaned_text or "")
+    output_chars = total_output_chars or cleaned_length
     record_tts_usage(
         app,
         usage_context,
@@ -899,8 +902,8 @@ def _record_stream_summary_usage(
         model=tts_model or "",
         is_stream=True,
         input=raw_length,
-        output=cleaned_length,
-        total=cleaned_length,
+        output=output_chars,
+        total=output_chars,
         word_count=total_word_count,
         duration_ms=int(duration_ms or 0),
         latency_ms=0,
@@ -1056,6 +1059,7 @@ def _yield_stream_tts_audio_segments(
         duration_ms,
         segment_text,
         word_count,
+        usage_characters,
         latency_ms,
     ) in _yield_tts_segments(
         text=text,
@@ -1076,6 +1080,13 @@ def _yield_stream_tts_audio_segments(
         stats["total_word_count"] = int(stats.get("total_word_count", 0)) + int(
             word_count or 0
         )
+        segment_output_chars = resolve_tts_billable_chars(
+            segment_text,
+            int(usage_characters or 0),
+        )
+        stats["total_output_chars"] = int(stats.get("total_output_chars", 0)) + int(
+            segment_output_chars or 0
+        )
         _record_stream_segment_usage(
             app,
             usage_context,
@@ -1083,6 +1094,7 @@ def _yield_stream_tts_audio_segments(
             tts_model=tts_model,
             segment_text=segment_text,
             word_count=int(word_count or 0),
+            usage_characters=int(usage_characters or 0),
             duration_ms=int(duration_ms or 0),
             latency_ms=int(latency_ms or 0),
             parent_usage_bid=parent_usage_bid,
@@ -1429,6 +1441,7 @@ def stream_preview_tts_audio(
             )
             segment_count = int(stats.get("segment_count", 0))
             total_word_count = int(stats.get("total_word_count", 0))
+            total_output_chars = int(stats.get("total_output_chars", 0))
 
             oss_url, duration_ms = _finalize_tts_stream_audio(
                 app,
@@ -1452,6 +1465,7 @@ def stream_preview_tts_audio(
                 raw_text=text or "",
                 cleaned_text=cleaned_text,
                 total_word_count=total_word_count,
+                total_output_chars=total_output_chars,
                 duration_ms=int(duration_ms or 0),
                 segment_count=segment_count,
                 usage_metadata=usage_metadata,

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -18,7 +18,7 @@ from flaskr.service.common import raise_error
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.metering import UsageContext, record_tts_usage
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
-from flaskr.service.tts import preprocess_for_tts
+from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
 from flaskr.service.tts.pipeline import split_text_for_tts
 from flaskr.service.tts.validation import validate_tts_settings_strict
 from flaskr.util.uuid import generate_id
@@ -104,6 +104,7 @@ def build_tts_preview_response(
     def event_stream():
         total_duration_ms = 0
         total_word_count = 0
+        total_output_chars = 0
         try:
             for index, segment_text in enumerate(segments):
                 result = synthesize_text(
@@ -115,7 +116,12 @@ def build_tts_preview_response(
                 )
                 total_duration_ms += int(result.duration_ms or 0)
                 word_count = int(getattr(result, "word_count", 0) or 0)
+                segment_output_chars = resolve_tts_billable_chars(
+                    segment_text,
+                    int(getattr(result, "usage_characters", 0) or 0),
+                )
                 total_word_count += word_count
+                total_output_chars += segment_output_chars
                 record_tts_usage(
                     app,
                     usage_context,
@@ -123,8 +129,8 @@ def build_tts_preview_response(
                     model=validated.model or "",
                     is_stream=True,
                     input=len(segment_text or ""),
-                    output=len(segment_text or ""),
-                    total=len(segment_text or ""),
+                    output=segment_output_chars,
+                    total=segment_output_chars,
                     word_count=word_count,
                     duration_ms=int(result.duration_ms or 0),
                     latency_ms=0,
@@ -156,8 +162,8 @@ def build_tts_preview_response(
                 model=validated.model or "",
                 is_stream=True,
                 input=len(text or ""),
-                output=len(cleaned_text or ""),
-                total=len(cleaned_text or ""),
+                output=total_output_chars or len(cleaned_text or ""),
+                total=total_output_chars or len(cleaned_text or ""),
                 word_count=total_word_count,
                 duration_ms=total_duration_ms,
                 latency_ms=0,

--- a/src/api/flaskr/service/tts/__init__.py
+++ b/src/api/flaskr/service/tts/__init__.py
@@ -33,6 +33,13 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 _FENCE = "```"
 
 
+def resolve_tts_billable_chars(text: str, usage_characters: int = 0) -> int:
+    provider_usage_characters = int(usage_characters or 0)
+    if provider_usage_characters > 0:
+        return provider_usage_characters
+    return len(text or "")
+
+
 def _strip_incomplete_fenced_code(text: str) -> tuple[str, bool]:
     """
     Strip an incomplete fenced code block from the end of the buffer.

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -36,7 +36,7 @@ from flaskr.api.tts import (
     VoiceSettings,
     AudioSettings,
 )
-from flaskr.service.tts import preprocess_for_tts
+from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
     get_audio_duration_ms,
@@ -742,6 +742,7 @@ def synthesize_long_text_to_oss(
     usage_parent_bid = ""
     usage_metadata: Optional[dict] = None
     total_word_count = 0
+    total_output_chars = 0
     if usage_context is not None:
         usage_parent_bid = parent_usage_bid or generate_id(app)
 
@@ -786,7 +787,12 @@ def synthesize_long_text_to_oss(
                 audio_parts.append(result.audio_data)
                 if usage_context is not None:
                     segment_length = len(segment_text or "")
+                    segment_output_chars = resolve_tts_billable_chars(
+                        segment_text,
+                        int(getattr(result, "usage_characters", 0) or 0),
+                    )
                     total_word_count += int(result.word_count or 0)
+                    total_output_chars += segment_output_chars
                     latency_ms = int((time.monotonic() - segment_start) * 1000)
                     record_tts_usage(
                         app,
@@ -795,8 +801,8 @@ def synthesize_long_text_to_oss(
                         model=(model or "").strip(),
                         is_stream=False,
                         input=segment_length,
-                        output=segment_length,
-                        total=segment_length,
+                        output=segment_output_chars,
+                        total=segment_output_chars,
                         word_count=int(result.word_count or 0),
                         duration_ms=int(result.duration_ms or 0),
                         latency_ms=latency_ms,
@@ -845,7 +851,12 @@ def synthesize_long_text_to_oss(
                 if usage_context is not None:
                     segment_text = segment_map.get(index, "")
                     segment_length = len(segment_text or "")
+                    segment_output_chars = resolve_tts_billable_chars(
+                        segment_text,
+                        int(getattr(result, "usage_characters", 0) or 0),
+                    )
                     total_word_count += int(result.word_count or 0)
+                    total_output_chars += segment_output_chars
                     record_tts_usage(
                         app,
                         usage_context,
@@ -853,8 +864,8 @@ def synthesize_long_text_to_oss(
                         model=(model or "").strip(),
                         is_stream=False,
                         input=segment_length,
-                        output=segment_length,
-                        total=segment_length,
+                        output=segment_output_chars,
+                        total=segment_output_chars,
                         word_count=int(result.word_count or 0),
                         duration_ms=int(result.duration_ms or 0),
                         latency_ms=0,
@@ -886,8 +897,8 @@ def synthesize_long_text_to_oss(
             model=(model or "").strip(),
             is_stream=False,
             input=raw_length,
-            output=cleaned_length,
-            total=cleaned_length,
+            output=total_output_chars or cleaned_length,
+            total=total_output_chars or cleaned_length,
             word_count=total_word_count,
             duration_ms=int(duration_ms or 0),
             latency_ms=0,

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -28,7 +28,7 @@ from flaskr.api.tts import (
     get_default_audio_settings,
 )
 from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
-from flaskr.service.tts import preprocess_for_tts
+from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
     export_audio_range_best_effort,
@@ -137,6 +137,7 @@ class TTSSegment:
     audio_data: Optional[bytes] = None
     duration_ms: int = 0
     word_count: int = 0
+    usage_characters: int = 0
     latency_ms: int = 0
     error: Optional[str] = None
     is_ready: bool = False
@@ -147,6 +148,7 @@ class _MinimaxFallbackAudio:
     audio_data: bytes
     duration_ms: int
     word_count: int
+    usage_characters: int
     audio_format: str
 
 
@@ -218,6 +220,7 @@ class StreamingTTSProcessor:
         self._audio_bid = str(uuid.uuid4()).replace("-", "")
         self._usage_parent_bid = generate_id(app)
         self._word_count_total = 0
+        self._output_char_total = 0
         self._usage_scene = usage_scene
         self.usage_context = UsageContext(
             user_bid=user_bid,
@@ -482,6 +485,9 @@ class StreamingTTSProcessor:
                 segment.audio_data = result.audio_data
                 segment.duration_ms = result.duration_ms
                 segment.word_count = int(result.word_count or 0)
+                segment.usage_characters = int(
+                    getattr(result, "usage_characters", 0) or 0
+                )
                 segment.latency_ms = int((time.monotonic() - segment_start) * 1000)
                 segment.is_ready = True
 
@@ -503,10 +509,15 @@ class StreamingTTSProcessor:
                     is_stream=True,
                     parent_usage_bid=self._usage_parent_bid,
                     segment_index=segment.index,
+                    usage_characters=segment.usage_characters,
                 )
 
                 with self._lock:
                     self._word_count_total += segment.word_count
+                    self._output_char_total += resolve_tts_billable_chars(
+                        segment.text or "",
+                        segment.usage_characters,
+                    )
 
                 logger.debug(
                     f"TTS segment {segment.index} synthesized: "
@@ -1191,6 +1202,7 @@ class StreamingTTSProcessor:
                 raw_text=raw_text or "",
                 cleaned_text=cleaned_text or "",
                 total_word_count=self._word_count_total,
+                total_usage_characters=self._output_char_total,
                 duration_ms=final_duration_ms or 0,
                 segment_count=len(audio_data_list),
                 voice_settings=self.voice_settings,
@@ -1273,6 +1285,7 @@ class StreamingTTSProcessor:
             audio_data=audio_data,
             duration_ms=int(result.duration_ms or decoded_duration_ms or 0),
             word_count=int(result.word_count or 0),
+            usage_characters=int(getattr(result, "usage_characters", 0) or 0),
             audio_format=audio_format,
         )
 
@@ -1303,6 +1316,7 @@ class StreamingTTSProcessor:
             live_request_emitted_ms = 0
             request_duration_ms = 0
             request_word_count = 0
+            request_usage_characters = 0
             request_format = self.audio_settings.format or "mp3"
             request_subtitles: list[dict[str, Any]] = []
             request_final_subtitle_cues: list[dict[str, Any]] = []
@@ -1322,6 +1336,10 @@ class StreamingTTSProcessor:
                 if chunk.is_final:
                     request_duration_ms = int(chunk.duration_ms or request_duration_ms)
                     request_word_count = int(chunk.word_count or request_word_count)
+                    request_usage_characters = int(
+                        getattr(chunk, "usage_characters", 0)
+                        or request_usage_characters
+                    )
                 if chunk.subtitles:
                     self._extend_unique_minimax_subtitles(
                         request_subtitles,
@@ -1475,11 +1493,19 @@ class StreamingTTSProcessor:
                     request_duration_ms = int(fallback_audio.duration_ms or 0)
                     if fallback_audio.word_count:
                         request_word_count = int(fallback_audio.word_count or 0)
+                    if fallback_audio.usage_characters:
+                        request_usage_characters = int(
+                            fallback_audio.usage_characters or 0
+                        )
 
             if request_duration_ms <= 0:
                 request_duration_ms = source_emitted_ms or live_request_emitted_ms
             if request_word_count:
                 self._word_count_total += request_word_count
+            self._output_char_total += resolve_tts_billable_chars(
+                request_text,
+                request_usage_characters,
+            )
             if not request_final_subtitle_cues:
                 request_subtitle_cues = self._minimax_subtitles_to_cues(
                     request_subtitles,
@@ -1578,6 +1604,7 @@ class StreamingTTSProcessor:
                 is_stream=True,
                 parent_usage_bid=self._usage_parent_bid,
                 segment_index=request_index,
+                usage_characters=request_usage_characters,
             )
 
         with self._lock:
@@ -1636,8 +1663,13 @@ class StreamingTTSProcessor:
                 format=result.format or self.audio_settings.format or "mp3",
             )
         request_word_count = int(result.word_count or 0)
+        request_usage_characters = int(getattr(result, "usage_characters", 0) or 0)
         if request_word_count:
             self._word_count_total += request_word_count
+        self._output_char_total += resolve_tts_billable_chars(
+            request_text,
+            request_usage_characters,
+        )
 
         provider_subtitle_cues = self._apply_subtitle_context(
             list(getattr(result, "subtitle_cues", []) or [])
@@ -1684,6 +1716,7 @@ class StreamingTTSProcessor:
             is_stream=True,
             parent_usage_bid=self._usage_parent_bid,
             segment_index=0,
+            usage_characters=request_usage_characters,
         )
 
         with self._lock:

--- a/src/api/flaskr/service/tts/tts_usage_recorder.py
+++ b/src/api/flaskr/service/tts/tts_usage_recorder.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from flaskr.api.tts import VoiceSettings, AudioSettings
 
 from flaskr.service.metering import record_tts_usage
+from flaskr.service.tts import resolve_tts_billable_chars
 
 
 def build_tts_metadata(
@@ -55,6 +56,7 @@ def record_tts_segment_usage(
     is_stream: bool,
     parent_usage_bid: str,
     segment_index: int,
+    usage_characters: int = 0,
 ) -> None:
     """
     Record TTS usage for a single segment.
@@ -68,6 +70,7 @@ def record_tts_segment_usage(
         model: TTS model name
         segment_text: The text that was synthesized
         word_count: Number of words in the segment
+        usage_characters: Provider-reported billable characters, when available
         duration_ms: Audio duration in milliseconds
         latency_ms: Synthesis latency in milliseconds
         voice_settings: TTS voice configuration
@@ -77,6 +80,7 @@ def record_tts_segment_usage(
         segment_index: Index of this segment in the sequence
     """
     segment_length = len(segment_text or "")
+    output_chars = resolve_tts_billable_chars(segment_text, usage_characters)
     extra = build_tts_metadata(voice_settings, audio_settings)
 
     record_tts_usage(
@@ -86,8 +90,8 @@ def record_tts_segment_usage(
         model=model,
         is_stream=is_stream,
         input=segment_length,
-        output=segment_length,
-        total=segment_length,
+        output=output_chars,
+        total=output_chars,
         word_count=word_count,
         duration_ms=duration_ms,
         latency_ms=latency_ms,
@@ -113,6 +117,7 @@ def record_tts_aggregated_usage(
     voice_settings: "VoiceSettings",
     audio_settings: "AudioSettings",
     is_stream: bool = True,
+    total_usage_characters: int = 0,
 ) -> None:
     """
     Record aggregated TTS usage for all segments.
@@ -129,6 +134,7 @@ def record_tts_aggregated_usage(
         raw_text: Original input text (before preprocessing)
         cleaned_text: Cleaned text (after preprocessing)
         total_word_count: Total word count across all segments
+        total_usage_characters: Provider-reported billable characters across segments
         duration_ms: Total audio duration in milliseconds
         segment_count: Number of segments synthesized
         voice_settings: TTS voice configuration
@@ -136,6 +142,7 @@ def record_tts_aggregated_usage(
         is_stream: Whether this is a streaming request
     """
     extra = build_tts_metadata(voice_settings, audio_settings)
+    output_chars = resolve_tts_billable_chars(cleaned_text, total_usage_characters)
 
     record_tts_usage(
         app,
@@ -145,8 +152,8 @@ def record_tts_aggregated_usage(
         model=model,
         is_stream=is_stream,
         input=len(raw_text or ""),
-        output=len(cleaned_text or ""),
-        total=len(cleaned_text or ""),
+        output=output_chars,
+        total=output_chars,
         word_count=total_word_count,
         duration_ms=int(duration_ms or 0),
         latency_ms=0,

--- a/src/api/tests/service/metering/test_tts_usage_recorder.py
+++ b/src/api/tests/service/metering/test_tts_usage_recorder.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from flask import Flask
+
+from flaskr.service.metering import UsageContext, record_tts_usage
+from flaskr.service.tts.tts_usage_recorder import (
+    record_tts_aggregated_usage,
+    record_tts_segment_usage,
+)
+
+
+def _voice_settings():
+    return SimpleNamespace(
+        voice_id="voice-1",
+        speed=1.0,
+        pitch=0,
+        emotion="",
+        volume=1.0,
+    )
+
+
+def _audio_settings():
+    return SimpleNamespace(format="mp3", sample_rate=32000)
+
+
+def test_record_tts_usage_persists_supplied_output_without_provider_mapping(
+    monkeypatch,
+):
+    app = Flask(__name__)
+    captured = {}
+    enqueued = []
+
+    monkeypatch.setattr(
+        "flaskr.service.metering.recorder.generate_id",
+        lambda _app: "usage-tts-explicit-output",
+    )
+    monkeypatch.setattr(
+        "flaskr.service.metering.recorder._resolve_billable",
+        lambda _app, *, context, usage_scene: 1,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.metering.recorder._persist_usage_record",
+        lambda _app, record: captured.setdefault("record", record) or True,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.metering.recorder._enqueue_usage_settlement",
+        lambda _app, *, usage_bid: enqueued.append(usage_bid),
+    )
+
+    usage_bid = record_tts_usage(
+        app,
+        UsageContext(user_bid="user-1", shifu_bid="shifu-1"),
+        provider="minimax",
+        model="speech-2.8-turbo",
+        is_stream=True,
+        input=12,
+        output=7,
+        total=7,
+        word_count=13,
+        duration_ms=1000,
+    )
+
+    record = captured["record"]
+    assert usage_bid == "usage-tts-explicit-output"
+    assert record.input == 12
+    assert record.output == 7
+    assert record.total == 7
+    assert record.word_count == 13
+    assert enqueued == ["usage-tts-explicit-output"]
+
+
+def test_record_tts_segment_usage_uses_usage_characters_for_output(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_usage_recorder.record_tts_usage",
+        lambda _app, _context, **kwargs: captured.setdefault("kwargs", kwargs),
+    )
+
+    record_tts_segment_usage(
+        Flask(__name__),
+        UsageContext(user_bid="user-1", shifu_bid="shifu-1"),
+        provider="minimax",
+        model="speech-2.8-turbo",
+        segment_text="local text",
+        word_count=52,
+        usage_characters=26,
+        duration_ms=1000,
+        latency_ms=12,
+        voice_settings=_voice_settings(),
+        audio_settings=_audio_settings(),
+        is_stream=True,
+        parent_usage_bid="usage-parent-1",
+        segment_index=0,
+    )
+
+    kwargs = captured["kwargs"]
+    assert kwargs["input"] == len("local text")
+    assert kwargs["output"] == 26
+    assert kwargs["total"] == 26
+    assert kwargs["word_count"] == 52
+
+
+def test_record_tts_segment_usage_falls_back_to_local_length(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_usage_recorder.record_tts_usage",
+        lambda _app, _context, **kwargs: captured.setdefault("kwargs", kwargs),
+    )
+
+    record_tts_segment_usage(
+        Flask(__name__),
+        UsageContext(user_bid="user-1", shifu_bid="shifu-1"),
+        provider="volcengine",
+        model="seed-tts-2.0",
+        segment_text="local text",
+        word_count=2,
+        usage_characters=0,
+        duration_ms=1000,
+        latency_ms=12,
+        voice_settings=_voice_settings(),
+        audio_settings=_audio_settings(),
+        is_stream=True,
+        parent_usage_bid="usage-parent-1",
+        segment_index=0,
+    )
+
+    kwargs = captured["kwargs"]
+    assert kwargs["output"] == len("local text")
+    assert kwargs["total"] == len("local text")
+    assert kwargs["word_count"] == 2
+
+
+def test_record_tts_aggregated_usage_uses_total_usage_characters(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "flaskr.service.tts.tts_usage_recorder.record_tts_usage",
+        lambda _app, _context, **kwargs: captured.setdefault("kwargs", kwargs),
+    )
+
+    record_tts_aggregated_usage(
+        Flask(__name__),
+        UsageContext(user_bid="user-1", shifu_bid="shifu-1"),
+        usage_bid="usage-parent-1",
+        provider="minimax",
+        model="speech-2.8-turbo",
+        raw_text="raw text",
+        cleaned_text="localtext",
+        total_word_count=52,
+        total_usage_characters=26,
+        duration_ms=1000,
+        segment_count=2,
+        voice_settings=_voice_settings(),
+        audio_settings=_audio_settings(),
+        is_stream=True,
+    )
+
+    kwargs = captured["kwargs"]
+    assert kwargs["input"] == len("raw text")
+    assert kwargs["output"] == 26
+    assert kwargs["total"] == 26
+    assert kwargs["word_count"] == 52

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -75,6 +75,7 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
             duration_ms=123,
             audio_data=b"abc",
             word_count=5,
+            usage_characters=8,
         ),
         raising=False,
     )
@@ -124,8 +125,12 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
         assert context.billable == 1
         assert call["kwargs"]["record_level"] == 1
         assert call["kwargs"]["parent_usage_bid"] == "usage-parent-1"
+        assert call["kwargs"]["output"] == 8
+        assert call["kwargs"]["total"] == 8
 
     assert summary_call["kwargs"]["usage_bid"] == "usage-parent-1"
     assert summary_call["kwargs"]["record_level"] == 0
     assert summary_call["kwargs"]["segment_count"] == 2
     assert summary_call["kwargs"]["word_count"] == 10
+    assert summary_call["kwargs"]["output"] == 16
+    assert summary_call["kwargs"]["total"] == 16

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -5,9 +5,10 @@ import pytest
 
 
 class _FakeResponse:
-    def __init__(self, lines, *, status_error=None):
-        self._lines = lines
+    def __init__(self, lines=None, *, status_error=None, json_payload=None):
+        self._lines = lines or []
         self._status_error = status_error
+        self._json_payload = json_payload or {}
         self.headers = {"content-type": "text/event-stream"}
 
     def raise_for_status(self):
@@ -17,6 +18,9 @@ class _FakeResponse:
     def iter_lines(self, decode_unicode=True):
         _ = decode_unicode
         yield from self._lines
+
+    def json(self):
+        return self._json_payload
 
 
 def _sse_line(payload):
@@ -80,6 +84,7 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
                         "extra_info": {
                             "audio_length": 500,
                             "audio_sample_rate": 32000,
+                            "word_count": 2,
                             "usage_characters": 6,
                             "audio_format": "mp3",
                         },
@@ -105,7 +110,8 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     assert chunks[0].subtitles[0]["text"] == "First."
     assert chunks[-1].is_final is True
     assert chunks[-1].duration_ms == 500
-    assert chunks[-1].word_count == 6
+    assert chunks[-1].word_count == 2
+    assert chunks[-1].usage_characters == 6
     assert chunks[-1].subtitles[0]["text"] == "First."
     assert gate_calls[0]["rpm_limit"] == 60
     assert post_calls[0][0].endswith("GroupId=test-group")
@@ -115,6 +121,55 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     assert post_calls[0][1]["json"]["stream_options"] == {
         "exclude_aggregated_audio": True
     }
+
+
+def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch):
+    from flaskr.api.tts.base import AudioSettings, VoiceSettings
+    from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
+
+    config = {
+        "MINIMAX_API_KEY": "test-key",
+        "MINIMAX_GROUP_ID": "test-group",
+        "MINIMAX_TTS_MODEL": "speech-2.8-turbo",
+    }
+    post_calls = []
+
+    monkeypatch.setattr(
+        "flaskr.api.tts.minimax_provider.get_config",
+        lambda key: config.get(key, ""),
+    )
+
+    def _fake_post(url, **kwargs):
+        post_calls.append((url, kwargs))
+        return _FakeResponse(
+            json_payload={
+                "data": {"audio": "6161", "status": 2},
+                "extra_info": {
+                    "audio_length": 9900,
+                    "audio_sample_rate": 32000,
+                    "word_count": 52,
+                    "usage_characters": 26,
+                    "audio_format": "mp3",
+                },
+                "trace_id": "trace-1",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    monkeypatch.setattr("flaskr.api.tts.minimax_provider.requests.post", _fake_post)
+
+    result = MinimaxTTSProvider().synthesize(
+        text="今天是不是很开心呀(laughs)，当然了！",
+        voice_settings=VoiceSettings(voice_id="male-qn-qingse"),
+        audio_settings=AudioSettings(format="mp3", sample_rate=32000),
+        model="speech-2.8-turbo",
+    )
+
+    assert result.audio_data == b"aa"
+    assert result.duration_ms == 9900
+    assert result.word_count == 52
+    assert result.usage_characters == 26
+    assert post_calls[0][0].endswith("GroupId=test-group")
 
 
 def test_minimax_http_streaming_raises_on_business_error(monkeypatch):
@@ -157,6 +212,8 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     calls = []
+    segment_usage_calls = []
+    aggregate_usage_calls = []
 
     class _FakeMinimaxProvider:
         def stream_synthesize(self, **kwargs):
@@ -178,6 +235,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
                 duration_ms=1000,
                 format="mp3",
                 word_count=10,
+                usage_characters=26,
                 subtitles=[],
             )
 
@@ -221,11 +279,11 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage",
-        lambda **_kwargs: None,
+        lambda **kwargs: segment_usage_calls.append(kwargs),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_usage_recorder.record_tts_aggregated_usage",
-        lambda **_kwargs: None,
+        lambda **kwargs: aggregate_usage_calls.append(kwargs),
     )
 
     app = SimpleNamespace()
@@ -280,6 +338,10 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
         (0, 400),
         (500, 1000),
     ]
+    assert segment_usage_calls[0]["word_count"] == 10
+    assert segment_usage_calls[0]["usage_characters"] == 26
+    assert aggregate_usage_calls[0]["total_word_count"] == 10
+    assert aggregate_usage_calls[0]["total_usage_characters"] == 26
 
 
 def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(


### PR DESCRIPTION
## Background

MiniMax T2A documents `extra_info.usage_characters` as the billing character count. Production MiniMax TTS rates use `tts_output_chars`, and settlement reads that value from `bill_usage.output`.

The issue was not the MiniMax API call itself. The usage-recording path mixed the provider billing count into the generic `word_count` field while `bill_usage.output/total` still stored local text length, so settlement did not use MiniMax's returned billing character count.

## What Changed

- Added explicit `usage_characters` fields to `TTSResult` and MiniMax HTTP stream chunks.
- Split MiniMax response parsing:
  - `extra_info.word_count` -> `word_count`
  - `extra_info.usage_characters` -> `usage_characters`
- Restored `record_tts_usage` to pure persistence of caller-supplied `output`, `total`, and `word_count`; it no longer performs provider-specific billing inference.
- Updated TTS call sites to write billable characters explicitly:
  - When `usage_characters > 0`, segment/root `output` and `total` use the provider-reported count.
  - When `usage_characters` is missing, the existing local text-length fallback is preserved.
- Covered long-text OSS synthesis, Markdown streaming TTS, creator/debug preview, and learn-flow TTS usage records.

## Scope

- This only fixes newly created MiniMax TTS usage records going forward.
- No DB schema changes.
- No historical repair, backfill, recharge, or ledger adjustment is included.
- Other providers keep the existing local text-length behavior because their default `usage_characters` is `0`.

## Validation

- `cd src/api && pytest tests/service/metering/test_tts_usage_recorder.py -q`
- `cd src/api && pytest tests/service/tts/test_minimax_http_streaming.py -q`
- `cd src/api && pytest tests/service/shifu/test_tts_preview_helper.py tests/service/learn/test_generated_block_tts_av_mode.py tests/service/billing/test_usage_settlement.py::test_settle_tts_usage_supports_char_mode_when_request_rate_missing -q`
- `cd src/api && pytest tests/service/tts/test_streaming_tts_finalize_segmentation.py -q`
- `cd src/api && pytest tests/service/metering/test_tts_usage_recorder.py tests/service/tts/test_minimax_http_streaming.py tests/service/shifu/test_tts_preview_helper.py tests/service/learn/test_generated_block_tts_av_mode.py tests/service/billing/test_usage_settlement.py::test_settle_tts_usage_supports_char_mode_when_request_rate_missing tests/service/tts/test_streaming_tts_finalize_segmentation.py -q`
- `cd src/api && pre-commit run ruff-check --files flaskr/api/tts/base.py flaskr/api/tts/minimax_provider.py flaskr/service/learn/learn_funcs.py flaskr/service/metering/recorder.py flaskr/service/shifu/tts_preview.py flaskr/service/tts/__init__.py flaskr/service/tts/pipeline.py flaskr/service/tts/streaming_tts.py flaskr/service/tts/tts_usage_recorder.py tests/service/metering/test_tts_usage_recorder.py tests/service/shifu/test_tts_preview_helper.py tests/service/tts/test_minimax_http_streaming.py`
- `cd src/api && pre-commit run ruff-format --files flaskr/api/tts/base.py flaskr/api/tts/minimax_provider.py flaskr/service/learn/learn_funcs.py flaskr/service/metering/recorder.py flaskr/service/shifu/tts_preview.py flaskr/service/tts/__init__.py flaskr/service/tts/pipeline.py flaskr/service/tts/streaming_tts.py flaskr/service/tts/tts_usage_recorder.py tests/service/metering/test_tts_usage_recorder.py tests/service/shifu/test_tts_preview_helper.py tests/service/tts/test_minimax_http_streaming.py`
- `cd src/api && pre-commit run check-architecture-boundaries --files flaskr/service/learn/learn_funcs.py flaskr/service/shifu/tts_preview.py flaskr/service/tts/__init__.py flaskr/service/tts/pipeline.py flaskr/service/tts/streaming_tts.py flaskr/service/tts/tts_usage_recorder.py`
- `git diff --check`

## Known Unrelated Issue

`cd src/api && pytest tests/service/metering/test_recording.py -q` still has an existing SQLite fixture issue: the test database does not create `shifu_draft_shifus`, and the failure occurs in demo-course billable resolution. The other 7 tests in that file pass; the `-k tts` subset hits the same missing-table path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced TTS metering system to accurately track actual character usage reported by providers instead of relying on input text length, enabling more precise billing calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->