### PR TITLE
fix: validate SMS mobile before Aliyun send

### DIFF
--- a/src/api/flaskr/service/common/phone_numbers.py
+++ b/src/api/flaskr/service/common/phone_numbers.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import re
+
+
+SMS_MOBILE_PATTERN = re.compile(r"^1\d{10}$")
+
 
 def normalize_phone_identifier(phone: str | None) -> str:
     """Normalize phone identifiers used by auth and import flows."""
@@ -10,3 +15,9 @@ def normalize_phone_identifier(phone: str | None) -> str:
     if normalized.startswith("+86"):
         normalized = normalized[3:].strip()
     return normalized
+
+
+def is_valid_sms_mobile(phone: str | None) -> bool:
+    """Return whether a phone identifier is valid for SMS delivery in China."""
+
+    return bool(SMS_MOBILE_PATTERN.fullmatch(normalize_phone_identifier(phone)))

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -19,7 +19,10 @@ import json
 
 from flaskr.service.config.funcs import get_config as get_dynamic_config
 from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
-from flaskr.service.common.phone_numbers import normalize_phone_identifier
+from flaskr.service.common.phone_numbers import (
+    is_valid_sms_mobile,
+    normalize_phone_identifier,
+)
 from flaskr.service.user.repository import get_user_entity_by_bid, mark_user_roles
 from flaskr.service.user.token_store import token_store
 from flaskr.util import generate_id
@@ -152,6 +155,8 @@ def send_sms_code(
     with app.app_context():
         if not phone:
             raise_param_error("mobile")
+        if not is_valid_sms_mobile(phone):
+            raise_param_error("mobile format invalid")
         if require_captcha:
             consume_captcha_ticket(app, captcha_ticket)
 

--- a/src/api/tests/test_phone_numbers.py
+++ b/src/api/tests/test_phone_numbers.py
@@ -1,4 +1,7 @@
-from flaskr.service.common.phone_numbers import is_valid_sms_mobile, normalize_phone_identifier
+from flaskr.service.common.phone_numbers import (
+    is_valid_sms_mobile,
+    normalize_phone_identifier,
+)
 
 
 def test_normalize_phone_identifier_strips_cn_prefix():

--- a/src/api/tests/test_phone_numbers.py
+++ b/src/api/tests/test_phone_numbers.py
@@ -1,0 +1,16 @@
+from flaskr.service.common.phone_numbers import is_valid_sms_mobile, normalize_phone_identifier
+
+
+def test_normalize_phone_identifier_strips_cn_prefix():
+    assert normalize_phone_identifier("+8613800000000") == "13800000000"
+
+
+def test_is_valid_sms_mobile_accepts_cn_mobile():
+    assert is_valid_sms_mobile("13800000000") is True
+    assert is_valid_sms_mobile("+8613800000000") is True
+
+
+def test_is_valid_sms_mobile_rejects_invalid_mobile():
+    assert is_valid_sms_mobile("186380295265") is False
+    assert is_valid_sms_mobile("23800000000") is False
+    assert is_valid_sms_mobile("") is False


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-07 16:02-16:03（Asia/Shanghai）出现 2 条 AI-Shifu 生产报错：

- endpoint: `/api/user/console_send_sms_code`
- error: Aliyun SMS send failed, `code=isv.MOBILE_NUMBER_ILLEGAL`, `message=手机号码格式错误`
- sample mobile: `186380295265`（12 位，非有效手机号）

## 修复内容

- 增加短信手机号格式校验：仅允许归一化后的中国大陆手机号 `1xxxxxxxxxx`。
- 在调用阿里云短信前拦截无效手机号并返回参数错误，避免无效输入继续触发外部 SMS 发送失败日志。
- 补充手机号归一化/校验单测。

## 验证

- `python3.11 -m py_compile src/api/flaskr/service/common/phone_numbers.py src/api/flaskr/service/user/utils.py src/api/tests/test_phone_numbers.py`
- `python3.11` 直接加载 `phone_numbers.py` 执行校验断言通过
- `git diff --check`

本机 Python 环境缺少 pytest/Flask，未能运行完整 pytest。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened SMS phone number validation to check for proper format before processing requests, ensuring invalid phone numbers are rejected early with clearer error messaging.

* **Tests**
  * Added comprehensive test coverage for phone number validation and normalization, including international format handling and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->