### PR TITLE
fix: preserve API base URL for local cook-web dev

### DIFF
--- a/src/cook-web/src/app/api/config/route.ts
+++ b/src/cook-web/src/app/api/config/route.ts
@@ -21,7 +21,19 @@ export async function GET(request: Request) {
         .split(',')[0]
         .trim()
         .toLowerCase();
-      if (requestHost && requestHost !== configuredHost) {
+      const requestHostname = requestHost.split(':')[0];
+      const isLocalDevelopmentHost =
+        requestHostname === 'localhost' ||
+        requestHostname === '127.0.0.1' ||
+        requestHostname === '0.0.0.0' ||
+        requestHostname === '[::1]' ||
+        requestHostname.endsWith('.localhost');
+
+      if (
+        requestHost &&
+        requestHost !== configuredHost &&
+        !isLocalDevelopmentHost
+      ) {
         return NextResponse.json({ apiBaseUrl: '' });
       }
     } catch {


### PR DESCRIPTION
## Summary
- keep the configured API base URL when Cook Web is served from local development hosts
- prevent localhost dev from being treated as a custom/white-label domain
- fixes local `next dev` requests falling back to local `/api/*` routes and returning 404

## Verification
- Inspected the route logic and generated diff
- `npm run type-check` could not run in this workspace because `tsc` is not installed in `src/cook-web/node_modules`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API configuration handling for local development environments. The application now correctly preserves API base URL settings when running on localhost, 127.0.0.1, and other local development hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->