### PR TITLE
fix: support mysql grouped course credit usage

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -5951,6 +5951,7 @@ def get_operator_course_credit_usages(
             )
             .select_from(usage_rows)
             .group_by(
+                group_key_expr,
                 usage_rows.c.user_bid,
                 usage_rows.c.outline_item_bid,
                 usage_scene_expr,


### PR DESCRIPTION
## Summary
- Add the generated group key expression to the grouped course credit usage query group-by list.
- Fix MySQL only_full_group_by failures on the operator course detail credit usage tab.

## Tests
- cd src/api && pytest -q tests/service/shifu/test_admin_course_detail.py -k 'course_credit_usages or coerce_operator_datetime'\n- git diff --check\n- /Users/iris/.codex/bin/branch_context_manager.py sync && report && pre-pr-review && pre-push-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect grouping behavior in paginated course credit usage results to ensure operators view accurately aggregated data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->