### PR TITLE
fix: preserve operator user timestamp display

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -64,6 +64,18 @@ offset.
 - Display uses browser timezone from `getBrowserTimeZone()`
 - Invalid or empty values render as empty/placeholder labels
 
+### Current exception: operator user record timestamps
+
+- Operator user record fields `created_at` and `updated_at` currently come from
+  backend payloads as wall-clock values without timezone semantics.
+- Until those backend fields are migrated to timezone-qualified ISO strings, the
+  operator user list/detail pages should preserve the returned wall-clock time
+  with `formatOperatorNaiveDateTime`.
+- This exception only applies to the user-record timestamps above.
+- Event timestamps such as `last_login_at`, `last_learning_at`, and other
+  timezone-qualified activity fields should continue to use the browser-timezone
+  rendering flow.
+
 ## Implementation Plan
 
 1. Add a shared admin datetime helper in Cook Web and move the current

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -733,7 +733,7 @@ describe('AdminOperationUserDetailPage', () => {
     });
   });
 
-  test('renders detail timestamps with operator UTC formatting', async () => {
+  test('renders detail timestamps with field-specific formatting', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationUserDetail.mockResolvedValue({
       ...detailResponse,
@@ -766,7 +766,7 @@ describe('AdminOperationUserDetailPage', () => {
 
     expect(screen.getByText('2026-04-14 18:30:00')).toBeInTheDocument();
     expect(screen.getByText('2026-04-14 19:30:00')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-13 18:15:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-14 01:15:00')).toBeInTheDocument();
     expect(screen.getAllByText('2026-04-30 18:00:00').length).toBeGreaterThan(
       0,
     );

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/useUserDetailViewModel.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/useUserDetailViewModel.tsx
@@ -10,7 +10,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
-import { formatOperatorUtcDateTime } from '../dateTime';
+import {
+  formatOperatorNaiveDateTime,
+  formatOperatorUtcDateTime,
+} from '../dateTime';
 import type {
   AdminOperationUserCourseItem,
   AdminOperationUserCreditSummary,
@@ -229,7 +232,7 @@ export default function useUserDetailViewModel({
       {
         key: 'createdAt',
         label: tOperationsUsers('table.createdAt'),
-        value: formatOperatorUtcDateTime(detail.created_at),
+        value: formatOperatorNaiveDateTime(detail.created_at),
       },
     ],
     [

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -604,6 +604,48 @@ describe('AdminOperationUsersPage', () => {
     ).toBeInTheDocument();
   });
 
+  test('keeps user created and updated timestamps as returned wall-clock time', async () => {
+    mockGetAdminOperationUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'timezone-user',
+          mobile: '',
+          email: 'timezone-user@example.com',
+          nickname: 'Timezone User',
+          user_status: 'registered',
+          user_role: 'regular',
+          user_roles: ['regular'],
+          login_methods: ['email'],
+          registration_source: 'email',
+          language: 'zh-CN',
+          learning_course_count: 0,
+          learning_courses: [],
+          created_course_count: 0,
+          created_courses: [],
+          total_paid_amount: '0',
+          available_credits: '0',
+          subscription_credits: '0',
+          topup_credits: '0',
+          credits_expire_at: '',
+          last_login_at: '',
+          last_learning_at: '',
+          created_at: '2026-06-09T12:01:50+08:00',
+          updated_at: '2026-06-09T13:01:50+08:00',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+
+    await renderResolvedPage();
+
+    expect(screen.getByText('2026-06-09 12:01:50')).toBeInTheDocument();
+    expect(screen.getByText('2026-06-09 13:01:50')).toBeInTheDocument();
+    expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
+  });
+
   test('formats overview counts and credits without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';
     mockGetAdminOperationUsersOverview.mockResolvedValueOnce({

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -66,7 +66,10 @@ import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
 import { buildAdminOperationsCourseDetailUrl } from '../operation-course-routes';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
-import { formatOperatorUtcDateTime } from './dateTime';
+import {
+  formatOperatorNaiveDateTime,
+  formatOperatorUtcDateTime,
+} from './dateTime';
 import { normalizeLoginMethodLabelKey } from './loginMethodUtils';
 import UserCreditGrantDialog from './UserCreditGrantDialog';
 import useOperatorGuard from '../useOperatorGuard';
@@ -1497,7 +1500,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.created_at),
+                            formatOperatorNaiveDateTime(user.created_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1505,7 +1508,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('updatedAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.updated_at),
+                            formatOperatorNaiveDateTime(user.updated_at),
                           )}
                         </TableCell>
                         <TableCell


### PR DESCRIPTION
## Summary
- keep operator user created/updated timestamps as returned wall-clock values
- retain UTC-aware formatting for login, learning, credit expiry, and other event timestamps
- add coverage for user-management timestamp display and detail field-specific formatting

## Validation
- cd src/cook-web && npm run test -- --runTestsByPath src/app/admin/operations/users/dateTime.test.ts src/app/admin/operations/users/page.test.tsx 'src/app/admin/operations/users/[user_bid]/page.test.tsx' --runInBand
- cd src/cook-web && npm run type-check

## Notes
- Push hook warned that self-review metadata was missing/stale; no local branch_context_manager.py script exists in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User creation and update timestamps in the admin operations section now display local time correctly without timezone conversion.

* **Tests**
  * Updated timestamp formatting tests to verify the new wall-clock time display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->