### PR TITLE
refactor: split promotion management page

### DIFF
--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -693,6 +693,29 @@ const FormField = ({
   </div>
 );
 
+const StickyActionTableEmptyRow = ({
+  content,
+  colSpan,
+  actionStyle,
+}: {
+  content: React.ReactNode;
+  colSpan: number;
+  actionStyle?: React.CSSProperties;
+}) => (
+  <TableRow className='hover:bg-transparent'>
+    <TableCell
+      colSpan={colSpan}
+      className='px-4 py-10 text-center text-sm text-muted-foreground'
+    >
+      {content}
+    </TableCell>
+    <TableCell
+      className={TABLE_ACTION_CELL_CLASS}
+      style={actionStyle}
+    />
+  </TableRow>
+);
+
 const SearchField = ({
   label,
   children,
@@ -2920,7 +2943,7 @@ export default function AdminOperationPromotionsPage() {
             emptyColSpan={14}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
-            table={emptyRow => (
+            table={() => (
               <Table containerClassName='overflow-visible max-h-none'>
                 <TableHeader>
                   <TableRow>
@@ -3025,7 +3048,13 @@ export default function AdminOperationPromotionsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {emptyRow}
+                  {!coupons.length ? (
+                    <StickyActionTableEmptyRow
+                      content={tPromotion('messages.emptyCoupons')}
+                      colSpan={13}
+                      actionStyle={getCouponColumnStyle('action')}
+                    />
+                  ) : null}
                   {coupons.map(item => (
                     <TableRow key={item.coupon_bid}>
                       <TableCell
@@ -3493,7 +3522,7 @@ export default function AdminOperationPromotionsPage() {
             emptyColSpan={12}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
-            table={emptyRow => (
+            table={() => (
               <Table containerClassName='overflow-visible max-h-none'>
                 <TableHeader>
                   <TableRow>
@@ -3584,7 +3613,13 @@ export default function AdminOperationPromotionsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {emptyRow}
+                  {!campaigns.length ? (
+                    <StickyActionTableEmptyRow
+                      content={tPromotion('messages.emptyCampaigns')}
+                      colSpan={11}
+                      actionStyle={getCampaignColumnStyle('action')}
+                    />
+                  ) : null}
                   {campaigns.map(item => (
                     <TableRow key={item.promo_bid}>
                       <TableCell

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -695,16 +695,16 @@ const FormField = ({
 
 const StickyActionTableEmptyRow = ({
   content,
-  colSpan,
+  contentColSpan,
   actionStyle,
 }: {
   content: React.ReactNode;
-  colSpan: number;
+  contentColSpan: number;
   actionStyle?: React.CSSProperties;
 }) => (
   <TableRow className='hover:bg-transparent'>
     <TableCell
-      colSpan={colSpan}
+      colSpan={contentColSpan}
       className='px-4 py-10 text-center text-sm text-muted-foreground'
     >
       {content}
@@ -2938,9 +2938,7 @@ export default function AdminOperationPromotionsPage() {
           ) : null}
           <AdminTableShell
             loading={couponLoading}
-            isEmpty={!coupons.length}
-            emptyContent={tPromotion('messages.emptyCoupons')}
-            emptyColSpan={14}
+            isEmpty={false}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
             table={() => (
@@ -3051,7 +3049,9 @@ export default function AdminOperationPromotionsPage() {
                   {!coupons.length ? (
                     <StickyActionTableEmptyRow
                       content={tPromotion('messages.emptyCoupons')}
-                      colSpan={13}
+                      contentColSpan={
+                        Object.keys(COUPON_DEFAULT_COLUMN_WIDTHS).length - 1
+                      }
                       actionStyle={getCouponColumnStyle('action')}
                     />
                   ) : null}
@@ -3517,9 +3517,7 @@ export default function AdminOperationPromotionsPage() {
           ) : null}
           <AdminTableShell
             loading={campaignLoading}
-            isEmpty={!campaigns.length}
-            emptyContent={tPromotion('messages.emptyCampaigns')}
-            emptyColSpan={12}
+            isEmpty={false}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
             table={() => (
@@ -3616,7 +3614,9 @@ export default function AdminOperationPromotionsPage() {
                   {!campaigns.length ? (
                     <StickyActionTableEmptyRow
                       content={tPromotion('messages.emptyCampaigns')}
-                      colSpan={11}
+                      contentColSpan={
+                        Object.keys(CAMPAIGN_DEFAULT_COLUMN_WIDTHS).length - 1
+                      }
                       actionStyle={getCampaignColumnStyle('action')}
                     />
                   ) : null}


### PR DESCRIPTION
## Summary
- Split the promotion management page into focused frontend components for coupon and campaign management.
- Keep coupon/campaign table empty states aligned with sticky action columns.
- Clean up unused table empty-state props based on PR review feedback.

## Tests
- NODE_PATH=/Users/iris/ai-shifu/src/cook-web/node_modules /Users/iris/ai-shifu/src/cook-web/node_modules/.bin/jest --runTestsByPath src/app/admin/operations/promotions/page.test.tsx --runInBand
- NODE_PATH=/Users/iris/ai-shifu/src/cook-web/node_modules /Users/iris/ai-shifu/src/cook-web/node_modules/.bin/eslint src/app/admin/operations/promotions/page.tsx
- pre-commit run -a
