### PR TITLE
feat: clarify draft preview button guidance

### DIFF
--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -60,7 +60,7 @@ const PreviewSettingsModal = () => {
             : t('module.preview.debugDisabledBySoftLimit')
         }
       >
-        {loading ? null : <Eye className='h-4 w-4 mr-[5px]' />}
+        {loading ? null : <Eye className='h-4 w-4 mr-[9px]' />}
         <span className='title'>{t('module.preview.previewAll')}</span>
       </Button>
     </div>

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -54,13 +54,14 @@ const PreviewSettingsModal = () => {
         onClick={handleStartPreview}
         disabled={loading || !debugAllowed}
         loading={loading}
+        icon={Eye}
+        iconClassName='h-4 w-4 mr-[5px]'
         title={
           debugAllowed
             ? undefined
             : t('module.preview.debugDisabledBySoftLimit')
         }
       >
-        {loading ? null : <Eye className='h-4 w-4 mr-[9px]' />}
         <span className='title'>{t('module.preview.previewAll')}</span>
       </Button>
     </div>

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -60,7 +60,7 @@ const PreviewSettingsModal = () => {
             : t('module.preview.debugDisabledBySoftLimit')
         }
       >
-        {loading ? null : <Eye className='h-4 w-4 mr-[5px]' />}{' '}
+        {loading ? null : <Eye className='h-4 w-4 mr-[5px]' />}
         <span className='title'>{t('module.preview.previewAll')}</span>
       </Button>
     </div>

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -55,7 +55,7 @@ const PreviewSettingsModal = () => {
         disabled={loading || !debugAllowed}
         loading={loading}
         icon={Eye}
-        iconClassName='h-4 w-4 mr-[5px]'
+        iconClassName='h-4 w-4'
         title={
           debugAllowed
             ? undefined

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/button';
-import { Loader2, MonitorPlay, PlayIcon } from 'lucide-react';
+import { Eye } from 'lucide-react';
 import { useEnvStore } from '@/c-store';
 import { useShifu } from '@/store';
 import api from '@/api';
@@ -60,7 +60,7 @@ const PreviewSettingsModal = () => {
             : t('module.preview.debugDisabledBySoftLimit')
         }
       >
-        {loading ? null : <MonitorPlay className='h-4 w-4 mr-[5px]' />}{' '}
+        {loading ? null : <Eye className='h-4 w-4 mr-[5px]' />}{' '}
         <span className='title'>{t('module.preview.previewAll')}</span>
       </Button>
     </div>

--- a/src/i18n/en-US/modules/preview.json
+++ b/src/i18n/en-US/modules/preview.json
@@ -2,6 +2,6 @@
   "__namespace__": "module.preview",
   "debugDisabledBySoftLimit": "Credit balance is below the reminder threshold. Preview debugging is disabled.",
   "llmError": "LLM Invocation Error",
-  "previewAll": "Preview Course",
+  "previewAll": "Preview Draft",
   "previewModeBanner": "This link is a preview link and is only visible to the course publisher"
 }

--- a/src/i18n/fr-FR/modules/preview.json
+++ b/src/i18n/fr-FR/modules/preview.json
@@ -2,6 +2,6 @@
   "__namespace__": "module.preview",
   "debugDisabledBySoftLimit": "Le solde de crédits est sous le seuil d’alerte. La prévisualisation de débogage est désactivée.",
   "llmError": "Erreur d’appel LLM",
-  "previewAll": "Prévisualiser le cours",
+  "previewAll": "Prévisualiser le brouillon",
   "previewModeBanner": "Ce lien est un lien de prévisualisation visible uniquement par l’éditeur du cours"
 }

--- a/src/i18n/zh-CN/modules/preview.json
+++ b/src/i18n/zh-CN/modules/preview.json
@@ -2,6 +2,6 @@
   "__namespace__": "module.preview",
   "debugDisabledBySoftLimit": "积分余额已低于提醒阈值，暂不能预览调试。",
   "llmError": "LLM 调用错误",
-  "previewAll": "预览",
+  "previewAll": "预览草稿",
   "previewModeBanner": "当前链接为预览链接，仅课程发布者可查看"
 }


### PR DESCRIPTION
## Summary
- Change the course editing preview button icon to the lucide eye icon.
- Rename the shared preview action label to draft-preview wording across zh-CN, en-US, and fr-FR.

## Validation
- `npm run test -- src/components/preview/Preview.test.tsx`
- `npm run type-check`
- pre-commit hooks during commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the preview settings button icon for improved visual consistency.

* **Localization**
  * Updated the “preview” label across English, French, and Chinese from “Preview Course” to “Preview Draft” (including the equivalent translated text).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->