### PR TITLE
refactor: split credit notification operator services

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -47,19 +47,10 @@ from flaskr.service.billing.models import (
 )
 from flaskr.service.billing.api import (
     build_billing_catalog,
-    dry_run_credit_notifications,
-    get_credit_notification_detail,
-    get_operator_credit_notification_overview as build_credit_notification_overview,
     grant_referral_reward_credits_to_user,
     grant_manual_credits_to_user,
     grant_manual_plan_to_user,
-    list_credit_notification_templates,
-    list_credit_notifications,
     load_referral_reward_summary,
-    load_credit_notification_policy_for_operator,
-    requeue_credit_notification,
-    save_credit_notification_policy,
-    sync_credit_notification_template,
 )
 from flaskr.service.billing.primitives import (
     credit_decimal_to_number,
@@ -7241,86 +7232,6 @@ def grant_operator_user_credits(
             ledger_bid=str(grant_result.ledger_bid or "").strip(),
             summary=summary,
         )
-
-
-def get_operator_credit_notification_overview(app: Flask) -> dict[str, Any]:
-    return build_credit_notification_overview(app)
-
-
-def list_operator_credit_notifications(
-    app: Flask,
-    *,
-    page_index: int = 1,
-    page_size: int = 20,
-    filters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    return list_credit_notifications(
-        app,
-        page_index=page_index,
-        page_size=page_size,
-        filters=filters,
-    )
-
-
-def get_operator_credit_notification_detail(
-    app: Flask,
-    *,
-    notification_bid: str,
-) -> dict[str, Any]:
-    return get_credit_notification_detail(app, notification_bid=notification_bid)
-
-
-def get_operator_credit_notification_config(app: Flask) -> dict[str, Any]:
-    with app.app_context():
-        return load_credit_notification_policy_for_operator()
-
-
-def update_operator_credit_notification_config(
-    app: Flask,
-    *,
-    payload: dict[str, Any],
-) -> dict[str, Any]:
-    save_credit_notification_policy(app, payload, preserve_opt_out=True)
-    with app.app_context():
-        return load_credit_notification_policy_for_operator()
-
-
-def sync_operator_credit_notification_template(
-    app: Flask,
-    *,
-    notification_type: str,
-    template_code: str,
-) -> dict[str, Any]:
-    return sync_credit_notification_template(
-        app,
-        notification_type=notification_type,
-        template_code=template_code,
-    )
-
-
-def list_operator_credit_notification_templates(app: Flask) -> dict[str, Any]:
-    return list_credit_notification_templates(app)
-
-
-def dry_run_operator_credit_notifications(
-    app: Flask,
-    *,
-    notification_type: str = "",
-    creator_bid: str = "",
-) -> dict[str, Any]:
-    return dry_run_credit_notifications(
-        app,
-        notification_type=notification_type,
-        creator_bid=creator_bid,
-    )
-
-
-def requeue_operator_credit_notification(
-    app: Flask,
-    *,
-    notification_bid: str,
-) -> dict[str, Any]:
-    return requeue_credit_notification(app, notification_bid=notification_bid)
 
 
 def _load_bill_usage_record_map(

--- a/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
+++ b/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
@@ -54,8 +54,8 @@ def update_operator_credit_notification_config(
     *,
     payload: dict[str, Any],
 ) -> dict[str, Any]:
-    save_credit_notification_policy(app, payload, preserve_opt_out=True)
     with app.app_context():
+        save_credit_notification_policy(app, payload, preserve_opt_out=True)
         return load_credit_notification_policy_for_operator()
 
 

--- a/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
+++ b/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask
+
+from flaskr.service.billing.api import (
+    dry_run_credit_notifications,
+    get_credit_notification_detail,
+    get_operator_credit_notification_overview as build_credit_notification_overview,
+    list_credit_notification_templates,
+    list_credit_notifications,
+    load_credit_notification_policy_for_operator,
+    requeue_credit_notification,
+    save_credit_notification_policy,
+    sync_credit_notification_template,
+)
+
+
+def get_operator_credit_notification_overview(app: Flask) -> dict[str, Any]:
+    return build_credit_notification_overview(app)
+
+
+def list_operator_credit_notifications(
+    app: Flask,
+    *,
+    page_index: int = 1,
+    page_size: int = 20,
+    filters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return list_credit_notifications(
+        app,
+        page_index=page_index,
+        page_size=page_size,
+        filters=filters,
+    )
+
+
+def get_operator_credit_notification_detail(
+    app: Flask,
+    *,
+    notification_bid: str,
+) -> dict[str, Any]:
+    return get_credit_notification_detail(app, notification_bid=notification_bid)
+
+
+def get_operator_credit_notification_config(app: Flask) -> dict[str, Any]:
+    with app.app_context():
+        return load_credit_notification_policy_for_operator()
+
+
+def update_operator_credit_notification_config(
+    app: Flask,
+    *,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    save_credit_notification_policy(app, payload, preserve_opt_out=True)
+    with app.app_context():
+        return load_credit_notification_policy_for_operator()
+
+
+def sync_operator_credit_notification_template(
+    app: Flask,
+    *,
+    notification_type: str,
+    template_code: str,
+) -> dict[str, Any]:
+    return sync_credit_notification_template(
+        app,
+        notification_type=notification_type,
+        template_code=template_code,
+    )
+
+
+def list_operator_credit_notification_templates(app: Flask) -> dict[str, Any]:
+    return list_credit_notification_templates(app)
+
+
+def dry_run_operator_credit_notifications(
+    app: Flask,
+    *,
+    notification_type: str = "",
+    creator_bid: str = "",
+) -> dict[str, Any]:
+    return dry_run_credit_notifications(
+        app,
+        notification_type=notification_type,
+        creator_bid=creator_bid,
+    )
+
+
+def requeue_operator_credit_notification(
+    app: Flask,
+    *,
+    notification_bid: str,
+) -> dict[str, Any]:
+    return requeue_credit_notification(app, notification_bid=notification_bid)

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -37,7 +37,6 @@ from flaskr.service.promo.api import (
 from flaskr.service.shifu.admin import (
     OPERATOR_ORDER_LIST_MAX_PAGE_SIZE,
     copy_operator_course,
-    dry_run_operator_credit_notifications,
     get_operator_course_chapter_detail,
     get_operator_course_credit_usage_details,
     get_operator_course_credit_usages,
@@ -48,9 +47,6 @@ from flaskr.service.shifu.admin import (
     get_operator_course_prompt,
     get_operator_course_ratings,
     get_operator_course_users,
-    get_operator_credit_notification_config,
-    get_operator_credit_notification_detail,
-    get_operator_credit_notification_overview,
     get_operator_user_credit_usage_detail,
     get_operator_user_credits,
     get_operator_user_detail,
@@ -59,12 +55,18 @@ from flaskr.service.shifu.admin import (
     grant_operator_user_credits,
     grant_operator_user_package,
     list_operator_courses,
+    list_operator_users,
+    transfer_operator_course_creator,
+)
+from flaskr.service.shifu.admin_operations.credit_notifications import (
+    dry_run_operator_credit_notifications,
+    get_operator_credit_notification_config,
+    get_operator_credit_notification_detail,
+    get_operator_credit_notification_overview,
     list_operator_credit_notification_templates,
     list_operator_credit_notifications,
-    list_operator_users,
     requeue_operator_credit_notification,
     sync_operator_credit_notification_template,
-    transfer_operator_course_creator,
     update_operator_credit_notification_config,
 )
 from flaskr.service.shifu.admin_dtos import (

--- a/src/api/tests/service/shifu/test_admin_credit_notifications.py
+++ b/src/api/tests/service/shifu/test_admin_credit_notifications.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from flaskr.service.shifu.admin_operations import credit_notifications as module
+
+
+def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
+    app = Flask(__name__)
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(
+        module,
+        "build_credit_notification_overview",
+        lambda received_app: calls.append(("overview", received_app)) or {"total": 1},
+    )
+    monkeypatch.setattr(
+        module,
+        "list_credit_notifications",
+        lambda received_app, **kwargs: calls.append(("list", kwargs)) or {"items": []},
+    )
+    monkeypatch.setattr(
+        module,
+        "get_credit_notification_detail",
+        lambda received_app, **kwargs: (
+            calls.append(("detail", kwargs))
+            or {"notification_bid": kwargs["notification_bid"]}
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "sync_credit_notification_template",
+        lambda received_app, **kwargs: (
+            calls.append(("sync", kwargs)) or {"template_code": kwargs["template_code"]}
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "list_credit_notification_templates",
+        lambda received_app: calls.append(("templates", received_app)) or {"items": []},
+    )
+    monkeypatch.setattr(
+        module,
+        "dry_run_credit_notifications",
+        lambda received_app, **kwargs: (
+            calls.append(("dry_run", kwargs)) or {"ok": True}
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "requeue_credit_notification",
+        lambda received_app, **kwargs: (
+            calls.append(("requeue", kwargs)) or {"status": "enqueued"}
+        ),
+    )
+
+    assert module.get_operator_credit_notification_overview(app) == {"total": 1}
+    assert module.list_operator_credit_notifications(
+        app,
+        page_index=2,
+        page_size=30,
+        filters={"status": "sent"},
+    ) == {"items": []}
+    assert module.get_operator_credit_notification_detail(
+        app,
+        notification_bid="notification-1",
+    ) == {"notification_bid": "notification-1"}
+    assert module.sync_operator_credit_notification_template(
+        app,
+        notification_type="credit_granted",
+        template_code="SMS_001",
+    ) == {"template_code": "SMS_001"}
+    assert module.list_operator_credit_notification_templates(app) == {"items": []}
+    assert module.dry_run_operator_credit_notifications(
+        app,
+        notification_type="low_balance",
+        creator_bid="creator-1",
+    ) == {"ok": True}
+    assert module.requeue_operator_credit_notification(
+        app,
+        notification_bid="notification-2",
+    ) == {"status": "enqueued"}
+
+    assert calls == [
+        ("overview", app),
+        ("list", {"page_index": 2, "page_size": 30, "filters": {"status": "sent"}}),
+        ("detail", {"notification_bid": "notification-1"}),
+        (
+            "sync",
+            {"notification_type": "credit_granted", "template_code": "SMS_001"},
+        ),
+        ("templates", app),
+        ("dry_run", {"notification_type": "low_balance", "creator_bid": "creator-1"}),
+        ("requeue", {"notification_bid": "notification-2"}),
+    ]
+
+
+def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
+    app = Flask(__name__)
+    saved_payloads: list[tuple[object, dict[str, object], bool]] = []
+    policies = [{"version": 1}, {"version": 2}]
+
+    monkeypatch.setattr(
+        module,
+        "load_credit_notification_policy_for_operator",
+        lambda: policies.pop(0),
+    )
+
+    def fake_save_policy(
+        received_app: Flask,
+        payload: dict[str, object],
+        *,
+        preserve_opt_out: bool,
+    ) -> None:
+        saved_payloads.append((received_app, payload, preserve_opt_out))
+
+    monkeypatch.setattr(module, "save_credit_notification_policy", fake_save_policy)
+
+    assert module.get_operator_credit_notification_config(app) == {"version": 1}
+    assert module.update_operator_credit_notification_config(
+        app,
+        payload={"enabled": True},
+    ) == {"version": 2}
+    assert saved_payloads == [(app, {"enabled": True}, True)]


### PR DESCRIPTION
## Summary
- Move operator credit notification service wrappers out of `shifu/admin.py` into `admin_operations/credit_notifications.py`.
- Update operator admin route imports to use the new module while preserving existing URLs, request payloads, and response shapes.
- Add focused delegation tests for the new wrapper module, including policy save behavior with `preserve_opt_out=True`.

## Scope
- No frontend changes.
- No database or migration changes.
- No notification business logic changes.

## Verification
- `cd src/api && pytest tests/service/shifu/test_admin_credit_notifications.py tests/service/billing/test_credit_notifications.py -q`
- `pre-commit run -a` via branch pre-PR review
- `python scripts/check_architecture_boundaries.py` was run during local self-check
- Backend and nginx were restarted locally; `curl http://localhost:8080/api/runtime-config` returned OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved and reorganized operator credit-notification admin endpoints and logic to a new operations module for clearer structure and maintainability.

* **Tests**
  * Added tests to ensure operator credit-notification endpoints behave correctly and that notification configuration updates preserve opt-out settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->