### PR TITLE
feat: add local development environment hostname check logic

### DIFF
--- a/src/cook-web/src/app/api/config/route.ts
+++ b/src/cook-web/src/app/api/config/route.ts
@@ -31,7 +31,9 @@ export async function GET(request: Request) {
       // is not a valid authority, so fall back to a plain split.
       let requestHostname: string;
       try {
-        requestHostname = new URL(`http://${requestHost}`).hostname.toLowerCase();
+        requestHostname = new URL(
+          `http://${requestHost}`,
+        ).hostname.toLowerCase();
       } catch {
         requestHostname = requestHost.split(':')[0];
       }

--- a/src/cook-web/src/app/api/config/route.ts
+++ b/src/cook-web/src/app/api/config/route.ts
@@ -21,7 +21,18 @@ export async function GET(request: Request) {
         .split(',')[0]
         .trim()
         .toLowerCase();
-      if (requestHost && requestHost !== configuredHost) {
+      // Local development serves the frontend on localhost while pointing at a
+      // remote API (e.g. dev.sh sets NEXT_PUBLIC_API_BASE_URL to a remote
+      // host). There is no same-origin /api proxy on localhost, so always
+      // return the configured absolute base instead of treating the host
+      // mismatch as a white-label domain.
+      const requestHostname = requestHost.split(':')[0];
+      const isLocalhost =
+        requestHostname === 'localhost' ||
+        requestHostname === '127.0.0.1' ||
+        requestHostname === '0.0.0.0' ||
+        requestHostname === '::1';
+      if (!isLocalhost && requestHost && requestHost !== configuredHost) {
         return NextResponse.json({ apiBaseUrl: '' });
       }
     } catch {

--- a/src/cook-web/src/app/api/config/route.ts
+++ b/src/cook-web/src/app/api/config/route.ts
@@ -26,12 +26,21 @@ export async function GET(request: Request) {
       // host). There is no same-origin /api proxy on localhost, so always
       // return the configured absolute base instead of treating the host
       // mismatch as a white-label domain.
-      const requestHostname = requestHost.split(':')[0];
+      // Parse the host as an authority so the port is stripped correctly for
+      // both IPv4 and bracketed IPv6 forms (e.g. "[::1]:3000"). A bare "::1"
+      // is not a valid authority, so fall back to a plain split.
+      let requestHostname: string;
+      try {
+        requestHostname = new URL(`http://${requestHost}`).hostname.toLowerCase();
+      } catch {
+        requestHostname = requestHost.split(':')[0];
+      }
       const isLocalhost =
         requestHostname === 'localhost' ||
         requestHostname === '127.0.0.1' ||
         requestHostname === '0.0.0.0' ||
-        requestHostname === '::1';
+        requestHostname === '::1' ||
+        requestHostname === '[::1]';
       if (!isLocalhost && requestHost && requestHost !== configuredHost) {
         return NextResponse.json({ apiBaseUrl: '' });
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local development handling for `GET /api/config` so it now correctly returns the configured absolute API base URL for common local hosts (including IPv6), instead of returning an empty value due to host mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->