### PR TITLE
fix: handle empty mdflow risk control text

### DIFF
--- a/src/api/flaskr/service/check_risk/funcs.py
+++ b/src/api/flaskr/service/check_risk/funcs.py
@@ -22,7 +22,7 @@ def add_risk_control_result(
         risk_control_result = RiskControlResult(
             chat_id=chat_id,
             user_id=user_id,
-            text=text,
+            text=text or "",
             check_vendor=check_vendor,
             check_result=check_result,
             check_resp=check_resp,
@@ -35,8 +35,17 @@ def add_risk_control_result(
 
 
 def check_text_with_risk_control(
-    app: Flask, check_id: str, user_id: str, text: str
+    app: Flask, check_id: str, user_id: str, text: str | None
 ) -> CheckResultDTO:
+    if text is None or text == "":
+        return CheckResultDTO(
+            check_result=CHECK_RESULT_PASS,
+            risk_labels=[],
+            risk_label_ids=[],
+            provider="skip_empty",
+            raw_data={"reason": "empty_text"},
+        )
+
     log_id = check_id + datetime.now().strftime("%Y%m%d%H%M%S")
 
     res = check_text(app, log_id, text, user_id)

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1507,7 +1507,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         """
         user_id = request.user.user_id
         json_data = request.get_json() or {}
-        content = json_data.get("data")
+        content = json_data.get("data") or ""
         base_revision = json_data.get("base_revision")
         if base_revision is not None:
             try:

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -152,6 +152,7 @@ def save_shifu_mdflow(
     """
     Save shifu mdflow
     """
+    content = content or ""
     with app.app_context():
         lock_latest = isinstance(base_revision, int) and base_revision >= 0
         outline_query = DraftOutlineItem.query.filter(

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -310,6 +310,50 @@ def test_save_shifu_mdflow_conflicts_when_outline_deleted(app):
     assert result["meta"]["revision"] == deleted_revision
 
 
+def test_save_shifu_mdflow_normalizes_none_content(app, monkeypatch):
+    shifu_bid = "shifu-mdflow-none-content-1"
+    outline_bid = "outline-mdflow-none-content-1"
+
+    base_id = _add_outline_version(
+        app, shifu_bid, outline_bid, "Original", "user-none-content-1", 0
+    )
+    risk_checked_texts = []
+
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.check_text_with_risk_control",
+        lambda _app, _check_id, _user_id, text: risk_checked_texts.append(text),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.get_profile_item_definition_list",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.add_profile_item_quick",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.save_outline_history",
+        lambda *_args, **_kwargs: 999999,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.cleanup_outline_history_versions",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = save_shifu_mdflow(
+        app,
+        "user-none-content-2",
+        shifu_bid,
+        outline_bid,
+        None,
+        base_revision=base_id,
+    )
+
+    assert result["conflict"] is False
+    assert risk_checked_texts == [""]
+    assert get_shifu_mdflow(app, shifu_bid, outline_bid) == ""
+
+
 def test_save_shifu_mdflow_returns_outline_revision_not_history_log(app, monkeypatch):
     shifu_bid = "shifu-mdflow-revision-1"
     outline_bid = "outline-mdflow-revision-1"

--- a/src/cook-web/src/store/useShifu.tsx
+++ b/src/cook-web/src/store/useShifu.tsx
@@ -1835,9 +1835,12 @@ export const ShifuProvider = ({
     }
     const shifu_bid = payload?.shifu_bid ?? currentShifu?.bid ?? '';
     const outline_bid = payload?.outline_bid ?? (currentNode?.bid || '');
-    const data = payload?.data ?? currentMdflow.current;
+    const data = payload?.data ?? currentMdflow.current ?? '';
     const resolvedBaseRevision =
       payload?.base_revision ?? baseRevision ?? undefined;
+    if (!shifu_bid || !outline_bid) {
+      return;
+    }
     if (saveMdflowLockRef.current.inflight) {
       if (outline_bid && saveMdflowLockRef.current.outlineId !== outline_bid) {
         // When another outline save is in-flight, skip cross-outline saves


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-03 10:09 左右连续告警：

- `POST /api/shifu/shifus/e7e8eb072a3f4bfd80b0d33f5a505bd5/outlines/*/mdflow`
- `save_shifu_mdflow -> check_text_with_risk_control -> add_risk_control_result`
- MySQL `IntegrityError: (1048, "Column 'text' cannot be null")`
- 插入 `risk_control_result.text` 时参数为 `None`

## 修复内容

- 后端保存 mdflow 时将缺失/空的 `data` 规范化为空字符串，避免 `None` 继续进入风控检查和草稿内容。
- 风控结果入库时兜底 `text or ""`，避免其它调用方传空导致非业务 500。
- 空文本风控直接返回通过并标记 `provider=skip_empty`，不再调用外部文本审核。
- 前端保存 mdflow 时兜底空字符串，并在缺少 `shifu_bid` / `outline_bid` 时跳过保存，减少异常请求。
- 增加 `save_shifu_mdflow(None)` 回归测试。

## 验证

- 基于最新 `origin/main`（`b93d888a`）创建修复分支。
- `python3 -m py_compile src/api/flaskr/service/check_risk/funcs.py src/api/flaskr/service/shifu/route.py src/api/flaskr/service/shifu/shifu_mdflow_funcs.py src/api/tests/test_mdflow_adapter.py` ✅
- `git diff --check HEAD~1..HEAD` ✅
- `python3 -m pytest src/api/tests/test_mdflow_adapter.py::test_save_shifu_mdflow_normalizes_none_content -q` 未运行成功：本机系统 Python 未安装 pytest（`No module named pytest`）。

## 巡检备注

同一 24h 内其它告警已去重/跳过：短信手机号格式/流控属于外部输入或供应商限制；听课 TTS 无可朗读文本已由 #1862 覆盖；TTS preview 资源与音色不匹配更像供应商资源配置/音色选择问题，未在本 PR 中硬改。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Risk checking now handles empty or null text by marking checks as passed with empty risk labels.
  * Content saving operations normalize missing values to empty strings to prevent null propagation.
  * Added validation to skip save operations when required identifiers are missing.

* **Tests**
  * Added test to verify proper normalization of null content during save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->