### PR TITLE
fix: initialize current outline item in run context

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1371,7 +1371,7 @@ class RunScriptContextV2:
         self._shifu_info = shifu_info
         self.shifu_ids = []
         self.outline_item_ids = []
-        self.current_outline_item = None
+        self._current_outline_item = None
         self._run_type = RunType.INPUT
         self._can_continue = True
         self._stop_event = stop_event

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -232,6 +232,32 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
         asyncio.run(runner())
 
 
+class CurrentOutlineItemInitializationTests(unittest.TestCase):
+    def test_missing_outline_in_history_initializes_current_outline_item(self):
+        app = Flask("current-outline-item-init-tests")
+        ctx = RunScriptContextV2(
+            app=app,
+            struct=HistoryItem(
+                bid="shifu-1",
+                id=1,
+                type="shifu",
+                children=[],
+            ),
+            outline_item_info=types.SimpleNamespace(
+                bid="outline-missing",
+                title="Missing outline",
+                shifu_bid="shifu-1",
+            ),
+            user_info=types.SimpleNamespace(user_id="user-1"),
+            shifu_info=types.SimpleNamespace(bid="shifu-1"),
+            preview_mode=False,
+            is_paid=True,
+        )
+
+        self.assertIsNone(ctx._current_outline_item)
+        self.assertEqual(ctx._get_current_outline_block_count(), 0)
+
+
 class NextChapterInteractionTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-04 17:41 左右连续告警：

```
/api/learn/shifu/aee5f1eaf5664835b3583f85cd4c90bf/run/35baf4917d4643449d4cf6763c066534
run_script 6 'RunScriptContextV2' object has no attribute '_current_outline_item'
```

堆栈指向 `flaskr/service/learn/context_v2.py`：`_get_current_outline_block_count` 读取 `self._current_outline_item` 时对象未初始化。

## 修复内容

- 在 `RunScriptContextV2.__init__` 中统一初始化 `self._current_outline_item = None`。
- 保留后续从历史结构匹配当前大纲时覆盖该值的行为。
- 增加回归用例，覆盖历史结构未命中当前大纲时仍可安全返回 block count 0，不再抛 `AttributeError`。

## 验证

- ✅ `python3 -m py_compile src/api/flaskr/service/learn/context_v2.py src/api/tests/service/learn/test_context_v2.py`
- ✅ `git diff --check`
- ⚠️ `python3 -m pytest tests/service/learn/test_context_v2.py::CurrentOutlineItemInitializationTests::test_missing_outline_in_history_initializes_current_outline_item -q` 未运行：本机系统 Python 缺少 pytest。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization issue that could cause incorrect state handling when outline information is unavailable.

* **Tests**
  * Added validation tests for outline initialization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->