### PR TITLE
fix: config fallback for missing DB rows

### DIFF
--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -151,7 +151,7 @@ def get_config(key: str, default: str = None) -> str:
                         .first()
                     )
                     if not config:
-                        return default
+                        return get_config_from_common(key, default)
                     raw_value = config.value
                     if bool(config.is_encrypted):
                         value = _decrypt_config(app, raw_value)

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -377,6 +377,32 @@ class TestGetConfig:
 
     @patch("flaskr.service.config.funcs.get_config_from_common")
     @patch("flaskr.service.config.funcs.redis")
+    @patch("flaskr.service.config.funcs.Config")
+    def test_get_config_uses_common_default_when_database_config_is_missing(
+        self, mock_config_class, mock_redis, mock_get_config_from_common, app
+    ):
+        """Registered config defaults should survive missing DB rows."""
+        with app.app_context():
+            app.config["REDIS_KEY_PREFIX"] = "test:"
+            mock_get_config_from_common.return_value = 0.5
+            mock_redis.get.return_value = None
+            mock_lock = MagicMock()
+            mock_lock.acquire.return_value = True
+            mock_redis.lock.return_value = mock_lock
+
+            mock_query = MagicMock()
+            mock_query.filter.return_value.order_by.return_value.first.return_value = (
+                None
+            )
+            mock_config_class.query = mock_query
+
+            result = get_config("MIN_SHIFU_PRICE")
+            assert result == 0.5
+            mock_get_config_from_common.assert_called_once_with("MIN_SHIFU_PRICE", None)
+            assert mock_lock.release.call_count >= 1
+
+    @patch("flaskr.service.config.funcs.get_config_from_common")
+    @patch("flaskr.service.config.funcs.redis")
     def test_get_config_lock_failed(self, mock_redis, mock_get_config_from_common, app):
         """Test that get_config returns None when lock acquisition fails."""
         with app.app_context():


### PR DESCRIPTION
## Summary
- Fall back to registered common config defaults when a DB-backed config row is missing.
- Add a regression test for MIN_SHIFU_PRICE so missing SaaS config rows do not pass None into plugin extensions.

## Root Cause
service.config.get_config() returned the caller default for missing DB-backed rows. For calls without an explicit default, plugin extensions received None for registered config keys such as MIN_SHIFU_PRICE and could crash during type conversion.

## Validation
- pytest tests/service/config/test_funcs.py -q
- pytest tests/service/shifu/test_shifu_draft_info.py -q
- git diff --check
- commit hooks: ruff check, ruff format, architecture and translation gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration retrieval fallback mechanism to properly use registered common defaults when database configurations are unavailable, improving consistency and reliability in configuration handling across the system.

* **Tests**
  * Added comprehensive test coverage for configuration fallback scenarios when database entries are missing, verifying correct default resolution and resource cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->