### PR TITLE
feat: align preview regenerate with block flow

### DIFF
--- a/src/cook-web/src/__tests__/preview-submission.test.ts
+++ b/src/cook-web/src/__tests__/preview-submission.test.ts
@@ -91,4 +91,30 @@ describe('preview submission helpers', () => {
       ),
     ).toBe(2);
   });
+
+  it('returns 0 when resolving regenerate fallback block index with empty items', () => {
+    expect(resolvePreviewRegenerateFallbackBlockIndex([], 0)).toBe(0);
+  });
+
+  it('clamps out-of-range block indexes before resolving regenerate fallback block index', () => {
+    expect(
+      resolvePreviewRegenerateFallbackBlockIndex(
+        [
+          { type: ChatContentItemType.CONTENT, element_index: 0 },
+          { type: ChatContentItemType.INTERACTION, element_index: 1 },
+        ],
+        99,
+      ),
+    ).toBe(1);
+
+    expect(
+      resolvePreviewRegenerateFallbackBlockIndex(
+        [
+          { type: ChatContentItemType.LIKE_STATUS },
+          { type: ChatContentItemType.CONTENT, element_index: 4 },
+        ],
+        -2,
+      ),
+    ).toBe(0);
+  });
 });

--- a/src/cook-web/src/__tests__/preview-submission.test.ts
+++ b/src/cook-web/src/__tests__/preview-submission.test.ts
@@ -1,6 +1,7 @@
 import {
   buildPreviewInteractionUserInput,
   resolvePreviewGeneratedBlockBid,
+  resolvePreviewRegenerateStartIndex,
   resolvePreviewRequestBlockIndex,
 } from '@/components/lesson-preview/preview-submission';
 
@@ -36,5 +37,28 @@ describe('preview submission helpers', () => {
         fallbackBid: 'preview-element-1',
       }),
     ).toBe('7');
+  });
+
+  it('resolves regenerate truncation to the first item of the same block', () => {
+    expect(
+      resolvePreviewRegenerateStartIndex(
+        [
+          { element_bid: 'block-0-a', generated_block_bid: '0' },
+          { element_bid: 'block-1-a', generated_block_bid: '1' },
+          { element_bid: 'block-1-b', generated_block_bid: '1' },
+          { element_bid: 'block-2-a', generated_block_bid: '2' },
+        ],
+        2,
+      ),
+    ).toBe(1);
+  });
+
+  it('falls back to the target index when the block bid is missing', () => {
+    expect(
+      resolvePreviewRegenerateStartIndex(
+        [{ element_bid: 'preview-runtime-1', generated_block_bid: '' }],
+        0,
+      ),
+    ).toBe(0);
   });
 });

--- a/src/cook-web/src/__tests__/preview-submission.test.ts
+++ b/src/cook-web/src/__tests__/preview-submission.test.ts
@@ -1,9 +1,11 @@
 import {
   buildPreviewInteractionUserInput,
   resolvePreviewGeneratedBlockBid,
+  resolvePreviewRegenerateFallbackBlockIndex,
   resolvePreviewRegenerateStartIndex,
   resolvePreviewRequestBlockIndex,
 } from '@/components/lesson-preview/preview-submission';
+import { ChatContentItemType } from '@/c-types/chatUi';
 
 describe('preview submission helpers', () => {
   it('falls back to current block_index when generated_block_bid is not numeric', () => {
@@ -60,5 +62,33 @@ describe('preview submission helpers', () => {
         0,
       ),
     ).toBe(0);
+  });
+
+  it('prefers the item element_index when resolving regenerate fallback block index', () => {
+    expect(
+      resolvePreviewRegenerateFallbackBlockIndex(
+        [
+          { type: ChatContentItemType.CONTENT, element_index: 0 },
+          { type: ChatContentItemType.LIKE_STATUS },
+          { type: ChatContentItemType.CONTENT, element_index: 3 },
+        ],
+        2,
+      ),
+    ).toBe(3);
+  });
+
+  it('counts only actionable items when element_index is missing', () => {
+    expect(
+      resolvePreviewRegenerateFallbackBlockIndex(
+        [
+          { type: ChatContentItemType.CONTENT },
+          { type: ChatContentItemType.LIKE_STATUS },
+          { type: ChatContentItemType.ASK },
+          { type: ChatContentItemType.INTERACTION },
+          { type: ChatContentItemType.CONTENT },
+        ],
+        4,
+      ),
+    ).toBe(2);
   });
 });

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
@@ -234,6 +234,53 @@ describe('LessonPreview billing action', () => {
     expect(onRefresh).toHaveBeenCalledWith('text-1');
   });
 
+  test('prefers a text parent when generated block items include mixed element types', () => {
+    const onRefresh = jest.fn();
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'text-1',
+        generated_block_bid: '0',
+        content: '第一段内容',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        is_final: true,
+      },
+      {
+        element_bid: 'html-1',
+        generated_block_bid: '0',
+        content: '<div>rich block</div>',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'html',
+        is_final: true,
+      },
+      {
+        element_bid: 'feedback-1',
+        generated_block_bid: 'feedback-1',
+        parent_element_bid: '',
+        parent_block_bid: '0',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={onRefresh}
+        onSend={jest.fn()}
+        showGenerateBtn
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'regenerate-text-1' }));
+
+    expect(onRefresh).toHaveBeenCalledWith('text-1');
+    expect(
+      screen.queryByRole('button', { name: 'regenerate-html-1' }),
+    ).not.toBeInTheDocument();
+  });
+
   test('does not expose regenerate when the preview generate action is disabled', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
@@ -80,8 +80,25 @@ jest.mock('@/c-components/ChatUi/ContentBlock', () => ({
 
 jest.mock('@/c-components/ChatUi/InteractionBlock', () => ({
   __esModule: true,
-  default: ({ element_bid }: { element_bid?: string }) => (
-    <div data-testid='interaction-block'>{element_bid}</div>
+  default: ({
+    element_bid,
+    showGenerateBtn,
+    onRefresh,
+  }: {
+    element_bid?: string;
+    showGenerateBtn?: boolean;
+    onRefresh?: (elementBid: string) => void;
+  }) => (
+    <div data-testid='interaction-block'>
+      <span>{element_bid}</span>
+      {showGenerateBtn ? (
+        <button
+          type='button'
+          aria-label={`regenerate-${element_bid}`}
+          onClick={() => onRefresh?.(element_bid || '')}
+        />
+      ) : null}
+    </div>
   ),
 }));
 
@@ -177,6 +194,172 @@ describe('LessonPreview billing action', () => {
     expect(screen.queryByText('typing')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'finish-text-1' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('routes preview regenerate from helper row to the parent content item', () => {
+    const onRefresh = jest.fn();
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'text-1',
+        generated_block_bid: '0',
+        content: '第一段内容',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        is_final: true,
+        is_speakable: true,
+      },
+      {
+        element_bid: 'text-1-feedback',
+        generated_block_bid: 'text-1-feedback',
+        parent_element_bid: 'text-1',
+        parent_block_bid: '0',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={onRefresh}
+        onSend={jest.fn()}
+        showGenerateBtn
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'regenerate-text-1' }));
+
+    expect(onRefresh).toHaveBeenCalledWith('text-1');
+  });
+
+  test('does not expose regenerate when the preview generate action is disabled', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'text-1',
+        generated_block_bid: '0',
+        content: '第一段内容',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        is_final: true,
+        is_speakable: true,
+      },
+      {
+        element_bid: 'text-1-feedback',
+        generated_block_bid: 'text-1-feedback',
+        parent_element_bid: 'text-1',
+        parent_block_bid: '0',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'regenerate-text-1' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not expose regenerate for helper rows without a valid parent item', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'missing-parent-feedback',
+        generated_block_bid: 'missing-parent-feedback',
+        parent_element_bid: 'missing-parent',
+        parent_block_bid: '9',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+        showGenerateBtn
+      />,
+    );
+
+    expect(screen.queryByTestId('interaction-block')).not.toBeInTheDocument();
+  });
+
+  test('does not expose regenerate for interaction parent blocks', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'interaction-1',
+        generated_block_bid: '2',
+        content: '["完全不了解","略知一二"]',
+        type: ChatContentItemType.INTERACTION,
+        is_final: true,
+      },
+      {
+        element_bid: 'interaction-1-feedback',
+        generated_block_bid: 'interaction-1-feedback',
+        parent_element_bid: 'interaction-1',
+        parent_block_bid: '2',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+        showGenerateBtn
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'regenerate-interaction-1' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not expose regenerate for non-text content blocks', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'rich-1',
+        generated_block_bid: '3',
+        content: '<div>rich block</div>',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'html',
+        is_final: true,
+      },
+      {
+        element_bid: 'rich-1-feedback',
+        generated_block_bid: 'rich-1-feedback',
+        parent_element_bid: 'rich-1',
+        parent_block_bid: '3',
+        type: ChatContentItemType.LIKE_STATUS,
+      },
+    ];
+
+    render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+        showGenerateBtn
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'regenerate-rich-1' }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -71,6 +71,29 @@ interface LessonPreviewProps {
 const noop = () => {};
 const ENABLE_PREVIEW_TYPEWRITER = false;
 
+const isRegeneratablePreviewParent = (
+  item?: ChatContentItem,
+): item is ChatContentItem => {
+  if (!item) {
+    return false;
+  }
+
+  const itemBid = item.element_bid || item.generated_block_bid || '';
+  const generatedBlockBid = item.generated_block_bid || '';
+  if (
+    !itemBid ||
+    !generatedBlockBid ||
+    itemBid === 'loading' ||
+    generatedBlockBid === 'loading'
+  ) {
+    return false;
+  }
+
+  return (
+    item.type === ChatContentItemType.CONTENT && item.element_type === 'text'
+  );
+};
+
 const LessonPreview: React.FC<LessonPreviewProps> = ({
   loading,
   items = [],
@@ -134,6 +157,16 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
     items.forEach(item => {
       if (item.element_bid) {
         map.set(item.element_bid, item);
+      }
+    });
+    return map;
+  }, [items]);
+
+  const itemByGeneratedBlockBid = React.useMemo(() => {
+    const map = new Map<string, ChatContentItem>();
+    items.forEach(item => {
+      if (item.generated_block_bid) {
+        map.set(item.generated_block_bid, item);
       }
     });
     return map;
@@ -229,8 +262,6 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
     );
   }, [items]);
 
-  // console.log('visibleItems', visibleItems, items);
-
   return (
     <div className={cn(styles.lessonPreview, 'text-sm')}>
       <div className='flex items-baseline gap-2 pt-[4px]'>
@@ -287,11 +318,20 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
           {!showEmpty &&
             visibleItems.map((item, idx) => {
               if (item.type === ChatContentItemType.LIKE_STATUS) {
-                const parentBlockBid =
-                  item.parent_block_bid || item.parent_element_bid || '';
-                const parentContentItem = parentBlockBid
-                  ? itemByElementBid.get(parentBlockBid)
-                  : undefined;
+                const parentElementBid = item.parent_element_bid || '';
+                const parentBlockBid = item.parent_block_bid || '';
+                const parentContentItem =
+                  (parentElementBid
+                    ? itemByElementBid.get(parentElementBid)
+                    : undefined) ||
+                  (parentBlockBid
+                    ? itemByElementBid.get(parentBlockBid) ||
+                      itemByGeneratedBlockBid.get(parentBlockBid)
+                    : undefined);
+                const parentActionBid =
+                  parentContentItem?.element_bid ||
+                  parentElementBid ||
+                  parentBlockBid;
                 const isTextParent =
                   parentContentItem?.type === ChatContentItemType.CONTENT &&
                   parentContentItem?.element_type === 'text';
@@ -301,11 +341,18 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                 const parentPrimaryTrack = getAudioTrackByPosition(
                   parentContentItem?.audioTracks ?? [],
                 );
-                const hasPreviewAudioCapability = Boolean(
-                  onRequestAudioForBlock &&
-                  (parentContentItem?.element_bid || parentBlockBid),
+                const shouldRenderGenerateAction = Boolean(
+                  showGenerateBtn &&
+                  isRegeneratablePreviewParent(parentContentItem) &&
+                  parentActionBid,
                 );
-                if (!shouldRenderAudioAction || !hasPreviewAudioCapability) {
+                const hasPreviewAudioCapability = Boolean(
+                  onRequestAudioForBlock && parentActionBid,
+                );
+                if (
+                  !shouldRenderGenerateAction &&
+                  (!shouldRenderAudioAction || !hasPreviewAudioCapability)
+                ) {
                   return null;
                 }
                 return (
@@ -316,11 +363,12 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                   >
                     <InteractionBlock
                       shifu_bid={shifuBid}
-                      element_bid={parentBlockBid}
+                      element_bid={parentActionBid}
                       onRefresh={onRefresh}
                       onToggleAskExpanded={noop}
                       disableAskButton
                       disableInteractionButtons
+                      showGenerateBtn={shouldRenderGenerateAction}
                       extraActions={
                         onRequestAudioForBlock && shouldRenderAudioAction ? (
                           <AudioPlayer
@@ -335,7 +383,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                             onRequestAudio={() =>
                               onRequestAudioForBlock({
                                 shifuBid,
-                                blockId: parentBlockBid,
+                                blockId: parentActionBid,
                                 text: parentContentItem?.content || '',
                               })
                             }

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -94,6 +94,19 @@ const isRegeneratablePreviewParent = (
   );
 };
 
+const shouldPreferGeneratedBlockItem = (
+  currentItem: ChatContentItem,
+  nextItem: ChatContentItem,
+): boolean => {
+  if (isRegeneratablePreviewParent(currentItem)) {
+    return false;
+  }
+  if (isRegeneratablePreviewParent(nextItem)) {
+    return true;
+  }
+  return false;
+};
+
 const LessonPreview: React.FC<LessonPreviewProps> = ({
   loading,
   items = [],
@@ -166,7 +179,10 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
     const map = new Map<string, ChatContentItem>();
     items.forEach(item => {
       if (item.generated_block_bid) {
-        map.set(item.generated_block_bid, item);
+        const existing = map.get(item.generated_block_bid);
+        if (!existing || shouldPreferGeneratedBlockItem(existing, item)) {
+          map.set(item.generated_block_bid, item);
+        }
       }
     });
     return map;

--- a/src/cook-web/src/components/lesson-preview/preview-submission.ts
+++ b/src/cook-web/src/components/lesson-preview/preview-submission.ts
@@ -31,6 +31,20 @@ export const resolvePreviewRegenerateStartIndex = (
   return firstBlockIndex === -1 ? targetIndex : firstBlockIndex;
 };
 
+export const resolvePreviewRegenerateFallbackBlockIndex = (
+  items: Pick<ChatContentItem, 'type' | 'element_index'>[],
+  blockStartIndex: number,
+): number => {
+  const targetItem = items[blockStartIndex];
+  if (typeof targetItem?.element_index === 'number') {
+    return targetItem.element_index;
+  }
+
+  return items.slice(0, blockStartIndex).filter(item => {
+    return item.type === 'content' || item.type === 'interaction';
+  }).length;
+};
+
 export const buildPreviewInteractionUserInput = (
   variableName: string,
   values: string[],

--- a/src/cook-web/src/components/lesson-preview/preview-submission.ts
+++ b/src/cook-web/src/components/lesson-preview/preview-submission.ts
@@ -1,9 +1,34 @@
+import type { ChatContentItem } from '@/c-types/chatUi';
+
 export const resolvePreviewRequestBlockIndex = (
   generatedBlockBid: string,
   fallbackBlockIndex = 0,
 ): number => {
   const parsedValue = Number.parseInt(generatedBlockBid, 10);
   return Number.isNaN(parsedValue) ? fallbackBlockIndex : parsedValue;
+};
+
+export const resolvePreviewRegenerateStartIndex = (
+  items: Pick<ChatContentItem, 'generated_block_bid' | 'element_bid'>[],
+  targetIndex: number,
+): number => {
+  if (targetIndex < 0 || targetIndex >= items.length) {
+    return -1;
+  }
+
+  const targetItem = items[targetIndex];
+  const targetGeneratedBlockBid =
+    targetItem.generated_block_bid || targetItem.element_bid || '';
+  if (!targetGeneratedBlockBid) {
+    return targetIndex;
+  }
+
+  const firstBlockIndex = items.findIndex(
+    item =>
+      (item.generated_block_bid || item.element_bid || '') ===
+      targetGeneratedBlockBid,
+  );
+  return firstBlockIndex === -1 ? targetIndex : firstBlockIndex;
 };
 
 export const buildPreviewInteractionUserInput = (

--- a/src/cook-web/src/components/lesson-preview/preview-submission.ts
+++ b/src/cook-web/src/components/lesson-preview/preview-submission.ts
@@ -35,12 +35,20 @@ export const resolvePreviewRegenerateFallbackBlockIndex = (
   items: Pick<ChatContentItem, 'type' | 'element_index'>[],
   blockStartIndex: number,
 ): number => {
-  const targetItem = items[blockStartIndex];
+  if (!items.length) {
+    return 0;
+  }
+
+  const resolvedIndex = Math.min(
+    Math.max(blockStartIndex, 0),
+    items.length - 1,
+  );
+  const targetItem = items[resolvedIndex];
   if (typeof targetItem?.element_index === 'number') {
     return targetItem.element_index;
   }
 
-  return items.slice(0, blockStartIndex).filter(item => {
+  return items.slice(0, resolvedIndex).filter(item => {
     return item.type === 'content' || item.type === 'interaction';
   }).length;
 };

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -4,6 +4,80 @@ import {
   replacePreviewLoadingWithBusinessError,
 } from './usePreviewChat';
 
+jest.mock('sse.js', () => ({
+  SSE: jest.fn(),
+}));
+
+jest.mock('remark-flow', () => ({
+  createInteractionParser: () => ({
+    parseToRemarkFormat: jest.fn(),
+  }),
+}));
+
+jest.mock('@/c-api/studyV2', () => ({
+  ELEMENT_TYPE: {
+    TEXT: 'text',
+    HTML: 'html',
+    INTERACTION: 'interaction',
+  },
+  LIKE_STATUS: {
+    NONE: 'none',
+  },
+}));
+
+jest.mock('@/store', () => {
+  const useUserStore = jest.fn();
+  (
+    useUserStore as typeof useUserStore & {
+      getState: () => { getToken: () => string };
+    }
+  ).getState = () => ({
+    getToken: () => '',
+  });
+
+  return {
+    useShifu: () => ({
+      actions: {},
+    }),
+    useUserStore,
+  };
+});
+
+jest.mock('@/hooks/useToast', () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock('@/lib/request', () => ({
+  attachSseBusinessResponseFallback: jest.fn(),
+}));
+
+jest.mock('@/lib/request-trace', () => ({
+  buildTraceHeaders: jest.fn(() => ({
+    headers: {},
+    requestId: 'request-id',
+    harnessRunId: 'harness-run-id',
+  })),
+}));
+
+jest.mock('@/config/environment', () => ({
+  getDynamicApiBaseUrl: jest.fn(async () => ''),
+}));
+
+jest.mock('@/c-utils/envUtils', () => ({
+  getStringEnv: jest.fn(() => ''),
+}));
+
+jest.mock('@/c-utils/markdownUtils', () => ({
+  mergeStreamingMarkdownText: jest.fn((_prev: string, next: string) => next),
+  maskIncompleteMermaidBlock: jest.fn((content: string) => content),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 describe('usePreviewChat business error rendering', () => {
   test('replaces loading placeholder with backend business error message', () => {
     const items: ChatContentItem[] = [

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -40,6 +40,7 @@ import { PreviewVariablesMap, savePreviewVariables } from './variableStorage';
 import {
   buildPreviewInteractionUserInput,
   resolvePreviewGeneratedBlockBid,
+  resolvePreviewRegenerateStartIndex,
   resolvePreviewRequestBlockIndex,
 } from './preview-submission';
 
@@ -235,6 +236,17 @@ const resolveElementType = (
     return null;
   }
   return rawElementType.toLowerCase() as ElementType;
+};
+
+const resolveElementIndex = (
+  elementRecord: Partial<StudyRecordItem> | null,
+): number | undefined => {
+  if (!elementRecord) {
+    return undefined;
+  }
+  return typeof elementRecord.element_index === 'number'
+    ? elementRecord.element_index
+    : undefined;
 };
 
 const buildVariablesSnapshot = (
@@ -875,6 +887,7 @@ export function usePreviewChat() {
         responseGeneratedBlockBid: response.generated_block_bid,
         fallbackBid: itemBid,
       });
+      const elementIndex = resolveElementIndex(elementRecord);
       const elementContent =
         typeof elementRecord?.content === 'string' ? elementRecord.content : '';
       const isInteractionElement = elementType === ELEMENT_TYPE.INTERACTION;
@@ -946,6 +959,7 @@ export function usePreviewChat() {
           readonly: false,
           type: nextItemType,
           element_type: elementType || undefined,
+          element_index: elementIndex,
           is_final: Boolean(elementRecord?.is_final),
           sequence_number:
             typeof elementRecord?.sequence_number === 'number'
@@ -1678,24 +1692,34 @@ export function usePreviewChat() {
         return;
       }
 
-      const targetItem = newList[needChangeItemIndex];
+      const blockStartIndex = resolvePreviewRegenerateStartIndex(
+        newList,
+        needChangeItemIndex,
+      );
+      if (blockStartIndex === -1) {
+        return;
+      }
+
+      const targetItem = newList[blockStartIndex];
       const targetGeneratedBlockBid =
-        getPreviewItemGeneratedBlockBid(targetItem) || elementBid;
+        getPreviewItemGeneratedBlockBid(targetItem) ||
+        getPreviewItemGeneratedBlockBid(newList[needChangeItemIndex]) ||
+        elementBid;
 
       const nextBlockIndex = resolvePreviewRequestBlockIndex(
         targetGeneratedBlockBid,
-        needChangeItemIndex,
+        blockStartIndex,
       );
 
       const removedBlockIds = originalList
-        .slice(needChangeItemIndex)
+        .slice(blockStartIndex)
         .map(item => resolvePreviewItemBid(item))
         .filter((item): item is string => Boolean(item));
       if (removedBlockIds.length) {
         removeAutoSubmittedBlocks(removedBlockIds);
       }
 
-      newList.length = needChangeItemIndex;
+      newList.length = blockStartIndex;
       setTrackedContentList(newList);
       const latestMdflow = resolveLatestMdflow();
       startPreview({

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -40,6 +40,7 @@ import { PreviewVariablesMap, savePreviewVariables } from './variableStorage';
 import {
   buildPreviewInteractionUserInput,
   resolvePreviewGeneratedBlockBid,
+  resolvePreviewRegenerateFallbackBlockIndex,
   resolvePreviewRegenerateStartIndex,
   resolvePreviewRequestBlockIndex,
 } from './preview-submission';
@@ -1705,10 +1706,14 @@ export function usePreviewChat() {
         getPreviewItemGeneratedBlockBid(targetItem) ||
         getPreviewItemGeneratedBlockBid(newList[needChangeItemIndex]) ||
         elementBid;
+      const fallbackBlockIndex = resolvePreviewRegenerateFallbackBlockIndex(
+        newList,
+        blockStartIndex,
+      );
 
       const nextBlockIndex = resolvePreviewRequestBlockIndex(
         targetGeneratedBlockBid,
-        blockStartIndex,
+        fallbackBlockIndex,
       );
 
       const removedBlockIds = originalList

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import ScriptEditor from './ShifuEdit';
 
 const refreshLabel = 'refresh';
 const mockMarkdownFlowEditor = jest.fn();
+const mockLessonPreview = jest.fn();
 const mockTrackEvent = jest.fn();
 
 jest.mock('next/dynamic', () => () => {
@@ -63,7 +70,13 @@ jest.mock('../loading', () => {
   MockLoading.displayName = 'MockLoading';
   return MockLoading;
 });
-jest.mock('@/components/lesson-preview', () => () => null);
+jest.mock('@/components/lesson-preview', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    mockLessonPreview(props);
+    return null;
+  },
+}));
 jest.mock('./DraftConflictDialog', () => ({
   __esModule: true,
   default: ({
@@ -271,6 +284,7 @@ describe('ShifuEdit draft conflict checks', () => {
 
   beforeEach(() => {
     mockMarkdownFlowEditor.mockReset();
+    mockLessonPreview.mockReset();
     mockTrackEvent.mockReset();
     mockLoadDraftMeta.mockReset();
     mockLoadModels.mockReset();
@@ -513,6 +527,23 @@ describe('ShifuEdit draft conflict checks', () => {
     historyLink.click();
 
     expect(mockTrackEvent).toHaveBeenCalledWith('creator_lesson_history_click');
+  });
+
+  test('enables regenerate actions for editable lesson preview', async () => {
+    setLessonNode();
+
+    render(<ScriptEditor id='shifu-1' />);
+    fireEvent.click(screen.getByLabelText('module.shifu.previewArea.open'));
+
+    await waitFor(() => {
+      expect(mockLessonPreview).toHaveBeenCalled();
+    });
+
+    expect(mockLessonPreview.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        showGenerateBtn: true,
+      }),
+    );
   });
 
   test('renders the dedicated history layout in history mode', async () => {

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -546,6 +546,25 @@ describe('ShifuEdit draft conflict checks', () => {
     );
   });
 
+  test('does not enable regenerate actions before shifu data is ready', async () => {
+    setLessonNode();
+    mockShifuState.currentShifu =
+      null as unknown as typeof mockShifuState.currentShifu;
+
+    render(<ScriptEditor id='shifu-1' />);
+    fireEvent.click(screen.getByLabelText('module.shifu.previewArea.open'));
+
+    await waitFor(() => {
+      expect(mockLessonPreview).toHaveBeenCalled();
+    });
+
+    expect(mockLessonPreview.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        showGenerateBtn: false,
+      }),
+    );
+  });
+
   test('renders the dedicated history layout in history mode', async () => {
     setLessonNode();
     baseActions.loadMdflowHistory.mockResolvedValue([

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -1706,7 +1706,9 @@ const ScriptEditor = ({
                   }
                   actionType={hideRestoreActionType}
                   actionDisabled={hideRestoreActionDisabled}
-                  showGenerateBtn={!currentShifu?.readonly}
+                  showGenerateBtn={Boolean(
+                    currentShifu && !currentShifu.readonly,
+                  )}
                 />
               </div>
             </div>

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -1706,7 +1706,7 @@ const ScriptEditor = ({
                   }
                   actionType={hideRestoreActionType}
                   actionDisabled={hideRestoreActionDisabled}
-                  showGenerateBtn={false}
+                  showGenerateBtn={!currentShifu?.readonly}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- switch preview regenerate truncation to the first record of the selected generated block
- expose preview regenerate actions from helper rows for editable shifu preview
- add focused tests for block-based regenerate routing and preview helpers

## Verification
- npm test -- --runInBand src/__tests__/preview-submission.test.ts src/components/lesson-preview/LessonPreview.test.tsx src/components/lesson-preview/usePreviewChat.test.ts src/components/shifu-edit/ShifuEdit.test.tsx
- npm run type-check
- npm run lint
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content regeneration for lesson previews with a regenerate button for eligible text items.

* **Bug Fixes**
  * Improved parent selection (prefers textual parents) and robust fallback/indexing when regenerating preview content.
  * Audio/preview actions now use the resolved parent action id for correct behavior.

* **Tests**
  * Expanded test coverage for regeneration logic, fallback/index computations, and preview error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->