### PR TITLE
fix: preserve operator detail wall-clock timestamps

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -73,8 +73,15 @@ offset.
   formatter helpers instead of applying browser-timezone conversion.
 - Current exceptions:
   - operator user record `created_at` / `updated_at`
+  - operator user credit ledger `created_at`
+  - operator user credit usage detail `created_at`
   - operator course metadata `basic_info.created_at` / `basic_info.updated_at`
   - operator course list metadata `created_at` / `updated_at`
+  - operator course credit usage `created_at`
+  - operator course credit usage detail `created_at`
+  - operator course follow-up `created_at` / `latest_follow_up_at`
+  - operator course follow-up detail `basic_info.created_at` / timeline `created_at`
+  - operator course ratings `rated_at` / `latest_rated_at`
   - operator chapter metadata `updated_at`
   - operator learn order metadata `created_at`
   - operator credit order metadata `created_at`

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -12,9 +12,7 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import {
-  formatAdminNaiveDateTime,
-} from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx
@@ -12,7 +12,9 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminNaiveDateTime,
+} from '@/app/admin/lib/dateTime';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
@@ -786,7 +788,7 @@ export default function CourseCreditUsageTab({
                             style={getColumnStyle('createdAt')}
                           >
                             <AdminTooltipText
-                              text={formatAdminUtcDateTime(row.created_at)}
+                              text={formatAdminNaiveDateTime(row.created_at)}
                               emptyValue={emptyValue}
                               className='mx-auto block max-w-full tabular-nums'
                             />
@@ -977,7 +979,7 @@ export default function CourseCreditUsageTab({
                         {detailData.items.map(detail => (
                           <TableRow key={detail.usage_bid}>
                             <TableCell className='border-r border-border py-2.5 text-center text-xs text-muted-foreground/70'>
-                              {formatAdminUtcDateTime(detail.created_at) ||
+                              {formatAdminNaiveDateTime(detail.created_at) ||
                                 emptyValue}
                             </TableCell>
                             <TableCell className='border-r border-border py-2.5 text-center text-sm font-medium tabular-nums text-foreground'>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -17,7 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/Sheet';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { cn } from '@/lib/utils';
 import type { AdminOperationCourseFollowUpDetailResponse } from '../../operation-course-types';
 
@@ -300,7 +300,8 @@ export default function FollowUpDetailSheet({
                 <DetailRow
                   label={t('detail.followUps.drawer.fields.followUpTime')}
                   value={
-                    formatAdminUtcDateTime(basicInfo?.created_at) || emptyValue
+                    formatAdminNaiveDateTime(basicInfo?.created_at) ||
+                    emptyValue
                   }
                 />
                 <DetailRow
@@ -370,7 +371,7 @@ export default function FollowUpDetailSheet({
                             ) : null}
                           </div>
                           <span className='text-xs text-muted-foreground'>
-                            {formatAdminUtcDateTime(item.created_at) ||
+                            {formatAdminNaiveDateTime(item.created_at) ||
                               emptyValue}
                           </span>
                         </div>

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -599,9 +599,7 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     ).toBeInTheDocument();
   });
 
-  test(
-    'keeps follow-up timestamps as returned wall-clock time when browser timezone changes',
-    async () => {
+  test('keeps follow-up timestamps as returned wall-clock time when browser timezone changes', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationCourseFollowUps.mockResolvedValueOnce({
       summary: {
@@ -641,42 +639,38 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     expect(document.body.textContent).toContain('01:30:00');
     expect(document.body.textContent).not.toContain('2026-04-04');
     expect(document.body.textContent).not.toContain('18:30:00');
-    },
-  );
+  });
 
-  test(
-    'keeps follow-up detail drawer timestamps as returned wall-clock time',
-    async () => {
-      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+  test('keeps follow-up detail drawer timestamps as returned wall-clock time', async () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
 
-      render(<AdminOperationCourseFollowUpsPage />);
+    render(<AdminOperationCourseFollowUpsPage />);
 
-      await screen.findByText('Second follow-up question');
+    await screen.findByText('Second follow-up question');
 
-      fireEvent.click(
-        screen.getAllByRole('button', {
-          name: 'module.operationsCourse.detail.followUps.table.detailAction',
-        })[0],
-      );
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.operationsCourse.detail.followUps.table.detailAction',
+      })[0],
+    );
 
-      expect(
-        await screen.findByText(
-          'module.operationsCourse.detail.followUps.drawer.title',
-        ),
-      ).toBeInTheDocument();
-      expect(screen.getAllByText('2026-04-05 11:02:00').length).toBeGreaterThan(
-        0,
-      );
-      expect(screen.getAllByText('2026-04-05 11:01:00').length).toBeGreaterThan(
-        0,
-      );
-      expect(screen.getAllByText('2026-04-05 11:02:02').length).toBeGreaterThan(
-        0,
-      );
-      expect(screen.queryByText('2026-04-05 04:02:00')).not.toBeInTheDocument();
-      expect(screen.queryByText('2026-04-05 04:01:00')).not.toBeInTheDocument();
-    },
-  );
+    expect(
+      await screen.findByText(
+        'module.operationsCourse.detail.followUps.drawer.title',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('2026-04-05 11:02:00').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText('2026-04-05 11:01:00').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText('2026-04-05 11:02:02').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText('2026-04-05 04:02:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-04-05 04:01:00')).not.toBeInTheDocument();
+  });
 
   test('ignores a late detail response after the drawer is closed', async () => {
     const deferredDetail =

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -599,7 +599,9 @@ describe('AdminOperationCourseFollowUpsPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders summary time with UTC formatting when UTC crosses local day boundaries', async () => {
+  test(
+    'keeps follow-up timestamps as returned wall-clock time when browser timezone changes',
+    async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationCourseFollowUps.mockResolvedValueOnce({
       summary: {
@@ -635,9 +637,46 @@ describe('AdminOperationCourseFollowUpsPage', () => {
 
     await screen.findByText('Cross-day follow-up question');
 
-    expect(document.body.textContent).toContain('2026-04-04');
-    expect(document.body.textContent).toContain('18:30:00');
-  });
+    expect(document.body.textContent).toContain('2026-04-05');
+    expect(document.body.textContent).toContain('01:30:00');
+    expect(document.body.textContent).not.toContain('2026-04-04');
+    expect(document.body.textContent).not.toContain('18:30:00');
+    },
+  );
+
+  test(
+    'keeps follow-up detail drawer timestamps as returned wall-clock time',
+    async () => {
+      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+
+      render(<AdminOperationCourseFollowUpsPage />);
+
+      await screen.findByText('Second follow-up question');
+
+      fireEvent.click(
+        screen.getAllByRole('button', {
+          name: 'module.operationsCourse.detail.followUps.table.detailAction',
+        })[0],
+      );
+
+      expect(
+        await screen.findByText(
+          'module.operationsCourse.detail.followUps.drawer.title',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText('2026-04-05 11:02:00').length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.getAllByText('2026-04-05 11:01:00').length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.getAllByText('2026-04-05 11:02:02').length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.queryByText('2026-04-05 04:02:00')).not.toBeInTheDocument();
+      expect(screen.queryByText('2026-04-05 04:01:00')).not.toBeInTheDocument();
+    },
+  );
 
   test('ignores a late detail response after the drawer is closed', async () => {
     const deferredDetail =

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -17,7 +17,7 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -499,7 +499,8 @@ export default function AdminOperationCourseFollowUpsPage() {
         key: 'latestFollowUpAt',
         label: tOperations('detail.followUps.summary.latestFollowUpAt'),
         value:
-          formatAdminUtcDateTime(fullSummary.latest_follow_up_at) || emptyValue,
+          formatAdminNaiveDateTime(fullSummary.latest_follow_up_at) ||
+          emptyValue,
         tone: 'timestamp' as const,
       },
     ],
@@ -907,7 +908,7 @@ export default function AdminOperationCourseFollowUpsPage() {
                                       style={getColumnStyle('createdAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           item.created_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -650,18 +650,16 @@ describe('AdminOperationCourseDetailPage', () => {
       total: 1,
     });
     mockGetAdminOperationCourseCreditUsageDetails.mockResolvedValueOnce({
-      usage_bid: 'usage-listen',
       page: 1,
       page_count: 1,
-      page_size: 20,
+      page_size: 10,
       total: 1,
       items: [
         {
           usage_bid: 'usage-detail-1',
           created_at: '2026-04-08T12:20:00Z',
           content: 'Listen detail content',
-          consumed_credits: '2',
-          usage_units: 1,
+          consumed_credits: 2,
           input_tokens: 0,
           output_tokens: 0,
           word_count: 180,

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -616,6 +616,90 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
   });
 
+  test(
+    'keeps course credit usage created_at values as returned wall-clock time',
+    async () => {
+      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+      mockGetAdminOperationCourseCreditUsages.mockResolvedValueOnce({
+        view: 'grouped',
+        items: [
+          {
+            group_key: 'student-1:lesson-1:learning:listen',
+            usage_bid: 'usage-listen',
+            progress_record_bid: 'progress-1',
+            generated_block_bid: '',
+            user_bid: 'student-1',
+            mobile: '13900001234',
+            email: '',
+            nickname: 'Bob',
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            lesson_outline_item_bid: 'lesson-1',
+            lesson_title: 'Lesson 1',
+            usage_scene: 'learning',
+            usage_mode: 'listen',
+            provider: 'volcengine',
+            model: 'cancan-2.0',
+            usage_count: 1,
+            model_variant_count: 1,
+            consumed_credits: 2,
+            created_at: '2026-04-08T12:30:00Z',
+          },
+        ],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 1,
+      });
+      mockGetAdminOperationCourseCreditUsageDetails.mockResolvedValueOnce({
+        usage_bid: 'usage-listen',
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 1,
+        items: [
+          {
+            usage_bid: 'usage-detail-1',
+            created_at: '2026-04-08T12:20:00Z',
+            content: 'Listen detail content',
+            consumed_credits: '2',
+            usage_units: 1,
+            input_tokens: 0,
+            output_tokens: 0,
+            word_count: 180,
+            duration_ms: 30000,
+            segment_count: 1,
+          },
+        ],
+      });
+
+      render(<AdminOperationCourseDetailPage />);
+
+      await openCreditUsageTab();
+
+      expect(screen.getByText('2026-04-08 12:30:00')).toBeInTheDocument();
+      expect(screen.queryByText('2026-04-08 05:30:00')).not.toBeInTheDocument();
+
+      const usageRow = (await screen.findByText('Lesson 1')).closest('tr');
+      expect(usageRow).not.toBeNull();
+      fireEvent.click(
+        within(usageRow as HTMLElement).getByRole('button', {
+          name: 'module.operationsCourse.detail.creditUsage.details.openUsageDetails',
+        }),
+      );
+
+      const dialog = await screen.findByRole('dialog');
+      await waitFor(() => {
+        expect(
+          within(dialog).getByText('2026-04-08 12:20:00'),
+        ).toBeInTheDocument();
+      });
+      expect(
+        within(dialog).queryByText('2026-04-08 05:20:00'),
+      ).not.toBeInTheDocument();
+    },
+  );
+
   test('loads credit usage tab on demand and renders credit rows', async () => {
     render(<AdminOperationCourseDetailPage />);
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -616,89 +616,86 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
   });
 
-  test(
-    'keeps course credit usage created_at values as returned wall-clock time',
-    async () => {
-      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
-      mockGetAdminOperationCourseCreditUsages.mockResolvedValueOnce({
-        view: 'grouped',
-        items: [
-          {
-            group_key: 'student-1:lesson-1:learning:listen',
-            usage_bid: 'usage-listen',
-            progress_record_bid: 'progress-1',
-            generated_block_bid: '',
-            user_bid: 'student-1',
-            mobile: '13900001234',
-            email: '',
-            nickname: 'Bob',
-            chapter_outline_item_bid: 'chapter-1',
-            chapter_title: 'Chapter 1',
-            lesson_outline_item_bid: 'lesson-1',
-            lesson_title: 'Lesson 1',
-            usage_scene: 'learning',
-            usage_mode: 'listen',
-            provider: 'volcengine',
-            model: 'cancan-2.0',
-            usage_count: 1,
-            model_variant_count: 1,
-            consumed_credits: 2,
-            created_at: '2026-04-08T12:30:00Z',
-          },
-        ],
-        page: 1,
-        page_count: 1,
-        page_size: 20,
-        total: 1,
-      });
-      mockGetAdminOperationCourseCreditUsageDetails.mockResolvedValueOnce({
-        usage_bid: 'usage-listen',
-        page: 1,
-        page_count: 1,
-        page_size: 20,
-        total: 1,
-        items: [
-          {
-            usage_bid: 'usage-detail-1',
-            created_at: '2026-04-08T12:20:00Z',
-            content: 'Listen detail content',
-            consumed_credits: '2',
-            usage_units: 1,
-            input_tokens: 0,
-            output_tokens: 0,
-            word_count: 180,
-            duration_ms: 30000,
-            segment_count: 1,
-          },
-        ],
-      });
+  test('keeps course credit usage created_at values as returned wall-clock time', async () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+    mockGetAdminOperationCourseCreditUsages.mockResolvedValueOnce({
+      view: 'grouped',
+      items: [
+        {
+          group_key: 'student-1:lesson-1:learning:listen',
+          usage_bid: 'usage-listen',
+          progress_record_bid: 'progress-1',
+          generated_block_bid: '',
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          chapter_outline_item_bid: 'chapter-1',
+          chapter_title: 'Chapter 1',
+          lesson_outline_item_bid: 'lesson-1',
+          lesson_title: 'Lesson 1',
+          usage_scene: 'learning',
+          usage_mode: 'listen',
+          provider: 'volcengine',
+          model: 'cancan-2.0',
+          usage_count: 1,
+          model_variant_count: 1,
+          consumed_credits: 2,
+          created_at: '2026-04-08T12:30:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+    mockGetAdminOperationCourseCreditUsageDetails.mockResolvedValueOnce({
+      usage_bid: 'usage-listen',
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+      items: [
+        {
+          usage_bid: 'usage-detail-1',
+          created_at: '2026-04-08T12:20:00Z',
+          content: 'Listen detail content',
+          consumed_credits: '2',
+          usage_units: 1,
+          input_tokens: 0,
+          output_tokens: 0,
+          word_count: 180,
+          duration_ms: 30000,
+          segment_count: 1,
+        },
+      ],
+    });
 
-      render(<AdminOperationCourseDetailPage />);
+    render(<AdminOperationCourseDetailPage />);
 
-      await openCreditUsageTab();
+    await openCreditUsageTab();
 
-      expect(screen.getByText('2026-04-08 12:30:00')).toBeInTheDocument();
-      expect(screen.queryByText('2026-04-08 05:30:00')).not.toBeInTheDocument();
+    expect(screen.getByText('2026-04-08 12:30:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-08 05:30:00')).not.toBeInTheDocument();
 
-      const usageRow = (await screen.findByText('Lesson 1')).closest('tr');
-      expect(usageRow).not.toBeNull();
-      fireEvent.click(
-        within(usageRow as HTMLElement).getByRole('button', {
-          name: 'module.operationsCourse.detail.creditUsage.details.openUsageDetails',
-        }),
-      );
+    const usageRow = (await screen.findByText('Lesson 1')).closest('tr');
+    expect(usageRow).not.toBeNull();
+    fireEvent.click(
+      within(usageRow as HTMLElement).getByRole('button', {
+        name: 'module.operationsCourse.detail.creditUsage.details.openUsageDetails',
+      }),
+    );
 
-      const dialog = await screen.findByRole('dialog');
-      await waitFor(() => {
-        expect(
-          within(dialog).getByText('2026-04-08 12:20:00'),
-        ).toBeInTheDocument();
-      });
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
       expect(
-        within(dialog).queryByText('2026-04-08 05:20:00'),
-      ).not.toBeInTheDocument();
-    },
-  );
+        within(dialog).getByText('2026-04-08 12:20:00'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(dialog).queryByText('2026-04-08 05:20:00'),
+    ).not.toBeInTheDocument();
+  });
 
   test('loads credit usage tab on demand and renders credit rows', async () => {
     render(<AdminOperationCourseDetailPage />);

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -282,51 +282,48 @@ describe('AdminOperationCourseRatingsPage', () => {
     ).toHaveAttribute('href', '/admin/operations/course-1');
   });
 
-  test(
-    'keeps rating timestamps as returned wall-clock time when browser timezone changes',
-    async () => {
-      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
-      mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
-        summary: {
-          average_score: '4.5',
-          rating_count: 1,
-          user_count: 1,
-          latest_rated_at: '2026-04-05T01:30:00Z',
+  test('keeps rating timestamps as returned wall-clock time when browser timezone changes', async () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+    mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
+      summary: {
+        average_score: '4.5',
+        rating_count: 1,
+        user_count: 1,
+        latest_rated_at: '2026-04-05T01:30:00Z',
+      },
+      items: [
+        {
+          lesson_feedback_bid: 'feedback-1',
+          progress_record_bid: 'progress-1',
+          user_bid: 'student-1',
+          mobile: '13900001235',
+          email: '',
+          nickname: 'Bob',
+          chapter_outline_item_bid: 'chapter-1',
+          chapter_title: 'Chapter 1',
+          lesson_outline_item_bid: 'lesson-1',
+          lesson_title: 'Lesson 1',
+          score: 5,
+          comment: 'Very helpful lesson',
+          mode: 'read',
+          rated_at: '2026-04-05T01:30:00Z',
         },
-        items: [
-          {
-            lesson_feedback_bid: 'feedback-1',
-            progress_record_bid: 'progress-1',
-            user_bid: 'student-1',
-            mobile: '13900001235',
-            email: '',
-            nickname: 'Bob',
-            chapter_outline_item_bid: 'chapter-1',
-            chapter_title: 'Chapter 1',
-            lesson_outline_item_bid: 'lesson-1',
-            lesson_title: 'Lesson 1',
-            score: 5,
-            comment: 'Very helpful lesson',
-            mode: 'read',
-            rated_at: '2026-04-05T01:30:00Z',
-          },
-        ],
-        page: 1,
-        page_size: 20,
-        total: 1,
-        page_count: 1,
-      });
+      ],
+      page: 1,
+      page_size: 20,
+      total: 1,
+      page_count: 1,
+    });
 
-      render(<AdminOperationCourseRatingsPage />);
+    render(<AdminOperationCourseRatingsPage />);
 
-      await screen.findByText('Very helpful lesson');
+    await screen.findByText('Very helpful lesson');
 
-      expect(document.body.textContent).toContain('2026-04-05');
-      expect(document.body.textContent).toContain('01:30:00');
-      expect(document.body.textContent).not.toContain('2026-04-04');
-      expect(document.body.textContent).not.toContain('18:30:00');
-    },
-  );
+    expect(document.body.textContent).toContain('2026-04-05');
+    expect(document.body.textContent).toContain('01:30:00');
+    expect(document.body.textContent).not.toContain('2026-04-04');
+    expect(document.body.textContent).not.toContain('18:30:00');
+  });
 
   test('formats rating summary counts without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -5,6 +5,7 @@ import AdminOperationCourseRatingsPage from './page';
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockGetAdminOperationCourseRatings = jest.fn();
+const mockBrowserTimeZone = jest.fn(() => 'UTC');
 const mockTranslationCache = new Map<string, { t: (key: string) => string }>();
 let mockLanguage = 'en-US';
 const mockEnvState = {
@@ -67,6 +68,10 @@ jest.mock('@/c-store', () => ({
       defaultLoginMethod: string;
     }) => unknown,
   ) => selector(mockEnvState),
+}));
+
+jest.mock('@/lib/browser-timezone', () => ({
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -174,6 +179,8 @@ describe('AdminOperationCourseRatingsPage', () => {
     mockReplace.mockReset();
     mockPush.mockReset();
     mockGetAdminOperationCourseRatings.mockReset();
+    mockBrowserTimeZone.mockReset();
+    mockBrowserTimeZone.mockReturnValue('UTC');
     mockLanguage = 'en-US';
     mockEnvState.loginMethodsEnabled = ['phone'];
     mockEnvState.defaultLoginMethod = 'phone';
@@ -274,6 +281,52 @@ describe('AdminOperationCourseRatingsPage', () => {
       }),
     ).toHaveAttribute('href', '/admin/operations/course-1');
   });
+
+  test(
+    'keeps rating timestamps as returned wall-clock time when browser timezone changes',
+    async () => {
+      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+      mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
+        summary: {
+          average_score: '4.5',
+          rating_count: 1,
+          user_count: 1,
+          latest_rated_at: '2026-04-05T01:30:00Z',
+        },
+        items: [
+          {
+            lesson_feedback_bid: 'feedback-1',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-1',
+            mobile: '13900001235',
+            email: '',
+            nickname: 'Bob',
+            chapter_outline_item_bid: 'chapter-1',
+            chapter_title: 'Chapter 1',
+            lesson_outline_item_bid: 'lesson-1',
+            lesson_title: 'Lesson 1',
+            score: 5,
+            comment: 'Very helpful lesson',
+            mode: 'read',
+            rated_at: '2026-04-05T01:30:00Z',
+          },
+        ],
+        page: 1,
+        page_size: 20,
+        total: 1,
+        page_count: 1,
+      });
+
+      render(<AdminOperationCourseRatingsPage />);
+
+      await screen.findByText('Very helpful lesson');
+
+      expect(document.body.textContent).toContain('2026-04-05');
+      expect(document.body.textContent).toContain('01:30:00');
+      expect(document.body.textContent).not.toContain('2026-04-04');
+      expect(document.body.textContent).not.toContain('18:30:00');
+    },
+  );
 
   test('formats rating summary counts without grouping in Chinese locale', async () => {
     mockLanguage = 'zh-CN';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -15,7 +15,7 @@ import {
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
 import { useEnvStore } from '@/c-store';
 import ErrorDisplay from '@/components/ErrorDisplay';
@@ -443,7 +443,7 @@ export default function AdminOperationCourseRatingsPage() {
         key: 'latestRatedAt',
         label: tOperations('detail.ratings.summary.latestRatedAt'),
         value:
-          formatAdminUtcDateTime(fullSummary.latest_rated_at) || emptyValue,
+          formatAdminNaiveDateTime(fullSummary.latest_rated_at) || emptyValue,
         tone: 'timestamp' as const,
       },
     ],
@@ -993,7 +993,7 @@ export default function AdminOperationCourseRatingsPage() {
                                       style={getColumnStyle('ratedAt')}
                                     >
                                       <AdminTooltipText
-                                        text={formatAdminUtcDateTime(
+                                        text={formatAdminNaiveDateTime(
                                           item.rated_at,
                                         )}
                                         emptyValue={emptyValue}

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx
@@ -48,7 +48,10 @@ import {
   FILTER_ALL_OPTION,
   sanitizeCreditFiltersByType,
 } from './creditFilterUtils';
-import { formatOperatorUtcDateTime } from '../dateTime';
+import {
+  formatOperatorNaiveDateTime,
+  formatOperatorUtcDateTime,
+} from '../dateTime';
 
 type ErrorState = { message: string; code?: number };
 
@@ -444,7 +447,7 @@ const CreditUsageDetailDialog = ({
                         }
                       >
                         <TableCell className='border-r border-border py-2.5 text-center text-xs text-muted-foreground/70'>
-                          {formatOperatorUtcDateTime(item.created_at) ||
+                          {formatOperatorNaiveDateTime(item.created_at) ||
                             emptyValue}
                         </TableCell>
                         <TableCell className='border-r border-border py-2.5 text-center text-sm font-medium tabular-nums text-foreground'>
@@ -926,7 +929,7 @@ export default function UserCreditLedgerTab({
   const renderCreatedAtCell = (createdAt: string) => (
     <TableCell className='max-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-center'>
       <AdminTooltipText
-        text={formatOperatorUtcDateTime(createdAt)}
+        text={formatOperatorNaiveDateTime(createdAt)}
         emptyValue={emptyValue}
         alwaysShowTooltip
       />

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -838,7 +838,9 @@ describe('AdminOperationUserDetailPage', () => {
     fireEvent.click(openDetailButton);
 
     const dialog = await screen.findByRole('dialog');
-    expect(within(dialog).getByText('2026-04-18 10:00:00')).toBeInTheDocument();
+    expect(
+      await within(dialog).findByText('2026-04-18 10:00:00'),
+    ).toBeInTheDocument();
     expect(
       within(dialog).queryByText('2026-04-18 03:00:00'),
     ).not.toBeInTheDocument();

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -733,7 +733,9 @@ describe('AdminOperationUserDetailPage', () => {
     });
   });
 
-  test('renders detail timestamps with field-specific formatting', async () => {
+  test(
+    'renders user detail timestamps with field-specific formatting',
+    async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationUserDetail.mockResolvedValue({
       ...detailResponse,
@@ -770,10 +772,85 @@ describe('AdminOperationUserDetailPage', () => {
     expect(screen.getAllByText('2026-04-30 18:00:00').length).toBeGreaterThan(
       0,
     );
-    expect(screen.getAllByText('2026-04-17 18:00:00').length).toBeGreaterThan(
+    expect(screen.getAllByText('2026-04-18 01:00:00').length).toBeGreaterThan(
       0,
     );
-  });
+    expect(screen.queryByText('2026-04-17 18:00:00')).not.toBeInTheDocument();
+    },
+  );
+
+  test(
+    'keeps user credit usage detail created_at as returned wall-clock time',
+    async () => {
+      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+      mockGetAdminOperationUserCredits.mockResolvedValue({
+        ...creditsResponse,
+        items: [
+          {
+            ...creditsResponse.items[0],
+            entry_type: 'consume',
+            source_type: 'usage',
+            display_entry_type: 'preview_consume',
+            display_source_type: 'usage',
+            amount: '-6',
+            created_at: '2026-04-18T01:00:00Z',
+            usage_bid: 'usage-1',
+            course_bid: 'course-usage-1',
+            course_name: 'Usage Course',
+            chapter_title: 'Chapter A',
+            lesson_title: 'Lesson B',
+            usage_scene: 'learning',
+            usage_mode: 'ask',
+          },
+        ],
+      });
+      mockGetAdminOperationUserCreditUsageDetail.mockResolvedValue({
+        usage_bid: 'usage-1',
+        course_bid: 'course-usage-1',
+        course_name: 'Usage Course',
+        chapter_title: 'Chapter A',
+        lesson_title: 'Lesson B',
+        usage_scene: 'learning',
+        usage_mode: 'ask',
+        total_consumed_credits: '6',
+        items: [
+          {
+            usage_bid: 'usage-1',
+            created_at: '2026-04-18T10:00:00Z',
+            content: 'Generated answer content',
+            consumed_credits: '6',
+            usage_units: 120,
+            input_tokens: 100,
+            output_tokens: 20,
+            word_count: 0,
+            duration_ms: 0,
+            segment_count: 0,
+          },
+        ],
+      });
+
+      render(<AdminOperationUserDetailPage />);
+
+      fireEvent.click(
+        await screen.findByRole('button', {
+          name: 'module.operationsUser.detail.creditLedgerFilters.typeOptions.consume',
+        }),
+      );
+
+      const openDetailButton = await screen.findByRole('button', {
+        name: 'module.operationsUser.detail.creditUsageDetail.actions.openAriaLabel',
+      });
+      fireEvent.click(openDetailButton);
+
+      const dialog = await screen.findByRole('dialog');
+      expect(
+        within(dialog).getByText('2026-04-18 10:00:00'),
+      ).toBeInTheDocument();
+      expect(
+        within(dialog).queryByText('2026-04-18 03:00:00'),
+      ).not.toBeInTheDocument();
+    },
+  );
 
   test('keeps note column empty for system ledger rows without manual note', async () => {
     mockGetAdminOperationUserCredits.mockResolvedValue({

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -733,9 +733,7 @@ describe('AdminOperationUserDetailPage', () => {
     });
   });
 
-  test(
-    'renders user detail timestamps with field-specific formatting',
-    async () => {
+  test('renders user detail timestamps with field-specific formatting', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationUserDetail.mockResolvedValue({
       ...detailResponse,
@@ -776,81 +774,75 @@ describe('AdminOperationUserDetailPage', () => {
       0,
     );
     expect(screen.queryByText('2026-04-17 18:00:00')).not.toBeInTheDocument();
-    },
-  );
+  });
 
-  test(
-    'keeps user credit usage detail created_at as returned wall-clock time',
-    async () => {
-      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
-      mockGetAdminOperationUserCredits.mockResolvedValue({
-        ...creditsResponse,
-        items: [
-          {
-            ...creditsResponse.items[0],
-            entry_type: 'consume',
-            source_type: 'usage',
-            display_entry_type: 'preview_consume',
-            display_source_type: 'usage',
-            amount: '-6',
-            created_at: '2026-04-18T01:00:00Z',
-            usage_bid: 'usage-1',
-            course_bid: 'course-usage-1',
-            course_name: 'Usage Course',
-            chapter_title: 'Chapter A',
-            lesson_title: 'Lesson B',
-            usage_scene: 'learning',
-            usage_mode: 'ask',
-          },
-        ],
-      });
-      mockGetAdminOperationUserCreditUsageDetail.mockResolvedValue({
-        usage_bid: 'usage-1',
-        course_bid: 'course-usage-1',
-        course_name: 'Usage Course',
-        chapter_title: 'Chapter A',
-        lesson_title: 'Lesson B',
-        usage_scene: 'learning',
-        usage_mode: 'ask',
-        total_consumed_credits: '6',
-        items: [
-          {
-            usage_bid: 'usage-1',
-            created_at: '2026-04-18T10:00:00Z',
-            content: 'Generated answer content',
-            consumed_credits: '6',
-            usage_units: 120,
-            input_tokens: 100,
-            output_tokens: 20,
-            word_count: 0,
-            duration_ms: 0,
-            segment_count: 0,
-          },
-        ],
-      });
+  test('keeps user credit usage detail created_at as returned wall-clock time', async () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+    mockGetAdminOperationUserCredits.mockResolvedValue({
+      ...creditsResponse,
+      items: [
+        {
+          ...creditsResponse.items[0],
+          entry_type: 'consume',
+          source_type: 'usage',
+          display_entry_type: 'preview_consume',
+          display_source_type: 'usage',
+          amount: '-6',
+          created_at: '2026-04-18T01:00:00Z',
+          usage_bid: 'usage-1',
+          course_bid: 'course-usage-1',
+          course_name: 'Usage Course',
+          chapter_title: 'Chapter A',
+          lesson_title: 'Lesson B',
+          usage_scene: 'learning',
+          usage_mode: 'ask',
+        },
+      ],
+    });
+    mockGetAdminOperationUserCreditUsageDetail.mockResolvedValue({
+      usage_bid: 'usage-1',
+      course_bid: 'course-usage-1',
+      course_name: 'Usage Course',
+      chapter_title: 'Chapter A',
+      lesson_title: 'Lesson B',
+      usage_scene: 'learning',
+      usage_mode: 'ask',
+      total_consumed_credits: '6',
+      items: [
+        {
+          usage_bid: 'usage-1',
+          created_at: '2026-04-18T10:00:00Z',
+          content: 'Generated answer content',
+          consumed_credits: '6',
+          usage_units: 120,
+          input_tokens: 100,
+          output_tokens: 20,
+          word_count: 0,
+          duration_ms: 0,
+          segment_count: 0,
+        },
+      ],
+    });
 
-      render(<AdminOperationUserDetailPage />);
+    render(<AdminOperationUserDetailPage />);
 
-      fireEvent.click(
-        await screen.findByRole('button', {
-          name: 'module.operationsUser.detail.creditLedgerFilters.typeOptions.consume',
-        }),
-      );
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'module.operationsUser.detail.creditLedgerFilters.typeOptions.consume',
+      }),
+    );
 
-      const openDetailButton = await screen.findByRole('button', {
-        name: 'module.operationsUser.detail.creditUsageDetail.actions.openAriaLabel',
-      });
-      fireEvent.click(openDetailButton);
+    const openDetailButton = await screen.findByRole('button', {
+      name: 'module.operationsUser.detail.creditUsageDetail.actions.openAriaLabel',
+    });
+    fireEvent.click(openDetailButton);
 
-      const dialog = await screen.findByRole('dialog');
-      expect(
-        within(dialog).getByText('2026-04-18 10:00:00'),
-      ).toBeInTheDocument();
-      expect(
-        within(dialog).queryByText('2026-04-18 03:00:00'),
-      ).not.toBeInTheDocument();
-    },
-  );
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('2026-04-18 10:00:00')).toBeInTheDocument();
+    expect(
+      within(dialog).queryByText('2026-04-18 03:00:00'),
+    ).not.toBeInTheDocument();
+  });
 
   test('keeps note column empty for system ledger rows without manual note', async () => {
     mockGetAdminOperationUserCredits.mockResolvedValue({


### PR DESCRIPTION
## Summary
- restore wall-clock rendering for operator detail surfaces whose created/rated/follow-up timestamps should not be browser-timezone shifted
- fix user credit ledger and course credit usage detail timestamps in both list and drawer views
- align follow-up and ratings pages with the same wall-clock contract and expand focused regression coverage

## Testing
- cd src/cook-web && npm run test -- --runInBand --runTestsByPath "$PWD/src/app/admin/operations/users/[user_bid]/page.test.tsx" "$PWD/src/app/admin/operations/[shifu_bid]/page.test.tsx" "$PWD/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx" "$PWD/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx"
- cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/users/[user_bid]/UserCreditLedgerTab.tsx' --file 'src/app/admin/operations/[shifu_bid]/CourseCreditUsageTab.tsx' --file 'src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx' --file 'src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx' --file 'src/app/admin/operations/[shifu_bid]/ratings/page.tsx' --file 'src/app/admin/operations/users/[user_bid]/page.test.tsx' --file 'src/app/admin/operations/[shifu_bid]/page.test.tsx' --file 'src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx' --file 'src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx'\n- cd src/cook-web && npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin timestamp displays now show backend "wall-clock" values (naive times) across course credit usage, follow-ups, ratings, and operator credit ledger pages.

* **Documentation**
  * Expanded the exception list of admin/operator timestamp fields that should use naive formatting.

* **Tests**
  * Added/updated tests to verify timestamps preserve returned wall-clock times across affected admin pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->