### PR TITLE
fix: handle upload and SMS template ops alerts

### DIFF
--- a/src/api/flaskr/api/sms/aliyun.py
+++ b/src/api/flaskr/api/sms/aliyun.py
@@ -150,7 +150,8 @@ def query_sms_template_list_ali(
     except (TypeError, ValueError):
         normalized_page_size = 50
     request.page_index = max(normalized_page_index, 1)
-    request.page_size = min(max(normalized_page_size, 1), 100)
+    # Aliyun Dysmsapi rejects PageSize values above 50 with InvalidPageSize.
+    request.page_size = min(max(normalized_page_size, 1), 50)
     runtime = util_models.RuntimeOptions()
     try:
         return client.query_sms_template_list_with_options(request, runtime)

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -993,7 +993,7 @@ def list_credit_notification_templates(app: Flask) -> dict[str, Any]:
             }
 
         now = datetime.now()
-        response = query_sms_template_list_ali(app, page_index=1, page_size=100)
+        response = query_sms_template_list_ali(app, page_index=1, page_size=50)
         body = getattr(response, "body", None)
         response_code = _template_body_value(body, "code") if body is not None else ""
         if body is None or (response_code and response_code != "OK"):

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -112,9 +112,17 @@ def upload_file(app, user_id: str, resource_id: str, file) -> str:
         isUpdate = False
         if resource_id == "":
             file_id = str(uuid.uuid4()).replace("-", "")
+            resource = None
         else:
-            isUpdate = True
             file_id = resource_id
+            resource = Resource.query.filter_by(resource_id=file_id).first()
+            if resource is not None:
+                isUpdate = True
+            else:
+                app.logger.warning(
+                    "upload_file received missing resource_id=%s; creating a new resource",
+                    file_id,
+                )
 
         content_type = get_image_content_type(file.filename)
         result = upload_to_storage(
@@ -126,7 +134,6 @@ def upload_file(app, user_id: str, resource_id: str, file) -> str:
         )
 
         if isUpdate:
-            resource = Resource.query.filter_by(resource_id=file_id).first()
             resource.name = file.filename
             resource.oss_bucket = result.bucket
             resource.oss_name = result.object_key

--- a/src/api/tests/test_shifu_upload_file.py
+++ b/src/api/tests/test_shifu_upload_file.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from flaskr.dao import db
+from flaskr.service.resource.models import Resource
+from flaskr.service.shifu import funcs
+
+
+def test_upload_file_creates_resource_when_resource_id_is_missing(app, monkeypatch):
+    class DummyFile:
+        filename = "avatar.png"
+
+    uploaded = SimpleNamespace(
+        bucket="bucket",
+        object_key="missing-resource-id",
+        url="https://example.test/avatar.png",
+    )
+
+    monkeypatch.setattr(funcs, "get_image_content_type", lambda _filename: "image/png")
+    monkeypatch.setattr(funcs, "upload_to_storage", lambda *args, **kwargs: uploaded)
+
+    with app.app_context():
+        db.session.query(Resource).filter_by(resource_id="missing-resource-id").delete()
+        db.session.commit()
+
+        result = funcs.upload_file(app, "user-1", "missing-resource-id", DummyFile())
+
+        resource = Resource.query.filter_by(resource_id="missing-resource-id").first()
+        assert result == uploaded.url
+        assert resource is not None
+        assert resource.name == "avatar.png"
+        assert resource.oss_bucket == uploaded.bucket
+        assert resource.oss_name == uploaded.object_key
+        assert resource.url == uploaded.url
+        assert resource.created_by == "user-1"
+        assert resource.updated_by == "user-1"

--- a/src/api/tests/test_sms_aliyun.py
+++ b/src/api/tests/test_sms_aliyun.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from flask import Flask
+
+from flaskr.api.sms import aliyun
+
+
+def test_query_sms_template_list_caps_page_size_at_provider_limit(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, _config):
+            pass
+
+        def query_sms_template_list_with_options(self, request, _runtime):
+            captured["page_index"] = request.page_index
+            captured["page_size"] = request.page_size
+            return SimpleNamespace(body=SimpleNamespace(code="OK"))
+
+    monkeypatch.setattr(aliyun, "Dysmsapi20170525Client", FakeClient)
+
+    app = Flask(__name__)
+    app.config["ALIBABA_CLOUD_SMS_ACCESS_KEY_ID"] = "ak"
+    app.config["ALIBABA_CLOUD_SMS_ACCESS_KEY_SECRET"] = "sk"
+
+    aliyun.query_sms_template_list_ali(app, page_index=0, page_size=100)
+
+    assert captured == {"page_index": 1, "page_size": 50}


### PR DESCRIPTION
## 群内报错来源

来自「运维保障群」2026-06-01 过去 24 小时内的 AI-Shifu 报错巡检：

1. `/api/shifu/upfile` 两次 500：
   - `AttributeError: 'NoneType' object has no attribute 'name'`
   - 发生在 `upload_file` 更新 `resource_id` 时，数据库里查不到对应 `Resource` 记录仍继续写字段。
2. `/api/shifu/admin/operations/credit-notifications/templates` 短信模板列表报错：
   - Aliyun Dysmsapi `InvalidPageSize`
   - 当前调用 `QuerySmsTemplateList` 使用 `page_size=100`，超过阿里云文档允许的 `1~50`。

## 修复内容

- `upload_file`：当请求带了 `resource_id` 但本地没有对应 `Resource` 记录时，不再对 `None` 写字段；记录 warning，并按该 `resource_id` 创建新资源记录，避免上传接口 500。
- Aliyun SMS 模板列表：
  - `query_sms_template_list_ali` 将 `page_size` 上限从 100 收敛到 50。
  - 运营后台短信模板列表调用从 `page_size=100` 改为 `page_size=50`，符合阿里云 API 文档。
- 补充单测覆盖上述两个分支。

## 验证

- `python -m py_compile src/api/flaskr/service/shifu/funcs.py src/api/flaskr/api/sms/aliyun.py src/api/flaskr/service/billing/credit_notifications.py src/api/tests/test_shifu_upload_file.py src/api/tests/test_sms_aliyun.py` ✅
- `git diff --check` ✅
- 尝试运行目标 pytest：
  - `python -m pytest tests/test_shifu_upload_file.py tests/test_sms_aliyun.py tests/service/shifu/test_admin_credit_notifications.py -q`
  - 当前本机缺少测试依赖 `prometheus_client`，未能完整执行；已通过语法编译与 diff check 做最小验证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SMS template pagination to properly comply with provider limits.
  * Improved file upload handling to correctly determine when to create or update resources based on availability.

* **Tests**
  * Added test coverage for SMS template pagination behavior.
  * Added test coverage for file upload resource creation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->