### PR TITLE
fix: handle orphan outline nodes in build_outline_tree and delete_unit

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -116,7 +116,13 @@ def build_outline_tree(app, shifu_bid: str) -> list[ShifuOutlineTreeNode]:
                 if node not in parent_node.children:
                     parent_node.add_child(node)
             else:
-                app.logger.error(f"Parent node not found for position: {position}")
+                # Data consistency issue: parent node missing (e.g. partial deletion).
+                # Add orphan node to root level so its content is not silently lost.
+                app.logger.warning(
+                    f"Parent node not found for position: {position} in shifu"
+                    f" {shifu_bid}. Adding as root-level orphan to preserve content."
+                )
+                outline_tree.append(node)
 
     return outline_tree
 
@@ -543,32 +549,27 @@ def delete_unit(app, user_id: str, unit_id: str):
         if not unit_to_delete:
             raise_error("server.shifu.unitNotFound")
 
-        # build outline tree to find all children
-        outline_tree = build_outline_tree(app, unit_to_delete.shifu_bid)
+        # collect all descendant ids using parent_bid DB queries to correctly
+        # handle nodes that may be orphaned (not reachable via the position tree).
+        def collect_all_descendants_bids(parent_bid: str) -> list[str]:
+            """Recursively collect all descendant bids via parent_bid DB field."""
+            children = DraftOutlineItem.query.filter(
+                DraftOutlineItem.shifu_bid == unit_to_delete.shifu_bid,
+                DraftOutlineItem.parent_bid == parent_bid,
+                DraftOutlineItem.deleted == 0,
+            ).all()
+            # de-duplicate by outline_item_bid (latest version only)
+            seen = {}
+            for c in children:
+                if c.outline_item_bid not in seen or c.id > seen[c.outline_item_bid].id:
+                    seen[c.outline_item_bid] = c
+            result = []
+            for child in seen.values():
+                result.append(child.outline_item_bid)
+                result.extend(collect_all_descendants_bids(child.outline_item_bid))
+            return result
 
-        # find the node to delete
-        def find_node_by_id(nodes: list[ShifuOutlineTreeNode], target_id: str):
-            for node in nodes:
-                if node.outline_id == target_id:
-                    return node
-                if node.children:
-                    found = find_node_by_id(node.children, target_id)
-                    if found:
-                        return found
-            return None
-
-        node_to_delete = find_node_by_id(outline_tree, unit_id)
-        if not node_to_delete:
-            raise_error("server.shifu.unitNotFound")
-
-        # collect all node ids to delete (including children)
-        def collect_all_node_ids(node: ShifuOutlineTreeNode):
-            ids = [node.outline_id]
-            for child in node.children:
-                ids.extend(collect_all_node_ids(child))
-            return ids
-
-        ids_to_delete = collect_all_node_ids(node_to_delete)
+        ids_to_delete = [unit_id] + collect_all_descendants_bids(unit_id)
 
         # mark all related outlines as deleted
         for item_id in ids_to_delete:


### PR DESCRIPTION
## 问题来源

运维保障群 2026-06-18 14:47–14:48 持续报警（50+ ERROR 消息）：
```
[ERROR] build_outline_tree Parent node not found for position: 0204
```
API：`/api/shifu/shifus/f1260f80af38406886d85f007eca99b6/outlines`（多 pod 同时报错）

## 根因分析

`build_outline_tree` 用 `position` 字段构建大纲树。当某父节点（如 `position=02`）被软删除，但子节点（如 `position=0204`）因历史 bug 未被级联删除时：
- 子节点在 `nodes_map` 中找不到父节点
- 当前代码：记录 ERROR 并**静默丢弃**该孤儿节点 → 内容对用户不可见
- 每次查询该师傅大纲都会触发 ERROR，产生大量告警噪音

同时，`delete_unit` 通过遍历大纲树来收集要删除的子节点，若子节点已经是孤儿（不在树中），则无法被收集到 → 删除时遗留孤儿节点，循环产生问题。

## 修复内容

### Fix 1：`build_outline_tree`
- 孤儿节点改为添加到根级别（而非静默丢弃），确保内容不丢失
- 日志级别从 ERROR 降为 WARNING（数据不一致是根因，代码层面已防御性处理）

### Fix 2：`delete_unit`
- 废弃基于大纲树遍历来查找子节点的方式
- 改用 `parent_bid` 字段递归 DB 查询（`collect_all_descendants_bids`）
- 确保已孤儿化的子节点也能被正确软删除，防止未来继续产生孤儿

## 验证

- Python 语法检查通过（`ast.parse`）
- 逻辑回归：正常树结构不受影响（仅 else 分支改变行为）
- `delete_unit` 改动：使用 `parent_bid` 字段，该字段在创建节点时已正确赋值（见 `create_outline`）

## 注意

当前生产中 shifu `f1260f80af38406886d85f007eca99b6` 存在孤儿数据，此 PR 部署后：
1. ERROR 日志消失（降为 WARNING）
2. 孤儿节点在大纲树中以根级别显示，用户可手动删除
3. 后续删除操作将正确级联，不再产生新孤儿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Outline items with missing parents are now preserved at the root level instead of being silently removed
* Deletion of outline items now properly removes all descendant items, including those in unreachable states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->