### PR TITLE
fix: preserve operator user activity timestamps

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -78,6 +78,7 @@ offset.
   - operator user credit usage detail `created_at`
   - operator course metadata `basic_info.created_at` / `basic_info.updated_at`
   - operator course list metadata `created_at` / `updated_at`
+  - operator course users `last_learning_at` / `last_login_at` / `joined_at`
   - operator course credit usage `created_at`
   - operator course credit usage detail `created_at`
   - operator course follow-up `created_at` / `latest_follow_up_at`

--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -73,6 +73,7 @@ offset.
   formatter helpers instead of applying browser-timezone conversion.
 - Current exceptions:
   - operator user record `created_at` / `updated_at`
+  - operator user activity `last_login_at` / `last_learning_at`
   - operator user credit ledger `created_at`
   - operator user credit usage detail `created_at`
   - operator course metadata `basic_info.created_at` / `basic_info.updated_at`

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -496,7 +496,9 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLearnedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminNaiveDateTime(row.last_learning_at)}
+                            text={formatAdminNaiveDateTime(
+                              row.last_learning_at,
+                            )}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseUsersTab.tsx
@@ -10,7 +10,7 @@ import {
   getAdminStickyRightCellClass,
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { formatAdminNaiveDateTime } from '@/app/admin/lib/dateTime';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent } from '@/components/ui/Card';
@@ -496,7 +496,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLearnedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminUtcDateTime(row.last_learning_at)}
+                            text={formatAdminNaiveDateTime(row.last_learning_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />
@@ -506,7 +506,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('lastLoginAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminUtcDateTime(row.last_login_at)}
+                            text={formatAdminNaiveDateTime(row.last_login_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />
@@ -516,7 +516,7 @@ export default function CourseUsersTab({
                           style={getColumnStyle('joinedAt')}
                         >
                           <AdminTooltipText
-                            text={formatAdminUtcDateTime(row.joined_at)}
+                            text={formatAdminNaiveDateTime(row.joined_at)}
                             emptyValue={emptyValue}
                             className='mx-auto block max-w-full tabular-nums'
                           />

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -616,6 +616,47 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
   });
 
+  test(
+    'keeps course user activity timestamps as returned wall-clock time',
+    async () => {
+      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+      mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
+        items: [
+          {
+            user_bid: 'student-1',
+            mobile: '13900001234',
+            email: '',
+            nickname: 'Bob',
+            user_role: 'student',
+            learned_lesson_count: 1,
+            total_lesson_count: 3,
+            learning_status: 'learning',
+            is_paid: true,
+            total_paid_amount: '88',
+            last_learning_at: '2026-04-08T11:30:00Z',
+            joined_at: '2026-04-07T09:00:00Z',
+            last_login_at: '2026-04-08T12:00:00Z',
+          },
+        ],
+        page: 1,
+        page_count: 1,
+        page_size: 20,
+        total: 1,
+      });
+
+      render(<AdminOperationCourseDetailPage />);
+
+      await openUsersTab();
+
+      expect(screen.getByText('2026-04-08 11:30:00')).toBeInTheDocument();
+      expect(screen.getByText('2026-04-08 12:00:00')).toBeInTheDocument();
+      expect(screen.getByText('2026-04-07 09:00:00')).toBeInTheDocument();
+      expect(screen.queryByText('2026-04-08 04:30:00')).not.toBeInTheDocument();
+      expect(screen.queryByText('2026-04-08 05:00:00')).not.toBeInTheDocument();
+      expect(screen.queryByText('2026-04-07 02:00:00')).not.toBeInTheDocument();
+    },
+  );
+
   test('keeps course credit usage created_at values as returned wall-clock time', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationCourseCreditUsages.mockResolvedValueOnce({

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -616,46 +616,43 @@ describe('AdminOperationCourseDetailPage', () => {
     expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
   });
 
-  test(
-    'keeps course user activity timestamps as returned wall-clock time',
-    async () => {
-      mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
-      mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
-        items: [
-          {
-            user_bid: 'student-1',
-            mobile: '13900001234',
-            email: '',
-            nickname: 'Bob',
-            user_role: 'student',
-            learned_lesson_count: 1,
-            total_lesson_count: 3,
-            learning_status: 'learning',
-            is_paid: true,
-            total_paid_amount: '88',
-            last_learning_at: '2026-04-08T11:30:00Z',
-            joined_at: '2026-04-07T09:00:00Z',
-            last_login_at: '2026-04-08T12:00:00Z',
-          },
-        ],
-        page: 1,
-        page_count: 1,
-        page_size: 20,
-        total: 1,
-      });
+  test('keeps course user activity timestamps as returned wall-clock time', async () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+    mockGetAdminOperationCourseUsers.mockResolvedValueOnce({
+      items: [
+        {
+          user_bid: 'student-1',
+          mobile: '13900001234',
+          email: '',
+          nickname: 'Bob',
+          user_role: 'student',
+          learned_lesson_count: 1,
+          total_lesson_count: 3,
+          learning_status: 'learning',
+          is_paid: true,
+          total_paid_amount: '88',
+          last_learning_at: '2026-04-08T11:30:00Z',
+          joined_at: '2026-04-07T09:00:00Z',
+          last_login_at: '2026-04-08T12:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
 
-      render(<AdminOperationCourseDetailPage />);
+    render(<AdminOperationCourseDetailPage />);
 
-      await openUsersTab();
+    await openUsersTab();
 
-      expect(screen.getByText('2026-04-08 11:30:00')).toBeInTheDocument();
-      expect(screen.getByText('2026-04-08 12:00:00')).toBeInTheDocument();
-      expect(screen.getByText('2026-04-07 09:00:00')).toBeInTheDocument();
-      expect(screen.queryByText('2026-04-08 04:30:00')).not.toBeInTheDocument();
-      expect(screen.queryByText('2026-04-08 05:00:00')).not.toBeInTheDocument();
-      expect(screen.queryByText('2026-04-07 02:00:00')).not.toBeInTheDocument();
-    },
-  );
+    expect(screen.getByText('2026-04-08 11:30:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-08 12:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-07 09:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-08 04:30:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-04-08 05:00:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-04-07 02:00:00')).not.toBeInTheDocument();
+  });
 
   test('keeps course credit usage created_at values as returned wall-clock time', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/page.test.tsx
@@ -764,9 +764,11 @@ describe('AdminOperationUserDetailPage', () => {
       name: 'module.operationsUser.detail.title',
     });
 
-    expect(screen.getByText('2026-04-14 18:30:00')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-14 19:30:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-15 01:30:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-15 02:30:00')).toBeInTheDocument();
     expect(screen.getByText('2026-04-14 01:15:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-14 18:30:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-04-14 19:30:00')).not.toBeInTheDocument();
     expect(screen.getAllByText('2026-04-30 18:00:00').length).toBeGreaterThan(
       0,
     );

--- a/src/cook-web/src/app/admin/operations/users/[user_bid]/useUserDetailViewModel.tsx
+++ b/src/cook-web/src/app/admin/operations/users/[user_bid]/useUserDetailViewModel.tsx
@@ -227,7 +227,7 @@ export default function useUserDetailViewModel({
       {
         key: 'lastLoginAt',
         label: tOperationsUsers('table.lastLoginAt'),
-        value: formatOperatorUtcDateTime(detail.last_login_at),
+        value: formatOperatorNaiveDateTime(detail.last_login_at),
       },
       {
         key: 'createdAt',
@@ -285,7 +285,7 @@ export default function useUserDetailViewModel({
       {
         key: 'lastLearningAt',
         label: tOperationsUsers('table.lastLearningAt'),
-        value: formatOperatorUtcDateTime(detail.last_learning_at),
+        value: formatOperatorNaiveDateTime(detail.last_learning_at),
       },
     ],
     [

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -607,7 +607,7 @@ describe('AdminOperationUsersPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('keeps user metadata timestamps as wall-clock time and converts event timestamps by browser timezone', async () => {
+  test('keeps user activity and metadata timestamps as returned wall-clock time', async () => {
     mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockGetAdminOperationUsers.mockResolvedValueOnce({
       items: [
@@ -645,11 +645,13 @@ describe('AdminOperationUsersPage', () => {
 
     await renderResolvedPage();
 
-    expect(screen.getByText('2026-06-09 07:01:50')).toBeInTheDocument();
-    expect(screen.getByText('2026-06-09 08:01:50')).toBeInTheDocument();
+    expect(screen.getByText('2026-06-09 14:01:50')).toBeInTheDocument();
+    expect(screen.getByText('2026-06-09 15:01:50')).toBeInTheDocument();
     expect(screen.getByText('2026-06-09 12:01:50')).toBeInTheDocument();
     expect(screen.getByText('2026-06-09 13:01:50')).toBeInTheDocument();
     expect(screen.queryByText('2026-06-09 04:01:50')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-06-09 07:01:50')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-06-09 08:01:50')).not.toBeInTheDocument();
     expect(screen.queryByText('2026-06-08 21:01:50')).not.toBeInTheDocument();
     expect(screen.queryByText('2026-06-08 22:01:50')).not.toBeInTheDocument();
   });

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -1484,7 +1484,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLoginAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.last_login_at),
+                            formatOperatorNaiveDateTime(user.last_login_at),
                           )}
                         </TableCell>
                         <TableCell
@@ -1492,7 +1492,7 @@ export default function AdminOperationUsersPage() {
                           style={getColumnStyle('lastLearningAt')}
                         >
                           {renderTooltipText(
-                            formatOperatorUtcDateTime(user.last_learning_at),
+                            formatOperatorNaiveDateTime(user.last_learning_at),
                           )}
                         </TableCell>
                         <TableCell


### PR DESCRIPTION
## Summary
- keep operator user activity timestamps (`last_login_at` and `last_learning_at`) as returned wall-clock values in the user list and user detail surfaces
- align the user list and user detail timestamp tests with the wall-clock rendering contract

## Testing
- cd src/cook-web && npm run test -- --runInBand --runTestsByPath "$PWD/src/app/admin/operations/users/page.test.tsx" "$PWD/src/app/admin/operations/users/[user_bid]/page.test.tsx"
- cd src/cook-web && npm run lint -- --file 'src/app/admin/operations/users/page.tsx' --file 'src/app/admin/operations/users/[user_bid]/useUserDetailViewModel.tsx' --file 'src/app/admin/operations/users/page.test.tsx' --file 'src/app/admin/operations/users/[user_bid]/page.test.tsx'\n- cd src/cook-web && npm run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User activity timestamps (last login, last learning, joined) now display as wall‑clock time consistently across admin user lists, course user tables, and detail views.
* **Documentation**
  * Clarified admin time‑display guidance to include operator user activity fields retaining wall‑clock formatting.
* **Tests**
  * Added/updated tests to expect wall‑clock timestamp outputs and remove prior timezone‑shifted expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->