### PR TITLE
refactor: polish credit notification admin flows

### DIFF
--- a/docs/exec-plans/active/billing-credit-notifications.md
+++ b/docs/exec-plans/active/billing-credit-notifications.md
@@ -21,6 +21,8 @@
 - [x] 2026-05-21 17:07 CST: Added teacher-facing balance state and softlimit debug blocking on frontend and backend preview/debug paths.
 - [x] 2026-05-21 17:07 CST: Added focused backend/task/frontend tests and ran validation; architecture boundary check is blocked only by unrelated pre-existing untracked route-support files.
 - [x] 2026-05-22 18:35 CST: Extended low-balance notifications with estimated-days thresholds based on finalized daily ledger consumption, structured operator form fields, dry-run details, and focused tests.
+- [ ] 2026-06-19 21:20 CST: Start the follow-up PR on `refactor/billing-credit-notifications`, focused on records/config request-state cleanup, requeue refresh behavior, and config-side experience polish without changing the notification-center core model.
+- [ ] 2026-06-19 21:36 CST: Defer the next-step `CreditNotificationConfigTab.tsx` split (dry-run, template sync, managed-list dialog state isolation) to a separate follow-up PR so the current branch stays scoped to request-state and records-tab polish.
 
 ## Surprises & Discoveries
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -239,6 +239,7 @@ export function CreditNotificationConfigTab({
   configLoading,
   configError,
   dryRunResult,
+  dryRunError,
   templateSyncResults,
   templateSyncLoading,
   templateOptions,
@@ -257,6 +258,7 @@ export function CreditNotificationConfigTab({
   configLoading: boolean;
   configError: string;
   dryRunResult: AdminOperationCreditNotificationDryRunResponse | null;
+  dryRunError: string;
   templateSyncResults: Partial<
     Record<
       KnownNotificationType,
@@ -997,6 +999,7 @@ export function CreditNotificationConfigTab({
 
         <CreditNotificationDryRunPanel
           dryRunResult={dryRunResult}
+          dryRunError={dryRunError}
           dryRun={dryRun}
         />
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next';
-import ErrorDisplay from '@/components/ErrorDisplay';
 import { Button } from '@/components/ui/Button';
 import type { AdminOperationCreditNotificationDryRunResponse } from '../operation-credit-notification-types';
 import { CreditNotificationConfigSection as ConfigSection } from './CreditNotificationFormPrimitives';
@@ -75,10 +74,12 @@ export function CreditNotificationDryRunPanel({
         </Button>
       </div>
       {dryRunError ? (
-        <ErrorDisplay
-          errorCode={0}
-          errorMessage={dryRunError}
-        />
+        <div
+          role='alert'
+          className='rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive'
+        >
+          {dryRunError}
+        </div>
       ) : null}
       {dryRunResult ? (
         <details className='rounded-md border border-border bg-white p-3 text-xs text-muted-foreground'>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
@@ -1,13 +1,16 @@
 import { useTranslation } from 'react-i18next';
+import ErrorDisplay from '@/components/ErrorDisplay';
 import { Button } from '@/components/ui/Button';
 import type { AdminOperationCreditNotificationDryRunResponse } from '../operation-credit-notification-types';
 import { CreditNotificationConfigSection as ConfigSection } from './CreditNotificationFormPrimitives';
 
 export function CreditNotificationDryRunPanel({
   dryRunResult,
+  dryRunError,
   dryRun,
 }: {
   dryRunResult: AdminOperationCreditNotificationDryRunResponse | null;
+  dryRunError: string;
   dryRun: () => void;
 }) {
   const { t } = useTranslation();
@@ -71,6 +74,12 @@ export function CreditNotificationDryRunPanel({
           {t('module.operationsCreditNotifications.actions.dryRun')}
         </Button>
       </div>
+      {dryRunError ? (
+        <ErrorDisplay
+          errorCode={0}
+          errorMessage={dryRunError}
+        />
+      ) : null}
       {dryRunResult ? (
         <details className='rounded-md border border-border bg-white p-3 text-xs text-muted-foreground'>
           <summary className='cursor-pointer text-foreground'>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationOverviewCards.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationOverviewCards.tsx
@@ -1,0 +1,99 @@
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import type { AdminOperationCreditNotificationOverview } from '../operation-credit-notification-types';
+import type { NotificationOverviewCardKey } from './creditNotificationUtils';
+
+export function CreditNotificationOverviewCards({
+  overview,
+  applyOverviewFilter,
+}: {
+  overview: AdminOperationCreditNotificationOverview;
+  applyOverviewFilter: (cardKey: NotificationOverviewCardKey) => void;
+}) {
+  const { t } = useTranslation();
+  const overviewItems = [
+    {
+      key: 'total' as const,
+      label: t('module.operationsCreditNotifications.overview.total'),
+      value: overview.total,
+      tooltip: t('module.operationsCreditNotifications.overview.totalTooltip'),
+    },
+    {
+      key: 'pending' as const,
+      label: t('module.operationsCreditNotifications.overview.pending'),
+      value: overview.pending,
+      tooltip: t(
+        'module.operationsCreditNotifications.overview.pendingTooltip',
+      ),
+    },
+    {
+      key: 'sent' as const,
+      label: t('module.operationsCreditNotifications.overview.sent'),
+      value: overview.sent,
+      tooltip: t('module.operationsCreditNotifications.overview.sentTooltip'),
+    },
+    {
+      key: 'failed' as const,
+      label: t('module.operationsCreditNotifications.overview.failed'),
+      value: overview.failed,
+      tooltip: t('module.operationsCreditNotifications.overview.failedTooltip'),
+    },
+    {
+      key: 'skipped' as const,
+      label: t('module.operationsCreditNotifications.overview.skipped'),
+      value: overview.skipped,
+      tooltip: t(
+        'module.operationsCreditNotifications.overview.skippedTooltip',
+      ),
+    },
+  ];
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className='grid gap-3 md:grid-cols-3 xl:grid-cols-5'>
+        {overviewItems.map(item => (
+          <div
+            key={item.key}
+            className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
+          >
+            <div className='flex items-start justify-between gap-2'>
+              <button
+                type='button'
+                aria-label={item.label}
+                className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                onClick={() => applyOverviewFilter(item.key)}
+              >
+                <div className='text-sm text-muted-foreground'>
+                  {item.label}
+                </div>
+                <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
+                  {item.value}
+                </div>
+              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type='button'
+                    aria-label={item.tooltip}
+                    className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
+                  >
+                    <QuestionMarkCircleIcon className='h-4 w-4' />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className='max-w-56 text-left leading-5'>
+                  {item.tooltip}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </div>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
@@ -98,6 +98,9 @@ export function CreditNotificationRecordsFilter({
         onValueChange={value => {
           const nextValue = value === ALL_OPTION_VALUE ? '' : value;
           updateDraftFilter('delivery_status', nextValue);
+          if (nextValue !== 'not_sent') {
+            updateDraftFilter('skip_reason', '');
+          }
         }}
       >
         <SelectTrigger className='h-9'>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
@@ -1,0 +1,316 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
+import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import AdminFilter from '@/app/admin/components/AdminFilter';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import {
+  ALL_OPTION_VALUE,
+  type NotificationFilters,
+  type NotificationOverviewCardKey,
+  NOTIFICATION_DELIVERY_STATUSES,
+  NOTIFICATION_SOURCE_TYPES,
+  NOTIFICATION_SKIP_REASONS,
+  NOTIFICATION_TYPES,
+} from './creditNotificationUtils';
+
+const SELECT_ITEM_CLASS = 'pl-3 pr-8';
+const SELECT_ITEM_INDICATOR_CLASS = 'left-auto right-2';
+
+export function CreditNotificationRecordsFilter({
+  draftFilters,
+  updateDraftFilter,
+  searchRecords,
+  resetRecords,
+  activeOverviewCardKey,
+  activeOverviewLabel,
+  clearOverviewFilter,
+  resolveDeliveryStatusLabel,
+  resolveSkipReasonLabel,
+  resolveTypeLabel,
+  resolveSourceTypeLabel,
+}: {
+  draftFilters: NotificationFilters;
+  updateDraftFilter: (field: keyof NotificationFilters, value: string) => void;
+  searchRecords: () => void;
+  resetRecords: () => void;
+  activeOverviewCardKey: NotificationOverviewCardKey | null;
+  activeOverviewLabel: string;
+  clearOverviewFilter: () => void;
+  resolveDeliveryStatusLabel: (value: string) => string;
+  resolveSkipReasonLabel: (value: string) => string;
+  resolveTypeLabel: (value: string) => string;
+  resolveSourceTypeLabel: (value: string) => string;
+}) {
+  const { t } = useTranslation();
+  const [filtersExpanded, setFiltersExpanded] = useState(false);
+  const clearLabel = t('common.core.close');
+
+  const filterItems = useMemo(() => {
+    const renderTypeSelect = () => (
+      <Select
+        value={draftFilters.notification_type || ALL_OPTION_VALUE}
+        onValueChange={value =>
+          updateDraftFilter(
+            'notification_type',
+            value === ALL_OPTION_VALUE ? '' : value,
+          )
+        }
+      >
+        <SelectTrigger className='h-9'>
+          <SelectValue
+            placeholder={t(
+              'module.operationsCreditNotifications.filters.notificationType',
+            )}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value={ALL_OPTION_VALUE}
+            className={SELECT_ITEM_CLASS}
+            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+          >
+            {t('module.operationsCreditNotifications.filters.all')}
+          </SelectItem>
+          {NOTIFICATION_TYPES.map(type => (
+            <SelectItem
+              key={type}
+              value={type}
+              className={SELECT_ITEM_CLASS}
+              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+            >
+              {resolveTypeLabel(type)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+
+    const renderStatusSelect = () => (
+      <Select
+        value={draftFilters.delivery_status || ALL_OPTION_VALUE}
+        onValueChange={value => {
+          const nextValue = value === ALL_OPTION_VALUE ? '' : value;
+          updateDraftFilter('delivery_status', nextValue);
+        }}
+      >
+        <SelectTrigger className='h-9'>
+          <SelectValue
+            placeholder={t(
+              'module.operationsCreditNotifications.filters.status',
+            )}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value={ALL_OPTION_VALUE}
+            className={SELECT_ITEM_CLASS}
+            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+          >
+            {t('module.operationsCreditNotifications.filters.all')}
+          </SelectItem>
+          {NOTIFICATION_DELIVERY_STATUSES.map(status => (
+            <SelectItem
+              key={status}
+              value={status}
+              className={SELECT_ITEM_CLASS}
+              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+            >
+              {resolveDeliveryStatusLabel(status)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+
+    const renderSkipReasonSelect = () => (
+      <Select
+        value={draftFilters.skip_reason || ALL_OPTION_VALUE}
+        onValueChange={value =>
+          updateDraftFilter(
+            'skip_reason',
+            value === ALL_OPTION_VALUE ? '' : value,
+          )
+        }
+      >
+        <SelectTrigger className='h-9'>
+          <SelectValue
+            placeholder={t(
+              'module.operationsCreditNotifications.filters.skipReason',
+            )}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value={ALL_OPTION_VALUE}
+            className={SELECT_ITEM_CLASS}
+            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+          >
+            {t('module.operationsCreditNotifications.filters.all')}
+          </SelectItem>
+          {NOTIFICATION_SKIP_REASONS.map(reason => (
+            <SelectItem
+              key={reason}
+              value={reason}
+              className={SELECT_ITEM_CLASS}
+              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+            >
+              {resolveSkipReasonLabel(reason)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+
+    const renderSourceTypeSelect = () => (
+      <Select
+        value={draftFilters.source_type || ALL_OPTION_VALUE}
+        onValueChange={value =>
+          updateDraftFilter(
+            'source_type',
+            value === ALL_OPTION_VALUE ? '' : value,
+          )
+        }
+      >
+        <SelectTrigger className='h-9'>
+          <SelectValue
+            placeholder={t(
+              'module.operationsCreditNotifications.filters.sourceType',
+            )}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            value={ALL_OPTION_VALUE}
+            className={SELECT_ITEM_CLASS}
+            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+          >
+            {t('module.operationsCreditNotifications.filters.all')}
+          </SelectItem>
+          {NOTIFICATION_SOURCE_TYPES.map(sourceType => (
+            <SelectItem
+              key={sourceType}
+              value={sourceType}
+              className={SELECT_ITEM_CLASS}
+              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
+            >
+              {resolveSourceTypeLabel(sourceType)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+
+    const renderCreatedAtRange = () => (
+      <AdminDateRangeFilter
+        startValue={draftFilters.start_time}
+        endValue={draftFilters.end_time}
+        onChange={range => {
+          updateDraftFilter('start_time', range.start);
+          updateDraftFilter('end_time', range.end);
+        }}
+        placeholder={t(
+          'module.operationsCreditNotifications.filters.timeRangePlaceholder',
+        )}
+        resetLabel={t('module.operationsCreditNotifications.actions.reset')}
+        clearLabel={clearLabel}
+      />
+    );
+
+    const renderCreatorInput = () => (
+      <AdminClearableInput
+        value={draftFilters.creator_keyword}
+        placeholder={t(
+          'module.operationsCreditNotifications.filters.creatorPlaceholder',
+        )}
+        clearLabel={clearLabel}
+        onChange={value => updateDraftFilter('creator_keyword', value)}
+      />
+    );
+
+    return [
+      {
+        key: 'notification_type',
+        label: t(
+          'module.operationsCreditNotifications.filters.notificationType',
+        ),
+        component: renderTypeSelect(),
+      },
+      {
+        key: 'status',
+        label: t('module.operationsCreditNotifications.filters.status'),
+        component: renderStatusSelect(),
+      },
+      ...(draftFilters.delivery_status === 'not_sent'
+        ? [
+            {
+              key: 'skip_reason',
+              label: t(
+                'module.operationsCreditNotifications.filters.skipReason',
+              ),
+              component: renderSkipReasonSelect(),
+            },
+          ]
+        : []),
+      {
+        key: 'creator_keyword',
+        label: t('module.operationsCreditNotifications.filters.creator'),
+        component: renderCreatorInput(),
+      },
+      {
+        key: 'source_type',
+        label: t('module.operationsCreditNotifications.filters.sourceType'),
+        component: renderSourceTypeSelect(),
+      },
+      {
+        key: 'created_at',
+        label: t('module.operationsCreditNotifications.filters.createdTime'),
+        component: renderCreatedAtRange(),
+      },
+    ];
+  }, [
+    clearLabel,
+    draftFilters,
+    resolveDeliveryStatusLabel,
+    resolveSkipReasonLabel,
+    resolveSourceTypeLabel,
+    resolveTypeLabel,
+    t,
+    updateDraftFilter,
+  ]);
+
+  return (
+    <AdminFilter
+      items={filterItems}
+      expanded={filtersExpanded}
+      onExpandedChange={setFiltersExpanded}
+      onReset={resetRecords}
+      onSearch={searchRecords}
+      resetLabel={t('module.operationsCreditNotifications.actions.reset')}
+      searchLabel={t('module.operationsCreditNotifications.actions.search')}
+      expandLabel={t('common.core.expand')}
+      collapseLabel={t('common.core.collapse')}
+      collapsedCount={3}
+      surface='card'
+      layoutPreset='operations'
+      activeFilter={
+        activeOverviewCardKey
+          ? {
+              label: t(
+                'module.operationsCreditNotifications.overview.activeFilter',
+              ),
+              value: activeOverviewLabel,
+              clearAriaLabel: `${activeOverviewLabel} ${clearLabel}`,
+              onClear: clearOverviewFilter,
+            }
+          : null
+      }
+    />
+  );
+}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
-import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
-import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
@@ -17,13 +13,6 @@ import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableCol
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/Select';
-import {
   Table,
   TableBody,
   TableCell,
@@ -31,31 +20,22 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import type {
   AdminOperationCreditNotificationItem,
   AdminOperationCreditNotificationOverview,
 } from '../operation-credit-notification-types';
 import {
-  ALL_OPTION_VALUE,
   EMPTY_LABEL,
   type ErrorState,
   type NotificationFilters,
   type NotificationOverviewCardKey,
-  NOTIFICATION_DELIVERY_STATUSES,
-  NOTIFICATION_SOURCE_TYPES,
-  NOTIFICATION_SKIP_REASONS,
-  NOTIFICATION_TYPES,
   resolveCreditNotificationErrorText,
   resolveNotificationDeliveryStatus,
   resolveNotificationSkipReason,
 } from './creditNotificationUtils';
 import { CreditNotificationDetailSheet } from './CreditNotificationDetailSheet';
+import { CreditNotificationOverviewCards } from './CreditNotificationOverviewCards';
+import { CreditNotificationRecordsFilter } from './CreditNotificationRecordsFilter';
 
 const COLUMN_MIN_WIDTH = 90;
 const COLUMN_MAX_WIDTH = 460;
@@ -74,8 +54,6 @@ const TABLE_CELL_CLASS =
   'border-r border-border px-3 py-2 align-middle last:border-r-0';
 const TABLE_TEXT_CELL_CLASS =
   'overflow-hidden whitespace-nowrap border-r border-border px-3 py-2 text-center text-ellipsis last:border-r-0';
-const SELECT_ITEM_CLASS = 'pl-3 pr-8';
-const SELECT_ITEM_INDICATOR_CLASS = 'left-auto right-2';
 const TABLE_INLINE_ACTION_BUTTON_CLASS =
   'inline-flex h-8 items-center justify-center rounded-md px-2.5 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2';
 
@@ -155,178 +133,26 @@ export function CreditNotificationRecordsTab({
     [getResizeHandleProps],
   );
 
-  const [filtersExpanded, setFiltersExpanded] = React.useState(false);
   const [detailNotificationBid, setDetailNotificationBid] = React.useState('');
-  const clearLabel = t('common.core.close');
-
-  const overviewItems = React.useMemo(
-    () => [
-      {
-        key: 'total',
-        label: t('module.operationsCreditNotifications.overview.total'),
-        value: overview.total,
-        tooltip: t(
-          'module.operationsCreditNotifications.overview.totalTooltip',
-        ),
-        onClick: () => applyOverviewFilter('total'),
-      },
-      {
-        key: 'pending',
-        label: t('module.operationsCreditNotifications.overview.pending'),
-        value: overview.pending,
-        tooltip: t(
-          'module.operationsCreditNotifications.overview.pendingTooltip',
-        ),
-        onClick: () => applyOverviewFilter('pending'),
-      },
-      {
-        key: 'sent',
-        label: t('module.operationsCreditNotifications.overview.sent'),
-        value: overview.sent,
-        tooltip: t('module.operationsCreditNotifications.overview.sentTooltip'),
-        onClick: () => applyOverviewFilter('sent'),
-      },
-      {
-        key: 'failed',
-        label: t('module.operationsCreditNotifications.overview.failed'),
-        value: overview.failed,
-        tooltip: t(
-          'module.operationsCreditNotifications.overview.failedTooltip',
-        ),
-        onClick: () => applyOverviewFilter('failed'),
-      },
-      {
-        key: 'skipped',
-        label: t('module.operationsCreditNotifications.overview.skipped'),
-        value: overview.skipped,
-        tooltip: t(
-          'module.operationsCreditNotifications.overview.skippedTooltip',
-        ),
-        onClick: () => applyOverviewFilter('skipped'),
-      },
-    ],
-    [applyOverviewFilter, overview, t],
-  );
 
   const activeOverviewItem = React.useMemo(
     () =>
       activeOverviewCardKey
-        ? overviewItems.find(item => item.key === activeOverviewCardKey) || null
+        ? (
+            {
+              total: t('module.operationsCreditNotifications.overview.total'),
+              pending: t(
+                'module.operationsCreditNotifications.overview.pending',
+              ),
+              sent: t('module.operationsCreditNotifications.overview.sent'),
+              failed: t('module.operationsCreditNotifications.overview.failed'),
+              skipped: t(
+                'module.operationsCreditNotifications.overview.skipped',
+              ),
+            } as Record<NotificationOverviewCardKey, string>
+          )[activeOverviewCardKey] || ''
         : null,
-    [activeOverviewCardKey, overviewItems],
-  );
-
-  const renderTypeSelect = () => (
-    <Select
-      value={draftFilters.notification_type || ALL_OPTION_VALUE}
-      onValueChange={value =>
-        updateDraftFilter(
-          'notification_type',
-          value === ALL_OPTION_VALUE ? '' : value,
-        )
-      }
-    >
-      <SelectTrigger className='h-9'>
-        <SelectValue
-          placeholder={t(
-            'module.operationsCreditNotifications.filters.notificationType',
-          )}
-        />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem
-          value={ALL_OPTION_VALUE}
-          className={SELECT_ITEM_CLASS}
-          indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-        >
-          {t('module.operationsCreditNotifications.filters.all')}
-        </SelectItem>
-        {NOTIFICATION_TYPES.map(type => (
-          <SelectItem
-            key={type}
-            value={type}
-            className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-          >
-            {resolveTypeLabel(type)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-
-  const renderStatusSelect = () => (
-    <Select
-      value={draftFilters.delivery_status || ALL_OPTION_VALUE}
-      onValueChange={value => {
-        const nextValue = value === ALL_OPTION_VALUE ? '' : value;
-        updateDraftFilter('delivery_status', nextValue);
-      }}
-    >
-      <SelectTrigger className='h-9'>
-        <SelectValue
-          placeholder={t('module.operationsCreditNotifications.filters.status')}
-        />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem
-          value={ALL_OPTION_VALUE}
-          className={SELECT_ITEM_CLASS}
-          indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-        >
-          {t('module.operationsCreditNotifications.filters.all')}
-        </SelectItem>
-        {NOTIFICATION_DELIVERY_STATUSES.map(status => (
-          <SelectItem
-            key={status}
-            value={status}
-            className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-          >
-            {resolveDeliveryStatusLabel(status)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-
-  const renderSkipReasonSelect = () => (
-    <Select
-      value={draftFilters.skip_reason || ALL_OPTION_VALUE}
-      onValueChange={value =>
-        updateDraftFilter(
-          'skip_reason',
-          value === ALL_OPTION_VALUE ? '' : value,
-        )
-      }
-    >
-      <SelectTrigger className='h-9'>
-        <SelectValue
-          placeholder={t(
-            'module.operationsCreditNotifications.filters.skipReason',
-          )}
-        />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem
-          value={ALL_OPTION_VALUE}
-          className={SELECT_ITEM_CLASS}
-          indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-        >
-          {t('module.operationsCreditNotifications.filters.all')}
-        </SelectItem>
-        {NOTIFICATION_SKIP_REASONS.map(reason => (
-          <SelectItem
-            key={reason}
-            value={reason}
-            className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-          >
-            {resolveSkipReasonLabel(reason)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    [activeOverviewCardKey, t],
   );
 
   const resolveSourceTypeLabel = (value: string) =>
@@ -334,109 +160,6 @@ export function CreditNotificationRecordsTab({
       `module.operationsCreditNotifications.sourceType.${value}`,
       value || EMPTY_LABEL,
     );
-
-  const renderSourceTypeSelect = () => (
-    <Select
-      value={draftFilters.source_type || ALL_OPTION_VALUE}
-      onValueChange={value =>
-        updateDraftFilter(
-          'source_type',
-          value === ALL_OPTION_VALUE ? '' : value,
-        )
-      }
-    >
-      <SelectTrigger className='h-9'>
-        <SelectValue
-          placeholder={t(
-            'module.operationsCreditNotifications.filters.sourceType',
-          )}
-        />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem
-          value={ALL_OPTION_VALUE}
-          className={SELECT_ITEM_CLASS}
-          indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-        >
-          {t('module.operationsCreditNotifications.filters.all')}
-        </SelectItem>
-        {NOTIFICATION_SOURCE_TYPES.map(sourceType => (
-          <SelectItem
-            key={sourceType}
-            value={sourceType}
-            className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
-          >
-            {resolveSourceTypeLabel(sourceType)}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-
-  const renderCreatedAtRange = () => (
-    <AdminDateRangeFilter
-      startValue={draftFilters.start_time}
-      endValue={draftFilters.end_time}
-      onChange={range => {
-        updateDraftFilter('start_time', range.start);
-        updateDraftFilter('end_time', range.end);
-      }}
-      placeholder={t(
-        'module.operationsCreditNotifications.filters.timeRangePlaceholder',
-      )}
-      resetLabel={t('module.operationsCreditNotifications.actions.reset')}
-      clearLabel={clearLabel}
-    />
-  );
-
-  const renderCreatorInput = () => (
-    <AdminClearableInput
-      value={draftFilters.creator_keyword}
-      placeholder={t(
-        'module.operationsCreditNotifications.filters.creatorPlaceholder',
-      )}
-      clearLabel={clearLabel}
-      onChange={value => updateDraftFilter('creator_keyword', value)}
-    />
-  );
-
-  const filterItems = [
-    {
-      key: 'notification_type',
-      label: t('module.operationsCreditNotifications.filters.notificationType'),
-      component: renderTypeSelect(),
-    },
-    {
-      key: 'status',
-      label: t('module.operationsCreditNotifications.filters.status'),
-      component: renderStatusSelect(),
-    },
-    ...(draftFilters.delivery_status === 'not_sent'
-      ? [
-          {
-            key: 'skip_reason',
-            label: t('module.operationsCreditNotifications.filters.skipReason'),
-            component: renderSkipReasonSelect(),
-          },
-        ]
-      : []),
-    {
-      key: 'creator_keyword',
-      label: t('module.operationsCreditNotifications.filters.creator'),
-      component: renderCreatorInput(),
-    },
-    {
-      key: 'source_type',
-      label: t('module.operationsCreditNotifications.filters.sourceType'),
-      component: renderSourceTypeSelect(),
-    },
-    {
-      key: 'created_at',
-      label: t('module.operationsCreditNotifications.filters.createdTime'),
-      component: renderCreatedAtRange(),
-    },
-  ];
 
   const resolveReasonDisplay = React.useCallback(
     (item: AdminOperationCreditNotificationItem) => {
@@ -456,72 +179,23 @@ export function CreditNotificationRecordsTab({
 
   return (
     <div className='flex min-h-0 flex-col gap-4'>
-      <TooltipProvider delayDuration={150}>
-        <div className='grid gap-3 md:grid-cols-3 xl:grid-cols-5'>
-          {overviewItems.map(item => (
-            <div
-              key={item.key}
-              className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
-            >
-              <div className='flex items-start justify-between gap-2'>
-                <button
-                  type='button'
-                  aria-label={item.label}
-                  className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                  onClick={item.onClick}
-                >
-                  <div className='text-sm text-muted-foreground'>
-                    {item.label}
-                  </div>
-                  <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                    {item.value}
-                  </div>
-                </button>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type='button'
-                      aria-label={item.tooltip}
-                      className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                    >
-                      <QuestionMarkCircleIcon className='h-4 w-4' />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className='max-w-56 text-left leading-5'>
-                    {item.tooltip}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            </div>
-          ))}
-        </div>
-      </TooltipProvider>
+      <CreditNotificationOverviewCards
+        overview={overview}
+        applyOverviewFilter={applyOverviewFilter}
+      />
 
-      <AdminFilter
-        items={filterItems}
-        expanded={filtersExpanded}
-        onExpandedChange={setFiltersExpanded}
-        onReset={resetRecords}
-        onSearch={searchRecords}
-        resetLabel={t('module.operationsCreditNotifications.actions.reset')}
-        searchLabel={t('module.operationsCreditNotifications.actions.search')}
-        expandLabel={t('common.core.expand')}
-        collapseLabel={t('common.core.collapse')}
-        collapsedCount={3}
-        surface='card'
-        layoutPreset='operations'
-        activeFilter={
-          activeOverviewItem
-            ? {
-                label: t(
-                  'module.operationsCreditNotifications.overview.activeFilter',
-                ),
-                value: activeOverviewItem.label,
-                clearAriaLabel: `${activeOverviewItem.label} ${clearLabel}`,
-                onClear: clearOverviewFilter,
-              }
-            : null
-        }
+      <CreditNotificationRecordsFilter
+        draftFilters={draftFilters}
+        updateDraftFilter={updateDraftFilter}
+        searchRecords={searchRecords}
+        resetRecords={resetRecords}
+        activeOverviewCardKey={activeOverviewCardKey}
+        activeOverviewLabel={activeOverviewItem || ''}
+        clearOverviewFilter={clearOverviewFilter}
+        resolveDeliveryStatusLabel={resolveDeliveryStatusLabel}
+        resolveSkipReasonLabel={resolveSkipReasonLabel}
+        resolveTypeLabel={resolveTypeLabel}
+        resolveSourceTypeLabel={resolveSourceTypeLabel}
       />
 
       {error ? (

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -441,6 +441,10 @@ describe('AdminOperationCreditNotificationsPage', () => {
     expect(mockToast).toHaveBeenCalledWith({
       title: 'module.operationsCreditNotifications.messages.requeueDone',
     });
+    await waitFor(() => {
+      expect(mockGetRecords).toHaveBeenCalledTimes(2);
+      expect(mockGetOverview).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('surfaces requeue failures without refreshing records as success', async () => {
@@ -1255,6 +1259,28 @@ describe('AdminOperationCreditNotificationsPage', () => {
     expect(
       screen.getByText(/"notification_type": "low_balance"/),
     ).toBeInTheDocument();
+  });
+
+  it('shows dry-run failures inside config without polluting records error state', async () => {
+    mockDryRun.mockRejectedValueOnce(new Error('dry run unavailable'));
+
+    render(<AdminOperationCreditNotificationsPage />);
+
+    await openConfigTab();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.operationsCreditNotifications.actions.dryRun',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('dry run unavailable')).toBeInTheDocument();
+    });
+    expect(mockGetRecords).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText('module.operationsCreditNotifications.loadError'),
+    ).not.toBeInTheDocument();
   });
 
   it('saves estimated-days low balance thresholds from the structured form', async () => {

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -106,7 +106,9 @@ export default function AdminOperationCreditNotificationsPage() {
     });
   const [activeOverviewCardKey, setActiveOverviewCardKey] =
     React.useState<NotificationOverviewCardKey | null>(null);
-  const [error, setError] = React.useState<ErrorState | null>(null);
+  const [recordsError, setRecordsError] = React.useState<ErrorState | null>(
+    null,
+  );
   const [policy, setPolicy] =
     React.useState<AdminOperationCreditNotificationPolicy>(createDefaultPolicy);
   const [configError, setConfigError] = React.useState('');
@@ -114,6 +116,7 @@ export default function AdminOperationCreditNotificationsPage() {
   const [configLoading, setConfigLoading] = React.useState(false);
   const [dryRunResult, setDryRunResult] =
     React.useState<AdminOperationCreditNotificationDryRunResponse | null>(null);
+  const [dryRunError, setDryRunError] = React.useState('');
   const [templateSyncResults, setTemplateSyncResults] = React.useState<
     Partial<
       Record<
@@ -255,7 +258,7 @@ export default function AdminOperationCreditNotificationsPage() {
       const requestId = requestIdRef.current + 1;
       requestIdRef.current = requestId;
       setLoading(true);
-      setError(null);
+      setRecordsError(null);
       try {
         const response = (await api.getAdminOperationCreditNotifications({
           page_index: targetPage,
@@ -284,7 +287,7 @@ export default function AdminOperationCreditNotificationsPage() {
           return;
         }
         const resolvedError = requestError as ErrorWithCode;
-        setError({
+        setRecordsError({
           message:
             resolvedError.message ||
             t('module.operationsCreditNotifications.loadError'),
@@ -310,8 +313,7 @@ export default function AdminOperationCreditNotificationsPage() {
     setConfigLoading(true);
     setConfigError('');
     try {
-      await fetchConfig();
-      void fetchTemplateOptions();
+      await Promise.all([fetchConfig(), fetchTemplateOptions()]);
     } catch (requestError) {
       configLoadStartedRef.current = false;
       const resolvedError = requestError as ErrorWithCode;
@@ -330,10 +332,12 @@ export default function AdminOperationCreditNotificationsPage() {
       return;
     }
     const initialFilters = createDefaultFilters();
-    fetchOverview().catch(() => {
-      setOverview({ total: 0, pending: 0, sent: 0, failed: 0, skipped: 0 });
-    });
-    void fetchRecords(1, initialFilters);
+    void Promise.all([
+      fetchOverview().catch(() => {
+        setOverview({ total: 0, pending: 0, sent: 0, failed: 0, skipped: 0 });
+      }),
+      fetchRecords(1, initialFilters),
+    ]);
   }, [fetchOverview, fetchRecords, isReady]);
 
   React.useEffect(() => {
@@ -642,6 +646,7 @@ export default function AdminOperationCreditNotificationsPage() {
 
   const dryRun = React.useCallback(async () => {
     try {
+      setDryRunError('');
       const response = (await api.dryRunAdminOperationCreditNotifications({
         notification_type: draftFilters.notification_type.trim(),
         creator_bid: '',
@@ -649,10 +654,8 @@ export default function AdminOperationCreditNotificationsPage() {
       setDryRunResult(response);
     } catch (requestError) {
       const resolvedError = requestError as ErrorWithCode;
-      setError({
-        message: resolvedError.message || t('common.core.submitFailed'),
-        code: resolvedError.code,
-      });
+      setDryRunResult(null);
+      setDryRunError(resolvedError.message || t('common.core.submitFailed'));
     }
   }, [draftFilters.notification_type, t]);
 
@@ -677,8 +680,10 @@ export default function AdminOperationCreditNotificationsPage() {
         toast({
           title: t('module.operationsCreditNotifications.messages.requeueDone'),
         });
-        await fetchRecords(pageIndex, appliedFilters);
-        await fetchOverview();
+        await Promise.all([
+          fetchRecords(pageIndex, appliedFilters),
+          fetchOverview().catch(() => undefined),
+        ]);
       } catch (requestError) {
         const resolvedError = requestError as ErrorWithCode;
         toast({
@@ -745,7 +750,7 @@ export default function AdminOperationCreditNotificationsPage() {
           <CreditNotificationRecordsTab
             items={items}
             loading={loading}
-            error={error}
+            error={recordsError}
             total={total}
             overview={overview}
             activeOverviewCardKey={activeOverviewCardKey}
@@ -775,6 +780,7 @@ export default function AdminOperationCreditNotificationsPage() {
             configLoading={configLoading}
             configError={configError}
             dryRunResult={dryRunResult}
+            dryRunError={dryRunError}
             templateSyncResults={templateSyncResults}
             templateSyncLoading={templateSyncLoading}
             templateOptions={templateOptions}


### PR DESCRIPTION
## Summary
- tighten the admin credit-notification page request-state boundaries so records, config, and dry-run failures no longer bleed into each other
- make config-side resource loading and post-requeue refreshes more efficient by parallelizing the relevant requests
- split the records tab into focused overview-card and filter components while preserving the current operator behaviors

## Testing
- cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/credit-notifications/page.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npx eslint src/app/admin/operations/credit-notifications/page.tsx src/app/admin/operations/credit-notifications/page.test.tsx src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx src/app/admin/operations/credit-notifications/CreditNotificationRecordsTab.tsx src/app/admin/operations/credit-notifications/CreditNotificationOverviewCards.tsx src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
- python scripts/check_repo_harness.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline error messaging for failed dry-run operations in the credit notifications configuration panel.
* **Performance**
  * Improved responsiveness by loading overview and records concurrently, and refreshing both together after requeue completion.
* **Bug Fixes**
  * Improved error isolation so dry-run failures no longer impact the records table’s error state/display.
* **Tests**
  * Expanded UI test coverage for requeue-triggered fetches and dry-run error rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->