### PR TITLE
feat: lazy load credit notification config tab

### DIFF
--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import ErrorDisplay from '@/components/ErrorDisplay';
+import Loading from '@/components/loading';
 import { Button } from '@/components/ui/Button';
 import { toast } from '@/hooks/useToast';
 import { Input } from '@/components/ui/Input';
@@ -235,6 +236,7 @@ function ConfigCard({
 export function CreditNotificationConfigTab({
   policy,
   configLoaded,
+  configLoading,
   configError,
   dryRunResult,
   templateSyncResults,
@@ -252,6 +254,7 @@ export function CreditNotificationConfigTab({
 }: {
   policy: AdminOperationCreditNotificationPolicy;
   configLoaded: boolean;
+  configLoading: boolean;
   configError: string;
   dryRunResult: AdminOperationCreditNotificationDryRunResponse | null;
   templateSyncResults: Partial<
@@ -478,6 +481,14 @@ export function CreditNotificationConfigTab({
           'module.operationsCreditNotifications.config.fields.optedOutCreators',
         );
   const managedListCanDelete = managedListDialog === 'blocked';
+
+  if (configLoading && !configLoaded) {
+    return (
+      <div className='flex h-full min-h-0 items-center justify-center'>
+        <Loading />
+      </div>
+    );
+  }
 
   return (
     <div className='flex h-full min-h-0 flex-col'>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -206,9 +206,7 @@ const openConfigTab = async ({
   await waitFor(() => {
     expect(mockGetConfig).toHaveBeenCalled();
   });
-  await waitFor(() => {
-    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
-  });
+  await screen.findByText('module.operationsCreditNotifications.config.title');
   if (waitForTemplates) {
     await waitFor(() => {
       expect(mockGetTemplates).toHaveBeenCalled();

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -199,6 +199,9 @@ const openConfigTab = async () => {
       }),
     ).toHaveAttribute('data-state', 'active');
   });
+  await waitFor(() => {
+    expect(mockGetConfig).toHaveBeenCalled();
+  });
 };
 
 const openRecordMoreMenu = () => {
@@ -365,6 +368,8 @@ describe('AdminOperationCreditNotificationsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Creator One')).toBeInTheDocument();
     });
+    expect(mockGetConfig).not.toHaveBeenCalled();
+    expect(mockGetTemplates).not.toHaveBeenCalled();
     expect(
       screen.getByRole('tab', {
         name: 'module.operationsCreditNotifications.tabs.records',
@@ -686,9 +691,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('saves structured config changes without exposing a raw JSON editor', async () => {
     const { container } = render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     expect(container.querySelector('textarea')).toBeNull();
@@ -823,9 +825,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
 
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     expect(
@@ -843,9 +842,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('shows recommended templates without marking config dirty before saving', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     expect(screen.getByText('Grant')).toBeInTheDocument();
@@ -868,9 +864,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('writes recommended templates when saving config', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     fireEvent.click(
@@ -895,9 +888,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('extracts blocked creators from spreadsheet-style pasted contacts and rejects invalid rows', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     const blockedCreatorsInput = screen.getByLabelText(
@@ -947,9 +937,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
 
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     const blockedCreatorsInput = screen.getByLabelText(
@@ -1010,9 +997,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
 
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     expect(screen.getByText(/13800000000/)).toBeInTheDocument();
@@ -1071,9 +1055,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('asks before leaving config tab with unsaved changes and restores discarded edits', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     const blockedCreatorsInput = screen.getByLabelText(
@@ -1134,9 +1115,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('shows dynamic template placeholders and tolerance copy', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     expect(
@@ -1174,9 +1152,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('shows estimated-days and fallback placeholders when the low-balance mode is enabled', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     fireEvent.click(
@@ -1204,9 +1179,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('syncs and displays Aliyun template variables without saving them into policy', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     const templateInputs = screen.getAllByLabelText(
@@ -1255,9 +1227,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('keeps dry-run in the policy config tab', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     fireEvent.click(
@@ -1280,9 +1249,6 @@ describe('AdminOperationCreditNotificationsPage', () => {
   it('saves estimated-days low balance thresholds from the structured form', async () => {
     render(<AdminOperationCreditNotificationsPage />);
 
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-    });
     await openConfigTab();
 
     fireEvent.click(

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -185,7 +185,11 @@ const mockUpdateConfig =
 const mockDryRun = api.dryRunAdminOperationCreditNotifications as jest.Mock;
 const mockToast = toast as jest.Mock;
 
-const openConfigTab = async () => {
+const openConfigTab = async ({
+  waitForTemplates = true,
+}: {
+  waitForTemplates?: boolean;
+} = {}) => {
   const configTab = screen.getByRole('tab', {
     name: 'module.operationsCreditNotifications.tabs.config',
   });
@@ -202,6 +206,15 @@ const openConfigTab = async () => {
   await waitFor(() => {
     expect(mockGetConfig).toHaveBeenCalled();
   });
+  await waitFor(() => {
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+  });
+  if (waitForTemplates) {
+    await waitFor(() => {
+      expect(mockGetTemplates).toHaveBeenCalled();
+    });
+    await screen.findByText('Grant');
+  }
 };
 
 const openRecordMoreMenu = () => {
@@ -578,7 +591,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
     mockGetConfig.mockRejectedValueOnce(new Error('config unavailable'));
     render(<AdminOperationCreditNotificationsPage />);
 
-    await openConfigTab();
+    await openConfigTab({ waitForTemplates: false });
 
     expect(screen.getByText('config unavailable')).toBeInTheDocument();
     expect(

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -139,6 +139,7 @@ export default function AdminOperationCreditNotificationsPage() {
     { type: 'tab'; tab: PageTab } | { type: 'href'; href: string } | null
   >(null);
   const requestIdRef = React.useRef(0);
+  const configLoadStartedRef = React.useRef(false);
   const isConfigDirty = React.useMemo(
     () => JSON.stringify(policy) !== JSON.stringify(savedPolicy),
     [policy, savedPolicy],
@@ -300,32 +301,43 @@ export default function AdminOperationCreditNotificationsPage() {
     [t],
   );
 
-  React.useEffect(() => {
-    if (!isReady) {
+  const loadConfigResources = React.useCallback(async () => {
+    if (configLoaded || configLoadStartedRef.current) {
       return;
     }
-    const initialFilters = createDefaultFilters();
-    fetchConfig().catch(requestError => {
+    configLoadStartedRef.current = true;
+    setConfigError('');
+    try {
+      await fetchConfig();
+      void fetchTemplateOptions();
+    } catch (requestError) {
+      configLoadStartedRef.current = false;
       const resolvedError = requestError as ErrorWithCode;
       setConfigLoaded(false);
       setConfigError(
         resolvedError.message ||
           t('module.operationsCreditNotifications.config.loadFailed'),
       );
-    });
-    void fetchTemplateOptions();
+    }
+  }, [configLoaded, fetchConfig, fetchTemplateOptions, t]);
+
+  React.useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+    const initialFilters = createDefaultFilters();
     fetchOverview().catch(() => {
       setOverview({ total: 0, pending: 0, sent: 0, failed: 0, skipped: 0 });
     });
     void fetchRecords(1, initialFilters);
-  }, [
-    fetchConfig,
-    fetchOverview,
-    fetchRecords,
-    fetchTemplateOptions,
-    isReady,
-    t,
-  ]);
+  }, [fetchOverview, fetchRecords, isReady]);
+
+  React.useEffect(() => {
+    if (!isReady || activeTab !== 'config') {
+      return;
+    }
+    void loadConfigResources();
+  }, [activeTab, isReady, loadConfigResources]);
 
   const updateDraftFilter = React.useCallback(
     (field: keyof NotificationFilters, value: string) => {

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -302,11 +302,11 @@ export default function AdminOperationCreditNotificationsPage() {
   );
 
   const loadConfigResources = React.useCallback(async () => {
-    if (configLoaded || configLoadStartedRef.current) {
+    if (configLoadStartedRef.current) {
       return;
     }
     configLoadStartedRef.current = true;
-    setConfigError('');
+    setConfigError(current => (current ? '' : current));
     try {
       await fetchConfig();
       void fetchTemplateOptions();
@@ -319,7 +319,7 @@ export default function AdminOperationCreditNotificationsPage() {
           t('module.operationsCreditNotifications.config.loadFailed'),
       );
     }
-  }, [configLoaded, fetchConfig, fetchTemplateOptions, t]);
+  }, [fetchConfig, fetchTemplateOptions, t]);
 
   React.useEffect(() => {
     if (!isReady) {

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -308,7 +308,7 @@ export default function AdminOperationCreditNotificationsPage() {
     }
     configLoadStartedRef.current = true;
     setConfigLoading(true);
-    setConfigError(current => (current ? '' : current));
+    setConfigError('');
     try {
       await fetchConfig();
       void fetchTemplateOptions();

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -111,6 +111,7 @@ export default function AdminOperationCreditNotificationsPage() {
     React.useState<AdminOperationCreditNotificationPolicy>(createDefaultPolicy);
   const [configError, setConfigError] = React.useState('');
   const [configLoaded, setConfigLoaded] = React.useState(false);
+  const [configLoading, setConfigLoading] = React.useState(false);
   const [dryRunResult, setDryRunResult] =
     React.useState<AdminOperationCreditNotificationDryRunResponse | null>(null);
   const [templateSyncResults, setTemplateSyncResults] = React.useState<
@@ -306,6 +307,7 @@ export default function AdminOperationCreditNotificationsPage() {
       return;
     }
     configLoadStartedRef.current = true;
+    setConfigLoading(true);
     setConfigError(current => (current ? '' : current));
     try {
       await fetchConfig();
@@ -318,6 +320,8 @@ export default function AdminOperationCreditNotificationsPage() {
         resolvedError.message ||
           t('module.operationsCreditNotifications.config.loadFailed'),
       );
+    } finally {
+      setConfigLoading(false);
     }
   }, [fetchConfig, fetchTemplateOptions, t]);
 
@@ -768,6 +772,7 @@ export default function AdminOperationCreditNotificationsPage() {
           <CreditNotificationConfigTab
             policy={policy}
             configLoaded={configLoaded}
+            configLoading={configLoading}
             configError={configError}
             dryRunResult={dryRunResult}
             templateSyncResults={templateSyncResults}


### PR DESCRIPTION
## Summary
- Stop loading credit notification policy config and template options on the default records tab.
- Load config resources only when the config tab becomes active, while preserving direct `?tab=config` behavior.
- Update credit notification page tests for lazy config loading.

## Validation
- `cd src/cook-web && npm test -- src/app/admin/operations/credit-notifications/page.test.tsx --runInBand`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint -- --file src/app/admin/operations/credit-notifications/page.tsx --file src/app/admin/operations/credit-notifications/page.test.tsx`
- `git diff --check`
- `/Users/iris/.codex/bin/branch_context_manager.py sync && /Users/iris/.codex/bin/branch_context_manager.py report && /Users/iris/.codex/bin/branch_context_manager.py pre-pr-review && /Users/iris/.codex/bin/branch_context_manager.py pre-push-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Config and template data now load on-demand when opening the Config tab, reducing initial page load and background network activity.
* **Bug Fixes**
  * Stops config/template fetches while viewing the Records tab to avoid redundant requests and improve responsiveness.
* **New Features**
  * Config tab shows a focused loading state while configuration is being fetched.
* **Tests**
  * Test suite updated to reliably wait for config/template loading behavior and handle config-load failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->