### PR TITLE
refactor: harden operator management audit and filters

### DIFF
--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -14,7 +14,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from flask import Flask, has_app_context
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import false, func, or_
+from sqlalchemy import func, or_
 
 from flaskr.api.sms.aliyun import (
     get_sms_template_ali,
@@ -583,6 +583,7 @@ def save_credit_notification_policy(
     payload: dict[str, Any],
     *,
     preserve_opt_out: bool = False,
+    updated_by: str = "system",
 ) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise_param_error("policy")
@@ -603,6 +604,7 @@ def save_credit_notification_policy(
         serialized,
         is_secret=False,
         remark="Credit notification SMS policy config",
+        updated_by=updated_by,
     )
     if not ok:
         raise_error("server.common.systemError")
@@ -2863,8 +2865,14 @@ def enqueue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
         }
 
 
-def requeue_credit_notification(app: Flask, *, notification_bid: str) -> dict[str, Any]:
+def requeue_credit_notification(
+    app: Flask,
+    *,
+    notification_bid: str,
+    operator_user_bid: str = "",
+) -> dict[str, Any]:
     normalized_notification_bid = _normalize_bid(notification_bid)
+    normalized_operator_user_bid = _normalize_bid(operator_user_bid)
     if not normalized_notification_bid:
         return {"status": "invalid_notification_bid", "enqueued": False}
     with app.app_context():
@@ -2911,6 +2919,14 @@ def requeue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
             notification is not None
             and notification.status == CREDIT_NOTIFICATION_STATUS_FAILED_PROVIDER
         ):
+            metadata = (
+                dict(notification.metadata_json)
+                if isinstance(notification.metadata_json, dict)
+                else {}
+            )
+            if normalized_operator_user_bid:
+                metadata["last_requeued_by"] = normalized_operator_user_bid
+            metadata["last_requeued_at"] = datetime.now().isoformat()
             notification.status = CREDIT_NOTIFICATION_STATUS_PENDING
             notification.error_code = ""
             notification.error_message = ""
@@ -2918,6 +2934,7 @@ def requeue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
             notification.attempted_at = None
             notification.sent_at = None
             notification.updated_at = datetime.now()
+            notification.metadata_json = metadata
             db.session.add(notification)
             db.session.commit()
             record_credit_notification_event(
@@ -3102,12 +3119,17 @@ def list_credit_notifications(
             matched_creator_bids = _load_matching_creator_bids_for_keyword(
                 creator_keyword
             )
-            if matched_creator_bids:
-                query = query.filter(
-                    NotificationRecord.creator_bid.in_(matched_creator_bids)
-                )
-            else:
-                query = query.filter(false())
+            if not matched_creator_bids:
+                return {
+                    "page": safe_page_index,
+                    "page_size": safe_page_size,
+                    "page_count": 0,
+                    "total": 0,
+                    "items": [],
+                }
+            query = query.filter(
+                NotificationRecord.creator_bid.in_(matched_creator_bids)
+            )
         start_time = normalized_filters.get("start_time")
         end_time = normalized_filters.get("end_time")
         if isinstance(start_time, datetime):

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -2926,7 +2926,9 @@ def requeue_credit_notification(
             )
             if normalized_operator_user_bid:
                 metadata["last_requeued_by"] = normalized_operator_user_bid
-            metadata["last_requeued_at"] = datetime.now().isoformat()
+            metadata["last_requeued_at"] = _format_operator_datetime(
+                app, datetime.now()
+            )
             notification.status = CREDIT_NOTIFICATION_STATUS_PENDING
             notification.error_code = ""
             notification.error_message = ""

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -12,10 +12,16 @@ from flaskr.framework import extensible
 from sqlalchemy.exc import SQLAlchemyError
 import random
 
+MAX_UPDATED_BY_LEN = 36
+
 
 class ConfigCache(BaseModel):
     is_encrypted: bool = Field(default=False)
     value: str = Field(default="")
+
+
+def _normalize_updated_by(value: str) -> str:
+    return (str(value or "").strip() or "system")[:MAX_UPDATED_BY_LEN]
 
 
 def _get_fernet_key(app: Flask) -> bytes:
@@ -168,12 +174,12 @@ def add_config(
     is_secret: bool = False,
     remark: str = "",
     updated_by: str = "system",
-) -> None:
+) -> bool | None:
     """
     Add config to database.
     """
     with app.app_context():
-        normalized_updated_by = str(updated_by or "").strip() or "system"
+        normalized_updated_by = _normalize_updated_by(updated_by)
         app.logger.info(
             f"Adding config: {key}, value: {value}, is_secret: {is_secret}, remark: {remark}"
         )
@@ -242,7 +248,7 @@ def update_config(
     Update config in database.
     """
     with app.app_context():
-        normalized_updated_by = str(updated_by or "").strip() or "system"
+        normalized_updated_by = _normalize_updated_by(updated_by)
         env_value = get_config_from_common(key, None)
         if env_value:
             return False

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -180,11 +180,6 @@ def add_config(
     """
     with app.app_context():
         normalized_updated_by = _normalize_updated_by(updated_by)
-        app.logger.info(
-            "Adding config: %s, is_secret: %s",
-            key,
-            is_secret,
-        )
         env_value = get_config_from_common(key, None)
         if env_value is not None:
             return

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -180,8 +180,13 @@ def add_config(
     """
     with app.app_context():
         normalized_updated_by = _normalize_updated_by(updated_by)
+        safe_value = "***" if is_secret else value
         app.logger.info(
-            f"Adding config: {key}, value: {value}, is_secret: {is_secret}, remark: {remark}"
+            "Adding config: %s, value: %s, is_secret: %s, remark: %s",
+            key,
+            safe_value,
+            is_secret,
+            remark,
         )
         env_value = get_config_from_common(key, None)
         if env_value is not None:
@@ -250,7 +255,7 @@ def update_config(
     with app.app_context():
         normalized_updated_by = _normalize_updated_by(updated_by)
         env_value = get_config_from_common(key, None)
-        if env_value:
+        if env_value is not None:
             return False
         cache_key = _get_config_cache_key(app, key)
         cache = redis.get(cache_key)

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -162,12 +162,18 @@ def get_config(key: str, default: str = None) -> str:
 
 
 def add_config(
-    app: Flask, key: str, value: str, is_secret: bool = False, remark: str = ""
+    app: Flask,
+    key: str,
+    value: str,
+    is_secret: bool = False,
+    remark: str = "",
+    updated_by: str = "system",
 ) -> None:
     """
     Add config to database.
     """
     with app.app_context():
+        normalized_updated_by = str(updated_by or "").strip() or "system"
         app.logger.info(
             f"Adding config: {key}, value: {value}, is_secret: {is_secret}, remark: {remark}"
         )
@@ -190,7 +196,7 @@ def add_config(
             existing_config.value = value
             existing_config.is_encrypted = is_secret
             existing_config.remark = remark
-            existing_config.updated_by = "system"
+            existing_config.updated_by = normalized_updated_by
             db.session.commit()
             cache_key = _get_config_cache_key(app, key)
             redis.set(
@@ -210,7 +216,7 @@ def add_config(
                 deleted=0,
                 is_encrypted=is_secret,
                 remark=remark,
-                updated_by="",
+                updated_by=normalized_updated_by,
             )
             db.session.add(config)
             db.session.commit()
@@ -225,12 +231,18 @@ def add_config(
 
 
 def update_config(
-    app: Flask, key: str, value: str, is_secret: bool = False, remark: str = ""
+    app: Flask,
+    key: str,
+    value: str,
+    is_secret: bool = False,
+    remark: str = "",
+    updated_by: str = "system",
 ) -> bool:
     """
     Update config in database.
     """
     with app.app_context():
+        normalized_updated_by = str(updated_by or "").strip() or "system"
         env_value = get_config_from_common(key, None)
         if env_value:
             return False
@@ -261,14 +273,14 @@ def update_config(
                     deleted=0,
                     is_encrypted=is_secret,
                     remark=remark,
-                    updated_by="system",
+                    updated_by=normalized_updated_by,
                 )
                 db.session.add(config)
             else:
                 config.value = value
                 config.is_encrypted = is_secret
                 config.remark = remark
-                config.updated_by = "system"
+                config.updated_by = normalized_updated_by
             db.session.commit()
             redis.set(
                 cache_key,

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -180,11 +180,10 @@ def add_config(
     """
     with app.app_context():
         normalized_updated_by = _normalize_updated_by(updated_by)
-        safe_value = "***" if is_secret else value
         app.logger.info(
             "Adding config: %s, value: %s, is_secret: %s, remark: %s",
             key,
-            safe_value,
+            "***",
             is_secret,
             remark,
         )

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -181,11 +181,9 @@ def add_config(
     with app.app_context():
         normalized_updated_by = _normalize_updated_by(updated_by)
         app.logger.info(
-            "Adding config: %s, value: %s, is_secret: %s, remark: %s",
+            "Adding config: %s, is_secret: %s",
             key,
-            "***",
             is_secret,
-            remark,
         )
         env_value = get_config_from_common(key, None)
         if env_value is not None:

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -518,13 +518,11 @@ def _load_matching_user_bids_for_keyword(keyword: str) -> List[str]:
         AuthCredential.deleted == 0,
     )
 
-    return sorted(
-        {
-            str(row.user_bid or "").strip()
-            for row in user_rows.union(credential_rows).all()
-            if str(getattr(row, "user_bid", "") or "").strip()
-        }
-    )
+    bids = {
+        str(row.user_bid or "").strip()
+        for row in user_rows.union(credential_rows).all()
+    }
+    return sorted(bid for bid in bids if bid)
 
 
 def _load_matching_shifu_bids_for_course_name(course_name: str) -> List[str]:

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -236,6 +236,25 @@ def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
     return None
 
 
+def _normalize_order_status_filter(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    normalized = str(value or "").strip()
+    if normalized.isdigit():
+        return int(normalized)
+    return None
+
+
+def _normalize_order_datetime_filter(
+    value: Any, *, is_end: bool = False
+) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    return _parse_datetime(str(value or "").strip(), is_end=is_end)
+
+
 def _trim_import_activation_nickname(value: str) -> str:
     """Trim nickname content around non-text separators."""
     text = str(value or "").strip()
@@ -479,40 +498,33 @@ def _load_matching_user_bids_for_keyword(keyword: str) -> List[str]:
     if not normalized_keyword:
         return []
 
-    matched_user_bids = set()
-    for row in (
-        UserEntity.query.filter(
-            db.or_(
-                UserEntity.user_bid == normalized_keyword,
-                UserEntity.user_identify == normalized_keyword,
-            )
-        )
-        .yield_per(200)
-        .enable_eagerloads(False)
-    ):
-        user_bid = str(row.user_bid or "").strip()
-        if user_bid:
-            matched_user_bids.add(user_bid)
-
     normalized_credential_identifier = (
         normalized_keyword.lower()
         if EMAIL_PATTERN.fullmatch(normalized_keyword)
         else normalized_keyword
     )
-    for row in (
-        AuthCredential.query.filter(
-            AuthCredential.identifier == normalized_credential_identifier,
-            AuthCredential.provider_name.in_(["phone", "email", "google"]),
-            AuthCredential.deleted == 0,
-        )
-        .yield_per(200)
-        .enable_eagerloads(False)
-    ):
-        user_bid = str(row.user_bid or "").strip()
-        if user_bid:
-            matched_user_bids.add(user_bid)
+    user_rows = db.session.query(UserEntity.user_bid.label("user_bid")).filter(
+        UserEntity.deleted == 0,
+        db.or_(
+            UserEntity.user_bid == normalized_keyword,
+            UserEntity.user_identify == normalized_keyword,
+        ),
+    )
+    credential_rows = db.session.query(
+        AuthCredential.user_bid.label("user_bid")
+    ).filter(
+        AuthCredential.identifier == normalized_credential_identifier,
+        AuthCredential.provider_name.in_(["phone", "email", "google"]),
+        AuthCredential.deleted == 0,
+    )
 
-    return sorted(matched_user_bids)
+    return sorted(
+        {
+            str(row.user_bid or "").strip()
+            for row in user_rows.union(credential_rows).all()
+            if str(getattr(row, "user_bid", "") or "").strip()
+        }
+    )
 
 
 def _load_matching_shifu_bids_for_course_name(course_name: str) -> List[str]:
@@ -894,19 +906,22 @@ def list_orders(
                     return PageNationDTO(page_index, page_size, 0, [])
                 query = query.filter(Order.shifu_bid.in_(allowed_bids))
 
-        status = filters.get("status")
-        if status is not None and str(status).isdigit():
-            query = query.filter(Order.status == int(status))
+        status = _normalize_order_status_filter(filters.get("status"))
+        if status is not None:
+            query = query.filter(Order.status == status)
 
         payment_channel = filters.get("payment_channel")
         if payment_channel:
             query = query.filter(Order.payment_channel == payment_channel)
 
-        start_time = _parse_datetime(filters.get("start_time", ""))
+        start_time = _normalize_order_datetime_filter(filters.get("start_time"))
         if start_time:
             query = query.filter(Order.created_at >= start_time)
 
-        end_time = _parse_datetime(filters.get("end_time", ""), is_end=True)
+        end_time = _normalize_order_datetime_filter(
+            filters.get("end_time"),
+            is_end=True,
+        )
         if end_time:
             query = query.filter(Order.created_at <= end_time)
 
@@ -966,9 +981,9 @@ def list_operator_orders(
                 return PageNationDTO(page_index, page_size, 0, [])
             query = query.filter(Order.shifu_bid.in_(matched_shifu_bids))
 
-        status = filters.get("status")
-        if status is not None and str(status).isdigit():
-            query = query.filter(Order.status == int(status))
+        status = _normalize_order_status_filter(filters.get("status"))
+        if status is not None:
+            query = query.filter(Order.status == status)
 
         payment_channel = str(filters.get("payment_channel", "") or "").strip()
         if payment_channel:
@@ -978,12 +993,12 @@ def list_operator_orders(
         if order_source:
             query = _apply_order_source_filter(query, order_source)
 
-        start_time = _parse_datetime(str(filters.get("start_time", "") or ""))
+        start_time = _normalize_order_datetime_filter(filters.get("start_time"))
         if start_time:
             query = query.filter(Order.created_at >= start_time)
 
-        end_time = _parse_datetime(
-            str(filters.get("end_time", "") or ""),
+        end_time = _normalize_order_datetime_filter(
+            filters.get("end_time"),
             is_end=True,
         )
         if end_time:

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -327,7 +327,7 @@ def _apply_keyword_filter(query, keyword: str, user_bid_field, *text_fields):
 
 
 def _build_coupon_status_filter(status: str):
-    normalized = str(status or "").strip()
+    normalized = str(status or "").strip().lower()
     if not normalized:
         return None
     now = _now_local_naive()
@@ -354,7 +354,7 @@ def _build_coupon_status_filter(status: str):
 
 
 def _build_campaign_status_filter(status: str):
-    normalized = str(status or "").strip()
+    normalized = str(status or "").strip().lower()
     if not normalized:
         return None
     now = _now_local_naive()

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -350,7 +350,7 @@ def _build_coupon_status_filter(status: str):
             enabled_filter,
             Coupon.end < now,
         )
-    return None
+    raise_param_error("status")
 
 
 def _build_campaign_status_filter(status: str):
@@ -377,7 +377,7 @@ def _build_campaign_status_filter(status: str):
             enabled_filter,
             PromoCampaign.end_at < now,
         )
-    return None
+    raise_param_error("status")
 
 
 def _generate_random_coupon_code(length: int = 12) -> str:
@@ -642,15 +642,22 @@ def _find_course_bids_by_name(keyword: str) -> set[str]:
     normalized = str(keyword or "").strip()
     if not normalized:
         return set()
+    like_pattern = f"%{normalized}%"
     results = set()
     for model in (PublishedShifu, DraftShifu):
-        records = model.query.filter(
-            model.deleted == 0,
-            model.title.like(f"%{normalized}%"),
-        ).all()
-        for record in records:
-            if record.shifu_bid:
-                results.add(record.shifu_bid)
+        rows = (
+            db.session.query(model.shifu_bid)
+            .filter(
+                model.deleted == 0,
+                model.title.like(like_pattern),
+            )
+            .distinct()
+            .all()
+        )
+        for row in rows:
+            shifu_bid = str(row[0] or "").strip()
+            if shifu_bid:
+                results.add(shifu_bid)
     return results
 
 
@@ -709,6 +716,21 @@ def _list_promotion_coupons(
         )
     if course_query:
         course_bids = _resolve_course_query_bids(course_query)
+        if not course_bids:
+            return _build_paged_response(
+                AdminPromotionSummaryDTO(
+                    total=0,
+                    active=0,
+                    usage_count=0,
+                    latest_usage_at="",
+                    covered_courses=0,
+                    discount_amount="0",
+                ),
+                page,
+                page_size,
+                0,
+                [],
+            )
         query = query.filter(
             Coupon.filter.in_(
                 [
@@ -798,11 +820,11 @@ def _list_promotion_coupons(
 
     start = (page - 1) * page_size
     paged = query.order_by(Coupon.id.desc()).offset(start).limit(page_size).all()
-    course_bids = [
-        _parse_coupon_scope(coupon.filter or "{}")[1]
+    coupon_scope_map = {
+        coupon.coupon_bid: _parse_coupon_scope(coupon.filter or "{}")
         for coupon in paged
-        if _parse_coupon_scope(coupon.filter or "{}")[1]
-    ]
+    }
+    course_bids = [scope[1] for scope in coupon_scope_map.values() if scope[1]]
     course_map = _load_shifu_map(course_bids)
     user_name_map = _load_user_name_map(
         [coupon.created_user_bid for coupon in paged if coupon.created_user_bid]
@@ -1624,6 +1646,21 @@ def list_operator_promotion_campaigns(
         )
     if course_query:
         course_bids = _resolve_course_query_bids(course_query)
+        if not course_bids:
+            return _build_paged_response(
+                AdminPromotionSummaryDTO(
+                    total=0,
+                    active=0,
+                    usage_count=0,
+                    latest_usage_at="",
+                    covered_courses=0,
+                    discount_amount="0",
+                ),
+                page,
+                page_size,
+                0,
+                [],
+            )
         query = query.filter(PromoCampaign.shifu_bid.in_(course_bids))
     start_time = filters.get("start_time")
     end_time = filters.get("end_time")

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2250,30 +2250,26 @@ def _find_matching_user_bids_by_identifier(keyword: str) -> Optional[Set[str]]:
     if not normalized:
         return None
 
-    credential_rows = (
-        db.session.query(AuthCredential.user_bid)
-        .filter(
-            AuthCredential.deleted == 0,
-            AuthCredential.provider_name.in_(["phone", "email", "google"]),
-            AuthCredential.identifier.ilike(f"%{normalized}%"),
-        )
-        .all()
+    like_pattern = f"%{normalized}%"
+    credential_rows = db.session.query(
+        AuthCredential.user_bid.label("user_bid")
+    ).filter(
+        AuthCredential.deleted == 0,
+        AuthCredential.provider_name.in_(["phone", "email", "google"]),
+        AuthCredential.identifier.ilike(like_pattern),
     )
-    user_bids = {row[0] for row in credential_rows if row and row[0]}
-    identify_rows = (
-        db.session.query(UserEntity.user_bid)
-        .filter(
-            UserEntity.deleted == 0,
-            or_(
-                UserEntity.user_bid.ilike(f"%{normalized}%"),
-                UserEntity.user_identify.ilike(f"%{normalized}%"),
-            ),
-        )
-        .all()
+    identify_rows = db.session.query(UserEntity.user_bid.label("user_bid")).filter(
+        UserEntity.deleted == 0,
+        or_(
+            UserEntity.user_bid.ilike(like_pattern),
+            UserEntity.user_identify.ilike(like_pattern),
+        ),
     )
-    for row in identify_rows:
-        if row and row[0]:
-            user_bids.add(row[0])
+    user_bids = {
+        str(row.user_bid or "").strip()
+        for row in credential_rows.union(identify_rows).all()
+        if str(getattr(row, "user_bid", "") or "").strip()
+    }
     return user_bids
 
 
@@ -3871,13 +3867,23 @@ def _clear_shifu_creator_cache(app: Flask, shifu_bid: str) -> None:
         redis.delete(cache_key)
 
 
-def _update_course_creator_bid(shifu_bid: str, creator_user_bid: str) -> None:
+def _update_course_creator_bid(
+    shifu_bid: str,
+    creator_user_bid: str,
+    updated_user_bid: str = "",
+) -> None:
+    draft_values = {DraftShifu.created_user_bid: creator_user_bid}
+    published_values = {PublishedShifu.created_user_bid: creator_user_bid}
+    normalized_updated_user_bid = str(updated_user_bid or "").strip()
+    if normalized_updated_user_bid:
+        draft_values[DraftShifu.updated_user_bid] = normalized_updated_user_bid
+        published_values[PublishedShifu.updated_user_bid] = normalized_updated_user_bid
     DraftShifu.query.filter(DraftShifu.shifu_bid == shifu_bid).update(
-        {DraftShifu.created_user_bid: creator_user_bid},
+        draft_values,
         synchronize_session=False,
     )
     PublishedShifu.query.filter(PublishedShifu.shifu_bid == shifu_bid).update(
-        {PublishedShifu.created_user_bid: creator_user_bid},
+        published_values,
         synchronize_session=False,
     )
 
@@ -3888,11 +3894,13 @@ def transfer_operator_course_creator(
     shifu_bid: str,
     contact_type: str,
     identifier: str,
+    operator_user_bid: str = "",
 ) -> Dict[str, Any]:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
         normalized_contact_type = str(contact_type or "").strip().lower()
         normalized_identifier = _normalize_identifier(identifier)
+        normalized_operator_user_bid = str(operator_user_bid or "").strip()
 
         latest_course = _load_latest_course_for_transfer(normalized_shifu_bid)
         if not latest_course:
@@ -3912,7 +3920,18 @@ def transfer_operator_course_creator(
         created_new_user = target_creator_result["created_new_user"]
         granted_demo_permissions = target_creator_result["granted_demo_permissions"]
         creator_granted_now = target_creator_result["creator_granted_now"]
-        _update_course_creator_bid(normalized_shifu_bid, target_user_bid)
+        _update_course_creator_bid(
+            normalized_shifu_bid,
+            target_user_bid,
+            updated_user_bid=normalized_operator_user_bid,
+        )
+        if normalized_operator_user_bid and getattr(latest_course, "id", 0):
+            save_shifu_history(
+                app,
+                normalized_operator_user_bid,
+                normalized_shifu_bid,
+                int(latest_course.id),
+            )
 
         db.session.commit()
         if previous_creator_user_bid:

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -2265,12 +2265,11 @@ def _find_matching_user_bids_by_identifier(keyword: str) -> Optional[Set[str]]:
             UserEntity.user_identify.ilike(like_pattern),
         ),
     )
-    user_bids = {
+    bids = {
         str(row.user_bid or "").strip()
         for row in credential_rows.union(identify_rows).all()
-        if str(getattr(row, "user_bid", "") or "").strip()
     }
-    return user_bids
+    return {bid for bid in bids if bid}
 
 
 def _build_operator_user_summary(

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -3875,8 +3875,11 @@ def _update_course_creator_bid(
     published_values = {PublishedShifu.created_user_bid: creator_user_bid}
     normalized_updated_user_bid = str(updated_user_bid or "").strip()
     if normalized_updated_user_bid:
+        updated_at = datetime.now()
         draft_values[DraftShifu.updated_user_bid] = normalized_updated_user_bid
+        draft_values[DraftShifu.updated_at] = updated_at
         published_values[PublishedShifu.updated_user_bid] = normalized_updated_user_bid
+        published_values[PublishedShifu.updated_at] = updated_at
     DraftShifu.query.filter(DraftShifu.shifu_bid == shifu_bid).update(
         draft_values,
         synchronize_session=False,

--- a/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
+++ b/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
@@ -53,9 +53,15 @@ def update_operator_credit_notification_config(
     app: Flask,
     *,
     payload: dict[str, Any],
+    operator_user_bid: str = "",
 ) -> dict[str, Any]:
     with app.app_context():
-        save_credit_notification_policy(app, payload, preserve_opt_out=True)
+        save_credit_notification_policy(
+            app,
+            payload,
+            preserve_opt_out=True,
+            updated_by=operator_user_bid,
+        )
         return load_credit_notification_policy_for_operator()
 
 
@@ -93,5 +99,10 @@ def requeue_operator_credit_notification(
     app: Flask,
     *,
     notification_bid: str,
+    operator_user_bid: str = "",
 ) -> dict[str, Any]:
-    return requeue_credit_notification(app, notification_bid=notification_bid)
+    return requeue_credit_notification(
+        app,
+        notification_bid=notification_bid,
+        operator_user_bid=operator_user_bid,
+    )

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -1444,6 +1444,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
 
         return make_common_response(
             get_operator_user_credits(
@@ -1860,6 +1865,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             get_operator_course_credit_usages(
                 app,
@@ -2016,6 +2026,11 @@ def register_admin_operations_routes(
             field_name="include_summary",
             default=True,
         )
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             get_operator_course_ratings(
                 app,
@@ -2111,6 +2126,11 @@ def register_admin_operations_routes(
             request.args.get("include_summary", None),
             field_name="include_summary",
             default=True,
+        )
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
         )
         return make_common_response(
             get_operator_course_follow_ups(

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -111,7 +111,9 @@ CREDIT_NOTIFICATION_SKIP_REASON_VALUES = {
 }
 
 
-def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | None:
+def _parse_datetime_filter(
+    value: str, *, field_name: str, is_end: bool = False
+) -> datetime | None:
     if not value:
         return None
     normalized = str(value).strip()
@@ -128,7 +130,7 @@ def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | No
             return parsed
         except ValueError:
             continue
-    raise_param_error("datetime format invalid")
+    raise_param_error(field_name)
 
 
 def _normalize_query_text(raw_value: object) -> str:
@@ -360,18 +362,22 @@ def register_admin_operations_routes(
             ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
             "updated_start_time": _parse_datetime_filter(
                 request.args.get("updated_start_time", ""),
+                field_name="updated_start_time",
                 is_end=False,
             ),
             "updated_end_time": _parse_datetime_filter(
                 request.args.get("updated_end_time", ""),
+                field_name="updated_end_time",
                 is_end=True,
             ),
         }
@@ -505,10 +511,12 @@ def register_admin_operations_routes(
             "quick_filter": _normalize_query_text(request.args.get("quick_filter")),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -622,10 +630,12 @@ def register_admin_operations_routes(
             ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -720,10 +730,12 @@ def register_admin_operations_routes(
             "source_bid": _normalize_query_text(request.args.get("source_bid")),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -931,10 +943,12 @@ def register_admin_operations_routes(
         page_size = min(page_size, OPERATOR_ORDER_LIST_MAX_PAGE_SIZE)
         start_time = _parse_datetime_filter(
             request.args.get("start_time", ""),
+            field_name="start_time",
             is_end=False,
         )
         end_time = _parse_datetime_filter(
             request.args.get("end_time", ""),
+            field_name="end_time",
             is_end=True,
         )
         _validate_datetime_range(start_time, end_time, field_name="start_time")
@@ -1029,10 +1043,12 @@ def register_admin_operations_routes(
             ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -1214,10 +1230,12 @@ def register_admin_operations_routes(
             ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -1417,10 +1435,12 @@ def register_admin_operations_routes(
             "usage_mode": request.args.get("usage_mode", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -1831,10 +1851,12 @@ def register_admin_operations_routes(
             "view": request.args.get("view", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -1980,10 +2002,12 @@ def register_admin_operations_routes(
             "sort_by": request.args.get("sort_by", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }
@@ -2074,10 +2098,12 @@ def register_admin_operations_routes(
             "chapter_keyword": request.args.get("chapter_keyword", ""),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
+                field_name="start_time",
                 is_end=False,
             ),
             "end_time": _parse_datetime_filter(
                 request.args.get("end_time", ""),
+                field_name="end_time",
                 is_end=True,
             ),
         }

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -82,6 +82,33 @@ from flaskr.service.shifu.admin_dtos import (
 MAX_CONTACT_LENGTH = 320
 PHONE_PATTERN = re.compile(r"^\d{11}$")
 EMAIL_PATTERN = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
+OPERATOR_USER_STATUS_VALUES = {"unregistered", "registered", "trial", "paid"}
+OPERATOR_USER_ROLE_VALUES = {"operator", "creator", "learner", "regular"}
+PROMOTION_COUPON_STATUS_VALUES = {"inactive", "not_started", "active", "expired"}
+PROMOTION_CAMPAIGN_STATUS_VALUES = {"inactive", "not_started", "active", "ended"}
+PROMOTION_COUPON_USAGE_STATUS_VALUES = {"901", "902", "903", "904"}
+CREDIT_NOTIFICATION_STATUS_VALUES = {
+    "pending",
+    "sent",
+    "skipped",
+    "skipped_no_mobile",
+    "skipped_opt_out",
+    "suppressed_duplicate",
+    "failed_provider",
+}
+CREDIT_NOTIFICATION_DELIVERY_STATUS_VALUES = {
+    "pending",
+    "sent",
+    "failed",
+    "not_sent",
+}
+CREDIT_NOTIFICATION_SKIP_REASON_VALUES = {
+    "contact",
+    "duplicate",
+    "policy",
+    "stale",
+    "template_params",
+}
 
 
 def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | None:
@@ -102,6 +129,43 @@ def _parse_datetime_filter(value: str, *, is_end: bool = False) -> datetime | No
         except ValueError:
             continue
     raise_param_error("datetime format invalid")
+
+
+def _normalize_query_text(raw_value: object) -> str:
+    return str(raw_value or "").strip()
+
+
+def _parse_choice_query_param(
+    raw_value: object,
+    *,
+    field_name: str,
+    allowed_values: set[str],
+) -> str:
+    normalized = _normalize_query_text(raw_value).lower()
+    if not normalized:
+        return ""
+    if normalized not in allowed_values:
+        raise_param_error(field_name)
+    return normalized
+
+
+def _parse_digit_query_param(raw_value: object, *, field_name: str) -> str:
+    normalized = _normalize_query_text(raw_value)
+    if not normalized:
+        return ""
+    if not normalized.isdigit():
+        raise_param_error(field_name)
+    return normalized
+
+
+def _validate_datetime_range(
+    start_time: datetime | None,
+    end_time: datetime | None,
+    *,
+    field_name: str,
+) -> None:
+    if start_time is not None and end_time is not None and start_time > end_time:
+        raise_param_error(field_name)
 
 
 def _parse_boolean_query_param(
@@ -287,11 +351,13 @@ def register_admin_operations_routes(
         )
 
         filters = {
-            "shifu_bid": request.args.get("shifu_bid", ""),
-            "course_name": request.args.get("course_name", ""),
-            "course_status": request.args.get("course_status", ""),
-            "quick_filter": request.args.get("quick_filter", ""),
-            "creator_keyword": request.args.get("creator_keyword", ""),
+            "shifu_bid": _normalize_query_text(request.args.get("shifu_bid")),
+            "course_name": _normalize_query_text(request.args.get("course_name")),
+            "course_status": _normalize_query_text(request.args.get("course_status")),
+            "quick_filter": _normalize_query_text(request.args.get("quick_filter")),
+            "creator_keyword": _normalize_query_text(
+                request.args.get("creator_keyword")
+            ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -309,6 +375,16 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
+        _validate_datetime_range(
+            filters["updated_start_time"],
+            filters["updated_end_time"],
+            field_name="updated_start_time",
+        )
         return make_common_response(
             list_operator_courses(app, page_index, page_size, filters)
         )
@@ -412,13 +488,21 @@ def register_admin_operations_routes(
         )
 
         filters = {
-            "user_bid": request.args.get("user_bid", ""),
-            "identifier": request.args.get("identifier", ""),
-            "mobile": request.args.get("mobile", ""),
-            "nickname": request.args.get("nickname", ""),
-            "user_status": request.args.get("user_status", ""),
-            "user_role": request.args.get("user_role", ""),
-            "quick_filter": request.args.get("quick_filter", ""),
+            "user_bid": _normalize_query_text(request.args.get("user_bid")),
+            "identifier": _normalize_query_text(request.args.get("identifier")),
+            "mobile": _normalize_query_text(request.args.get("mobile")),
+            "nickname": _normalize_query_text(request.args.get("nickname")),
+            "user_status": _parse_choice_query_param(
+                request.args.get("user_status"),
+                field_name="user_status",
+                allowed_values=OPERATOR_USER_STATUS_VALUES,
+            ),
+            "user_role": _parse_choice_query_param(
+                request.args.get("user_role"),
+                field_name="user_role",
+                allowed_values=OPERATOR_USER_ROLE_VALUES,
+            ),
+            "quick_filter": _normalize_query_text(request.args.get("quick_filter")),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -428,6 +512,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             list_operator_users(app, page_index, page_size, filters)
         )
@@ -519,13 +608,18 @@ def register_admin_operations_routes(
         page_size = min(page_size, OPERATOR_ORDER_LIST_MAX_PAGE_SIZE)
 
         filters = {
-            "user_keyword": request.args.get("user_keyword", ""),
-            "order_bid": request.args.get("order_bid", ""),
-            "shifu_bid": request.args.get("shifu_bid", ""),
-            "course_name": request.args.get("course_name", ""),
-            "status": request.args.get("status", ""),
-            "order_source": request.args.get("order_source", ""),
-            "payment_channel": request.args.get("payment_channel", ""),
+            "user_keyword": _normalize_query_text(request.args.get("user_keyword")),
+            "order_bid": _normalize_query_text(request.args.get("order_bid")),
+            "shifu_bid": _normalize_query_text(request.args.get("shifu_bid")),
+            "course_name": _normalize_query_text(request.args.get("course_name")),
+            "status": _parse_digit_query_param(
+                request.args.get("status"),
+                field_name="status",
+            ),
+            "order_source": _normalize_query_text(request.args.get("order_source")),
+            "payment_channel": _normalize_query_text(
+                request.args.get("payment_channel")
+            ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -535,6 +629,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             list_operator_orders(app, page_index, page_size, filters)
         )
@@ -590,17 +689,35 @@ def register_admin_operations_routes(
             default=20,
         )
         filters = {
-            "creator_bid": request.args.get("creator_bid", ""),
-            "creator_keyword": request.args.get("creator_keyword", ""),
-            "target_user_bid": request.args.get("target_user_bid", ""),
-            "mobile": request.args.get("mobile", ""),
-            "notification_type": request.args.get("notification_type", ""),
-            "channel": request.args.get("channel", ""),
-            "status": request.args.get("status", ""),
-            "delivery_status": request.args.get("delivery_status", ""),
-            "skip_reason": request.args.get("skip_reason", ""),
-            "source_type": request.args.get("source_type", ""),
-            "source_bid": request.args.get("source_bid", ""),
+            "creator_bid": _normalize_query_text(request.args.get("creator_bid")),
+            "creator_keyword": _normalize_query_text(
+                request.args.get("creator_keyword")
+            ),
+            "target_user_bid": _normalize_query_text(
+                request.args.get("target_user_bid")
+            ),
+            "mobile": _normalize_query_text(request.args.get("mobile")),
+            "notification_type": _normalize_query_text(
+                request.args.get("notification_type")
+            ),
+            "channel": _normalize_query_text(request.args.get("channel")),
+            "status": _parse_choice_query_param(
+                request.args.get("status"),
+                field_name="status",
+                allowed_values=CREDIT_NOTIFICATION_STATUS_VALUES,
+            ),
+            "delivery_status": _parse_choice_query_param(
+                request.args.get("delivery_status"),
+                field_name="delivery_status",
+                allowed_values=CREDIT_NOTIFICATION_DELIVERY_STATUS_VALUES,
+            ),
+            "skip_reason": _parse_choice_query_param(
+                request.args.get("skip_reason"),
+                field_name="skip_reason",
+                allowed_values=CREDIT_NOTIFICATION_SKIP_REASON_VALUES,
+            ),
+            "source_type": _normalize_query_text(request.args.get("source_type")),
+            "source_bid": _normalize_query_text(request.args.get("source_bid")),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -610,6 +727,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             list_operator_credit_notifications(
                 app,
@@ -653,7 +775,11 @@ def register_admin_operations_routes(
         if not isinstance(payload, dict):
             raise_param_error("credit_notification_config")
         return make_common_response(
-            update_operator_credit_notification_config(app, payload=payload)
+            update_operator_credit_notification_config(
+                app,
+                payload=payload,
+                operator_user_bid=str(getattr(request.user, "user_id", "") or ""),
+            )
         )
 
     @app.route(
@@ -713,6 +839,7 @@ def register_admin_operations_routes(
             requeue_operator_credit_notification(
                 app,
                 notification_bid=notification_bid,
+                operator_user_bid=str(getattr(request.user, "user_id", "") or ""),
             )
         )
 
@@ -802,29 +929,45 @@ def register_admin_operations_routes(
             default=20,
         )
         page_size = min(page_size, OPERATOR_ORDER_LIST_MAX_PAGE_SIZE)
+        start_time = _parse_datetime_filter(
+            request.args.get("start_time", ""),
+            is_end=False,
+        )
+        end_time = _parse_datetime_filter(
+            request.args.get("end_time", ""),
+            is_end=True,
+        )
+        _validate_datetime_range(start_time, end_time, field_name="start_time")
         return make_common_response(
             build_operator_credit_orders_page(
                 app,
                 page_index=page_index,
                 page_size=page_size,
-                creator_keyword=request.args.get("creator_keyword", ""),
-                product_keyword=request.args.get("product_keyword", ""),
-                bill_order_bid=request.args.get("bill_order_bid", ""),
-                credit_order_kind=request.args.get("credit_order_kind", ""),
-                status=request.args.get("status", ""),
+                creator_keyword=_normalize_query_text(
+                    request.args.get("creator_keyword")
+                ),
+                product_keyword=_normalize_query_text(
+                    request.args.get("product_keyword")
+                ),
+                bill_order_bid=_normalize_query_text(
+                    request.args.get("bill_order_bid")
+                ),
+                credit_order_kind=_normalize_query_text(
+                    request.args.get("credit_order_kind")
+                ),
+                status=_parse_digit_query_param(
+                    request.args.get("status"),
+                    field_name="status",
+                ),
                 has_available_credits=_parse_boolean_query_param(
                     request.args.get("has_available_credits"),
                     field_name="has_available_credits",
                 ),
-                payment_provider=request.args.get("payment_provider", ""),
-                start_time=_parse_datetime_filter(
-                    request.args.get("start_time", ""),
-                    is_end=False,
+                payment_provider=_normalize_query_text(
+                    request.args.get("payment_provider")
                 ),
-                end_time=_parse_datetime_filter(
-                    request.args.get("end_time", ""),
-                    is_end=True,
-                ),
+                start_time=start_time,
+                end_time=end_time,
             )
         )
 
@@ -871,15 +1014,19 @@ def register_admin_operations_routes(
         )
 
         filters = {
-            "keyword": request.args.get("keyword", ""),
-            "name": request.args.get("name", ""),
-            "course_query": request.args.get("course_query", ""),
-            "shifu_bid": request.args.get("shifu_bid", ""),
-            "course_name": request.args.get("course_name", ""),
-            "usage_type": request.args.get("usage_type", ""),
-            "ops_state": request.args.get("ops_state", ""),
-            "discount_type": request.args.get("discount_type", ""),
-            "status": request.args.get("status", ""),
+            "keyword": _normalize_query_text(request.args.get("keyword")),
+            "name": _normalize_query_text(request.args.get("name")),
+            "course_query": _normalize_query_text(request.args.get("course_query")),
+            "shifu_bid": _normalize_query_text(request.args.get("shifu_bid")),
+            "course_name": _normalize_query_text(request.args.get("course_name")),
+            "usage_type": _normalize_query_text(request.args.get("usage_type")),
+            "ops_state": _normalize_query_text(request.args.get("ops_state")),
+            "discount_type": _normalize_query_text(request.args.get("discount_type")),
+            "status": _parse_choice_query_param(
+                request.args.get("status"),
+                field_name="status",
+                allowed_values=PROMOTION_COUPON_STATUS_VALUES,
+            ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -889,6 +1036,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             list_operator_promotion_coupons(app, page_index, page_size, filters)
         )
@@ -993,8 +1145,12 @@ def register_admin_operations_routes(
             default=20,
         )
         filters = {
-            "keyword": request.args.get("keyword", ""),
-            "status": request.args.get("status", ""),
+            "keyword": _normalize_query_text(request.args.get("keyword")),
+            "status": _parse_choice_query_param(
+                request.args.get("status"),
+                field_name="status",
+                allowed_values=PROMOTION_COUPON_USAGE_STATUS_VALUES,
+            ),
         }
         return make_common_response(
             list_operator_promotion_coupon_usages(
@@ -1020,7 +1176,7 @@ def register_admin_operations_routes(
             default=20,
         )
         filters = {
-            "keyword": request.args.get("keyword", ""),
+            "keyword": _normalize_query_text(request.args.get("keyword")),
         }
         return make_common_response(
             list_operator_promotion_coupon_codes(
@@ -1044,14 +1200,18 @@ def register_admin_operations_routes(
         )
 
         filters = {
-            "keyword": request.args.get("keyword", ""),
-            "course_query": request.args.get("course_query", ""),
-            "shifu_bid": request.args.get("shifu_bid", ""),
-            "course_name": request.args.get("course_name", ""),
-            "apply_type": request.args.get("apply_type", ""),
-            "channel": request.args.get("channel", ""),
-            "discount_type": request.args.get("discount_type", ""),
-            "status": request.args.get("status", ""),
+            "keyword": _normalize_query_text(request.args.get("keyword")),
+            "course_query": _normalize_query_text(request.args.get("course_query")),
+            "shifu_bid": _normalize_query_text(request.args.get("shifu_bid")),
+            "course_name": _normalize_query_text(request.args.get("course_name")),
+            "apply_type": _normalize_query_text(request.args.get("apply_type")),
+            "channel": _normalize_query_text(request.args.get("channel")),
+            "discount_type": _normalize_query_text(request.args.get("discount_type")),
+            "status": _parse_choice_query_param(
+                request.args.get("status"),
+                field_name="status",
+                allowed_values=PROMOTION_CAMPAIGN_STATUS_VALUES,
+            ),
             "start_time": _parse_datetime_filter(
                 request.args.get("start_time", ""),
                 is_end=False,
@@ -1061,6 +1221,11 @@ def register_admin_operations_routes(
                 is_end=True,
             ),
         }
+        _validate_datetime_range(
+            filters["start_time"],
+            filters["end_time"],
+            field_name="start_time",
+        )
         return make_common_response(
             list_operator_promotion_campaigns(app, page_index, page_size, filters)
         )
@@ -2033,5 +2198,6 @@ def register_admin_operations_routes(
                 shifu_bid=shifu_bid,
                 contact_type=contact_type,
                 identifier=identifiers[0],
+                operator_user_bid=str(getattr(request.user, "user_id", "") or ""),
             )
         )

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -6,6 +6,7 @@ from flask import Flask
 from sqlalchemy import and_, case
 
 from flaskr.dao import db
+from flaskr.service.common.models import raise_param_error
 from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserListDTO,
     AdminOperationUserOverviewDTO,
@@ -220,7 +221,7 @@ def list_operator_users(
             elif user_status == OPERATOR_USER_STATUS_PAID:
                 query = query.filter(UserEntity.state == USER_STATE_PAID)
             else:
-                query = query.filter(db.text("1 = 0"))
+                raise_param_error("user_status")
         if user_role == OPERATOR_USER_ROLE_OPERATOR:
             query = query.filter(UserEntity.is_operator == 1)
         elif user_role == OPERATOR_USER_ROLE_CREATOR:
@@ -239,6 +240,8 @@ def list_operator_users(
                 UserEntity.is_creator == 0,
                 ~UserEntity.user_bid.in_(db.session.query(learner_subquery.c.user_bid)),
             )
+        elif user_role:
+            raise_param_error("user_role")
         if start_time:
             query = query.filter(UserEntity.created_at >= start_time)
         if end_time:

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -646,6 +646,31 @@ def test_credit_notification_policy_persists_operator_updated_by(
         assert config.updated_by == "operator-audit-1"
 
 
+def test_credit_notification_policy_truncates_operator_updated_by(
+    credit_notifications_app: Flask,
+) -> None:
+    app = credit_notifications_app
+    updated_by = "operator-audit-" + ("x" * 40)
+
+    save_credit_notification_policy(
+        app,
+        {"enabled": False},
+        updated_by=updated_by,
+    )
+
+    with app.app_context():
+        config = (
+            Config.query.filter(
+                Config.key == "BILL_CREDIT_NOTIFICATION_SMS_CONFIG",
+                Config.deleted == 0,
+            )
+            .order_by(Config.id.desc())
+            .first()
+        )
+        assert config is not None
+        assert config.updated_by == updated_by[:36]
+
+
 def test_credit_notification_policy_resolves_list_creator_details(
     credit_notifications_app: Flask,
 ) -> None:
@@ -2298,6 +2323,7 @@ def test_requeue_records_operator_audit_metadata(
         ).one()
         assert notification.metadata_json["last_requeued_by"] == "operator-audit-2"
         assert notification.metadata_json["last_requeued_at"]
+        assert notification.metadata_json["last_requeued_at"].endswith("Z")
 
 
 def test_provider_exception_marks_notification_failed(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -59,6 +59,7 @@ from flaskr.service.billing.tasks import (
     send_credit_notification_task,
 )
 from flaskr.service.common.models import AppException
+from flaskr.service.config.models import Config
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
 from flaskr.service.user.repository import (
     create_user_entity,
@@ -619,6 +620,30 @@ def test_credit_notification_policy_can_preserve_opt_out_list(
         "creator_bids": ["creator-opted-out"],
         "mobiles": ["13800000000"],
     }
+
+
+def test_credit_notification_policy_persists_operator_updated_by(
+    credit_notifications_app: Flask,
+) -> None:
+    app = credit_notifications_app
+
+    save_credit_notification_policy(
+        app,
+        {"enabled": False},
+        updated_by="operator-audit-1",
+    )
+
+    with app.app_context():
+        config = (
+            Config.query.filter(
+                Config.key == "BILL_CREDIT_NOTIFICATION_SMS_CONFIG",
+                Config.deleted == 0,
+            )
+            .order_by(Config.id.desc())
+            .first()
+        )
+        assert config is not None
+        assert config.updated_by == "operator-audit-1"
 
 
 def test_credit_notification_policy_resolves_list_creator_details(
@@ -2230,6 +2255,49 @@ def test_requeue_keeps_failed_status_when_enqueue_fails(
             notification_bid=staged["notification_bid"]
         ).one()
         assert notification.status == CREDIT_NOTIFICATION_STATUS_FAILED_PROVIDER
+
+
+def test_requeue_records_operator_audit_metadata(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    _seed_creator(app)
+    _enable_policy(app)
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.send_sms_ali",
+        lambda app, mobile, *, template_code, template_params, sign_name=None: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
+        lambda app, *, notification_bid: {
+            "status": "enqueued",
+            "notification_bid": notification_bid,
+            "enqueued": True,
+        },
+    )
+
+    with app.app_context():
+        _seed_credit_ledger(ledger_bid="ledger-requeue-audit")
+
+    staged = stage_credit_granted_notification(
+        app,
+        ledger_bid="ledger-requeue-audit",
+        enqueue=False,
+    )
+    deliver_credit_notification(app, notification_bid=str(staged["notification_bid"]))
+    requeue_credit_notification(
+        app,
+        notification_bid=str(staged["notification_bid"]),
+        operator_user_bid="operator-audit-2",
+    )
+
+    with app.app_context():
+        notification = NotificationRecord.query.filter_by(
+            notification_bid=staged["notification_bid"]
+        ).one()
+        assert notification.metadata_json["last_requeued_by"] == "operator-audit-2"
+        assert notification.metadata_json["last_requeued_at"]
 
 
 def test_provider_exception_marks_notification_failed(

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -468,12 +468,17 @@ class TestAddConfig:
                 None
             )
             mock_config_class.query = mock_query
+            app.logger.info = MagicMock()
 
             result = add_config(
                 app, "test_key", "plain_value", is_secret=True, remark="secret remark"
             )
             assert result is True
             mock_encrypt.assert_called_once_with(app, "plain_value")
+            assert all(
+                "plain_value" not in str(call_args)
+                for call_args in app.logger.info.call_args_list
+            )
             mock_config_class.assert_called_once()
             mock_db.session.add.assert_called_once()
             mock_db.session.commit.assert_called_once()
@@ -762,6 +767,16 @@ class TestUpdateConfig:
         """Test that update_config returns False if environment config exists."""
         with app.app_context():
             mock_get_config_from_common.return_value = "env-value"
+            result = update_config(app, "test_key", "new_value")
+            assert result is False
+
+    @patch("flaskr.service.config.funcs.get_config_from_common")
+    def test_update_config_skips_if_empty_env_exists(
+        self, mock_get_config_from_common, app
+    ):
+        """Test that update_config respects empty string environment overrides."""
+        with app.app_context():
+            mock_get_config_from_common.return_value = ""
             result = update_config(app, "test_key", "new_value")
             assert result is False
 

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -437,6 +437,10 @@ class TestAddConfig:
                 "test_value" not in str(call_args)
                 for call_args in app.logger.info.call_args_list
             )
+            assert all(
+                "test remark" not in str(call_args)
+                for call_args in app.logger.info.call_args_list
+            )
             mock_config_class.assert_called_once()
             mock_db.session.add.assert_called_once()
             mock_db.session.commit.assert_called_once()
@@ -482,6 +486,10 @@ class TestAddConfig:
             mock_encrypt.assert_called_once_with(app, "plain_value")
             assert all(
                 "plain_value" not in str(call_args)
+                for call_args in app.logger.info.call_args_list
+            )
+            assert all(
+                "secret remark" not in str(call_args)
                 for call_args in app.logger.info.call_args_list
             )
             mock_config_class.assert_called_once()

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -427,11 +427,16 @@ class TestAddConfig:
                 None
             )
             mock_config_class.query = mock_query
+            app.logger.info = MagicMock()
 
             result = add_config(
                 app, "test_key", "test_value", is_secret=False, remark="test remark"
             )
             assert result is True
+            assert all(
+                "test_value" not in str(call_args)
+                for call_args in app.logger.info.call_args_list
+            )
             mock_config_class.assert_called_once()
             mock_db.session.add.assert_called_once()
             mock_db.session.commit.assert_called_once()

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -289,6 +289,58 @@ def test_list_operator_orders_applies_order_source_filter():
     assert isinstance(result, PageNationDTO)
 
 
+def test_list_operator_orders_reuses_preparsed_status_and_datetimes():
+    app = Flask(__name__)
+    order = DummyOrder()
+    start_time = datetime(2026, 4, 1, 0, 0, 0)
+    end_time = datetime(2026, 4, 30, 23, 59, 59)
+
+    query_mock = MagicMock()
+    query_mock.filter.return_value = query_mock
+    query_mock.count.return_value = 1
+    query_mock.order_by.return_value = query_mock
+    query_mock.offset.return_value = query_mock
+    query_mock.limit.return_value = query_mock
+    query_mock.all.return_value = [order]
+
+    with patch("flaskr.service.order.admin.Order") as order_model_mock:
+        with patch("flaskr.service.order.admin._parse_datetime") as parse_datetime_mock:
+            with patch("flaskr.service.order.admin._load_shifu_map") as shifu_map_mock:
+                with patch(
+                    "flaskr.service.order.admin._load_user_map"
+                ) as user_map_mock:
+                    with patch(
+                        "flaskr.service.order.admin._load_coupon_code_map"
+                    ) as coupon_map_mock:
+                        order_model_mock.query = query_mock
+                        order_model_mock.deleted = column("deleted")
+                        order_model_mock.status = column("status")
+                        order_model_mock.created_at = column("created_at")
+                        shifu_map_mock.return_value = {"shifu-1": DummyShifu()}
+                        user_map_mock.return_value = {
+                            "user-1": {
+                                "mobile": "18800001111",
+                                "email": "",
+                                "nickname": "Tester",
+                            }
+                        }
+                        coupon_map_mock.return_value = {}
+
+                        result = list_operator_orders(
+                            app,
+                            1,
+                            20,
+                            {
+                                "status": 502,
+                                "start_time": start_time,
+                                "end_time": end_time,
+                            },
+                        )
+
+    parse_datetime_mock.assert_not_called()
+    assert isinstance(result, PageNationDTO)
+
+
 def test_get_operator_order_overview_returns_aggregates():
     app = Flask(__name__)
     summary = SimpleNamespace(
@@ -633,30 +685,38 @@ def test_resolve_order_source_prefers_manual_open_api_and_coupon():
 
 def test_load_matching_user_bids_for_keyword_ignores_deleted_credentials():
     user_query = MagicMock()
-    (
-        user_query.filter.return_value.yield_per.return_value.enable_eagerloads.return_value
-    ) = []
+    user_filtered_query = MagicMock()
+    user_query.filter.return_value = user_filtered_query
 
     credential_query = MagicMock()
-    (
-        credential_query.filter.return_value.yield_per.return_value.enable_eagerloads.return_value
-    ) = [SimpleNamespace(user_bid="user-2")]
+    credential_filtered_query = MagicMock()
+    credential_query.filter.return_value = credential_filtered_query
+    union_query = MagicMock()
+    user_filtered_query.union.return_value = union_query
+    union_query.all.return_value = [SimpleNamespace(user_bid="user-2")]
 
     fake_user_entity = SimpleNamespace(
-        query=user_query,
         user_bid=column("user_bid"),
+        deleted=column("deleted"),
         user_identify=column("user_identify"),
     )
     fake_auth_credential = SimpleNamespace(
-        query=credential_query,
+        user_bid=column("user_bid"),
         identifier=column("identifier"),
         provider_name=column("provider_name"),
         deleted=column("deleted"),
     )
 
-    with patch("flaskr.service.order.admin.UserEntity", fake_user_entity):
-        with patch("flaskr.service.order.admin.AuthCredential", fake_auth_credential):
-            result = _load_matching_user_bids_for_keyword("Test@Example.com")
+    db_mock = MagicMock()
+    db_mock.or_ = lambda *args: ("or", args)
+    db_mock.session.query.side_effect = [user_query, credential_query]
+
+    with patch("flaskr.service.order.admin.db", db_mock):
+        with patch("flaskr.service.order.admin.UserEntity", fake_user_entity):
+            with patch(
+                "flaskr.service.order.admin.AuthCredential", fake_auth_credential
+            ):
+                result = _load_matching_user_bids_for_keyword("Test@Example.com")
 
     filter_args = credential_query.filter.call_args.args
 

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -1898,7 +1898,7 @@ def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
 
     active_response = test_client.get(
         "/api/shifu/admin/operations/promotions/coupons",
-        query_string={"page_index": 1, "page_size": 20, "status": "active"},
+        query_string={"page_index": 1, "page_size": 20, "status": "Active"},
         headers={"Token": "test-token"},
     )
     active_payload = active_response.get_json(force=True)
@@ -2017,7 +2017,7 @@ def test_admin_promotions_campaign_list_compatibly_displays_legacy_status_rows(
 
     active_response = test_client.get(
         "/api/shifu/admin/operations/promotions/campaigns",
-        query_string={"page_index": 1, "page_size": 20, "status": "active"},
+        query_string={"page_index": 1, "page_size": 20, "status": "ACTIVE"},
         headers={"Token": "test-token"},
     )
     active_payload = active_response.get_json(force=True)

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from flaskr.dao import db
+from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
 from flaskr.service.promo.admin import _format_promotion_admin_datetime
@@ -156,6 +157,38 @@ def test_admin_promotions_coupons_route_requires_operator(test_client, monkeypat
 
     assert response.status_code == 200
     assert payload["code"] == 401
+
+
+@pytest.mark.parametrize(
+    ("path", "query_string"),
+    [
+        (
+            "/api/shifu/admin/operations/promotions/coupons",
+            "page_index=1&page_size=20&status=invalid",
+        ),
+        (
+            "/api/shifu/admin/operations/promotions/campaigns",
+            "page_index=1&page_size=20&status=invalid",
+        ),
+    ],
+)
+def test_admin_promotions_routes_reject_invalid_status_filter(
+    test_client,
+    monkeypatch,
+    path,
+    query_string,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        f"{path}?{query_string}",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == "Params Error status"
 
 
 def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch):
@@ -1167,6 +1200,43 @@ def test_admin_promotions_coupon_usage_list_supports_keyword_filter(
     assert usage_payload["data"]["summary"]["usage_count"] == 1
     assert usage_payload["data"]["items"][0]["user_bid"] == "learner-2"
     assert usage_payload["data"]["items"][0]["order_bid"] == "order-2"
+
+
+def test_admin_promotions_coupon_usage_list_rejects_invalid_status(
+    app, test_client, monkeypatch
+):
+    _mock_operator(monkeypatch)
+
+    with app.app_context():
+        _seed_user("operator-1", "operator@example.com", "Operator", is_operator=True)
+        coupon = Coupon(
+            coupon_bid="coupon-invalid-status",
+            name="Invalid Status Coupon",
+            code="INVALIDSTATUS",
+            usage_type=COUPON_APPLY_TYPE_ALL,
+            discount_type=COUPON_TYPE_FIXED,
+            value=Decimal("10"),
+            total_count=1,
+            used_count=0,
+            filter="{}",
+            start=datetime(2026, 4, 24, 10, 0, 0),
+            end=datetime(2026, 5, 24, 10, 0, 0),
+            status=1,
+            created_user_bid="operator-1",
+            updated_user_bid="operator-1",
+        )
+        db.session.add(coupon)
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/promotions/coupons/coupon-invalid-status/usages",
+        query_string={"page_index": 1, "page_size": 20, "status": "999"},
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
 
 
 def test_admin_promotions_coupon_update_keeps_used_records_unchanged(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2276,6 +2276,7 @@ def test_admin_operation_course_credit_usages_ignores_blank_model_variant(
     [
         ("mode=invalid_mode", "mode"),
         ("usage_scene=invalid_scene", "usage_scene"),
+        ("start_time=2026-05-02&end_time=2026-05-01", "start_time"),
     ],
 )
 def test_admin_operation_course_credit_usages_route_rejects_invalid_filters(
@@ -2931,6 +2932,24 @@ def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(
     assert user_bid_filtered_payload["data"]["total"] == 0
 
 
+def test_admin_operation_course_follow_ups_route_rejects_inverted_time_range(
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/courses/course-detail/follow-ups"
+        "?page=1&page_size=20&start_time=2026-05-02&end_time=2026-05-01",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == "Params Error start_time"
+
+
 def test_admin_operation_course_follow_ups_route_supports_google_email_credentials(
     app,
     test_client,
@@ -3250,6 +3269,7 @@ def test_admin_operation_course_ratings_route_returns_summary_and_filters(
         ("mode=invalid_mode", "mode"),
         ("has_comment=not_bool", "has_comment"),
         ("sort_by=bad_sort", "sort_by"),
+        ("start_time=2026-05-02&end_time=2026-05-01", "start_time"),
     ],
 )
 def test_admin_operation_course_ratings_route_rejects_invalid_filters(

--- a/src/api/tests/service/shifu/test_admin_credit_notifications.py
+++ b/src/api/tests/service/shifu/test_admin_credit_notifications.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from flask import Flask
 
+from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.shifu.admin_operations import credit_notifications as module
 
 
@@ -91,13 +94,16 @@ def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
         ),
         ("templates", app),
         ("dry_run", {"notification_type": "low_balance", "creator_bid": "creator-1"}),
-        ("requeue", {"notification_bid": "notification-2"}),
+        (
+            "requeue",
+            {"notification_bid": "notification-2", "operator_user_bid": ""},
+        ),
     ]
 
 
 def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
     app = Flask(__name__)
-    saved_payloads: list[tuple[object, dict[str, object], bool]] = []
+    saved_payloads: list[tuple[object, dict[str, object], bool, str]] = []
     policies = [{"version": 1}, {"version": 2}]
 
     monkeypatch.setattr(
@@ -111,8 +117,9 @@ def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
         payload: dict[str, object],
         *,
         preserve_opt_out: bool,
+        updated_by: str = "system",
     ) -> None:
-        saved_payloads.append((received_app, payload, preserve_opt_out))
+        saved_payloads.append((received_app, payload, preserve_opt_out, updated_by))
 
     monkeypatch.setattr(module, "save_credit_notification_policy", fake_save_policy)
 
@@ -120,5 +127,101 @@ def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
     assert module.update_operator_credit_notification_config(
         app,
         payload={"enabled": True},
+        operator_user_bid="operator-1",
     ) == {"version": 2}
-    assert saved_payloads == [(app, {"enabled": True}, True)]
+    assert saved_payloads == [(app, {"enabled": True}, True, "operator-1")]
+
+
+def test_operator_credit_notification_services_pass_operator_audit_context(
+    monkeypatch,
+):
+    app = Flask(__name__)
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(
+        module,
+        "save_credit_notification_policy",
+        lambda received_app, payload, **kwargs: calls.append(
+            ("save", {"app": received_app, "payload": payload, **kwargs})
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "load_credit_notification_policy_for_operator",
+        lambda: {"ok": True},
+    )
+    monkeypatch.setattr(
+        module,
+        "requeue_credit_notification",
+        lambda received_app, **kwargs: (
+            calls.append(("requeue", {"app": received_app, **kwargs}))
+            or {"status": "enqueued"}
+        ),
+    )
+
+    assert module.update_operator_credit_notification_config(
+        app,
+        payload={"enabled": True},
+        operator_user_bid="operator-1",
+    ) == {"ok": True}
+    assert (
+        module.requeue_operator_credit_notification(
+            app,
+            notification_bid="notification-1",
+            operator_user_bid="operator-2",
+        )["status"]
+        == "enqueued"
+    )
+    assert calls == [
+        (
+            "save",
+            {
+                "app": app,
+                "payload": {"enabled": True},
+                "preserve_opt_out": True,
+                "updated_by": "operator-1",
+            },
+        ),
+        (
+            "requeue",
+            {
+                "app": app,
+                "notification_bid": "notification-1",
+                "operator_user_bid": "operator-2",
+            },
+        ),
+    ]
+
+
+def test_credit_notification_list_route_rejects_invalid_status_filters(
+    test_client,
+    monkeypatch,
+):
+    dummy_user = SimpleNamespace(
+        user_id="operator-1",
+        is_operator=True,
+        is_creator=False,
+        language="en-US",
+    )
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: dummy_user,
+        raising=False,
+    )
+
+    invalid_cases = [
+        {"status": "unknown"},
+        {"delivery_status": "later"},
+        {"skip_reason": "mystery"},
+    ]
+
+    for query_string in invalid_cases:
+        response = test_client.get(
+            "/api/shifu/admin/operations/credit-notifications",
+            query_string={"page_index": 1, "page_size": 20, **query_string},
+            headers={"Token": "test-token"},
+        )
+        payload = response.get_json(force=True)
+
+        assert response.status_code == 200
+        assert payload["code"] == ERROR_CODE["server.common.paramsError"]

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -4186,6 +4186,24 @@ def test_admin_operation_user_credits_route_returns_payload(
     assert scene_payload["data"]["items"][0]["usage_scene"] == "preview"
 
 
+def test_admin_operation_user_credits_route_rejects_inverted_time_range(
+    test_client,
+    monkeypatch,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/users/user-credits-route/credits"
+        "?page_index=1&page_size=20&start_time=2026-05-02&end_time=2026-05-01",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == "Params Error start_time"
+
+
 def test_admin_operation_user_credit_grant_route_returns_payload(
     app,
     test_client,

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -3918,6 +3918,7 @@ def test_admin_operation_users_route_returns_filtered_payload(
     [
         ("page_index=1&page_size=20&user_status=invalid", "user_status"),
         ("page_index=1&page_size=20&user_role=invalid", "user_role"),
+        ("page_index=1&page_size=20&start_time=not-a-date", "start_time"),
         (
             "page_index=1&page_size=20&start_time=2026-05-02&end_time=2026-05-01",
             "start_time",

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2722,6 +2722,7 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
     assert ledger.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT
     assert ledger.source_type == CREDIT_SOURCE_TYPE_MANUAL
     assert ledger.metadata_json["grant_type"] == "manual_grant"
+    assert ledger.metadata_json["operator_user_bid"] == "operator-1"
     assert ledger.metadata_json["grant_channel"] == "operator_user_management"
     assert ledger.metadata_json["display_name"] == "模型扣费补偿"
     assert ledger.metadata_json["note"] == "ops support"
@@ -3283,7 +3284,14 @@ def test_grant_operator_user_package_creates_manual_paid_order_and_summary(app):
     assert order.status == BILLING_ORDER_STATUS_PAID
     assert order.payment_provider == "manual"
     assert order.metadata_json["checkout_type"] == "admin_manual_plan_grant"
+    assert order.metadata_json["operator_user_bid"] == "operator-1"
     assert order.metadata_json["request_id"] == "package-grant-request-1"
+    assert (
+        order.metadata_json["notification_extensions"]["admin_manual_plan_grant"][
+            "operator_user_bid"
+        ]
+        == "operator-1"
+    )
     assert (
         order.metadata_json["notification_extensions"]["admin_manual_plan_grant"][
             "status"
@@ -3292,6 +3300,8 @@ def test_grant_operator_user_package_creates_manual_paid_order_and_summary(app):
     )
     assert subscription is not None
     assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+    assert subscription.metadata_json["operator_user_bid"] == "operator-1"
+    assert subscription.metadata_json["request_id"] == "package-grant-request-1"
     assert ledger is not None
     assert ledger.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT
     assert ledger.source_type == CREDIT_SOURCE_TYPE_SUBSCRIPTION
@@ -3901,6 +3911,36 @@ def test_admin_operation_users_route_returns_filtered_payload(
             "updated_at": _format_operator_datetime(datetime(2026, 4, 6, 12, 0, 0)),
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("query_string", "expected_param"),
+    [
+        ("page_index=1&page_size=20&user_status=invalid", "user_status"),
+        ("page_index=1&page_size=20&user_role=invalid", "user_role"),
+        (
+            "page_index=1&page_size=20&start_time=2026-05-02&end_time=2026-05-01",
+            "start_time",
+        ),
+    ],
+)
+def test_admin_operation_users_route_rejects_invalid_filter_params(
+    test_client,
+    monkeypatch,
+    query_string,
+    expected_param,
+):
+    _mock_operator(monkeypatch)
+
+    response = test_client.get(
+        f"/api/shifu/admin/operations/users?{query_string}",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+    assert payload["message"] == f"Params Error {expected_param}"
 
 
 def test_admin_operation_user_detail_route_returns_payload(

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -337,11 +337,16 @@ def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
     target_email = f"{uuid.uuid4().hex[:10]}@example.com"
+    old_updated_at = datetime(2026, 1, 1, 0, 0, 0)
 
     with app.app_context():
         _seed_user(app, user_bid=old_creator_bid, email="route-old@example.com")
         _seed_user(app, user_bid=target_user_bid, email=target_email)
         _seed_course(shifu_bid, old_creator_bid)
+        DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).update(
+            {DraftShifu.updated_at: old_updated_at},
+            synchronize_session=False,
+        )
         db.session.commit()
 
     _mock_operator(monkeypatch)
@@ -364,6 +369,7 @@ def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):
     with app.app_context():
         latest_draft = DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).one()
         assert latest_draft.updated_user_bid == "operator-1"
+        assert latest_draft.updated_at > old_updated_at
 
 
 def test_transfer_creator_records_operator_history_entry(app):

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -13,7 +13,12 @@ from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
 from flaskr.service.billing.models import BillingOrder, BillingProduct
 from flaskr.service.shifu.admin import transfer_operator_course_creator
 from flaskr.service.shifu.funcs import shifu_permission_verification
-from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
+from flaskr.service.shifu.models import (
+    AiCourseAuth,
+    DraftShifu,
+    LogDraftStruct,
+    PublishedShifu,
+)
 from flaskr.service.shifu.permissions import get_user_shifu_permissions
 from flaskr.service.shifu.utils import get_shifu_creator_bid
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
@@ -210,6 +215,8 @@ def test_transfer_creator_creates_missing_user_and_preserves_shared_auth(
         assert auth is not None
         assert auth.status == 1
         assert get_shifu_creator_bid(app, shifu_bid) == target_user_bid
+        latest_draft = DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).one()
+        assert latest_draft.updated_user_bid == old_creator_bid
         assert (
             shifu_permission_verification(app, old_creator_bid, shifu_bid, "edit")
             is False
@@ -354,6 +361,42 @@ def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):
     assert response.status_code == 200
     assert payload["code"] == 0
     assert payload["data"]["target_creator_user_bid"] == target_user_bid
+    with app.app_context():
+        latest_draft = DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).one()
+        assert latest_draft.updated_user_bid == "operator-1"
+
+
+def test_transfer_creator_records_operator_history_entry(app):
+    shifu_bid = uuid.uuid4().hex[:32]
+    old_creator_bid = uuid.uuid4().hex[:32]
+    target_user_bid = uuid.uuid4().hex[:32]
+    target_email = f"{uuid.uuid4().hex[:10]}@example.com"
+
+    with app.app_context():
+        _seed_user(app, user_bid=old_creator_bid, email="history-old@example.com")
+        _seed_user(app, user_bid=target_user_bid, email=target_email)
+        _seed_course(shifu_bid, old_creator_bid)
+        db.session.commit()
+
+        before_count = LogDraftStruct.query.filter_by(
+            created_user_bid="operator-history-1",
+            shifu_bid=shifu_bid,
+        ).count()
+
+        transfer_operator_course_creator(
+            app,
+            shifu_bid=shifu_bid,
+            contact_type="email",
+            identifier=target_email,
+            operator_user_bid="operator-history-1",
+        )
+
+        after_count = LogDraftStruct.query.filter_by(
+            created_user_bid="operator-history-1",
+            shifu_bid=shifu_bid,
+        ).count()
+
+        assert after_count == before_count + 1
 
 
 def test_transfer_creator_promotes_existing_viewer_to_owner_permissions(


### PR DESCRIPTION
Summary

Harden operator management audit and filters.

- unify operator list query validation
- add audit context for credit notifications and course transfer
- tighten promo/order filter handling
- add targeted regression tests

Validation:
- pre-commit run --files ...
- pytest -q tests/service/shifu/test_admin_users.py tests/service/shifu/test_transfer_creator.py tests/service/shifu/test_admin_credit_notifications.py tests/service/promo/test_admin_promotions.py tests/service/billing/test_credit_notifications.py tests/service/order/test_admin_orders.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin actions now record operator audit info (operator ID persisted/truncated) for billing/config updates and requeues; config updates normalize/store an "updated_by" value.
  * Course creator transfer records operator history for auditing; several admin APIs accept operator context.

* **Bug Fixes**
  * Stronger validation for many filter parameters (invalid values now return parameter errors).
  * Queries that resolve to no matches return immediate empty paged responses.
  * Datetime ranges normalized/validated (start ≤ end); requeued notifications record requeue metadata and timestamps.

* **Tests**
  * Added/updated tests covering operator audit context, filter validation, config logging, and requeue metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->