### PR TITLE
[codex] Check only changed Cook Web Prettier files

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js (match Cook Web engines)
         uses: actions/setup-node@v4
@@ -27,7 +29,10 @@ jobs:
           cd src/cook-web
           npm ci
 
-      - name: Check Prettier formatting
+      - name: Check Prettier formatting for changed files
+        env:
+          PRETTIER_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          PRETTIER_HEAD_SHA: ${{ github.sha }}
         run: |
           cd src/cook-web
-          npm run format:check
+          npm run format:check:changed

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -153,7 +153,7 @@ services:
       - ./observability/otel-collector-config.yml:/etc/otel-collector-config.yml
 
   ai-shifu-prometheus:
-    image: prom/prometheus:v2.2.2
+    image: prom/prometheus:v2.54.1
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus

--- a/scripts/test_prettier_check_changed.py
+++ b/scripts/test_prettier_check_changed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for the Cook Web changed-files Prettier helper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "src/cook-web/scripts/prettier-check-changed.mjs"
+
+
+def run(
+    command: list[str], cwd: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+class PrettierCheckChangedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tempdir.name)
+        self.cook_web = self.repo / "src/cook-web"
+        (self.cook_web / "src").mkdir(parents=True)
+        (self.repo / "src/api").mkdir(parents=True)
+
+        run(["git", "init"], self.repo)
+        run(["git", "config", "user.email", "test@example.com"], self.repo)
+        run(["git", "config", "user.name", "Test User"], self.repo)
+
+        (self.cook_web / "src/existing.ts").write_text("const value = 1;\n")
+        (self.repo / "src/api/app.py").write_text("print('hello')\n")
+        run(["git", "add", "."], self.repo)
+        run(["git", "commit", "-m", "base"], self.repo)
+        self.base = run(["git", "rev-parse", "HEAD"], self.repo).stdout.strip()
+
+        self.fake_bin = self.repo / "fake-bin"
+        self.fake_bin.mkdir()
+        self.args_file = self.repo / "npx-args.txt"
+        (self.fake_bin / "npx").write_text(
+            '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$FAKE_NPX_ARGS"\nexit 0\n'
+        )
+        (self.fake_bin / "npx").chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def script_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["PATH"] = f"{self.fake_bin}{os.pathsep}{env['PATH']}"
+        env["FAKE_NPX_ARGS"] = str(self.args_file)
+        return env
+
+    def commit_changes(self, message: str) -> str:
+        run(["git", "add", "."], self.repo)
+        result = run(["git", "commit", "-m", message], self.repo)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return run(["git", "rev-parse", "HEAD"], self.repo).stdout.strip()
+
+    def test_checks_only_changed_cook_web_files(self) -> None:
+        (self.cook_web / "src/existing.ts").write_text("const value = 2;\n")
+        (self.cook_web / "docs").mkdir()
+        (self.cook_web / "docs/notes.md").write_text("# Notes\n")
+        (self.repo / "src/api/app.py").write_text("print('outside cook web')\n")
+        head = self.commit_changes("change cook web and backend")
+
+        result = run(
+            ["node", str(SCRIPT_PATH), "--base", self.base, "--head", head],
+            self.cook_web,
+            self.script_env(),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        args = self.args_file.read_text().splitlines()
+        self.assertEqual(args[:4], ["prettier", "--check", "--ignore-unknown", "--"])
+        self.assertCountEqual(args[4:], ["docs/notes.md", "src/existing.ts"])
+
+    def test_skips_prettier_when_no_cook_web_files_changed(self) -> None:
+        (self.repo / "src/api/app.py").write_text("print('outside only')\n")
+        head = self.commit_changes("change backend only")
+
+        result = run(
+            ["node", str(SCRIPT_PATH), "--base", self.base, "--head", head],
+            self.cook_web,
+            self.script_env(),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.args_file.exists())
+        self.assertIn("No changed Cook Web files", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -15,6 +15,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "format:check:changed": "node scripts/prettier-check-changed.mjs",
     "precommit": "lint-staged",
     "test": "jest",
     "test:e2e": "npx @playwright/test test",

--- a/src/cook-web/scripts/prettier-check-changed.mjs
+++ b/src/cook-web/scripts/prettier-check-changed.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const COOK_WEB_PREFIX = 'src/cook-web/';
+const ZERO_SHA = /^0{40}$/;
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const options = {
+    base: process.env.PRETTIER_BASE_SHA,
+    head: process.env.PRETTIER_HEAD_SHA || 'HEAD',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+    } else if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.head) {
+    fail('Missing head ref. Pass --head or set PRETTIER_HEAD_SHA.');
+  }
+
+  return options;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+function git(args, cwd, options = {}) {
+  return run('git', args, { cwd, ...options });
+}
+
+function gitOutput(args, cwd) {
+  const result = git(args, cwd);
+  if (result.status !== 0) {
+    fail(result.stderr.trim() || `git ${args.join(' ')} failed`);
+  }
+  return result.stdout;
+}
+
+function commitExists(ref, repoRoot) {
+  const result = git(['rev-parse', '--verify', `${ref}^{commit}`], repoRoot, {
+    stdio: 'ignore',
+  });
+  return result.status === 0;
+}
+
+function resolveBaseRef(base, head, repoRoot) {
+  if (base && !ZERO_SHA.test(base)) {
+    if (!commitExists(base, repoRoot)) {
+      fail(`Base ref is not available in this checkout: ${base}`);
+    }
+    return base;
+  }
+
+  const parent = `${head}^`;
+  if (commitExists(parent, repoRoot)) {
+    return parent;
+  }
+
+  return null;
+}
+
+function readChangedCookWebFiles(repoRoot, base, head) {
+  const diffTarget = base ? [`${base}...${head}`] : [head];
+  const command = base ? 'diff' : 'ls-tree';
+  const args = base
+    ? [
+        command,
+        '--name-only',
+        '--diff-filter=ACMR',
+        '-z',
+        ...diffTarget,
+        '--',
+        'src/cook-web',
+      ]
+    : [command, '-r', '--name-only', '-z', ...diffTarget, '--', 'src/cook-web'];
+
+  const output = gitOutput(args, repoRoot);
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .filter(file => file.startsWith(COOK_WEB_PREFIX))
+    .map(file => file.slice(COOK_WEB_PREFIX.length));
+}
+
+function runPrettier(cookWebRoot, files) {
+  if (files.length === 0) {
+    console.log('No changed Cook Web files to check.');
+    return 0;
+  }
+
+  console.log(
+    `Checking Prettier formatting for ${files.length} changed Cook Web file(s).`,
+  );
+  for (const file of files) {
+    console.log(`  ${file}`);
+  }
+
+  const result = run(
+    'npx',
+    ['prettier', '--check', '--ignore-unknown', '--', ...files],
+    {
+      cwd: cookWebRoot,
+      stdio: 'inherit',
+    },
+  );
+
+  if (result.signal) {
+    console.error(`Prettier exited after signal ${result.signal}.`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}
+
+const { base, head } = parseArgs(process.argv.slice(2));
+const repoRoot = gitOutput(
+  ['rev-parse', '--show-toplevel'],
+  process.cwd(),
+).trim();
+const cookWebRoot = path.join(repoRoot, 'src/cook-web');
+
+if (!commitExists(head, repoRoot)) {
+  fail(`Head ref is not available in this checkout: ${head}`);
+}
+
+const resolvedBase = resolveBaseRef(base, head, repoRoot);
+const changedFiles = readChangedCookWebFiles(repoRoot, resolvedBase, head);
+process.exit(runPrettier(cookWebRoot, changedFiles));


### PR DESCRIPTION
## Summary

- switch the Cook Web Prettier workflow to check only changed `src/cook-web` files
- add a Node helper that compares CI base/head refs and skips unchanged Cook Web PRs
- add focused Python coverage for changed-file filtering and no-op behavior
- restore the dev runtime harness Prometheus image pin after the release-version bump pointed it at a non-existent tag

## Validation

- `npm ci` from `src/cook-web`
- `python scripts/test_prettier_check_changed.py`
- `npm run format:check:changed -- --base HEAD~1 --head HEAD`
- `pre-commit run --files .github/workflows/prettier-check.yml src/cook-web/package.json src/cook-web/scripts/prettier-check-changed.mjs scripts/test_prettier_check_changed.py`
- `docker manifest inspect prom/prometheus:v2.54.1`
- `cd docker && docker compose -f docker-compose.dev.yml config` with a temporary empty `.env`
- `cd docker && docker compose -f docker-compose.dev.yml pull ai-shifu-prometheus` with a temporary empty `.env`
- `python scripts/check_repo_harness.py`
- `pre-commit run --files docker/docker-compose.dev.yml`

Closes #1868


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated core monitoring infrastructure dependency to the latest stable version, enhancing performance, stability, and security across deployment environments.
- Optimized code quality verification processes for improved efficiency and faster feedback during development cycles.
- Expanded automated testing infrastructure for development tooling to ensure continued reliability and code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->