### PR TITLE
feat: add operator referral reward grants

### DIFF
--- a/src/api/flaskr/service/billing/api.py
+++ b/src/api/flaskr/service/billing/api.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from flaskr.service.billing.manual_credit_grants import grant_manual_credits_to_user
+from flaskr.service.billing.referral_reward_grants import (
+    grant_referral_reward_credits_to_user,
+    load_referral_reward_summary,
+)
 from flaskr.service.billing.manual_plan_grants import grant_manual_plan_to_user
 from flaskr.service.billing.credit_notifications import (
     assert_creator_debug_allowed,
@@ -30,6 +34,7 @@ __all__ = [
     "dry_run_credit_notifications",
     "assert_creator_debug_allowed",
     "grant_manual_credits_to_user",
+    "grant_referral_reward_credits_to_user",
     "grant_manual_plan_to_user",
     "get_operator_credit_order_detail",
     "get_credit_notification_detail",
@@ -38,6 +43,7 @@ __all__ = [
     "list_credit_notifications",
     "load_credit_notification_policy",
     "load_credit_notification_policy_for_operator",
+    "load_referral_reward_summary",
     "requeue_credit_notification",
     "resolve_creator_limit_state",
     "save_credit_notification_policy",

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -1599,6 +1599,51 @@ def _suppressed_duplicate_result(
     )
 
 
+def suppress_pending_expiring_notifications_for_bucket(
+    app: Flask,
+    *,
+    wallet_bucket_bid: str,
+    effective_to: datetime | None = None,
+) -> int:
+    """Skip stale unsent expiry reminders after a bucket expiry is extended."""
+
+    normalized_wallet_bucket_bid = _normalize_bid(wallet_bucket_bid)
+    if not normalized_wallet_bucket_bid:
+        return 0
+
+    with _maybe_app_context(app):
+        now = datetime.now()
+        rows = (
+            NotificationRecord.query.filter(
+                NotificationRecord.deleted == 0,
+                NotificationRecord.notification_type
+                == CREDIT_NOTIFICATION_TYPE_EXPIRING,
+                NotificationRecord.source_type == SOURCE_TYPE_WALLET_BUCKET,
+                NotificationRecord.source_bid == normalized_wallet_bucket_bid,
+                NotificationRecord.status.in_(CREDIT_NOTIFICATION_PROCESSABLE_STATUSES),
+            )
+            .order_by(NotificationRecord.id.asc())
+            .all()
+        )
+        for row in rows:
+            metadata = dict(row.metadata_json or {})
+            metadata["superseded_by_effective_to"] = (
+                _serialize_dt(app, effective_to) if effective_to is not None else ""
+            )
+            row.metadata_json = metadata
+            _finalize_notification(
+                row,
+                status="skipped",
+                now=now,
+                error_code="expiry_extended",
+                error_message="Credit expiry was extended before delivery.",
+            )
+            db.session.add(row)
+        if rows:
+            db.session.flush()
+        return len(rows)
+
+
 def _find_credit_expiring_creator_window_record(
     *,
     creator_bid: str,

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -1622,6 +1622,7 @@ def suppress_pending_expiring_notifications_for_bucket(
                 NotificationRecord.source_bid == normalized_wallet_bucket_bid,
                 NotificationRecord.status.in_(CREDIT_NOTIFICATION_PROCESSABLE_STATUSES),
             )
+            .with_for_update()
             .order_by(NotificationRecord.id.asc())
             .all()
         )

--- a/src/api/flaskr/service/billing/grant_results.py
+++ b/src/api/flaskr/service/billing/grant_results.py
@@ -47,10 +47,12 @@ class ReferralRewardSummary:
     available_credits: int | float
     expires_at: datetime | None
     wallet_bucket_bid: str = ""
+    grant_count: int = 0
 
     def to_payload(self) -> dict[str, Any]:
         return {
             "available_credits": self.available_credits,
             "expires_at": self.expires_at,
             "wallet_bucket_bid": self.wallet_bucket_bid,
+            "grant_count": self.grant_count,
         }

--- a/src/api/flaskr/service/billing/grant_results.py
+++ b/src/api/flaskr/service/billing/grant_results.py
@@ -1,0 +1,56 @@
+"""Shared result payloads for operator credit grants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(slots=True, frozen=True)
+class ManualCreditGrantResult:
+    """Resolved state for one manual credit grant request."""
+
+    status: str
+    user_bid: str
+    amount: int | float
+    grant_source: str
+    validity_preset: str
+    expires_at: datetime | None
+    wallet_bucket_bid: str
+    ledger_bid: str
+    display_name: str = ""
+    note: str = ""
+    metadata_json: dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "user_bid": self.user_bid,
+            "amount": self.amount,
+            "grant_source": self.grant_source,
+            "validity_preset": self.validity_preset,
+            "expires_at": self.expires_at,
+            "display_name": self.display_name,
+            "note": self.note,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "ledger_bid": self.ledger_bid,
+            "metadata_json": self.metadata_json,
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_payload()[key]
+
+
+@dataclass(slots=True, frozen=True)
+class ReferralRewardSummary:
+    available_credits: int | float
+    expires_at: datetime | None
+    wallet_bucket_bid: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "available_credits": self.available_credits,
+            "expires_at": self.expires_at,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+        }

--- a/src/api/flaskr/service/billing/manual_credit_grants.py
+++ b/src/api/flaskr/service/billing/manual_credit_grants.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -13,6 +12,7 @@ from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.util.uuid import generate_id
 
 from .credit_notifications import stage_credit_granted_notification
+from .grant_results import ManualCreditGrantResult
 from .primitives import (
     credit_decimal_to_number as _credit_decimal_to_number,
     normalize_bid as _normalize_bid,
@@ -44,41 +44,6 @@ MANUAL_CREDIT_VALIDITY_PRESETS = (
     MANUAL_CREDIT_VALIDITY_3M,
     MANUAL_CREDIT_VALIDITY_1Y,
 )
-
-
-@dataclass(slots=True, frozen=True)
-class ManualCreditGrantResult:
-    """Resolved state for one manual credit grant request."""
-
-    status: str
-    user_bid: str
-    amount: int | float
-    grant_source: str
-    validity_preset: str
-    expires_at: datetime | None
-    wallet_bucket_bid: str
-    ledger_bid: str
-    display_name: str = ""
-    note: str = ""
-    metadata_json: dict[str, Any] = field(default_factory=dict)
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "status": self.status,
-            "user_bid": self.user_bid,
-            "amount": self.amount,
-            "grant_source": self.grant_source,
-            "validity_preset": self.validity_preset,
-            "expires_at": self.expires_at,
-            "display_name": self.display_name,
-            "note": self.note,
-            "wallet_bucket_bid": self.wallet_bucket_bid,
-            "ledger_bid": self.ledger_bid,
-            "metadata_json": self.metadata_json,
-        }
-
-    def __getitem__(self, key: str) -> Any:
-        return self.to_payload()[key]
 
 
 def _normalize_credit_amount(value: Any) -> Decimal:

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -1,0 +1,356 @@
+"""Referral reward credit grant helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from flask import Flask
+from sqlalchemy.exc import IntegrityError
+
+from flaskr.dao import db
+from flaskr.service.common.models import raise_param_error
+from flaskr.util.uuid import generate_id
+
+from .bucket_categories import resolve_credit_bucket_priority
+from .consts import (
+    CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+    CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    CREDIT_SOURCE_TYPE_MANUAL,
+)
+from .credit_notifications import (
+    stage_credit_granted_notification,
+    suppress_pending_expiring_notifications_for_bucket,
+)
+from .grant_results import ManualCreditGrantResult, ReferralRewardSummary
+from .models import CreditLedgerEntry, CreditWalletBucket
+from .primitives import (
+    credit_decimal_to_number as _credit_decimal_to_number,
+    normalize_bid as _normalize_bid,
+    quantize_credit_amount as _quantize_credit_amount,
+    to_decimal as _to_decimal,
+)
+from .queries import add_months as _add_months
+from .wallets import (
+    _expire_credit_wallet_buckets_in_session,
+    _load_or_create_credit_wallet,
+    persist_credit_wallet_snapshot,
+    refresh_credit_wallet_snapshot,
+    sync_credit_bucket_status,
+)
+
+REFERRAL_REWARD_GRANT_TYPE = "referral_reward"
+REFERRAL_REWARD_SCENE = "referral"
+REFERRAL_REWARD_PROGRAM = "referral_reward"
+REFERRAL_REWARD_VALIDITY_STRATEGY = "stack_by_reward_scene"
+REFERRAL_REWARD_VALIDITY_MONTHS = 1
+REFERRAL_REWARD_GRANT_SOURCE = "reward"
+REFERRAL_REWARD_VALIDITY_PRESET = "1m"
+
+
+def _normalize_referral_reward_amount(value: Any) -> Decimal:
+    normalized = str(value or "").strip()
+    if not normalized or not normalized.isdigit():
+        raise_param_error("amount")
+    try:
+        parsed = _quantize_credit_amount(Decimal(normalized))
+    except (InvalidOperation, TypeError, ValueError, ArithmeticError):
+        raise_param_error("amount")
+    if not parsed.is_finite() or parsed <= Decimal("0"):
+        raise_param_error("amount")
+    return parsed
+
+
+def _serialize_metadata_datetime(value: datetime | None) -> str:
+    return value.isoformat() if value is not None else ""
+
+
+def _is_referral_reward_metadata(metadata: Any) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    return str(metadata.get("grant_type") or "").strip() == REFERRAL_REWARD_GRANT_TYPE
+
+
+def _base_referral_reward_metadata() -> dict[str, str]:
+    return {
+        "grant_type": REFERRAL_REWARD_GRANT_TYPE,
+        "reward_scene": REFERRAL_REWARD_SCENE,
+        "reward_program": REFERRAL_REWARD_PROGRAM,
+        "validity_strategy": REFERRAL_REWARD_VALIDITY_STRATEGY,
+    }
+
+
+def _load_active_referral_reward_buckets(
+    creator_bid: str,
+    *,
+    as_of: datetime,
+    for_update: bool = False,
+) -> list[CreditWalletBucket]:
+    query = CreditWalletBucket.query.filter(
+        CreditWalletBucket.deleted == 0,
+        CreditWalletBucket.creator_bid == _normalize_bid(creator_bid),
+        CreditWalletBucket.source_type == CREDIT_SOURCE_TYPE_MANUAL,
+        CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+        CreditWalletBucket.available_credits > Decimal("0"),
+        CreditWalletBucket.effective_to.isnot(None),
+        CreditWalletBucket.effective_to > as_of,
+    ).order_by(
+        CreditWalletBucket.effective_to.desc(),
+        CreditWalletBucket.id.desc(),
+    )
+    if for_update:
+        query = query.with_for_update()
+    return [
+        bucket
+        for bucket in query.all()
+        if _is_referral_reward_metadata(bucket.metadata_json)
+    ]
+
+
+def load_referral_reward_summary(
+    app: Flask,
+    *,
+    creator_bid: str,
+    as_of: datetime | None = None,
+) -> ReferralRewardSummary:
+    with app.app_context():
+        scan_at = as_of or datetime.now()
+        buckets = _load_active_referral_reward_buckets(
+            creator_bid,
+            as_of=scan_at,
+        )
+        available = sum(
+            (_to_decimal(bucket.available_credits) for bucket in buckets),
+            start=Decimal("0"),
+        )
+        expires_at = buckets[0].effective_to if buckets else None
+        wallet_bucket_bid = str(buckets[0].wallet_bucket_bid or "") if buckets else ""
+        return ReferralRewardSummary(
+            available_credits=_credit_decimal_to_number(available),
+            expires_at=expires_at,
+            wallet_bucket_bid=wallet_bucket_bid,
+        )
+
+
+def _load_existing_referral_reward_result(
+    *,
+    creator_bid: str,
+    ledger_key: str,
+) -> ManualCreditGrantResult | None:
+    existing_entry = (
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.creator_bid == creator_bid,
+            CreditLedgerEntry.idempotency_key == ledger_key,
+        )
+        .order_by(CreditLedgerEntry.id.desc())
+        .first()
+    )
+    if existing_entry is None:
+        return None
+    return ManualCreditGrantResult(
+        status="noop_existing",
+        user_bid=str(existing_entry.creator_bid or "").strip(),
+        amount=_credit_decimal_to_number(_to_decimal(existing_entry.amount)),
+        grant_source=str(
+            (existing_entry.metadata_json or {}).get("grant_source")
+            or REFERRAL_REWARD_GRANT_SOURCE
+        ),
+        validity_preset=REFERRAL_REWARD_VALIDITY_PRESET,
+        expires_at=existing_entry.expires_at,
+        wallet_bucket_bid=str(existing_entry.wallet_bucket_bid or "").strip(),
+        ledger_bid=str(existing_entry.ledger_bid or "").strip(),
+        metadata_json=dict(existing_entry.metadata_json or {}),
+    )
+
+
+def grant_referral_reward_credits_to_user(
+    app: Flask,
+    *,
+    user_bid: str,
+    operator_user_bid: str,
+    request_id: str,
+    amount: str,
+    note: str = "",
+    grant_channel: str = "operator_user_management",
+) -> ManualCreditGrantResult:
+    """Grant referral reward credits and extend the referral reward pool."""
+
+    with app.app_context():
+        normalized_user_bid = _normalize_bid(user_bid)
+        normalized_operator_user_bid = _normalize_bid(operator_user_bid)
+        normalized_request_id = _normalize_bid(request_id)
+        normalized_note = str(note or "").strip()
+
+        if not normalized_user_bid:
+            raise_param_error("user_bid")
+        if not normalized_operator_user_bid:
+            raise_param_error("operator_user_bid")
+        if not normalized_request_id:
+            raise_param_error("request_id")
+        if len(normalized_note) > 255:
+            raise_param_error("note")
+
+        granted_amount = _normalize_referral_reward_amount(amount)
+        granted_at = datetime.now()
+        ledger_key = f"operator_referral_reward:{normalized_request_id}"
+        existing_result = _load_existing_referral_reward_result(
+            creator_bid=normalized_user_bid,
+            ledger_key=ledger_key,
+        )
+        if existing_result is not None:
+            return existing_result
+
+        _expire_credit_wallet_buckets_in_session(
+            app,
+            creator_bid=normalized_user_bid,
+            expire_before=granted_at,
+        )
+        wallet = _load_or_create_credit_wallet(app, normalized_user_bid)
+        db.session.refresh(wallet, with_for_update=True)
+        buckets = _load_active_referral_reward_buckets(
+            normalized_user_bid,
+            as_of=granted_at,
+            for_update=True,
+        )
+        bucket = buckets[0] if buckets else None
+        previous_effective_to = bucket.effective_to if bucket is not None else None
+        base_effective_to = (
+            previous_effective_to
+            if previous_effective_to is not None and previous_effective_to > granted_at
+            else granted_at
+        )
+        new_effective_to = _add_months(
+            base_effective_to,
+            REFERRAL_REWARD_VALIDITY_MONTHS,
+        )
+
+        base_metadata = _base_referral_reward_metadata()
+        if bucket is None:
+            bucket = CreditWalletBucket(
+                wallet_bucket_bid=generate_id(app),
+                wallet_bid=wallet.wallet_bid,
+                creator_bid=normalized_user_bid,
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_MANUAL,
+                source_bid=REFERRAL_REWARD_PROGRAM,
+                priority=resolve_credit_bucket_priority(
+                    CREDIT_BUCKET_CATEGORY_SUBSCRIPTION
+                ),
+                original_credits=granted_amount,
+                available_credits=granted_amount,
+                reserved_credits=Decimal("0"),
+                consumed_credits=Decimal("0"),
+                expired_credits=Decimal("0"),
+                effective_from=granted_at,
+                effective_to=new_effective_to,
+                status=CREDIT_BUCKET_STATUS_ACTIVE,
+                metadata_json=base_metadata,
+            )
+            db.session.add(bucket)
+            db.session.flush()
+        else:
+            bucket.original_credits = _quantize_credit_amount(
+                _to_decimal(bucket.original_credits) + granted_amount
+            )
+            bucket.available_credits = _quantize_credit_amount(
+                _to_decimal(bucket.available_credits) + granted_amount
+            )
+            bucket.effective_to = new_effective_to
+            bucket.metadata_json = {
+                **(
+                    bucket.metadata_json
+                    if isinstance(bucket.metadata_json, dict)
+                    else {}
+                ),
+                **base_metadata,
+            }
+            bucket.updated_at = granted_at
+            sync_credit_bucket_status(bucket)
+            suppress_pending_expiring_notifications_for_bucket(
+                app,
+                wallet_bucket_bid=bucket.wallet_bucket_bid,
+                effective_to=new_effective_to,
+            )
+            CreditLedgerEntry.query.filter(
+                CreditLedgerEntry.deleted == 0,
+                CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                CreditLedgerEntry.source_type == CREDIT_SOURCE_TYPE_MANUAL,
+            ).update(
+                {"expires_at": new_effective_to},
+                synchronize_session=False,
+            )
+
+        refresh_credit_wallet_snapshot(wallet)
+        balance_after = _quantize_credit_amount(wallet.available_credits)
+        next_lifetime_granted = _quantize_credit_amount(
+            _to_decimal(wallet.lifetime_granted_credits) + granted_amount
+        )
+        ledger_metadata = {
+            **base_metadata,
+            "grant_source": REFERRAL_REWARD_GRANT_SOURCE,
+            "validity_preset": REFERRAL_REWARD_VALIDITY_PRESET,
+            "reward_credits": str(granted_amount),
+            "previous_effective_to": _serialize_metadata_datetime(
+                previous_effective_to
+            ),
+            "new_effective_to": _serialize_metadata_datetime(new_effective_to),
+            "operator_user_bid": normalized_operator_user_bid,
+            "grant_channel": grant_channel,
+            "note": normalized_note,
+        }
+        ledger_entry = CreditLedgerEntry(
+            ledger_bid=generate_id(app),
+            creator_bid=normalized_user_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_MANUAL,
+            source_bid=REFERRAL_REWARD_PROGRAM,
+            idempotency_key=ledger_key,
+            amount=granted_amount,
+            balance_after=balance_after,
+            expires_at=new_effective_to,
+            consumable_from=granted_at,
+            metadata_json=ledger_metadata,
+        )
+        persist_credit_wallet_snapshot(
+            wallet,
+            available_credits=wallet.available_credits,
+            reserved_credits=wallet.reserved_credits,
+            lifetime_granted_credits=next_lifetime_granted,
+            updated_at=granted_at,
+        )
+        db.session.add(ledger_entry)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            existing_result = _load_existing_referral_reward_result(
+                creator_bid=normalized_user_bid,
+                ledger_key=ledger_key,
+            )
+            if existing_result is not None:
+                return existing_result
+            raise
+
+        stage_credit_granted_notification(
+            app,
+            ledger_bid=ledger_entry.ledger_bid,
+            commit=True,
+            enqueue=True,
+        )
+        return ManualCreditGrantResult(
+            status="granted",
+            user_bid=normalized_user_bid,
+            amount=_credit_decimal_to_number(granted_amount),
+            grant_source=REFERRAL_REWARD_GRANT_SOURCE,
+            validity_preset=REFERRAL_REWARD_VALIDITY_PRESET,
+            expires_at=new_effective_to,
+            wallet_bucket_bid=str(bucket.wallet_bucket_bid or "").strip(),
+            ledger_bid=str(ledger_entry.ledger_bid or "").strip(),
+            metadata_json=ledger_metadata,
+        )

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -108,6 +108,19 @@ def _load_active_referral_reward_buckets(
     ]
 
 
+def _count_referral_reward_grants(creator_bid: str) -> int:
+    return int(
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.creator_bid == _normalize_bid(creator_bid),
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            CreditLedgerEntry.source_type == CREDIT_SOURCE_TYPE_MANUAL,
+            CreditLedgerEntry.source_bid == REFERRAL_REWARD_PROGRAM,
+        ).count()
+        or 0
+    )
+
+
 def load_referral_reward_summary(
     app: Flask,
     *,
@@ -130,6 +143,7 @@ def load_referral_reward_summary(
             available_credits=_credit_decimal_to_number(available),
             expires_at=expires_at,
             wallet_bucket_bid=wallet_bucket_bid,
+            grant_count=_count_referral_reward_grants(creator_bid),
         )
 
 

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -93,7 +93,6 @@ def _load_active_referral_reward_buckets(
         CreditWalletBucket.creator_bid == _normalize_bid(creator_bid),
         CreditWalletBucket.source_type == CREDIT_SOURCE_TYPE_MANUAL,
         CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
-        CreditWalletBucket.available_credits > Decimal("0"),
         CreditWalletBucket.effective_to.isnot(None),
         CreditWalletBucket.effective_to > as_of,
     ).order_by(
@@ -162,6 +161,7 @@ def _load_existing_referral_reward_result(
         expires_at=existing_entry.expires_at,
         wallet_bucket_bid=str(existing_entry.wallet_bucket_bid or "").strip(),
         ledger_bid=str(existing_entry.ledger_bid or "").strip(),
+        note=str((existing_entry.metadata_json or {}).get("note") or "").strip(),
         metadata_json=dict(existing_entry.metadata_json or {}),
     )
 
@@ -352,5 +352,6 @@ def grant_referral_reward_credits_to_user(
             expires_at=new_effective_to,
             wallet_bucket_bid=str(bucket.wallet_bucket_bid or "").strip(),
             ledger_bid=str(ledger_entry.ledger_bid or "").strip(),
+            note=normalized_note,
             metadata_json=ledger_metadata,
         )

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -7473,6 +7473,7 @@ def get_operator_user_grant_bootstrap(
                 ),
                 expires_at=_format_operator_datetime(referral_summary.expires_at),
                 wallet_bucket_bid=str(referral_summary.wallet_bucket_bid or ""),
+                grant_count=int(referral_summary.grant_count or 0),
             ),
         )
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -50,10 +50,12 @@ from flaskr.service.billing.api import (
     dry_run_credit_notifications,
     get_credit_notification_detail,
     get_operator_credit_notification_overview as build_credit_notification_overview,
+    grant_referral_reward_credits_to_user,
     grant_manual_credits_to_user,
     grant_manual_plan_to_user,
     list_credit_notification_templates,
     list_credit_notifications,
+    load_referral_reward_summary,
     load_credit_notification_policy_for_operator,
     requeue_credit_notification,
     save_credit_notification_policy,
@@ -125,6 +127,7 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserCreditGrantResultDTO,
     AdminOperationUserCreditGrantRequestDTO,
     AdminOperationUserGrantBootstrapDTO,
+    AdminOperationUserReferralRewardSummaryDTO,
     AdminOperationUserPackageGrantRequestDTO,
     AdminOperationUserPackageGrantResultDTO,
     AdminOperationCourseSummaryDTO,
@@ -290,6 +293,8 @@ COURSE_CREDIT_USAGE_SCENE_PREVIEW = "preview"
 COURSE_CREDIT_USAGE_SCENE_DEBUG = "debug"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_REWARD = "reward"
 OPERATOR_USER_CREDIT_GRANT_SOURCE_COMPENSATION = "compensation"
+OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL = "manual_credit"
+OPERATOR_USER_CREDIT_GRANT_TYPE_REFERRAL_REWARD = "referral_reward"
 OPERATOR_USER_CREDIT_TYPE_ALL = "all"
 OPERATOR_USER_CREDIT_TYPE_CONSUME = "consume"
 OPERATOR_USER_CREDIT_TYPE_GRANT = "grant"
@@ -310,12 +315,31 @@ OPERATOR_USER_CREDIT_GRANT_SOURCES = {
     OPERATOR_USER_CREDIT_GRANT_SOURCE_REWARD,
     OPERATOR_USER_CREDIT_GRANT_SOURCE_COMPENSATION,
 }
+OPERATOR_USER_CREDIT_GRANT_TYPES = {
+    OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL,
+    OPERATOR_USER_CREDIT_GRANT_TYPE_REFERRAL_REWARD,
+}
 OPERATOR_USER_CREDIT_FILTER_TYPES = {
     OPERATOR_USER_CREDIT_TYPE_ALL,
     OPERATOR_USER_CREDIT_TYPE_CONSUME,
     OPERATOR_USER_CREDIT_TYPE_GRANT,
     OPERATOR_USER_CREDIT_TYPE_OTHER,
 }
+
+
+def _resolve_operator_credit_grant_type(
+    grant_type: str,
+    *,
+    fallback: str = OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL,
+) -> str:
+    normalized_grant_type = str(grant_type or "").strip().lower()
+    if normalized_grant_type == "manual_grant":
+        return OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL
+    if normalized_grant_type in OPERATOR_USER_CREDIT_GRANT_TYPES:
+        return normalized_grant_type
+    return fallback
+
+
 OPERATOR_USER_CREDIT_FILTER_GRANT_SOURCES = {
     OPERATOR_USER_CREDIT_FILTER_GRANT_SOURCE_ALL,
     OPERATOR_USER_CREDIT_FILTER_GRANT_SOURCE_SUBSCRIPTION,
@@ -7134,6 +7158,13 @@ def grant_operator_user_credits(
 
         user = _load_operator_user_or_raise(normalized_user_bid)
         _assert_operator_user_grant_target_supported(user)
+        normalized_grant_type = (
+            str(payload.grant_type or OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL)
+            .strip()
+            .lower()
+        )
+        if normalized_grant_type not in OPERATOR_USER_CREDIT_GRANT_TYPES:
+            raise_param_error("grant_type")
         normalized_grant_source = str(payload.grant_source or "").strip().lower()
         if normalized_grant_source not in OPERATOR_USER_CREDIT_GRANT_SOURCES:
             raise_param_error("grant_source")
@@ -7147,19 +7178,37 @@ def grant_operator_user_credits(
             raise_param_error("request_id")
         normalized_display_name = str(payload.display_name or "").strip()
         normalized_note = str(payload.note or "").strip()
-        grant_result = grant_manual_credits_to_user(
-            app,
-            user_bid=normalized_user_bid,
-            operator_user_bid=normalized_operator_user_bid,
-            request_id=normalized_request_id,
-            amount=payload.amount,
-            grant_source=normalized_grant_source,
-            validity_preset=normalized_validity_preset,
-            display_name=normalized_display_name,
-            note=normalized_note,
-        )
+        if normalized_grant_type == OPERATOR_USER_CREDIT_GRANT_TYPE_REFERRAL_REWARD:
+            if normalized_grant_source != OPERATOR_USER_CREDIT_GRANT_SOURCE_REWARD:
+                raise_param_error("grant_source")
+            if normalized_validity_preset != OPERATOR_USER_CREDIT_VALIDITY_1M:
+                raise_param_error("validity_preset")
+            grant_result = grant_referral_reward_credits_to_user(
+                app,
+                user_bid=normalized_user_bid,
+                operator_user_bid=normalized_operator_user_bid,
+                request_id=normalized_request_id,
+                amount=payload.amount,
+                note=normalized_note,
+            )
+        else:
+            grant_result = grant_manual_credits_to_user(
+                app,
+                user_bid=normalized_user_bid,
+                operator_user_bid=normalized_operator_user_bid,
+                request_id=normalized_request_id,
+                amount=payload.amount,
+                grant_source=normalized_grant_source,
+                validity_preset=normalized_validity_preset,
+                display_name=normalized_display_name,
+                note=normalized_note,
+            )
 
         persisted_metadata = _normalize_metadata_json(grant_result.metadata_json)
+        resolved_grant_type = _resolve_operator_credit_grant_type(
+            str(persisted_metadata.get("grant_type") or "").strip(),
+            fallback=normalized_grant_type,
+        )
         resolved_grant_source = str(
             persisted_metadata.get("grant_source") or normalized_grant_source
         ).strip()
@@ -7180,6 +7229,7 @@ def grant_operator_user_credits(
             status=str(grant_result.status or "granted"),
             user_bid=normalized_user_bid,
             amount=resolved_amount,
+            grant_type=resolved_grant_type,
             grant_source=resolved_grant_source,
             validity_preset=resolved_validity_preset,
             expires_at=_format_operator_datetime(grant_result.expires_at),
@@ -7398,11 +7448,17 @@ def get_operator_user_grant_bootstrap(
         user = _load_operator_user_or_raise(normalized_user_bid)
         _assert_operator_user_grant_target_supported(user)
         catalog = build_billing_catalog(app)
+        server_time = datetime.now()
         current_subscription_product_display_name_i18n_key = (
             _load_active_subscription_product_display_name_i18n_key(
                 normalized_user_bid,
-                as_of=datetime.now(),
+                as_of=server_time,
             )
+        )
+        referral_summary = load_referral_reward_summary(
+            app,
+            creator_bid=normalized_user_bid,
+            as_of=server_time,
         )
         return AdminOperationUserGrantBootstrapDTO(
             plans=catalog.plans,
@@ -7410,6 +7466,16 @@ def get_operator_user_grant_bootstrap(
                 current_subscription_product_display_name_i18n_key
             ),
             notification_status="template_pending",
+            server_time=_format_operator_datetime(server_time),
+            referral_reward_summary=AdminOperationUserReferralRewardSummaryDTO(
+                available_credits=_format_decimal(
+                    _quantize_credit_amount(
+                        Decimal(str(referral_summary.available_credits or 0))
+                    )
+                ),
+                expires_at=_format_operator_datetime(referral_summary.expires_at),
+                wallet_bucket_bid=str(referral_summary.wallet_bucket_bid or ""),
+            ),
         )
 
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -7158,8 +7158,11 @@ def grant_operator_user_credits(
 
         user = _load_operator_user_or_raise(normalized_user_bid)
         _assert_operator_user_grant_target_supported(user)
-        normalized_grant_type = _resolve_operator_credit_grant_type(
-            str(payload.grant_type or "").strip(),
+        raw_grant_type = str(payload.grant_type or "").strip()
+        normalized_grant_type = (
+            OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL
+            if not raw_grant_type
+            else _resolve_operator_credit_grant_type(raw_grant_type, fallback="")
         )
         if normalized_grant_type not in OPERATOR_USER_CREDIT_GRANT_TYPES:
             raise_param_error("grant_type")

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -7158,10 +7158,8 @@ def grant_operator_user_credits(
 
         user = _load_operator_user_or_raise(normalized_user_bid)
         _assert_operator_user_grant_target_supported(user)
-        normalized_grant_type = (
-            str(payload.grant_type or OPERATOR_USER_CREDIT_GRANT_TYPE_MANUAL)
-            .strip()
-            .lower()
+        normalized_grant_type = _resolve_operator_credit_grant_type(
+            str(payload.grant_type or "").strip(),
         )
         if normalized_grant_type not in OPERATOR_USER_CREDIT_GRANT_TYPES:
             raise_param_error("grant_type")

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -496,6 +496,11 @@ class AdminOperationUserReferralRewardSummaryDTO(BaseModel):
         description="Current active referral reward wallet bucket identifier",
         required=False,
     )
+    grant_count: int = Field(
+        default=0,
+        description="Successful referral reward grant count",
+        required=False,
+    )
 
     def __json__(self) -> dict[str, Any]:
         return self.model_dump()

--- a/src/api/flaskr/service/shifu/admin_dtos.py
+++ b/src/api/flaskr/service/shifu/admin_dtos.py
@@ -410,6 +410,11 @@ class AdminOperationUserCreditGrantRequestDTO(BaseModel):
         required=True,
     )
     amount: str = Field(..., description="Granted credits amount", required=True)
+    grant_type: str = Field(
+        default="manual_credit",
+        description="Grant type: manual_credit or referral_reward",
+        required=False,
+    )
     grant_source: str = Field(
         ..., description="Grant source: reward or compensation", required=True
     )
@@ -434,6 +439,11 @@ class AdminOperationUserCreditGrantResultDTO(BaseModel):
     status: str = Field(default="granted", description="Grant result status")
     user_bid: str = Field(..., description="Target user business identifier")
     amount: str = Field(..., description="Granted credits amount", required=False)
+    grant_type: str = Field(
+        default="manual_credit",
+        description="Grant type: manual_credit or referral_reward",
+        required=False,
+    )
     grant_source: str = Field(
         ..., description="Grant source: reward or compensation", required=False
     )
@@ -468,6 +478,30 @@ class AdminOperationUserCreditGrantResultDTO(BaseModel):
 
 
 @register_schema_to_swagger
+class AdminOperationUserReferralRewardSummaryDTO(BaseModel):
+    """Current referral reward pool shown in the operator grant dialog."""
+
+    available_credits: str = Field(
+        default="0",
+        description="Current active referral reward credits",
+        required=False,
+    )
+    expires_at: str = Field(
+        default="",
+        description="Current active referral reward expiry timestamp",
+        required=False,
+    )
+    wallet_bucket_bid: str = Field(
+        default="",
+        description="Current active referral reward wallet bucket identifier",
+        required=False,
+    )
+
+    def __json__(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
+@register_schema_to_swagger
 class AdminOperationUserGrantBootstrapDTO(BaseModel):
     """Operator grant dialog bootstrap payload."""
 
@@ -486,6 +520,16 @@ class AdminOperationUserGrantBootstrapDTO(BaseModel):
         description="Current admin package notification template status",
         required=False,
     )
+    server_time: str = Field(
+        default="",
+        description="Server timestamp used for grant previews",
+        required=False,
+    )
+    referral_reward_summary: AdminOperationUserReferralRewardSummaryDTO = Field(
+        default_factory=AdminOperationUserReferralRewardSummaryDTO,
+        description="Current referral reward pool summary",
+        required=False,
+    )
 
     def __json__(self) -> dict[str, Any]:
         return {
@@ -494,6 +538,8 @@ class AdminOperationUserGrantBootstrapDTO(BaseModel):
                 self.current_subscription_product_display_name_i18n_key
             ),
             "notification_status": self.notification_status,
+            "server_time": self.server_time,
+            "referral_reward_summary": self.referral_reward_summary.__json__(),
         }
 
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -34,6 +34,9 @@ from flaskr.service.billing.consts import (
     CREDIT_SOURCE_TYPE_TOPUP,
     CREDIT_SOURCE_TYPE_USAGE,
 )
+from flaskr.service.billing import (
+    referral_reward_grants as referral_reward_grants_module,
+)
 from flaskr.service.billing.models import CreditWallet, CreditWalletBucket
 from flaskr.service.billing.models import (
     BillingOrder,
@@ -2653,6 +2656,7 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
 
     assert result.user_bid == "credits-grant-target"
     assert result.amount == "5"
+    assert result.grant_type == "manual_credit"
     assert result.grant_source == "compensation"
     assert result.validity_preset == "7d"
     assert result.expires_at.endswith("Z")
@@ -2720,6 +2724,174 @@ def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app):
     assert second_result.ledger_bid == first_result.ledger_bid
     assert second_result.wallet_bucket_bid == first_result.wallet_bucket_bid
     assert len(ledger_entries) == 1
+
+
+def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monkeypatch):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
+
+    monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
+
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="referral-reward-target",
+            identify="referral-reward-target@example.com",
+            nickname="Referral Reward Target",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "referral-reward-target@example.com")],
+        )
+
+        first_result = grant_operator_user_credits(
+            app,
+            user_bid="referral-reward-target",
+            operator_user_bid="operator-1",
+            payload=AdminOperationUserCreditGrantRequestDTO(
+                request_id="referral-reward-request-1",
+                amount="1000",
+                grant_type="referral_reward",
+                grant_source="reward",
+                validity_preset="1m",
+                note="first referral",
+            ),
+        )
+        second_result = grant_operator_user_credits(
+            app,
+            user_bid="referral-reward-target",
+            operator_user_bid="operator-1",
+            payload=AdminOperationUserCreditGrantRequestDTO(
+                request_id="referral-reward-request-2",
+                amount="800",
+                grant_type="referral_reward",
+                grant_source="reward",
+                validity_preset="1m",
+                note="second referral",
+            ),
+        )
+
+        buckets = CreditWalletBucket.query.filter_by(
+            creator_bid="referral-reward-target",
+            deleted=0,
+        ).all()
+        ledgers = (
+            CreditLedgerEntry.query.filter_by(
+                creator_bid="referral-reward-target",
+                deleted=0,
+            )
+            .order_by(CreditLedgerEntry.id.asc())
+            .all()
+        )
+        bootstrap = get_operator_user_grant_bootstrap(
+            app,
+            user_bid="referral-reward-target",
+        )
+
+    assert first_result.grant_type == "referral_reward"
+    assert first_result.expires_at == "2026-05-21T00:00:00Z"
+    assert second_result.grant_type == "referral_reward"
+    assert second_result.expires_at == "2026-06-21T00:00:00Z"
+    assert second_result.wallet_bucket_bid == first_result.wallet_bucket_bid
+    assert second_result.amount == "800"
+    assert second_result.summary.available_credits == "1800"
+    assert len(buckets) == 1
+    assert buckets[0].metadata_json["grant_type"] == "referral_reward"
+    assert buckets[0].metadata_json["validity_strategy"] == "stack_by_reward_scene"
+    assert Decimal(str(buckets[0].available_credits)) == Decimal("1800")
+    assert len(ledgers) == 2
+    assert ledgers[0].expires_at == ledgers[1].expires_at == buckets[0].effective_to
+    assert Decimal(ledgers[1].metadata_json["reward_credits"]) == Decimal("800")
+    assert ledgers[1].metadata_json["previous_effective_to"]
+    assert ledgers[1].metadata_json["new_effective_to"]
+    assert bootstrap.referral_reward_summary.available_credits == "1800"
+    assert bootstrap.referral_reward_summary.expires_at == second_result.expires_at
+
+
+def test_grant_operator_user_referral_reward_is_idempotent_for_repeated_request_id(
+    app,
+):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="referral-reward-idempotent",
+            identify="referral-reward-idempotent@example.com",
+            nickname="Referral Reward Idempotent",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "referral-reward-idempotent@example.com")],
+        )
+
+        payload = AdminOperationUserCreditGrantRequestDTO(
+            request_id="referral-reward-idempotent-request",
+            amount="1000",
+            grant_type="referral_reward",
+            grant_source="reward",
+            validity_preset="1m",
+            note="retry-safe referral",
+        )
+        first_result = grant_operator_user_credits(
+            app,
+            user_bid="referral-reward-idempotent",
+            operator_user_bid="operator-1",
+            payload=payload,
+        )
+        second_result = grant_operator_user_credits(
+            app,
+            user_bid="referral-reward-idempotent",
+            operator_user_bid="operator-1",
+            payload=payload,
+        )
+
+        buckets = CreditWalletBucket.query.filter_by(
+            creator_bid="referral-reward-idempotent",
+            deleted=0,
+        ).all()
+        ledger_entries = CreditLedgerEntry.query.filter_by(
+            creator_bid="referral-reward-idempotent",
+            deleted=0,
+        ).all()
+
+    assert first_result.ledger_bid
+    assert second_result.ledger_bid == first_result.ledger_bid
+    assert second_result.wallet_bucket_bid == first_result.wallet_bucket_bid
+    assert second_result.summary.available_credits == "1000"
+    assert len(buckets) == 1
+    assert len(ledger_entries) == 1
+
+
+def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="referral-reward-invalid-amount",
+            identify="referral-reward-invalid-amount@example.com",
+            nickname="Referral Reward Invalid Amount",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "referral-reward-invalid-amount@example.com")],
+        )
+
+        with pytest.raises(AppException):
+            grant_operator_user_credits(
+                app,
+                user_bid="referral-reward-invalid-amount",
+                operator_user_bid="operator-1",
+                payload=AdminOperationUserCreditGrantRequestDTO(
+                    request_id="referral-reward-invalid-amount-request",
+                    amount="1000.5",
+                    grant_type="referral_reward",
+                    grant_source="reward",
+                    validity_preset="1m",
+                ),
+            )
 
 
 def test_grant_operator_user_credits_returns_persisted_payload_for_reused_request_id(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2810,6 +2810,7 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
     assert ledgers[1].metadata_json["new_effective_to"]
     assert bootstrap.referral_reward_summary.available_credits == "1800"
     assert bootstrap.referral_reward_summary.expires_at == second_result.expires_at
+    assert bootstrap.referral_reward_summary.grant_count == 2
 
 
 def test_grant_operator_user_referral_reward_extends_empty_active_bucket(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -37,6 +37,7 @@ from flaskr.service.billing.consts import (
 from flaskr.service.billing import (
     referral_reward_grants as referral_reward_grants_module,
 )
+from flaskr.service.billing.bucket_categories import resolve_credit_bucket_priority
 from flaskr.service.billing.models import CreditWallet, CreditWalletBucket
 from flaskr.service.billing.models import (
     BillingOrder,
@@ -2811,6 +2812,87 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
     assert bootstrap.referral_reward_summary.expires_at == second_result.expires_at
 
 
+def test_grant_operator_user_referral_reward_extends_empty_active_bucket(
+    app, monkeypatch
+):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
+
+    monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
+
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="referral-reward-empty-active",
+            identify="referral-reward-empty-active@example.com",
+            nickname="Referral Reward Empty Active",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "referral-reward-empty-active@example.com")],
+        )
+        _seed_credit_wallet(
+            creator_bid="referral-reward-empty-active",
+            wallet_bid="wallet-referral-reward-empty-active",
+            available_credits="0",
+        )
+        db.session.add(
+            CreditWalletBucket(
+                wallet_bucket_bid="bucket-referral-reward-empty-active",
+                wallet_bid="wallet-referral-reward-empty-active",
+                creator_bid="referral-reward-empty-active",
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_MANUAL,
+                source_bid="referral_reward",
+                priority=resolve_credit_bucket_priority(
+                    CREDIT_BUCKET_CATEGORY_SUBSCRIPTION
+                ),
+                original_credits=Decimal("1000"),
+                available_credits=Decimal("0"),
+                reserved_credits=Decimal("0"),
+                consumed_credits=Decimal("1000"),
+                expired_credits=Decimal("0"),
+                effective_from=datetime(2026, 4, 1, 0, 0, 0),
+                effective_to=datetime(2026, 5, 21, 0, 0, 0),
+                status=CREDIT_BUCKET_STATUS_ACTIVE,
+                metadata_json={
+                    "grant_type": "referral_reward",
+                    "validity_strategy": "stack_by_reward_scene",
+                },
+            )
+        )
+        db.session.commit()
+
+        result = grant_operator_user_credits(
+            app,
+            user_bid="referral-reward-empty-active",
+            operator_user_bid="operator-1",
+            payload=AdminOperationUserCreditGrantRequestDTO(
+                request_id="referral-reward-empty-active-request",
+                amount="1000",
+                grant_type="referral_reward",
+                grant_source="reward",
+                validity_preset="1m",
+                note="extend empty active bucket",
+            ),
+        )
+
+        buckets = CreditWalletBucket.query.filter_by(
+            creator_bid="referral-reward-empty-active",
+            deleted=0,
+        ).all()
+
+    assert result.wallet_bucket_bid == "bucket-referral-reward-empty-active"
+    assert result.expires_at == "2026-06-21T00:00:00Z"
+    assert result.note == "extend empty active bucket"
+    assert len(buckets) == 1
+    assert buckets[0].effective_to == datetime(2026, 6, 21, 0, 0, 0)
+    assert Decimal(str(buckets[0].available_credits)) == Decimal("1000")
+
+
 def test_grant_operator_user_referral_reward_is_idempotent_for_repeated_request_id(
     app,
 ):
@@ -2861,6 +2943,7 @@ def test_grant_operator_user_referral_reward_is_idempotent_for_repeated_request_
     assert second_result.ledger_bid == first_result.ledger_bid
     assert second_result.wallet_bucket_bid == first_result.wallet_bucket_bid
     assert second_result.summary.available_credits == "1000"
+    assert second_result.note == "retry-safe referral"
     assert len(buckets) == 1
     assert len(ledger_entries) == 1
 
@@ -2892,6 +2975,38 @@ def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app):
                     validity_preset="1m",
                 ),
             )
+
+
+def test_grant_operator_user_credits_accepts_legacy_manual_grant_type(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="credits-grant-legacy-manual-type",
+            identify="credits-grant-legacy-manual-type@example.com",
+            nickname="Credits Grant Legacy Manual Type",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "credits-grant-legacy-manual-type@example.com")],
+        )
+
+        result = grant_operator_user_credits(
+            app,
+            user_bid="credits-grant-legacy-manual-type",
+            operator_user_bid="operator-1",
+            payload=AdminOperationUserCreditGrantRequestDTO(
+                request_id="grant-request-legacy-manual-type",
+                amount="5",
+                grant_type="manual_grant",
+                grant_source="reward",
+                validity_preset="1d",
+                note="legacy type",
+            ),
+        )
+
+    assert result.grant_type == "manual_credit"
+    assert result.note == "legacy type"
 
 
 def test_grant_operator_user_credits_returns_persisted_payload_for_reused_request_id(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -3010,6 +3010,44 @@ def test_grant_operator_user_credits_accepts_legacy_manual_grant_type(app):
     assert result.note == "legacy type"
 
 
+def test_grant_operator_user_credits_rejects_unknown_grant_type(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="credits-grant-unknown-type",
+            identify="credits-grant-unknown-type@example.com",
+            nickname="Credits Grant Unknown Type",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 20, 9, 0, 0),
+            updated_at=datetime(2026, 4, 20, 10, 0, 0),
+            providers=[("email", "credits-grant-unknown-type@example.com")],
+        )
+
+        with pytest.raises(AppException) as exc_info:
+            grant_operator_user_credits(
+                app,
+                user_bid="credits-grant-unknown-type",
+                operator_user_bid="operator-1",
+                payload=AdminOperationUserCreditGrantRequestDTO(
+                    request_id="grant-request-unknown-type",
+                    amount="5",
+                    grant_type="unknown_type",
+                    grant_source="reward",
+                    validity_preset="1d",
+                    note="invalid type",
+                ),
+            )
+        ledger_count = CreditLedgerEntry.query.filter_by(
+            creator_bid="credits-grant-unknown-type",
+            deleted=0,
+        ).count()
+
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+    assert "grant_type" in exc_info.value.message
+    assert ledger_count == 0
+
+
 def test_grant_operator_user_credits_returns_persisted_payload_for_reused_request_id(
     app,
 ):

--- a/src/cook-web/src/app/admin/operations/operation-user-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-user-types.ts
@@ -175,6 +175,7 @@ export type AdminOperationUserCreditUsageDetailResponse = {
 export type AdminOperationUserCreditGrantRequest = {
   request_id: string;
   amount: string;
+  grant_type?: string;
   grant_source: string;
   validity_preset: string;
   note?: string;
@@ -183,6 +184,7 @@ export type AdminOperationUserCreditGrantRequest = {
 export type AdminOperationUserCreditGrantResponse = {
   user_bid: string;
   amount: string;
+  grant_type: string;
   grant_source: string;
   validity_preset: string;
   expires_at: string;
@@ -191,10 +193,18 @@ export type AdminOperationUserCreditGrantResponse = {
   summary: AdminOperationUserCreditSummary;
 };
 
+export type AdminOperationUserReferralRewardSummary = {
+  available_credits: string;
+  expires_at: string;
+  wallet_bucket_bid: string;
+};
+
 export type AdminOperationUserGrantBootstrapResponse = {
   plans: BillingPlan[];
   current_subscription_product_display_name_i18n_key: string;
   notification_status: string;
+  server_time: string;
+  referral_reward_summary: AdminOperationUserReferralRewardSummary;
 };
 
 export type AdminOperationUserPackageGrantRequest = {

--- a/src/cook-web/src/app/admin/operations/operation-user-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-user-types.ts
@@ -197,6 +197,7 @@ export type AdminOperationUserReferralRewardSummary = {
   available_credits: string;
   expires_at: string;
   wallet_bucket_bid: string;
+  grant_count: number;
 };
 
 export type AdminOperationUserGrantBootstrapResponse = {

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
@@ -573,6 +573,12 @@ describe('UserCreditGrantDialog', () => {
       target: { value: '1200.50' },
     });
     expect(referralRewardAmountInput).toHaveValue('1200');
+    fireEvent.change(referralRewardAmountInput, {
+      target: { value: String(Number.MAX_SAFE_INTEGER + 1) },
+    });
+    expect(referralRewardAmountInput).toHaveValue(
+      String(Number.MAX_SAFE_INTEGER + 1),
+    );
     fireEvent.change(
       screen.getByPlaceholderText(
         'module.operationsUser.grantDialog.placeholders.note',
@@ -582,6 +588,20 @@ describe('UserCreditGrantDialog', () => {
       },
     );
 
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.grantDialog.confirmButton',
+      }),
+    );
+    expect(
+      screen.getByText(
+        'module.operationsUser.grantDialog.validation.referralRewardAmountRequired',
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.change(referralRewardAmountInput, {
+      target: { value: '1200' },
+    });
     fireEvent.click(
       screen.getByRole('button', {
         name: 'module.operationsUser.grantDialog.confirmButton',

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
@@ -515,6 +515,7 @@ describe('UserCreditGrantDialog', () => {
         available_credits: '1000',
         expires_at: '2026-05-21T00:00:00Z',
         wallet_bucket_bid: 'bucket-referral',
+        grant_count: 2,
       },
     });
     mockGrantAdminOperationUserCredits.mockResolvedValueOnce({
@@ -560,6 +561,12 @@ describe('UserCreditGrantDialog', () => {
         'module.operationsUser.grantDialog.referralReward.currentExpireAt',
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'module.operationsUser.grantDialog.referralReward.grantCount',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.getByDisplayValue('1000')).toBeInTheDocument();
 
     const referralRewardAmountInput = screen.getByPlaceholderText(
@@ -616,6 +623,11 @@ describe('UserCreditGrantDialog', () => {
     expect(
       screen.getByText(
         'module.operationsUser.grantDialog.confirmSummary.referralEstimatedCredits',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'module.operationsUser.grantDialog.confirmSummary.referralGrantCount',
       ),
     ).toBeInTheDocument();
 

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
@@ -260,6 +260,7 @@ describe('UserCreditGrantDialog', () => {
     mockGrantAdminOperationUserCredits.mockResolvedValue({
       user_bid: 'user-1',
       amount: '10',
+      grant_type: 'manual_credit',
       grant_source: 'reward',
       validity_preset: '1d',
       expires_at: '2026-04-22T00:00:00Z',
@@ -500,6 +501,129 @@ describe('UserCreditGrantDialog', () => {
     expect(mockToast).toHaveBeenCalledWith({
       title: 'module.operationsUser.grantDialog.submitSuccess',
     });
+  });
+
+  test('submits a referral reward grant with preview summary', async () => {
+    const handleGranted = jest.fn();
+    const handleOpenChange = jest.fn();
+    mockGetAdminOperationUserGrantBootstrap.mockResolvedValueOnce({
+      plans: [],
+      current_subscription_product_display_name_i18n_key: '',
+      notification_status: 'template_pending',
+      server_time: '2026-04-21T00:00:00Z',
+      referral_reward_summary: {
+        available_credits: '1000',
+        expires_at: '2026-05-21T00:00:00Z',
+        wallet_bucket_bid: 'bucket-referral',
+      },
+    });
+    mockGrantAdminOperationUserCredits.mockResolvedValueOnce({
+      user_bid: 'user-1',
+      amount: '1200',
+      grant_type: 'referral_reward',
+      grant_source: 'reward',
+      validity_preset: '1m',
+      expires_at: '2026-06-21T00:00:00Z',
+      wallet_bucket_bid: 'bucket-referral',
+      ledger_bid: 'ledger-referral',
+      summary: {
+        available_credits: '2200',
+        subscription_credits: '2200',
+        topup_credits: '0',
+        credits_expire_at: '2026-06-21T00:00:00Z',
+        has_active_subscription: true,
+      },
+    });
+
+    render(
+      <UserCreditGrantDialog
+        open
+        user={baseUser}
+        onOpenChange={handleOpenChange}
+        onGranted={handleGranted}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOperationUserGrantBootstrap).toHaveBeenCalledWith({
+        user_bid: 'user-1',
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.grantDialog.modeOptions.referralReward',
+      }),
+    );
+    expect(
+      screen.getByText(
+        'module.operationsUser.grantDialog.referralReward.currentExpireAt',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1000')).toBeInTheDocument();
+
+    const referralRewardAmountInput = screen.getByPlaceholderText(
+      'module.operationsUser.grantDialog.placeholders.referralRewardAmount',
+    );
+    fireEvent.change(referralRewardAmountInput, {
+      target: { value: '1,200' },
+    });
+    expect(referralRewardAmountInput).toHaveValue('1200');
+    fireEvent.change(referralRewardAmountInput, {
+      target: { value: '1200.50' },
+    });
+    expect(referralRewardAmountInput).toHaveValue('1200');
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        'module.operationsUser.grantDialog.placeholders.note',
+      ),
+      {
+        target: { value: 'referral note' },
+      },
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.grantDialog.confirmButton',
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        'module.operationsUser.grantDialog.referralRewardConfirmTitle',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'module.operationsUser.grantDialog.confirmSummary.referralEstimatedCredits',
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsUser.grantDialog.submitButton',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGrantAdminOperationUserCredits).toHaveBeenCalledWith({
+        user_bid: 'user-1',
+        request_id: 'testrequestid',
+        amount: '1200',
+        grant_type: 'referral_reward',
+        grant_source: 'reward',
+        validity_preset: '1m',
+        note: 'referral note',
+      });
+    });
+
+    expect(handleGranted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ledger_bid: 'ledger-referral',
+        grant_type: 'referral_reward',
+      }),
+    );
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 
   test('prefetches package bootstrap on open and shows a loading placeholder without disabling the package field', async () => {

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -39,7 +39,10 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
-import { formatOperatorUtcDateTime } from './dateTime';
+import {
+  formatOperatorUtcDateTime,
+  parseOperatorUtcDateTime,
+} from './dateTime';
 import type {
   AdminOperationUserBenefitGrantResponse,
   AdminOperationUserCreditGrantRequest,
@@ -58,7 +61,7 @@ type UserCreditGrantDialogProps = {
   onGranted: (result: AdminOperationUserBenefitGrantResponse) => void;
 };
 
-type GrantMode = 'credits' | 'package';
+type GrantMode = 'credits' | 'package' | 'referralReward';
 
 type CreditFormState = {
   source: string;
@@ -69,6 +72,11 @@ type CreditFormState = {
 
 type PackageFormState = {
   productBid: string;
+  note: string;
+};
+
+type ReferralRewardFormState = {
+  amount: string;
   note: string;
 };
 
@@ -92,6 +100,11 @@ const BASE_CREDIT_FORM_STATE: Omit<CreditFormState, 'validityPreset'> = {
 
 const BASE_PACKAGE_FORM_STATE: PackageFormState = {
   productBid: '',
+  note: '',
+};
+
+const BASE_REFERRAL_REWARD_FORM_STATE: ReferralRewardFormState = {
+  amount: '1000',
   note: '',
 };
 
@@ -141,6 +154,55 @@ const sanitizePositiveDecimalInput = (value: string): string => {
   return `${integerPart}.${decimalParts.join('')}`;
 };
 
+const validatePositiveIntegerAmount = (value: string): boolean => {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    return false;
+  }
+  return Number(normalized) > 0;
+};
+
+const normalizeNumericText = (value: string): string =>
+  value
+    .replace(/[０-９]/g, char =>
+      String.fromCharCode(char.charCodeAt(0) - 0xfee0),
+    )
+    .replace(/[，．]/g, char => (char === '，' ? ',' : '.'))
+    .replace(/[\s,]/g, '');
+
+const sanitizePositiveIntegerInput = (
+  value: string,
+  fallbackValue = '',
+): string => {
+  const normalized = normalizeNumericText(value);
+  if (!normalized) {
+    return '';
+  }
+  const decimalMatch = normalized.match(/^(\d+)\.(\d*)$/);
+  if (decimalMatch) {
+    return /^0*$/.test(decimalMatch[2]) ? decimalMatch[1] : fallbackValue;
+  }
+  return /^\d+$/.test(normalized) ? normalized : fallbackValue;
+};
+
+const addMonths = (value: Date, months: number): Date => {
+  const monthIndex = value.getUTCMonth() + months;
+  const year = value.getUTCFullYear() + Math.floor(monthIndex / 12);
+  const month = ((monthIndex % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(
+    Date.UTC(
+      year,
+      month,
+      Math.min(value.getUTCDate(), lastDay),
+      value.getUTCHours(),
+      value.getUTCMinutes(),
+      value.getUTCSeconds(),
+      value.getUTCMilliseconds(),
+    ),
+  );
+};
+
 const addSelfManagedYears = (value: Date, years: number): Date => {
   const next = new Date(value.getTime());
   next.setFullYear(value.getFullYear() + years);
@@ -187,14 +249,18 @@ const SummaryField = ({
   label,
   value,
   className = '',
+  valueClassName = 'text-foreground',
 }: {
   label: string;
   value: string;
   className?: string;
+  valueClassName?: string;
 }) => (
   <div className={className}>
     <div className='text-[11px] font-medium text-muted-foreground'>{label}</div>
-    <div className='mt-1 break-all text-sm font-medium leading-5 text-foreground'>
+    <div
+      className={`mt-1 break-all text-sm font-medium leading-5 ${valueClassName}`}
+    >
       {value || '--'}
     </div>
   </div>
@@ -207,9 +273,9 @@ const ConfirmSummaryItem = ({
   label: string;
   value: string;
 }) => (
-  <div className='grid grid-cols-[96px_minmax(0,1fr)] gap-2'>
-    <span className='text-muted-foreground'>{label}</span>
-    <span className='break-all text-foreground'>{value}</span>
+  <div className='grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3'>
+    <span className='whitespace-nowrap text-muted-foreground'>{label}</span>
+    <span className='min-w-0 break-words text-foreground'>{value}</span>
   </div>
 );
 
@@ -282,6 +348,8 @@ export default function UserCreditGrantDialog({
   const [packageFormState, setPackageFormState] = useState<PackageFormState>(
     BASE_PACKAGE_FORM_STATE,
   );
+  const [referralRewardFormState, setReferralRewardFormState] =
+    useState<ReferralRewardFormState>(BASE_REFERRAL_REWARD_FORM_STATE);
   const [formErrors, setFormErrors] = useState<FormErrors>({});
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [requestId, setRequestId] = useState('');
@@ -297,6 +365,7 @@ export default function UserCreditGrantDialog({
     setGrantMode('credits');
     setCreditFormState(defaultCreditFormState);
     setPackageFormState(BASE_PACKAGE_FORM_STATE);
+    setReferralRewardFormState(BASE_REFERRAL_REWARD_FORM_STATE);
     setFormErrors({});
     setConfirmOpen(false);
     setRequestId(open ? uuidv4().replace(/-/g, '') : '');
@@ -455,6 +524,44 @@ export default function UserCreditGrantDialog({
         ),
       })
     : tOperationsUsers('grantDialog.packageFields.expiryHintPending');
+  const referralRewardSummary = bootstrapPayload?.referral_reward_summary;
+  const referralCurrentCredits = Number(
+    referralRewardSummary?.available_credits || 0,
+  );
+  const referralCurrentCreditsLabel = formatAdminCredits(
+    referralCurrentCredits,
+    i18n.language,
+  );
+  const referralCurrentExpiryLabel = referralRewardSummary?.expires_at
+    ? formatOperatorUtcDateTime(referralRewardSummary.expires_at)
+    : tOperationsUsers('grantDialog.referralReward.noActiveReward');
+  const referralRewardAmount = validatePositiveIntegerAmount(
+    referralRewardFormState.amount,
+  )
+    ? Number(referralRewardFormState.amount)
+    : 0;
+  const referralEstimatedCreditsLabel = formatAdminCredits(
+    referralCurrentCredits + referralRewardAmount,
+    i18n.language,
+  );
+  const referralPreviewBaseDate =
+    parseOperatorUtcDateTime(referralRewardSummary?.expires_at || '') ||
+    parseOperatorUtcDateTime(bootstrapPayload?.server_time || '') ||
+    grantedAt ||
+    new Date();
+  const referralPreviewNow =
+    parseOperatorUtcDateTime(bootstrapPayload?.server_time || '') ||
+    grantedAt ||
+    new Date();
+  const referralEstimatedExpiry = addMonths(
+    referralPreviewBaseDate > referralPreviewNow
+      ? referralPreviewBaseDate
+      : referralPreviewNow,
+    1,
+  ).toISOString();
+  const referralEstimatedExpiryLabel = formatOperatorUtcDateTime(
+    referralEstimatedExpiry,
+  );
 
   const updateCreditField = <K extends keyof CreditFormState>(
     key: K,
@@ -476,6 +583,19 @@ export default function UserCreditGrantDialog({
     setFormErrors(current => ({
       ...current,
       productBid: key === 'productBid' ? undefined : current.productBid,
+      submit: undefined,
+    }));
+  };
+
+  const updateReferralRewardField = <K extends keyof ReferralRewardFormState>(
+    key: K,
+    value: ReferralRewardFormState[K],
+  ) => {
+    setReferralRewardFormState(current => ({ ...current, [key]: value }));
+    setFormErrors(current => ({
+      ...current,
+      amount: key === 'amount' ? undefined : current.amount,
+      bootstrap: undefined,
       submit: undefined,
     }));
   };
@@ -506,7 +626,7 @@ export default function UserCreditGrantDialog({
           'grantDialog.validityHint',
         );
       }
-    } else {
+    } else if (grantMode === 'package') {
       if (!packageFormState.productBid) {
         nextErrors.productBid = tOperationsUsers(
           'grantDialog.validation.productRequired',
@@ -514,6 +634,19 @@ export default function UserCreditGrantDialog({
       }
       if (!bootstrapPayload?.plans.length && !bootstrapLoading) {
         nextErrors.bootstrap = tOperationsUsers('grantDialog.bootstrapError');
+      }
+    } else {
+      if (!validatePositiveIntegerAmount(referralRewardFormState.amount)) {
+        nextErrors.amount = tOperationsUsers(
+          'grantDialog.validation.referralRewardAmountRequired',
+        );
+      }
+      if (!bootstrapPayload) {
+        nextErrors.bootstrap = tOperationsUsers(
+          bootstrapLoading
+            ? 'grantDialog.placeholders.productLoading'
+            : 'grantDialog.bootstrapError',
+        );
       }
     }
 
@@ -552,7 +685,7 @@ export default function UserCreditGrantDialog({
           user_bid: user.user_bid,
           ...payload,
         })) as AdminOperationUserCreditGrantResponse;
-      } else {
+      } else if (grantMode === 'package') {
         const payload: AdminOperationUserPackageGrantRequest = {
           request_id: requestId,
           product_bid: packageFormState.productBid,
@@ -562,6 +695,19 @@ export default function UserCreditGrantDialog({
           user_bid: user.user_bid,
           ...payload,
         })) as AdminOperationUserPackageGrantResponse;
+      } else {
+        const payload: AdminOperationUserCreditGrantRequest = {
+          request_id: requestId,
+          amount: referralRewardFormState.amount.trim(),
+          grant_type: 'referral_reward',
+          grant_source: 'reward',
+          validity_preset: '1m',
+          note: referralRewardFormState.note.trim(),
+        };
+        result = (await api.grantAdminOperationUserCredits({
+          user_bid: user.user_bid,
+          ...payload,
+        })) as AdminOperationUserCreditGrantResponse;
       }
 
       toast({
@@ -619,48 +765,94 @@ export default function UserCreditGrantDialog({
             value: creditFormState.note.trim() || '--',
           },
         ]
-      : [
-          {
-            id: 'mode',
-            label: tOperationsUsers('grantDialog.confirmSummary.mode'),
-            value: tOperationsUsers('grantDialog.modeOptions.package'),
-          },
-          {
-            id: 'package',
-            label: tOperationsUsers('grantDialog.confirmSummary.package'),
-            value: packageName,
-          },
-          {
-            id: 'packageCredits',
-            label: tOperationsUsers(
-              'grantDialog.confirmSummary.packageCredits',
-            ),
-            value: packageCreditsLabel,
-          },
-          {
-            id: 'packageValidity',
-            label: tOperationsUsers(
-              'grantDialog.confirmSummary.packageValidity',
-            ),
-            value: packageValidityLabel,
-          },
-          {
-            id: 'packageExpireAt',
-            label: tOperationsUsers(
-              'grantDialog.confirmSummary.packageExpireAt',
-            ),
-            value:
-              formatBillingCompactDateTime(
-                estimatedPlanExpiry,
-                i18n.language,
-              ) || '--',
-          },
-          {
-            id: 'note',
-            label: tOperationsUsers('grantDialog.confirmSummary.note'),
-            value: packageFormState.note.trim() || '--',
-          },
-        ];
+      : grantMode === 'package'
+        ? [
+            {
+              id: 'mode',
+              label: tOperationsUsers('grantDialog.confirmSummary.mode'),
+              value: tOperationsUsers('grantDialog.modeOptions.package'),
+            },
+            {
+              id: 'package',
+              label: tOperationsUsers('grantDialog.confirmSummary.package'),
+              value: packageName,
+            },
+            {
+              id: 'packageCredits',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.packageCredits',
+              ),
+              value: packageCreditsLabel,
+            },
+            {
+              id: 'packageValidity',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.packageValidity',
+              ),
+              value: packageValidityLabel,
+            },
+            {
+              id: 'packageExpireAt',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.packageExpireAt',
+              ),
+              value:
+                formatBillingCompactDateTime(
+                  estimatedPlanExpiry,
+                  i18n.language,
+                ) || '--',
+            },
+            {
+              id: 'note',
+              label: tOperationsUsers('grantDialog.confirmSummary.note'),
+              value: packageFormState.note.trim() || '--',
+            },
+          ]
+        : [
+            {
+              id: 'mode',
+              label: tOperationsUsers('grantDialog.confirmSummary.mode'),
+              value: tOperationsUsers('grantDialog.modeOptions.referralReward'),
+            },
+            {
+              id: 'referralCurrentCredits',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.referralCurrentCredits',
+              ),
+              value: referralCurrentCreditsLabel,
+            },
+            {
+              id: 'referralCurrentExpireAt',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.referralCurrentExpireAt',
+              ),
+              value: referralCurrentExpiryLabel,
+            },
+            {
+              id: 'amount',
+              label: tOperationsUsers('grantDialog.confirmSummary.amount'),
+              value: referralRewardFormState.amount.trim() || '--',
+            },
+            {
+              id: 'referralEstimatedCredits',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.referralEstimatedCredits',
+              ),
+              value: referralEstimatedCreditsLabel,
+            },
+            {
+              id: 'referralEstimatedExpireAt',
+              label: tOperationsUsers(
+                'grantDialog.confirmSummary.referralEstimatedExpireAt',
+              ),
+              value: referralEstimatedExpiryLabel,
+            },
+            {
+              id: 'note',
+              label: tOperationsUsers('grantDialog.confirmSummary.note'),
+              value: referralRewardFormState.note.trim() || '--',
+            },
+          ];
 
   return (
     <>
@@ -725,12 +917,17 @@ export default function UserCreditGrantDialog({
                       setGrantMode(value as GrantMode);
                       setFormErrors(current => ({
                         ...current,
+                        amount: undefined,
                         bootstrap: undefined,
                         productBid: undefined,
+                        source: undefined,
+                        validityPreset: undefined,
                         submit: undefined,
                       }));
                     }}
-                    options={(['credits', 'package'] as const).map(option => ({
+                    options={(
+                      ['credits', 'package', 'referralReward'] as const
+                    ).map(option => ({
                       value: option,
                       label: tOperationsUsers(
                         `grantDialog.modeOptions.${option}`,
@@ -852,7 +1049,7 @@ export default function UserCreditGrantDialog({
                     </div>
                   </div>
                 </>
-              ) : (
+              ) : grantMode === 'package' ? (
                 <>
                   <div className='space-y-2'>
                     <div className='grid gap-2 sm:grid-cols-[80px_minmax(0,1fr)] sm:items-center'>
@@ -957,6 +1154,106 @@ export default function UserCreditGrantDialog({
                     </div>
                   </div>
                 </>
+              ) : (
+                <>
+                  <div className='rounded-xl border border-border/70 bg-muted/[0.12] px-4 py-3'>
+                    <div className='grid gap-x-5 gap-y-3 sm:grid-cols-2'>
+                      <SummaryField
+                        label={tOperationsUsers(
+                          'grantDialog.referralReward.currentCredits',
+                        )}
+                        value={referralCurrentCreditsLabel}
+                      />
+                      <SummaryField
+                        label={tOperationsUsers(
+                          'grantDialog.referralReward.currentExpireAt',
+                        )}
+                        value={referralCurrentExpiryLabel}
+                        valueClassName={
+                          referralRewardSummary?.expires_at
+                            ? 'text-foreground'
+                            : 'text-muted-foreground'
+                        }
+                      />
+                      <SummaryField
+                        label={tOperationsUsers(
+                          'grantDialog.referralReward.validity',
+                        )}
+                        value={tOperationsUsers(
+                          'grantDialog.referralReward.oneMonth',
+                        )}
+                      />
+                    </div>
+                    <div className='mt-3 space-y-1 text-xs leading-5 text-muted-foreground'>
+                      <p>
+                        {tOperationsUsers(
+                          'grantDialog.referralReward.description',
+                        )}
+                      </p>
+                      <p>
+                        {tOperationsUsers(
+                          'grantDialog.referralReward.emptyDescription',
+                        )}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className='space-y-2'>
+                    <div className='grid gap-2 sm:grid-cols-[80px_minmax(0,1fr)] sm:items-center'>
+                      <div className='text-sm font-semibold leading-10 text-foreground/90'>
+                        {tOperationsUsers('grantDialog.fields.amount')}
+                      </div>
+                      <Input
+                        type='text'
+                        inputMode='numeric'
+                        autoComplete='off'
+                        value={referralRewardFormState.amount}
+                        onChange={event =>
+                          updateReferralRewardField(
+                            'amount',
+                            sanitizePositiveIntegerInput(
+                              event.target.value,
+                              referralRewardFormState.amount,
+                            ),
+                          )
+                        }
+                        placeholder={tOperationsUsers(
+                          'grantDialog.placeholders.referralRewardAmount',
+                        )}
+                        className='h-10'
+                      />
+                    </div>
+                    {formErrors.amount ? (
+                      <div className='text-xs text-destructive'>
+                        {formErrors.amount}
+                      </div>
+                    ) : null}
+                    {formErrors.bootstrap ? (
+                      <div className='text-xs text-destructive'>
+                        {formErrors.bootstrap}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className='space-y-2'>
+                    <div className='grid gap-2 sm:grid-cols-[80px_minmax(0,1fr)] sm:items-start'>
+                      <div className='pt-2 text-sm font-semibold leading-none text-foreground/90'>
+                        {tOperationsUsers('grantDialog.fields.note')}
+                      </div>
+                      <Textarea
+                        value={referralRewardFormState.note}
+                        onChange={event =>
+                          updateReferralRewardField('note', event.target.value)
+                        }
+                        placeholder={tOperationsUsers(
+                          'grantDialog.placeholders.note',
+                        )}
+                        rows={1}
+                        className='min-h-[40px] resize-y'
+                      />
+                    </div>
+                  </div>
+                </>
               )}
 
               {formErrors.submit ? (
@@ -993,21 +1290,27 @@ export default function UserCreditGrantDialog({
           }
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className='sm:max-w-[720px]'>
           <AlertDialogHeader>
             <AlertDialogTitle>
               {grantMode === 'credits'
                 ? tOperationsUsers('grantDialog.confirmTitle')
-                : tOperationsUsers('grantDialog.packageConfirmTitle')}
+                : grantMode === 'package'
+                  ? tOperationsUsers('grantDialog.packageConfirmTitle')
+                  : tOperationsUsers('grantDialog.referralRewardConfirmTitle')}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {grantMode === 'credits'
                 ? tOperationsUsers('grantDialog.confirmDescription')
-                : tOperationsUsers('grantDialog.packageConfirmDescription')}
+                : grantMode === 'package'
+                  ? tOperationsUsers('grantDialog.packageConfirmDescription')
+                  : tOperationsUsers(
+                      'grantDialog.referralRewardConfirmDescription',
+                    )}
             </AlertDialogDescription>
           </AlertDialogHeader>
 
-          <div className='space-y-3 text-sm'>
+          <div className='grid gap-x-8 gap-y-3 text-sm sm:grid-cols-2'>
             <ConfirmSummaryItem
               label={tOperationsUsers('grantDialog.summary.account')}
               value={accountLabel}

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -159,7 +159,8 @@ const validatePositiveIntegerAmount = (value: string): boolean => {
   if (!/^\d+$/.test(normalized)) {
     return false;
   }
-  return Number(normalized) > 0;
+  const parsed = BigInt(normalized);
+  return parsed > 0n && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
 };
 
 const normalizeNumericText = (value: string): string =>
@@ -642,11 +643,9 @@ export default function UserCreditGrantDialog({
         );
       }
       if (!bootstrapPayload) {
-        nextErrors.bootstrap = tOperationsUsers(
-          bootstrapLoading
-            ? 'grantDialog.placeholders.productLoading'
-            : 'grantDialog.bootstrapError',
-        );
+        nextErrors.bootstrap = bootstrapLoading
+          ? tOperationsUsers('grantDialog.referralReward.bootstrapLoading')
+          : tOperationsUsers('grantDialog.referralReward.bootstrapError');
       }
     }
 

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { CircleHelp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
 import api from '@/api';
@@ -39,6 +40,12 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import {
   formatOperatorUtcDateTime,
   parseOperatorUtcDateTime,
@@ -160,7 +167,7 @@ const validatePositiveIntegerAmount = (value: string): boolean => {
     return false;
   }
   const parsed = BigInt(normalized);
-  return parsed > 0n && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
+  return parsed > BigInt(0) && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
 };
 
 const normalizeNumericText = (value: string): string =>
@@ -252,13 +259,15 @@ const SummaryField = ({
   className = '',
   valueClassName = 'text-foreground',
 }: {
-  label: string;
+  label: ReactNode;
   value: string;
   className?: string;
   valueClassName?: string;
 }) => (
   <div className={className}>
-    <div className='text-[11px] font-medium text-muted-foreground'>{label}</div>
+    <div className='flex items-center gap-1 text-[11px] font-medium text-muted-foreground'>
+      {label}
+    </div>
     <div
       className={`mt-1 break-all text-sm font-medium leading-5 ${valueClassName}`}
     >
@@ -271,13 +280,43 @@ const ConfirmSummaryItem = ({
   label,
   value,
 }: {
-  label: string;
+  label: ReactNode;
   value: string;
 }) => (
   <div className='grid grid-cols-[132px_minmax(0,1fr)] items-start gap-3'>
-    <span className='whitespace-nowrap text-muted-foreground'>{label}</span>
+    <div className='flex items-center gap-1 whitespace-nowrap text-muted-foreground'>
+      {label}
+    </div>
     <span className='min-w-0 break-words text-foreground'>{value}</span>
   </div>
+);
+
+const ReferralGrantCountLabel = ({
+  label,
+  tooltip,
+}: {
+  label: string;
+  tooltip: string;
+}) => (
+  <>
+    <span>{label}</span>
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type='button'
+            aria-label={tooltip}
+            className='inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+          >
+            <CircleHelp className='h-3.5 w-3.5' />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className='z-[112] max-w-56 text-left text-xs leading-5'>
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  </>
 );
 
 const ChoiceChipGroup = ({
@@ -536,6 +575,9 @@ export default function UserCreditGrantDialog({
   const referralCurrentExpiryLabel = referralRewardSummary?.expires_at
     ? formatOperatorUtcDateTime(referralRewardSummary.expires_at)
     : tOperationsUsers('grantDialog.referralReward.noActiveReward');
+  const referralGrantCountLabel = String(
+    Number(referralRewardSummary?.grant_count || 0),
+  );
   const referralRewardAmount = validatePositiveIntegerAmount(
     referralRewardFormState.amount,
   )
@@ -826,6 +868,20 @@ export default function UserCreditGrantDialog({
                 'grantDialog.confirmSummary.referralCurrentExpireAt',
               ),
               value: referralCurrentExpiryLabel,
+            },
+            {
+              id: 'referralGrantCount',
+              label: (
+                <ReferralGrantCountLabel
+                  label={tOperationsUsers(
+                    'grantDialog.confirmSummary.referralGrantCount',
+                  )}
+                  tooltip={tOperationsUsers(
+                    'grantDialog.referralReward.grantCountTooltip',
+                  )}
+                />
+              ),
+              value: referralGrantCountLabel,
             },
             {
               id: 'amount',
@@ -1181,6 +1237,19 @@ export default function UserCreditGrantDialog({
                         value={tOperationsUsers(
                           'grantDialog.referralReward.oneMonth',
                         )}
+                      />
+                      <SummaryField
+                        label={
+                          <ReferralGrantCountLabel
+                            label={tOperationsUsers(
+                              'grantDialog.referralReward.grantCount',
+                            )}
+                            tooltip={tOperationsUsers(
+                              'grantDialog.referralReward.grantCountTooltip',
+                            )}
+                          />
+                        }
+                        value={referralGrantCountLabel}
                       />
                     </div>
                     <div className='mt-3 space-y-1 text-xs leading-5 text-muted-foreground'>

--- a/src/i18n/en-US/modules/operations-user.json
+++ b/src/i18n/en-US/modules/operations-user.json
@@ -247,6 +247,8 @@
       "validityPreset": "Select validity"
     },
     "referralReward": {
+      "bootstrapError": "Failed to load referral reward data. Please try again later.",
+      "bootstrapLoading": "Loading referral reward data...",
       "currentCredits": "Current Referral Reward Credits",
       "currentExpireAt": "Current Referral Reward Valid Until",
       "description": "Each referral reward grant adds the entered credits and extends the current referral reward validity by 1 month.",

--- a/src/i18n/en-US/modules/operations-user.json
+++ b/src/i18n/en-US/modules/operations-user.json
@@ -210,6 +210,7 @@
       "referralCurrentExpireAt": "Current Referral Reward Valid Until",
       "referralEstimatedCredits": "Estimated Credits After Grant",
       "referralEstimatedExpireAt": "Estimated Valid Until After Grant",
+      "referralGrantCount": "Rewarded Referral Count",
       "source": "Source",
       "validityPreset": "Validity"
     },
@@ -253,6 +254,8 @@
       "currentExpireAt": "Current Referral Reward Valid Until",
       "description": "Each referral reward grant adds the entered credits and extends the current referral reward validity by 1 month.",
       "emptyDescription": "If there is no active referral reward, validity starts from the grant time and lasts 1 month.",
+      "grantCount": "Rewarded Referral Count",
+      "grantCountTooltip": "The data source is temporarily based on the number of referral reward grants.",
       "noActiveReward": "No active referral reward",
       "oneMonth": "1 month",
       "validity": "Validity"

--- a/src/i18n/en-US/modules/operations-user.json
+++ b/src/i18n/en-US/modules/operations-user.json
@@ -206,6 +206,10 @@
       "packageCredits": "Credits",
       "packageExpireAt": "Estimated Valid Until",
       "packageValidity": "Validity",
+      "referralCurrentCredits": "Current Referral Reward Credits",
+      "referralCurrentExpireAt": "Current Referral Reward Valid Until",
+      "referralEstimatedCredits": "Estimated Credits After Grant",
+      "referralEstimatedExpireAt": "Estimated Valid Until After Grant",
       "source": "Source",
       "validityPreset": "Validity"
     },
@@ -220,7 +224,8 @@
     },
     "modeOptions": {
       "credits": "Grant Credits",
-      "package": "Grant Package"
+      "package": "Grant Package",
+      "referralReward": "Referral Reward"
     },
     "packageConfirmDescription": "Please confirm the package grant details. Once confirmed, it takes effect immediately.",
     "packageConfirmTitle": "Confirm Package Grant",
@@ -237,9 +242,21 @@
       "note": "Optional. Record the reason for this grant",
       "product": "Select a package",
       "productLoading": "Loading packages...",
+      "referralRewardAmount": "Enter reward credits",
       "source": "Select source",
       "validityPreset": "Select validity"
     },
+    "referralReward": {
+      "currentCredits": "Current Referral Reward Credits",
+      "currentExpireAt": "Current Referral Reward Valid Until",
+      "description": "Each referral reward grant adds the entered credits and extends the current referral reward validity by 1 month.",
+      "emptyDescription": "If there is no active referral reward, validity starts from the grant time and lasts 1 month.",
+      "noActiveReward": "No active referral reward",
+      "oneMonth": "1 month",
+      "validity": "Validity"
+    },
+    "referralRewardConfirmDescription": "Please confirm the referral reward grant details. Once confirmed, it takes effect immediately.",
+    "referralRewardConfirmTitle": "Confirm Referral Reward Grant",
     "sourceOptions": {
       "compensation": "Compensation",
       "reward": "Reward"
@@ -258,6 +275,7 @@
     "validation": {
       "amountRequired": "Enter a credit amount greater than 0",
       "productRequired": "Select a package",
+      "referralRewardAmountRequired": "Enter a positive integer credit amount",
       "sourceRequired": "Select a source",
       "validityPresetRequired": "Select a validity preset"
     },

--- a/src/i18n/fr-FR/modules/operations-user.json
+++ b/src/i18n/fr-FR/modules/operations-user.json
@@ -210,6 +210,7 @@
       "referralCurrentExpireAt": "Validité actuelle de la récompense de parrainage",
       "referralEstimatedCredits": "Crédits estimés après attribution",
       "referralEstimatedExpireAt": "Validité estimée après attribution",
+      "referralGrantCount": "Nombre de parrainages récompensés",
       "source": "Source",
       "validityPreset": "Validité"
     },
@@ -253,6 +254,8 @@
       "currentExpireAt": "Validité actuelle de la récompense de parrainage",
       "description": "Chaque attribution de récompense de parrainage ajoute les crédits saisis et prolonge la validité actuelle de 1 mois.",
       "emptyDescription": "S’il n’existe aucune récompense de parrainage active, la validité commence à l’heure d’attribution et dure 1 mois.",
+      "grantCount": "Nombre de parrainages récompensés",
+      "grantCountTooltip": "La source des données est temporairement basée sur le nombre d’attributions de récompense de parrainage.",
       "noActiveReward": "Aucune récompense de parrainage active",
       "oneMonth": "1 mois",
       "validity": "Validité"

--- a/src/i18n/fr-FR/modules/operations-user.json
+++ b/src/i18n/fr-FR/modules/operations-user.json
@@ -206,6 +206,10 @@
       "packageCredits": "Crédits",
       "packageExpireAt": "Date de fin estimée",
       "packageValidity": "Validité",
+      "referralCurrentCredits": "Crédits de récompense de parrainage actuels",
+      "referralCurrentExpireAt": "Validité actuelle de la récompense de parrainage",
+      "referralEstimatedCredits": "Crédits estimés après attribution",
+      "referralEstimatedExpireAt": "Validité estimée après attribution",
       "source": "Source",
       "validityPreset": "Validité"
     },
@@ -220,7 +224,8 @@
     },
     "modeOptions": {
       "credits": "Attribuer des crédits",
-      "package": "Attribuer un forfait"
+      "package": "Attribuer un forfait",
+      "referralReward": "Récompense de parrainage"
     },
     "packageConfirmDescription": "Veuillez confirmer les détails de l’attribution du forfait. Une fois confirmée, elle prend effet immédiatement.",
     "packageConfirmTitle": "Confirmer l’attribution du forfait",
@@ -237,9 +242,21 @@
       "note": "Optionnel. Indiquez la raison de cette attribution",
       "product": "Sélectionnez un forfait",
       "productLoading": "Chargement des forfaits...",
+      "referralRewardAmount": "Saisir les crédits de récompense",
       "source": "Sélectionnez une source",
       "validityPreset": "Sélectionnez une validité"
     },
+    "referralReward": {
+      "currentCredits": "Crédits de récompense de parrainage actuels",
+      "currentExpireAt": "Validité actuelle de la récompense de parrainage",
+      "description": "Chaque attribution de récompense de parrainage ajoute les crédits saisis et prolonge la validité actuelle de 1 mois.",
+      "emptyDescription": "S’il n’existe aucune récompense de parrainage active, la validité commence à l’heure d’attribution et dure 1 mois.",
+      "noActiveReward": "Aucune récompense de parrainage active",
+      "oneMonth": "1 mois",
+      "validity": "Validité"
+    },
+    "referralRewardConfirmDescription": "Veuillez confirmer les détails de la récompense de parrainage. Une fois confirmée, elle prend effet immédiatement.",
+    "referralRewardConfirmTitle": "Confirmer la récompense de parrainage",
     "sourceOptions": {
       "compensation": "Compensation",
       "reward": "Récompense"
@@ -258,6 +275,7 @@
     "validation": {
       "amountRequired": "Saisissez un montant de crédits supérieur à 0",
       "productRequired": "Sélectionnez un forfait",
+      "referralRewardAmountRequired": "Saisissez un nombre entier positif de crédits",
       "sourceRequired": "Sélectionnez une source",
       "validityPresetRequired": "Sélectionnez une validité"
     },

--- a/src/i18n/fr-FR/modules/operations-user.json
+++ b/src/i18n/fr-FR/modules/operations-user.json
@@ -247,6 +247,8 @@
       "validityPreset": "Sélectionnez une validité"
     },
     "referralReward": {
+      "bootstrapError": "Impossible de charger les données de récompense de parrainage. Veuillez réessayer plus tard.",
+      "bootstrapLoading": "Chargement des données de récompense de parrainage...",
       "currentCredits": "Crédits de récompense de parrainage actuels",
       "currentExpireAt": "Validité actuelle de la récompense de parrainage",
       "description": "Chaque attribution de récompense de parrainage ajoute les crédits saisis et prolonge la validité actuelle de 1 mois.",

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -210,6 +210,7 @@
       "referralCurrentExpireAt": "当前拉新奖励有效期",
       "referralEstimatedCredits": "发放后预计积分",
       "referralEstimatedExpireAt": "发放后预计有效期",
+      "referralGrantCount": "已奖励拉新次数",
       "source": "来源",
       "validityPreset": "有效期"
     },
@@ -253,6 +254,8 @@
       "currentExpireAt": "当前拉新奖励有效期",
       "description": "每次发放拉新奖励后，积分会增加本次填写的奖励积分；有效期会在当前拉新奖励有效期基础上顺延 1 个月。",
       "emptyDescription": "当前无有效拉新奖励时，有效期从发放时间起计算 1 个月。",
+      "grantCount": "已奖励拉新次数",
+      "grantCountTooltip": "数据来源暂定为发放拉新奖励次数。",
       "noActiveReward": "暂无有效拉新奖励",
       "oneMonth": "1个月",
       "validity": "有效期"

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -206,6 +206,10 @@
       "packageCredits": "积分数",
       "packageExpireAt": "预计截止日期",
       "packageValidity": "有效期",
+      "referralCurrentCredits": "当前拉新奖励积分",
+      "referralCurrentExpireAt": "当前拉新奖励有效期",
+      "referralEstimatedCredits": "发放后预计积分",
+      "referralEstimatedExpireAt": "发放后预计有效期",
       "source": "来源",
       "validityPreset": "有效期"
     },
@@ -220,7 +224,8 @@
     },
     "modeOptions": {
       "credits": "发放积分",
-      "package": "发放套餐"
+      "package": "发放套餐",
+      "referralReward": "拉新奖励"
     },
     "packageConfirmDescription": "请确认本次套餐发放信息，确认后将立即生效。",
     "packageConfirmTitle": "确认发放套餐",
@@ -237,9 +242,21 @@
       "note": "可选，记录本次发放说明",
       "product": "请选择套餐",
       "productLoading": "套餐加载中...",
+      "referralRewardAmount": "请输入奖励积分",
       "source": "请选择来源",
       "validityPreset": "请选择有效期"
     },
+    "referralReward": {
+      "currentCredits": "当前拉新奖励积分",
+      "currentExpireAt": "当前拉新奖励有效期",
+      "description": "每次发放拉新奖励后，积分会增加本次填写的奖励积分；有效期会在当前拉新奖励有效期基础上顺延 1 个月。",
+      "emptyDescription": "当前无有效拉新奖励时，有效期从发放时间起计算 1 个月。",
+      "noActiveReward": "暂无有效拉新奖励",
+      "oneMonth": "1个月",
+      "validity": "有效期"
+    },
+    "referralRewardConfirmDescription": "请确认本次拉新奖励发放信息，确认后将立即生效。",
+    "referralRewardConfirmTitle": "确认发放拉新奖励",
     "sourceOptions": {
       "compensation": "补偿",
       "reward": "奖励"
@@ -258,6 +275,7 @@
     "validation": {
       "amountRequired": "请输入大于 0 的积分数值",
       "productRequired": "请选择套餐",
+      "referralRewardAmountRequired": "请输入大于 0 的整数积分",
       "sourceRequired": "请选择来源",
       "validityPresetRequired": "请选择有效期"
     },

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -247,6 +247,8 @@
       "validityPreset": "请选择有效期"
     },
     "referralReward": {
+      "bootstrapError": "拉新奖励数据加载失败，请稍后重试。",
+      "bootstrapLoading": "拉新奖励数据加载中...",
       "currentCredits": "当前拉新奖励积分",
       "currentExpireAt": "当前拉新奖励有效期",
       "description": "每次发放拉新奖励后，积分会增加本次填写的奖励积分；有效期会在当前拉新奖励有效期基础上顺延 1 个月。",


### PR DESCRIPTION
## Summary
- The operator admin currently supports only regular credit grants and package grants, so referral rewards cannot be handled as a dedicated operational reward flow.
- Referral rewards need to add credits on each grant and extend the active referral reward validity by 1 month from the current referral reward expiry.
- The grant entry should show the current referral reward credits and expiry, then preview the estimated credits and expiry before final confirmation.

## Changes
- Added a Referral Reward mode to the operator user grant dialog, with a default editable reward amount of 1000 credits.
- Added backend referral reward grant logic that reuses the active referral reward credit bucket, stacks credits, and extends expiry by 1 month per grant.
- Added `grant_type`, referral reward bootstrap summary, idempotency handling, and stale expiry notification suppression when reward expiry is extended.
- Split shared grant result payloads and referral reward logic into focused backend modules to keep manual credit grant code smaller.
- Updated frontend types, i18n copy, and focused backend/frontend tests.

## Verification
- `cd src/api && pytest -q tests/service/shifu/test_admin_users.py -k 'grant_operator_user_referral_reward or grant_operator_user_credits'`
- `cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/users/UserCreditGrantDialog.tsx' --file 'src/app/admin/operations/users/UserCreditGrantDialog.test.tsx' --file 'src/app/admin/operations/operation-user-types.ts'`
- `cd src/cook-web && npm test -- --runTestsByPath 'src/app/admin/operations/users/UserCreditGrantDialog.test.tsx' --runInBand`
- `pre-commit run -a`
- `curl http://localhost:8080/api/runtime-config`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referral-reward credit grants added to operator user management with a grant-type selector (manual vs. referral reward).
  * UI: referral-reward mode in the credit grant dialog showing current/estimated credits, expiry preview, and confirmation summary.
  * API/Bootstrap: referral reward summary included in bootstrap responses (available credits, expiry, grant count).

* **Validation**
  * Referral amount must be a positive integer; improved input normalization and validation.

* **Quality**
  * Tests added to cover referral grants, idempotency, expiry/stacking behavior, and grant-type handling.

* **Localization**
  * i18n strings added for English, French, and Simplified Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-shifu/ai-shifu/pull/1845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->