### PR TITLE
fix: clarify classroom mode tooltip access

### DIFF
--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -9,7 +9,7 @@
   "generating": "Generating diagram...",
   "learningModeClassroom": "Classroom",
   "learningModeClassroomShort": "Classroom",
-  "learningModeClassroomTooltip": "Present slides and interactions on a shared screen",
+  "learningModeClassroomTooltip": "Present slides and interactions on a shared screen (teacher only)",
   "learningModeListen": "Listen",
   "learningModeListenShort": "Listen",
   "learningModeListenTooltip": "Automatically play narration and slides, learning as you listen",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -9,7 +9,7 @@
   "generating": "Génération du diagramme...",
   "learningModeClassroom": "Classe",
   "learningModeClassroomShort": "Classe",
-  "learningModeClassroomTooltip": "Présenter les diapositives et les interactions sur un écran partagé",
+  "learningModeClassroomTooltip": "Présenter les diapositives et les interactions sur un écran partagé (enseignant uniquement)",
   "learningModeListen": "Écouter",
   "learningModeListenShort": "Écouter",
   "learningModeListenTooltip": "Lancer automatiquement la narration et les diapositives pour apprendre en écoutant",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -9,7 +9,7 @@
   "generating": "插图生成中...",
   "learningModeClassroom": "课堂模式",
   "learningModeClassroomShort": "课堂",
-  "learningModeClassroomTooltip": "投屏展示幻灯片和互动",
+  "learningModeClassroomTooltip": "投屏展示幻灯片和互动（仅限老师）",
   "learningModeListen": "听课",
   "learningModeListenShort": "听",
   "learningModeListenTooltip": "自动播放语音和幻灯片，边听边学",


### PR DESCRIPTION
## Summary
- Shorten classroom mode tooltip copy
- Clarify that classroom mode is limited to teachers across supported locales

## Verification
- pre-commit hooks during commit: JSON, translation parity, translation key usage, locale metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated tooltip text for the screen presentation feature across English, French, and Chinese to clearly indicate it’s available for the teacher only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->