### PR TITLE
feat: add admin set password entry

### DIFF
--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
@@ -210,4 +210,26 @@ describe('MainMenuModal', () => {
       screen.queryByText('module.settings.setPassword'),
     ).not.toBeInTheDocument();
   });
+
+  test('hides set password entry when contact methods only contain whitespace', () => {
+    mockUserStoreState.userInfo = {
+      mobile: '   ',
+      email: '\t',
+      is_creator: false,
+    };
+
+    render(
+      <MainMenuModal
+        open
+        onClose={jest.fn()}
+        onBasicInfoClick={jest.fn()}
+        onPersonalInfoClick={jest.fn()}
+        isAdmin
+      />,
+    );
+
+    expect(
+      screen.queryByText('module.settings.setPassword'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import MainMenuModal from './MainMenuModal';
+
+const mockUpdateUserInfo = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockRefreshUserInfo = jest.fn();
+
+const mockEnvState = {
+  loginMethodsEnabled: ['password', 'phone'],
+};
+
+const mockUserStoreState = {
+  isLoggedIn: true,
+  userInfo: {
+    mobile: '13800000000',
+    email: 'user@example.com',
+    is_creator: false,
+  },
+  logout: jest.fn(),
+  refreshUserInfo: mockRefreshUserInfo,
+  updateUserInfo: jest.fn(),
+};
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, src }: { alt: string; src: string }) =>
+    React.createElement('img', { alt, src }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/i18n', () => ({
+  __esModule: true,
+  default: {
+    language: 'en-US',
+  },
+  normalizeLanguage: (language: string) => language,
+}));
+
+jest.mock('@/lib/utils', () => ({
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(' '),
+}));
+
+jest.mock('@/c-store/envStore', () => ({
+  __esModule: true,
+  useEnvStore: (selector: (state: typeof mockEnvState) => unknown) =>
+    selector(mockEnvState),
+}));
+
+jest.mock('@/store', () => ({
+  __esModule: true,
+  useUserStore: (selector: (state: typeof mockUserStoreState) => unknown) =>
+    selector(mockUserStoreState),
+}));
+
+jest.mock('@/c-common/hooks/useTracking', () => ({
+  EVENT_NAMES: {
+    USER_MENU_BASIC_INFO: 'USER_MENU_BASIC_INFO',
+    USER_MENU_PERSONALIZED: 'USER_MENU_PERSONALIZED',
+    USER_MENU_SET_PASSWORD: 'USER_MENU_SET_PASSWORD',
+    POP_LOGIN: 'POP_LOGIN',
+  },
+  useTracking: () => ({
+    trackEvent: mockTrackEvent,
+  }),
+}));
+
+jest.mock('@/c-service/Shifu', () => ({
+  shifu: {
+    loginTools: {
+      openLogin: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    updateUserInfo: (...args: unknown[]) => mockUpdateUserInfo(...args),
+  },
+}));
+
+jest.mock('@/c-store/useSystemStore', () => ({
+  useSystemStore: {
+    getState: () => ({
+      updateLanguage: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('@/components/language-select', () => ({
+  __esModule: true,
+  default: () => <div>language-select</div>,
+}));
+
+jest.mock('@/c-components/PopupModal', () => ({
+  __esModule: true,
+  default: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+}));
+
+jest.mock('../Settings/SetPasswordModal', () => ({
+  __esModule: true,
+  SetPasswordModal: undefined,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid='set-password-modal'>set-password-modal</div> : null,
+}));
+
+jest.mock('@/components/ui/AlertDialog', () => ({
+  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogAction: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('MainMenuModal', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockReset();
+    mockRefreshUserInfo.mockReset();
+    mockUpdateUserInfo.mockReset();
+    mockUserStoreState.isLoggedIn = true;
+    mockUserStoreState.userInfo = {
+      mobile: '13800000000',
+      email: 'user@example.com',
+      is_creator: false,
+    };
+    mockEnvState.loginMethodsEnabled = ['password', 'phone'];
+  });
+
+  test('shows set password entry in admin menu and opens the modal', () => {
+    render(
+      <MainMenuModal
+        open
+        onClose={jest.fn()}
+        onBasicInfoClick={jest.fn()}
+        onPersonalInfoClick={jest.fn()}
+        isAdmin
+      />,
+    );
+
+    expect(
+      screen.queryByText('component.menus.navigationMenus.personalInfo'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('component.menus.navigationMenus.createCourse'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('module.settings.setPassword'));
+
+    expect(
+      screen.getByTestId('set-password-modal'),
+    ).toBeInTheDocument();
+    expect(mockTrackEvent).toHaveBeenCalledWith('USER_MENU_SET_PASSWORD', {});
+  });
+
+  test('hides set password entry in admin menu when no password login or contact method is available', () => {
+    mockEnvState.loginMethodsEnabled = ['phone'];
+    mockUserStoreState.userInfo = {
+      mobile: '',
+      email: '',
+      is_creator: false,
+    };
+
+    render(
+      <MainMenuModal
+        open
+        onClose={jest.fn()}
+        onBasicInfoClick={jest.fn()}
+        onPersonalInfoClick={jest.fn()}
+        isAdmin
+      />,
+    );
+
+    expect(
+      screen.queryByText('module.settings.setPassword'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.test.tsx
@@ -114,22 +114,40 @@ jest.mock('../Settings/SetPasswordModal', () => ({
   __esModule: true,
   SetPasswordModal: undefined,
   default: ({ open }: { open: boolean }) =>
-    open ? <div data-testid='set-password-modal'>set-password-modal</div> : null,
+    open ? (
+      <div data-testid='set-password-modal'>set-password-modal</div>
+    ) : null,
 }));
 
 jest.mock('@/components/ui/AlertDialog', () => ({
-  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogAction: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
-    <button onClick={onClick}>{children}</button>
+  AlertDialog: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
   ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
   AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
     <button>{children}</button>
   ),
-  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 describe('MainMenuModal', () => {
@@ -166,9 +184,7 @@ describe('MainMenuModal', () => {
 
     fireEvent.click(screen.getByText('module.settings.setPassword'));
 
-    expect(
-      screen.getByTestId('set-password-modal'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('set-password-modal')).toBeInTheDocument();
     expect(mockTrackEvent).toHaveBeenCalledWith('USER_MENU_SET_PASSWORD', {});
   });
 

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
@@ -59,9 +59,11 @@ const MainMenuModal = ({
   const isPasswordEnabled = Array.isArray(loginMethodsEnabled)
     ? loginMethodsEnabled.includes('password')
     : false;
-  const canSetPassword = Boolean(
-    isPasswordEnabled && (userInfo?.mobile || userInfo?.email),
-  );
+  const hasMobile =
+    typeof userInfo?.mobile === 'string' && userInfo.mobile.trim() !== '';
+  const hasEmail =
+    typeof userInfo?.email === 'string' && userInfo.email.trim() !== '';
+  const canSetPassword = isPasswordEnabled && (hasMobile || hasEmail);
 
   const { trackEvent } = useTracking();
 

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
@@ -59,6 +59,9 @@ const MainMenuModal = ({
   const isPasswordEnabled = Array.isArray(loginMethodsEnabled)
     ? loginMethodsEnabled.includes('password')
     : false;
+  const canSetPassword = Boolean(
+    isPasswordEnabled && (userInfo?.mobile || userInfo?.email),
+  );
 
   const { trackEvent } = useTracking();
 
@@ -183,7 +186,7 @@ const MainMenuModal = ({
           className={styles.mainMenuModal}
           ref={htmlRef}
         >
-          {!isAdmin && (
+          {!isAdmin ? (
             <>
               <div
                 className={cn(styles.mainMenuModalRow, 'px-2.5')}
@@ -200,18 +203,18 @@ const MainMenuModal = ({
                   {t('component.menus.navigationMenus.personalInfo')}
                 </div>
               </div>
-              {isPasswordEnabled ? (
+              {canSetPassword ? (
                 <div
                   className={cn(styles.mainMenuModalRow, 'px-2.5')}
                   onClick={onSetPasswordClick}
-                  title={t('module.settings.password')}
+                  title={t('module.settings.setPassword')}
                 >
                   <KeyRound
                     className={styles.rowIcon}
                     size={16}
                   />
                   <div className={styles.rowTitle}>
-                    {t('module.settings.passwordPlaceholder')}
+                    {t('module.settings.setPassword')}
                   </div>
                 </div>
               ) : null}
@@ -237,7 +240,21 @@ const MainMenuModal = ({
                 </div>
               </div>
             </>
-          )}
+          ) : canSetPassword ? (
+            <div
+              className={cn(styles.mainMenuModalRow, 'px-2.5')}
+              onClick={onSetPasswordClick}
+              title={t('module.settings.setPassword')}
+            >
+              <KeyRound
+                className={styles.rowIcon}
+                size={16}
+              />
+              <div className={styles.rowTitle}>
+                {t('module.settings.setPassword')}
+              </div>
+            </div>
+          ) : null}
 
           <div className={styles.languageRow}>
             <div

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
@@ -105,6 +105,19 @@ const MainMenuModal = ({
     // @ts-expect-error EXPECT
     onClose?.(evt);
   };
+  const setPasswordRow = canSetPassword ? (
+    <div
+      className={cn(styles.mainMenuModalRow, 'px-2.5')}
+      onClick={onSetPasswordClick}
+      title={t('module.settings.setPassword')}
+    >
+      <KeyRound
+        className={styles.rowIcon}
+        size={16}
+      />
+      <div className={styles.rowTitle}>{t('module.settings.setPassword')}</div>
+    </div>
+  ) : null;
 
   const onAdminEntryClick = (evt: React.MouseEvent) => {
     evt.preventDefault();
@@ -205,21 +218,7 @@ const MainMenuModal = ({
                   {t('component.menus.navigationMenus.personalInfo')}
                 </div>
               </div>
-              {canSetPassword ? (
-                <div
-                  className={cn(styles.mainMenuModalRow, 'px-2.5')}
-                  onClick={onSetPasswordClick}
-                  title={t('module.settings.setPassword')}
-                >
-                  <KeyRound
-                    className={styles.rowIcon}
-                    size={16}
-                  />
-                  <div className={styles.rowTitle}>
-                    {t('module.settings.setPassword')}
-                  </div>
-                </div>
-              ) : null}
+              {setPasswordRow}
               <div
                 className={cn(styles.mainMenuModalRow, 'px-2.5')}
                 onClick={onAdminEntryClick}
@@ -242,21 +241,9 @@ const MainMenuModal = ({
                 </div>
               </div>
             </>
-          ) : canSetPassword ? (
-            <div
-              className={cn(styles.mainMenuModalRow, 'px-2.5')}
-              onClick={onSetPasswordClick}
-              title={t('module.settings.setPassword')}
-            >
-              <KeyRound
-                className={styles.rowIcon}
-                size={16}
-              />
-              <div className={styles.rowTitle}>
-                {t('module.settings.setPassword')}
-              </div>
-            </div>
-          ) : null}
+          ) : (
+            setPasswordRow
+          )}
 
           <div className={styles.languageRow}>
             <div


### PR DESCRIPTION
## Summary
- add a set-password entry to the admin user menu when password login is enabled and the account has a phone or email
- keep the admin menu scoped so it does not expose learner-only entries
- add focused tests for the admin menu set-password behavior

## Testing
- cd src/cook-web && npm test -- --runInBand --runTestsByPath "/Users/iris/ai-shifu/src/c-components/NavDrawer/MainMenuModal.test.tsx"
- cd src/cook-web && npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Set password" option can now appear for admin users and is shown only when password login is enabled and the user has a valid email or mobile.

* **Tests**
  * Added tests covering the "set password" menu behavior across admin/non-admin and various contact-info and login-method scenarios, including modal opening and analytics trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->