### PR TITLE
feat: add large page jump input

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminPagination.tsx
+++ b/src/cook-web/src/app/admin/components/AdminPagination.tsx
@@ -1,19 +1,34 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import {
   AppPagination,
   type AppPaginationProps,
 } from '@/components/pagination/AppPagination';
 import { cn } from '@/lib/utils';
 
-export type { AppPaginationProps as AdminPaginationProps } from '@/components/pagination/AppPagination';
+export type AdminPaginationProps = Omit<
+  AppPaginationProps,
+  'jumpInputAriaLabel'
+> & {
+  jumpInputAriaLabel?: AppPaginationProps['jumpInputAriaLabel'];
+};
 
 const ADMIN_PAGINATION_CLASS = '[&_li:last-child_a]:pr-0';
 
-export function AdminPagination({ className, ...props }: AppPaginationProps) {
+export function AdminPagination({
+  className,
+  jumpInputAriaLabel,
+  ...props
+}: AdminPaginationProps) {
+  const { t } = useTranslation();
+
   return (
     <AppPagination
       {...props}
+      jumpInputAriaLabel={
+        jumpInputAriaLabel ?? t('module.order.paginationJumpInputAriaLabel')
+      }
       className={cn(ADMIN_PAGINATION_CLASS, className)}
     />
   );

--- a/src/cook-web/src/components/pagination/AppPagination.test.tsx
+++ b/src/cook-web/src/components/pagination/AppPagination.test.tsx
@@ -149,4 +149,49 @@ describe('AppPagination', () => {
     expect(currentPageLink).toHaveAttribute('aria-current', 'page');
     expect(screen.queryByRole('link', { name: 'NaN' })).not.toBeInTheDocument();
   });
+
+  test('keeps jump input hidden below its threshold', () => {
+    render(
+      <AppPagination
+        pageIndex={5}
+        pageCount={9}
+        onPageChange={jest.fn()}
+        prevLabel='Previous'
+        nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
+      />,
+    );
+
+    expect(
+      screen.queryByRole('textbox', { name: 'Jump to page' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows jump input for large page sets and clamps out-of-range values', () => {
+    const onPageChange = jest.fn();
+
+    render(
+      <AppPagination
+        pageIndex={5}
+        pageCount={30}
+        onPageChange={onPageChange}
+        prevLabel='Previous'
+        nextLabel='Next'
+        prevAriaLabel='Go to previous page'
+        nextAriaLabel='Go to next page'
+      />,
+    );
+
+    const jumpInput = screen.getByRole('textbox', { name: 'Jump to page' });
+    fireEvent.change(jumpInput, { target: { value: '18abc' } });
+    expect(jumpInput).toHaveValue('18');
+
+    fireEvent.keyDown(jumpInput, { key: 'Enter' });
+    expect(onPageChange).toHaveBeenCalledWith(18);
+
+    fireEvent.change(jumpInput, { target: { value: '999' } });
+    fireEvent.blur(jumpInput);
+    expect(onPageChange).toHaveBeenLastCalledWith(30);
+  });
 });

--- a/src/cook-web/src/components/pagination/AppPagination.test.tsx
+++ b/src/cook-web/src/components/pagination/AppPagination.test.tsx
@@ -13,6 +13,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
         hideWhenSinglePage
       />,
     );
@@ -34,6 +35,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -61,6 +63,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -88,6 +91,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -116,6 +120,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -142,6 +147,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -160,6 +166,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -180,6 +187,7 @@ describe('AppPagination', () => {
         nextLabel='Next'
         prevAriaLabel='Go to previous page'
         nextAriaLabel='Go to next page'
+        jumpInputAriaLabel='Jump to page'
       />,
     );
 
@@ -187,8 +195,10 @@ describe('AppPagination', () => {
     fireEvent.change(jumpInput, { target: { value: '18abc' } });
     expect(jumpInput).toHaveValue('18');
 
+    jumpInput.focus();
     fireEvent.keyDown(jumpInput, { key: 'Enter' });
     expect(onPageChange).toHaveBeenCalledWith(18);
+    expect(onPageChange).toHaveBeenCalledTimes(1);
 
     fireEvent.change(jumpInput, { target: { value: '999' } });
     fireEvent.blur(jumpInput);

--- a/src/cook-web/src/components/pagination/AppPagination.tsx
+++ b/src/cook-web/src/components/pagination/AppPagination.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { MouseEvent } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent, KeyboardEvent, MouseEvent } from 'react';
 import {
   Pagination,
   PaginationContent,
@@ -21,9 +22,13 @@ export type AppPaginationProps = {
   nextAriaLabel: string;
   className?: string;
   hideWhenSinglePage?: boolean;
+  jumpInputThreshold?: number;
+  jumpInputAriaLabel?: string;
 };
 
 const MAX_VISIBLE_PAGES = 5;
+const DEFAULT_JUMP_INPUT_THRESHOLD = 20;
+const JUMP_INPUT_SEPARATOR = '/';
 const DISABLED_LINK_CLASS_NAME = 'pointer-events-none opacity-50';
 const ACTIVE_LINK_CLASS_NAME = 'pointer-events-none';
 
@@ -77,6 +82,8 @@ export function AppPagination({
   nextAriaLabel,
   className,
   hideWhenSinglePage = false,
+  jumpInputThreshold = DEFAULT_JUMP_INPUT_THRESHOLD,
+  jumpInputAriaLabel,
 }: AppPaginationProps) {
   const safePageCount = Number.isFinite(pageCount) ? pageCount : 1;
   const normalizedPageCount = Math.max(safePageCount, 1);
@@ -85,6 +92,15 @@ export function AppPagination({
     Math.max(safePageIndex, 1),
     normalizedPageCount,
   );
+  const shouldShowJumpInput =
+    normalizedPageCount >= Math.max(jumpInputThreshold, 1);
+  const [jumpInputValue, setJumpInputValue] = useState(
+    String(normalizedPageIndex),
+  );
+
+  useEffect(() => {
+    setJumpInputValue(String(normalizedPageIndex));
+  }, [normalizedPageIndex]);
 
   if (hideWhenSinglePage && normalizedPageCount <= 1) {
     return null;
@@ -102,6 +118,38 @@ export function AppPagination({
       }
       onPageChange(targetPage);
     };
+
+  const handleJumpInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setJumpInputValue(event.target.value.replace(/\D/g, ''));
+  };
+
+  const commitJumpInput = () => {
+    const targetPage = Number.parseInt(jumpInputValue, 10);
+    if (!Number.isFinite(targetPage)) {
+      setJumpInputValue(String(normalizedPageIndex));
+      return;
+    }
+    const normalizedTargetPage = Math.min(
+      Math.max(targetPage, 1),
+      normalizedPageCount,
+    );
+    setJumpInputValue(String(normalizedTargetPage));
+    if (normalizedTargetPage !== normalizedPageIndex) {
+      onPageChange(normalizedTargetPage);
+    }
+  };
+
+  const handleJumpInputBlur = () => {
+    commitJumpInput();
+  };
+
+  const handleJumpInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') {
+      return;
+    }
+    event.preventDefault();
+    commitJumpInput();
+  };
 
   return (
     <Pagination className={className}>
@@ -167,6 +215,24 @@ export function AppPagination({
             {nextLabel}
           </PaginationNext>
         </PaginationItem>
+
+        {shouldShowJumpInput && (
+          <PaginationItem className='ml-1 flex items-center gap-1 text-sm text-muted-foreground'>
+            <input
+              type='text'
+              inputMode='numeric'
+              pattern='[0-9]*'
+              value={jumpInputValue}
+              onChange={handleJumpInputChange}
+              onBlur={handleJumpInputBlur}
+              onKeyDown={handleJumpInputKeyDown}
+              aria-label={jumpInputAriaLabel || 'Jump to page'}
+              className='h-9 w-14 rounded-md border border-input bg-background px-2 text-center text-sm text-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20'
+            />
+            <span aria-hidden>{JUMP_INPUT_SEPARATOR}</span>
+            <span>{normalizedPageCount}</span>
+          </PaginationItem>
+        )}
       </PaginationContent>
     </Pagination>
   );

--- a/src/cook-web/src/components/pagination/AppPagination.tsx
+++ b/src/cook-web/src/components/pagination/AppPagination.tsx
@@ -23,7 +23,7 @@ export type AppPaginationProps = {
   className?: string;
   hideWhenSinglePage?: boolean;
   jumpInputThreshold?: number;
-  jumpInputAriaLabel?: string;
+  jumpInputAriaLabel: string;
 };
 
 const MAX_VISIBLE_PAGES = 5;
@@ -148,7 +148,7 @@ export function AppPagination({
       return;
     }
     event.preventDefault();
-    commitJumpInput();
+    event.currentTarget.blur();
   };
 
   return (
@@ -226,7 +226,7 @@ export function AppPagination({
               onChange={handleJumpInputChange}
               onBlur={handleJumpInputBlur}
               onKeyDown={handleJumpInputKeyDown}
-              aria-label={jumpInputAriaLabel || 'Jump to page'}
+              aria-label={jumpInputAriaLabel}
               className='h-9 w-14 rounded-md border border-input bg-background px-2 text-center text-sm text-foreground outline-none transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20'
             />
             <span aria-hidden>{JUMP_INPUT_SEPARATOR}</span>

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -2208,6 +2208,7 @@ export type I18nKey =
   | 'module.order.importActivation.success'
   | 'module.order.importActivation.successSummary'
   | 'module.order.importActivation.title'
+  | 'module.order.paginationJumpInputAriaLabel'
   | 'module.order.paginationNext'
   | 'module.order.paginationNextAriaLabel'
   | 'module.order.paginationPrev'

--- a/src/i18n/en-US/modules/order.json
+++ b/src/i18n/en-US/modules/order.json
@@ -101,6 +101,7 @@
   "paginationNextAriaLabel": "Go to next page",
   "paginationPrev": "Previous",
   "paginationPrevAriaLabel": "Go to previous page",
+  "paginationJumpInputAriaLabel": "Jump to page",
   "paymentChannel": {
     "alipay": "Alipay",
     "manual": "Manual",

--- a/src/i18n/en-US/modules/order.json
+++ b/src/i18n/en-US/modules/order.json
@@ -97,11 +97,11 @@
     "successSummary": "{count} mobile numbers imported successfully",
     "title": "Import Activation"
   },
+  "paginationJumpInputAriaLabel": "Jump to page",
   "paginationNext": "Next",
   "paginationNextAriaLabel": "Go to next page",
   "paginationPrev": "Previous",
   "paginationPrevAriaLabel": "Go to previous page",
-  "paginationJumpInputAriaLabel": "Jump to page",
   "paymentChannel": {
     "alipay": "Alipay",
     "manual": "Manual",

--- a/src/i18n/fr-FR/modules/order.json
+++ b/src/i18n/fr-FR/modules/order.json
@@ -97,11 +97,11 @@
     "successSummary": "{count} numéros mobiles importés avec succès",
     "title": "Importer une activation"
   },
+  "paginationJumpInputAriaLabel": "Aller à la page",
   "paginationNext": "Suivant",
   "paginationNextAriaLabel": "Aller à la page suivante",
   "paginationPrev": "Précédent",
   "paginationPrevAriaLabel": "Aller à la page précédente",
-  "paginationJumpInputAriaLabel": "Aller à la page",
   "paymentChannel": {
     "alipay": "Alipay",
     "manual": "Manuel",

--- a/src/i18n/fr-FR/modules/order.json
+++ b/src/i18n/fr-FR/modules/order.json
@@ -101,6 +101,7 @@
   "paginationNextAriaLabel": "Aller à la page suivante",
   "paginationPrev": "Précédent",
   "paginationPrevAriaLabel": "Aller à la page précédente",
+  "paginationJumpInputAriaLabel": "Aller à la page",
   "paymentChannel": {
     "alipay": "Alipay",
     "manual": "Manuel",

--- a/src/i18n/zh-CN/modules/order.json
+++ b/src/i18n/zh-CN/modules/order.json
@@ -101,6 +101,7 @@
   "paginationNextAriaLabel": "前往下一页",
   "paginationPrev": "上一页",
   "paginationPrevAriaLabel": "前往上一页",
+  "paginationJumpInputAriaLabel": "跳转到指定页",
   "paymentChannel": {
     "alipay": "支付宝",
     "manual": "人工",

--- a/src/i18n/zh-CN/modules/order.json
+++ b/src/i18n/zh-CN/modules/order.json
@@ -97,11 +97,11 @@
     "successSummary": "成功导入 {count} 个手机号",
     "title": "导入开通"
   },
+  "paginationJumpInputAriaLabel": "跳转到指定页",
   "paginationNext": "下一页",
   "paginationNextAriaLabel": "前往下一页",
   "paginationPrev": "上一页",
   "paginationPrevAriaLabel": "前往上一页",
-  "paginationJumpInputAriaLabel": "跳转到指定页",
   "paymentChannel": {
     "alipay": "支付宝",
     "manual": "人工",


### PR DESCRIPTION
## Summary
- Add a large-page jump input to the shared `AppPagination` / `AdminPagination` path.
- Keep the existing compact pagination unchanged for smaller page counts.
- Add focused tests for jump-input visibility, numeric filtering, Enter/blur commit, and range clamping.

## Scope
- No backend changes.
- No route, API, or page-specific business changes.
- No explicit `-10` / `+10` quick-jump buttons; the large-page enhancement stays lightweight with direct page input only.

## Verification
- `cd src/cook-web && npm test -- src/components/pagination/AppPagination.test.tsx --runInBand`
- `cd src/cook-web && npm run lint -- --file src/components/pagination/AppPagination.tsx --file src/components/pagination/AppPagination.test.tsx`
- `cd src/cook-web && npm run type-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "jump to page" numeric input to pagination controls for direct navigation; input validates and clamps values to valid page bounds and exposes an accessible label.

* **Accessibility**
  * Introduced a translatable aria-label for the jump input to improve screen reader support.

* **Tests**
  * Added tests covering visibility, input validation/clamping, Enter/blur behavior, and accessibility name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->