### PR TITLE
fix: harden lesson preview remount boundaries

### DIFF
--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -190,6 +190,7 @@ const ContentBlock = memo(
       prevProps.item.content === nextProps.item.content &&
       prevProps.mobileStyle === nextProps.mobileStyle &&
       prevProps.blockBid === nextProps.blockBid &&
+      prevProps.contentRenderKey === nextProps.contentRenderKey &&
       prevProps.item.isHistory === nextProps.item.isHistory &&
       prevProps.item.element_type === nextProps.item.element_type &&
       prevProps.confirmButtonText === nextProps.confirmButtonText &&

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -23,6 +23,7 @@ interface ContentBlockProps {
   item: ChatContentItem;
   mobileStyle: boolean;
   blockBid: string;
+  contentRenderKey?: string;
   confirmButtonText?: string;
   copyButtonText?: string;
   copiedButtonText?: string;
@@ -42,6 +43,7 @@ const ContentBlock = memo(
     item,
     mobileStyle,
     blockBid,
+    contentRenderKey,
     confirmButtonText,
     copyButtonText,
     copiedButtonText,
@@ -124,6 +126,7 @@ const ContentBlock = memo(
         {...(mobileStyle ? longPressEvent : {})}
       >
         <ContentRender
+          key={contentRenderKey}
           enableTypewriter={shouldEnableTypewriter}
           typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
           content={renderedContent}

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.test.tsx
@@ -56,15 +56,20 @@ jest.mock('@/c-components/ChatUi/ContentBlock', () => ({
   default: ({
     item,
     blockBid,
+    contentRenderKey,
     enableStreamingTypewriter,
     onTypeFinished,
   }: {
     item: ChatContentItem;
     blockBid: string;
+    contentRenderKey?: string;
     enableStreamingTypewriter?: boolean;
     onTypeFinished?: (blockBid: string, content: string) => void;
   }) => (
-    <div data-testid={item.element_bid}>
+    <div
+      data-testid={item.element_bid}
+      data-content-render-key={contentRenderKey}
+    >
       <span>{item.content}</span>
       {enableStreamingTypewriter ? <span>typing</span> : null}
       {onTypeFinished ? (
@@ -227,6 +232,15 @@ describe('LessonPreview billing action', () => {
     ).toBe('error:preview-business-error');
 
     expect(
+      resolveLessonPreviewItemKey({
+        element_bid: 'interaction-1',
+        generated_block_bid: 'block-2',
+        content: '请选择',
+        type: ChatContentItemType.INTERACTION,
+      } as ChatContentItem),
+    ).toBe('interaction:interaction-1');
+
+    expect(
       resolveLessonPreviewItemKey(
         {
           content: 'streaming text that should not become the key',
@@ -245,6 +259,56 @@ describe('LessonPreview billing action', () => {
         3,
       ),
     ).toBe('error:idx-3');
+  });
+
+  test('uses a dedicated preview content render key when typewriter state changes', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'text-1',
+        generated_block_bid: 'block-1',
+        content: '第一段内容',
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        shouldUseTypewriter: true,
+        is_final: false,
+      },
+    ];
+
+    const { rerender } = render(
+      <LessonPreview
+        loading={false}
+        items={items}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('text-1')).toHaveAttribute(
+      'data-content-render-key',
+      'preview:content:text-1:text:typing',
+    );
+
+    rerender(
+      <LessonPreview
+        loading={false}
+        items={[
+          {
+            ...items[0],
+            is_final: true,
+            shouldUseTypewriter: false,
+          },
+        ]}
+        shifuBid='shifu-1'
+        onRefresh={jest.fn()}
+        onSend={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('text-1')).toHaveAttribute(
+      'data-content-render-key',
+      'preview:content:text-1:text:static',
+    );
   });
 
   test('routes preview regenerate from helper row to the parent content item', () => {

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -117,19 +117,54 @@ const resolveLessonPreviewItemIdentity = (
   item.parent_block_bid ||
   (index !== undefined ? `idx-${index}` : '');
 
-export const resolveLessonPreviewItemKey = (
-  item: ChatContentItem,
-  index?: number,
-) => {
+const resolveLessonPreviewItemTypeKey = (item: ChatContentItem) => {
   if (item.type === ChatContentItemType.LIKE_STATUS) {
-    return `like:${resolveLessonPreviewItemIdentity(item, index)}`;
+    return 'like';
   }
 
   if (item.type === ChatContentItemType.ERROR) {
-    return `error:${resolveLessonPreviewItemIdentity(item, index)}`;
+    return 'error';
   }
 
-  return `content:${resolveLessonPreviewItemIdentity(item, index)}`;
+  if (item.type === ChatContentItemType.INTERACTION) {
+    return 'interaction';
+  }
+
+  if (item.type === ChatContentItemType.ASK) {
+    return 'ask';
+  }
+
+  return 'content';
+};
+
+export const resolveLessonPreviewItemKey = (
+  item: ChatContentItem,
+  index?: number,
+) =>
+  `${resolveLessonPreviewItemTypeKey(item)}:${resolveLessonPreviewItemIdentity(
+    item,
+    index,
+  )}`;
+
+const resolveLessonPreviewContentRenderKey = (
+  item: ChatContentItem,
+  enableStreamingTypewriter: boolean,
+) => {
+  const hasStreamingTypewriterIntent =
+    item.type === ChatContentItemType.CONTENT &&
+    item.element_type === 'text' &&
+    item.shouldUseTypewriter === true &&
+    item.is_final !== true;
+
+  return [
+    'preview',
+    resolveLessonPreviewItemTypeKey(item),
+    item.element_bid || item.generated_block_bid || '',
+    item.element_type || '',
+    enableStreamingTypewriter || hasStreamingTypewriterIntent
+      ? 'typing'
+      : 'static',
+  ].join(':');
 };
 
 const LessonPreview: React.FC<LessonPreviewProps> = ({
@@ -453,6 +488,10 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                       blockBid={
                         item.element_bid || item.generated_block_bid || ''
                       }
+                      contentRenderKey={resolveLessonPreviewContentRenderKey(
+                        item,
+                        false,
+                      )}
                       confirmButtonText={confirmButtonText}
                       copyButtonText={copyButtonText}
                       copiedButtonText={copiedButtonText}
@@ -476,38 +515,47 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                 );
               }
 
-              return (
-                <div
-                  key={resolveLessonPreviewItemKey(item, idx)}
-                  className='p-0 relative'
-                  style={{
+                return (
+                  <div
+                    key={resolveLessonPreviewItemKey(item, idx)}
+                    className='p-0 relative'
+                    style={{
                     maxWidth: '100%',
                     margin: !idx ? '0' : '40px 0 0 0',
                   }}
                 >
-                  <ContentBlock
-                    item={item}
-                    mobileStyle={false}
-                    blockBid={
-                      item.element_bid || item.generated_block_bid || ''
-                    }
-                    enableStreamingTypewriter={
+                  {(() => {
+                    const enableStreamingTypewriter =
                       ENABLE_PREVIEW_TYPEWRITER &&
                       shouldEnablePreviewTypewriter(
                         item,
                         previewTypewriterCache[item.element_bid || ''],
-                      )
-                    }
-                    confirmButtonText={confirmButtonText}
-                    copyButtonText={copyButtonText}
-                    copiedButtonText={copiedButtonText}
-                    onSend={onSend}
-                    onTypeFinished={
-                      ENABLE_PREVIEW_TYPEWRITER
-                        ? handlePreviewTypeFinished
-                        : undefined
-                    }
-                  />
+                      );
+
+                    return (
+                      <ContentBlock
+                        item={item}
+                        mobileStyle={false}
+                        blockBid={
+                          item.element_bid || item.generated_block_bid || ''
+                        }
+                        contentRenderKey={resolveLessonPreviewContentRenderKey(
+                          item,
+                          enableStreamingTypewriter,
+                        )}
+                        enableStreamingTypewriter={enableStreamingTypewriter}
+                        confirmButtonText={confirmButtonText}
+                        copyButtonText={copyButtonText}
+                        copiedButtonText={copiedButtonText}
+                        onSend={onSend}
+                        onTypeFinished={
+                          ENABLE_PREVIEW_TYPEWRITER
+                            ? handlePreviewTypeFinished
+                            : undefined
+                        }
+                      />
+                    );
+                  })()}
                 </div>
               );
             })}

--- a/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
+++ b/src/cook-web/src/components/lesson-preview/LessonPreview.tsx
@@ -515,11 +515,11 @@ const LessonPreview: React.FC<LessonPreviewProps> = ({
                 );
               }
 
-                return (
-                  <div
-                    key={resolveLessonPreviewItemKey(item, idx)}
-                    className='p-0 relative'
-                    style={{
+              return (
+                <div
+                  key={resolveLessonPreviewItemKey(item, idx)}
+                  className='p-0 relative'
+                  style={{
                     maxWidth: '100%',
                     margin: !idx ? '0' : '40px 0 0 0',
                   }}


### PR DESCRIPTION
 ## Summary
  - stabilize lesson preview item keys so interaction rows no longer share the same key namespace as content rows
  - add a dedicated preview content remount key so ContentRender remounts cleanly across typing/static state changes
  - cover the preview key and remount behavior with focused LessonPreview tests

  ## Testing
  - cd src/cook-web && npm test -- --runInBand src/components/lesson-preview/LessonPreview.test.tsx
  - cd src/cook-web && npm run type-check
  - cd src/cook-web && npm run lint
  - pre-commit run -a