### PR TITLE
feat: optimize operator user course counts

### DIFF
--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -4562,6 +4562,7 @@ def _load_operator_user_course_count_maps(
         end_time=None,
         updated_start_time=None,
         updated_end_time=None,
+        lightweight=True,
     )
     created_published = _load_latest_shifus(
         PublishedShifu,
@@ -4572,6 +4573,7 @@ def _load_operator_user_course_count_maps(
         end_time=None,
         updated_start_time=None,
         updated_end_time=None,
+        lightweight=True,
     )
     merged_created_courses, _, _ = _merge_courses(created_drafts, created_published)
     for course in merged_created_courses:
@@ -4636,9 +4638,15 @@ def _load_operator_user_course_count_maps(
             if str(row.shifu_bid or "").strip()
         }
     )
-    learned_drafts = _load_latest_courses_by_shifu_bids(DraftShifu, learned_shifu_bids)
+    learned_drafts = _load_latest_courses_by_shifu_bids(
+        DraftShifu,
+        learned_shifu_bids,
+        lightweight=True,
+    )
     learned_published = _load_latest_courses_by_shifu_bids(
-        PublishedShifu, learned_shifu_bids
+        PublishedShifu,
+        learned_shifu_bids,
+        lightweight=True,
     )
     merged_learned_courses, _, _ = _merge_courses(learned_drafts, learned_published)
     visible_learned_shifu_bids = {

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1184,6 +1184,48 @@ def test_list_operator_users_returns_learning_and_created_courses(app):
     ]
 
 
+def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch):
+    load_calls = []
+
+    def fake_load_latest_shifus(model, **kwargs):
+        load_calls.append(("latest", model.__name__, kwargs.get("lightweight")))
+        return []
+
+    def fake_load_latest_courses_by_shifu_bids(
+        model,
+        shifu_bids,
+        *,
+        lightweight=False,
+    ):
+        load_calls.append(("by_bids", model.__name__, tuple(shifu_bids), lightweight))
+        return []
+
+    monkeypatch.setattr(
+        admin_module,
+        "_load_latest_shifus",
+        fake_load_latest_shifus,
+    )
+    monkeypatch.setattr(
+        admin_module,
+        "_load_latest_courses_by_shifu_bids",
+        fake_load_latest_courses_by_shifu_bids,
+    )
+
+    with app.app_context():
+        created_count_map, learning_count_map = (
+            admin_module._load_operator_user_course_count_maps(["user-no-activity"])
+        )
+
+    assert created_count_map == {"user-no-activity": 0}
+    assert learning_count_map == {"user-no-activity": 0}
+    assert load_calls == [
+        ("latest", "DraftShifu", True),
+        ("latest", "PublishedShifu", True),
+        ("by_bids", "DraftShifu", (), True),
+        ("by_bids", "PublishedShifu", (), True),
+    ]
+
+
 def test_list_operator_users_includes_creator_credit_summaries(app):
     with app.app_context():
         active_start_at, active_end_at = _build_active_window()


### PR DESCRIPTION
## Summary
- use lightweight course rows when calculating operator user created/learning course counts
- keep operator user list API shape and filtering behavior unchanged
- add regression coverage to prevent count paths from loading full course objects

## Tests
- cd src/api && pytest tests/service/shifu/test_admin_users.py -q
- cd src/cook-web && npm test -- src/app/admin/operations/users/page.test.tsx --runInBand
- pre-commit run -a

## Notes
- API and nginx were restarted locally; /api/runtime-config returned 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of user course count operations.

* **Tests**
  * Added test coverage validating user course count computation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->