### PR TITLE
fix: guard shifu detail save against missing name

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -458,7 +458,11 @@ def save_shifu_draft_info(
             tts_pitch = validated.pitch
             tts_emotion = validated.emotion
 
-        # Validate input lengths
+        # Validate input before reading lengths so malformed/partial requests
+        # return a controlled business error instead of a TypeError.
+        if not shifu_name:
+            raise_error("server.shifu.shifuNameRequired")
+        shifu_description = shifu_description or ""
         if len(shifu_name) > SHIFU_NAME_MAX_LENGTH:
             raise_error_with_args(
                 "server.shifu.shifuNameTooLong", max_length=SHIFU_NAME_MAX_LENGTH

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -195,9 +195,7 @@ def test_save_shifu_draft_info_rejects_missing_name_without_type_error(
     assert "object of type" not in str(exc_info.value)
 
 
-def test_save_shifu_draft_info_treats_missing_description_as_empty(
-    app, monkeypatch
-):
+def test_save_shifu_draft_info_treats_missing_description_as_empty(app, monkeypatch):
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -166,3 +166,67 @@ def test_save_and_get_shifu_draft_info_roundtrip_ask_provider_config(app, monkey
     assert detail.ask_temperature == pytest.approx(0.8)
     assert detail.ask_system_prompt == "ask prompt"
     assert detail.ask_provider_config == ask_provider_config
+
+
+def test_save_shifu_draft_info_rejects_missing_name_without_type_error(
+    app, monkeypatch
+):
+    from flaskr.service.common.models import AppException
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    _mock_shifu_permissions(monkeypatch)
+
+    with pytest.raises(AppException) as exc_info:
+        shifu_draft_funcs.save_shifu_draft_info(
+            app=app,
+            user_id="owner-missing-name",
+            shifu_id="test-save-shifu-missing-name",
+            shifu_name=None,
+            shifu_description="desc",
+            shifu_avatar="res",
+            shifu_keywords=["test"],
+            shifu_model="gpt-test",
+            shifu_temperature=0.3,
+            shifu_price=1.23,
+            shifu_system_prompt="",
+            base_url="http://localhost:5000",
+        )
+
+    assert "object of type" not in str(exc_info.value)
+
+
+def test_save_shifu_draft_info_treats_missing_description_as_empty(
+    app, monkeypatch
+):
+    from flaskr.service.shifu import shifu_draft_funcs
+    from flaskr.service.shifu.models import DraftShifu
+
+    shifu_bid = "test-save-shifu-none-description"
+    owner_bid = "owner-none-description"
+    _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.23"))
+    _mock_shifu_permissions(monkeypatch)
+
+    result = shifu_draft_funcs.save_shifu_draft_info(
+        app=app,
+        user_id=owner_bid,
+        shifu_id=shifu_bid,
+        shifu_name="Test Shifu",
+        shifu_description=None,
+        shifu_avatar="res",
+        shifu_keywords=["test"],
+        shifu_model="gpt-test",
+        shifu_temperature=0.3,
+        shifu_price=1.23,
+        shifu_system_prompt="",
+        base_url="http://localhost:5000",
+    )
+
+    assert result.description == ""
+    with app.app_context():
+        latest = (
+            DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+            .order_by(DraftShifu.id.desc())
+            .first()
+        )
+        assert latest is not None
+        assert latest.description == ""


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-06 13:32 左右连续 3 条 AI-Shifu 生产报错：

- `POST /api/shifu/shifus/e7e8eb072a3f4bfd80b0d33f5a505bd5/detail`
- `save_shifu_draft_info` 中对 `shifu_name=None` 执行 `len(shifu_name)`
- 异常：`TypeError: object of type 'NoneType' has no len()`

## 修复内容

- 在 `save_shifu_draft_info` 中先校验缺失课程名，返回已有的 `server.shifu.shifuNameRequired` 业务错误，避免 500 TypeError。
- 将缺失的 `description` 归一为空字符串，避免后续 `len(None)`。
- 增加回归测试覆盖缺失 name / description 场景。

## 验证

- ✅ `python3.11 -m py_compile src/api/flaskr/service/shifu/shifu_draft_funcs.py`
- ✅ `git diff --check`
- ⚠️ 本机 Python 环境缺少 `pytest`/`flask`/`sqlalchemy`，`.venv-shifu` 指向的 Python 无执行权限，未能本机运行完整 pytest。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for required fields with consistent error messaging when names are missing.
  * Improved handling of missing descriptions to prevent malformed requests from causing errors.

* **Tests**
  * Expanded test coverage for edge cases in data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->