### PR TITLE
fix: use course owner for preview billing admission

### DIFF
--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -56,7 +56,10 @@ from flaskr.framework.plugin.inject import inject
 from flaskr.service.common.models import raise_param_error, raise_error, ERROR_CODE
 from flaskr.service.billing.admission import admit_creator_usage
 from flaskr.service.billing.api import assert_creator_debug_allowed
-from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
+from flaskr.service.metering.consts import (
+    BILL_USAGE_SCENE_DEBUG,
+    BILL_USAGE_SCENE_PREVIEW,
+)
 from .consts import UNIT_TYPE_GUEST
 from functools import wraps
 from enum import Enum
@@ -71,6 +74,7 @@ from flaskr.api.langfuse import (
     get_langfuse_client,
 )
 from flaskr.dao import db
+from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.service.shifu.models import AiCourseAuth
 from flaskr.service.shifu.utils import get_shifu_creator_bid
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
@@ -276,6 +280,15 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             app,
             creator_bid=creator_bid,
             usage_scene=BILL_USAGE_SCENE_DEBUG,
+        )
+
+    def _admit_creator_preview_usage_for_shifu(shifu_bid: str) -> None:
+        if is_builtin_demo_shifu(app, shifu_bid):
+            return None
+        return admit_creator_usage(
+            app,
+            shifu_bid=shifu_bid,
+            usage_scene=BILL_USAGE_SCENE_PREVIEW,
         )
 
     def _validate_contacts(contact_type: str, contacts: list[str]) -> list[str]:
@@ -1080,7 +1093,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         user_id = request.user.user_id
         variables = request.get_json().get("variables")
         base_url = _get_request_base_url()
-        _admit_creator_debug_usage()
+        _admit_creator_preview_usage_for_shifu(shifu_bid)
         return make_common_response(
             preview_shifu_draft(app, user_id, shifu_bid, variables, base_url)
         )

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -284,8 +284,8 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     def _admit_creator_preview_usage_for_shifu(shifu_bid: str) -> None:
         if is_builtin_demo_shifu(app, shifu_bid):
-            return None
-        return admit_creator_usage(
+            return
+        admit_creator_usage(
             app,
             shifu_bid=shifu_bid,
             usage_scene=BILL_USAGE_SCENE_PREVIEW,

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -47,6 +47,7 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_TYPE_TTS,
 )
 from flaskr.service.metering.models import BillUsageRecord
+from flaskr.service.shifu.models import DraftShifu
 
 
 @pytest.fixture
@@ -174,12 +175,14 @@ def _create_usage(
     usage_scene: int = BILL_USAGE_SCENE_PROD,
     record_level: int = 0,
     billable: int = 1,
+    user_bid: str = "learner-1",
+    shifu_bid: str = "shifu-1",
 ) -> BillUsageRecord:
     return BillUsageRecord(
         usage_bid=usage_bid,
         parent_usage_bid="",
-        user_bid="learner-1",
-        shifu_bid="shifu-1",
+        user_bid=user_bid,
+        shifu_bid=shifu_bid,
         outline_item_bid="",
         progress_record_bid="",
         generated_block_bid="",
@@ -208,6 +211,89 @@ def _create_usage(
         created_at=datetime(2026, 4, 8, 12, 0, 0),
         updated_at=datetime(2026, 4, 8, 12, 0, 0),
     )
+
+
+def test_settle_preview_usage_charges_course_owner_not_preview_operator(
+    billing_settlement_app: Flask,
+) -> None:
+    owner_bid = "owner-preview-settlement"
+    collaborator_bid = "collaborator-preview-settlement"
+    shifu_bid = "shifu-preview-settlement"
+
+    with billing_settlement_app.app_context():
+        owner_wallet = _create_wallet(owner_bid, "5.0000000000")
+        collaborator_wallet = _create_wallet(collaborator_bid, "5.0000000000")
+        dao.db.session.add_all(
+            [
+                DraftShifu(
+                    shifu_bid=shifu_bid,
+                    created_user_bid=owner_bid,
+                ),
+                owner_wallet,
+                collaborator_wallet,
+                _create_bucket(
+                    creator_bid=owner_bid,
+                    wallet_bid=owner_wallet.wallet_bid,
+                    bucket_bid="bucket-preview-owner",
+                    category=CREDIT_BUCKET_CATEGORY_FREE,
+                    priority=10,
+                    available_credits="5.0000000000",
+                ),
+                _create_bucket(
+                    creator_bid=collaborator_bid,
+                    wallet_bid=collaborator_wallet.wallet_bid,
+                    bucket_bid="bucket-preview-collaborator",
+                    category=CREDIT_BUCKET_CATEGORY_FREE,
+                    priority=10,
+                    available_credits="5.0000000000",
+                ),
+                _create_rate(
+                    rate_bid="rate-preview-owner-settlement",
+                    usage_type=BILL_USAGE_TYPE_LLM,
+                    billing_metric=BILLING_METRIC_LLM_INPUT_TOKENS,
+                    usage_scene=BILL_USAGE_SCENE_PREVIEW,
+                    credits_per_unit="1.0000000000",
+                ),
+                _create_usage(
+                    usage_bid="usage-preview-owner-settlement",
+                    usage_type=BILL_USAGE_TYPE_LLM,
+                    provider="openai",
+                    model="gpt-preview",
+                    input_value=1000,
+                    input_cache=0,
+                    output=0,
+                    total=1000,
+                    usage_scene=BILL_USAGE_SCENE_PREVIEW,
+                    user_bid=collaborator_bid,
+                    shifu_bid=shifu_bid,
+                ),
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = settle_bill_usage(
+            billing_settlement_app,
+            usage_bid="usage-preview-owner-settlement",
+        )
+
+        owner_wallet = CreditWallet.query.filter_by(creator_bid=owner_bid).one()
+        collaborator_wallet = CreditWallet.query.filter_by(
+            creator_bid=collaborator_bid
+        ).one()
+        entry = CreditLedgerEntry.query.filter_by(
+            source_bid="usage-preview-owner-settlement"
+        ).one()
+        usage = BillUsageRecord.query.filter_by(
+            usage_bid="usage-preview-owner-settlement"
+        ).one()
+
+        assert payload["status"] == "settled"
+        assert payload["creator_bid"] == owner_bid
+        assert payload["consumed_credits"] == 1
+        assert entry.creator_bid == owner_bid
+        assert owner_wallet.available_credits == Decimal("4.0000000000")
+        assert collaborator_wallet.available_credits == Decimal("5.0000000000")
+        assert usage.user_bid == collaborator_bid
 
 
 def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -10,8 +10,8 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
 
     assert "from flaskr.service.billing.admission import admit_creator_usage" in source
     assert "reserve_creator_runtime_slot" not in source
-    assert "BILL_USAGE_SCENE_DEBUG" in source
-    assert "BILL_USAGE_SCENE_PREVIEW" in source
+    assert "usage_scene=BILL_USAGE_SCENE_DEBUG" in source
+    assert "usage_scene=BILL_USAGE_SCENE_PREVIEW" in source
     assert "def _admit_creator_debug_usage() -> None:" in source
     assert (
         "def _admit_creator_preview_usage_for_shifu(shifu_bid: str) -> None:" in source

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -10,9 +10,14 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
 
     assert "from flaskr.service.billing.admission import admit_creator_usage" in source
     assert "reserve_creator_runtime_slot" not in source
-    assert "from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG" in source
+    assert "BILL_USAGE_SCENE_DEBUG" in source
+    assert "BILL_USAGE_SCENE_PREVIEW" in source
     assert "def _admit_creator_debug_usage() -> None:" in source
+    assert (
+        "def _admit_creator_preview_usage_for_shifu(shifu_bid: str) -> None:" in source
+    )
     assert source.count("_admit_creator_debug_usage()") >= 3
+    assert "_admit_creator_preview_usage_for_shifu(shifu_bid)" in source
     assert "def ask_preview_api():" in source
     assert "def tts_preview_api():" in source
     assert "@bypass_token_validation\n    def ask_preview_api():" not in source

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
 from flask import Flask
 
+import flaskr.dao as dao
 import flaskr.common.config as common_config
+from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 
 
 def _reset_config_cache(*keys: str) -> None:
@@ -47,6 +50,45 @@ def _make_draft(shifu_bid: str = "course-1") -> SimpleNamespace:
         ask_llm_system_prompt="",
         ask_provider_config="{}",
     )
+
+
+def _seed_preview_route_course(
+    app,
+    *,
+    shifu_bid: str,
+    owner_bid: str,
+    collaborator_bid: str,
+) -> None:
+    from flaskr.service.shifu.models import AiCourseAuth, DraftShifu
+
+    with app.app_context():
+        AiCourseAuth.query.filter_by(course_id=shifu_bid).delete()
+        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
+        dao.db.session.add(
+            DraftShifu(
+                shifu_bid=shifu_bid,
+                title="Preview Route Course",
+                description="desc",
+                avatar_res_bid="avatar-1",
+                keywords="test",
+                llm="gpt-test",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                price=Decimal("0"),
+                created_user_bid=owner_bid,
+                updated_user_bid=owner_bid,
+            )
+        )
+        dao.db.session.add(
+            AiCourseAuth(
+                course_auth_id=f"auth-{shifu_bid}-{collaborator_bid}",
+                course_id=shifu_bid,
+                user_id=collaborator_bid,
+                auth_type=json.dumps(["view"]),
+                status=1,
+            )
+        )
+        dao.db.session.commit()
 
 
 def _build_detail_for_base_url(monkeypatch, base_url: str):
@@ -135,6 +177,53 @@ def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch):
         )
 
     assert preview_url == "https://forwarded.example.com/c/course-1?preview=true"
+
+
+def test_shifu_preview_endpoint_admits_course_owner_usage_for_collaborator(
+    monkeypatch,
+    test_client,
+    app,
+):
+    shifu_bid = "preview-route-owner-admission"
+    owner_bid = "owner-preview-route-admission"
+    collaborator_bid = "collaborator-preview-route-admission"
+    captured: dict[str, object] = {}
+    _seed_preview_route_course(
+        app,
+        shifu_bid=shifu_bid,
+        owner_bid=owner_bid,
+        collaborator_bid=collaborator_bid,
+    )
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: SimpleNamespace(
+            user_id=collaborator_bid,
+            is_creator=True,
+            is_operator=False,
+            language="en-US",
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.route.admit_creator_usage",
+        lambda _app, **kwargs: captured.setdefault("admission", kwargs),
+        raising=False,
+    )
+
+    resp = test_client.post(
+        f"/api/shifu/shifus/{shifu_bid}/preview",
+        headers={"Token": "test-token"},
+        json={"variables": {}},
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"].endswith(f"/c/{shifu_bid}?preview=true")
+    assert captured["admission"] == {
+        "shifu_bid": shifu_bid,
+        "usage_scene": BILL_USAGE_SCENE_PREVIEW,
+    }
 
 
 def test_shifu_publish_url_builder_uses_public_base():


### PR DESCRIPTION
## Summary
- Route course preview billing admission through shifu_bid with the preview scene so ownership resolves to the course owner.
- Keep standalone debug preview admission on the current creator path.
- Add settlement and route-level regression coverage for collaborator preview billing.

## Root Cause
The shifu preview URL endpoint used creator debug admission based on the current operator. Collaborator previews could therefore check the collaborator account instead of the course owner, while settlement later resolves charges from the course shifu_bid.

## Validation
- python3 -m py_compile src/api/flaskr/service/shifu/route.py src/api/tests/service/billing/test_usage_settlement.py src/api/tests/service/shifu/test_shifu_public_urls.py src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
- git diff --check
- pre-commit hooks passed during commit after ruff-format applied one test formatting change
- Focused pytest was attempted but could not complete locally: the direct environment lacked colorlog; installing requirements under Python 3.14 failed building gevent==24.10.3; the existing Python 3.11 project venv hung without output and was stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview usage is now metered under a dedicated preview billing scene instead of the debug scene.
  * Course owners are charged for preview activity when appropriate.

* **Tests**
  * Added tests to verify preview billing and that course owners are billed in collaborative preview scenarios.
  * Enhanced billing settlement tests to allow creating usage records tied to different users and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->