### PR TITLE
fix: skip listen TTS for non-speakable blocks

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1233,10 +1233,17 @@ def stream_generated_block_audio(
                 str(element.content_text or "") for element in speakable_elements
             ]
             if not speakable_segments:
-                raise_error_with_args(
-                    "server.common.paramsError",
-                    param_message="No speakable text elements available for TTS synthesis",
+                app.logger.info(
+                    "skip listen-mode TTS for non-speakable generated block | shifu_bid=%s | generated_block_bid=%s | user_bid=%s",
+                    shifu_bid,
+                    generated_block_bid,
+                    user_bid,
                 )
+                yield _build_tts_done_message(
+                    outline_bid=generated_block.outline_item_bid or "",
+                    generated_block_bid=generated_block_bid,
+                )
+                return
 
             expected_segment_count = len(speakable_segments)
             existing_by_position: dict[int, LearnGeneratedAudio] = {}

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -503,6 +503,85 @@ class TestGeneratedBlockListenTtsElementFirst:
             assert records[0].subtitle_cues[0]["text"] == "First."
             assert records[1].subtitle_cues[0]["text"] == "Second."
 
+    def test_stream_generated_block_audio_listen_finishes_non_speakable_block(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "user-non-speakable-1"
+        shifu_bid = "shifu-non-speakable-1"
+        generated_block_bid = "gen-non-speakable-1"
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-non-speakable-1",
+                    user_bid=user_bid,
+                    block_bid="block-non-speakable-1",
+                    outline_item_bid="outline-non-speakable-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content="<svg><text>visual only</text></svg>",
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.add(
+                self.LearnGeneratedElement(
+                    element_bid="el-non-speakable-1",
+                    progress_record_bid="progress-non-speakable-1",
+                    user_bid=user_bid,
+                    generated_block_bid=generated_block_bid,
+                    outline_item_bid="outline-non-speakable-1",
+                    shifu_bid=shifu_bid,
+                    run_session_bid="run-non-speakable-1",
+                    run_event_seq=1,
+                    event_type="element",
+                    role="teacher",
+                    element_index=0,
+                    element_type="svg",
+                    change_type="render",
+                    is_renderable=1,
+                    is_new=1,
+                    is_marker=0,
+                    sequence_number=1,
+                    is_speakable=0,
+                    is_navigable=1,
+                    is_final=1,
+                    content_text="",
+                    payload="",
+                    status=1,
+                    deleted=0,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=False,
+                listen=True,
+            )
+        )
+
+        assert synthesized_texts == []
+        assert [event.type for event in events] == [GeneratedType.DONE]
+
     def test_stream_generated_block_audio_listen_preserves_position_after_short_text(
         self, monkeypatch
     ):


### PR DESCRIPTION
## 来源

运维保障群 2026-06-12 15:23-15:31 多条生产告警：

- `GET /api/learn/shifu/742058fcf44f4a0b975538073811150c/generated-blocks/*/tts`
- `AppException: 参数错误 No speakable text elements available for TTS synthesis`
- 同一用户/课程多个 generated block 重复触发，均为 listen-mode TTS 请求。

## 修复

listen-mode TTS 基于已持久化的最终元素逐段合成音频。对只有 SVG/图片/交互等非可朗读元素的 generated block，之前会把“没有可朗读文本”当作参数错误抛出，导致 SSE error 被生产告警捕获。

本 PR 将该场景改为：

- 记录 info 日志说明跳过非可朗读 generated block；
- 返回 `DONE` SSE 事件并正常结束；
- 不调用 TTS 合成、不写入音频记录。

这样非文本块点击/触发 TTS 不再制造错误告警，同时保留真正的 TTS 配置、合成、上传异常为错误。

## 验证

- `python3 -m py_compile src/api/flaskr/service/learn/learn_funcs.py src/api/tests/service/learn/test_generated_block_tts_av_mode.py` ✅
- `git diff --check` ✅
- 尝试运行：`cd src/api && python3 -m pytest tests/service/learn/test_generated_block_tts_av_mode.py -q`，当前机器系统 Python 未安装 `pytest`，未能执行完整 pytest。

## 其他巡检发现但未在本 PR 处理

- `/api/referral/invite-profile`：`ValueError: no active referral campaign` 3 条，需确认当前生产是否应配置有效 referral campaign，暂不改代码。
- `/api/shifu/shifus/*/outlines/reorder`：`TypeError: 'NoneType' object is not iterable` 1 条，样本少，需继续结合请求体/复现定位。
- preview `BlockIndexError` 2 条，疑似前端/上下文请求的 block index 已越界，需单独评估交互语义。
- run_script 阿里云内容安全拦截 3 条，外部模型返回内容合规拦截，不适合直接代码修复。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in listen mode: Blocks containing exclusively non-speakable content no longer raise errors. The system now processes these gracefully, signaling completion without unnecessary audio synthesis operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->