### PR TITLE
feat: speed up typewriter rendering

### DIFF
--- a/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ContentBlock from '@/c-components/ChatUi/ContentBlock';
-import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-components/ChatUi/chatTypewriterConstants';
 
 const mockContentRender = jest.fn<null, [Record<string, unknown>]>(() => null);
 
@@ -110,7 +109,7 @@ describe('ContentBlock pay interaction overrides', () => {
     expect(mockContentRender).toHaveBeenCalledWith(
       expect.objectContaining({
         enableTypewriter: true,
-        typingSpeed: CHAT_TYPEWRITER_SPEED_MS,
+        typingSpeed: 30,
       }),
     );
   });

--- a/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ContentBlock from '@/c-components/ChatUi/ContentBlock';
+import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-components/ChatUi/chatTypewriterConstants';
 
 const mockContentRender = jest.fn<null, [Record<string, unknown>]>(() => null);
 
@@ -109,7 +110,7 @@ describe('ContentBlock pay interaction overrides', () => {
     expect(mockContentRender).toHaveBeenCalledWith(
       expect.objectContaining({
         enableTypewriter: true,
-        typingSpeed: 40,
+        typingSpeed: CHAT_TYPEWRITER_SPEED_MS,
       }),
     );
   });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -30,6 +30,7 @@ import {
   type AskMessage,
 } from './askState';
 import { useAskStateStore } from './useAskStateStore';
+import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-components/ChatUi/chatTypewriterConstants';
 export type { AskMessage } from './askState';
 
 export interface AskBlockProps {
@@ -662,7 +663,7 @@ export default function AskBlock({
                       lessonFeedbackInteractionDefaultValueOptions
                     }
                     enableTypewriter={shouldEnableMessageTypewriter}
-                    typingSpeed={30}
+                    typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
                     readonly={true}
                     copyButtonText={copyButtonText}
                     copiedButtonText={copiedButtonText}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -662,7 +662,7 @@ export default function AskBlock({
                       lessonFeedbackInteractionDefaultValueOptions
                     }
                     enableTypewriter={shouldEnableMessageTypewriter}
-                    typingSpeed={40}
+                    typingSpeed={30}
                     readonly={true}
                     copyButtonText={copyButtonText}
                     copiedButtonText={copiedButtonText}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -30,7 +30,7 @@ import {
   type AskMessage,
 } from './askState';
 import { useAskStateStore } from './useAskStateStore';
-import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-components/ChatUi/chatTypewriterConstants';
+import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 export type { AskMessage } from './askState';
 
 export interface AskBlockProps {

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/app/c/[[...id]]/Components/ChatUi/chatUiUtils';
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import { isPaySystemInteractionContent } from '@/c-utils/system-interaction';
-import { CHAT_TYPEWRITER_SPEED_MS } from './chatTypewriterConstants';
+import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 
 interface ContentBlockProps {
   item: ChatContentItem;

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -18,7 +18,7 @@ import {
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import { isPaySystemInteractionContent } from '@/c-utils/system-interaction';
 
-const STREAMING_TEXT_TYPING_SPEED = 40;
+const STREAMING_TEXT_TYPING_SPEED = 30;
 
 interface ContentBlockProps {
   item: ChatContentItem;

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -17,8 +17,7 @@ import {
 } from '@/app/c/[[...id]]/Components/ChatUi/chatUiUtils';
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import { isPaySystemInteractionContent } from '@/c-utils/system-interaction';
-
-const STREAMING_TEXT_TYPING_SPEED = 30;
+import { CHAT_TYPEWRITER_SPEED_MS } from './chatTypewriterConstants';
 
 interface ContentBlockProps {
   item: ChatContentItem;
@@ -126,7 +125,7 @@ const ContentBlock = memo(
       >
         <ContentRender
           enableTypewriter={shouldEnableTypewriter}
-          typingSpeed={STREAMING_TEXT_TYPING_SPEED}
+          typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
           content={renderedContent}
           onClickCustomButtonAfterContent={handleClick}
           customRenderBar={item.customRenderBar}

--- a/src/cook-web/src/c-components/ChatUi/chatTypewriterConstants.ts
+++ b/src/cook-web/src/c-components/ChatUi/chatTypewriterConstants.ts
@@ -1,0 +1,1 @@
+export const CHAT_TYPEWRITER_SPEED_MS = 30;

--- a/src/cook-web/src/c-components/ChatUi/chatTypewriterConstants.ts
+++ b/src/cook-web/src/c-components/ChatUi/chatTypewriterConstants.ts
@@ -1,1 +1,0 @@
-export const CHAT_TYPEWRITER_SPEED_MS = 30;

--- a/src/cook-web/src/c-constants/uiConstants.ts
+++ b/src/cook-web/src/c-constants/uiConstants.ts
@@ -65,6 +65,8 @@ export const calcFrameLayout = selector => {
 export const THEME_LIGHT = 'light';
 export const THEME_DARK = 'dark';
 
+export const CHAT_TYPEWRITER_SPEED_MS = 30;
+
 export const inWechat = () => {
   const ua = navigator.userAgent.toLowerCase();
   // @ts-expect-error EXPECT


### PR DESCRIPTION
## Summary

- Reduce learner read-mode content typewriter speed from 40ms to 30ms.
- Apply the same speed to follow-up answer typewriter rendering.

## Validation

- `cd src/cook-web && npm run type-check`
- Pre-commit hooks from `git commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Optimized chat message text streaming animation speed for faster message display and improved responsiveness during conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->