### PR TITLE
fix: avoid run script error alerts for app exceptions

### DIFF
--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -769,8 +769,12 @@ def run_script(
 
             if stream_error and not client_disconnected:
                 if isinstance(stream_error, Exception):
-                    app.logger.error("run_script error")
-                    app.logger.error(stream_error)
+                    is_app_exception = isinstance(stream_error, AppException)
+                    if is_app_exception:
+                        app.logger.info("run_script app exception: %s", stream_error)
+                    else:
+                        app.logger.error("run_script error")
+                        app.logger.error(stream_error)
                     error_traceback = "".join(
                         traceback.format_exception(
                             type(stream_error),
@@ -784,7 +788,7 @@ def run_script(
                         "traceback": error_traceback,
                     }
 
-                    if isinstance(stream_error, AppException):
+                    if is_app_exception:
                         app.logger.info(error_info)
                         error_content = str(stream_error)
                     else:


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-09 17:54 左右连续告警：

```
/api/learn/shifu/b7f3e1bab445448facb4f841e74e2766/run/94c04a0f8a36423aafb67d958c3fa8b1
/api/learn/shifu/b7f3e1bab445448facb4f841e74e2766/run/11d81e1ecc9d40ca8763109a0b5d7566
/api/learn/shifu/b7f3e1bab445448facb4f841e74e2766/run/3e8630d69e9d46febfff3d886471e49e
run_script error
大纲单元不存在
```

只读库排查确认：这些 `outline_bid` 对应的发布大纲行均已被标记 `deleted=1`，同课程随后生成了新的 outline bid。该类请求是用户访问旧/已删除大纲导致的业务 `AppException`，不应以 `ERROR run_script error` 形式触发运维告警。

## 修复内容

- `run_script` 流式错误处理中区分 `AppException` 与真正的未知异常。
- 对 `AppException` 使用 `info` 日志输出 `run_script app exception` 与错误详情，仍将原业务错误内容通过 SSE 返回给客户端。
- 未知异常保持原有 `ERROR run_script error` 日志与通用错误返回，避免掩盖真实服务异常。

## 验证

- ✅ `python3 -m py_compile src/api/flaskr/service/learn/runscript_v2.py`
- ✅ `git diff --check`
- ⚠️ `python3 -m pytest src/api/tests/service/learn/test_context_v2.py -q` 未运行：本机系统 Python 缺少 pytest。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in script execution to better distinguish and log different exception types appropriately.

* **Refactor**
  * Enhanced exception classification consistency in error reporting to ensure accurate error categorization and logging behavior throughout the execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->