### PR TITLE
feat:Refine listen playback speed control UI

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -219,6 +219,12 @@
   color: color-mix(in srgb, var(--foreground) 90%, transparent);
 }
 
+.listen-playback-speed-action:focus-visible {
+  background: color-mix(in srgb, var(--foreground) 4%, transparent) !important;
+  color: var(--foreground);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--foreground) 18%, transparent) !important;
+}
+
 .listen-playback-speed-action[data-state='open'] {
   background: color-mix(in srgb, var(--foreground) 4%, transparent) !important;
   color: var(--foreground);
@@ -233,7 +239,7 @@
   font-weight: 500;
   line-height: 1;
   letter-spacing: -0.03em;
-  color: color-mix(in srgb, var(--foreground) 84%, transparent);
+  color: inherit;
 }
 
 .listen-playback-speed-popover {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -197,38 +197,73 @@
 }
 
 .listen-playback-speed-action {
-  width: 48px !important;
-  min-width: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px !important;
+  min-width: 52px;
   height: 32px;
   padding: 0;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    opacity 160ms ease;
 }
 
-.listen-playback-speed-action__icon {
-  width: 44px !important;
-  height: 22px !important;
-  opacity: 0.9;
+.listen-playback-speed-action:hover {
+  background: color-mix(in srgb, var(--foreground) 3%, transparent) !important;
+  color: color-mix(in srgb, var(--foreground) 90%, transparent);
+}
+
+.listen-playback-speed-action[data-state='open'] {
+  background: color-mix(in srgb, var(--foreground) 4%, transparent) !important;
+  color: var(--foreground);
+}
+
+.listen-playback-speed-action__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 100%;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: color-mix(in srgb, var(--foreground) 84%, transparent);
 }
 
 .listen-playback-speed-popover {
   width: auto !important;
-  min-width: 284px;
+  min-width: 272px;
   padding: 8px !important;
+  border-radius: 16px !important;
+  border-color: color-mix(in srgb, var(--foreground) 10%, transparent) !important;
+  background: color-mix(in srgb, var(--card) 94%, white 6%) !important;
+  box-shadow:
+    0 12px 28px rgba(15, 23, 42, 0.11),
+    0 2px 8px rgba(15, 23, 42, 0.05) !important;
+  backdrop-filter: blur(18px);
   z-index: 120;
 }
 
 .listen-playback-speed-menu {
   display: grid;
-  grid-template-columns: repeat(5, 48px);
-  gap: 8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
   align-items: center;
   justify-content: center;
 }
 
 .listen-playback-speed-menu__title {
   grid-column: 1 / -1;
-  padding: 0 8px 4px;
-  color: var(--muted-foreground);
+  padding: 0 4px 4px;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
   font-size: 12px;
+  font-weight: 600;
   line-height: 16px;
   white-space: nowrap;
 }
@@ -237,33 +272,46 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  min-width: 48px;
-  height: 32px;
-  min-height: 32px;
-  padding: 0;
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 6px;
   border: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--foreground) 3%, transparent);
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
   cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .listen-playback-speed-option:hover {
   border-color: color-mix(in srgb, var(--foreground) 14%, transparent);
   background: color-mix(in srgb, var(--foreground) 7%, transparent);
+  color: var(--foreground);
 }
 
 .listen-playback-speed-option--active,
 .listen-playback-speed-option--active:hover {
-  border-color: color-mix(in srgb, var(--foreground) 18%, transparent);
+  border-color: color-mix(in srgb, var(--foreground) 13%, transparent);
   background: color-mix(in srgb, var(--foreground) 10%, transparent);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--foreground) 10%, transparent);
+  color: color-mix(in srgb, var(--foreground) 88%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--foreground) 5%, transparent),
+    0 2px 8px rgba(15, 23, 42, 0.05);
+  transform: translateY(-1px);
 }
 
-.listen-playback-speed-option__icon {
-  width: 44px;
-  height: 22px;
+.listen-playback-speed-option__label {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
   pointer-events: none;
   user-select: none;
 }
@@ -493,8 +541,8 @@
   }
 
   .listen-playback-speed-action {
-    width: 48px !important;
-    min-width: 48px;
+    width: 44px !important;
+    min-width: 44px;
     padding: 0;
   }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -241,7 +241,11 @@
   min-width: 272px;
   padding: 8px !important;
   border-radius: 16px !important;
-  border-color: color-mix(in srgb, var(--foreground) 10%, transparent) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--foreground) 10%,
+    transparent
+  ) !important;
   background: color-mix(in srgb, var(--card) 94%, white 6%) !important;
   box-shadow:
     0 12px 28px rgba(15, 23, 42, 0.11),

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -316,7 +316,7 @@ describe('ListenModeSlideRenderer', () => {
     });
   });
 
-  it('uses an icon-only control for opening playback speed options', () => {
+  it('renders the current playback speed as text in the trigger control', () => {
     writeListenPlaybackSpeedToStorage('course-1', 2);
 
     render(
@@ -339,12 +339,11 @@ describe('ListenModeSlideRenderer', () => {
       name: 'module.chat.listenPlaybackSpeedAriaLabel',
     });
 
-    expect(speedButton.querySelector('img')).toBeInTheDocument();
-    expect(speedButton.querySelector('svg')).not.toBeInTheDocument();
-    expect(speedButton).not.toHaveTextContent(/x/i);
+    expect(speedButton).toHaveTextContent('2x');
+    expect(speedButton.querySelector('img')).not.toBeInTheDocument();
   });
 
-  it('uses fixed SVG icons instead of text nodes for playback speed options', async () => {
+  it('renders playback speed options as text labels', async () => {
     render(
       <ListenModeSlideRenderer
         items={[
@@ -370,8 +369,8 @@ describe('ListenModeSlideRenderer', () => {
     for (const label of ['0.75x', '1x', '1.25x', '1.5x', '2x']) {
       const option = await screen.findByRole('radio', { name: label });
 
-      expect(option.querySelector('img')).toBeInTheDocument();
-      expect(option).not.toHaveTextContent(/x/i);
+      expect(option).toHaveTextContent(label);
+      expect(option.querySelector('img')).not.toBeInTheDocument();
     }
   });
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -56,11 +56,6 @@ import {
 import AskBlock from './AskBlock';
 import type { AskMessage } from './AskBlock';
 import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
-import ListenSpeed075Icon from '@/c-assets/newchat/light/listen-speed/speed-075.svg';
-import ListenSpeed100Icon from '@/c-assets/newchat/light/listen-speed/speed-100.svg';
-import ListenSpeed125Icon from '@/c-assets/newchat/light/listen-speed/speed-125.svg';
-import ListenSpeed150Icon from '@/c-assets/newchat/light/listen-speed/speed-150.svg';
-import ListenSpeed200Icon from '@/c-assets/newchat/light/listen-speed/speed-200.svg';
 import './ListenModeRenderer.scss';
 import { useListenContentData } from './useListenMode';
 import { buildAskListByAnchorElementBid } from './askState';
@@ -236,14 +231,6 @@ interface ListenPlaybackSpeedPlayerActionProps {
   onPlaybackSpeedChange: (playbackSpeed: ListenPlaybackSpeed) => void;
 }
 
-const LISTEN_PLAYBACK_SPEED_ICON_BY_VALUE = {
-  [0.75]: ListenSpeed075Icon,
-  [1]: ListenSpeed100Icon,
-  [1.25]: ListenSpeed125Icon,
-  [1.5]: ListenSpeed150Icon,
-  [2]: ListenSpeed200Icon,
-} satisfies Record<ListenPlaybackSpeed, string>;
-
 const ListenPlaybackSpeedPlayerAction = memo(
   ({
     ariaLabel,
@@ -253,6 +240,7 @@ const ListenPlaybackSpeedPlayerAction = memo(
     onPlaybackSpeedChange,
   }: ListenPlaybackSpeedPlayerActionProps) => {
     const [isOpen, setIsOpen] = useState(false);
+    const currentPlaybackSpeedLabel = formatListenPlaybackSpeed(playbackSpeed);
 
     const handlePlaybackSpeedChange = useCallback(
       (nextPlaybackSpeed: ListenPlaybackSpeed) => {
@@ -274,14 +262,9 @@ const ListenPlaybackSpeedPlayerAction = memo(
             title={ariaLabel}
             type='button'
           >
-            <Image
-              alt=''
-              aria-hidden='true'
-              height={22}
-              className='slide-player__icon listen-playback-speed-action__icon'
-              src={LISTEN_PLAYBACK_SPEED_ICON_BY_VALUE[playbackSpeed]}
-              width={44}
-            />
+            <span className='listen-playback-speed-action__label'>
+              {currentPlaybackSpeedLabel}
+            </span>
           </button>
         </PopoverTrigger>
         <PopoverContent
@@ -314,14 +297,9 @@ const ListenPlaybackSpeedPlayerAction = memo(
                   title={optionLabel}
                   type='button'
                 >
-                  <Image
-                    alt=''
-                    aria-hidden='true'
-                    className='listen-playback-speed-option__icon'
-                    height={22}
-                    src={LISTEN_PLAYBACK_SPEED_ICON_BY_VALUE[option]}
-                    width={44}
-                  />
+                  <span className='listen-playback-speed-option__label'>
+                    {optionLabel}
+                  </span>
                 </button>
               );
             })}


### PR DESCRIPTION
## Summary
- replace listen playback speed SVG assets with text-based speed labels
- refine the trigger and popover styling to better match the player controls
- update playback speed renderer tests to cover text labels

## Self-review
- checked the diff and confirmed the change is isolated to the playback speed trigger, popover styles, and related tests
- verified no i18n or API contract changes were introduced
- confirmed existing player controls outside the playback speed entry were not modified

## Testing
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm test -- --runInBand --runTestsByPath "$PWD/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx" "$PWD/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackSpeed.test.ts"
- python scripts/check_repo_harness.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned the listen-mode playback speed control to show text labels (e.g., "2x") instead of icons.
  * Restyled the playback-speed button, popover menu and option items for clearer hover/focus/active states, updated sizing and spacing, and improved visual depth and backdrop blur.
  * Adjusted mobile sizing for the playback-speed action for better fit.

* **Tests**
  * Updated tests to assert the new text-based speed trigger and option renderings (no icon img elements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->