### PR TITLE
feat: custom domain on detail/save links + per-creator logo home url

### DIFF
--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -66,7 +66,13 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @with_shifu_context()
     def get_runtime_config():
-        creator_bid = str(get_shifu_creator_bid() or "").strip()
+        # An explicit creator_bid lets surfaces without a shifu in the path
+        # (e.g. the /admin backend) fetch a creator's branding. Falls back to
+        # the shifu-context creator when absent, so existing callers are
+        # unaffected. Branding here is public display data already served to
+        # learners, so no sensitive data is exposed.
+        explicit_creator_bid = str(request.args.get("creator_bid", "") or "").strip()
+        creator_bid = explicit_creator_bid or str(get_shifu_creator_bid() or "").strip()
         request_host = _extract_request_host()
         legal_urls = RuntimeLegalUrlsDTO(
             agreement=RuntimeLocalizedUrlDTO(

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -810,7 +810,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                                     $ref: "#/components/schemas/ShifuDetailDto"
         """
         user_id = request.user.user_id
-        base_url = _get_request_base_url()
+        base_url = _resolve_publish_base_url(app)
         app.logger.info(f"get shifu detail, user_id: {user_id}, shifu_bid: {shifu_bid}")
         return make_common_response(
             get_shifu_draft_info(app, user_id, shifu_bid, base_url)
@@ -963,7 +963,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         use_learner_language = json_data.get("use_learner_language")
         if isinstance(use_learner_language, str):
             use_learner_language = use_learner_language.lower() == "true"
-        base_url = _get_request_base_url()
+        base_url = _resolve_publish_base_url(app)
         return make_common_response(
             save_shifu_draft_info(
                 app,

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -329,6 +329,36 @@ def test_runtime_config_uses_shifu_context_for_creator_branding(
     }
 
 
+def test_runtime_config_uses_explicit_creator_bid_param(
+    runtime_config_client,
+) -> None:
+    # The /admin backend has no shifu_bid in the path; an explicit creator_bid
+    # query param must resolve that creator's branding directly.
+    response = runtime_config_client.get(
+        "/api/runtime-config?creator_bid=creator-1",
+        headers={"Host": "localhost"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["logoWideUrl"] == "https://cdn.example.com/creator-wide.png"
+    assert payload["homeUrl"] == "https://creator.example.com/home"
+    assert payload["entitlements"]["branding_enabled"] is True
+
+
+def test_runtime_config_without_creator_param_keeps_global_defaults(
+    runtime_config_client,
+) -> None:
+    # No shifu_bid and no creator_bid -> existing behavior unchanged (global).
+    response = runtime_config_client.get(
+        "/api/runtime-config",
+        headers={"Host": "localhost"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["logoWideUrl"] != "https://cdn.example.com/creator-wide.png"
+    assert payload["entitlements"]["branding_enabled"] is False
+
+
 def test_runtime_billing_builder_and_route_config_use_dto_outputs(
     runtime_config_client,
 ) -> None:

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -10,6 +10,7 @@ import { useBillingOverview } from '@/hooks/useBillingData';
 import { useUserStore } from '@/store';
 import { WelcomeTrialDialog } from '@/components/billing/WelcomeTrialDialog';
 import { ContactSideRail } from '@/components/contact/ContactSideRail';
+import { applyCreatorBranding } from '@/lib/initializeEnvData';
 import { buildAdminMenuItems } from './admin-menu';
 import { SidebarContent } from './SidebarContent';
 
@@ -50,6 +51,16 @@ const MainInterface = ({
   useEffect(() => {
     document.title = t('common.core.adminTitle');
   }, [t, i18n.language]);
+
+  // The /admin path carries no shifu_bid, so the bootstrap runtime-config
+  // cannot resolve a creator. Once the logged-in creator is known, re-fetch
+  // their branding so the sidebar logo and its click-through use the creator's
+  // own logo/home url (falls back to defaults when unconfigured).
+  useEffect(() => {
+    if (hasResolvedAdminSession && currentUserId) {
+      applyCreatorBranding(currentUserId);
+    }
+  }, [hasResolvedAdminSession, currentUserId]);
 
   useEffect(() => {
     const html = document.documentElement;

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -21,6 +21,54 @@ const normalizeStringArray = (value: unknown, fallback: string[]): string[] => {
 
 let initPromise: Promise<void> | null = null;
 
+const resolveRuntimeBase = async (): Promise<string> => {
+  const apiBaseUrl = (await getDynamicApiBaseUrl()) || '';
+  const normalizedBase = apiBaseUrl.replace(/\/+$/, '');
+  return (
+    normalizedBase ||
+    ((useEnvStore.getState() as EnvStoreState).baseURL || '').replace(
+      /\/+$/,
+      '',
+    ) ||
+    ''
+  );
+};
+
+const buildRuntimeConfigUrl = (resolvedBase: string): string => {
+  // Absolute URL: respect whether path already includes /api
+  if (resolvedBase.startsWith('http')) {
+    try {
+      const parsed = new URL(resolvedBase);
+      const path = parsed.pathname.replace(/\/+$/, '');
+      const endsWithApi = path.endsWith('/api');
+      return `${resolvedBase}${
+        endsWithApi ? '/runtime-config' : '/api/runtime-config'
+      }`;
+    } catch {
+      // fall through to relative handling
+    }
+  }
+
+  // Handle empty base - use simple relative path
+  if (!resolvedBase) {
+    return '/api/runtime-config';
+  }
+
+  // Relative URL (e.g. "/api" or "/backend")
+  const cleanBase = resolvedBase;
+  const endsWithApi =
+    cleanBase === '/api' ||
+    cleanBase.endsWith('/api') ||
+    cleanBase === 'api' ||
+    cleanBase.endsWith('api');
+  const baseWithLeading = cleanBase.startsWith('/')
+    ? cleanBase
+    : `/${cleanBase}`;
+  return endsWithApi
+    ? `${baseWithLeading}/runtime-config`
+    : `${baseWithLeading}/api/runtime-config`;
+};
+
 const loadRuntimeConfig = async () => {
   const {
     updateAppId,
@@ -49,56 +97,13 @@ const loadRuntimeConfig = async () => {
     updateCourseId,
   } = useEnvStore.getState() as EnvStoreState;
 
-  const apiBaseUrl = (await getDynamicApiBaseUrl()) || '';
-  const normalizedBase = apiBaseUrl.replace(/\/+$/, '');
-  const resolvedBase =
-    normalizedBase ||
-    ((useEnvStore.getState() as EnvStoreState).baseURL || '').replace(
-      /\/+$/,
-      '',
-    ) ||
-    '';
+  const resolvedBase = await resolveRuntimeBase();
 
   if (resolvedBase) {
     await updateBaseURL(resolvedBase);
   }
 
-  const buildRuntimeUrl = () => {
-    // Absolute URL: respect whether path already includes /api
-    if (resolvedBase.startsWith('http')) {
-      try {
-        const parsed = new URL(resolvedBase);
-        const path = parsed.pathname.replace(/\/+$/, '');
-        const endsWithApi = path.endsWith('/api');
-        return `${resolvedBase}${
-          endsWithApi ? '/runtime-config' : '/api/runtime-config'
-        }`;
-      } catch {
-        // fall through to relative handling
-      }
-    }
-
-    // Handle empty base - use simple relative path
-    if (!resolvedBase) {
-      return '/api/runtime-config';
-    }
-
-    // Relative URL (e.g. "/api" or "/backend")
-    const cleanBase = resolvedBase;
-    const endsWithApi =
-      cleanBase === '/api' ||
-      cleanBase.endsWith('/api') ||
-      cleanBase === 'api' ||
-      cleanBase.endsWith('api');
-    const baseWithLeading = cleanBase.startsWith('/')
-      ? cleanBase
-      : `/${cleanBase}`;
-    return endsWithApi
-      ? `${baseWithLeading}/runtime-config`
-      : `${baseWithLeading}/api/runtime-config`;
-  };
-
-  const runtimeUrl = buildRuntimeUrl();
+  const runtimeUrl = buildRuntimeConfigUrl(resolvedBase);
 
   const pathShifuBid =
     typeof window !== 'undefined'
@@ -246,4 +251,59 @@ export const initializeEnvData = async (): Promise<void> => {
   }
 
   await initPromise;
+};
+
+/**
+ * Re-fetch runtime-config for an explicit creator and apply that creator's
+ * branding (logo + home url) to the env store. Used by the /admin backend,
+ * whose path has no shifu_bid, so the logged-in creator's branding can drive
+ * the sidebar logo and its click-through target.
+ *
+ * Safe by design: fields are only overridden when the creator has a value, so
+ * a creator without custom branding keeps the global defaults (never blanks
+ * out the default logo). Any fetch/parse failure is swallowed.
+ */
+export const applyCreatorBranding = async (
+  creatorBid: string,
+): Promise<void> => {
+  const normalizedCreatorBid = (creatorBid || '').trim();
+  if (!normalizedCreatorBid) {
+    return;
+  }
+  try {
+    const resolvedBase = await resolveRuntimeBase();
+    const runtimeUrl = buildRuntimeConfigUrl(resolvedBase);
+    const url = `${runtimeUrl}?creator_bid=${encodeURIComponent(
+      normalizedCreatorBid,
+    )}`;
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) {
+      return;
+    }
+    const payload = await res.json();
+    const runtimeConfig = payload?.data ?? payload;
+    if (!runtimeConfig) {
+      return;
+    }
+    const {
+      updateHomeUrl,
+      updateLogoWideUrl,
+      updateLogoSquareUrl,
+      updateFaviconUrl,
+    } = useEnvStore.getState() as EnvStoreState;
+    if (runtimeConfig.homeUrl) {
+      await updateHomeUrl(runtimeConfig.homeUrl);
+    }
+    if (runtimeConfig.logoWideUrl) {
+      await updateLogoWideUrl(runtimeConfig.logoWideUrl);
+    }
+    if (runtimeConfig.logoSquareUrl) {
+      await updateLogoSquareUrl(runtimeConfig.logoSquareUrl);
+    }
+    if (runtimeConfig.faviconUrl) {
+      await updateFaviconUrl(runtimeConfig.faviconUrl);
+    }
+  } catch (error) {
+    console.warn('Failed to apply creator branding', error);
+  }
 };

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -259,9 +259,10 @@ export const initializeEnvData = async (): Promise<void> => {
  * whose path has no shifu_bid, so the logged-in creator's branding can drive
  * the sidebar logo and its click-through target.
  *
- * Safe by design: fields are only overridden when the creator has a value, so
- * a creator without custom branding keeps the global defaults (never blanks
- * out the default logo). Any fetch/parse failure is swallowed.
+ * Branding fields are applied unconditionally (with sensible fallbacks),
+ * mirroring the bootstrap loader, so switching to a creator without custom
+ * branding resets to the backend-provided global defaults instead of leaving a
+ * previous creator's values behind. Any fetch/parse failure is swallowed.
  */
 export const applyCreatorBranding = async (
   creatorBid: string,
@@ -291,18 +292,10 @@ export const applyCreatorBranding = async (
       updateLogoSquareUrl,
       updateFaviconUrl,
     } = useEnvStore.getState() as EnvStoreState;
-    if (runtimeConfig.homeUrl) {
-      await updateHomeUrl(runtimeConfig.homeUrl);
-    }
-    if (runtimeConfig.logoWideUrl) {
-      await updateLogoWideUrl(runtimeConfig.logoWideUrl);
-    }
-    if (runtimeConfig.logoSquareUrl) {
-      await updateLogoSquareUrl(runtimeConfig.logoSquareUrl);
-    }
-    if (runtimeConfig.faviconUrl) {
-      await updateFaviconUrl(runtimeConfig.faviconUrl);
-    }
+    await updateHomeUrl(runtimeConfig.homeUrl || '/');
+    await updateLogoWideUrl(runtimeConfig.logoWideUrl || '');
+    await updateLogoSquareUrl(runtimeConfig.logoSquareUrl || '');
+    await updateFaviconUrl(runtimeConfig.faviconUrl || '');
   } catch (error) {
     console.warn('Failed to apply creator branding', error);
   }


### PR DESCRIPTION
Two white-label gaps exposed after accessing online using a custom domain name (app.zhishicat.com). ** Principle: Each change will only take effect if the creator has a custom domain name/branding. Otherwise, the existing logic will be reversed and app.ai-shifu.cn will have no impact on creators who have not yet been opened. **

## Bug1: Backstage course details [Preview address][Learning address] are still the main domain name

- `get_shifu_detail_api` / `save_shifu_detail_api` Use the ready-made `_resolve_publish_base_url(app)`(consistent with publish/preview, there is `@with_shifu_context()` for both). Use it if you hit a custom domain name verified by the author, otherwise you will fall back to the default.

## Bug2:Logo clicks to jump can be customized according to the creator

- ** Learning/c**:`LogoWithText` has used `homeUrl`,runtime-config has pressed `/c/<id>→creator` to issue `branding.home_url`,** There are zero changes to the front end **, only need to write data.

- ** Background/admin**(no shifu_bid path):

- Add optional runtime-config for backend `config.py`? creator_bid=`parameter (the behavior remains completely unchanged when not passed;branding is to publicly display data, and the interface is inherently`@bypass_token_validation`).

- The front-end 'initializeEnvData.ts' extracts reusable base/url parsing and adds 'applyCreatorBranding(creatorBid)'(the brand field is only overwritten when there is a value, and the default logo will not be cleared).

- `admin/layout.tsx` presses its `user_id` once after the login creator is ready to pull it again to drive the sidebar logo and its jump.

##Data (O &amp; M)

`doc/domain/setup_white_label.py` + `deploy.sh` Add `--home-url` / `HOME_URL` and write the logo jump address in `branding.home_url`(leave blank to leave the default).

##Test

- `pytest tests/service/shifu/`(230) + `test_runtime_config_billing.py` Added creator_bid parameter case (including regression of "Keep global default without passing creator_bid").

- Front-end `type-check` + `lint` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit creator branding in runtime configuration with fallback to default settings.
  * Admin dashboard now automatically applies creator-specific branding (logos, URLs, favicon) after session authentication.

* **Tests**
  * Added test coverage for creator branding resolution precedence and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->