### PR TITLE
feat: add filter layout shell

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminFilter.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminFilter.test.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import AdminFilter, { type AdminFilterItem } from './AdminFilter';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AdminFilter, {
+  type AdminFilterActiveFilter,
+  type AdminFilterItem,
+} from './AdminFilter';
 
 const renderFilter = ({
   expanded = false,
   items,
+  activeFilter,
+  layoutPreset,
+  surface,
 }: {
   expanded?: boolean;
   items?: AdminFilterItem[];
+  activeFilter?: AdminFilterActiveFilter | null;
+  layoutPreset?: 'default' | 'operations';
+  surface?: 'plain' | 'card';
 } = {}) =>
   render(
     <AdminFilter
@@ -42,6 +51,9 @@ const renderFilter = ({
       collapsedGridClassName='collapsed-grid-test'
       expandedGridClassName='expanded-grid-test'
       labelColon
+      activeFilter={activeFilter}
+      layoutPreset={layoutPreset}
+      surface={surface}
     />,
   );
 
@@ -74,5 +86,53 @@ describe('AdminFilter', () => {
     expect(screen.getByLabelText('Type filter')).toBeInTheDocument();
     expect(screen.getByLabelText('Course filter')).toBeInTheDocument();
     expect(screen.getByLabelText('Status filter')).toBeInTheDocument();
+  });
+
+  test('renders the card surface and active filter chip', () => {
+    const onClear = jest.fn();
+    const { container } = renderFilter({
+      surface: 'card',
+      activeFilter: {
+        label: 'Active filter',
+        value: 'Recent courses',
+        clearAriaLabel: 'Clear recent courses',
+        onClear,
+      },
+    });
+
+    expect(container.firstChild).toHaveClass('rounded-xl');
+    expect(screen.getByText('Active filter')).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Clear recent courses' }),
+    );
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies operations preset defaults when custom classes are not provided', () => {
+    const { container } = render(
+      <AdminFilter
+        items={[
+          {
+            key: 'type',
+            label: 'Type',
+            component: <input aria-label='Type filter' />,
+          },
+        ]}
+        expanded={false}
+        onExpandedChange={() => undefined}
+        onReset={() => undefined}
+        onSearch={() => undefined}
+        resetLabel='Reset'
+        searchLabel='Search'
+        expandLabel='Expand'
+        collapseLabel='Collapse'
+        layoutPreset='operations'
+      />,
+    );
+
+    expect(screen.getByText('Type')).toHaveClass("after:content-[':']");
+    expect(screen.getByText('Type')).toHaveClass('w-20');
+    expect(container.querySelector('.xl\\:grid-cols-3')).toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/components/AdminFilter.tsx
+++ b/src/cook-web/src/app/admin/components/AdminFilter.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, X } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
 
@@ -10,6 +10,13 @@ export type AdminFilterItem = {
   contentClassName?: string;
   itemClassName?: string;
   labelClassName?: string;
+};
+
+export type AdminFilterActiveFilter = {
+  label: ReactNode;
+  value: ReactNode;
+  clearAriaLabel: string;
+  onClear: () => void;
 };
 
 type AdminFilterProps = {
@@ -32,10 +39,18 @@ type AdminFilterProps = {
   expandedGridClassName?: string;
   labelColon?: boolean;
   showToggle?: boolean;
+  surface?: 'plain' | 'card';
+  layoutPreset?: 'default' | 'operations';
+  activeFilter?: AdminFilterActiveFilter | null;
+  testId?: string;
 };
 
 const ADMIN_FILTER_LABEL_CLASS =
   'shrink-0 whitespace-nowrap text-[length:var(--text-sm-font-size,14px)] not-italic font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]';
+const ADMIN_FILTER_CARD_CLASS =
+  'rounded-xl border border-border bg-white p-4 shadow-sm transition-all';
+const ADMIN_FILTER_ACTIVE_CHIP_CLASS =
+  'inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted';
 
 const AdminFilterField = ({
   item,
@@ -94,6 +109,10 @@ const AdminFilterActions = ({
   | 'collapsedGridClassName'
   | 'expandedGridClassName'
   | 'labelColon'
+  | 'surface'
+  | 'layoutPreset'
+  | 'activeFilter'
+  | 'testId'
 >) => (
   <div className='flex shrink-0 items-center justify-end'>
     <Button
@@ -150,33 +169,75 @@ export default function AdminFilter({
   expandedLabelClassName,
   collapsedGridClassName,
   expandedGridClassName,
-  labelColon = false,
+  labelColon,
   showToggle,
+  surface = 'plain',
+  layoutPreset = 'default',
+  activeFilter,
+  testId,
 }: AdminFilterProps) {
   const canToggle = showToggle ?? items.length > collapsedCount;
   const collapsedItems = items.slice(0, collapsedCount);
+  const isOperationsPreset = layoutPreset === 'operations';
   const resolvedCollapsedLabelClassName =
-    collapsedLabelClassName ?? labelClassName;
+    collapsedLabelClassName ??
+    labelClassName ??
+    (isOperationsPreset ? 'w-20 text-right' : undefined);
   const resolvedExpandedLabelClassName =
-    expandedLabelClassName ?? labelClassName;
+    expandedLabelClassName ??
+    labelClassName ??
+    (isOperationsPreset ? 'w-20 text-right' : undefined);
+  const resolvedContentClassName =
+    contentClassName ?? (isOperationsPreset ? 'min-w-0' : undefined);
+  const resolvedCollapsedGridClassName =
+    collapsedGridClassName ??
+    (isOperationsPreset ? 'gap-x-5 xl:grid-cols-3' : undefined);
+  const resolvedExpandedGridClassName =
+    expandedGridClassName ??
+    (isOperationsPreset ? 'gap-x-5 xl:grid-cols-3' : undefined);
+  const resolvedLabelColon = labelColon ?? isOperationsPreset;
 
   return (
-    <div className={cn('w-full bg-white', className)}>
+    <div
+      data-testid={testId}
+      className={cn(
+        'w-full',
+        surface === 'card' ? ADMIN_FILTER_CARD_CLASS : 'bg-white',
+        activeFilter && 'space-y-4',
+        className,
+      )}
+    >
+      {activeFilter ? (
+        <div className='flex flex-wrap items-center gap-2'>
+          <span className='text-sm text-muted-foreground'>
+            {activeFilter.label}
+          </span>
+          <button
+            type='button'
+            aria-label={activeFilter.clearAriaLabel}
+            className={ADMIN_FILTER_ACTIVE_CHIP_CLASS}
+            onClick={activeFilter.onClear}
+          >
+            <span>{activeFilter.value}</span>
+            <X className='h-3.5 w-3.5' />
+          </button>
+        </div>
+      ) : null}
       {!expanded ? (
         <div className='flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between'>
           <div
             className={cn(
               'grid min-w-0 flex-1 grid-cols-1 gap-x-7 gap-y-4 xl:grid-cols-[repeat(3,minmax(0,245px))]',
-              collapsedGridClassName,
+              resolvedCollapsedGridClassName,
             )}
           >
             {collapsedItems.map(item => (
               <AdminFilterField
                 key={item.key}
                 item={item}
-                contentClassName={contentClassName}
+                contentClassName={resolvedContentClassName}
                 labelClassName={resolvedCollapsedLabelClassName}
-                labelColon={labelColon}
+                labelColon={resolvedLabelColon}
               />
             ))}
           </div>
@@ -197,16 +258,16 @@ export default function AdminFilter({
           <div
             className={cn(
               'grid min-w-0 grid-cols-1 gap-x-7 gap-y-4 xl:grid-cols-3',
-              expandedGridClassName,
+              resolvedExpandedGridClassName,
             )}
           >
             {items.map(item => (
               <AdminFilterField
                 key={item.key}
                 item={item}
-                contentClassName={contentClassName}
+                contentClassName={resolvedContentClassName}
                 labelClassName={resolvedExpandedLabelClassName}
-                labelColon={labelColon}
+                labelColon={resolvedLabelColon}
               />
             ))}
           </div>

--- a/src/cook-web/src/app/admin/operations/CourseFiltersSection.tsx
+++ b/src/cook-web/src/app/admin/operations/CourseFiltersSection.tsx
@@ -1,4 +1,3 @@
-import { X } from 'lucide-react';
 import AdminFilter, {
   type AdminFilterItem,
 } from '@/app/admin/components/AdminFilter';
@@ -37,46 +36,31 @@ export default function CourseFiltersSection({
   onQuickFilter,
 }: CourseFiltersSectionProps) {
   return (
-    <div
-      className='rounded-xl border border-border bg-white p-4 mb-5 shadow-sm transition-all'
-      data-testid='admin-operations-filters'
-    >
-      <div className='space-y-4'>
-        {activeQuickFilterCard ? (
-          <div className='flex flex-wrap items-center gap-2'>
-            <span className='text-sm text-muted-foreground'>
-              {activeFilterLabel}
-            </span>
-            <button
-              type='button'
-              aria-label={`${activeQuickFilterCard.label} ${clearLabel}`}
-              className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
-              onClick={() => onQuickFilter('')}
-            >
-              <span>{activeQuickFilterCard.label}</span>
-              <X className='h-3.5 w-3.5' />
-            </button>
-          </div>
-        ) : null}
-        <AdminFilter
-          items={items}
-          expanded={expanded}
-          onExpandedChange={onExpandedChange}
-          onReset={onReset}
-          onSearch={onSearch}
-          resetLabel={resetLabel}
-          searchLabel={searchLabel}
-          expandLabel={expandLabel}
-          collapseLabel={collapseLabel}
-          collapsedCount={2}
-          className='bg-transparent'
-          contentClassName='min-w-0'
-          labelClassName='w-20 text-right'
-          collapsedGridClassName='gap-x-5 xl:grid-cols-3'
-          expandedGridClassName='gap-x-5 xl:grid-cols-3'
-          labelColon
-        />
-      </div>
-    </div>
+    <AdminFilter
+      testId='admin-operations-filters'
+      items={items}
+      expanded={expanded}
+      onExpandedChange={onExpandedChange}
+      onReset={onReset}
+      onSearch={onSearch}
+      resetLabel={resetLabel}
+      searchLabel={searchLabel}
+      expandLabel={expandLabel}
+      collapseLabel={collapseLabel}
+      collapsedCount={2}
+      surface='card'
+      layoutPreset='operations'
+      className='mb-5'
+      activeFilter={
+        activeQuickFilterCard
+          ? {
+              label: activeFilterLabel,
+              value: activeQuickFilterCard.label,
+              clearAriaLabel: `${activeQuickFilterCard.label} ${clearLabel}`,
+              onClear: () => onQuickFilter(''),
+            }
+          : null
+      }
+    />
   );
 }

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
@@ -498,48 +497,32 @@ export function CreditNotificationRecordsTab({
         </div>
       </TooltipProvider>
 
-      <div className='rounded-xl border border-border bg-white p-4 shadow-sm transition-all'>
-        <div className='space-y-4'>
-          {activeOverviewItem ? (
-            <div className='flex flex-wrap items-center gap-2'>
-              <span className='text-sm text-muted-foreground'>
-                {t(
+      <AdminFilter
+        items={filterItems}
+        expanded={filtersExpanded}
+        onExpandedChange={setFiltersExpanded}
+        onReset={resetRecords}
+        onSearch={searchRecords}
+        resetLabel={t('module.operationsCreditNotifications.actions.reset')}
+        searchLabel={t('module.operationsCreditNotifications.actions.search')}
+        expandLabel={t('common.core.expand')}
+        collapseLabel={t('common.core.collapse')}
+        collapsedCount={3}
+        surface='card'
+        layoutPreset='operations'
+        activeFilter={
+          activeOverviewItem
+            ? {
+                label: t(
                   'module.operationsCreditNotifications.overview.activeFilter',
-                )}
-              </span>
-              <button
-                type='button'
-                aria-label={`${activeOverviewItem.label} ${clearLabel}`}
-                className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
-                onClick={clearOverviewFilter}
-              >
-                <span>{activeOverviewItem.label}</span>
-                <X className='h-3.5 w-3.5' />
-              </button>
-            </div>
-          ) : null}
-          <AdminFilter
-            items={filterItems}
-            expanded={filtersExpanded}
-            onExpandedChange={setFiltersExpanded}
-            onReset={resetRecords}
-            onSearch={searchRecords}
-            resetLabel={t('module.operationsCreditNotifications.actions.reset')}
-            searchLabel={t(
-              'module.operationsCreditNotifications.actions.search',
-            )}
-            expandLabel={t('common.core.expand')}
-            collapseLabel={t('common.core.collapse')}
-            collapsedCount={3}
-            className='bg-transparent'
-            contentClassName='min-w-0'
-            labelClassName='w-20 text-right'
-            collapsedGridClassName='gap-x-5 xl:grid-cols-3'
-            expandedGridClassName='gap-x-5 xl:grid-cols-3'
-            labelColon
-          />
-        </div>
-      </div>
+                ),
+                value: activeOverviewItem.label,
+                clearAriaLabel: `${activeOverviewItem.label} ${clearLabel}`,
+                onClear: clearOverviewFilter,
+              }
+            : null
+        }
+      />
 
       {error ? (
         <ErrorDisplay


### PR DESCRIPTION
## Summary
- Add reusable AdminFilter card surface, operations layout preset, and active filter chip support.
- Migrate the course management and credit notification record filters to the shared filter shell.
- Cover the new AdminFilter layout options with focused tests.

## Tests
- `npm test -- src/app/admin/components/AdminFilter.test.tsx --runInBand`
- `npm test -- src/app/admin/operations/page.test.tsx --runInBand`
- `npm test -- src/app/admin/operations/credit-notifications/page.test.tsx --runInBand`
- `npm run lint -- --file src/app/admin/components/AdminFilter.tsx --file src/app/admin/components/AdminFilter.test.tsx --file src/app/admin/operations/CourseFiltersSection.tsx --file src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx`
- `npm run type-check`
- `pre-commit run -a`
