### PR TITLE
fix: login session reset

### DIFF
--- a/src/cook-web/src/app/login/page.test.tsx
+++ b/src/cook-web/src/app/login/page.test.tsx
@@ -172,4 +172,19 @@ describe('AuthPage', () => {
       expect(logoutMock).not.toHaveBeenCalled();
     });
   });
+
+  it('does not reset the session created by a successful login on the login page', async () => {
+    const { rerender } = render(<AuthPage />);
+
+    await waitFor(() => {
+      expect(logoutMock).not.toHaveBeenCalled();
+    });
+
+    mockUserState.isLoggedIn = true;
+    rerender(<AuthPage />);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(logoutMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/cook-web/src/app/login/page.tsx
+++ b/src/cook-web/src/app/login/page.tsx
@@ -38,7 +38,7 @@ export default function AuthPage() {
   const userInfo = useUserStore(state => state.userInfo);
   const isLoggedIn = useUserStore(state => state.isLoggedIn);
   const logout = useUserStore(state => state.logout);
-  const loginSessionResetRef = useRef(false);
+  const loginSessionResetCheckedRef = useRef(false);
   const [logoSrc, setLogoSrc] = useState<string | StaticImageData>(
     environment.logoWideUrl || logoHorizontal,
   );
@@ -54,17 +54,6 @@ export default function AuthPage() {
   useEffect(() => {
     setLogoSrc(logoWideUrl || environment.logoWideUrl || logoHorizontal);
   }, [logoWideUrl]);
-
-  useEffect(() => {
-    if (!isLoggedIn || loginSessionResetRef.current) {
-      return;
-    }
-
-    loginSessionResetRef.current = true;
-    void logout(false).catch(() => {
-      loginSessionResetRef.current = false;
-    });
-  }, [isLoggedIn, logout]);
 
   const normalizedMethods = useMemo(() => {
     const fallback = environment.loginMethodsEnabled;
@@ -124,6 +113,21 @@ export default function AuthPage() {
 
   const searchParams = useSearchParams();
   const isInitialized = useUserStore(state => state.isInitialized);
+
+  useEffect(() => {
+    if (!isInitialized || loginSessionResetCheckedRef.current) {
+      return;
+    }
+
+    loginSessionResetCheckedRef.current = true;
+    if (!isLoggedIn) {
+      return;
+    }
+
+    void logout(false).catch(() => {
+      loginSessionResetCheckedRef.current = false;
+    });
+  }, [isInitialized, isLoggedIn, logout]);
 
   const resolveRedirectPath = useCallback(() => {
     const fallback = '/admin';


### PR DESCRIPTION
## Summary
- Limit the login-page session reset to the initial initialized session check.
- Preserve the authenticated session created by a successful SMS login on the login page.
- Add regression coverage for the successful-login state transition.

## Root Cause
The prior phone-rebinding fix reset any authenticated session observed on `/login`. After SMS verification succeeded, `login()` changed `isLoggedIn` to `true`, so the login page immediately called `logout(false)` and replaced the new token with a guest token. The next protected page then prompted for login again.

## Validation
- `git diff --check`
- `npm --prefix src/cook-web test -- --runTestsByPath src/app/login/page.test.tsx --runInBand`
- `npm --prefix src/cook-web test -- --runTestsByPath src/components/auth/PhoneLogin.test.tsx --runInBand`
- `npm --prefix src/cook-web run type-check`
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the login page would incorrectly trigger logout behavior on subsequent re-renders after successful user authentication.

* **Tests**
  * Added test coverage to verify login session behavior remains stable during user initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->