### PR TITLE
fix: preserve operator metadata timestamp display

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -64,6 +64,20 @@ offset.
 - Display uses browser timezone from `getBrowserTimeZone()`
 - Invalid or empty values render as empty/placeholder labels
 
+### Current exceptions: wall-clock metadata fields
+
+- Some admin/operator metadata fields still come from backend payloads as
+  wall-clock values without timezone semantics.
+- Until those fields are migrated to timezone-qualified ISO strings, the
+  frontend should preserve the returned wall-clock time with the naive
+  formatter helpers instead of applying browser-timezone conversion.
+- Current exceptions:
+  - operator user record `created_at` / `updated_at`
+  - operator course metadata `basic_info.created_at` / `basic_info.updated_at`
+- Event timestamps such as login, learning activity, and other
+  timezone-qualified fields should continue to use the browser-timezone
+  rendering flow.
+
 ## Implementation Plan
 
 1. Add a shared admin datetime helper in Cook Web and move the current

--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -74,6 +74,11 @@ offset.
 - Current exceptions:
   - operator user record `created_at` / `updated_at`
   - operator course metadata `basic_info.created_at` / `basic_info.updated_at`
+  - operator course list metadata `created_at` / `updated_at`
+  - operator chapter metadata `updated_at`
+  - operator learn order metadata `created_at`
+  - operator credit order metadata `created_at`
+  - operator order detail metadata `created_at` / `updated_at`
 - Event timestamps such as login, learning activity, and other
   timezone-qualified fields should continue to use the browser-timezone
   rendering flow.

--- a/src/cook-web/src/app/admin/operations/CourseTableSection.tsx
+++ b/src/cook-web/src/app/admin/operations/CourseTableSection.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   getAdminStickyRightCellClass,
@@ -281,7 +281,7 @@ export default function CourseTableSection({
                     style={getColumnStyle('updatedAt')}
                   >
                     {renderTooltipText(
-                      formatAdminUtcDateTime(course.updated_at),
+                      formatAdminNaiveDateTime(course.updated_at),
                       'mx-auto block',
                     )}
                   </TableCell>
@@ -290,7 +290,7 @@ export default function CourseTableSection({
                     style={getColumnStyle('createdAt')}
                   >
                     {renderTooltipText(
-                      formatAdminUtcDateTime(course.created_at),
+                      formatAdminNaiveDateTime(course.created_at),
                       'mx-auto block',
                     )}
                   </TableCell>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseChaptersTab.tsx
@@ -52,7 +52,7 @@ type CourseChaptersTabProps = {
     secondary: string;
   };
   formatCount: (value: number, locale: string) => string;
-  formatAdminUtcDateTime: (value?: string) => string;
+  formatAdminNaiveDateTime: (value?: string) => string;
   getColumnStyle: (key: ChapterColumnKey) => {
     width: number;
     minWidth: number;
@@ -75,7 +75,7 @@ export default function CourseChaptersTab({
   resolveContentStatusLabel,
   resolveModifierDisplay,
   formatCount,
-  formatAdminUtcDateTime,
+  formatAdminNaiveDateTime,
   getColumnStyle,
   getResizeHandleProps,
   tOperations,
@@ -309,7 +309,7 @@ export default function CourseChaptersTab({
                       >
                         <AdminTooltipText
                           text={
-                            formatAdminUtcDateTime(chapter.updated_at) ||
+                            formatAdminNaiveDateTime(chapter.updated_at) ||
                             emptyValue
                           }
                           emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -549,6 +549,66 @@ describe('AdminOperationCourseDetailPage', () => {
     ).toHaveAttribute('href', '/admin/operations');
   });
 
+  test('keeps course detail metadata timestamps as returned wall-clock time', async () => {
+    mockGetAdminOperationCourseDetail.mockResolvedValueOnce({
+      basic_info: {
+        shifu_bid: 'course-1',
+        course_name: 'Course One',
+        course_status: 'published',
+        creator_user_bid: 'creator-1',
+        creator_mobile: '13800001234',
+        creator_email: '',
+        creator_nickname: 'Alice',
+        created_at: '2026-06-09T12:01:50+08:00',
+        updated_at: '2026-06-09T13:01:50+08:00',
+      },
+      metrics: {
+        visit_count_30d: 34,
+        learner_count: 12,
+        order_count: 4,
+        order_amount: '88',
+        follow_up_count: 9,
+        rating_score: '4.2',
+        credit_consumed_total: 120,
+        credit_usage_count: 18,
+        credit_user_count: 6,
+        completed_credit_user_count: 3,
+        completed_user_avg_credits: 20,
+      },
+      chapters: [
+        {
+          outline_item_bid: 'chapter-timezone',
+          title: 'Timezone Chapter',
+          parent_bid: '',
+          position: '1',
+          node_type: 'chapter',
+          learning_permission: 'guest',
+          is_visible: true,
+          content_status: 'empty',
+          follow_up_count: 0,
+          rating_score: '',
+          rating_count: 0,
+          modifier_user_bid: 'creator-1',
+          modifier_mobile: '13800001234',
+          modifier_email: '',
+          modifier_nickname: 'Alice',
+          updated_at: '2026-06-09T13:01:50+08:00',
+          children: [],
+        },
+      ],
+    });
+
+    render(<AdminOperationCourseDetailPage />);
+
+    await screen.findByText('Timezone Chapter');
+
+    expect(screen.getByText('2026-06-09 12:01:50')).toBeInTheDocument();
+    expect(screen.getAllByText('2026-06-09 13:01:50').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
+  });
+
   test('loads credit usage tab on demand and renders credit rows', async () => {
     render(<AdminOperationCourseDetailPage />);
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -1425,6 +1425,9 @@ export default function AdminOperationCourseDetailPage() {
       {
         label: tOperations('detail.fields.createdAt'),
         value:
+          // Course metadata timestamps currently come from backend payloads as
+          // wall-clock values, so preserve them without browser-timezone
+          // conversion until those fields migrate to timezone-qualified ISO.
           formatAdminNaiveDateTime(detail.basic_info.created_at) || emptyValue,
       },
       {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import api from '@/api';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import { copyText } from '@/c-utils/textutils';
@@ -1425,12 +1425,12 @@ export default function AdminOperationCourseDetailPage() {
       {
         label: tOperations('detail.fields.createdAt'),
         value:
-          formatAdminUtcDateTime(detail.basic_info.created_at) || emptyValue,
+          formatAdminNaiveDateTime(detail.basic_info.created_at) || emptyValue,
       },
       {
         label: tOperations('detail.fields.updatedAt'),
         value:
-          formatAdminUtcDateTime(detail.basic_info.updated_at) || emptyValue,
+          formatAdminNaiveDateTime(detail.basic_info.updated_at) || emptyValue,
       },
     ],
     [
@@ -1540,7 +1540,7 @@ export default function AdminOperationCourseDetailPage() {
                   resolveContentStatusLabel={resolveContentStatusLabel}
                   resolveModifierDisplay={resolveModifierDisplay}
                   formatCount={formatCount}
-                  formatAdminUtcDateTime={formatAdminUtcDateTime}
+                  formatAdminNaiveDateTime={formatAdminNaiveDateTime}
                   getColumnStyle={getChapterColumnStyle}
                   getResizeHandleProps={getChapterResizeHandleProps}
                   tOperations={tOperations}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -3,7 +3,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminNaiveDateTime,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import {
   formatAdminCredits,
   formatAdminPrice,
@@ -255,7 +258,9 @@ export default function CreditOrderDetailDialog({
                 />
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
-                  value={formatAdminUtcDateTime(order.created_at) || emptyValue}
+                  value={
+                    formatAdminNaiveDateTime(order.created_at) || emptyValue
+                  }
                 />
                 <DetailRow
                   label={tOperationsOrder('creditOrders.detail.labels.paidAt')}

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -241,7 +241,7 @@ describe('CreditOrdersTab', () => {
           provider_reference_id: 'charge_1',
           failure_code: '',
           failure_message: '',
-          created_at: '2026-04-27T09:00:00Z',
+          created_at: '2026-04-27T09:00:00+08:00',
           paid_at: '2026-04-27T10:00:00Z',
           failed_at: null,
           refunded_at: null,
@@ -312,7 +312,7 @@ describe('CreditOrdersTab', () => {
         provider_reference_id: 'charge_1',
         failure_code: '',
         failure_message: '',
-        created_at: '2026-04-27T09:00:00Z',
+        created_at: '2026-04-27T09:00:00+08:00',
         paid_at: '2026-04-27T10:00:00Z',
         failed_at: null,
         refunded_at: null,
@@ -352,6 +352,8 @@ describe('CreditOrdersTab', () => {
     });
 
     expect(await screen.findByText('bill-order-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-27 09:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-27 01:00:00')).not.toBeInTheDocument();
     expect(
       screen.queryByText('module.operationsOrder.overview.activeFilter'),
     ).not.toBeInTheDocument();
@@ -633,6 +635,10 @@ describe('CreditOrdersTab', () => {
         'module.operationsOrder.creditOrders.detail.title',
       ),
     ).toBeInTheDocument();
+    expect(screen.getAllByText('2026-04-27 09:00:00').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText('2026-04-27 01:00:00')).not.toBeInTheDocument();
   });
 
   test('shows detail error state when detail request fails', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -8,7 +8,7 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
@@ -896,7 +896,7 @@ export default function CreditOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatAdminUtcDateTime(order.created_at) ||
+                            formatAdminNaiveDateTime(order.created_at) ||
                               EMPTY_STATE_LABEL,
                           )}
                         </TableCell>

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -185,8 +185,8 @@ describe('LearnOrdersTab', () => {
           order_source: 'user_purchase',
           order_source_key: 'module.operationsOrder.source.userPurchase',
           coupon_codes: ['FREE100'],
-          created_at: '2026-04-23T10:00:00Z',
-          updated_at: '2026-04-23T11:00:00Z',
+          created_at: '2026-04-23T10:00:00+08:00',
+          updated_at: '2026-04-23T11:00:00+08:00',
         },
       ],
       page: 1,
@@ -217,6 +217,8 @@ describe('LearnOrdersTab', () => {
     });
 
     expect(await screen.findByText('order-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-23 10:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-23 02:00:00')).not.toBeInTheDocument();
     expect(
       screen.queryByText('module.operationsOrder.overview.activeFilter'),
     ).not.toBeInTheDocument();

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -9,7 +9,7 @@ import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import {
   formatAdminCount,
   formatAdminNumber,
@@ -836,7 +836,7 @@ export default function LearnOrdersTab() {
                           style={getColumnStyle('createdAt')}
                         >
                           {renderTooltipText(
-                            formatAdminUtcDateTime(order.created_at),
+                            formatAdminNaiveDateTime(order.created_at),
                           )}
                         </TableCell>
                         <TableCell

--- a/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx
@@ -103,8 +103,8 @@ describe('OperatorOrderDetailSheet', () => {
         order_source: '',
         order_source_key: '',
         coupon_codes: ['FREE100'],
-        created_at: '2026-04-23T10:00:00Z',
-        updated_at: '2026-04-23T11:00:00Z',
+        created_at: '2026-04-23T10:00:00+08:00',
+        updated_at: '2026-04-23T11:00:00+08:00',
       },
       payment: {
         payment_channel: 'manual',
@@ -145,6 +145,9 @@ describe('OperatorOrderDetailSheet', () => {
       await screen.findByText('module.operationsOrder.detail.title'),
     ).toBeInTheDocument();
     expect(screen.getByText('order-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-23 10:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-23 11:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-23 02:00:00')).not.toBeInTheDocument();
     expect(
       screen.getByText('module.operationsOrder.source.importActivation'),
     ).toBeInTheDocument();

--- a/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import api from '@/api';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Badge } from '@/components/ui/Badge';
@@ -209,13 +209,13 @@ const OperatorOrderDetailSheet = ({
                 <DetailRow
                   label={t('module.order.fields.createdAt')}
                   value={
-                    formatAdminUtcDateTime(summary.created_at) || emptyValue
+                    formatAdminNaiveDateTime(summary.created_at) || emptyValue
                   }
                 />
                 <DetailRow
                   label={tOperationsOrder('table.updatedAt')}
                   value={
-                    formatAdminUtcDateTime(summary.updated_at) || emptyValue
+                    formatAdminNaiveDateTime(summary.updated_at) || emptyValue
                   }
                 />
               </Section>

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -682,6 +682,41 @@ describe('OperationsPage', () => {
     expect(screen.queryByText('76,384')).not.toBeInTheDocument();
   });
 
+  test('keeps course metadata timestamps as returned wall-clock time', async () => {
+    mockGetAdminOperationCourses.mockResolvedValueOnce({
+      items: [
+        {
+          shifu_bid: 'course-timezone',
+          course_name: 'Timezone Course',
+          course_status: 'published',
+          price: '0',
+          course_model: '',
+          has_course_prompt: false,
+          creator_user_bid: 'creator-1',
+          creator_mobile: '',
+          creator_email: 'creator@example.com',
+          creator_nickname: '',
+          updater_user_bid: 'editor-1',
+          updater_mobile: '',
+          updater_email: 'editor@example.com',
+          updater_nickname: '',
+          created_at: '2026-06-09T12:01:50+08:00',
+          updated_at: '2026-06-09T13:01:50+08:00',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+
+    await renderAndWaitForLoadedPage();
+
+    expect(screen.getByText('2026-06-09 12:01:50')).toBeInTheDocument();
+    expect(screen.getByText('2026-06-09 13:01:50')).toBeInTheDocument();
+    expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
+  });
+
   test('navigates from course name and transfers creator from the action menu', async () => {
     await renderAndWaitForLoadedPage();
 


### PR DESCRIPTION
## Summary
- keep operator course metadata timestamps as returned wall-clock values
- keep operator order created/updated metadata timestamps as returned wall-clock values
- retain UTC-aware formatting for event timestamps such as paid/failed times, usage events, follow-ups, ratings, credits, and promo records

## Validation
- cd src/cook-web && npm run test -- --runTestsByPath src/app/admin/operations/page.test.tsx 'src/app/admin/operations/[shifu_bid]/page.test.tsx' src/app/admin/operations/orders/LearnOrdersTab.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx --runInBand
- cd src/cook-web && npm run type-check

## Notes
- Push hook warned that self-review metadata was missing/stale; no local branch_context_manager.py script exists in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure admin timestamps render as backend wall-clock (naive) values instead of being UTC-converted across course lists, chapters, and order views.

* **Tests**
  * Updated tests to assert wall-clock/local datetime rendering and to verify UTC-shifted times are not shown.

* **Documentation**
  * Clarified admin time-display guidance, expanding exceptions to include additional metadata fields preserved as wall-clock values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->