### PR TITLE
fix: stabilize lesson preview list keys

### DIFF
--- a/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import LessonPreview from './LessonPreview';
+import { resolveLessonPreviewItemKey } from './LessonPreview';
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
 
 const mockPush = jest.fn();
@@ -195,6 +196,35 @@ describe('LessonPreview billing action', () => {
     expect(
       screen.queryByRole('button', { name: 'finish-text-1' }),
     ).not.toBeInTheDocument();
+  });
+
+  test('builds stable preview item keys from business ids instead of list indexes', () => {
+    expect(
+      resolveLessonPreviewItemKey({
+        element_bid: 'text-1',
+        generated_block_bid: 'block-1',
+        content: '第一段内容',
+        type: ChatContentItemType.CONTENT,
+      } as ChatContentItem),
+    ).toBe('content:text-1');
+
+    expect(
+      resolveLessonPreviewItemKey({
+        element_bid: 'feedback-1',
+        generated_block_bid: 'feedback-block-1',
+        parent_element_bid: 'text-1',
+        parent_block_bid: 'block-1',
+        type: ChatContentItemType.LIKE_STATUS,
+      } as ChatContentItem),
+    ).toBe('like:feedback-1');
+
+    expect(
+      resolveLessonPreviewItemKey({
+        generated_block_bid: 'preview-business-error',
+        content: 'error',
+        type: ChatContentItemType.ERROR,
+      } as ChatContentItem),
+    ).toBe('error:preview-business-error');
   });
 
   test('routes preview regenerate from helper row to the parent content item', () => {

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
@@ -198,7 +198,7 @@ describe('LessonPreview billing action', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('builds stable preview item keys from business ids instead of list indexes', () => {
+  test('builds stable preview item keys from business ids and falls back to idx only when needed', () => {
     expect(
       resolveLessonPreviewItemKey({
         element_bid: 'text-1',
@@ -225,6 +225,26 @@ describe('LessonPreview billing action', () => {
         type: ChatContentItemType.ERROR,
       } as ChatContentItem),
     ).toBe('error:preview-business-error');
+
+    expect(
+      resolveLessonPreviewItemKey(
+        {
+          content: 'streaming text that should not become the key',
+          type: ChatContentItemType.CONTENT,
+        } as ChatContentItem,
+        7,
+      ),
+    ).toBe('content:idx-7');
+
+    expect(
+      resolveLessonPreviewItemKey(
+        {
+          content: '',
+          type: ChatContentItemType.ERROR,
+        } as ChatContentItem,
+        3,
+      ),
+    ).toBe('error:idx-3');
   });
 
   test('routes preview regenerate from helper row to the parent content item', () => {

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -107,6 +107,26 @@ const shouldPreferGeneratedBlockItem = (
   return false;
 };
 
+const resolveLessonPreviewItemIdentity = (item: ChatContentItem) =>
+  item.element_bid ||
+  item.generated_block_bid ||
+  item.parent_element_bid ||
+  item.parent_block_bid ||
+  item.content ||
+  'unknown';
+
+export const resolveLessonPreviewItemKey = (item: ChatContentItem) => {
+  if (item.type === ChatContentItemType.LIKE_STATUS) {
+    return `like:${resolveLessonPreviewItemIdentity(item)}`;
+  }
+
+  if (item.type === ChatContentItemType.ERROR) {
+    return `error:${resolveLessonPreviewItemIdentity(item)}`;
+  }
+
+  return `content:${resolveLessonPreviewItemIdentity(item)}`;
+};
+
 const LessonPreview: React.FC<LessonPreviewProps> = ({
   loading,
   items = [],
@@ -373,7 +393,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                 }
                 return (
                   <div
-                    key={`${idx}-like`}
+                    key={resolveLessonPreviewItemKey(item)}
                     className='p-0'
                     style={{ maxWidth: '100%' }}
                   >
@@ -418,7 +438,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                   item.business_code === CREDIT_INSUFFICIENT_BUSINESS_CODE;
                 return (
                   <div
-                    key={`${idx}-error`}
+                    key={resolveLessonPreviewItemKey(item)}
                     className='p-0 relative'
                     style={{ maxWidth: '100%' }}
                   >
@@ -453,7 +473,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
 
               return (
                 <div
-                  key={`${idx}-content`}
+                  key={resolveLessonPreviewItemKey(item)}
                   className='p-0 relative'
                   style={{
                     maxWidth: '100%',

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -107,24 +107,29 @@ const shouldPreferGeneratedBlockItem = (
   return false;
 };
 
-const resolveLessonPreviewItemIdentity = (item: ChatContentItem) =>
+const resolveLessonPreviewItemIdentity = (
+  item: ChatContentItem,
+  index?: number,
+) =>
   item.element_bid ||
   item.generated_block_bid ||
   item.parent_element_bid ||
   item.parent_block_bid ||
-  item.content ||
-  'unknown';
+  (index !== undefined ? `idx-${index}` : '');
 
-export const resolveLessonPreviewItemKey = (item: ChatContentItem) => {
+export const resolveLessonPreviewItemKey = (
+  item: ChatContentItem,
+  index?: number,
+) => {
   if (item.type === ChatContentItemType.LIKE_STATUS) {
-    return `like:${resolveLessonPreviewItemIdentity(item)}`;
+    return `like:${resolveLessonPreviewItemIdentity(item, index)}`;
   }
 
   if (item.type === ChatContentItemType.ERROR) {
-    return `error:${resolveLessonPreviewItemIdentity(item)}`;
+    return `error:${resolveLessonPreviewItemIdentity(item, index)}`;
   }
 
-  return `content:${resolveLessonPreviewItemIdentity(item)}`;
+  return `content:${resolveLessonPreviewItemIdentity(item, index)}`;
 };
 
 const LessonPreview: React.FC<LessonPreviewProps> = ({
@@ -393,7 +398,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                 }
                 return (
                   <div
-                    key={resolveLessonPreviewItemKey(item)}
+                    key={resolveLessonPreviewItemKey(item, idx)}
                     className='p-0'
                     style={{ maxWidth: '100%' }}
                   >
@@ -438,7 +443,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                   item.business_code === CREDIT_INSUFFICIENT_BUSINESS_CODE;
                 return (
                   <div
-                    key={resolveLessonPreviewItemKey(item)}
+                    key={resolveLessonPreviewItemKey(item, idx)}
                     className='p-0 relative'
                     style={{ maxWidth: '100%' }}
                   >
@@ -473,7 +478,7 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
 
               return (
                 <div
-                  key={resolveLessonPreviewItemKey(item)}
+                  key={resolveLessonPreviewItemKey(item, idx)}
                   className='p-0 relative'
                   style={{
                     maxWidth: '100%',


### PR DESCRIPTION
## Summary
- replace index-based keys in  with stable business keys
- keep preview helper rows ( / ) on distinct key namespaces to avoid DOM reuse collisions
- add regression coverage for preview item key generation

## Context
This targets the learner preview crash reported as  on . The preview list is updated incrementally by SSE and was previously rendered with index keys, which is unsafe when loading, content, interaction, and helper rows are inserted or replaced in the middle of the list.

## Verification
- 
- 
> cook-web@2.2.2 type-check
> tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added coverage to ensure lesson preview item `key` values are generated deterministically from business identifiers, with correct handling for like-status and error items.
  * Verified fallback behavior when required identifiers are missing, using index-based keys.

* **Improvements**
  * Updated lesson preview rendering to use stable, content-based `key` values (with safe fallbacks) to improve UI consistency during reordering or content updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->