### PR TITLE
fix: restore preview listen tts backfill

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1179,7 +1179,8 @@ def stream_generated_block_audio(
             raise_error("server.learn.generatedBlockNotFound")
 
         raw_text = generated_block.generated_content or ""
-        if not listen:
+
+        def _resolve_existing_single_block_audio():
             existing_audios = (
                 LearnGeneratedAudio.query.filter(
                     LearnGeneratedAudio.generated_block_bid == generated_block_bid,
@@ -1191,23 +1192,30 @@ def stream_generated_block_audio(
                 .order_by(LearnGeneratedAudio.id.desc())
                 .all()
             )
-            existing_audio = next(
+            return next(
                 (
                     audio
                     for audio in existing_audios
                     if _audio_record_matches_speakable_text(audio, raw_text)
+                    and audio.oss_url
                 ),
                 None,
             )
-            if existing_audio and existing_audio.oss_url:
-                yield _build_audio_complete_message(
-                    outline_bid=generated_block.outline_item_bid or "",
-                    generated_block_bid=generated_block_bid,
-                    audio_url=existing_audio.oss_url,
-                    audio_bid=existing_audio.audio_bid,
-                    duration_ms=existing_audio.duration_ms or 0,
-                    subtitle_cues=_subtitle_cues_from_audio_record(existing_audio),
-                )
+
+        def _yield_existing_single_block_audio(existing_audio: LearnGeneratedAudio):
+            yield _build_audio_complete_message(
+                outline_bid=generated_block.outline_item_bid or "",
+                generated_block_bid=generated_block_bid,
+                audio_url=existing_audio.oss_url,
+                audio_bid=existing_audio.audio_bid,
+                duration_ms=existing_audio.duration_ms or 0,
+                subtitle_cues=_subtitle_cues_from_audio_record(existing_audio),
+            )
+
+        if not listen:
+            existing_audio = _resolve_existing_single_block_audio()
+            if existing_audio:
+                yield from _yield_existing_single_block_audio(existing_audio)
                 return
 
         provider, tts_model, voice_settings, _audio_settings = (
@@ -1217,6 +1225,33 @@ def stream_generated_block_audio(
                 preview_mode=preview_mode,
             )
         )
+
+        def _yield_single_block_audio():
+            cleaned_text = preprocess_for_tts(raw_text)
+            if not cleaned_text or len(cleaned_text.strip()) < 2:
+                raise_error_with_args(
+                    "server.common.paramsError",
+                    param_message="No speakable text available for TTS synthesis",
+                )
+
+            def _generate_single_audio():
+                yield from _yield_run_tts_audio_events(
+                    app=app,
+                    text=raw_text,
+                    provider=provider,
+                    tts_model=tts_model,
+                    voice_settings=voice_settings,
+                    generated_block=generated_block,
+                    user_bid=user_bid,
+                    shifu_bid=shifu_bid,
+                    preview_mode=preview_mode,
+                )
+
+            yield from _yield_with_tts_error_mapping(
+                app,
+                unknown_error_log="TTS streaming synthesis failed",
+                body=_generate_single_audio,
+            )
 
         if listen:
             from flaskr.service.learn.listen_element_history import (
@@ -1233,6 +1268,13 @@ def stream_generated_block_audio(
                 str(element.content_text or "") for element in speakable_elements
             ]
             if not speakable_segments:
+                if preview_mode:
+                    existing_audio = _resolve_existing_single_block_audio()
+                    if existing_audio:
+                        yield from _yield_existing_single_block_audio(existing_audio)
+                        return
+                    yield from _yield_single_block_audio()
+                    return
                 raise_error_with_args(
                     "server.common.paramsError",
                     param_message="No speakable text elements available for TTS synthesis",
@@ -1340,31 +1382,7 @@ def stream_generated_block_audio(
 
             return
 
-        cleaned_text = preprocess_for_tts(raw_text)
-        if not cleaned_text or len(cleaned_text.strip()) < 2:
-            raise_error_with_args(
-                "server.common.paramsError",
-                param_message="No speakable text available for TTS synthesis",
-            )
-
-        def _generate_single_audio():
-            yield from _yield_run_tts_audio_events(
-                app=app,
-                text=raw_text,
-                provider=provider,
-                tts_model=tts_model,
-                voice_settings=voice_settings,
-                generated_block=generated_block,
-                user_bid=user_bid,
-                shifu_bid=shifu_bid,
-                preview_mode=preview_mode,
-            )
-
-        yield from _yield_with_tts_error_mapping(
-            app,
-            unknown_error_log="TTS streaming synthesis failed",
-            body=_generate_single_audio,
-        )
+        yield from _yield_single_block_audio()
 
 
 def stream_preview_tts_audio(

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1272,8 +1272,16 @@ def stream_generated_block_audio(
                     existing_audio = _resolve_existing_single_block_audio()
                     if existing_audio:
                         yield from _yield_existing_single_block_audio(existing_audio)
+                        yield _build_tts_done_message(
+                            outline_bid=generated_block.outline_item_bid or "",
+                            generated_block_bid=generated_block_bid,
+                        )
                         return
                     yield from _yield_single_block_audio()
+                    yield _build_tts_done_message(
+                        outline_bid=generated_block.outline_item_bid or "",
+                        generated_block_bid=generated_block_bid,
+                    )
                     return
                 raise_error_with_args(
                     "server.common.paramsError",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1253,6 +1253,97 @@ def stream_generated_block_audio(
                 body=_generate_single_audio,
             )
 
+        def _yield_preview_single_block_audio():
+            cleaned_text = preprocess_for_tts(raw_text)
+            if not cleaned_text or len(cleaned_text.strip()) < 2:
+                raise_error_with_args(
+                    "server.common.paramsError",
+                    param_message="No speakable text available for TTS synthesis",
+                )
+
+            audio_bid = uuid.uuid4().hex
+            usage_context = _build_tts_usage_context(
+                user_bid=user_bid,
+                shifu_bid=shifu_bid,
+                audio_bid=audio_bid,
+                usage_scene=BILL_USAGE_SCENE_PREVIEW,
+                outline_item_bid=generated_block.outline_item_bid,
+                progress_record_bid=generated_block.progress_record_bid,
+                generated_block_bid=generated_block.generated_block_bid,
+            )
+            parent_usage_bid = generate_id(app)
+            usage_metadata = _build_tts_usage_metadata(
+                voice_settings=voice_settings,
+                audio_settings=_audio_settings,
+            )
+            stats = {"segment_count": 0, "total_word_count": 0}
+            audio_parts: list[bytes] = []
+            subtitle_cues: list[dict] = []
+
+            def _generate_preview_audio():
+                yield from _yield_stream_tts_audio_segments(
+                    app=app,
+                    text=raw_text,
+                    provider=provider,
+                    tts_model=tts_model,
+                    voice_settings=voice_settings,
+                    audio_settings=_audio_settings,
+                    usage_context=usage_context,
+                    parent_usage_bid=parent_usage_bid,
+                    usage_metadata=usage_metadata,
+                    outline_bid=generated_block.outline_item_bid or "",
+                    generated_block_bid=generated_block.generated_block_bid or "",
+                    audio_parts=audio_parts,
+                    subtitle_cues=subtitle_cues,
+                    stats=stats,
+                )
+                segment_count = int(stats.get("segment_count", 0))
+                total_word_count = int(stats.get("total_word_count", 0))
+                total_output_chars = int(stats.get("total_output_chars", 0))
+
+                oss_url, duration_ms = _finalize_tts_stream_audio(
+                    app,
+                    audio_parts=audio_parts,
+                    subtitle_cues=subtitle_cues,
+                    audio_bid=audio_bid,
+                    audio_settings=_audio_settings,
+                    voice_settings=voice_settings,
+                    tts_model=tts_model,
+                    cleaned_text=cleaned_text,
+                    segment_count=segment_count,
+                    persist_audio=False,
+                )
+
+                _record_stream_summary_usage(
+                    app,
+                    usage_context,
+                    usage_bid=parent_usage_bid,
+                    provider=provider,
+                    tts_model=tts_model,
+                    raw_text=raw_text,
+                    cleaned_text=cleaned_text,
+                    total_word_count=total_word_count,
+                    total_output_chars=total_output_chars,
+                    duration_ms=int(duration_ms or 0),
+                    segment_count=segment_count,
+                    usage_metadata=usage_metadata,
+                )
+
+                yield _build_audio_complete_message(
+                    outline_bid=generated_block.outline_item_bid or "",
+                    generated_block_bid=generated_block.generated_block_bid or "",
+                    audio_url=oss_url,
+                    audio_bid=audio_bid,
+                    duration_ms=int(duration_ms or 0),
+                    subtitle_cues=subtitle_cues,
+                )
+
+            yield from _yield_with_tts_error_mapping(
+                app,
+                unknown_error_log="Preview listen fallback TTS synthesis failed",
+                body=_generate_preview_audio,
+            )
+
         if listen:
             from flaskr.service.learn.listen_element_history import (
                 get_final_elements_for_generated_block,
@@ -1277,7 +1368,7 @@ def stream_generated_block_audio(
                             generated_block_bid=generated_block_bid,
                         )
                         return
-                    yield from _yield_single_block_audio()
+                    yield from _yield_preview_single_block_audio()
                     yield _build_tts_done_message(
                         outline_bid=generated_block.outline_item_bid or "",
                         generated_block_bid=generated_block_bid,

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -562,7 +562,7 @@ class TestGeneratedBlockListenTtsElementFirst:
         assert audio_complete_events[0].content.subtitle_cues[0].text == (
             generated_content
         )
-        assert events[-1].type == GeneratedType.AUDIO_COMPLETE
+        assert events[-1].type == GeneratedType.DONE
 
     def test_stream_generated_block_audio_preview_listen_reuses_cached_block_audio(
         self, monkeypatch
@@ -659,7 +659,7 @@ class TestGeneratedBlockListenTtsElementFirst:
         assert audio_complete_events[0].content.subtitle_cues[0].text == (
             generated_content
         )
-        assert events[-1].type == GeneratedType.AUDIO_COMPLETE
+        assert events[-1].type == GeneratedType.DONE
 
     def test_stream_generated_block_audio_listen_preserves_position_after_short_text(
         self, monkeypatch

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -503,6 +503,164 @@ class TestGeneratedBlockListenTtsElementFirst:
             assert records[0].subtitle_cues[0]["text"] == "First."
             assert records[1].subtitle_cues[0]["text"] == "Second."
 
+    def test_stream_generated_block_audio_preview_listen_falls_back_to_block_tts_without_final_elements(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "user-preview-listen-fallback-1"
+        shifu_bid = "shifu-preview-listen-fallback-1"
+        generated_block_bid = "gen-preview-listen-fallback-1"
+        generated_content = "Preview listen fallback content."
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-preview-listen-fallback-1",
+                    user_bid=user_bid,
+                    block_bid="block-preview-listen-fallback-1",
+                    outline_item_bid="outline-preview-listen-fallback-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content=generated_content,
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=True,
+                listen=True,
+            )
+        )
+
+        audio_complete_events = [
+            event for event in events if event.type == GeneratedType.AUDIO_COMPLETE
+        ]
+
+        assert synthesized_texts == [generated_content]
+        assert len(audio_complete_events) == 1
+        assert audio_complete_events[0].content.audio_url.endswith(".mp3")
+        assert audio_complete_events[0].content.subtitle_cues[0].text == (
+            generated_content
+        )
+        assert events[-1].type == GeneratedType.AUDIO_COMPLETE
+
+    def test_stream_generated_block_audio_preview_listen_reuses_cached_block_audio(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+        from flaskr.service.tts.models import AUDIO_STATUS_COMPLETED
+
+        user_bid = "user-preview-listen-cache-1"
+        shifu_bid = "shifu-preview-listen-cache-1"
+        generated_block_bid = "gen-preview-listen-cache-1"
+        generated_content = "Preview listen cached content."
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-preview-listen-cache-1",
+                    user_bid=user_bid,
+                    block_bid="block-preview-listen-cache-1",
+                    outline_item_bid="outline-preview-listen-cache-1",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content=generated_content,
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.add(
+                self.LearnGeneratedAudio(
+                    audio_bid="audio-preview-listen-cache-1",
+                    generated_block_bid=generated_block_bid,
+                    position=0,
+                    progress_record_bid="progress-preview-listen-cache-1",
+                    user_bid=user_bid,
+                    shifu_bid=shifu_bid,
+                    oss_url="https://example.com/preview-listen-cache.mp3",
+                    oss_bucket="test-bucket",
+                    oss_object_key="tts-audio/preview-listen-cache.mp3",
+                    duration_ms=1000,
+                    file_size=10,
+                    audio_format="mp3",
+                    sample_rate=24000,
+                    voice_id="voice",
+                    voice_settings={},
+                    model="test-model",
+                    text_length=len(generated_content),
+                    segment_count=1,
+                    subtitle_cues=[
+                        {
+                            "text": generated_content,
+                            "start_ms": 0,
+                            "end_ms": 1000,
+                            "segment_index": 0,
+                            "position": 0,
+                        }
+                    ],
+                    status=AUDIO_STATUS_COMPLETED,
+                    deleted=0,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=True,
+                listen=True,
+            )
+        )
+
+        audio_complete_events = [
+            event for event in events if event.type == GeneratedType.AUDIO_COMPLETE
+        ]
+
+        assert synthesized_texts == []
+        assert len(audio_complete_events) == 1
+        assert audio_complete_events[0].content.audio_url == (
+            "https://example.com/preview-listen-cache.mp3"
+        )
+        assert audio_complete_events[0].content.subtitle_cues[0].text == (
+            generated_content
+        )
+        assert events[-1].type == GeneratedType.AUDIO_COMPLETE
+
     def test_stream_generated_block_audio_listen_preserves_position_after_short_text(
         self, monkeypatch
     ):

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
@@ -20,6 +21,21 @@ if not hasattr(dao, "redis_client"):
     dao.redis_client = None
 
 
+@dataclass
+class _FakeVoiceSettings:
+    voice_id: str = "voice"
+    speed: float = 1.0
+    pitch: int = 0
+    emotion: str = ""
+    volume: float = 1.0
+
+
+@dataclass
+class _FakeAudioSettings:
+    format: str = "mp3"
+    sample_rate: int = 24000
+
+
 def _patch_run_tts_processor(monkeypatch):
     synthesized_texts = []
 
@@ -28,22 +44,16 @@ def _patch_run_tts_processor(monkeypatch):
         lambda *_args, **_kwargs: (
             "minimax",
             "test-model",
-            type(
-                "Voice",
-                (),
-                {
-                    "voice_id": "voice",
-                    "speed": 1.0,
-                    "pitch": 0,
-                    "emotion": "",
-                    "volume": 1.0,
-                },
-            )(),
-            type("Audio", (), {"format": "mp3", "sample_rate": 24000})(),
+            _FakeVoiceSettings(),
+            _FakeAudioSettings(),
         ),
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.is_tts_configured",
+        lambda _provider: True,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.is_tts_configured",
         lambda _provider: True,
     )
     monkeypatch.setattr(
@@ -64,7 +74,15 @@ def _patch_run_tts_processor(monkeypatch):
         _fake_synthesize_text,
     )
     monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.synthesize_text",
+        _fake_synthesize_text,
+    )
+    monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
+        lambda parts: b"".join(parts),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.concat_audio_best_effort",
         lambda parts: b"".join(parts),
     )
     monkeypatch.setattr(
@@ -72,7 +90,18 @@ def _patch_run_tts_processor(monkeypatch):
         lambda *_args, **_kwargs: 1000,
     )
     monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.get_audio_duration_ms",
+        lambda *_args, **_kwargs: 1000,
+    )
+    monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
+        lambda _app, _audio_bytes, audio_bid: (
+            f"https://example.com/{audio_bid}.mp3",
+            "test-bucket",
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.upload_audio_to_oss",
         lambda _app, _audio_bytes, audio_bid: (
             f"https://example.com/{audio_bid}.mp3",
             "test-bucket",
@@ -85,6 +114,10 @@ def _patch_run_tts_processor(monkeypatch):
     monkeypatch.setattr(
         "flaskr.service.tts.tts_usage_recorder.record_tts_aggregated_usage",
         lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.record_tts_usage",
+        lambda *_args, **_kwargs: None,
     )
 
     return synthesized_texts
@@ -563,6 +596,19 @@ class TestGeneratedBlockListenTtsElementFirst:
             generated_content
         )
         assert events[-1].type == GeneratedType.DONE
+
+        with self.app.app_context():
+            records = (
+                self.LearnGeneratedAudio.query.filter(
+                    self.LearnGeneratedAudio.generated_block_bid == generated_block_bid,
+                    self.LearnGeneratedAudio.user_bid == user_bid,
+                    self.LearnGeneratedAudio.shifu_bid == shifu_bid,
+                    self.LearnGeneratedAudio.deleted == 0,
+                )
+                .order_by(self.LearnGeneratedAudio.position.asc())
+                .all()
+            )
+            assert records == []
 
     def test_stream_generated_block_audio_preview_listen_reuses_cached_block_audio(
         self, monkeypatch

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -653,10 +653,6 @@ export const NewChatComponents = ({
       return;
     }
 
-    if (previewMode) {
-      return;
-    }
-
     const contentItems = items.filter(isContentItemWithElementBid);
 
     if (!contentItems.length) {
@@ -857,7 +853,7 @@ export const NewChatComponents = ({
   }, [lessonId]);
 
   const autoPlayTargetBlockBid = useMemo(() => {
-    if (!autoPlayAudio || previewMode) {
+    if (!autoPlayAudio) {
       return null;
     }
 
@@ -887,7 +883,7 @@ export const NewChatComponents = ({
     }
 
     return null;
-  }, [autoPlayAudio, currentPlayingBlockBid, items, previewMode]);
+  }, [autoPlayAudio, currentPlayingBlockBid, items]);
 
   const mobileInteractionPrimaryTrack = useMemo(
     () =>

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -369,6 +369,56 @@ describe('useChatLogicHook stream cleanup', () => {
     );
   });
 
+  it('allows preview listen mode to request generated-block audio backfill', async () => {
+    mockGetLessonStudyRecord.mockResolvedValueOnce({
+      mdflow: '',
+      elements: [
+        {
+          element_type: 'content',
+          content: 'Preview history content without audio',
+          generated_block_bid: 'preview-content-1',
+          element_bid: 'preview-content-1',
+          like_status: 'none',
+          user_input: '',
+        },
+      ],
+      slides: [],
+      records: [],
+    });
+    mockStreamGeneratedBlockAudio.mockReturnValue({
+      close: jest.fn(),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useChatLogicHook({
+          ...buildBaseParams(),
+          previewMode: true,
+          listenRequestEnabled: true,
+        }),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      void result.current.requestAudioForBlock('preview-content-1', {
+        listen: true,
+      });
+      await Promise.resolve();
+    });
+
+    expect(mockStreamGeneratedBlockAudio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generated_block_bid: 'preview-content-1',
+        preview_mode: true,
+        listen: true,
+      }),
+    );
+  });
+
   it('uses generated_block_bid for audio backfill and writes audio to speakable elements by history order', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -452,7 +452,9 @@ function useChatLogicHook({
     [lessonRunContentCacheKey],
   );
 
-  const allowTtsStreaming = !effectivePreviewMode;
+  // Learner preview uses the same generated-block TTS contract as live courses.
+  // Keep preview-specific request params, but do not disable audio streaming.
+  const allowTtsStreaming = true;
 
   const resolveElementItemBid = useCallback(
     (

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type Reveal from 'reveal.js';
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
 import {
@@ -60,6 +60,62 @@ describe('useListenContentData', () => {
 });
 
 describe('useListenAudioSequence', () => {
+  it('starts the listen audio sequence in preview mode when playback is requested', async () => {
+    let currentPage = 0;
+    const slide = jest.fn((page: number) => {
+      currentPage = page;
+    });
+    const deckRef = {
+      current: {
+        getIndices: () => ({ h: currentPage }),
+        slide,
+      } as unknown as Reveal.Api,
+    };
+    const currentPptPageRef = { current: 0 };
+    const activeElementBidRef = { current: null };
+    const pendingAutoNextRef = { current: false };
+    const shouldStartSequenceRef = { current: false };
+    const content = createContentItem();
+    const contentByBid = new Map<string, ChatContentItem>([
+      ['content-1', content],
+    ]);
+    const audioContentByBid = new Map<string, ChatContentItem>([
+      ['content-1', content],
+    ]);
+    const setIsAudioPlaying = jest.fn();
+
+    const { result } = renderHook(() =>
+      useListenAudioSequence({
+        audioAndInteractionList: [createAudioItem({ page: 0 })],
+        deckRef,
+        currentPptPageRef,
+        activeElementBidRef,
+        pendingAutoNextRef,
+        shouldStartSequenceRef,
+        sequenceStartSignal: 0,
+        contentByBid,
+        audioContentByBid,
+        shouldRenderEmptyPpt: false,
+        getNextContentBid: () => null,
+        goToBlock: () => false,
+        resolveContentBid: resolveListenAudioSourceBid,
+        allowAutoPlayback: true,
+        isAudioPlaying: false,
+        setIsAudioPlaying,
+      }),
+    );
+
+    act(() => {
+      result.current.handlePlay();
+    });
+
+    await waitFor(() =>
+      expect(result.current.activeSequenceElementBid).toBe(
+        buildListenAudioSequenceBid('content-1', 0),
+      ),
+    );
+  });
+
   it('resyncs the active slide when a buffering item receives its final page', async () => {
     let currentPage = 0;
     const slide = jest.fn((page: number) => {
@@ -101,7 +157,6 @@ describe('useListenAudioSequence', () => {
           sequenceStartSignal,
           contentByBid,
           audioContentByBid,
-          previewMode: false,
           shouldRenderEmptyPpt: false,
           getNextContentBid: () => null,
           goToBlock: () => false,
@@ -176,7 +231,6 @@ describe('useListenAudioSequence', () => {
           sequenceStartSignal,
           contentByBid,
           audioContentByBid,
-          previewMode: false,
           shouldRenderEmptyPpt: false,
           getNextContentBid: () => null,
           goToBlock: () => false,
@@ -266,7 +320,6 @@ describe('useListenAudioSequence', () => {
           sequenceStartSignal,
           contentByBid,
           audioContentByBid,
-          previewMode: false,
           shouldRenderEmptyPpt: false,
           getNextContentBid: () => null,
           goToBlock: () => false,

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
@@ -734,7 +734,6 @@ interface UseListenAudioSequenceParams {
   sequenceStartSignal: number;
   contentByBid: Map<string, ChatContentItem>;
   audioContentByBid: Map<string, ChatContentItem>;
-  previewMode: boolean;
   shouldRenderEmptyPpt: boolean;
   getNextContentBid: (currentBid: string | null) => string | null;
   goToBlock: (blockBid: string) => boolean;
@@ -754,7 +753,6 @@ export const useListenAudioSequence = ({
   sequenceStartSignal,
   contentByBid,
   audioContentByBid,
-  previewMode,
   shouldRenderEmptyPpt,
   getNextContentBid,
   goToBlock,
@@ -962,7 +960,7 @@ export const useListenAudioSequence = ({
     const prevLength = prevAudioSequenceLengthRef.current;
     const nextLength = audioAndInteractionList.length;
     prevAudioSequenceLengthRef.current = nextLength;
-    if (previewMode || !nextLength) {
+    if (!nextLength) {
       return;
     }
     if (!allowAutoPlayback) {
@@ -1095,7 +1093,6 @@ export const useListenAudioSequence = ({
   }, [
     audioAndInteractionList,
     playAudioSequenceFromIndex,
-    previewMode,
     allowAutoPlayback,
     sequenceInteraction,
     deckRef,
@@ -1108,7 +1105,7 @@ export const useListenAudioSequence = ({
   ]);
 
   useEffect(() => {
-    if (previewMode || !allowAutoPlayback || !activeAudioBid) {
+    if (!allowAutoPlayback || !activeAudioBid) {
       return;
     }
     if (isSequencePausedRef.current) {
@@ -1143,7 +1140,6 @@ export const useListenAudioSequence = ({
     activeAudioBid,
     audioAndInteractionList,
     allowAutoPlayback,
-    previewMode,
     syncToSequencePage,
   ]);
 
@@ -1343,9 +1339,6 @@ export const useListenAudioSequence = ({
   }, [playAudioSequenceFromIndex, tryAdvanceToNextBlock]);
 
   const handlePlay = useCallback(() => {
-    if (previewMode) {
-      return;
-    }
     isSequencePausedRef.current = false;
     if (!activeAudioBid && audioSequenceListRef.current.length) {
       const currentPage =
@@ -1355,7 +1348,6 @@ export const useListenAudioSequence = ({
     }
     audioPlayerRef.current?.play();
   }, [
-    previewMode,
     activeAudioBid,
     startSequenceFromPage,
     deckRef,
@@ -1364,14 +1356,11 @@ export const useListenAudioSequence = ({
 
   const handlePause = useCallback(
     (traceId?: string) => {
-      if (previewMode) {
-        return;
-      }
       isSequencePausedRef.current = true;
       clearAudioSequenceTimer();
       audioPlayerRef.current?.pause({ traceId });
     },
-    [previewMode, clearAudioSequenceTimer],
+    [clearAudioSequenceTimer],
   );
 
   useEffect(() => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useListenMode.ts
@@ -1347,12 +1347,7 @@ export const useListenAudioSequence = ({
       return;
     }
     audioPlayerRef.current?.play();
-  }, [
-    activeAudioBid,
-    startSequenceFromPage,
-    deckRef,
-    currentPptPageRef,
-  ]);
+  }, [activeAudioBid, startSequenceFromPage, deckRef, currentPptPageRef]);
 
   const handlePause = useCallback(
     (traceId?: string) => {


### PR DESCRIPTION
## Summary
- allow learner preview listen mode to request generated-block TTS, history backfill, and autoplay like the published learner flow
- add a preview listen backend fallback that synthesizes block-level audio when preview runs have no persisted final elements
- reuse cached block audio for preview listen fallback and cover the preview flow with focused frontend and backend tests

## Testing
- cd src/cook-web && npm test -- --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx src/app/c/[[...id]]/Components/ChatUi/useListenMode.test.tsx
- cd src/cook-web && npm run type-check
- cd src/api && pytest -q tests/service/learn/test_generated_block_tts_av_mode.py -k "preview_listen_falls_back or preview_listen_reuses_cached_block_audio or listen_uses_text_elements_only or non_listen_uses_run_tts_processor"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Preview mode now supports audio playback and generation with automatic caching for improved performance.

* **Bug Fixes**
  * Audio backfill now functions correctly during preview mode.
  * Enhanced listen mode audio sequencing for better playback control.

* **Tests**
  * Added comprehensive test coverage for preview listen functionality and audio caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->