### PR TITLE
chore: sync PR metadata guidance

### DIFF
--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -27,6 +27,10 @@ alwaysApply: true
 - For complex design work, create an ExecPlan under `docs/exec-plans/active/`
   and maintain it according to `PLANS.md`.
 
+- When a branch already has an open PR, keep the PR title and description in
+  sync with the latest code changes so they accurately describe the current
+  implementation and verification state.
+
 - Keep generated knowledge artifacts in sync by running
   `python scripts/build_repo_knowledge_index.py` after docs structure or
   metadata changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,10 @@
 - For complex design work, create an ExecPlan in `docs/exec-plans/active/` and
   maintain it according to `PLANS.md`.
 
+- When a branch already has an open PR, keep the PR title and description in
+  sync with the latest code changes so they accurately describe the current
+  implementation and verification state.
+
 - Regenerate repository knowledge indexes with
   `python scripts/build_repo_knowledge_index.py` after moving docs or changing
   required metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ to.
   before creating new abstractions.
 - Use ExecPlans for complex work. `PLANS.md` defines the format, and active
   plans live under `docs/exec-plans/active/`.
+- When a branch already has an open PR, keep the PR title and description in
+  sync with the latest code changes so they accurately describe the current
+  implementation and verification state.
 - Keep shared instruction surfaces aligned. When shared rules move, update the
   touched `AGENTS.md`, `CLAUDE.md`, generated `.cursor` rules, and generated
   `.github` instructions in the same change.

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1653,6 +1653,10 @@ def build_documents() -> dict[Path, str]:
                 "For complex design work, create an ExecPlan under "
                 "`docs/exec-plans/active/` and maintain it according to "
                 "`PLANS.md`.",
+                "When a branch already has an open PR, keep the PR title and "
+                "description in sync with the latest code changes so they "
+                "accurately describe the current implementation and "
+                "verification state.",
                 "Keep generated knowledge artifacts in sync by running "
                 "`python scripts/build_repo_knowledge_index.py` after docs "
                 "structure or metadata changes.",
@@ -1805,6 +1809,10 @@ def build_documents() -> dict[Path, str]:
                 "For complex design work, create an ExecPlan in "
                 "`docs/exec-plans/active/` and maintain it according to "
                 "`PLANS.md`.",
+                "When a branch already has an open PR, keep the PR title and "
+                "description in sync with the latest code changes so they "
+                "accurately describe the current implementation and "
+                "verification state.",
                 "Regenerate repository knowledge indexes with "
                 "`python scripts/build_repo_knowledge_index.py` after moving docs "
                 "or changing required metadata.",


### PR DESCRIPTION
## Summary

- Add repository guidance requiring existing PR titles and descriptions to stay synchronized with latest code changes.
- Update the AI collaboration docs generator so Cursor and Copilot mirrors retain the same rule.
- Regenerate the affected Cursor and Copilot instruction mirrors.

## Validation

- `python3 scripts/check_repo_harness.py`
- pre-commit hooks during `git commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI collaboration guidelines to require PR titles and descriptions remain synchronized with the latest code changes and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->