### PR TITLE
refactor: unify coupon ops state rules

### DIFF
--- a/docs/exec-plans/active/operator-promotion-ops-state-rules.md
+++ b/docs/exec-plans/active/operator-promotion-ops-state-rules.md
@@ -1,0 +1,202 @@
+# ExecPlan: Operator Promotion Ops State Rules
+
+## Purpose / Big Picture
+
+Unify the operator-facing `ops_state` rules used by the promotions and creator
+redemption-code pages so filtering, badges, enable/disable guidance, and future
+export behavior all read from one consistent source of truth. Today the feature
+works, but pieces of the rule set are scattered across backend filter code and
+frontend page helpers, which makes drift likely as more states or UI surfaces
+arrive.
+
+This plan keeps the scope narrow: align `ops_state` semantics for existing
+states such as `expiring_soon` and `used_up`, reuse current APIs where
+possible, and avoid mixing in unrelated second-round visual polish or export
+features.
+
+## Progress
+
+- [x] 2026-06-18 11:20 CST: Audited current backend `ops_state` rules and
+  frontend badge/filter mappings for the operator promotions page. Confirmed
+  the current rule set is coupon-only; creator redemption currently reuses the
+  backend coupon list helper but does not expose an `ops_state` filter in its
+  frontend.
+- [x] 2026-06-18 12:05 CST: Chose the first-step ownership model: backend now
+  computes coupon `ops_states`, while the frontend consumes that field through
+  a shared helper for badges and filter option wiring.
+- [x] 2026-06-18 12:20 CST: Implemented the shared `ops_state` path for coupon
+  rows and updated focused backend/frontend tests.
+- [x] 2026-06-18 12:45 CST: Exposed the same coupon `ops_state` filter contract
+  on the creator redemption frontend so both operator surfaces now send the
+  same backend filter parameter and consume the same returned badge states.
+- [x] 2026-06-18 14:20 CST: Added focused backend/frontend tests for
+  `expiring_soon`, `used_up`, empty/default `ops_states`, creator redemption
+  `ops_state` request passthrough, and the creator-only status filter option
+  guard that removes `ended`.
+- [x] 2026-06-18 14:25 CST: Ran narrow validation for promo/admin timezone and
+  creator-redemption flows; recorded remaining scope-risk notes around the
+  unrelated local-dev config route and dashboard/timezone hardening changes.
+
+## Surprises & Discoveries
+
+- The current `ops_state` feature is narrower than the roadmap wording
+  suggests. The backend coupon list helper `_list_promotion_coupons()` accepts
+  `ops_state`, but there is no parallel `ops_state` filter for campaign rows,
+  and the creator redemption frontend does not expose this filter yet.
+- Frontend already duplicates coupon-side `ops_state` semantics in
+  `promotionPageShared.tsx` via `isPromotionExpiringSoon()` and
+  `isCouponUsedUp()` to render attention badges. That means filtering logic
+  and display logic can drift even before any new states are added.
+- The current coupon `ops_state` filter applies only two states:
+  `expiring_soon` and `used_up`. It is separate from `computed_status`
+  (`inactive`, `not_started`, `expired`, `active`).
+- Creator redemption table was already reusing the shared coupon badge helper,
+  so once backend `ops_states` shipped the remaining gap was only the missing
+  frontend filter control and request param wiring.
+
+## Decision Log
+
+- 2026-06-18: Keep backend as the source of truth for accepted coupon
+  `ops_state` values. The backend now returns `ops_states` on coupon list/detail
+  items, and the frontend uses a shared helper to render badges and shared
+  filter options from those returned states instead of recomputing
+  `expiring_soon` / `used_up` locally.
+- 2026-06-18: Extend the same shared coupon `ops_state` filter options to the
+  creator redemption page instead of introducing a second creator-only status
+  vocabulary.
+- Pending: whether the shared helper should live beside the promotions page
+  (`promotionPageShared.tsx`) first, or in a more generic admin operations
+  utility module immediately.
+
+## Outcomes & Retrospective
+
+- Coupon `ops_state` ownership is now consistent: backend computes
+  `ops_states`, promotions and creator-redemption frontend surfaces both
+  consume that field for filtering/badges, and the creator page no longer uses
+  the operator-only “ops filter” wording.
+- The main remaining risk is PR scope: the branch also carries a local-dev
+  `api/config` loopback override and dashboard timezone hardening that are
+  useful but not directly part of coupon `ops_state` unification. They should
+  either be called out explicitly in the PR description or split if a narrower
+  review surface is preferred.
+
+## Context and Orientation
+
+- Backend entry point today:
+  - `src/api/flaskr/service/promo/admin.py`
+- Frontend entry points today:
+  - `src/cook-web/src/app/admin/operations/promotions/page.tsx`
+  - `src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx`
+- Existing tests to extend first:
+  - `src/cook-web/src/app/admin/operations/promotions/page.test.tsx`
+  - `src/api/tests/service/promo/test_admin_promotions.py`
+
+The current backend already accepts `ops_state` in at least part of the
+promotions filter flow, while the frontend owns parts of the label, attention
+badge, and interaction logic. That means the first task is not “add a new
+feature,” but “map the actual current rule ownership and remove duplicated
+interpretations.”
+
+## Plan of Work
+
+1. Audit the current rule set on both backend and frontend.
+2. Choose one shared rule ownership model and document it before coding.
+3. Implement the shared rule path with the smallest API/UI surface change that
+   still removes duplicated logic.
+4. Update both filtering and display consumers together.
+5. Lock the behavior with focused tests.
+
+## Concrete Steps
+
+1. Inspect `src/api/flaskr/service/promo/admin.py` to list:
+   - accepted `ops_state` filter values
+   - the actual data predicates behind each value
+   - any coupon/activity-specific divergences
+2. Inspect `src/cook-web/src/app/admin/operations/promotions/page.tsx` and
+   `promotionPageShared.tsx` to list:
+   - where status badges are derived
+   - where filter options are declared
+   - where action gating depends on state-like conditions
+3. Record the current matrix in this plan:
+   - activity rows vs coupon rows
+   - backend filter semantics vs frontend display semantics
+4. Decide the ownership model:
+   - preferred default: keep backend as the filter source of truth and extract a
+     shared frontend helper for label/badge/view logic
+   - alternative only if clearly simpler: backend returns richer `ops_state`
+     display data directly
+5. Implement the shared helper/module and replace ad-hoc page-local branching.
+6. Update tests to cover:
+   - `expiring_soon`
+   - `used_up`
+   - empty/default `ops_state`
+   - unchanged action availability for enable/disable/edit flows
+
+### Current audit matrix
+
+#### Backend
+
+- Coupon list filter entry point:
+  `src/api/flaskr/service/promo/admin.py::_list_promotion_coupons()`
+- Accepted `ops_state` values today:
+  - `expiring_soon`
+    - predicate: `Coupon.end >= now && Coupon.end <= now + 7 days`
+  - `used_up`
+    - predicate: `Coupon.used_count >= Coupon.total_count`
+- No coupon-side backend guard currently excludes inactive / expired rows from
+  these predicates; they are combined with whatever other filters the caller
+  passed.
+- Campaign list currently has no parallel `ops_state` filter implementation.
+
+#### Frontend
+
+- Coupon filter dropdown lives in
+  `src/cook-web/src/app/admin/operations/promotions/page.tsx`
+  and exposes:
+  - `expiring_soon`
+  - `used_up`
+- Coupon table attention badges live in
+  `src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx`
+  and currently render only when `item.computed_status === 'active'`:
+  - `used_up` if `used_count >= total_count`
+  - `expiring_soon` if `end_at` is within `PROMOTION_EXPIRING_SOON_DAYS`
+- Coupon enable/disable action gating is separate again:
+  - `canEnableCouponItem()`
+  - `shouldShowCouponStatusToggle()`
+- Campaign rows only use `computed_status`; they do not have `ops_state`
+  filters or attention badges today.
+
+## Validation and Acceptance
+
+- Promotions and creator redemption code pages show the same meaning for each
+  `ops_state` label and filter option.
+- Filtering by `ops_state` still returns the same rows as before for existing
+  supported states.
+- No user-facing strings are hardcoded outside shared i18n JSON.
+- Focused tests pass:
+  - backend promo tests covering `ops_state` filters
+  - frontend promotions page tests covering filter/badge behavior
+- `git diff --check` passes.
+
+## Idempotence and Recovery
+
+- The branch can be re-audited safely by rerunning the same backend/frontend
+  inspections and comparing the documented matrix against code.
+- If the shared helper approach proves too invasive, keep the backend contract
+  unchanged and land a narrower extraction inside
+  `promotionPageShared.tsx` first.
+- If validation shows hidden coupon/activity divergences, stop broad
+  generalization and document the divergence explicitly before proceeding.
+
+## Interfaces and Dependencies
+
+- Backend:
+  - `src/api/flaskr/service/promo/admin.py`
+  - any DTO or serializer files touched by promotions filters/results
+- Frontend:
+  - `src/cook-web/src/app/admin/operations/promotions/page.tsx`
+  - `src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx`
+  - related admin UI filter/badge helpers if extraction becomes necessary
+- Validation dependencies:
+  - `src/api/tests/service/promo/test_admin_promotions.py`
+  - `src/cook-web/src/app/admin/operations/promotions/page.test.tsx`

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -15,6 +15,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Creator Dashboard Request Splitting](./active/creator-dashboard-request-splitting.md)
 - [Observability Artifacts, Consistency Probes, and Frontend Trace IDs](./active/observability-artifacts-consistency-frontend-trace.md)
 - [ExecPlan: Operator Credit Grant Package](./active/operator-credit-grant-package.md)
+- [ExecPlan: Operator Promotion Ops State Rules](./active/operator-promotion-ops-state-rules.md)
 - [ExecPlan: Package Campaigns](./active/package-campaigns.md)
 - [老带新邀请奖励实施计划](./active/referral-invitation-rewards.md)
 

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -28,6 +28,7 @@
 | `docs/exec-plans/active/creator-dashboard-request-splitting.md` | Creator Dashboard Request Splitting | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/observability-artifacts-consistency-frontend-trace.md` | Observability Artifacts, Consistency Probes, and Frontend Trace IDs | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/operator-credit-grant-package.md` | ExecPlan: Operator Credit Grant Package | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/operator-promotion-ops-state-rules.md` | ExecPlan: Operator Promotion Ops State Rules | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/package-campaigns.md` | ExecPlan: Package Campaigns | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/referral-invitation-rewards.md` | 老带新邀请奖励实施计划 | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/admin-orders-page-slimming.md` | Admin Orders Page Slimming | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `9`
 - Product specs: `10`
 - References: `3`
-- Active ExecPlans: `11`
+- Active ExecPlans: `12`
 - Completed ExecPlans: `6`
 
 ## Boundary Baseline

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -2008,8 +2008,11 @@ def _build_dashboard_course_learners(
     for row in page_rows:
         user_bid = str(getattr(row, "user_bid", "") or "").strip()
         contact = contact_map.get(user_bid, {"mobile": "", "email": ""})
-        last_learning_at = getattr(row, "last_learning_at", None)
-        joined_at = getattr(row, "joined_at", None)
+        last_learning_at = _coerce_datetime(
+            app,
+            getattr(row, "last_learning_at", None),
+        )
+        joined_at = _coerce_datetime(app, getattr(row, "joined_at", None))
         paged_items.append(
             DashboardCourseDetailLearnerItemDTO(
                 user_bid=user_bid,

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -539,6 +539,20 @@ def _compute_coupon_status(coupon: Coupon) -> str:
     return "active"
 
 
+def _compute_coupon_ops_states(coupon: Coupon) -> list[str]:
+    now = _now_local_naive()
+    states: list[str] = []
+    if int(coupon.used_count or 0) >= int(coupon.total_count or 0):
+        states.append("used_up")
+    if (
+        coupon.end
+        and coupon.end >= now
+        and coupon.end <= now + timedelta(days=PROMOTION_EXPIRING_SOON_DAYS)
+    ):
+        states.append("expiring_soon")
+    return states
+
+
 def _compute_campaign_status(campaign: PromoCampaign) -> str:
     now = _now_local_naive()
     if not is_campaign_enabled_for_runtime(campaign):
@@ -558,6 +572,7 @@ def _build_coupon_item(
     scope_type, shifu_bid = _parse_coupon_scope(coupon.filter or "{}")
     course = course_map.get(shifu_bid)
     computed_status = _compute_coupon_status(coupon)
+    ops_states = _compute_coupon_ops_states(coupon)
     usage_type = int(coupon.usage_type or COUPON_APPLY_TYPE_ALL)
     created_user_bid = coupon.created_user_bid or ""
     return AdminPromotionCouponItemDTO(
@@ -581,6 +596,7 @@ def _build_coupon_item(
         end_at=_format_promotion_admin_datetime(coupon.end),
         total_count=int(coupon.total_count or 0),
         used_count=int(coupon.used_count or 0),
+        ops_states=ops_states,
         computed_status=computed_status,
         computed_status_key=COUPON_COMPUTED_STATUS_KEY_MAP[computed_status],
         created_user_bid=created_user_bid,

--- a/src/api/flaskr/service/promo/admin_dtos.py
+++ b/src/api/flaskr/service/promo/admin_dtos.py
@@ -47,6 +47,9 @@ class AdminPromotionCouponItemDTO(_DTOBase):
     end_at: str = Field(..., description="Coupon end time", required=False)
     total_count: int = Field(..., description="Total count", required=False)
     used_count: int = Field(..., description="Used count", required=False)
+    ops_states: List[str] = Field(
+        ..., description="Operator-facing operational states", required=False
+    )
     computed_status: str = Field(..., description="Computed status", required=False)
     computed_status_key: str = Field(
         ..., description="Computed status i18n key", required=False

--- a/src/api/flaskr/util/timezone.py
+++ b/src/api/flaskr/util/timezone.py
@@ -44,11 +44,22 @@ def get_app_timezone(app: Flask, tz_name: str | None = None) -> ZoneInfo:
     return ZoneInfo("UTC")
 
 
-def _coerce_datetime(app: Flask, value: datetime | str | None) -> datetime | None:
+def _coerce_datetime(
+    app: Flask,
+    value: datetime | str | bytes | bytearray | None,
+) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
         return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8")
+        except UnicodeDecodeError:
+            app.logger.warning(
+                "Failed to decode datetime bytes for timezone conversion",
+            )
+            return None
     if isinstance(value, str):
         stripped_value = value.strip()
         if not stripped_value:
@@ -74,7 +85,7 @@ def _coerce_datetime(app: Flask, value: datetime | str | None) -> datetime | Non
 
 def serialize_with_app_timezone(
     app: Flask,
-    dt: datetime | str | None,
+    dt: datetime | str | bytes | bytearray | None,
     tz_name: str | None = None,
 ) -> str | None:
     dt = _coerce_datetime(app, dt)
@@ -89,7 +100,7 @@ def serialize_with_app_timezone(
 
 def format_with_app_timezone(
     app: Flask,
-    dt: datetime | str | None,
+    dt: datetime | str | bytes | bytearray | None,
     fmt: str,
     tz_name: str | None = None,
 ) -> str | None:

--- a/src/api/tests/common/test_timezone.py
+++ b/src/api/tests/common/test_timezone.py
@@ -37,3 +37,21 @@ def test_serialize_with_app_timezone_accepts_offset_datetime_string() -> None:
         serialize_with_app_timezone(app, "2026-05-20T08:40:51Z", "Asia/Shanghai")
         == "2026-05-20T16:40:51+08:00"
     )
+
+
+def test_serialize_with_app_timezone_accepts_mysql_datetime_bytes() -> None:
+    app = _make_app()
+
+    assert (
+        serialize_with_app_timezone(app, b"2026-05-20 16:40:51", "UTC")
+        == "2026-05-20T08:40:51+00:00"
+    )
+    assert (
+        format_with_app_timezone(
+            app,
+            b"2026-05-20 16:40:51",
+            "%Y-%m-%d %H:%M:%S",
+            "UTC",
+        )
+        == "2026-05-20 08:40:51"
+    )

--- a/src/api/tests/common/test_timezone.py
+++ b/src/api/tests/common/test_timezone.py
@@ -55,3 +55,5 @@ def test_serialize_with_app_timezone_accepts_mysql_datetime_bytes() -> None:
         )
         == "2026-05-20 08:40:51"
     )
+    assert serialize_with_app_timezone(app, b"invalid-date", "UTC") is None
+    assert format_with_app_timezone(app, b"invalid-date", "%Y-%m-%d", "UTC") is None

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -258,6 +258,7 @@ def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch
     assert list_payload["data"]["summary"]["usage_count"] == 1
     assert list_payload["data"]["items"][0]["name"] == "Spring Batch"
     assert list_payload["data"]["items"][0]["course_name"] == "Coupon Course"
+    assert list_payload["data"]["items"][0]["ops_states"] == ["expiring_soon"]
 
     filtered_list_response = test_client.get(
         "/api/shifu/admin/operations/promotions/coupons",
@@ -290,6 +291,9 @@ def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch
     assert expiring_coupon_payload["code"] == 0
     assert expiring_coupon_payload["data"]["total"] == 1
     assert expiring_coupon_payload["data"]["items"][0]["coupon_bid"] == coupon_bid
+    assert expiring_coupon_payload["data"]["items"][0]["ops_states"] == [
+        "expiring_soon"
+    ]
 
     non_matching_expiring_response = test_client.get(
         "/api/shifu/admin/operations/promotions/coupons",
@@ -404,6 +408,10 @@ def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch
     assert used_up_payload["code"] == 0
     assert used_up_payload["data"]["total"] == 1
     assert used_up_payload["data"]["items"][0]["coupon_bid"] == coupon_bid
+    assert set(used_up_payload["data"]["items"][0]["ops_states"]) == {
+        "used_up",
+        "expiring_soon",
+    }
 
     status_response = test_client.post(
         f"/api/shifu/admin/operations/promotions/coupons/{coupon_bid}/status",
@@ -417,6 +425,51 @@ def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch
         coupon = Coupon.query.filter(Coupon.coupon_bid == coupon_bid).first()
         assert coupon is not None
         assert coupon.status == 0
+
+
+def test_admin_promotions_coupon_list_returns_empty_ops_states_by_default(
+    app, test_client, monkeypatch
+):
+    _mock_operator(monkeypatch)
+    monkeypatch.setattr(
+        "flaskr.service.promo.admin._now_local_naive",
+        lambda: datetime(2026, 5, 20, 12, 0, 0),
+    )
+
+    with app.app_context():
+        _seed_user("operator-1", "operator@example.com", "Operator", is_operator=True)
+        _seed_course("course-1", "Coupon Course")
+
+        coupon = Coupon()
+        coupon.coupon_bid = "stable-coupon"
+        coupon.name = "Stable Coupon"
+        coupon.code = "STABLE"
+        coupon.usage_type = COUPON_APPLY_TYPE_ALL
+        coupon.discount_type = COUPON_TYPE_FIXED
+        coupon.value = Decimal("20")
+        coupon.filter = '{"course_id": "course-1"}'
+        coupon.total_count = 10
+        coupon.used_count = 1
+        coupon.status = 1
+        coupon.created_user_bid = "operator-1"
+        coupon.updated_user_bid = "operator-1"
+        coupon.start = datetime(2026, 4, 24, 10, 0, 0)
+        coupon.end = datetime(2026, 8, 24, 10, 0, 0)
+        db.session.add(coupon)
+        db.session.commit()
+
+    response = test_client.get(
+        "/api/shifu/admin/operations/promotions/coupons",
+        query_string={"page_index": 1, "page_size": 20},
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["total"] == 1
+    assert payload["data"]["items"][0]["coupon_bid"] == "stable-coupon"
+    assert payload["data"]["items"][0]["ops_states"] == []
 
 
 def test_creator_redemption_code_route_creates_course_scoped_coupon(
@@ -569,6 +622,7 @@ def test_creator_redemption_code_list_shows_only_owned_course_batches(
     assert payload["data"]["items"][0]["course_name"] == "Creator Course"
     assert payload["data"]["items"][0]["created_user_bid"] == "creator-1"
     assert payload["data"]["items"][0]["created_user_name"] == "Creator"
+    assert payload["data"]["items"][0]["ops_states"] == []
 
     all_response = test_client.get(
         "/api/order/admin/orders/redemption-codes",
@@ -580,6 +634,7 @@ def test_creator_redemption_code_list_shows_only_owned_course_batches(
     assert all_payload["code"] == 0
     assert all_payload["data"]["total"] == 1
     assert all_payload["data"]["items"][0]["coupon_bid"] != "other-coupon"
+    assert all_payload["data"]["items"][0]["ops_states"] == []
 
 
 def test_creator_redemption_code_usage_route_requires_owned_course_coupon(

--- a/src/cook-web/src/app/admin/operations/operation-promotion-types.ts
+++ b/src/cook-web/src/app/admin/operations/operation-promotion-types.ts
@@ -32,6 +32,7 @@ export type AdminPromotionCouponItem = {
   end_at: string;
   total_count: number;
   used_count: number;
+  ops_states?: string[];
   enabled?: boolean;
   computed_status: string;
   computed_status_key: string;

--- a/src/cook-web/src/app/admin/operations/promotions/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.test.tsx
@@ -1956,6 +1956,7 @@ describe('AdminOperationPromotionsPage', () => {
           end_at: soonEndAt,
           total_count: 10,
           used_count: 10,
+          ops_states: ['used_up', 'expiring_soon'],
           computed_status: 'active',
           computed_status_key: 'module.operationsPromotion.status.active',
           created_at: '2026-04-24T10:00:00Z',
@@ -2010,6 +2011,7 @@ describe('AdminOperationPromotionsPage', () => {
           end_at: soonEndAt,
           total_count: 10,
           used_count: 0,
+          ops_states: ['expiring_soon'],
           computed_status: 'not_started',
           computed_status_key: 'module.operationsPromotion.status.notStarted',
           created_at: '2026-04-24T10:00:00Z',
@@ -2031,6 +2033,7 @@ describe('AdminOperationPromotionsPage', () => {
           end_at: soonEndAt,
           total_count: 10,
           used_count: 10,
+          ops_states: ['used_up', 'expiring_soon'],
           computed_status: 'inactive',
           computed_status_key: 'module.operationsPromotion.status.inactive',
           created_at: '2026-04-24T10:00:00Z',
@@ -2047,6 +2050,58 @@ describe('AdminOperationPromotionsPage', () => {
 
     await screen.findByText('Upcoming Coupon');
     await screen.findByText('Inactive Coupon');
+
+    expect(
+      screen.queryByText('module.operationsPromotion.opsState.usedUp'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('module.operationsPromotion.opsState.expiringSoon'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not show coupon attention badges when an active coupon has no ops states', async () => {
+    mockGetCoupons.mockResolvedValueOnce({
+      summary: {
+        total: 1,
+        active: 1,
+        usage_count: 0,
+        latest_usage_at: '',
+        covered_courses: 1,
+        discount_amount: '0',
+      },
+      items: [
+        {
+          coupon_bid: 'coupon-stable',
+          name: 'Stable Coupon',
+          code: 'STABLE',
+          usage_type: 801,
+          usage_type_key: 'module.operationsPromotion.usageType.generic',
+          discount_type: 701,
+          discount_type_key: 'module.operationsPromotion.discountType.fixed',
+          value: '20',
+          scope_type: 'single_course',
+          shifu_bid: 'course-1',
+          course_name: 'Coupon Course',
+          start_at: '2026-04-24T10:00:00Z',
+          end_at: '2026-08-24T10:00:00Z',
+          total_count: 10,
+          used_count: 1,
+          ops_states: [],
+          computed_status: 'active',
+          computed_status_key: 'module.operationsPromotion.status.active',
+          created_at: '2026-04-24T10:00:00Z',
+          updated_at: '2026-04-24T11:00:00Z',
+        },
+      ],
+      page: 1,
+      page_count: 1,
+      page_size: 20,
+      total: 1,
+    });
+
+    render(<AdminOperationPromotionsPage />);
+
+    await screen.findByText('Stable Coupon');
 
     expect(
       screen.queryByText('module.operationsPromotion.opsState.usedUp'),

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -78,6 +78,7 @@ import {
   COLUMN_MIN_WIDTH,
   COUPON_COLUMN_WIDTH_STORAGE_KEY,
   COUPON_DEFAULT_COLUMN_WIDTHS,
+  COUPON_OPS_STATE_OPTIONS,
   type CouponColumnKey,
   type CouponFilters,
   type CouponFormState,
@@ -1174,18 +1175,15 @@ export default function AdminOperationPromotionsPage() {
             >
               {t('common.core.all')}
             </SelectItem>
-            <SelectItem
-              value='expiring_soon'
-              className={SINGLE_SELECT_ITEM_CLASS}
-            >
-              {tPromotion('opsState.expiringSoon')}
-            </SelectItem>
-            <SelectItem
-              value='used_up'
-              className={SINGLE_SELECT_ITEM_CLASS}
-            >
-              {tPromotion('opsState.usedUp')}
-            </SelectItem>
+            {COUPON_OPS_STATE_OPTIONS.map(option => (
+              <SelectItem
+                key={option.value}
+                value={option.value}
+                className={SINGLE_SELECT_ITEM_CLASS}
+              >
+                {tPromotion(option.labelKey)}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       ),

--- a/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
@@ -164,6 +164,16 @@ export const PAGE_SIZE = 20;
 export const EMPTY_VALUE = '--';
 export const ALL_OPTION_VALUE = '__all__';
 export const PROMOTION_EXPIRING_SOON_DAYS = 7;
+export const COUPON_OPS_STATE_OPTIONS = [
+  {
+    value: 'expiring_soon',
+    labelKey: 'opsState.expiringSoon',
+  },
+  {
+    value: 'used_up',
+    labelKey: 'opsState.usedUp',
+  },
+] as const;
 export const COLUMN_MIN_WIDTH = 90;
 export const COLUMN_MAX_WIDTH = 420;
 export const COUPON_COLUMN_WIDTH_STORAGE_KEY =
@@ -1081,20 +1091,13 @@ export const parseDateValue = (value: string) => {
   return parsed;
 };
 
-export const isPromotionExpiringSoon = (endAt?: string) => {
-  const endDate = parseDateValue(endAt || '');
-  if (!endDate) {
-    return false;
-  }
-  const now = new Date();
-  const diff = endDate.getTime() - now.getTime();
-  return (
-    diff >= 0 && diff <= PROMOTION_EXPIRING_SOON_DAYS * 24 * 60 * 60 * 1000
-  );
-};
+export const resolveCouponOpsStates = (item: AdminPromotionCouponItem) =>
+  Array.isArray(item.ops_states) ? item.ops_states : [];
 
-export const isCouponUsedUp = (item: AdminPromotionCouponItem) =>
-  Number(item.used_count || 0) >= Number(item.total_count || 0);
+export const couponHasOpsState = (
+  item: AdminPromotionCouponItem,
+  state: (typeof COUPON_OPS_STATE_OPTIONS)[number]['value'],
+) => resolveCouponOpsStates(item).includes(state);
 
 export const renderCouponAttentionBadges = (
   item: AdminPromotionCouponItem,
@@ -1104,7 +1107,7 @@ export const renderCouponAttentionBadges = (
     return [];
   }
 
-  if (isCouponUsedUp(item)) {
+  if (couponHasOpsState(item, 'used_up')) {
     return [
       <Badge
         key='used-up'
@@ -1116,7 +1119,7 @@ export const renderCouponAttentionBadges = (
     ];
   }
 
-  if (isPromotionExpiringSoon(item.end_at)) {
+  if (couponHasOpsState(item, 'expiring_soon')) {
     return [
       <Badge
         key='expiring-soon'

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select';
+import { COUPON_OPS_STATE_OPTIONS } from '@/app/admin/operations/promotions/promotionPageShared';
 import { cn } from '@/lib/utils';
 import {
   FILTER_LABEL_CLASS,
@@ -69,7 +70,17 @@ export default function CreatorRedemptionCodesFilterPanel({
       { value: 'not_started', label: tPromotion('status.notStarted') },
       { value: 'inactive', label: tPromotion('status.inactive') },
       { value: 'expired', label: tPromotion('status.expired') },
-      { value: 'ended', label: tPromotion('status.ended') },
+    ],
+    [t, tPromotion],
+  );
+
+  const opsStateOptions = useMemo(
+    () => [
+      { value: '', label: t('module.order.filters.all') },
+      ...COUPON_OPS_STATE_OPTIONS.map(option => ({
+        value: option.value,
+        label: tPromotion(option.labelKey),
+      })),
     ],
     [t, tPromotion],
   );
@@ -142,6 +153,36 @@ export default function CreatorRedemptionCodesFilterPanel({
           </SelectTrigger>
           <SelectContent>
             {statusOptions.map(option => (
+              <SelectItem
+                key={option.value || 'all'}
+                value={toSelectValue(option.value)}
+                className={SINGLE_SELECT_ITEM_CLASS}
+                indicatorClassName={SINGLE_SELECT_INDICATOR_CLASS}
+              >
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ),
+    },
+    {
+      key: 'ops_state',
+      label: t('module.order.redemptionCodes.opsState'),
+      component: (
+        <Select
+          value={toSelectValue(filters.ops_state)}
+          onValueChange={value =>
+            onFilterChange('ops_state', fromSelectValue(value))
+          }
+        >
+          <SelectTrigger className='h-9'>
+            <SelectValue
+              placeholder={t('module.order.redemptionCodes.opsState')}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {opsStateOptions.map(option => (
               <SelectItem
                 key={option.value || 'all'}
                 value={toSelectValue(option.value)}

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx
@@ -52,6 +52,56 @@ jest.mock('@/components/loading', () => ({
   default: () => <div data-testid='loading-indicator' />,
 }));
 
+jest.mock('@/components/ui/Select', () => {
+  const ReactModule = jest.requireActual('react') as typeof React;
+  const SelectContext = ReactModule.createContext<{
+    value: string;
+    onValueChange: (value: string) => void;
+  }>({
+    value: '',
+    onValueChange: () => undefined,
+  });
+
+  return {
+    __esModule: true,
+    Select: ({
+      value,
+      onValueChange,
+      children,
+    }: React.PropsWithChildren<{
+      value: string;
+      onValueChange: (value: string) => void;
+    }>) => (
+      <SelectContext.Provider value={{ value, onValueChange }}>
+        <div>{children}</div>
+      </SelectContext.Provider>
+    ),
+    SelectTrigger: ({ children }: React.PropsWithChildren) => (
+      <div>{children}</div>
+    ),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => (
+      <span>{placeholder}</span>
+    ),
+    SelectContent: ({ children }: React.PropsWithChildren) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      value,
+      children,
+    }: React.PropsWithChildren<{ value: string }>) => {
+      const context = ReactModule.useContext(SelectContext);
+      return (
+        <button
+          type='button'
+          onClick={() => context.onValueChange(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
 const CONFIRM_STATUS_LABEL = 'confirm-status';
 
 jest.mock('@/app/admin/components/AdminRowActions', () => ({
@@ -522,5 +572,39 @@ describe('CreatorRedemptionCodesTab', () => {
     expect(screen.queryByText('Batch A')).not.toBeInTheDocument();
     expect(screen.queryByText('Batch B')).not.toBeInTheDocument();
     expect(screen.queryByText('3/20')).not.toBeInTheDocument();
+  });
+
+  test('passes ops state filters to the redemption code list request', async () => {
+    render(<CreatorRedemptionCodesTab />);
+
+    await screen.findByText('Batch A');
+    fireEvent.click(screen.getByText('common.core.expand'));
+    fireEvent.click(screen.getByText('opsState.usedUp'));
+    fireEvent.click(screen.getByText('module.order.filters.search'));
+
+    await waitFor(() => {
+      expect(mockGetCreatorCourseRedemptionCodes).toHaveBeenLastCalledWith({
+        page_index: 1,
+        page_size: 20,
+        keyword: '',
+        name: '',
+        course_query: '',
+        usage_type: '',
+        ops_state: 'used_up',
+        discount_type: '',
+        status: '',
+        start_time: '',
+        end_time: '',
+      });
+    });
+  });
+
+  test('does not expose ended as a creator redemption status filter option', async () => {
+    render(<CreatorRedemptionCodesTab />);
+
+    await screen.findByText('Batch A');
+    fireEvent.click(screen.getByText('common.core.expand'));
+
+    expect(screen.queryByText('status.ended')).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
+++ b/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
@@ -14,6 +14,7 @@ export type RedemptionCodeFilters = {
   name: string;
   course_query: string;
   usage_type: string;
+  ops_state: string;
   discount_type: string;
   status: string;
   start_time: string;
@@ -31,6 +32,7 @@ export const createDefaultFilters = (): RedemptionCodeFilters => ({
   name: '',
   course_query: '',
   usage_type: '',
+  ops_state: '',
   discount_type: '',
   status: '',
   start_time: '',

--- a/src/cook-web/src/app/admin/orders/useCreatorRedemptionCodesList.ts
+++ b/src/cook-web/src/app/admin/orders/useCreatorRedemptionCodesList.ts
@@ -57,6 +57,7 @@ export const useCreatorRedemptionCodesList = ({
           name: resolvedFilters.name.trim(),
           course_query: resolvedFilters.course_query.trim(),
           usage_type: resolvedFilters.usage_type,
+          ops_state: resolvedFilters.ops_state,
           discount_type: resolvedFilters.discount_type,
           status: resolvedFilters.status,
           start_time: resolvedFilters.start_time,

--- a/src/i18n/en-US/modules/order.json
+++ b/src/i18n/en-US/modules/order.json
@@ -132,6 +132,7 @@
     "emptyList": "No redemption codes",
     "loadCoursesFailed": "Failed to load courses. Please try again later.",
     "loadFailed": "Failed to load redemption codes. Please refresh and try again.",
+    "opsState": "Status Flag",
     "submitting": "Creating...",
     "tooManyCourses": "Only the first published courses are shown. Please refine the course list if needed.",
     "totalCount": "Redemption codes: {count}",

--- a/src/i18n/fr-FR/modules/order.json
+++ b/src/i18n/fr-FR/modules/order.json
@@ -132,6 +132,7 @@
     "emptyList": "Aucun code",
     "loadCoursesFailed": "Échec du chargement des cours. Veuillez réessayer plus tard.",
     "loadFailed": "Échec du chargement des codes. Veuillez actualiser et réessayer.",
+    "opsState": "Marqueur d'état",
     "submitting": "Création...",
     "tooManyCourses": "Seuls les premiers cours publiés sont affichés. Veuillez affiner la liste des cours si nécessaire.",
     "totalCount": "Codes: {count}",

--- a/src/i18n/zh-CN/modules/order.json
+++ b/src/i18n/zh-CN/modules/order.json
@@ -132,6 +132,7 @@
     "emptyList": "暂无兑换码",
     "loadCoursesFailed": "课程列表加载失败，请稍后重试",
     "loadFailed": "兑换码列表加载失败，请刷新后重试",
+    "opsState": "状态标记",
     "submitting": "创建中...",
     "tooManyCourses": "当前仅展示前部分已发布课程，如需更多课程请缩小筛选范围。",
     "totalCount": "兑换码数：{count}",


### PR DESCRIPTION
## Summary
- unify coupon `ops_state` ownership by computing `ops_states` in the backend and consuming the returned field across operator promotions and creator redemption pages
- align creator redemption filtering with the shared coupon ops-state contract, remove the invalid `ended` status option, and switch the creator-facing filter label to a creator-specific wording
- harden local admin/debugging support by allowing loopback `api/config` overrides for `localhost:3000 -> localhost:8080` and by normalizing dashboard datetime strings/bytes before timezone serialization

## Testing
- `cd src/api && pytest -q tests/common/test_timezone.py`
- `cd src/api && pytest -q tests/service/dashboard/test_dashboard_routes.py -k 'format_dashboard_datetime_display_preserves_naive_mysql_strings'`
- `cd src/api && pytest -q tests/service/promo/test_admin_promotions.py -k 'ops_state or empty_ops_states'`
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/promotions/page.test.tsx`
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx`
- `cd src/cook-web && npm run type-check`
- `python scripts/check_repo_harness.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operators can now view operational state indicators ("used up," "expiring soon") on promotional coupons and redemption codes
  * Added filtering capabilities by operational state in promotions and creator redemption code management interfaces
  * Improved date/time handling for better timezone consistency across the platform
  * Added multi-language support (English, French, Chinese) for operational state labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->