### PR TITLE
fix: validate shifu outline payloads

### DIFF
--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1267,7 +1267,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                     $ref: "#/components/schemas/SimpleOutlineDto"
         """
         user_id = request.user.user_id
-        json_data = request.get_json() or {}
+        json_data = request.get_json(silent=True) or {}
         if not isinstance(json_data, dict):
             raise_param_error("json body")
         parent_bid = json_data.get("parent_bid")
@@ -1591,7 +1591,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                             description: latest outline content draft revision
         """
         user_id = request.user.user_id
-        json_data = request.get_json() or {}
+        json_data = request.get_json(silent=True) or {}
         if not isinstance(json_data, dict):
             raise_param_error("json body")
         content = json_data.get("data") or ""

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1267,15 +1267,18 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                     $ref: "#/components/schemas/SimpleOutlineDto"
         """
         user_id = request.user.user_id
-        parent_bid = request.get_json().get("parent_bid")
-        name = request.get_json().get("name")
-        description = request.get_json().get("description", "")
+        json_data = request.get_json() or {}
+        if not isinstance(json_data, dict):
+            raise_param_error("json body")
+        parent_bid = json_data.get("parent_bid")
+        name = json_data.get("name")
+        description = json_data.get("description", "")
         # No defaults: None is passed through to create_outline, which applies its
         # own fallback (a new outline still needs a concrete type/visibility).
-        type = request.get_json().get("type")
-        index = request.get_json().get("index", None)
-        system_prompt = request.get_json().get("system_prompt", None)
-        is_hidden = request.get_json().get("is_hidden")
+        type = json_data.get("type")
+        index = json_data.get("index", None)
+        system_prompt = json_data.get("system_prompt", None)
+        is_hidden = json_data.get("is_hidden")
         if isinstance(is_hidden, str):
             is_hidden = is_hidden.lower() == "true"
         return make_common_response(
@@ -1589,6 +1592,8 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         """
         user_id = request.user.user_id
         json_data = request.get_json() or {}
+        if not isinstance(json_data, dict):
+            raise_param_error("json body")
         content = json_data.get("data") or ""
         base_revision = json_data.get("base_revision")
         if base_revision is not None:

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -275,7 +275,9 @@ def create_outline(
         if is_hidden is None:
             is_hidden = False
 
-        # validate name length
+        # validate name
+        if not isinstance(outline_name, str) or not outline_name.strip():
+            raise_param_error("name")
         if len(outline_name) > 100:
             raise_error("server.shifu.outlineNameTooLong")
 

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -278,6 +278,7 @@ def create_outline(
         # validate name
         if not isinstance(outline_name, str) or not outline_name.strip():
             raise_param_error("name")
+        outline_name = outline_name.strip()
         if len(outline_name) > 100:
             raise_error("server.shifu.outlineNameTooLong")
 

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -77,7 +77,7 @@ def test_create_outline_route_rejects_missing_name_without_500(
     _seed_shifu_with_outline(app, shifu_bid, outline_bid, owner_bid, "seed")
     _mock_user(monkeypatch, owner_bid)
 
-    resp = test_client.post(
+    resp = test_client.put(
         f"/api/shifu/shifus/{shifu_bid}/outlines",
         headers={"Token": "test-token"},
         json={"name": None},

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -68,6 +68,46 @@ def _seed_shifu_with_outline(
         return int(outline.id)
 
 
+def test_create_outline_route_rejects_missing_name_without_500(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "test-route-create-outline-invalid-name"
+    outline_bid = "test-route-create-outline-seed"
+    owner_bid = "test-route-create-outline-owner"
+    _seed_shifu_with_outline(app, shifu_bid, outline_bid, owner_bid, "seed")
+    _mock_user(monkeypatch, owner_bid)
+
+    resp = test_client.post(
+        f"/api/shifu/shifus/{shifu_bid}/outlines",
+        headers={"Token": "test-token"},
+        json={"name": None},
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+
+
+def test_save_mdflow_route_rejects_non_object_json_without_500(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "test-route-save-mdflow-invalid-body"
+    outline_bid = "test-route-save-mdflow-invalid-outline"
+    owner_bid = "test-route-save-mdflow-invalid-owner"
+    _seed_shifu_with_outline(app, shifu_bid, outline_bid, owner_bid, "seed")
+    _mock_user(monkeypatch, owner_bid)
+
+    resp = test_client.post(
+        f"/api/shifu/shifus/{shifu_bid}/outlines/{outline_bid}/mdflow",
+        headers={"Token": "test-token"},
+        json="not-an-object",
+    )
+    payload = resp.get_json(force=True)
+
+    assert resp.status_code == 200
+    assert payload["code"] == ERROR_CODE["server.common.paramsError"]
+
+
 def test_get_mdflow_history_version_detail_route_success(monkeypatch, test_client, app):
     shifu_bid = "test-route-history-detail-1"
     outline_bid = "test-route-outline-1"


### PR DESCRIPTION
## 来源

运维保障群近 24 小时报错巡检发现 AI-Shifu 生产环境出现课程大纲相关 payload 异常：

- `2026-06-13 16:56/16:57` `/api/shifu/shifus/{shifu_bid}/outlines`：`TypeError: object of type 'NoneType' has no len()`，由 `name=null` 进入 `create_outline()` 后直接 `len(outline_name)` 触发。
- `2026-06-13 17:10` `/api/shifu/shifus/{shifu_bid}/outlines/{outline_bid}/mdflow`：`AttributeError: 'str' object has no attribute 'get'`，由 JSON body 为字符串而非对象时直接调用 `.get()` 触发。

## 修复

- `create_outline_api`：复用一次 `request.get_json()`，并校验 JSON body 必须是对象。
- `save_mdflow_api`：校验 JSON body 必须是对象，非法 payload 返回参数错误，不再进入 500。
- `create_outline()`：补充 `outline_name` 类型/非空校验，`None` 或空白名称返回参数错误，不再触发 `len(None)`。
- 新增回归测试覆盖：
  - 创建大纲 `name=null` 不再 500。
  - 保存 mdflow 时 JSON body 为字符串不再 500。

## 验证

- ✅ `python3 -m py_compile src/api/flaskr/service/shifu/route.py src/api/flaskr/service/shifu/shifu_outline_funcs.py src/api/tests/service/shifu/test_mdflow_history_routes.py`
- ✅ `git diff --check`
- ⚠️ `cd src/api && python3 -m pytest tests/service/shifu/test_mdflow_history_routes.py -q` 未执行成功：当前机器系统 Python 未安装 `pytest`（`No module named pytest`）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint request handling by validating that JSON bodies are objects before processing.
  * Added stricter validation for outline names, including clearer handling of missing/empty values.
* **Tests**
  * Added new route-focused tests to confirm invalid JSON and missing required fields return the expected parameter error behavior (without server errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->