### PR TITLE
[codex] fix referral default campaign bootstrap

### DIFF
--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -26,6 +26,7 @@ from flaskr.util.uuid import generate_id
 
 from .consts import (
     REFERRAL_CAMPAIGN_STATUS_ACTIVE,
+    REFERRAL_INVITEE_BENEFIT_EXISTING_TRIAL_ONLY,
     REFERRAL_INVITE_CODE_STATUS_ACTIVE,
     REFERRAL_INVITE_EVENT_TYPES,
     REFERRAL_RELATION_STATUS_REGISTERED,
@@ -37,6 +38,9 @@ from .consts import (
     REFERRAL_REWARD_GRANTED_STATUSES,
     REFERRAL_REWARD_STATUS_GENERATED,
     REFERRAL_REWARD_STATUS_SKIPPED_CAP,
+    REFERRAL_REWARD_TARGET_INVITER,
+    REFERRAL_REWARD_TIMING_IMMEDIATE_EXTEND_OR_DEFER,
+    REFERRAL_REWARD_TYPE_BILLING_PLAN_CYCLE,
     REFERRAL_RULE_STATUS_ACTIVE,
     REFERRAL_TRIGGER_INVITED_REGISTRATION,
 )
@@ -54,6 +58,14 @@ from .reward_queue import build_referral_reward_queue
 
 _INVITE_CODE_ALPHABET = string.ascii_uppercase + string.digits
 _INVITE_CODE_LENGTH = 8
+_DEFAULT_CAMPAIGN_CODE = "domestic_creator_invite_202606"
+_DEFAULT_CAMPAIGN_NAME = "Domestic creator invite"
+_DEFAULT_RULE_CODE = "inviter_monthly_pro_first_12"
+_DEFAULT_REWARD_PRODUCT_CODE = "creator-plan-monthly-pro"
+_DEFAULT_REWARD_CREDIT_AMOUNT = Decimal("1000.0000000000")
+_DEFAULT_REWARD_VALIDITY_DAYS = 30
+_DEFAULT_REWARD_CAP_COUNT = 12
+_DEFAULT_RULES_COPY_I18N_KEY = "module.referral.rules.domesticCreatorInvite"
 
 
 @dataclass(slots=True, frozen=True)
@@ -175,6 +187,62 @@ def load_active_campaign(*, now: datetime | None = None) -> ReferralCampaign | N
         if _feature_flag_enabled(str(campaign.feature_flag_key or "")):
             return campaign
     return None
+
+
+def _bootstrap_default_campaign_if_empty(app: Flask) -> ReferralCampaign | None:
+    existing = (
+        ReferralCampaign.query.filter(ReferralCampaign.deleted == 0)
+        .order_by(ReferralCampaign.id.asc())
+        .first()
+    )
+    if existing is not None:
+        return None
+
+    campaign = ReferralCampaign(
+        campaign_bid=generate_id(app),
+        campaign_code=_DEFAULT_CAMPAIGN_CODE,
+        campaign_name=_DEFAULT_CAMPAIGN_NAME,
+        campaign_status=REFERRAL_CAMPAIGN_STATUS_ACTIVE,
+        feature_flag_key="",
+        starts_at=None,
+        ends_at=None,
+        invite_route_template="/invite/{invite_code}",
+        inviter_eligibility={"registered_phone_user": True},
+        invitee_eligibility={"created_new_phone_user": True},
+        invitee_benefit_policy=REFERRAL_INVITEE_BENEFIT_EXISTING_TRIAL_ONLY,
+        rules_copy_i18n_key=_DEFAULT_RULES_COPY_I18N_KEY,
+        metadata_json={"source": "runtime_default"},
+    )
+    rule = ReferralCampaignRewardRule(
+        reward_rule_bid=generate_id(app),
+        campaign_bid=campaign.campaign_bid,
+        rule_code=_DEFAULT_RULE_CODE,
+        rule_status=REFERRAL_RULE_STATUS_ACTIVE,
+        trigger_event=REFERRAL_TRIGGER_INVITED_REGISTRATION,
+        reward_target=REFERRAL_REWARD_TARGET_INVITER,
+        reward_type=REFERRAL_REWARD_TYPE_BILLING_PLAN_CYCLE,
+        reward_product_code=_DEFAULT_REWARD_PRODUCT_CODE,
+        reward_cycle_count=1,
+        reward_credit_amount=_DEFAULT_REWARD_CREDIT_AMOUNT,
+        reward_credit_validity_days=_DEFAULT_REWARD_VALIDITY_DAYS,
+        reward_cap_scope=REFERRAL_REWARD_CAP_SCOPE_PER_INVITER,
+        reward_cap_count=_DEFAULT_REWARD_CAP_COUNT,
+        reward_timing_policy=REFERRAL_REWARD_TIMING_IMMEDIATE_EXTEND_OR_DEFER,
+        priority=10,
+        starts_at=None,
+        ends_at=None,
+        metadata_json={"source": "runtime_default"},
+    )
+    db.session.add_all([campaign, rule])
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+    else:
+        app.logger.warning(
+            "Bootstrapped default referral campaign because no campaign existed"
+        )
+    return load_active_campaign()
 
 
 def load_campaign_by_bid(
@@ -351,6 +419,8 @@ def build_invite_profile(app: Flask, *, inviter_user_bid: str) -> InviteProfileD
         if not normalized_inviter:
             raise ValueError("inviter_user_bid is required")
         campaign = load_active_campaign()
+        if campaign is None:
+            campaign = _bootstrap_default_campaign_if_empty(app)
         if campaign is None:
             raise ValueError("no active referral campaign")
         rule = select_reward_rule(campaign)

--- a/src/api/tests/service/referral/test_referral_service.py
+++ b/src/api/tests/service/referral/test_referral_service.py
@@ -147,6 +147,38 @@ def test_invite_profile_lazily_creates_stable_campaign_scoped_code(
         assert first.reward_remaining_count == 12
 
 
+def test_invite_profile_bootstraps_default_campaign_when_empty(
+    referral_app,
+    monkeypatch,
+) -> None:
+    with referral_app.app_context():
+        monkeypatch.setattr(
+            "flaskr.service.referral.service._resolve_public_origin",
+            lambda: "https://frontend.example",
+        )
+
+        profile = build_invite_profile(
+            referral_app,
+            inviter_user_bid="inviter-profile-default",
+        )
+
+        campaign = ReferralCampaign.query.one()
+        rule = ReferralCampaignRewardRule.query.one()
+        assert campaign.campaign_code == "domestic_creator_invite_202606"
+        assert campaign.campaign_status == REFERRAL_CAMPAIGN_STATUS_ACTIVE
+        assert rule.campaign_bid == campaign.campaign_bid
+        assert rule.rule_code == "inviter_monthly_pro_first_12"
+        assert rule.reward_product_code == "creator-plan-monthly-pro"
+        assert rule.reward_credit_amount == Decimal("1000.0000000000")
+        assert rule.reward_credit_validity_days == 30
+        assert rule.reward_cap_count == 12
+        assert profile.campaign_bid == campaign.campaign_bid
+        assert profile.reward_remaining_count == 12
+        assert profile.invite_url == (
+            f"https://frontend.example/invite/{profile.invite_code}"
+        )
+
+
 def test_invite_profile_includes_creator_reward_queue(
     referral_app,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Fix `/api/referral/invite-profile` returning 500 when `referral_campaigns` has no active or existing campaign rows.
- Add runtime bootstrap for the default referral campaign/rule only when the campaign table is empty.
- Preserve operator control: if any non-deleted campaign already exists but is paused, expired, or disabled, the runtime does not override it.
- No new database tables, no Alembic migration, no K8S changes.

## Root Cause

The referral campaign configuration was moved into `referral_campaigns` / `referral_campaign_reward_rules`, but `build_invite_profile()` assumed an active campaign already existed. A fresh or unconfigured environment therefore raised `ValueError("no active referral campaign")` and surfaced as a 500.

## Validation

- `cd src/api && pytest tests/service/referral/test_referral_service.py tests/service/referral/test_referral_admin.py tests/service/referral/test_referral_campaign_admin.py tests/service/referral/test_referral_campaign_admin_routes.py tests/service/billing/test_referral_plan_rewards.py -q` -> `28 passed`
- `cd src/api && ruff check flaskr/service/referral/service.py tests/service/referral/test_referral_service.py`
- `git diff --check`

## Rollout

- The same fix has been cherry-picked to `upstream/dev02` as `afb6ea444` so the existing dev02 auto-deploy flow can pick it up.

