### PR TITLE
fix: validate outline reorder payload

### DIFF
--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1170,7 +1170,12 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                         $ref: "#/components/schemas/OutlineDto"
         """
         user_id = request.user.user_id
-        outlines = request.get_json().get("outlines")
+        json_data = request.get_json(silent=True) or {}
+        if not isinstance(json_data, dict):
+            raise_param_error("body")
+        outlines = json_data.get("outlines")
+        if not isinstance(outlines, list):
+            raise_param_error("outlines")
         app.logger.info(type(outlines))
         app.logger.info(
             f"reorder outline tree, user_id: {user_id}, shifu_bid: {shifu_bid}, outlines: {outlines}"

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -23,7 +23,7 @@ from .consts import (
 from .models import DraftOutlineItem
 from ...dao import db
 from ...util import generate_id
-from ..common.models import raise_error
+from ..common.models import raise_error, raise_param_error
 from flaskr.service.check_risk.funcs import check_text_with_risk_control
 from decimal import Decimal
 from .shifu_history_manager import (
@@ -42,7 +42,7 @@ from flaskr.common.i18n_utils import get_markdownflow_output_language
 
 def convert_outline_to_reorder_outline_item_dto(
     json_array: list[dict],
-) -> ReorderOutlineItemDto:
+) -> list[ReorderOutlineItemDto]:
     """
     convert outline to reorder outline item dto
     Args:
@@ -50,15 +50,25 @@ def convert_outline_to_reorder_outline_item_dto(
     Returns:
         The reorder outline item dto
     """
-    return [
-        ReorderOutlineItemDto(
-            bid=item.get("bid"),
-            children=convert_outline_to_reorder_outline_item_dto(
-                item.get("children", [])
-            ),
+    if not isinstance(json_array, list):
+        raise_param_error("outlines")
+
+    outline_items = []
+    for item in json_array:
+        if not isinstance(item, dict):
+            raise_param_error("outlines")
+        children = item.get("children", [])
+        if children is None:
+            children = []
+        if not isinstance(children, list):
+            raise_param_error("outlines.children")
+        outline_items.append(
+            ReorderOutlineItemDto(
+                bid=item.get("bid"),
+                children=convert_outline_to_reorder_outline_item_dto(children),
+            )
         )
-        for item in json_array
-    ]
+    return outline_items
 
 
 def __get_existing_outline_items(shifu_bid: str) -> list[DraftOutlineItem]:

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -1,8 +1,13 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
+import pytest
+
 import flaskr.dao as dao
-from flaskr.service.common.models import ERROR_CODE
+from flaskr.service.common.models import AppException, ERROR_CODE
+from flaskr.service.shifu.shifu_outline_funcs import (
+    convert_outline_to_reorder_outline_item_dto,
+)
 
 
 def _get_models():
@@ -173,3 +178,19 @@ def test_restore_mdflow_history_route_returns_deleted_flag(
     assert payload["code"] == 0
     assert payload["data"]["lesson_deleted"] is True
     assert payload["data"]["restored"] is False
+
+
+def test_convert_reorder_outline_rejects_none_payload():
+    with pytest.raises(AppException) as exc_info:
+        convert_outline_to_reorder_outline_item_dto(None)
+
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_convert_reorder_outline_rejects_non_list_children():
+    with pytest.raises(AppException) as exc_info:
+        convert_outline_to_reorder_outline_item_dto(
+            [{"bid": "outline-a", "children": {"bid": "outline-b"}}]
+        )
+
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]


### PR DESCRIPTION
## 群内报错来源\n\n运维保障群 2026-06-15 20:15 左右多次收到 AI-Shifu 生产报错：\n\n- 接口：`/api/shifu/shifus/844d7aa5ff2747869b39968f001e1775/outlines/reorder`\n- 异常：`TypeError: 'NoneType' object is not iterable`\n- 堆栈：`update_chapter_order_api -> reorder_outline_tree -> convert_outline_to_reorder_outline_item_dto`，当请求体缺少/传空 `outlines` 时直接迭代 `None`。\n\n## 修复内容\n\n- reorder 接口读取 JSON 时兼容空/非法 body。\n- 在路由层校验 `outlines` 必须为数组，非法输入返回参数错误。\n- 在 DTO 转换函数中校验根节点和 children 类型，`children: null` 归一为空数组，避免递归迭代 `None` 或非数组对象。\n- 增加回归测试覆盖 `None` payload 和非数组 children。\n\n## 验证\n\n- ✅ `python3 -m py_compile src/api/flaskr/service/shifu/route.py src/api/flaskr/service/shifu/shifu_outline_funcs.py src/api/tests/service/shifu/test_mdflow_history_routes.py`\n- ✅ `git diff --check`\n- ⚠️ `python3 -m pytest src/api/tests/service/shifu/test_mdflow_history_routes.py -q` 未执行成功：本机系统 Python 缺少 pytest；`.venv-shifu/bin/python` 无执行权限。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened request handling for outline submissions by validating the incoming JSON body and ensuring the `outlines` payload is a proper list.
  * Improved outline-to-reorder conversion by validating input structure and safely normalizing missing `children` values.

* **Tests**
  * Added unit tests to confirm proper error responses for invalid outline inputs, including `None` payloads and incorrect `children` types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->