### PR TITLE
feat: add metric card shell

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
@@ -53,4 +53,64 @@ describe('AdminMetricCardGroup', () => {
       screen.getByRole('button', { name: 'Pending notification records' }),
     ).toBeInTheDocument();
   });
+
+  test('applies className when the group has no title', () => {
+    const { container } = render(
+      <AdminMetricCardGroup
+        className='metric-group-wrapper'
+        items={[
+          {
+            key: 'sent',
+            label: 'Sent notifications',
+            value: 8,
+            tooltip: 'Sent notification records',
+          },
+        ]}
+      />,
+    );
+
+    expect(container.firstChild).toHaveClass('metric-group-wrapper');
+  });
+
+  test('keeps card hover on non-clickable card-mode metrics', () => {
+    render(
+      <AdminMetricCardGroup
+        items={[
+          {
+            key: 'paid',
+            label: 'Paid amount',
+            value: '$18',
+            tooltip: 'Total paid amount',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Paid amount').closest('.rounded-lg')).toHaveClass(
+      'hover:border-primary/30',
+    );
+  });
+
+  test('limits clickable card-mode hover to the metric control', () => {
+    render(
+      <AdminMetricCardGroup
+        items={[
+          {
+            key: 'failed',
+            label: 'Failed notifications',
+            value: 2,
+            tooltip: 'Failed notification records',
+            onClick: jest.fn(),
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Failed notifications' }),
+    ).toHaveClass('metric-control');
+    expect(
+      screen.getByText('Failed notifications').closest('.rounded-lg'),
+    ).toHaveClass('has-[.metric-control:hover]:border-primary/30');
+  });
 });

--- a/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AdminMetricCardGroup } from './AdminMetricCard';
+
+describe('AdminMetricCardGroup', () => {
+  test('renders the titled card group and handles metric clicks', () => {
+    const onClick = jest.fn();
+
+    render(
+      <AdminMetricCardGroup
+        title='Data overview'
+        items={[
+          {
+            key: 'total',
+            label: 'Total courses',
+            value: '18',
+            tooltip: 'All course records',
+            onClick,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Data overview')).toBeInTheDocument();
+    expect(screen.getByText('Total courses')).toBeInTheDocument();
+    expect(screen.getByText('18')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Total courses' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('supports inset control hover mode without changing tooltip labels', () => {
+    render(
+      <AdminMetricCardGroup
+        items={[
+          {
+            key: 'pending',
+            label: 'Pending notifications',
+            value: 12,
+            tooltip: 'Pending notification records',
+            onClick: jest.fn(),
+          },
+        ]}
+        cardHoverMode='control'
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Pending notifications' }),
+    ).toHaveClass('-m-2');
+    expect(
+      screen.getByRole('button', { name: 'Pending notification records' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
@@ -35,7 +35,10 @@ type AdminMetricCardGroupProps = {
 };
 
 const CARD_CLASS = 'rounded-lg border border-border/70 bg-muted/20 p-4';
-const CARD_HOVER_CLASS =
+const CONTROL_TARGET_CLASS = 'metric-control';
+const CLICKABLE_CARD_HOVER_CLASS =
+  'transition-colors has-[.metric-control:hover]:border-primary/30 has-[.metric-control:hover]:bg-primary/[0.04]';
+const STATIC_CARD_HOVER_CLASS =
   'transition-colors hover:border-primary/30 hover:bg-primary/[0.04]';
 const CONTROL_CLASS =
   'group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2';
@@ -71,7 +74,8 @@ export function AdminMetricCard({
     <div
       className={cn(
         CARD_CLASS,
-        onClick && hoverMode === 'card' && CARD_HOVER_CLASS,
+        hoverMode === 'card' &&
+          (onClick ? CLICKABLE_CARD_HOVER_CLASS : STATIC_CARD_HOVER_CLASS),
         className,
       )}
     >
@@ -82,6 +86,7 @@ export function AdminMetricCard({
             aria-label={label}
             className={cn(
               CONTROL_CLASS,
+              hoverMode === 'card' && CONTROL_TARGET_CLASS,
               hoverMode === 'control' && INSET_CONTROL_CLASS,
             )}
             onClick={onClick}
@@ -138,7 +143,7 @@ export function AdminMetricCardGroup({
   );
 
   if (!title) {
-    return grid;
+    return className ? <div className={className}>{grid}</div> : grid;
   }
 
   return (

--- a/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from 'react';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+export type AdminMetricCardHoverMode = 'card' | 'control';
+
+export type AdminMetricCardItem = {
+  key: string;
+  label: string;
+  value: ReactNode;
+  tooltip: string;
+  onClick?: () => void;
+};
+
+type AdminMetricCardProps = Omit<AdminMetricCardItem, 'key'> & {
+  hoverMode?: AdminMetricCardHoverMode;
+  className?: string;
+  valueClassName?: string;
+};
+
+type AdminMetricCardGroupProps = {
+  items: AdminMetricCardItem[];
+  title?: ReactNode;
+  className?: string;
+  gridClassName?: string;
+  cardHoverMode?: AdminMetricCardHoverMode;
+  tooltipDelayDuration?: number;
+  valueClassName?: string;
+};
+
+const CARD_CLASS = 'rounded-lg border border-border/70 bg-muted/20 p-4';
+const CARD_HOVER_CLASS =
+  'transition-colors hover:border-primary/30 hover:bg-primary/[0.04]';
+const CONTROL_CLASS =
+  'group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2';
+const INSET_CONTROL_CLASS =
+  '-m-2 rounded-md border border-transparent p-2 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]';
+const TOOLTIP_TRIGGER_CLASS =
+  'inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2';
+
+export function AdminMetricCard({
+  label,
+  value,
+  tooltip,
+  onClick,
+  hoverMode = 'card',
+  className,
+  valueClassName,
+}: AdminMetricCardProps) {
+  const content = (
+    <>
+      <div className='text-sm text-muted-foreground'>{label}</div>
+      <div
+        className={cn(
+          'mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary',
+          valueClassName,
+        )}
+      >
+        {value}
+      </div>
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        CARD_CLASS,
+        onClick && hoverMode === 'card' && CARD_HOVER_CLASS,
+        className,
+      )}
+    >
+      <div className='flex items-start justify-between gap-2'>
+        {onClick ? (
+          <button
+            type='button'
+            aria-label={label}
+            className={cn(
+              CONTROL_CLASS,
+              hoverMode === 'control' && INSET_CONTROL_CLASS,
+            )}
+            onClick={onClick}
+          >
+            {content}
+          </button>
+        ) : (
+          <div className='min-w-0 flex-1'>{content}</div>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type='button'
+              aria-label={tooltip}
+              className={TOOLTIP_TRIGGER_CLASS}
+            >
+              <QuestionMarkCircleIcon className='h-4 w-4' />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className='max-w-56 text-left leading-5'>
+            {tooltip}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+export function AdminMetricCardGroup({
+  items,
+  title,
+  className,
+  gridClassName,
+  cardHoverMode = 'card',
+  tooltipDelayDuration = 150,
+  valueClassName,
+}: AdminMetricCardGroupProps) {
+  const grid = (
+    <TooltipProvider delayDuration={tooltipDelayDuration}>
+      <div className={cn('grid gap-3', gridClassName)}>
+        {items.map(item => (
+          <AdminMetricCard
+            key={item.key}
+            label={item.label}
+            value={item.value}
+            tooltip={item.tooltip}
+            onClick={item.onClick}
+            hoverMode={cardHoverMode}
+            valueClassName={valueClassName}
+          />
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+
+  if (!title) {
+    return grid;
+  }
+
+  return (
+    <div
+      className={cn(
+        'mb-5 rounded-xl border border-border bg-white p-4 shadow-sm',
+        className,
+      )}
+    >
+      <div className='mb-3'>
+        <h2 className='text-base font-semibold text-foreground'>{title}</h2>
+      </div>
+      {grid}
+    </div>
+  );
+}

--- a/src/cook-web/src/app/admin/operations/CourseOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/CourseOverviewSection.tsx
@@ -1,10 +1,4 @@
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { AdminMetricCardGroup } from '@/app/admin/components/AdminMetricCard';
 import {
   type CourseQuickFilterKey,
   formatCount,
@@ -32,50 +26,18 @@ export default function CourseOverviewSection({
   onQuickFilter,
 }: CourseOverviewSectionProps) {
   return (
-    <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm'>
-      <div className='mb-3'>
-        <h2 className='text-base font-semibold text-foreground'>{title}</h2>
-      </div>
-      <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-3 min-[1680px]:grid-cols-6'>
-        {cards.map(card => (
-          <div
-            key={card.key}
-            className='rounded-lg border border-border/70 bg-muted/20 p-4'
-          >
-            <div className='flex items-start justify-between gap-2'>
-              <button
-                type='button'
-                aria-label={card.label}
-                className='group -m-2 min-w-0 flex-1 rounded-md border border-transparent p-2 text-left transition-colors hover:border-primary/30 hover:bg-primary/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                onClick={() => onQuickFilter(card.quickFilterKey)}
-              >
-                <div className='text-sm text-muted-foreground'>
-                  {card.label}
-                </div>
-                <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                  {formatCount(card.value, locale)}
-                </div>
-              </button>
-              <TooltipProvider delayDuration={0}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type='button'
-                      aria-label={card.tooltip}
-                      className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                    >
-                      <QuestionMarkCircleIcon className='h-4 w-4' />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className='max-w-56 text-left leading-5'>
-                    {card.tooltip}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <AdminMetricCardGroup
+      title={title}
+      items={cards.map(card => ({
+        key: card.key,
+        label: card.label,
+        value: formatCount(card.value, locale),
+        tooltip: card.tooltip,
+        onClick: () => onQuickFilter(card.quickFilterKey),
+      }))}
+      gridClassName='md:grid-cols-2 xl:grid-cols-3 min-[1680px]:grid-cols-6'
+      cardHoverMode='control'
+      tooltipDelayDuration={0}
+    />
   );
 }

--- a/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
@@ -1,13 +1,8 @@
 'use client';
 
 import React from 'react';
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { X } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { AdminMetricCardGroup } from '@/app/admin/components/AdminMetricCard';
 import { cn } from '@/lib/utils';
 
 type OrderOverviewCard = {
@@ -51,58 +46,13 @@ export default function OrderOverviewSection({
         </div>
       ) : null}
 
-      <div
-        className={cn(
-          'grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4 min-[1680px]:grid-cols-6',
+      <AdminMetricCardGroup
+        items={cards}
+        gridClassName={cn(
+          'grid-cols-2 md:grid-cols-3 xl:grid-cols-4 min-[1680px]:grid-cols-6',
           gridClassName,
         )}
-      >
-        {cards.map(card => {
-          const content = (
-            <>
-              <div className='text-sm text-muted-foreground'>{card.label}</div>
-              <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                {card.value}
-              </div>
-            </>
-          );
-
-          return (
-            <div
-              key={card.key}
-              className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
-            >
-              <div className='flex items-start justify-between gap-2'>
-                {card.onClick ? (
-                  <button
-                    type='button'
-                    className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                    onClick={card.onClick}
-                  >
-                    {content}
-                  </button>
-                ) : (
-                  <div className='min-w-0 flex-1'>{content}</div>
-                )}
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type='button'
-                      aria-label={card.tooltip}
-                      className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                    >
-                      <QuestionMarkCircleIcon className='h-4 w-4' />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className='max-w-56 text-left leading-5'>
-                    {card.tooltip}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      />
 
       {activeCardLabel && onClearActive ? (
         <div className='mt-4 flex flex-wrap items-center gap-2'>


### PR DESCRIPTION
## Summary
- Add reusable AdminMetricCard and AdminMetricCardGroup components for admin overview metrics.
- Migrate course management and order overview sections to the shared metric card shell.
- Keep existing metric click handlers, grid layouts, and hover modes unchanged.

## Tests
- `npm test -- src/app/admin/components/AdminMetricCard.test.tsx --runInBand`
- `npm test -- src/app/admin/operations/page.test.tsx --runInBand`
- `npm test -- src/app/admin/operations/orders/LearnOrdersTab.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx --runInBand`
- `npm run lint -- --file src/app/admin/components/AdminMetricCard.tsx --file src/app/admin/components/AdminMetricCard.test.tsx --file src/app/admin/operations/CourseOverviewSection.tsx --file src/app/admin/operations/orders/OrderOverviewSection.tsx`
- `npm run type-check`
- `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable metric-card UI with configurable hover modes, clickable metrics, and built-in tooltip help.

* **Refactor**
  * Replaced per-card implementations in overview sections with the new metric-card group to standardize layout and behavior.

* **Tests**
  * Expanded test coverage verifying rendering, tooltip text, hover styling variations, and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->