### PR TITLE
fix: prevent login page phone rebinding

### DIFF
--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -458,9 +458,17 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             course_id = payload.get("course_id", None)
             language = payload.get("language", None)
             login_context = payload.get("login_context", None)
-            user_id = (
-                None if getattr(request, "user", None) is None else request.user.user_id
-            )
+            current_user = getattr(request, "user", None)
+            # Only pass an anonymous/guest token through SMS login so temporary
+            # learning records can be claimed. If a real authenticated account
+            # reaches the login page and verifies another phone number, this
+            # endpoint must behave as login, not implicit phone rebinding.
+            user_id = None
+            if current_user is not None and not (
+                getattr(current_user, "mobile", "")
+                or getattr(current_user, "email", "")
+            ):
+                user_id = current_user.user_id
             if not mobile:
                 raise_param_error("mobile")
             if not sms_code:

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -133,6 +133,53 @@ def test_sms_login_route_logs_in_with_phone_code(test_client):
     assert body["data"]["userInfo"]["mobile"] == phone
 
 
+def test_sms_login_route_does_not_rebind_authenticated_account_phone(
+    test_client, app
+):
+    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user.models import AuthCredential, UserInfo as UserEntity
+
+    original_phone = "15500005551"
+    next_phone = "15500005552"
+
+    with app.app_context():
+        original_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=original_phone, code="9999"
+        )
+        original_user_bid = original_token.userInfo.user_id
+
+    resp, body = _post_json(
+        test_client,
+        "/api/user/login_sms",
+        {
+            "mobile": next_phone,
+            "sms_code": "9999",
+            "language": "zh-CN",
+            "login_context": "admin",
+        },
+        headers={"Token": original_token.token},
+    )
+
+    assert resp.status_code == 200
+    assert body["code"] == 0
+    assert body["data"]["userInfo"]["mobile"] == next_phone
+    assert body["data"]["userInfo"]["user_id"] != original_user_bid
+
+    with app.app_context():
+        original_entity = UserEntity.query.filter_by(user_bid=original_user_bid).first()
+        assert original_entity is not None
+        assert original_entity.user_identify == original_phone
+
+        original_credentials = AuthCredential.query.filter_by(
+            user_bid=original_user_bid,
+            provider_name="phone",
+            deleted=0,
+        ).all()
+        assert [credential.identifier for credential in original_credentials] == [
+            original_phone
+        ]
+
+
 def test_sms_login_route_normalizes_cn_prefix(test_client, app):
     from flaskr.service.user.models import AuthCredential, UserInfo as UserEntity
 

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -133,9 +133,7 @@ def test_sms_login_route_logs_in_with_phone_code(test_client):
     assert body["data"]["userInfo"]["mobile"] == phone
 
 
-def test_sms_login_route_does_not_rebind_authenticated_account_phone(
-    test_client, app
-):
+def test_sms_login_route_does_not_rebind_authenticated_account_phone(test_client, app):
     import flaskr.service.user.phone_flow as phone_flow
     from flaskr.service.user.models import AuthCredential, UserInfo as UserEntity
 

--- a/src/cook-web/src/app/login/page.test.tsx
+++ b/src/cook-web/src/app/login/page.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import AuthPage from './page';
+
+const replaceMock = jest.fn();
+const logoutMock = jest.fn(() => Promise.resolve());
+
+const mockUserState = {
+  userInfo: null as { language?: string } | null,
+  isLoggedIn: false,
+  isInitialized: true,
+  logout: logoutMock,
+};
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+  useSearchParams: () => ({
+    get: jest.fn(() => null),
+  }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, src }: { alt?: string; src?: string }) => (
+    <img
+      alt={alt || ''}
+      src={src || ''}
+    />
+  ),
+}));
+
+jest.mock('@/store', () => ({
+  useUserStore: (selector: (state: typeof mockUserState) => unknown) =>
+    selector(mockUserState),
+}));
+
+const mockEnvState = {
+  logoWideUrl: '',
+  loginMethodsEnabled: ['phone'],
+  defaultLoginMethod: 'phone',
+};
+
+jest.mock('@/c-store', () => ({
+  useEnvStore: (selector: (state: typeof mockEnvState) => unknown) =>
+    selector(mockEnvState),
+}));
+
+jest.mock('@/config/environment', () => ({
+  environment: {
+    logoWideUrl: '',
+    loginMethodsEnabled: ['phone'],
+    defaultLoginMethod: 'phone',
+  },
+}));
+
+jest.mock('@/i18n', () => ({
+  __esModule: true,
+  browserLanguage: 'zh-CN',
+  normalizeLanguage: (value: string | null | undefined) => value || '',
+  default: {
+    changeLanguage: jest.fn(() => Promise.resolve()),
+    hasResourceBundle: jest.fn(() => true),
+    resolvedLanguage: 'zh-CN',
+    language: 'zh-CN',
+    options: { defaultNS: 'common' },
+  },
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    ready: true,
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/auth/PhoneLogin', () => ({
+  PhoneLogin: () => <div data-testid='phone-login' />,
+}));
+
+jest.mock('@/components/auth/EmailLogin', () => ({
+  EmailLogin: () => <div data-testid='email-login' />,
+}));
+
+jest.mock('@/components/auth/FeedbackForm', () => ({
+  FeedbackForm: () => <div data-testid='feedback-form' />,
+}));
+
+jest.mock('@/components/auth/GoogleLoginButton', () => ({
+  GoogleLoginButton: () => <button type='button'>google</button>,
+}));
+
+jest.mock('@/components/auth/PasswordLogin', () => ({
+  PasswordLogin: () => <div data-testid='password-login' />,
+}));
+
+jest.mock('@/components/language-select', () => ({
+  __esModule: true,
+  default: () => <div data-testid='language-select' />,
+}));
+
+jest.mock('@/components/TermsCheckbox', () => ({
+  TermsCheckbox: () => <label>terms</label>,
+}));
+
+jest.mock('@/components/auth/TermsConfirmDialog', () => ({
+  TermsConfirmDialog: () => <div data-testid='terms-dialog' />,
+}));
+
+jest.mock('@/hooks/useGoogleAuth', () => ({
+  useGoogleAuth: () => ({
+    startGoogleLogin: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/ui/Tabs', () => ({
+  Tabs: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsList: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsTrigger: ({ children }: { children?: React.ReactNode }) => (
+    <button type='button'>{children}</button>
+  ),
+}));
+
+jest.mock('@/components/ui/Card', () => ({
+  Card: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardDescription: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardFooter: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardHeader: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  CardTitle: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+describe('AuthPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserState.userInfo = null;
+    mockUserState.isLoggedIn = false;
+    mockUserState.isInitialized = true;
+  });
+
+  it('switches an authenticated browser session to a guest session on the login page', async () => {
+    mockUserState.isLoggedIn = true;
+
+    render(<AuthPage />);
+
+    await waitFor(() => {
+      expect(logoutMock).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('does not reset an already-guest login page session', async () => {
+    render(<AuthPage />);
+
+    await waitFor(() => {
+      expect(logoutMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/cook-web/src/app/login/page.tsx
+++ b/src/cook-web/src/app/login/page.tsx
@@ -36,6 +36,9 @@ export default function AuthPage() {
   const [authMode, setAuthMode] = useState<'login' | 'feedback'>('login');
   const [isI18nReady, setIsI18nReady] = useState(false);
   const userInfo = useUserStore(state => state.userInfo);
+  const isLoggedIn = useUserStore(state => state.isLoggedIn);
+  const logout = useUserStore(state => state.logout);
+  const loginSessionResetRef = useRef(false);
   const [logoSrc, setLogoSrc] = useState<string | StaticImageData>(
     environment.logoWideUrl || logoHorizontal,
   );
@@ -51,6 +54,17 @@ export default function AuthPage() {
   useEffect(() => {
     setLogoSrc(logoWideUrl || environment.logoWideUrl || logoHorizontal);
   }, [logoWideUrl]);
+
+  useEffect(() => {
+    if (!isLoggedIn || loginSessionResetRef.current) {
+      return;
+    }
+
+    loginSessionResetRef.current = true;
+    void logout(false).catch(() => {
+      loginSessionResetRef.current = false;
+    });
+  }, [isLoggedIn, logout]);
 
   const normalizedMethods = useMemo(() => {
     const fallback = environment.loginMethodsEnabled;


### PR DESCRIPTION
## Summary
- Reset an authenticated browser session to a guest session when the `/login` page is opened, so business-initiated login redirects do not keep sending the previous real-user token to `/user/login_sms`.
- Harden `/user/login_sms` so it only uses an existing request user as `origin_user_id` when that token is anonymous/guest; real authenticated accounts no longer get implicitly rebound when another phone number is verified.
- Add regression coverage for both the login page session reset and the authenticated SMS-login no-rebind path.

## Verification
- `python -m py_compile src/api/flaskr/route/user.py src/api/tests/service/user/test_password_routes.py`
- `git diff --check`

## Not run / environment blockers
- `python -m pytest src/api/tests/service/user/test_password_routes.py::test_sms_login_route_does_not_rebind_authenticated_account_phone -q` failed before running tests: local Python env is missing `prometheus_client`.
- `npm --prefix src/cook-web test -- --runTestsByPath src/app/login/page.test.tsx --runInBand` failed before running tests: `jest` is not installed locally.
- `npm --prefix src/cook-web ci` cannot install in this checkout because `package.json` and `package-lock.json` are out of sync (missing optional dependency lock entries reported by npm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login page now automatically terminates an active session when an authenticated user visits the login interface.

* **Bug Fixes**
  * SMS login flow no longer rebinds an already-authenticated account to a different phone number; phone association preserved.

* **Tests**
  * Added tests covering login page session handling and SMS authentication/phone-rebinding scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->