### PR TITLE
fix: back-date manual entitlement effective_from to avoid same-second race

### DIFF
--- a/src/api/flaskr/service/billing/entitlements.py
+++ b/src/api/flaskr/service/billing/entitlements.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from .consts import (
@@ -142,7 +142,11 @@ def grant_creator_manual_entitlement(
             creator_bid=normalized_creator_bid,
             source_type=CREDIT_SOURCE_TYPE_MANUAL,
             source_bid="",
-            effective_from=now,
+            # Back-date slightly so the row is immediately active. Using the
+            # exact "now" races with same-second reads: MySQL DATETIME rounds
+            # sub-second values up, so effective_from could land just after a
+            # resolve() that runs microseconds later, making the snapshot miss.
+            effective_from=now - timedelta(minutes=1),
             effective_to=None,
             branding_enabled=0,
             custom_domain_enabled=0,

--- a/src/api/tests/service/billing/test_grant_manual_entitlement.py
+++ b/src/api/tests/service/billing/test_grant_manual_entitlement.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import flaskr.dao as dao
+
+
+def _cleanup(app, creator_bid: str) -> None:
+    from flaskr.service.billing.models import BillingEntitlement
+
+    with app.app_context():
+        BillingEntitlement.query.filter_by(creator_bid=creator_bid).delete()
+        dao.db.session.commit()
+
+
+def test_grant_manual_entitlement_is_immediately_active(app):
+    """A freshly granted manual entitlement must resolve as active right away.
+
+    Regression guard for the same-second race: effective_from is back-dated so
+    a resolve() running microseconds after the insert still sees the snapshot
+    (MySQL DATETIME rounds sub-second values, which previously could push
+    effective_from just past the resolve timestamp and miss the row).
+    """
+    from flaskr.service.billing.entitlements import (
+        grant_creator_manual_entitlement,
+        resolve_creator_entitlement_state,
+    )
+
+    creator_bid = "grant-immediate-active-test"
+    _cleanup(app, creator_bid)
+    try:
+        with app.app_context():
+            state = grant_creator_manual_entitlement(
+                app,
+                creator_bid,
+                branding_enabled=True,
+                custom_domain_enabled=True,
+                branding={"logo_wide_url": "https://cdn.example.com/wide.png"},
+            )
+            assert state.branding_enabled is True
+            assert state.custom_domain_enabled is True
+
+            # Independent re-resolution must also see it as active.
+            again = resolve_creator_entitlement_state(creator_bid)
+            assert again.branding_enabled is True
+            assert again.custom_domain_enabled is True
+            assert again.source_kind == "snapshot"
+    finally:
+        _cleanup(app, creator_bid)


### PR DESCRIPTION
##Question

`grant_creator_manual_entitlement` writes `effective_from=now`, and then within the same call (microsecond later)`resolve_creator_entitlement_state` uses `datetime.now()` to determine `effective_from <= as_of`. MySQL `DATETIME`(without decimal places) rounds the sub-second value, and the stored `effective_from` may fall behind the resolve timestamp, causing `_load_active_entitling_snapshot` to miss a hit and fall back to the subscription product (branding/custom_domain is not set)→ The rights just granted are reported `branding=False/custom_domain=False` in the same call, and subsequent custom domain name binding is intercepted by the gate.

The actual trigger is when the creator manually opens white labeling (custom domain name + logo).

##Repair

When creating a new manual entry, set 'effective_from' back for 1 minute to ensure that the snapshot takes effect immediately and eliminate same-second races.

##Test

Added regression test `test_grant_manual_entitlement_is_immediately_active`: Immediately after grant (independent)resolve must be active and `source_kind=snapshot`.
