### PR TITLE
fix: refresh preview continuation from latest mdflow

### DIFF
--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -79,7 +79,7 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
-describe('usePreviewChat business error rendering', () => {
+describe('usePreviewChat helpers and business error rendering', () => {
   test('builds interaction continuation preview params with latest mdflow', () => {
     expect(
       buildInteractionContinuationPreviewParams({

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -1,5 +1,6 @@
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
 import {
+  buildInteractionContinuationPreviewParams,
   buildPreviewBusinessErrorItem,
   replacePreviewLoadingWithBusinessError,
 } from './usePreviewChat';
@@ -79,6 +80,55 @@ jest.mock('react-i18next', () => ({
 }));
 
 describe('usePreviewChat business error rendering', () => {
+  test('builds interaction continuation preview params with latest mdflow', () => {
+    expect(
+      buildInteractionContinuationPreviewParams({
+        currentParams: {
+          shifuBid: 'shifu-1',
+          outlineBid: 'lesson-1',
+          mdflow: 'old prompt',
+          block_index: 1,
+          variables: { oldVar: 'old' },
+          user_input: { oldVar: ['old'] },
+        },
+        latestMdflow: 'new prompt',
+        blockIndex: 3,
+        variables: { answer: '42' },
+        userInput: { answer: ['42'] },
+      }),
+    ).toEqual({
+      shifuBid: 'shifu-1',
+      outlineBid: 'lesson-1',
+      mdflow: 'new prompt',
+      block_index: 3,
+      variables: { answer: '42' },
+      user_input: { answer: ['42'] },
+    });
+  });
+
+  test('drops stale interaction user input when continuation has no submission', () => {
+    expect(
+      buildInteractionContinuationPreviewParams({
+        currentParams: {
+          shifuBid: 'shifu-1',
+          outlineBid: 'lesson-1',
+          mdflow: 'old prompt',
+          block_index: 1,
+          user_input: { oldVar: ['old'] },
+        },
+        latestMdflow: 'new prompt',
+        blockIndex: 2,
+        variables: {},
+      }),
+    ).toEqual({
+      shifuBid: 'shifu-1',
+      outlineBid: 'lesson-1',
+      mdflow: 'new prompt',
+      block_index: 2,
+      variables: {},
+    });
+  });
+
   test('replaces loading placeholder with backend business error message', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -65,6 +65,35 @@ interface StartPreviewParams {
   visual_mode?: boolean;
 }
 
+export const buildInteractionContinuationPreviewParams = ({
+  currentParams,
+  latestMdflow,
+  blockIndex,
+  variables,
+  userInput,
+}: {
+  currentParams: StartPreviewParams;
+  latestMdflow: string;
+  blockIndex: number;
+  variables: PreviewVariablesMap;
+  userInput?: Record<string, string[]>;
+}): StartPreviewParams => {
+  const nextParams: StartPreviewParams = {
+    ...currentParams,
+    mdflow: latestMdflow,
+    block_index: blockIndex,
+    variables,
+  };
+
+  if (userInput) {
+    nextParams.user_input = userInput;
+  } else if ('user_input' in nextParams) {
+    delete nextParams.user_input;
+  }
+
+  return nextParams;
+};
+
 enum PREVIEW_SSE_OUTPUT_TYPE {
   ELEMENT = 'element',
   INTERACTION = 'interaction',
@@ -1650,19 +1679,16 @@ export function usePreviewChat() {
       const targetGeneratedBlockBid =
         getPreviewItemGeneratedBlockBid(targetItem) || blockBid;
 
-      const nextParams: StartPreviewParams = {
-        ...sseParams.current,
-        block_index: resolvePreviewRequestBlockIndex(
+      const nextParams = buildInteractionContinuationPreviewParams({
+        currentParams: sseParams.current,
+        latestMdflow: resolveLatestMdflow(),
+        blockIndex: resolvePreviewRequestBlockIndex(
           targetGeneratedBlockBid,
           sseParams.current.block_index ?? 0,
         ),
         variables: requestVariables,
-      };
-      if (userInputPayload) {
-        nextParams.user_input = userInputPayload;
-      } else if ('user_input' in nextParams) {
-        delete nextParams.user_input;
-      }
+        userInput: userInputPayload,
+      });
       startPreview(nextParams);
       return true;
     },
@@ -1674,6 +1700,7 @@ export function usePreviewChat() {
       updateContentListWithUserOperate,
       prefillInteractionBlock,
       resolveLastActionableBlockBid,
+      resolveLatestMdflow,
     ],
   );
 


### PR DESCRIPTION
## Summary
- refresh preview continuation requests with the latest edited mdflow before interaction re-generation
- reuse a helper to rebuild continuation params for selection and text-input interactions
- add focused tests for latest-mdflow continuation and stale user_input cleanup

## Testing
- cd src/cook-web && npm test -- --runInBand --runTestsByPath "$PWD/src/components/lesson-preview/usePreviewChat.test.ts" "$PWD/src/components/lesson-preview/LessonPreview.test.tsx"
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/components/lesson-preview/usePreviewChat.tsx --file src/components/lesson-preview/usePreviewChat.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved preview continuation after user interactions so the latest content, block position, and variables are used and stale user input is omitted.

* **Tests**
  * Added tests covering helper behavior and error rendering to validate correct parameter construction for continued previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->