### PR TITLE
feat: unify operator admin time select

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminTimeSelect.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTimeSelect.test.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AdminTimeSelect, { parseAdminTimeValue } from './AdminTimeSelect';
+
+const ControlledTimeSelect = ({
+  initialValue,
+  onChange,
+}: {
+  initialValue: string;
+  onChange: (value: string) => void;
+}) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <AdminTimeSelect
+      value={value}
+      onChange={nextValue => {
+        setValue(nextValue);
+        onChange(nextValue);
+      }}
+    />
+  );
+};
+
+describe('AdminTimeSelect', () => {
+  test('normalizes invalid time values to midnight', () => {
+    expect(parseAdminTimeValue('27:90')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('08:30')).toEqual({
+      hour: '08',
+      minute: '30',
+    });
+  });
+
+  test('selects hour and minute with HH:mm output', () => {
+    const handleChange = jest.fn();
+    render(
+      <ControlledTimeSelect
+        initialValue='08:15'
+        onChange={handleChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '08:15' }));
+    fireEvent.click(screen.getAllByRole('button', { name: '10' })[0]);
+    expect(handleChange).toHaveBeenLastCalledWith('10:15');
+
+    fireEvent.click(screen.getByRole('button', { name: '45' }));
+
+    expect(handleChange).toHaveBeenLastCalledWith('10:45');
+  });
+});

--- a/src/cook-web/src/app/admin/components/AdminTimeSelect.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTimeSelect.test.tsx
@@ -1,18 +1,24 @@
 import { useState } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import AdminTimeSelect, { parseAdminTimeValue } from './AdminTimeSelect';
 
 const ControlledTimeSelect = ({
   initialValue,
   onChange,
+  minTime,
+  maxTime,
 }: {
   initialValue: string;
   onChange: (value: string) => void;
+  minTime?: string;
+  maxTime?: string;
 }) => {
   const [value, setValue] = useState(initialValue);
   return (
     <AdminTimeSelect
       value={value}
+      minTime={minTime}
+      maxTime={maxTime}
       onChange={nextValue => {
         setValue(nextValue);
         onChange(nextValue);
@@ -23,13 +29,37 @@ const ControlledTimeSelect = ({
 
 describe('AdminTimeSelect', () => {
   test('normalizes invalid time values to midnight', () => {
+    expect(parseAdminTimeValue('08:30')).toEqual({
+      hour: '08',
+      minute: '30',
+    });
     expect(parseAdminTimeValue('27:90')).toEqual({
       hour: '00',
       minute: '00',
     });
-    expect(parseAdminTimeValue('08:30')).toEqual({
-      hour: '08',
-      minute: '30',
+    expect(parseAdminTimeValue('2023-10-27')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('2023-10-27Z')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('2023-10-27T00:00:00Z')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('08:30:15')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('08:30+08:00')).toEqual({
+      hour: '00',
+      minute: '00',
+    });
+    expect(parseAdminTimeValue('invalid-time')).toEqual({
+      hour: '00',
+      minute: '00',
     });
   });
 
@@ -43,11 +73,54 @@ describe('AdminTimeSelect', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: '08:15' }));
-    fireEvent.click(screen.getAllByRole('button', { name: '10' })[0]);
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Hour' })).getByRole('button', {
+        name: '10',
+      }),
+    );
     expect(handleChange).toHaveBeenLastCalledWith('10:15');
 
-    fireEvent.click(screen.getByRole('button', { name: '45' }));
+    fireEvent.click(
+      within(screen.getByRole('group', { name: 'Minute' })).getByRole(
+        'button',
+        { name: '45' },
+      ),
+    );
 
     expect(handleChange).toHaveBeenLastCalledWith('10:45');
+  });
+
+  test('disables options outside the min and max time range', () => {
+    const handleChange = jest.fn();
+    render(
+      <ControlledTimeSelect
+        initialValue='10:45'
+        minTime='10:30'
+        maxTime='11:15'
+        onChange={handleChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '10:45' }));
+
+    const hourGroup = screen.getByRole('group', { name: 'Hour' });
+    const minuteGroup = screen.getByRole('group', { name: 'Minute' });
+
+    expect(
+      within(hourGroup).getByRole('button', { name: '09' }),
+    ).toBeDisabled();
+    expect(
+      within(hourGroup).getByRole('button', { name: '12' }),
+    ).toBeDisabled();
+    expect(
+      within(minuteGroup).getByRole('button', { name: '15' }),
+    ).toBeDisabled();
+    expect(
+      within(minuteGroup).getByRole('button', { name: '30' }),
+    ).not.toBeDisabled();
+
+    fireEvent.click(within(hourGroup).getByRole('button', { name: '11' }));
+
+    expect(handleChange).toHaveBeenLastCalledWith('11:00');
   });
 });

--- a/src/cook-web/src/app/admin/components/AdminTimeSelect.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTimeSelect.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 const TIME_HOURS = Array.from({ length: 24 }, (_, index) =>
   String(index).padStart(2, '0'),
@@ -7,9 +8,10 @@ const TIME_HOURS = Array.from({ length: 24 }, (_, index) =>
 const TIME_MINUTES = Array.from({ length: 60 }, (_, index) =>
   String(index).padStart(2, '0'),
 );
+const DEFAULT_TIME = '00:00';
 
-function parseQuietTime(value: string) {
-  const matched = /^(\d{2}):(\d{2})$/.exec(value);
+export const parseAdminTimeValue = (value: string) => {
+  const matched = /^(\d{2}):(\d{2})$/.exec(String(value || '').trim());
   if (!matched) {
     return { hour: '00', minute: '00' };
   }
@@ -18,22 +20,48 @@ function parseQuietTime(value: string) {
     hour: TIME_HOURS.includes(hour) ? hour : '00',
     minute: TIME_MINUTES.includes(minute) ? minute : '00',
   };
-}
+};
 
-export function CreditNotificationQuietTimeSelect({
+type AdminTimeSelectProps = {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  triggerClassName?: string;
+  dropdownClassName?: string;
+};
+
+const renderTimeOptionClassName = (selected: boolean) =>
+  cn(
+    'flex h-8 w-full items-center justify-center rounded-sm text-sm transition-colors',
+    selected
+      ? 'bg-primary text-primary-foreground'
+      : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+  );
+
+const scrollTimeOptionIntoView = (
+  container: HTMLDivElement | null,
+  value: string,
+) => {
+  const option = container?.querySelector(`[data-time-value="${value}"]`);
+  if (option instanceof HTMLElement && option.scrollIntoView) {
+    option.scrollIntoView({ block: 'center' });
+  }
+};
+
+export default function AdminTimeSelect({
   id,
   value,
   onChange,
-}: {
-  id: string;
-  value: string;
-  onChange: (value: string) => void;
-}) {
+  className,
+  triggerClassName,
+  dropdownClassName,
+}: AdminTimeSelectProps) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const hourListRef = useRef<HTMLDivElement>(null);
   const minuteListRef = useRef<HTMLDivElement>(null);
-  const { hour, minute } = parseQuietTime(value);
+  const { hour, minute } = parseAdminTimeValue(value || DEFAULT_TIME);
   const displayTime = [hour, minute].join(':');
   const updateTime = (next: { hour?: string; minute?: string }) => {
     onChange(`${next.hour ?? hour}:${next.minute ?? minute}`);
@@ -48,9 +76,16 @@ export function CreditNotificationQuietTimeSelect({
         setOpen(false);
       }
     };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
     document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [open]);
 
@@ -58,30 +93,34 @@ export function CreditNotificationQuietTimeSelect({
     if (!open) {
       return;
     }
-    hourListRef.current
-      ?.querySelector(`[data-time-value="${hour}"]`)
-      ?.scrollIntoView({ block: 'center' });
-    minuteListRef.current
-      ?.querySelector(`[data-time-value="${minute}"]`)
-      ?.scrollIntoView({ block: 'center' });
+    scrollTimeOptionIntoView(hourListRef.current, hour);
+    scrollTimeOptionIntoView(minuteListRef.current, minute);
   }, [hour, minute, open]);
 
   return (
     <div
       ref={rootRef}
-      className='relative'
+      className={cn('relative', className)}
     >
       <button
         id={id}
         type='button'
-        className='flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 text-left text-sm ring-offset-background transition-colors hover:border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+        className={cn(
+          'flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 text-left text-sm ring-offset-background transition-colors hover:border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2',
+          triggerClassName,
+        )}
         onClick={() => setOpen(current => !current)}
       >
         <span className='text-base text-foreground'>{displayTime}</span>
         <ChevronDown className='h-4 w-4 text-muted-foreground' />
       </button>
       {open ? (
-        <div className='absolute left-0 top-full z-[112] mt-1 grid w-full min-w-44 grid-cols-2 overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md'>
+        <div
+          className={cn(
+            'absolute left-0 top-full z-[112] mt-1 grid w-full min-w-44 grid-cols-2 overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md',
+            dropdownClassName,
+          )}
+        >
           <div
             ref={hourListRef}
             className='max-h-56 overflow-y-auto border-r border-border p-1'
@@ -91,11 +130,7 @@ export function CreditNotificationQuietTimeSelect({
                 key={item}
                 type='button'
                 data-time-value={item}
-                className={`flex h-8 w-full items-center justify-center rounded-sm text-sm transition-colors ${
-                  item === hour
-                    ? 'bg-primary text-primary-foreground'
-                    : 'hover:bg-accent hover:text-accent-foreground'
-                }`}
+                className={renderTimeOptionClassName(item === hour)}
                 onClick={() => updateTime({ hour: item })}
               >
                 {item}
@@ -111,11 +146,7 @@ export function CreditNotificationQuietTimeSelect({
                 key={item}
                 type='button'
                 data-time-value={item}
-                className={`flex h-8 w-full items-center justify-center rounded-sm text-sm transition-colors ${
-                  item === minute
-                    ? 'bg-primary text-primary-foreground'
-                    : 'hover:bg-accent hover:text-accent-foreground'
-                }`}
+                className={renderTimeOptionClassName(item === minute)}
                 onClick={() => updateTime({ minute: item })}
               >
                 {item}

--- a/src/cook-web/src/app/admin/components/AdminTimeSelect.tsx
+++ b/src/cook-web/src/app/admin/components/AdminTimeSelect.tsx
@@ -26,17 +26,28 @@ type AdminTimeSelectProps = {
   id?: string;
   value: string;
   onChange: (value: string) => void;
+  minTime?: string;
+  maxTime?: string;
   className?: string;
   triggerClassName?: string;
   dropdownClassName?: string;
 };
 
-const renderTimeOptionClassName = (selected: boolean) =>
+const parseTimeBoundary = (value?: string) => {
+  const trimmedValue = String(value || '').trim();
+  const parsed = parseAdminTimeValue(trimmedValue);
+  const normalized = `${parsed.hour}:${parsed.minute}`;
+  return normalized === trimmedValue ? normalized : undefined;
+};
+
+const renderTimeOptionClassName = (selected: boolean, disabled: boolean) =>
   cn(
     'flex h-8 w-full items-center justify-center rounded-sm text-sm transition-colors',
-    selected
-      ? 'bg-primary text-primary-foreground'
-      : 'text-foreground hover:bg-accent hover:text-accent-foreground',
+    disabled
+      ? 'cursor-not-allowed text-muted-foreground/40'
+      : selected
+        ? 'bg-primary text-primary-foreground'
+        : 'text-foreground hover:bg-accent hover:text-accent-foreground',
   );
 
 const scrollTimeOptionIntoView = (
@@ -53,6 +64,8 @@ export default function AdminTimeSelect({
   id,
   value,
   onChange,
+  minTime,
+  maxTime,
   className,
   triggerClassName,
   dropdownClassName,
@@ -63,8 +76,32 @@ export default function AdminTimeSelect({
   const minuteListRef = useRef<HTMLDivElement>(null);
   const { hour, minute } = parseAdminTimeValue(value || DEFAULT_TIME);
   const displayTime = [hour, minute].join(':');
+  const normalizedMinTime = parseTimeBoundary(minTime);
+  const normalizedMaxTime = parseTimeBoundary(maxTime);
+  const isTimeDisabled = (nextHour: string, nextMinute: string) => {
+    const nextTime = `${nextHour}:${nextMinute}`;
+    if (normalizedMinTime && nextTime < normalizedMinTime) {
+      return true;
+    }
+    if (normalizedMaxTime && nextTime > normalizedMaxTime) {
+      return true;
+    }
+    return false;
+  };
+  const getFirstEnabledMinute = (nextHour: string) =>
+    TIME_MINUTES.find(nextMinute => !isTimeDisabled(nextHour, nextMinute));
+  const hasEnabledMinute = (nextHour: string) =>
+    Boolean(getFirstEnabledMinute(nextHour));
   const updateTime = (next: { hour?: string; minute?: string }) => {
-    onChange(`${next.hour ?? hour}:${next.minute ?? minute}`);
+    const nextHour = next.hour ?? hour;
+    let nextMinute = next.minute ?? minute;
+    if (next.hour && !next.minute && isTimeDisabled(nextHour, nextMinute)) {
+      nextMinute = getFirstEnabledMinute(nextHour) || nextMinute;
+    }
+    if (isTimeDisabled(nextHour, nextMinute)) {
+      return;
+    }
+    onChange(`${nextHour}:${nextMinute}`);
   };
 
   useEffect(() => {
@@ -123,35 +160,50 @@ export default function AdminTimeSelect({
         >
           <div
             ref={hourListRef}
+            role='group'
+            aria-label='Hour'
             className='max-h-56 overflow-y-auto border-r border-border p-1'
           >
-            {TIME_HOURS.map(item => (
-              <button
-                key={item}
-                type='button'
-                data-time-value={item}
-                className={renderTimeOptionClassName(item === hour)}
-                onClick={() => updateTime({ hour: item })}
-              >
-                {item}
-              </button>
-            ))}
+            {TIME_HOURS.map(item => {
+              const disabled = !hasEnabledMinute(item);
+              return (
+                <button
+                  key={item}
+                  type='button'
+                  data-time-value={item}
+                  disabled={disabled}
+                  className={renderTimeOptionClassName(item === hour, disabled)}
+                  onClick={() => updateTime({ hour: item })}
+                >
+                  {item}
+                </button>
+              );
+            })}
           </div>
           <div
             ref={minuteListRef}
+            role='group'
+            aria-label='Minute'
             className='max-h-56 overflow-y-auto p-1'
           >
-            {TIME_MINUTES.map(item => (
-              <button
-                key={item}
-                type='button'
-                data-time-value={item}
-                className={renderTimeOptionClassName(item === minute)}
-                onClick={() => updateTime({ minute: item })}
-              >
-                {item}
-              </button>
-            ))}
+            {TIME_MINUTES.map(item => {
+              const disabled = isTimeDisabled(hour, item);
+              return (
+                <button
+                  key={item}
+                  type='button'
+                  data-time-value={item}
+                  disabled={disabled}
+                  className={renderTimeOptionClassName(
+                    item === minute,
+                    disabled,
+                  )}
+                  onClick={() => updateTime({ minute: item })}
+                >
+                  {item}
+                </button>
+              );
+            })}
           </div>
         </div>
       ) : null}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Switch } from '@/components/ui/Switch';
+import AdminTimeSelect from '@/app/admin/components/AdminTimeSelect';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import type {
   AdminOperationCreditNotificationDryRunResponse,
@@ -30,7 +31,6 @@ import {
   CreditNotificationManagedListDialog,
   type CreditNotificationManagedListType as ManagedListType,
 } from './CreditNotificationManagedListDialog';
-import { CreditNotificationQuietTimeSelect } from './CreditNotificationQuietTimeSelect';
 import {
   CreditNotificationTypeConfigCard,
   getTemplateOptionsForType,
@@ -810,7 +810,7 @@ export function CreditNotificationConfigTab({
                   'module.operationsCreditNotifications.config.fieldTips.quietStart',
                 )}
               >
-                <CreditNotificationQuietTimeSelect
+                <AdminTimeSelect
                   id='credit-notification-quiet-start'
                   value={policy.quiet_hours.start}
                   onChange={value =>
@@ -829,7 +829,7 @@ export function CreditNotificationConfigTab({
                   'module.operationsCreditNotifications.config.fieldTips.quietEnd',
                 )}
               >
-                <CreditNotificationQuietTimeSelect
+                <AdminTimeSelect
                   id='credit-notification-quiet-end'
                   value={policy.quiet_hours.end}
                   onChange={value =>

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -12,6 +12,7 @@ import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
+import AdminTimeSelect from '@/app/admin/components/AdminTimeSelect';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -919,14 +920,10 @@ const PromotionDateTimePicker = ({
             />
             <div className='border-t border-border px-4 py-3'>
               <FormField label={timeLabel}>
-                <Input
-                  type='time'
-                  step={60}
-                  className='h-9'
+                <AdminTimeSelect
                   value={draftTime}
-                  min={minTime}
-                  max={maxTime}
-                  onChange={event => setDraftTime(event.target.value)}
+                  onChange={setDraftTime}
+                  dropdownClassName='bottom-full top-auto mb-1 mt-0'
                 />
               </FormField>
             </div>

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -923,6 +923,8 @@ const PromotionDateTimePicker = ({
                 <AdminTimeSelect
                   value={draftTime}
                   onChange={setDraftTime}
+                  minTime={minTime}
+                  maxTime={maxTime}
                   dropdownClassName='bottom-full top-auto mb-1 mt-0'
                 />
               </FormField>


### PR DESCRIPTION
## Summary
- Add shared `AdminTimeSelect` for operator admin time-only selection
- Replace the credit notification quiet-hours selector with the shared component
- Use the same time selector inside promotion date-time dialogs while preserving date range validation

## Tests
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/components/AdminTimeSelect.test.tsx src/app/admin/operations/credit-notifications/page.test.tsx src/app/admin/operations/promotions/page.test.tsx --runInBand`
- `cd src/cook-web && npm run lint -- --file src/app/admin/components/AdminTimeSelect.tsx --file src/app/admin/components/AdminTimeSelect.test.tsx --file src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx --file src/app/admin/operations/promotions/page.tsx`
- `cd src/cook-web && npm run type-check`
- `git diff --check`

## Notes
- Frontend-only change; no backend rebuild required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced native time inputs with a unified time-picker dropdown across admin screens; it closes on Escape or outside click and scrolls selected options into view.
  * Dropdowns now disable hours/minutes outside configured min/max ranges.

* **Bug Fixes**
  * Improved time parsing/normalization to default invalid or out-of-range entries to a safe value.

* **Tests**
  * Added end-to-end unit tests covering parsing, selection interactions, range enforcement, and emitted time values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->