### PR TITLE
fix: skip empty listen-mode TTS blocks

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1222,14 +1222,6 @@ def stream_generated_block_audio(
                 )
                 return
 
-        provider, tts_model, voice_settings, _audio_settings = (
-            _resolve_shifu_tts_settings(
-                app,
-                shifu_bid=shifu_bid,
-                preview_mode=preview_mode,
-            )
-        )
-
         if listen:
             from flaskr.service.learn.listen_element_history import (
                 get_final_elements_for_generated_block,
@@ -1245,10 +1237,26 @@ def stream_generated_block_audio(
                 str(element.content_text or "") for element in speakable_elements
             ]
             if not speakable_segments:
-                raise_error_with_args(
-                    "server.common.paramsError",
-                    param_message="No speakable text elements available for TTS synthesis",
+                app.logger.info(
+                    "skip listen-mode generated block TTS: no speakable elements, "
+                    "shifu_bid=%s, generated_block_bid=%s, user_bid=%s",
+                    shifu_bid,
+                    generated_block_bid,
+                    user_bid,
                 )
+                yield _build_tts_done_message(
+                    outline_bid=generated_block.outline_item_bid or "",
+                    generated_block_bid=generated_block_bid,
+                )
+                return
+
+            provider, tts_model, voice_settings, _audio_settings = (
+                _resolve_shifu_tts_settings(
+                    app,
+                    shifu_bid=shifu_bid,
+                    preview_mode=preview_mode,
+                )
+            )
 
             expected_segment_count = len(speakable_segments)
             existing_by_position: dict[int, LearnGeneratedAudio] = {}
@@ -1351,6 +1359,14 @@ def stream_generated_block_audio(
             )
 
             return
+
+        provider, tts_model, voice_settings, _audio_settings = (
+            _resolve_shifu_tts_settings(
+                app,
+                shifu_bid=shifu_bid,
+                preview_mode=preview_mode,
+            )
+        )
 
         cleaned_text = preprocess_for_tts(raw_text)
         if not cleaned_text or len(cleaned_text.strip()) < 2:

--- a/src/api/tests/test_learn_api.py
+++ b/src/api/tests/test_learn_api.py
@@ -1,7 +1,13 @@
 from decimal import Decimal
 
 from flaskr.dao import db
-from flaskr.service.learn.learn_funcs import get_outline_item_tree, get_shifu_info
+from flaskr.service.learn.learn_dtos import GeneratedType
+from flaskr.service.learn.learn_funcs import (
+    get_outline_item_tree,
+    get_shifu_info,
+    stream_generated_block_audio,
+)
+from flaskr.service.learn.models import LearnGeneratedBlock
 from flaskr.service.shifu.models import DraftOutlineItem, LogDraftStruct, PublishedShifu
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
@@ -23,6 +29,48 @@ def test_get_shifu_info_returns_dto(app):
     assert dto.title == "Test Shifu"
     assert dto.price == "9.99"
     assert dto.keywords == ["a", "b"]
+
+
+def test_stream_generated_block_audio_listen_skips_blocks_without_speakable_elements(
+    app, monkeypatch
+):
+    with app.app_context():
+        block = LearnGeneratedBlock(
+            generated_block_bid="generated-block-empty-tts",
+            progress_record_bid="progress-1",
+            user_bid="user-1",
+            block_bid="block-1",
+            outline_item_bid="outline-1",
+            shifu_bid="shifu-learn-1",
+            generated_content="",
+            status=1,
+            deleted=0,
+        )
+        db.session.add(block)
+        db.session.commit()
+
+    from flaskr.service.learn import listen_element_history
+
+    monkeypatch.setattr(
+        listen_element_history,
+        "get_final_elements_for_generated_block",
+        lambda **_kwargs: [],
+    )
+
+    events = list(
+        stream_generated_block_audio(
+            app,
+            shifu_bid="shifu-learn-1",
+            generated_block_bid="generated-block-empty-tts",
+            user_bid="user-1",
+            preview_mode=False,
+            listen=True,
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0].type == GeneratedType.DONE
+    assert events[0].generated_block_bid == "generated-block-empty-tts"
 
 
 def test_get_outline_item_tree_preview_mode(app):


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-02 13:46 左右多条生产告警：

- `POST /api/learn/shifu/<shifu_bid>/generated-blocks/<generated_block_bid>/tts?listen=true`
- 日志：`synthesize generated block audio failed`
- 异常：`参数错误 No speakable text elements available for TTS synthesis`
- 示例课程/块：`shifu_bid=ba91abb2b57e4edfb5855144dc780220`，多个 generated block 在听课模式 TTS 批量合成时触发。

## 修复内容

听课模式下，generated block 可能只包含图片/交互/其他非文本元素，没有可朗读文本。这种情况不应按后端错误抛出并触发运维告警。

本 PR 调整为：

- `listen=true` 且无 speakable elements 时，记录 info 日志；
- 直接返回 TTS `done` 事件并结束流；
- 延后解析 TTS provider/settings，避免无可朗读内容时做不必要配置校验；
- 增加单元测试覆盖空可朗读元素场景。

## 验证

- `python3 -m py_compile src/api/flaskr/service/learn/learn_funcs.py src/api/tests/test_learn_api.py` ✅
- `git diff --check` ✅
- `python3 -m pytest src/api/tests/test_learn_api.py -q` 未运行成功：当前机器系统 Python 缺少 pytest（`No module named pytest`），workspace 里的历史 venv Python 软链指向不存在的 `python3.14`。

## 备注

同窗口内的短信模板 `InvalidPageSize` 告警属于昨日已创建的修复 PR #1860 覆盖的问题，本 PR 不重复处理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved audio generation efficiency by skipping content blocks without speakable elements in listen mode, eliminating unnecessary processing and providing clearer feedback.

* **Tests**
  * Added test coverage for audio generation behavior when handling blocks without speakable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->