### PR TITLE
feat: optimize operator course list queries

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2975,7 +2975,7 @@ def _build_latest_operator_course_rows_subquery(
     )
     if base_query is None:
         return None
-    return base_query.subquery(alias_name)
+    return base_query.cte(alias_name)
 
 
 def _build_operator_course_candidate_query(
@@ -2985,6 +2985,7 @@ def _build_operator_course_candidate_query(
     creator_bids: Optional[Set[str]],
     start_time: Optional[datetime],
     end_time: Optional[datetime],
+    include_activity: bool = False,
 ):
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
@@ -3016,7 +3017,7 @@ def _build_operator_course_candidate_query(
                 draft_rows_subquery.c.created_user_bid,
             )
         )
-        .subquery("operator_course_draft_visible")
+        .cte("operator_course_draft_visible")
     )
     published_visible_subquery = (
         db.session.query(published_rows_subquery)
@@ -3027,7 +3028,7 @@ def _build_operator_course_candidate_query(
                 published_rows_subquery.c.created_user_bid,
             )
         )
-        .subquery("operator_course_published_visible")
+        .cte("operator_course_published_visible")
     )
 
     candidate_bids_subquery = (
@@ -3035,7 +3036,16 @@ def _build_operator_course_candidate_query(
         .union(
             db.session.query(published_visible_subquery.c.shifu_bid.label("shifu_bid"))
         )
-        .subquery("operator_course_candidate_bids")
+        .cte("operator_course_candidate_bids")
+    )
+    latest_activity_subquery = (
+        _build_operator_course_latest_activity_subquery(
+            candidate_bids_subquery,
+            draft_visible_subquery,
+            published_visible_subquery,
+        )
+        if include_activity
+        else None
     )
 
     selected_source_expr = case(
@@ -3046,62 +3056,72 @@ def _build_operator_course_candidate_query(
         (published_visible_subquery.c.id.isnot(None), literal(COURSE_STATUS_PUBLISHED)),
         else_=literal(COURSE_STATUS_UNPUBLISHED),
     )
-    candidate_query = (
-        db.session.query(
-            case(
-                (draft_visible_subquery.c.id.isnot(None), draft_visible_subquery.c.id),
-                else_=published_visible_subquery.c.id,
-            ).label("id"),
-            candidate_bids_subquery.c.shifu_bid.label("shifu_bid"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.title,
+    selected_columns = [
+        case(
+            (draft_visible_subquery.c.id.isnot(None), draft_visible_subquery.c.id),
+            else_=published_visible_subquery.c.id,
+        ).label("id"),
+        candidate_bids_subquery.c.shifu_bid.label("shifu_bid"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.title,
+            ),
+            else_=published_visible_subquery.c.title,
+        ).label("title"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.price,
+            ),
+            else_=published_visible_subquery.c.price,
+        ).label("price"),
+        case(
+            (draft_visible_subquery.c.id.isnot(None), draft_visible_subquery.c.llm),
+            else_=published_visible_subquery.c.llm,
+        ).label("llm"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.created_user_bid,
+            ),
+            else_=published_visible_subquery.c.created_user_bid,
+        ).label("created_user_bid"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.updated_user_bid,
+            ),
+            else_=published_visible_subquery.c.updated_user_bid,
+        ).label("updated_user_bid"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.created_at,
+            ),
+            else_=published_visible_subquery.c.created_at,
+        ).label("created_at"),
+        case(
+            (
+                draft_visible_subquery.c.id.isnot(None),
+                draft_visible_subquery.c.updated_at,
+            ),
+            else_=published_visible_subquery.c.updated_at,
+        ).label("updated_at"),
+        selected_source_expr.label("selected_source"),
+        course_status_expr.label("course_status"),
+    ]
+    if latest_activity_subquery is not None:
+        selected_columns.extend(
+            [
+                latest_activity_subquery.c.updated_at.label("activity_updated_at"),
+                latest_activity_subquery.c.updated_user_bid.label(
+                    "activity_updated_user_bid"
                 ),
-                else_=published_visible_subquery.c.title,
-            ).label("title"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.price,
-                ),
-                else_=published_visible_subquery.c.price,
-            ).label("price"),
-            case(
-                (draft_visible_subquery.c.id.isnot(None), draft_visible_subquery.c.llm),
-                else_=published_visible_subquery.c.llm,
-            ).label("llm"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.created_user_bid,
-                ),
-                else_=published_visible_subquery.c.created_user_bid,
-            ).label("created_user_bid"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.updated_user_bid,
-                ),
-                else_=published_visible_subquery.c.updated_user_bid,
-            ).label("updated_user_bid"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.created_at,
-                ),
-                else_=published_visible_subquery.c.created_at,
-            ).label("created_at"),
-            case(
-                (
-                    draft_visible_subquery.c.id.isnot(None),
-                    draft_visible_subquery.c.updated_at,
-                ),
-                else_=published_visible_subquery.c.updated_at,
-            ).label("updated_at"),
-            selected_source_expr.label("selected_source"),
-            course_status_expr.label("course_status"),
+            ]
         )
+    candidate_query = (
+        db.session.query(*selected_columns)
         .select_from(candidate_bids_subquery)
         .outerjoin(
             draft_visible_subquery,
@@ -3113,7 +3133,146 @@ def _build_operator_course_candidate_query(
             == candidate_bids_subquery.c.shifu_bid,
         )
     )
+    if latest_activity_subquery is not None:
+        candidate_query = candidate_query.outerjoin(
+            latest_activity_subquery,
+            latest_activity_subquery.c.shifu_bid == candidate_bids_subquery.c.shifu_bid,
+        )
     return candidate_query
+
+
+def _build_latest_outline_activity_subquery(
+    model,
+    candidate_bids_subquery,
+    *,
+    alias_name: str,
+):
+    latest_outline_rows_subquery = (
+        db.session.query(
+            model.shifu_bid.label("shifu_bid"),
+            model.outline_item_bid.label("outline_item_bid"),
+            db.func.max(model.id).label("max_id"),
+        )
+        .join(
+            candidate_bids_subquery,
+            model.shifu_bid == candidate_bids_subquery.c.shifu_bid,
+        )
+        .group_by(model.shifu_bid, model.outline_item_bid)
+        .cte(f"{alias_name}_latest_rows")
+    )
+    current_outline_rows_subquery = (
+        db.session.query(
+            model.shifu_bid.label("shifu_bid"),
+            model.updated_at.label("updated_at"),
+            model.updated_user_bid.label("updated_user_bid"),
+            model.id.label("id"),
+        )
+        .join(
+            latest_outline_rows_subquery,
+            model.id == latest_outline_rows_subquery.c.max_id,
+        )
+        .filter(model.deleted == 0)
+        .cte(f"{alias_name}_current_rows")
+    )
+    ranked_outline_activity_subquery = db.session.query(
+        current_outline_rows_subquery.c.shifu_bid.label("shifu_bid"),
+        current_outline_rows_subquery.c.updated_at.label("updated_at"),
+        current_outline_rows_subquery.c.updated_user_bid.label("updated_user_bid"),
+        db.func.row_number()
+        .over(
+            partition_by=current_outline_rows_subquery.c.shifu_bid,
+            order_by=[
+                current_outline_rows_subquery.c.updated_at.desc(),
+                current_outline_rows_subquery.c.id.desc(),
+            ],
+        )
+        .label("row_num"),
+    ).cte(f"{alias_name}_ranked")
+    return (
+        db.session.query(
+            ranked_outline_activity_subquery.c.shifu_bid.label("shifu_bid"),
+            ranked_outline_activity_subquery.c.updated_at.label("updated_at"),
+            ranked_outline_activity_subquery.c.updated_user_bid.label(
+                "updated_user_bid"
+            ),
+        )
+        .filter(ranked_outline_activity_subquery.c.row_num == 1)
+        .cte(alias_name)
+    )
+
+
+def _build_operator_course_latest_activity_subquery(
+    candidate_bids_subquery,
+    draft_visible_subquery,
+    published_visible_subquery,
+):
+    draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
+        DraftOutlineItem,
+        candidate_bids_subquery,
+        alias_name="operator_course_draft_outline_activity",
+    )
+    published_outline_activity_subquery = _build_latest_outline_activity_subquery(
+        PublishedOutlineItem,
+        candidate_bids_subquery,
+        alias_name="operator_course_published_outline_activity",
+    )
+
+    activity_sources_subquery = (
+        db.session.query(
+            draft_visible_subquery.c.shifu_bid.label("shifu_bid"),
+            draft_visible_subquery.c.updated_at.label("updated_at"),
+            draft_visible_subquery.c.updated_user_bid.label("updated_user_bid"),
+            literal(2).label("priority"),
+        )
+        .union_all(
+            db.session.query(
+                published_visible_subquery.c.shifu_bid.label("shifu_bid"),
+                published_visible_subquery.c.updated_at.label("updated_at"),
+                published_visible_subquery.c.updated_user_bid.label("updated_user_bid"),
+                literal(1).label("priority"),
+            ),
+            db.session.query(
+                draft_outline_activity_subquery.c.shifu_bid.label("shifu_bid"),
+                draft_outline_activity_subquery.c.updated_at.label("updated_at"),
+                draft_outline_activity_subquery.c.updated_user_bid.label(
+                    "updated_user_bid"
+                ),
+                literal(3).label("priority"),
+            ),
+            db.session.query(
+                published_outline_activity_subquery.c.shifu_bid.label("shifu_bid"),
+                published_outline_activity_subquery.c.updated_at.label("updated_at"),
+                published_outline_activity_subquery.c.updated_user_bid.label(
+                    "updated_user_bid"
+                ),
+                literal(4).label("priority"),
+            ),
+        )
+        .cte("operator_course_activity_sources")
+    )
+    ranked_activity_subquery = db.session.query(
+        activity_sources_subquery.c.shifu_bid.label("shifu_bid"),
+        activity_sources_subquery.c.updated_at.label("updated_at"),
+        activity_sources_subquery.c.updated_user_bid.label("updated_user_bid"),
+        db.func.row_number()
+        .over(
+            partition_by=activity_sources_subquery.c.shifu_bid,
+            order_by=[
+                activity_sources_subquery.c.updated_at.desc(),
+                activity_sources_subquery.c.priority.desc(),
+            ],
+        )
+        .label("row_num"),
+    ).cte("operator_course_ranked_activity")
+    return (
+        db.session.query(
+            ranked_activity_subquery.c.shifu_bid.label("shifu_bid"),
+            ranked_activity_subquery.c.updated_at.label("updated_at"),
+            ranked_activity_subquery.c.updated_user_bid.label("updated_user_bid"),
+        )
+        .filter(ranked_activity_subquery.c.row_num == 1)
+        .cte("operator_course_latest_activity")
+    )
 
 
 def _build_latest_shifus_query(
@@ -7613,6 +7772,7 @@ def list_operator_courses(
             creator_bids=creator_bids,
             start_time=start_time,
             end_time=end_time,
+            include_activity=True,
         )
         if candidate_query is None:
             return AdminOperationCourseListDTO(
@@ -7667,62 +7827,32 @@ def list_operator_courses(
                         candidate_subquery.c.shifu_bid.in_(paid_course_query)
                     )
 
-        candidate_rows = [
-            _build_operator_course_list_candidate(row) for row in query.all()
-        ]
-
-        candidate_shifu_bids = [
-            str(course.shifu_bid or "").strip()
-            for course in candidate_rows
-            if str(course.shifu_bid or "").strip()
-        ]
-        draft_activity_rows = _load_latest_courses_by_shifu_bids(
-            DraftShifu,
-            candidate_shifu_bids,
-            lightweight=True,
-        )
-        published_activity_rows = _load_latest_courses_by_shifu_bids(
-            PublishedShifu,
-            candidate_shifu_bids,
-            lightweight=True,
-        )
-        activity_map = _load_course_activity_map(
-            draft_activity_rows,
-            published_activity_rows,
-        )
-
-        def resolve_activity(course) -> Dict[str, Any]:
-            return activity_map.get(str(course.shifu_bid or "").strip(), {})
-
-        def resolve_updated_at(course) -> Optional[datetime]:
-            activity = resolve_activity(course)
-            return activity.get("updated_at") or course.updated_at
-
         if updated_start_time:
-            candidate_rows = [
-                course
-                for course in candidate_rows
-                if (resolve_updated_at(course) or datetime.min) >= updated_start_time
-            ]
+            query = query.filter(
+                candidate_subquery.c.activity_updated_at >= updated_start_time
+            )
         if updated_end_time:
-            candidate_rows = [
-                course
-                for course in candidate_rows
-                if (resolve_updated_at(course) or datetime.min) <= updated_end_time
-            ]
+            query = query.filter(
+                or_(
+                    candidate_subquery.c.activity_updated_at.is_(None),
+                    candidate_subquery.c.activity_updated_at <= updated_end_time,
+                )
+            )
 
-        candidate_rows = sorted(
-            candidate_rows,
-            key=lambda item: (
-                resolve_updated_at(item) or datetime.min,
-                item.created_at or datetime.min,
-                item.shifu_bid or "",
-            ),
-            reverse=True,
-        )
-        total = len(candidate_rows)
+        total = int(query.count() or 0)
         page_offset = (safe_page_index - 1) * safe_page_size
-        page_items = candidate_rows[page_offset : page_offset + safe_page_size]
+        page_rows = (
+            query.order_by(
+                candidate_subquery.c.activity_updated_at.desc(),
+                candidate_subquery.c.created_at.desc(),
+                candidate_subquery.c.shifu_bid.desc(),
+            )
+            .offset(page_offset)
+            .limit(safe_page_size)
+            .all()
+        )
+        page_items = [_build_operator_course_list_candidate(row) for row in page_rows]
+
         draft_page_items = [
             course for course in page_items if course.selected_source == "draft"
         ]
@@ -7731,6 +7861,13 @@ def list_operator_courses(
         ]
         _attach_course_prompt_flags(DraftShifu, draft_page_items)
         _attach_course_prompt_flags(PublishedShifu, published_page_items)
+
+        def resolve_activity(course) -> Dict[str, Any]:
+            return {
+                "updated_at": course.activity_updated_at or course.updated_at,
+                "updated_user_bid": course.activity_updated_user_bid
+                or course.updated_user_bid,
+            }
 
         user_bids = {
             user_bid

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -27,7 +27,7 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationCourseOverviewDTO,
     AdminOperationCourseSummaryDTO,
 )
-from flaskr.service.shifu.models import PublishedShifu
+from flaskr.service.shifu.models import PublishedOutlineItem, PublishedShifu
 from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 
 
@@ -1189,6 +1189,7 @@ def test_list_operator_courses_sql_path_preserves_merge_visibility_and_activity_
                 },
             }
             result = list_operator_courses(app, 1, 20, {})
+            second_page_result = list_operator_courses(app, 2, 1, {})
 
     assert result.total == 3
     assert [item.shifu_bid for item in result.items] == [
@@ -1203,6 +1204,83 @@ def test_list_operator_courses_sql_path_preserves_merge_visibility_and_activity_
     assert result.items[0].updater_nickname == "Editor One"
     assert result.items[1].course_status == "unpublished"
     assert result.items[2].course_status == "published"
+    assert second_page_result.total == 3
+    assert second_page_result.page == 2
+    assert second_page_result.page_count == 3
+    assert [item.shifu_bid for item in second_page_result.items] == [draft_only_bid]
+
+
+def test_list_operator_courses_sql_path_uses_current_outline_revisions_only(app):
+    creator_bid = uuid.uuid4().hex[:32]
+    shifu_bid = uuid.uuid4().hex[:32]
+    outline_item_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        DraftOutlineItem.query.delete()
+        PublishedOutlineItem.query.delete()
+        PublishedShifu.query.delete()
+        DraftShifu.query.delete()
+        db.session.commit()
+
+        db.session.add(
+            DraftShifu(
+                shifu_bid=shifu_bid,
+                title="Current Outline Revision Course",
+                description="desc",
+                avatar_res_bid="",
+                keywords="",
+                llm="gpt-test",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                price=Decimal("19"),
+                created_user_bid=creator_bid,
+                updated_user_bid=creator_bid,
+                created_at=datetime(2025, 4, 1, 9, 0, 0),
+                updated_at=datetime(2025, 4, 1, 10, 0, 0),
+            )
+        )
+        db.session.flush()
+        db.session.add_all(
+            [
+                DraftOutlineItem(
+                    outline_item_bid=outline_item_bid,
+                    shifu_bid=shifu_bid,
+                    title="Old Active Revision",
+                    parent_bid="",
+                    position="1",
+                    created_user_bid=creator_bid,
+                    updated_user_bid="old-outline-editor",
+                    updated_at=datetime(2025, 5, 5, 10, 0, 0),
+                ),
+                DraftOutlineItem(
+                    outline_item_bid=outline_item_bid,
+                    shifu_bid=shifu_bid,
+                    title="Current Deleted Revision",
+                    parent_bid="",
+                    position="1",
+                    deleted=1,
+                    created_user_bid=creator_bid,
+                    updated_user_bid="deleted-outline-editor",
+                    updated_at=datetime(2025, 5, 6, 10, 0, 0),
+                ),
+            ]
+        )
+        db.session.commit()
+
+        result = list_operator_courses(app, 1, 20, {})
+        filtered_result = list_operator_courses(
+            app,
+            1,
+            20,
+            {"updated_start_time": datetime(2025, 5, 1, 0, 0, 0)},
+        )
+
+    assert result.total == 1
+    assert result.items[0].shifu_bid == shifu_bid
+    assert result.items[0].updated_at == "2025-04-01T10:00:00Z"
+    assert result.items[0].updater_user_bid == creator_bid
+    assert filtered_result.total == 0
+    assert filtered_result.items == []
 
 
 def test_list_operator_courses_sql_path_filters_trimmed_builtin_demo_courses(app):


### PR DESCRIPTION
## Summary
- Move operator course list activity filtering, sorting, and pagination into the SQL path.
- Keep page-level enrichment for prompt flags and creator/updater details after pagination.
- Add regression coverage for SQL-path course pagination after activity ordering.

## Validation
- `cd src/api && pytest tests/service/shifu/test_admin_courses.py tests/service/shifu/test_admin_course_detail.py -q`
- `cd src/cook-web && npm test -- src/app/admin/operations/page.test.tsx --runInBand`
- `pre-commit run ruff-check --files src/api/flaskr/service/shifu/admin.py src/api/tests/service/shifu/test_admin_courses.py`
- `pre-commit run ruff-format --files src/api/flaskr/service/shifu/admin.py src/api/tests/service/shifu/test_admin_courses.py`
- `git diff --check`
- `/Users/iris/.codex/bin/branch_context_manager.py sync && /Users/iris/.codex/bin/branch_context_manager.py report && /Users/iris/.codex/bin/branch_context_manager.py pre-pr-review && /Users/iris/.codex/bin/branch_context_manager.py pre-push-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized course-listing queries so activity-based filtering, sorting, and pagination are executed in the database for faster, more consistent results.

* **New Features**
  * Listings show computed "latest activity" (timestamp and user/bid) and use that for ordering and filters.
  * Pagination metadata now reflects accurate totals and page counts.

* **Tests**
  * Added and updated tests to validate activity-aware listing, pagination, and revision visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->