### PR TITLE
fix: respect X-Forwarded-Port for non-standard port preview URLs

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -81,6 +81,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $ai_shifu_forwarded_proto;
             proxy_set_header X-Forwarded-Host $ai_shifu_forwarded_host;
+            proxy_set_header X-Forwarded-Port $server_port;
         }
         location / {
             proxy_pass http://ai-shifu-cook-web:5000;

--- a/docker/nginx.dev.conf
+++ b/docker/nginx.dev.conf
@@ -82,6 +82,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $ai_shifu_forwarded_proto;
             proxy_set_header X-Forwarded-Host $ai_shifu_forwarded_host;
+            proxy_set_header X-Forwarded-Port $server_port;
         }
 
         location / {

--- a/src/api/flaskr/common/public_urls.py
+++ b/src/api/flaskr/common/public_urls.py
@@ -68,8 +68,17 @@ def _request_origin() -> str:
 
     forwarded_proto = _first_header_value(request.headers.get("X-Forwarded-Proto"))
     forwarded_host = _first_header_value(request.headers.get("X-Forwarded-Host"))
+    forwarded_port = _first_header_value(request.headers.get("X-Forwarded-Port"))
     scheme = forwarded_proto or request.scheme
     host = forwarded_host or request.host
+
+    if forwarded_port and ":" not in host:
+        is_standard = (scheme == "http" and forwarded_port == "80") or (
+            scheme == "https" and forwarded_port == "443"
+        )
+        if not is_standard:
+            host = f"{host}:{forwarded_port}"
+
     return _normalize_origin(f"{scheme}://{host}")
 
 

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -140,3 +140,47 @@ def test_public_urls_reject_host_url_with_path(monkeypatch: pytest.MonkeyPatch):
 
     with pytest.raises(RuntimeError, match="without path"):
         build_google_oauth_callback_url()
+
+
+def test_public_urls_include_non_standard_port_from_forwarded_port(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("HOST_URL", raising=False)
+    monkeypatch.setenv("PATH_PREFIX", "/api")
+    _reset_config_cache("HOST_URL", "PATH_PREFIX")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/orders",
+        headers={
+            "X-Forwarded-Proto": "http",
+            "X-Forwarded-Host": "app.example.com",
+            "X-Forwarded-Port": "8080",
+        },
+    ):
+        assert (
+            build_google_oauth_callback_url()
+            == "http://app.example.com:8080/login/google-callback"
+        )
+
+
+def test_public_urls_omit_standard_port_from_forwarded_port(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("HOST_URL", raising=False)
+    monkeypatch.setenv("PATH_PREFIX", "/api")
+    _reset_config_cache("HOST_URL", "PATH_PREFIX")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/api/orders",
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "app.example.com",
+            "X-Forwarded-Port": "443",
+        },
+    ):
+        assert (
+            build_google_oauth_callback_url()
+            == "https://app.example.com/login/google-callback"
+        )


### PR DESCRIPTION
## Problem

When ai-shifu is deployed behind nginx on a non-standard port (e.g. `http://example.com:8080`), the preview and publish URLs generated by the backend drop the port, producing `http://example.com/c/{shifu_bid}?preview=true` instead of `http://example.com:8080/c/{shifu_bid}?preview=true`.

**Root cause:** nginx `$host` variable (used as fallback for `X-Forwarded-Host`) excludes the port. When `Origin` header is absent, `_request_origin()` constructs the origin from `X-Forwarded-Proto` + `X-Forwarded-Host`, losing the port.

## Solution

1. **nginx configs** — add `proxy_set_header X-Forwarded-Port $server_port` to the `/api/` proxy block
2. **`public_urls.py`** — read `X-Forwarded-Port` in `_request_origin()`, append to host for non-standard ports (not 80/443)
3. **Tests** — 2 new cases: port 8080 included, port 443 omitted

## Changes

| File | Change |
|------|--------|
| `src/api/flaskr/common/public_urls.py` | Read X-Forwarded-Port, append for non-standard ports |
| `docker/nginx.conf` | Add X-Forwarded-Port header |
| `docker/nginx.dev.conf` | Same |
| `src/api/tests/common/test_public_urls.py` | 2 new test cases |

## Safety

- Backward compatible: when `X-Forwarded-Port` is absent, behavior unchanged
- Standard ports (80/443) never appended
- `HOST_URL` env var still takes priority — only affects fallback path when `Origin` is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port handling for applications running behind a proxy. Callback URLs and public endpoints now correctly reflect forwarded port configurations, including non-standard ports.

* **Tests**
  * Added tests verifying correct port handling in proxy scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->