### PR TITLE
fix: use draft tts flag in preview

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -214,7 +214,7 @@ def get_shifu_info(app: Flask, shifu_bid: str, preview_mode: bool) -> LearnShifu
         )
         if not shifu:
             raise_error("server.shifu.shifuNotFound")
-        tts_enabled = bool(getattr(shifu, "tts_enabled", 0))
+        tts_enabled = bool(shifu.tts_enabled)
         return LearnShifuInfoDTO(
             bid=shifu.shifu_bid,
             title=shifu.title,

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -214,19 +214,7 @@ def get_shifu_info(app: Flask, shifu_bid: str, preview_mode: bool) -> LearnShifu
         )
         if not shifu:
             raise_error("server.shifu.shifuNotFound")
-        published_shifu = None
-        if preview_mode:
-            published_shifu = (
-                PublishedShifu.query.filter(
-                    PublishedShifu.shifu_bid == shifu_bid,
-                    PublishedShifu.deleted == 0,
-                )
-                .order_by(PublishedShifu.id.desc())
-                .first()
-            )
-        else:
-            published_shifu = shifu
-        tts_enabled = bool(getattr(published_shifu, "tts_enabled", 0))
+        tts_enabled = bool(getattr(shifu, "tts_enabled", 0))
         return LearnShifuInfoDTO(
             bid=shifu.shifu_bid,
             title=shifu.title,

--- a/src/api/tests/test_learn_api.py
+++ b/src/api/tests/test_learn_api.py
@@ -2,7 +2,12 @@ from decimal import Decimal
 
 from flaskr.dao import db
 from flaskr.service.learn.learn_funcs import get_outline_item_tree, get_shifu_info
-from flaskr.service.shifu.models import DraftOutlineItem, LogDraftStruct, PublishedShifu
+from flaskr.service.shifu.models import (
+    DraftOutlineItem,
+    DraftShifu,
+    LogDraftStruct,
+    PublishedShifu,
+)
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
 
@@ -23,6 +28,36 @@ def test_get_shifu_info_returns_dto(app):
     assert dto.title == "Test Shifu"
     assert dto.price == "9.99"
     assert dto.keywords == ["a", "b"]
+
+
+def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
+    with app.app_context():
+        draft = DraftShifu(
+            shifu_bid="shifu-learn-tts",
+            title="Draft Shifu",
+            description="Draft Desc",
+            price=Decimal("1.00"),
+            keywords="listen",
+            tts_enabled=1,
+        )
+        published = PublishedShifu(
+            shifu_bid="shifu-learn-tts",
+            title="Published Shifu",
+            description="Published Desc",
+            price=Decimal("2.00"),
+            keywords="listen",
+            tts_enabled=0,
+        )
+        db.session.add_all([draft, published])
+        db.session.commit()
+
+    preview_dto = get_shifu_info(app, "shifu-learn-tts", preview_mode=True)
+    live_dto = get_shifu_info(app, "shifu-learn-tts", preview_mode=False)
+
+    assert preview_dto.title == "Draft Shifu"
+    assert preview_dto.tts_enabled is True
+    assert live_dto.title == "Published Shifu"
+    assert live_dto.tts_enabled is False
 
 
 def test_get_outline_item_tree_preview_mode(app):


### PR DESCRIPTION
## Summary
- Fix learner preview mode so `tts_enabled` is read from the draft course data instead of the published course data.
- Add a regression test to cover preview/live `tts_enabled` behavior.

## Verification
- `cd src/api && pytest -q tests/test_learn_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Preview mode now consistently uses the content instance selected for preview when determining whether text-to-speech is enabled, removing redundant lookup paths.

* **Tests**
  * Added tests verifying that preview and live modes return correct text-to-speech settings for draft vs. published content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->