### PR TITLE
feat: unify operator admin table actions

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminRowActions.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminRowActions.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AdminRowActions from './AdminRowActions';
+
+jest.mock('@/components/ui/DropdownMenu', () => ({
+  __esModule: true,
+  DropdownMenu: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: React.PropsWithChildren) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onClick,
+  }: React.PropsWithChildren<{
+    disabled?: boolean;
+    onClick?: () => void;
+  }>) => (
+    <button
+      type='button'
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe('AdminRowActions', () => {
+  test('renders visible actions and invokes the selected handler', () => {
+    const edit = jest.fn();
+    const remove = jest.fn();
+
+    render(
+      <AdminRowActions
+        label='More'
+        actions={[
+          { key: 'edit', label: 'Edit', onClick: edit },
+          { key: 'hidden', label: 'Hidden', onClick: jest.fn(), hidden: true },
+          { key: 'remove', label: 'Remove', onClick: remove },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect(remove).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Hidden' })).toBeNull();
+  });
+
+  test('keeps disabled actions visible without invoking handlers', () => {
+    const grant = jest.fn();
+
+    render(
+      <AdminRowActions
+        label='More'
+        ariaLabel='More for user'
+        actions={[
+          {
+            key: 'grant',
+            label: 'Grant credits',
+            onClick: grant,
+            disabled: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'More for user' })).toBeEnabled();
+    expect(
+      screen.getByRole('button', { name: 'Grant credits' }),
+    ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grant credits' }));
+
+    expect(grant).not.toHaveBeenCalled();
+  });
+
+  test('renders nothing when every action is hidden', () => {
+    const { container } = render(
+      <AdminRowActions
+        label='More'
+        actions={[
+          { key: 'hidden', label: 'Hidden', onClick: jest.fn(), hidden: true },
+        ]}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/cook-web/src/app/admin/components/AdminRowActions.tsx
+++ b/src/cook-web/src/app/admin/components/AdminRowActions.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { ChevronDown } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
+import { cn } from '@/lib/utils';
+
+export type AdminRowActionItem = {
+  key: string;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  hidden?: boolean;
+};
+
+type AdminRowActionsProps = {
+  label: string;
+  ariaLabel?: string;
+  actions: AdminRowActionItem[];
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+};
+
+const ADMIN_ROW_ACTION_TRIGGER_CLASS =
+  'inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+export default function AdminRowActions({
+  label,
+  ariaLabel,
+  actions,
+  align = 'center',
+  className,
+}: AdminRowActionsProps) {
+  const visibleActions = actions.filter(action => !action.hidden);
+
+  if (!visibleActions.length) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type='button'
+          aria-label={ariaLabel}
+          className={cn(ADMIN_ROW_ACTION_TRIGGER_CLASS, className)}
+        >
+          {label}
+          <ChevronDown className='h-3.5 w-3.5' />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align}>
+        {visibleActions.map(action => (
+          <DropdownMenuItem
+            key={action.key}
+            disabled={action.disabled}
+            onClick={() => {
+              if (!action.disabled) {
+                action.onClick();
+              }
+            }}
+          >
+            {action.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/cook-web/src/app/admin/components/AdminTableShell.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AdminTableShell from './AdminTableShell';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+
+const MOCK_LOADING_LABEL = 'Loading';
+const NAME_LABEL = 'Name';
+const STATUS_LABEL = 'Status';
+
+jest.mock('@/components/loading', () => ({
+  __esModule: true,
+  default: () => <div>{MOCK_LOADING_LABEL}</div>,
+}));
+
+describe('AdminTableShell', () => {
+  test('passes the default empty row to table renderers', () => {
+    render(
+      <AdminTableShell
+        loading={false}
+        isEmpty
+        emptyContent='No records'
+        emptyColSpan={2}
+        table={emptyRow => (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{NAME_LABEL}</TableHead>
+                <TableHead>{STATUS_LABEL}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>{emptyRow}</TableBody>
+          </Table>
+        )}
+      />,
+    );
+
+    expect(screen.getByText('No records')).toBeInTheDocument();
+    expect(screen.getByText('No records').closest('td')).toHaveAttribute(
+      'colspan',
+      '2',
+    );
+  });
+
+  test('renders sticky action empty rows with a separate action cell', () => {
+    render(
+      <AdminTableShell
+        loading={false}
+        isEmpty
+        emptyContent='No campaigns'
+        stickyActionEmpty={{
+          contentColSpan: 3,
+          actionClassName: 'sticky-action-cell',
+        }}
+        table={emptyRow => (
+          <Table>
+            <TableBody>{emptyRow}</TableBody>
+          </Table>
+        )}
+      />,
+    );
+
+    const contentCell = screen.getByText('No campaigns').closest('td');
+
+    expect(contentCell).toHaveAttribute('colspan', '3');
+    expect(document.querySelector('.sticky-action-cell')).toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/app/admin/components/AdminTableShell.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.test.tsx
@@ -70,4 +70,63 @@ describe('AdminTableShell', () => {
     expect(contentCell).toHaveAttribute('colspan', '3');
     expect(document.querySelector('.sticky-action-cell')).toBeInTheDocument();
   });
+
+  test('does not render an empty footer when single-page pagination is hidden', () => {
+    render(
+      <AdminTableShell
+        loading={false}
+        isEmpty={false}
+        footerTestId='admin-table-footer'
+        pagination={{
+          pageIndex: 1,
+          pageCount: 1,
+          onPageChange: jest.fn(),
+          prevLabel: 'Previous',
+          nextLabel: 'Next',
+          prevAriaLabel: 'Go to previous page',
+          nextAriaLabel: 'Go to next page',
+          hideWhenSinglePage: true,
+        }}
+        table={
+          <Table>
+            <TableBody />
+          </Table>
+        }
+      />,
+    );
+
+    expect(screen.queryByTestId('admin-table-footer')).not.toBeInTheDocument();
+  });
+
+  test('keeps the footer visible for footnotes when single-page pagination is hidden', () => {
+    render(
+      <AdminTableShell
+        loading={false}
+        isEmpty={false}
+        footnote='Only finished records are included.'
+        footerTestId='admin-table-footer'
+        pagination={{
+          pageIndex: 1,
+          pageCount: 1,
+          onPageChange: jest.fn(),
+          prevLabel: 'Previous',
+          nextLabel: 'Next',
+          prevAriaLabel: 'Go to previous page',
+          nextAriaLabel: 'Go to next page',
+          hideWhenSinglePage: true,
+        }}
+        table={
+          <Table>
+            <TableBody />
+          </Table>
+        }
+      />,
+    );
+
+    expect(screen.getByTestId('admin-table-footer')).toBeInTheDocument();
+    expect(
+      screen.getByText('Only finished records are included.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+  });
 });

--- a/src/cook-web/src/app/admin/components/AdminTableShell.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.tsx
@@ -102,6 +102,19 @@ const renderEmptyRow = ({
   return <TableEmpty colSpan={emptyColSpan}>{emptyContent}</TableEmpty>;
 };
 
+const shouldRenderPagination = (pagination?: AdminPaginationProps) => {
+  if (!pagination) {
+    return false;
+  }
+
+  const safePageCount = Number.isFinite(pagination.pageCount)
+    ? pagination.pageCount
+    : 1;
+  const normalizedPageCount = Math.max(safePageCount, 1);
+
+  return !pagination.hideWhenSinglePage || normalizedPageCount > 1;
+};
+
 export default function AdminTableShell({
   loading,
   isEmpty,
@@ -135,9 +148,10 @@ export default function AdminTableShell({
   ) : (
     tableContent
   );
+  const hasVisiblePagination = shouldRenderPagination(pagination);
   const shouldRenderFooter =
     (showFooterWhenLoading || !loading) &&
-    Boolean(footnote || footer || pagination);
+    Boolean(footnote || footer || hasVisiblePagination);
 
   return (
     <div className={cn('flex min-h-0 flex-col', containerClassName)}>
@@ -183,7 +197,7 @@ export default function AdminTableShell({
           ) : (
             <div />
           )}
-          {pagination ? (
+          {hasVisiblePagination && pagination ? (
             <AdminPagination
               {...pagination}
               className={cn('mx-0 w-auto justify-end', pagination.className)}

--- a/src/cook-web/src/app/admin/components/AdminTableShell.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTableShell.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties, ReactNode } from 'react';
 import Loading from '@/components/loading';
-import { TableEmpty } from '@/components/ui/Table';
+import { TableCell, TableEmpty, TableRow } from '@/components/ui/Table';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { AdminPagination, type AdminPaginationProps } from './AdminPagination';
@@ -13,11 +13,20 @@ import {
 
 type AdminTableRenderer = (emptyRow: ReactNode | null) => ReactNode;
 
+type AdminStickyActionEmptyConfig = {
+  contentColSpan: number;
+  actionClassName?: string;
+  actionStyle?: CSSProperties;
+  contentClassName?: string;
+  rowClassName?: string;
+};
+
 type AdminTableShellProps = {
   loading: boolean;
   isEmpty: boolean;
   emptyContent?: ReactNode;
   emptyColSpan?: number;
+  stickyActionEmpty?: AdminStickyActionEmptyConfig;
   table: ReactNode | AdminTableRenderer;
   header?: ReactNode;
   footnote?: ReactNode;
@@ -51,11 +60,54 @@ const renderTableContent = (
   return table;
 };
 
+const renderEmptyRow = ({
+  emptyContent,
+  emptyColSpan,
+  stickyActionEmpty,
+}: {
+  emptyContent?: ReactNode;
+  emptyColSpan?: number;
+  stickyActionEmpty?: AdminStickyActionEmptyConfig;
+}) => {
+  if (!emptyContent) {
+    return null;
+  }
+
+  if (stickyActionEmpty) {
+    return (
+      <TableRow
+        className={cn('hover:bg-transparent', stickyActionEmpty.rowClassName)}
+      >
+        <TableCell
+          colSpan={stickyActionEmpty.contentColSpan}
+          className={cn(
+            'px-4 py-10 text-center text-sm text-muted-foreground',
+            stickyActionEmpty.contentClassName,
+          )}
+        >
+          {emptyContent}
+        </TableCell>
+        <TableCell
+          className={stickyActionEmpty.actionClassName}
+          style={stickyActionEmpty.actionStyle}
+        />
+      </TableRow>
+    );
+  }
+
+  if (!emptyColSpan) {
+    return null;
+  }
+
+  return <TableEmpty colSpan={emptyColSpan}>{emptyContent}</TableEmpty>;
+};
+
 export default function AdminTableShell({
   loading,
   isEmpty,
   emptyContent,
   emptyColSpan,
+  stickyActionEmpty,
   table,
   header,
   footnote,
@@ -73,10 +125,9 @@ export default function AdminTableShell({
   showFooterWhenLoading = false,
   tableWrapperStyle,
 }: AdminTableShellProps) {
-  const emptyRow =
-    isEmpty && emptyContent && emptyColSpan ? (
-      <TableEmpty colSpan={emptyColSpan}>{emptyContent}</TableEmpty>
-    ) : null;
+  const emptyRow = isEmpty
+    ? renderEmptyRow({ emptyContent, emptyColSpan, stickyActionEmpty })
+    : null;
 
   const tableContent = renderTableContent(table, emptyRow);
   const wrappedTableContent = withTooltipProvider ? (

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
@@ -37,6 +37,8 @@ type ChapterColumnKey =
   | 'ratingScore'
   | 'ratingCount';
 
+const CHAPTER_TABLE_COLUMN_COUNT = 11;
+
 type CourseChaptersTabProps = {
   rows: FlattenedChapterRow[];
   emptyValue: string;
@@ -92,7 +94,7 @@ export default function CourseChaptersTab({
           loading={false}
           isEmpty={rows.length === 0}
           emptyContent={tOperations('detail.chaptersTable.empty')}
-          emptyColSpan={11}
+          emptyColSpan={CHAPTER_TABLE_COLUMN_COUNT}
           withTooltipProvider
           tableWrapperClassName='overflow-auto'
           table={emptyRow => (

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import {
@@ -84,6 +83,10 @@ const CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS = {
 const CREDIT_USAGE_COLUMN_KEYS = Object.keys(
   CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS,
 ) as CreditUsageColumnKey[];
+const CREDIT_USAGE_DETAIL_TABLE_COLUMN_COUNT = {
+  read: 5,
+  listen: 6,
+} as const;
 const FILTER_ALL_OPTION = 'all';
 const EMPTY_CREDIT_USAGE_DETAIL_RESPONSE: AdminOperationCourseCreditUsageDetailListResponse =
   {
@@ -637,24 +640,21 @@ export default function CourseCreditUsageTab({
             loading={loading}
             isEmpty={!error && rows.length === 0}
             emptyContent={tOperations('detail.creditUsage.table.empty')}
-            emptyColSpan={9}
+            emptyColSpan={
+              Object.keys(CREDIT_USAGE_COLUMN_DEFAULT_WIDTHS).length
+            }
             withTooltipProvider={!error}
             tableWrapperClassName='overflow-auto'
             loadingClassName='min-h-[240px]'
-            footer={
-              pageCount > 1 ? (
-                <AdminPagination
-                  pageIndex={currentPage}
-                  pageCount={pageCount}
-                  onPageChange={onPageChange}
-                  prevLabel={t('module.order.paginationPrev')}
-                  nextLabel={t('module.order.paginationNext')}
-                  prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-                  nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-                  className='mx-0 w-auto justify-end'
-                />
-              ) : null
-            }
+            pagination={{
+              pageIndex: currentPage,
+              pageCount,
+              onPageChange,
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+            }}
             table={
               error ? (
                 <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>
@@ -913,24 +913,23 @@ export default function CourseCreditUsageTab({
               loading={detailLoading}
               isEmpty={!detailError && detailData.items.length === 0}
               emptyContent={tOperations('detail.creditUsage.details.empty')}
-              emptyColSpan={isListenDetail ? 6 : 5}
+              emptyColSpan={
+                isListenDetail
+                  ? CREDIT_USAGE_DETAIL_TABLE_COLUMN_COUNT.listen
+                  : CREDIT_USAGE_DETAIL_TABLE_COLUMN_COUNT.read
+              }
               withTooltipProvider={false}
               tableWrapperClassName='max-h-[52vh] overflow-auto'
               loadingClassName='min-h-[220px]'
-              footer={
-                Math.max(detailData.page_count || 0, 1) > 1 ? (
-                  <AdminPagination
-                    pageIndex={detailData.page || 1}
-                    pageCount={Math.max(detailData.page_count || 0, 1)}
-                    onPageChange={setDetailPage}
-                    prevLabel={t('module.order.paginationPrev')}
-                    nextLabel={t('module.order.paginationNext')}
-                    prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-                    nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-                    className='mx-0 w-auto justify-end'
-                  />
-                ) : null
-              }
+              pagination={{
+                pageIndex: detailData.page || 1,
+                pageCount: Math.max(detailData.page_count || 0, 1),
+                onPageChange: setDetailPage,
+                prevLabel: t('module.order.paginationPrev'),
+                nextLabel: t('module.order.paginationNext'),
+                prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+                nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+              }}
               table={
                 detailError ? (
                   <div className='flex min-h-[220px] items-center justify-center p-6 text-center'>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -654,6 +654,7 @@ export default function CourseCreditUsageTab({
               nextLabel: t('module.order.paginationNext'),
               prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
               nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+              hideWhenSinglePage: true,
             }}
             table={
               error ? (
@@ -929,6 +930,7 @@ export default function CourseCreditUsageTab({
                 nextLabel: t('module.order.paginationNext'),
                 prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
                 nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+                hideWhenSinglePage: true,
               }}
               table={
                 detailError ? (

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -2,7 +2,6 @@
 
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import {
@@ -41,6 +40,7 @@ import type {
   CourseUserPaymentStatus,
   UserColumnKey,
 } from './courseUsersTabConfig';
+import { USER_COLUMN_DEFAULT_WIDTHS } from './courseUsersTabConfig';
 
 type ErrorState = { message: string; code?: number };
 
@@ -269,24 +269,19 @@ export default function CourseUsersTab({
           loading={loading}
           isEmpty={!error && rows.length === 0}
           emptyContent={tOperations('detail.usersTable.empty')}
-          emptyColSpan={11}
+          emptyColSpan={Object.keys(USER_COLUMN_DEFAULT_WIDTHS).length}
           withTooltipProvider={!error}
           tableWrapperClassName='overflow-auto'
           loadingClassName='min-h-[240px]'
-          footer={
-            pageCount > 1 ? (
-              <AdminPagination
-                pageIndex={pageIndex}
-                pageCount={pageCount}
-                onPageChange={onPageChange}
-                prevLabel={t('module.order.paginationPrev')}
-                nextLabel={t('module.order.paginationNext')}
-                prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-                nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-                className='mx-0 w-auto justify-end'
-              />
-            ) : null
-          }
+          pagination={{
+            pageIndex,
+            pageCount,
+            onPageChange,
+            prevLabel: t('module.order.paginationPrev'),
+            nextLabel: t('module.order.paginationNext'),
+            prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+            nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+          }}
           table={
             error ? (
               <div className='flex min-h-[240px] items-center justify-center p-6 text-center'>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -281,6 +281,7 @@ export default function CourseUsersTab({
             nextLabel: t('module.order.paginationNext'),
             prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
             nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+            hideWhenSinglePage: true,
           }}
           table={
             error ? (

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -1027,6 +1027,7 @@ export default function AdminOperationCourseFollowUpsPage() {
                         'module.order.paginationNextAriaLabel',
                         'Go to next page',
                       ),
+                      hideWhenSinglePage: true,
                     }}
                   />
                 )}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
@@ -799,7 +798,7 @@ export default function AdminOperationCourseFollowUpsPage() {
                     loading={loading}
                     isEmpty={rows.length === 0}
                     emptyContent={tOperations('detail.followUps.table.empty')}
-                    emptyColSpan={6}
+                    emptyColSpan={Object.keys(COLUMN_DEFAULT_WIDTHS).length}
                     withTooltipProvider
                     tableWrapperClassName='overflow-auto'
                     loadingClassName='min-h-[240px]'
@@ -1014,25 +1013,21 @@ export default function AdminOperationCourseFollowUpsPage() {
                         </TableBody>
                       </Table>
                     )}
-                    footer={
-                      <AdminPagination
-                        pageIndex={currentPage}
-                        pageCount={pageCount}
-                        onPageChange={handlePageChange}
-                        prevLabel={t('module.order.paginationPrev', 'Previous')}
-                        nextLabel={t('module.order.paginationNext', 'Next')}
-                        prevAriaLabel={t(
-                          'module.order.paginationPrevAriaLabel',
-                          'Go to previous page',
-                        )}
-                        nextAriaLabel={t(
-                          'module.order.paginationNextAriaLabel',
-                          'Go to next page',
-                        )}
-                        className='mx-0 w-auto justify-end'
-                        hideWhenSinglePage
-                      />
-                    }
+                    pagination={{
+                      pageIndex: currentPage,
+                      pageCount,
+                      onPageChange: handlePageChange,
+                      prevLabel: t('module.order.paginationPrev', 'Previous'),
+                      nextLabel: t('module.order.paginationNext', 'Next'),
+                      prevAriaLabel: t(
+                        'module.order.paginationPrevAriaLabel',
+                        'Go to previous page',
+                      ),
+                      nextAriaLabel: t(
+                        'module.order.paginationNextAriaLabel',
+                        'Go to next page',
+                      ),
+                    }}
                   />
                 )}
               </CardContent>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -1017,16 +1017,10 @@ export default function AdminOperationCourseFollowUpsPage() {
                       pageIndex: currentPage,
                       pageCount,
                       onPageChange: handlePageChange,
-                      prevLabel: t('module.order.paginationPrev', 'Previous'),
-                      nextLabel: t('module.order.paginationNext', 'Next'),
-                      prevAriaLabel: t(
-                        'module.order.paginationPrevAriaLabel',
-                        'Go to previous page',
-                      ),
-                      nextAriaLabel: t(
-                        'module.order.paginationNextAriaLabel',
-                        'Go to next page',
-                      ),
+                      prevLabel: t('module.order.paginationPrev'),
+                      nextLabel: t('module.order.paginationNext'),
+                      prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+                      nextAriaLabel: t('module.order.paginationNextAriaLabel'),
                       hideWhenSinglePage: true,
                     }}
                   />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
@@ -891,7 +890,7 @@ export default function AdminOperationCourseRatingsPage() {
                     loading={loading}
                     isEmpty={rows.length === 0}
                     emptyContent={tOperations('detail.ratings.table.empty')}
-                    emptyColSpan={6}
+                    emptyColSpan={Object.keys(COLUMN_DEFAULT_WIDTHS).length}
                     withTooltipProvider
                     tableWrapperClassName='overflow-auto'
                     loadingClassName='min-h-[240px]'
@@ -1084,23 +1083,15 @@ export default function AdminOperationCourseRatingsPage() {
                         </TableBody>
                       </Table>
                     )}
-                    footer={
-                      <AdminPagination
-                        pageIndex={currentPage}
-                        pageCount={pageCount}
-                        onPageChange={handlePageChange}
-                        prevLabel={t('module.order.paginationPrev')}
-                        nextLabel={t('module.order.paginationNext')}
-                        prevAriaLabel={t(
-                          'module.order.paginationPrevAriaLabel',
-                        )}
-                        nextAriaLabel={t(
-                          'module.order.paginationNextAriaLabel',
-                        )}
-                        className='mx-0 w-auto justify-end'
-                        hideWhenSinglePage
-                      />
-                    }
+                    pagination={{
+                      pageIndex: currentPage,
+                      pageCount,
+                      onPageChange: handlePageChange,
+                      prevLabel: t('module.order.paginationPrev'),
+                      nextLabel: t('module.order.paginationNext'),
+                      prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+                      nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+                    }}
                   />
                 )}
               </CardContent>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -1091,6 +1091,7 @@ export default function AdminOperationCourseRatingsPage() {
                       nextLabel: t('module.order.paginationNext'),
                       prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
                       nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+                      hideWhenSinglePage: true,
                     }}
                   />
                 )}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
@@ -663,6 +663,7 @@ export function CreditNotificationRecordsTab({
           nextLabel: t('module.order.paginationNext'),
           prevAriaLabel: t('module.order.paginationPrev'),
           nextAriaLabel: t('module.order.paginationNext'),
+          hideWhenSinglePage: true,
         }}
         footerClassName='mt-3'
       />

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { ChevronDown, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
+import AdminRowActions from '@/app/admin/components/AdminRowActions';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -17,12 +17,6 @@ import {
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
 import {
   Select,
   SelectContent,
@@ -44,7 +38,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
 import type {
   AdminOperationCreditNotificationItem,
   AdminOperationCreditNotificationOverview,
@@ -494,7 +487,7 @@ export function CreditNotificationRecordsTab({
         loading={loading}
         isEmpty={items.length === 0}
         emptyContent={t('module.operationsCreditNotifications.empty')}
-        emptyColSpan={7}
+        emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
         withTooltipProvider
         tableWrapperClassName='max-h-[calc(100vh-22rem)] overflow-auto'
         table={emptyRow => (
@@ -631,42 +624,30 @@ export function CreditNotificationRecordsTab({
                     style={getColumnStyle('action')}
                   >
                     <div className='flex justify-center'>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type='button'
-                            className={cn(
-                              TABLE_INLINE_ACTION_BUTTON_CLASS,
-                              'gap-1',
-                            )}
-                          >
-                            {t(
-                              'module.operationsCreditNotifications.actions.more',
-                            )}
-                            <ChevronDown className='h-3.5 w-3.5' />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align='center'>
-                          <DropdownMenuItem
-                            onClick={() =>
-                              setDetailNotificationBid(item.notification_bid)
-                            }
-                          >
-                            {t(
+                      <AdminRowActions
+                        label={t(
+                          'module.operationsCreditNotifications.actions.more',
+                        )}
+                        className={TABLE_INLINE_ACTION_BUTTON_CLASS}
+                        actions={[
+                          {
+                            key: 'detail',
+                            label: t(
                               'module.operationsCreditNotifications.actions.detail',
-                            )}
-                          </DropdownMenuItem>
-                          {item.status === 'failed_provider' ? (
-                            <DropdownMenuItem
-                              onClick={() => requeue(item.notification_bid)}
-                            >
-                              {t(
-                                'module.operationsCreditNotifications.actions.requeue',
-                              )}
-                            </DropdownMenuItem>
-                          ) : null}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                            ),
+                            onClick: () =>
+                              setDetailNotificationBid(item.notification_bid),
+                          },
+                          {
+                            key: 'requeue',
+                            label: t(
+                              'module.operationsCreditNotifications.actions.requeue',
+                            ),
+                            hidden: item.status !== 'failed_provider',
+                            onClick: () => requeue(item.notification_bid),
+                          },
+                        ]}
+                      />
                     </div>
                   </TableCell>
                 </TableRow>
@@ -674,21 +655,15 @@ export function CreditNotificationRecordsTab({
             </TableBody>
           </Table>
         )}
-        footer={
-          pageCount > 1 ? (
-            <AdminPagination
-              className='mx-0 w-auto justify-end'
-              pageIndex={pageIndex}
-              pageCount={pageCount}
-              onPageChange={handlePageChange}
-              prevLabel={t('module.order.paginationPrev')}
-              nextLabel={t('module.order.paginationNext')}
-              prevAriaLabel={t('module.order.paginationPrev')}
-              nextAriaLabel={t('module.order.paginationNext')}
-              hideWhenSinglePage
-            />
-          ) : null
-        }
+        pagination={{
+          pageIndex,
+          pageCount,
+          onPageChange: handlePageChange,
+          prevLabel: t('module.order.paginationPrev'),
+          nextLabel: t('module.order.paginationNext'),
+          prevAriaLabel: t('module.order.paginationPrev'),
+          nextAriaLabel: t('module.order.paginationNext'),
+        }}
         footerClassName='mt-3'
       />
       <CreditNotificationDetailSheet

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -8,7 +8,6 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
@@ -747,7 +746,7 @@ export default function CreditOrdersTab() {
             loading={loading}
             isEmpty={orders.length === 0}
             emptyContent={tOperationsOrder('creditOrders.emptyList')}
-            emptyColSpan={11}
+            emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-21rem)] overflow-auto'
             table={emptyRow => (
@@ -997,21 +996,15 @@ export default function CreditOrdersTab() {
                 </TableBody>
               </Table>
             )}
-            footer={
-              pageCount > 1 ? (
-                <AdminPagination
-                  pageIndex={pageIndex}
-                  pageCount={pageCount}
-                  onPageChange={handlePageChange}
-                  prevLabel={t('module.order.paginationPrev')}
-                  nextLabel={t('module.order.paginationNext')}
-                  prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-                  nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-                  className='mx-0 w-auto justify-end'
-                  hideWhenSinglePage
-                />
-              ) : null
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: handlePageChange,
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+            }}
             footerClassName='mt-3'
           />
         </div>

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -1004,6 +1004,7 @@ export default function CreditOrdersTab() {
               nextLabel: t('module.order.paginationNext'),
               prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
               nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+              hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
           />

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -9,7 +9,6 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
   formatAdminCount,
@@ -715,7 +714,7 @@ export default function LearnOrdersTab() {
             loading={loading}
             isEmpty={orders.length === 0}
             emptyContent={tOperationsOrder('emptyList')}
-            emptyColSpan={11}
+            emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-21rem)] overflow-auto'
             table={emptyRow => (
@@ -951,21 +950,15 @@ export default function LearnOrdersTab() {
                 </TableBody>
               </Table>
             )}
-            footer={
-              pageCount > 1 ? (
-                <AdminPagination
-                  pageIndex={pageIndex}
-                  pageCount={pageCount}
-                  onPageChange={handlePageChange}
-                  prevLabel={t('module.order.paginationPrev')}
-                  nextLabel={t('module.order.paginationNext')}
-                  prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-                  nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-                  className='mx-0 w-auto justify-end'
-                  hideWhenSinglePage
-                />
-              ) : null
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: handlePageChange,
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+            }}
             footerClassName='mt-3'
           />
         </div>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -958,6 +958,7 @@ export default function LearnOrdersTab() {
               nextLabel: t('module.order.paginationNext'),
               prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
               nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+              hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
           />

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -11,7 +11,7 @@ import React, {
 } from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { Trans, useTranslation } from 'react-i18next';
-import { ChevronDown, Copy, X } from 'lucide-react';
+import { Copy, X } from 'lucide-react';
 import api from '@/api';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
@@ -20,7 +20,7 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import AdminRowActions from '@/app/admin/components/AdminRowActions';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { TITLE_MAX_LENGTH } from '@/c-constants/uiConstants';
@@ -69,12 +69,6 @@ import {
   TableRow,
 } from '@/components/ui/Table';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
-import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -86,7 +80,6 @@ import { useToast } from '@/hooks/useToast';
 import { copyText } from '@/c-utils/textutils';
 import { ErrorWithCode } from '@/lib/request';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
-import { cn } from '@/lib/utils';
 import { isValidEmail } from '@/lib/validators';
 import { buildAdminOperationsCourseDetailUrl } from './operation-course-routes';
 import type {
@@ -1569,7 +1562,7 @@ const OperationsPage = () => {
           loading={loading}
           isEmpty={courses.length === 0}
           emptyContent={tOperations('emptyList')}
-          emptyColSpan={11}
+          emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
           withTooltipProvider
           tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
           table={emptyRow => (
@@ -1797,34 +1790,23 @@ const OperationsPage = () => {
                         style={getColumnStyle('action')}
                       >
                         <div className='flex justify-center'>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type='button'
-                                className={cn(
-                                  TABLE_INLINE_ACTION_BUTTON_CLASS,
-                                  'gap-1',
-                                )}
-                              >
-                                {t('common.core.more')}
-                                <ChevronDown className='h-3.5 w-3.5' />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align='center'>
-                              <DropdownMenuItem
-                                onClick={() => handleCopyCourseClick(course)}
-                              >
-                                {tOperations('actions.copyCourse')}
-                              </DropdownMenuItem>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  handleTransferCreatorClick(course)
-                                }
-                              >
-                                {tOperations('actions.transferCreator')}
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                          <AdminRowActions
+                            label={t('common.core.more')}
+                            className={TABLE_INLINE_ACTION_BUTTON_CLASS}
+                            actions={[
+                              {
+                                key: 'copy',
+                                label: tOperations('actions.copyCourse'),
+                                onClick: () => handleCopyCourseClick(course),
+                              },
+                              {
+                                key: 'transfer',
+                                label: tOperations('actions.transferCreator'),
+                                onClick: () =>
+                                  handleTransferCreatorClick(course),
+                              },
+                            ]}
+                          />
                         </div>
                       </TableCell>
                     </TableRow>
@@ -1833,24 +1815,21 @@ const OperationsPage = () => {
               </TableBody>
             </Table>
           )}
-          footer={
-            <AdminPagination
-              pageIndex={pageIndex}
-              pageCount={pageCount}
-              onPageChange={handlePageChange}
-              prevLabel={t('module.order.paginationPrev', 'Previous')}
-              nextLabel={t('module.order.paginationNext', 'Next')}
-              prevAriaLabel={t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              )}
-              nextAriaLabel={t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              )}
-              className='justify-end w-auto mx-0'
-            />
-          }
+          pagination={{
+            pageIndex,
+            pageCount,
+            onPageChange: handlePageChange,
+            prevLabel: t('module.order.paginationPrev', 'Previous'),
+            nextLabel: t('module.order.paginationNext', 'Next'),
+            prevAriaLabel: t(
+              'module.order.paginationPrevAriaLabel',
+              'Go to previous page',
+            ),
+            nextAriaLabel: t(
+              'module.order.paginationNextAriaLabel',
+              'Go to next page',
+            ),
+          }}
         />
         <Dialog
           open={Boolean(promptDetailCourse)}

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -1819,16 +1819,10 @@ const OperationsPage = () => {
             pageIndex,
             pageCount,
             onPageChange: handlePageChange,
-            prevLabel: t('module.order.paginationPrev', 'Previous'),
-            nextLabel: t('module.order.paginationNext', 'Next'),
-            prevAriaLabel: t(
-              'module.order.paginationPrevAriaLabel',
-              'Go to previous page',
-            ),
-            nextAriaLabel: t(
-              'module.order.paginationNextAriaLabel',
-              'Go to next page',
-            ),
+            prevLabel: t('module.order.paginationPrev'),
+            nextLabel: t('module.order.paginationNext'),
+            prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+            nextAriaLabel: t('module.order.paginationNextAriaLabel'),
           }}
         />
         <Dialog

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { CalendarIcon, ChevronDown, Plus, X } from 'lucide-react';
+import { CalendarIcon, Plus, X } from 'lucide-react';
 import api from '@/api';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
@@ -11,7 +11,7 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import AdminRowActions from '@/app/admin/components/AdminRowActions';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -49,12 +49,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/Dialog';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import { Calendar } from '@/components/ui/Calendar';
@@ -180,6 +174,12 @@ const CAMPAIGN_DEFAULT_COLUMN_WIDTHS = {
   updatedAt: 170,
   createdAt: 170,
   action: 120,
+} as const;
+const PROMOTION_CODE_DIALOG_COLUMN_COUNT = 4;
+const PROMOTION_REDEMPTION_DIALOG_COLUMN_COUNT = 4;
+const PROMOTION_USAGE_DIALOG_COLUMN_COUNT = {
+  default: 4,
+  withCourse: 5,
 } as const;
 const SINGLE_SELECT_ITEM_CLASS =
   'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
@@ -656,29 +656,6 @@ const FormField = ({
   </div>
 );
 
-const StickyActionTableEmptyRow = ({
-  content,
-  contentColSpan,
-  actionStyle,
-}: {
-  content: React.ReactNode;
-  contentColSpan: number;
-  actionStyle?: React.CSSProperties;
-}) => (
-  <TableRow className='hover:bg-transparent'>
-    <TableCell
-      colSpan={contentColSpan}
-      className='px-4 py-10 text-center text-sm text-muted-foreground'
-    >
-      {content}
-    </TableCell>
-    <TableCell
-      className={TABLE_ACTION_CELL_CLASS}
-      style={actionStyle}
-    />
-  </TableRow>
-);
-
 const PromotionStatusConfirmDialog = ({
   changeTarget,
   submitting,
@@ -1080,7 +1057,7 @@ const PromotionCouponCodesDialog = ({
             loading={loading}
             isEmpty={codes.length === 0}
             emptyContent={tPromotion('messages.emptyCodes')}
-            emptyColSpan={4}
+            emptyColSpan={PROMOTION_CODE_DIALOG_COLUMN_COUNT}
             withTooltipProvider
             containerClassName='min-h-0 flex-1'
             tableWrapperClassName='min-h-0 flex-1 overflow-auto'
@@ -1125,25 +1102,22 @@ const PromotionCouponCodesDialog = ({
                 </TableBody>
               </Table>
             )}
-            footer={
-              <AdminPagination
-                pageIndex={pageIndex}
-                pageCount={pageCount}
-                onPageChange={page => void fetchCodes(page, appliedKeyword)}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-                hideWhenSinglePage
-              />
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: page => void fetchCodes(page, appliedKeyword),
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+              hideWhenSinglePage: true,
+            }}
             footerClassName='mt-3'
           />
         </div>
@@ -1227,7 +1201,7 @@ const PromotionCampaignRedemptionsDialog = ({
             loading={loading}
             isEmpty={redemptions.length === 0}
             emptyContent={tPromotion('messages.emptyRedemptions')}
-            emptyColSpan={4}
+            emptyColSpan={PROMOTION_REDEMPTION_DIALOG_COLUMN_COUNT}
             withTooltipProvider
             containerClassName='min-h-0 flex-1'
             tableWrapperClassName='min-h-0 flex-1 overflow-auto'
@@ -1272,25 +1246,22 @@ const PromotionCampaignRedemptionsDialog = ({
                 </TableBody>
               </Table>
             )}
-            footer={
-              <AdminPagination
-                pageIndex={pageIndex}
-                pageCount={pageCount}
-                onPageChange={page => void fetchRedemptions(page)}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-                hideWhenSinglePage
-              />
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: page => void fetchRedemptions(page),
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+              hideWhenSinglePage: true,
+            }}
             footerClassName='mt-3'
           />
         </div>
@@ -1372,7 +1343,11 @@ const PromotionCouponUsageDialog = ({
             loading={loading}
             isEmpty={usages.length === 0}
             emptyContent={tPromotion('messages.emptyUsages')}
-            emptyColSpan={showCourseColumn ? 5 : 4}
+            emptyColSpan={
+              showCourseColumn
+                ? PROMOTION_USAGE_DIALOG_COLUMN_COUNT.withCourse
+                : PROMOTION_USAGE_DIALOG_COLUMN_COUNT.default
+            }
             withTooltipProvider
             containerClassName='min-h-0 flex-1'
             tableWrapperClassName='min-h-0 flex-1 overflow-auto'
@@ -1429,25 +1404,22 @@ const PromotionCouponUsageDialog = ({
                 </TableBody>
               </Table>
             )}
-            footer={
-              <AdminPagination
-                pageIndex={pageIndex}
-                pageCount={pageCount}
-                onPageChange={page => void fetchUsages(page)}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-                hideWhenSinglePage
-              />
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: page => void fetchUsages(page),
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+              hideWhenSinglePage: true,
+            }}
             footerClassName='mt-3'
           />
         </div>
@@ -3042,10 +3014,17 @@ export default function AdminOperationPromotionsPage() {
           ) : null}
           <AdminTableShell
             loading={couponLoading}
-            isEmpty={false}
+            isEmpty={!coupons.length}
+            emptyContent={tPromotion('messages.emptyCoupons')}
+            stickyActionEmpty={{
+              contentColSpan:
+                Object.keys(COUPON_DEFAULT_COLUMN_WIDTHS).length - 1,
+              actionClassName: TABLE_ACTION_CELL_CLASS,
+              actionStyle: getCouponColumnStyle('action'),
+            }}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
-            table={() => (
+            table={emptyRow => (
               <Table containerClassName='overflow-visible max-h-none'>
                 <TableHeader>
                   <TableRow>
@@ -3150,15 +3129,7 @@ export default function AdminOperationPromotionsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {!coupons.length ? (
-                    <StickyActionTableEmptyRow
-                      content={tPromotion('messages.emptyCoupons')}
-                      contentColSpan={
-                        Object.keys(COUPON_DEFAULT_COLUMN_WIDTHS).length - 1
-                      }
-                      actionStyle={getCouponColumnStyle('action')}
-                    />
-                  ) : null}
+                  {emptyRow}
                   {coupons.map(item => (
                     <TableRow key={item.coupon_bid}>
                       <TableCell
@@ -3302,44 +3273,33 @@ export default function AdminOperationPromotionsPage() {
                         style={getCouponColumnStyle('action')}
                       >
                         <div className='flex justify-center'>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type='button'
-                                className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
-                              >
-                                {t('common.core.more')}
-                                <ChevronDown className='h-3.5 w-3.5' />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align='center'>
-                              <DropdownMenuItem
-                                onClick={() => void handleStartCouponEdit(item)}
-                              >
-                                {tPromotion('actions.edit')}
-                              </DropdownMenuItem>
-                              {Number(item.usage_type) === 802 ? (
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    void handleCouponCodeExport(item)
-                                  }
-                                >
-                                  {tPromotion('actions.exportCodes')}
-                                </DropdownMenuItem>
-                              ) : null}
-                              {shouldShowCouponStatusToggle(item) ? (
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    void handleCouponStatusToggle(item)
-                                  }
-                                >
-                                  {item.computed_status === 'inactive'
+                          <AdminRowActions
+                            label={t('common.core.more')}
+                            actions={[
+                              {
+                                key: 'edit',
+                                label: tPromotion('actions.edit'),
+                                onClick: () => void handleStartCouponEdit(item),
+                              },
+                              {
+                                key: 'export-codes',
+                                label: tPromotion('actions.exportCodes'),
+                                hidden: Number(item.usage_type) !== 802,
+                                onClick: () =>
+                                  void handleCouponCodeExport(item),
+                              },
+                              {
+                                key: 'toggle-status',
+                                label:
+                                  item.computed_status === 'inactive'
                                     ? tPromotion('actions.enable')
-                                    : tPromotion('actions.disable')}
-                                </DropdownMenuItem>
-                              ) : null}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                                    : tPromotion('actions.disable'),
+                                hidden: !shouldShowCouponStatusToggle(item),
+                                onClick: () =>
+                                  void handleCouponStatusToggle(item),
+                              },
+                            ]}
+                          />
                         </div>
                       </TableCell>
                     </TableRow>
@@ -3347,25 +3307,21 @@ export default function AdminOperationPromotionsPage() {
                 </TableBody>
               </Table>
             )}
-            footer={
-              <AdminPagination
-                pageIndex={couponPage}
-                pageCount={couponPageCount}
-                onPageChange={page => void fetchCoupons(page, couponFilters)}
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-                hideWhenSinglePage
-              />
-            }
+            pagination={{
+              pageIndex: couponPage,
+              pageCount: couponPageCount,
+              onPageChange: page => void fetchCoupons(page, couponFilters),
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+            }}
             footerClassName='mt-3'
           />
         </TabsContent>
@@ -3414,10 +3370,17 @@ export default function AdminOperationPromotionsPage() {
           ) : null}
           <AdminTableShell
             loading={campaignLoading}
-            isEmpty={false}
+            isEmpty={!campaigns.length}
+            emptyContent={tPromotion('messages.emptyCampaigns')}
+            stickyActionEmpty={{
+              contentColSpan:
+                Object.keys(CAMPAIGN_DEFAULT_COLUMN_WIDTHS).length - 1,
+              actionClassName: TABLE_ACTION_CELL_CLASS,
+              actionStyle: getCampaignColumnStyle('action'),
+            }}
             withTooltipProvider
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
-            table={() => (
+            table={emptyRow => (
               <Table containerClassName='overflow-visible max-h-none'>
                 <TableHeader>
                   <TableRow>
@@ -3508,15 +3471,7 @@ export default function AdminOperationPromotionsPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {!campaigns.length ? (
-                    <StickyActionTableEmptyRow
-                      content={tPromotion('messages.emptyCampaigns')}
-                      contentColSpan={
-                        Object.keys(CAMPAIGN_DEFAULT_COLUMN_WIDTHS).length - 1
-                      }
-                      actionStyle={getCampaignColumnStyle('action')}
-                    />
-                  ) : null}
+                  {emptyRow}
                   {campaigns.map(item => (
                     <TableRow key={item.promo_bid}>
                       <TableCell
@@ -3621,37 +3576,27 @@ export default function AdminOperationPromotionsPage() {
                         style={getCampaignColumnStyle('action')}
                       >
                         <div className='flex justify-center'>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type='button'
-                                className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
-                              >
-                                {t('common.core.more')}
-                                <ChevronDown className='h-3.5 w-3.5' />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align='center'>
-                              <DropdownMenuItem
-                                onClick={() =>
-                                  void handleStartCampaignEdit(item)
-                                }
-                              >
-                                {tPromotion('actions.edit')}
-                              </DropdownMenuItem>
-                              {shouldShowCampaignStatusToggle(item) ? (
-                                <DropdownMenuItem
-                                  onClick={() =>
-                                    void handleCampaignStatusToggle(item)
-                                  }
-                                >
-                                  {item.computed_status === 'inactive'
+                          <AdminRowActions
+                            label={t('common.core.more')}
+                            actions={[
+                              {
+                                key: 'edit',
+                                label: tPromotion('actions.edit'),
+                                onClick: () =>
+                                  void handleStartCampaignEdit(item),
+                              },
+                              {
+                                key: 'toggle-status',
+                                label:
+                                  item.computed_status === 'inactive'
                                     ? tPromotion('actions.enable')
-                                    : tPromotion('actions.disable')}
-                                </DropdownMenuItem>
-                              ) : null}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
+                                    : tPromotion('actions.disable'),
+                                hidden: !shouldShowCampaignStatusToggle(item),
+                                onClick: () =>
+                                  void handleCampaignStatusToggle(item),
+                              },
+                            ]}
+                          />
                         </div>
                       </TableCell>
                     </TableRow>
@@ -3659,27 +3604,21 @@ export default function AdminOperationPromotionsPage() {
                 </TableBody>
               </Table>
             )}
-            footer={
-              <AdminPagination
-                pageIndex={campaignPage}
-                pageCount={campaignPageCount}
-                onPageChange={page =>
-                  void fetchCampaigns(page, campaignFilters)
-                }
-                prevLabel={t('module.order.paginationPrev', 'Previous')}
-                nextLabel={t('module.order.paginationNext', 'Next')}
-                prevAriaLabel={t(
-                  'module.order.paginationPrevAriaLabel',
-                  'Go to previous page',
-                )}
-                nextAriaLabel={t(
-                  'module.order.paginationNextAriaLabel',
-                  'Go to next page',
-                )}
-                className='mx-0 w-auto justify-end'
-                hideWhenSinglePage
-              />
-            }
+            pagination={{
+              pageIndex: campaignPage,
+              pageCount: campaignPageCount,
+              onPageChange: page => void fetchCampaigns(page, campaignFilters),
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+            }}
             footerClassName='mt-3'
           />
         </TabsContent>

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -3321,6 +3321,7 @@ export default function AdminOperationPromotionsPage() {
                 'module.order.paginationNextAriaLabel',
                 'Go to next page',
               ),
+              hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
           />
@@ -3618,6 +3619,7 @@ export default function AdminOperationPromotionsPage() {
                 'module.order.paginationNextAriaLabel',
                 'Go to next page',
               ),
+              hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
           />

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -1106,16 +1106,10 @@ const PromotionCouponCodesDialog = ({
               pageIndex,
               pageCount,
               onPageChange: page => void fetchCodes(page, appliedKeyword),
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
@@ -1250,16 +1244,10 @@ const PromotionCampaignRedemptionsDialog = ({
               pageIndex,
               pageCount,
               onPageChange: page => void fetchRedemptions(page),
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
@@ -1408,16 +1396,10 @@ const PromotionCouponUsageDialog = ({
               pageIndex,
               pageCount,
               onPageChange: page => void fetchUsages(page),
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
@@ -3311,16 +3293,10 @@ export default function AdminOperationPromotionsPage() {
               pageIndex: couponPage,
               pageCount: couponPageCount,
               onPageChange: page => void fetchCoupons(page, couponFilters),
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'
@@ -3609,16 +3585,10 @@ export default function AdminOperationPromotionsPage() {
               pageIndex: campaignPage,
               pageCount: campaignPageCount,
               onPageChange: page => void fetchCampaigns(page, campaignFilters),
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
             footerClassName='mt-3'

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
@@ -1189,6 +1189,7 @@ export default function UserCreditLedgerTab({
             nextLabel: t('module.order.paginationNext'),
             prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
             nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+            hideWhenSinglePage: true,
           }}
           footerClassName='mt-0'
           table={emptyRow => (

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
@@ -4,7 +4,6 @@ import { useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import { formatAdminCredits } from '@/app/admin/lib/numberFormat';
@@ -35,7 +34,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type {
   AdminOperationUserCreditFilters,
@@ -53,6 +51,11 @@ import {
 import { formatOperatorUtcDateTime } from '../dateTime';
 
 type ErrorState = { message: string; code?: number };
+
+const CREDIT_USAGE_DETAIL_COLUMN_COUNT = {
+  read: 5,
+  listen: 6,
+} as const;
 
 type OperatorUsersTranslator = (
   key: string,
@@ -391,7 +394,11 @@ const CreditUsageDetailDialog = ({
               loading={false}
               isEmpty={items.length === 0}
               emptyContent={tOperationsUsers('detail.creditUsageDetail.empty')}
-              emptyColSpan={isListenDetail ? 6 : 5}
+              emptyColSpan={
+                isListenDetail
+                  ? CREDIT_USAGE_DETAIL_COLUMN_COUNT.listen
+                  : CREDIT_USAGE_DETAIL_COLUMN_COUNT.read
+              }
               withTooltipProvider={false}
               tableWrapperClassName='max-h-[52vh] overflow-auto'
               loadingClassName='min-h-[220px]'
@@ -1164,11 +1171,27 @@ export default function UserCreditLedgerTab({
           onSearch={onSearch}
           onReset={onReset}
         />
-        <TooltipProvider delayDuration={150}>
-          <div
-            className='min-h-0 flex-1 overflow-auto'
-            data-testid='admin-operation-user-credit-ledger-scroll'
-          >
+        <AdminTableShell
+          loading={loading}
+          isEmpty={!items.length}
+          emptyContent={tOperationsUsers('detail.emptyCredits')}
+          emptyColSpan={tableColumnCount}
+          withTooltipProvider
+          containerClassName='min-h-0 flex-1'
+          tableWrapperClassName='min-h-0 flex-1 overflow-auto'
+          tableWrapperTestId='admin-operation-user-credit-ledger-scroll'
+          loadingClassName='min-h-[220px]'
+          pagination={{
+            pageIndex,
+            pageCount,
+            onPageChange,
+            prevLabel: t('module.order.paginationPrev'),
+            nextLabel: t('module.order.paginationNext'),
+            prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+            nextAriaLabel: t('module.order.paginationNextAriaLabel'),
+          }}
+          footerClassName='mt-0'
+          table={emptyRow => (
             <Table className='table-fixed'>
               <colgroup>
                 {isConsumeView ? (
@@ -1334,23 +1357,10 @@ export default function UserCreditLedgerTab({
                   </TableRow>
                 )}
               </TableHeader>
-              <TableBody>{renderRows()}</TableBody>
+              <TableBody>{emptyRow ?? renderRows()}</TableBody>
             </Table>
-          </div>
-        </TooltipProvider>
-
-        {pageCount > 1 ? (
-          <AdminPagination
-            pageIndex={pageIndex}
-            pageCount={pageCount}
-            onPageChange={onPageChange}
-            prevLabel={t('module.order.paginationPrev')}
-            nextLabel={t('module.order.paginationNext')}
-            prevAriaLabel={t('module.order.paginationPrevAriaLabel')}
-            nextAriaLabel={t('module.order.paginationNextAriaLabel')}
-            className='justify-end w-auto mx-0'
-          />
-        ) : null}
+          )}
+        />
       </CardContent>
       <CreditUsageDetailDialog
         open={usageDetailOpen}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { AlertCircle, ChevronDown, X } from 'lucide-react';
+import { AlertCircle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
 import api from '@/api';
@@ -14,7 +14,7 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
-import { AdminPagination } from '@/app/admin/components/AdminPagination';
+import AdminRowActions from '@/app/admin/components/AdminRowActions';
 import {
   formatAdminCount,
   formatAdminCredits,
@@ -28,12 +28,6 @@ import {
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/DropdownMenu';
 import {
   Dialog,
   DialogContent,
@@ -1184,7 +1178,7 @@ export default function AdminOperationUsersPage() {
             loading={loading}
             isEmpty={users.length === 0}
             emptyContent={tOperationsUsers('emptyList')}
-            emptyColSpan={17}
+            emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
             tableWrapperClassName='max-h-[calc(100vh-18rem)] overflow-auto'
             table={emptyRow => (
               <Table>
@@ -1521,35 +1515,25 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('action')}
                         >
                           <div className='flex justify-center'>
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <button
-                                  type='button'
-                                  aria-label={tOperationsUsers(
-                                    'actions.moreForUser',
-                                    {
-                                      user: user.user_bid,
-                                    },
-                                  )}
-                                  className='inline-flex h-8 items-center justify-center gap-1 rounded-md px-2 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none'
-                                >
-                                  {t('common.core.more')}
-                                  <ChevronDown className='h-3.5 w-3.5' />
-                                </button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align='center'>
-                                <DropdownMenuItem
-                                  disabled={!canGrantBenefitsToUser(user)}
-                                  onClick={() => {
-                                    if (canGrantBenefitsToUser(user)) {
-                                      setGrantDialogUser(user);
-                                    }
-                                  }}
-                                >
-                                  {tOperationsUsers('actions.grantCredits')}
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
+                            <AdminRowActions
+                              label={t('common.core.more')}
+                              ariaLabel={tOperationsUsers(
+                                'actions.moreForUser',
+                                {
+                                  user: user.user_bid,
+                                },
+                              )}
+                              actions={[
+                                {
+                                  key: 'grant-credits',
+                                  label: tOperationsUsers(
+                                    'actions.grantCredits',
+                                  ),
+                                  disabled: !canGrantBenefitsToUser(user),
+                                  onClick: () => setGrantDialogUser(user),
+                                },
+                              ]}
+                            />
                           </div>
                         </TableCell>
                       </TableRow>
@@ -1558,26 +1542,21 @@ export default function AdminOperationUsersPage() {
                 </TableBody>
               </Table>
             )}
-            footer={
-              pageCount > 1 ? (
-                <AdminPagination
-                  pageIndex={pageIndex}
-                  pageCount={pageCount}
-                  onPageChange={handlePageChange}
-                  prevLabel={t('module.order.paginationPrev', 'Previous')}
-                  nextLabel={t('module.order.paginationNext', 'Next')}
-                  prevAriaLabel={t(
-                    'module.order.paginationPrevAriaLabel',
-                    'Go to previous page',
-                  )}
-                  nextAriaLabel={t(
-                    'module.order.paginationNextAriaLabel',
-                    'Go to next page',
-                  )}
-                  className='justify-end w-auto mx-0'
-                />
-              ) : null
-            }
+            pagination={{
+              pageIndex,
+              pageCount,
+              onPageChange: handlePageChange,
+              prevLabel: t('module.order.paginationPrev', 'Previous'),
+              nextLabel: t('module.order.paginationNext', 'Next'),
+              prevAriaLabel: t(
+                'module.order.paginationPrevAriaLabel',
+                'Go to previous page',
+              ),
+              nextAriaLabel: t(
+                'module.order.paginationNextAriaLabel',
+                'Go to next page',
+              ),
+            }}
           />
           <Dialog
             open={Boolean(courseDialog)}

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1556,6 +1556,7 @@ export default function AdminOperationUsersPage() {
                 'module.order.paginationNextAriaLabel',
                 'Go to next page',
               ),
+              hideWhenSinglePage: true,
             }}
           />
           <Dialog

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1546,16 +1546,10 @@ export default function AdminOperationUsersPage() {
               pageIndex,
               pageCount,
               onPageChange: handlePageChange,
-              prevLabel: t('module.order.paginationPrev', 'Previous'),
-              nextLabel: t('module.order.paginationNext', 'Next'),
-              prevAriaLabel: t(
-                'module.order.paginationPrevAriaLabel',
-                'Go to previous page',
-              ),
-              nextAriaLabel: t(
-                'module.order.paginationNextAriaLabel',
-                'Go to next page',
-              ),
+              prevLabel: t('module.order.paginationPrev'),
+              nextLabel: t('module.order.paginationNext'),
+              prevAriaLabel: t('module.order.paginationPrevAriaLabel'),
+              nextAriaLabel: t('module.order.paginationNextAriaLabel'),
               hideWhenSinglePage: true,
             }}
           />

--- a/src/cook-web/src/app/admin/orders/page.tsx
+++ b/src/cook-web/src/app/admin/orders/page.tsx
@@ -942,7 +942,7 @@ const OrdersPage = () => {
               loading={loading}
               isEmpty={orders.length === 0}
               emptyContent={t('module.order.emptyList')}
-              emptyColSpan={9}
+              emptyColSpan={Object.keys(DEFAULT_COLUMN_WIDTHS).length}
               withTooltipProvider
               tableWrapperClassName='max-h-[calc(100vh-20rem)] overflow-auto'
               footnote={t('module.order.totalCount', { count: total })}


### PR DESCRIPTION
## Summary
- add shared `AdminRowActions` for operator/admin row "More" menus
- extend `AdminTableShell` with sticky-action empty row support
- route operator table empty states and pagination through shared table shell props
- replace brittle empty column counts with column config lengths or named constants

## Tests
- `cd src/cook-web && NODE_PATH=/Users/iris/ai-shifu/src/cook-web/node_modules ./node_modules/.bin/eslint ...`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && NODE_PATH=/Users/iris/ai-shifu/src/cook-web/node_modules ./node_modules/.bin/jest --runTestsByPath ... --runInBand`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Row-action menus added to admin tables with proper handling for hidden and disabled actions.
  * Pagination is now integrated into table shells (inline controls, hidden when single page).
  * Empty-state rendering enhanced, including optional sticky action cells and dynamic column spanning.

* **Tests**
  * Added tests covering row-action behavior (visible/hidden/disabled) and table-shell empty/pagination rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->