### PR TITLE
fix: restore operator user detail scrolling

### DIFF
--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
@@ -1159,10 +1159,10 @@ export default function UserCreditLedgerTab({
 
   return (
     <Card
-      className='flex min-h-[360px] flex-1 flex-col shadow-sm'
+      className='flex h-fit flex-none flex-col shadow-sm'
       data-testid='admin-operation-user-credit-ledger-card'
     >
-      <CardContent className='flex min-h-0 flex-1 flex-col gap-4 pt-6'>
+      <CardContent className='flex flex-none flex-col gap-4 pt-6'>
         <CreditLedgerFilters
           filtersDraft={filtersDraft}
           loading={loading}
@@ -1177,8 +1177,8 @@ export default function UserCreditLedgerTab({
           emptyContent={tOperationsUsers('detail.emptyCredits')}
           emptyColSpan={tableColumnCount}
           withTooltipProvider
-          containerClassName='min-h-0 flex-1'
-          tableWrapperClassName='min-h-0 flex-1 overflow-auto'
+          containerClassName='h-fit flex-none'
+          tableWrapperClassName='h-fit max-h-[calc(100vh-22rem)] overflow-auto'
           tableWrapperTestId='admin-operation-user-credit-ledger-scroll'
           loadingClassName='min-h-[220px]'
           pagination={{

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -448,8 +448,11 @@ describe('AdminOperationUserDetailPage', () => {
     );
     expect(pageContainer).toHaveClass('h-full');
     expect(pageContainer).toHaveClass('overscroll-none');
-    expect(pageContainer).not.toHaveClass('overflow-hidden');
+    expect(pageContainer).toHaveClass('overflow-hidden');
     expect(pageContainer).not.toHaveClass('overflow-auto');
+    expect(
+      screen.getByTestId('admin-operation-user-detail-scroll'),
+    ).toHaveClass('overflow-y-auto');
     expect(
       screen.getByTestId('admin-operation-user-credit-ledger-scroll'),
     ).toHaveClass('overflow-auto');

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.tsx
@@ -811,7 +811,7 @@ export default function AdminOperationUserDetailPage() {
   return (
     <TooltipProvider delayDuration={150}>
       <div
-        className='h-full min-h-0 bg-stone-50 p-0 overscroll-none'
+        className='h-full min-h-0 overflow-hidden bg-stone-50 p-0 overscroll-none'
         data-testid='admin-operation-user-detail-page'
       >
         <div className='mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col overflow-hidden'>
@@ -828,7 +828,10 @@ export default function AdminOperationUserDetailPage() {
             <AdminTitle title={tOperationsUsers('detail.title')} />
           </div>
 
-          <div className='flex min-h-0 flex-1 flex-col pr-1'>
+          <div
+            className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-y-contain bg-stone-50 pr-1'
+            data-testid='admin-operation-user-detail-scroll'
+          >
             <div className='flex min-h-0 flex-1 flex-col gap-5 px-1 pb-6'>
               <UserDetailSummarySection
                 emptyValue={EMPTY_VALUE}


### PR DESCRIPTION
## Summary
- Restore a dedicated scroll container for the operator user detail page.
- Prevent the credit ledger card/table from stretching into large empty space when there are few rows.
- Add a regression assertion for the detail scroll container.

## Tests
- cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/users/[user_bid]/page.tsx' --file 'src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx' --file 'src/app/admin/operations/users/[user_bid]/page.test.tsx'\n- cd src/cook-web && npm test -- --runTestsByPath 'src/app/admin/operations/users/[user_bid]/page.test.tsx' --runInBand\n- git diff --check\n- /Users/iris/.codex/bin/branch_context_manager.py sync && report && pre-pr-review && pre-push-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior and layout stability in the admin user details panel by refining overflow handling and scroll container structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->