### PR TITLE
fix: avoid error alerts for orphan outline nodes

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -103,6 +103,8 @@ def build_outline_tree(app, shifu_bid: str) -> list[ShifuOutlineTreeNode]:
         node = ShifuOutlineTreeNode(item)
         nodes_map[item.position] = node
 
+    orphan_positions = []
+
     # build tree structure
     for position, node in nodes_map.items():
         if len(position) == 2:
@@ -116,7 +118,16 @@ def build_outline_tree(app, shifu_bid: str) -> list[ShifuOutlineTreeNode]:
                 if node not in parent_node.children:
                     parent_node.add_child(node)
             else:
-                app.logger.error(f"Parent node not found for position: {position}")
+                orphan_positions.append(position)
+
+    if orphan_positions:
+        app.logger.warning(
+            "Skipped %s orphan outline nodes without parent while building tree "
+            "for shifu %s, sample positions: %s",
+            len(orphan_positions),
+            shifu_bid,
+            orphan_positions[:10],
+        )
 
     return outline_tree
 

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -1,4 +1,6 @@
-from flaskr.service.shifu import shifu_publish_funcs
+from types import SimpleNamespace
+
+from flaskr.service.shifu import shifu_outline_funcs, shifu_publish_funcs
 
 
 def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch):
@@ -19,3 +21,23 @@ def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch):
 
     assert called["apply"] is True
     assert called["summary"] is True
+
+
+def test_build_outline_tree_warns_once_for_orphan_nodes(app, monkeypatch, caplog):
+    items = [
+        SimpleNamespace(outline_item_bid="root", position="01"),
+        SimpleNamespace(outline_item_bid="child", position="0101"),
+        SimpleNamespace(outline_item_bid="orphan", position="0702"),
+        SimpleNamespace(outline_item_bid="orphan2", position="0703"),
+    ]
+
+    monkeypatch.setattr(
+        shifu_outline_funcs, "__get_existing_outline_items", lambda _: items
+    )
+
+    tree = shifu_outline_funcs.build_outline_tree(app, "shifu-1")
+
+    assert [node.position for node in tree] == ["01"]
+    assert [node.position for node in tree[0].children] == ["0101"]
+    assert "Skipped 2 orphan outline nodes without parent" in caplog.text
+    assert "Parent node not found" not in caplog.text


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-06-09 18:00 ~ 2026-06-10 18:00 巡检发现 114 条同类告警：

- `build_outline_tree` 记录 `Parent node not found for position: 0702/0703`
- 触发接口覆盖 `/api/shifu/shifus/{shifu_bid}/outlines...` 与 `/api/shifu/shifus/{shifu_bid}/publish`
- 这些日志当前以 ERROR 输出，导致运维群高频告警

## 修复内容

- 构建大纲树时收集缺失父节点的孤儿节点，不再逐条 `error`。
- 对孤儿节点保持原有行为：不挂入树、不改变接口返回结构。
- 改为单条 `warning` 汇总 orphan 数量与前 10 个 position 样例，保留诊断信息但避免触发 ERROR 告警风暴。
- 增加回归测试覆盖：正常父子节点仍挂载，孤儿节点只产生汇总 warning。

## 验证

- `python3 -m py_compile src/api/flaskr/service/shifu/shifu_outline_funcs.py src/api/tests/test_shifu_funcs.py`
- `git diff --check`

备注：本机系统 Python 缺少 `pytest`，`python3 -m pytest src/api/tests/test_shifu_funcs.py -q` 未能执行（`No module named pytest`）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outline tree construction to gracefully handle missing parent nodes by logging warnings instead of errors, while maintaining normal tree structure for valid nodes.

* **Tests**
  * Added test coverage for orphan node handling in outline tree construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->