### PR TITLE
feat: cache dashboard follow-up details

### DIFF
--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx
@@ -241,8 +241,8 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
       summary: {
         follow_up_count: 2,
         user_count: 1,
-        lesson_count: 1,
-        latest_follow_up_at: '2026-04-05 19:02:00',
+        lesson_count: 2,
+        latest_follow_up_at: '2026-04-05 19:05:00',
       },
       items: [
         {
@@ -259,44 +259,96 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
           turn_index: 2,
           created_at: '2026-04-05 19:02:00',
         },
+        {
+          generated_block_bid: 'ask-3',
+          progress_record_bid: 'progress-1',
+          user_bid: 'student-1',
+          mobile: '13900001235',
+          email: '',
+          nickname: 'Bob',
+          chapter_title: 'Chapter 1',
+          lesson_title: 'Lesson 2',
+          follow_up_content: 'Third follow-up question',
+          has_source_output: false,
+          turn_index: 3,
+          created_at: '2026-04-05 19:05:00',
+        },
       ],
       page: 1,
       page_size: 20,
       total: 2,
       page_count: 1,
     });
-    mockGetDashboardCourseFollowUpDetail.mockResolvedValue({
-      basic_info: {
-        generated_block_bid: 'ask-2',
-        progress_record_bid: 'progress-1',
-        user_bid: 'student-1',
-        mobile: '13900001235',
-        email: '',
-        nickname: 'Bob',
-        chapter_title: 'Chapter 1',
-        lesson_title: 'Lesson 1',
-        created_at: '2026-04-05 19:02:00',
-        turn_index: 2,
+    mockGetDashboardCourseFollowUpDetail.mockImplementation(
+      async ({ generated_block_bid }: { generated_block_bid: string }) => {
+        if (generated_block_bid === 'ask-3') {
+          return {
+            basic_info: {
+              generated_block_bid: 'ask-3',
+              progress_record_bid: 'progress-1',
+              user_bid: 'student-1',
+              mobile: '13900001235',
+              email: '',
+              nickname: 'Bob',
+              chapter_title: 'Chapter 1',
+              lesson_title: 'Lesson 2',
+              created_at: '2026-04-05 19:05:00',
+              turn_index: 3,
+            },
+            current_record: {
+              follow_up_content: 'Third follow-up question',
+              answer_content: 'Third follow-up answer',
+            },
+            timeline: [
+              {
+                role: 'student',
+                content: 'Third follow-up question',
+                created_at: '2026-04-05 19:05:00',
+                is_current: true,
+              },
+              {
+                role: 'teacher',
+                content: 'Third follow-up answer',
+                created_at: '2026-04-05 19:05:08',
+                is_current: true,
+              },
+            ],
+          };
+        }
+        return {
+          basic_info: {
+            generated_block_bid: 'ask-2',
+            progress_record_bid: 'progress-1',
+            user_bid: 'student-1',
+            mobile: '13900001235',
+            email: '',
+            nickname: 'Bob',
+            chapter_title: 'Chapter 1',
+            lesson_title: 'Lesson 1',
+            created_at: '2026-04-05 19:02:00',
+            turn_index: 2,
+          },
+          current_record: {
+            follow_up_content: 'Second follow-up question',
+            answer_content: 'Second follow-up answer',
+          },
+          timeline: [
+            {
+              role: 'student',
+              content: 'Second follow-up question',
+              created_at: '2026-04-05 19:02:00',
+              is_current: true,
+            },
+            {
+              role: 'teacher',
+              content: 'Second follow-up answer',
+              created_at: '2026-04-05 19:02:10',
+              is_current: true,
+            },
+          ],
+        };
       },
-      current_record: {
-        follow_up_content: 'Second follow-up question',
-        answer_content: 'Second follow-up answer',
-      },
-      timeline: [
-        {
-          role: 'student',
-          content: 'Second follow-up question',
-          created_at: '2026-04-05 19:02:00',
-          is_current: true,
-        },
-        {
-          role: 'teacher',
-          content: 'Second follow-up answer',
-          created_at: '2026-04-05 19:02:10',
-          is_current: true,
-        },
-      ],
-    });
+    );
   });
 
   test('renders follow-up list with breadcrumbs back to dashboard and course detail', async () => {
@@ -397,9 +449,9 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
     });
 
     fireEvent.click(
-      screen.getByRole('button', {
+      screen.getAllByRole('button', {
         name: 'module.dashboard.detail.followUps.table.detailAction',
-      }),
+      })[0],
     );
 
     expect(
@@ -415,9 +467,9 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
         'module.dashboard.detail.followUps.drawer.currentRecordHint',
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByText('Second follow-up answer').length,
-    ).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Second follow-up answer')).length).toBe(
+      2,
+    );
     expect(
       screen.getAllByText(
         'module.dashboard.detail.followUps.drawer.timeline.current',
@@ -440,9 +492,9 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
     await screen.findByText('Second follow-up question');
 
     fireEvent.click(
-      screen.getByRole('button', {
+      screen.getAllByRole('button', {
         name: 'module.dashboard.detail.followUps.table.detailAction',
-      }),
+      })[0],
     );
 
     expect(await screen.findByTestId('loading-indicator')).toBeInTheDocument();
@@ -478,6 +530,71 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
     expect(
       screen.queryByText('Stale follow-up answer'),
     ).not.toBeInTheDocument();
+  });
+
+  test('reuses cached detail when reopening the same follow-up', async () => {
+    render(<AdminDashboardCourseFollowUpsPage />);
+
+    await screen.findByText('Second follow-up question');
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.dashboard.detail.followUps.table.detailAction',
+      })[0],
+    );
+
+    expect((await screen.findAllByText('Second follow-up answer')).length).toBe(
+      2,
+    );
+    expect(mockGetDashboardCourseFollowUpDetail).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: SHEET_CLOSE_LABEL }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.dashboard.detail.followUps.table.detailAction',
+      })[0],
+    );
+
+    expect((await screen.findAllByText('Second follow-up answer')).length).toBe(
+      2,
+    );
+    expect(mockGetDashboardCourseFollowUpDetail).toHaveBeenCalledTimes(1);
+  });
+
+  test('fetches a new detail payload when opening a different follow-up', async () => {
+    render(<AdminDashboardCourseFollowUpsPage />);
+
+    await screen.findByText('Third follow-up question');
+
+    const detailButtons = screen.getAllByRole('button', {
+      name: 'module.dashboard.detail.followUps.table.detailAction',
+    });
+
+    fireEvent.click(detailButtons[0]);
+    expect((await screen.findAllByText('Second follow-up answer')).length).toBe(
+      2,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: SHEET_CLOSE_LABEL }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(detailButtons[1]);
+    expect((await screen.findAllByText('Third follow-up answer')).length).toBe(
+      2,
+    );
+
+    expect(mockGetDashboardCourseFollowUpDetail).toHaveBeenCalledTimes(2);
+    expect(mockGetDashboardCourseFollowUpDetail).toHaveBeenNthCalledWith(2, {
+      shifu_bid: 'course-1',
+      generated_block_bid: 'ask-3',
+      timezone: 'Asia/Shanghai',
+    });
   });
 
   test('applies learner-scoped query filters from the url', async () => {

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
@@ -365,9 +365,6 @@ export default function AdminDashboardCourseFollowUpsPage() {
         if (cachedDetail) {
           detailCacheRef.current.delete(selectedGeneratedBlockBid);
           detailCacheRef.current.set(selectedGeneratedBlockBid, cachedDetail);
-          setDetail(cachedDetail);
-          setDetailError(null);
-          setDetailLoading(false);
           return;
         }
       }

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
@@ -359,7 +359,9 @@ export default function AdminDashboardCourseFollowUpsPage() {
       }
 
       if (!forceRefresh) {
-        const cachedDetail = detailCacheRef.current.get(selectedGeneratedBlockBid);
+        const cachedDetail = detailCacheRef.current.get(
+          selectedGeneratedBlockBid,
+        );
         if (cachedDetail) {
           detailCacheRef.current.delete(selectedGeneratedBlockBid);
           detailCacheRef.current.set(selectedGeneratedBlockBid, cachedDetail);
@@ -559,7 +561,9 @@ export default function AdminDashboardCourseFollowUpsPage() {
 
       detailRequestIdRef.current += 1;
       setSelectedGeneratedBlockBid(normalizedGeneratedBlockBid);
-      setDetail(detailCacheRef.current.get(normalizedGeneratedBlockBid) ?? null);
+      setDetail(
+        detailCacheRef.current.get(normalizedGeneratedBlockBid) ?? null,
+      );
       setDetailError(null);
       setDetailLoading(
         !detailCacheRef.current.has(normalizedGeneratedBlockBid),

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
@@ -59,6 +59,7 @@ type FollowUpFilters = {
 
 const PAGE_SIZE = 20;
 const ALL_SOURCE_STATUS = 'all';
+const DETAIL_CACHE_LIMIT = 20;
 
 const EMPTY_FOLLOW_UPS_RESPONSE: DashboardCourseFollowUpListResponse = {
   summary: {
@@ -283,6 +284,9 @@ export default function AdminDashboardCourseFollowUpsPage() {
   const [detailError, setDetailError] = useState<ErrorState | null>(null);
   const listRequestIdRef = useRef(0);
   const detailRequestIdRef = useRef(0);
+  const detailCacheRef = useRef(
+    new Map<string, DashboardCourseFollowUpDetailResponse>(),
+  );
 
   useEffect(() => {
     setFiltersDraft(initialFilters);
@@ -345,47 +349,75 @@ export default function AdminDashboardCourseFollowUpsPage() {
     [filters, shifuBid, timezone, unknownErrorMessage],
   );
 
-  const fetchFollowUpDetail = useCallback(async () => {
-    if (!shifuBid.trim() || !selectedGeneratedBlockBid.trim()) {
-      setDetailError({ message: unknownErrorMessage });
-      setDetail(EMPTY_FOLLOW_UP_DETAIL);
-      setDetailLoading(false);
-      return;
-    }
-
-    const requestId = detailRequestIdRef.current + 1;
-    detailRequestIdRef.current = requestId;
-    setDetailLoading(true);
-    setDetailError(null);
-
-    try {
-      const response = (await api.getDashboardCourseFollowUpDetail({
-        shifu_bid: shifuBid,
-        generated_block_bid: selectedGeneratedBlockBid,
-        ...(timezone ? { timezone } : {}),
-      })) as DashboardCourseFollowUpDetailResponse;
-      if (requestId !== detailRequestIdRef.current) {
-        return;
-      }
-      setDetail(response || EMPTY_FOLLOW_UP_DETAIL);
-    } catch (err) {
-      if (requestId !== detailRequestIdRef.current) {
-        return;
-      }
-      setDetail(EMPTY_FOLLOW_UP_DETAIL);
-      if (err instanceof ErrorWithCode) {
-        setDetailError({ message: err.message, code: err.code });
-      } else if (err instanceof Error) {
-        setDetailError({ message: err.message });
-      } else {
+  const fetchFollowUpDetail = useCallback(
+    async ({ forceRefresh = false }: { forceRefresh?: boolean } = {}) => {
+      if (!shifuBid.trim() || !selectedGeneratedBlockBid.trim()) {
         setDetailError({ message: unknownErrorMessage });
-      }
-    } finally {
-      if (requestId === detailRequestIdRef.current) {
+        setDetail(EMPTY_FOLLOW_UP_DETAIL);
         setDetailLoading(false);
+        return;
       }
-    }
-  }, [selectedGeneratedBlockBid, shifuBid, timezone, unknownErrorMessage]);
+
+      if (!forceRefresh) {
+        const cachedDetail = detailCacheRef.current.get(selectedGeneratedBlockBid);
+        if (cachedDetail) {
+          detailCacheRef.current.delete(selectedGeneratedBlockBid);
+          detailCacheRef.current.set(selectedGeneratedBlockBid, cachedDetail);
+          setDetail(cachedDetail);
+          setDetailError(null);
+          setDetailLoading(false);
+          return;
+        }
+      }
+
+      const requestId = detailRequestIdRef.current + 1;
+      detailRequestIdRef.current = requestId;
+      setDetailLoading(true);
+      setDetailError(null);
+
+      try {
+        const response = (await api.getDashboardCourseFollowUpDetail({
+          shifu_bid: shifuBid,
+          generated_block_bid: selectedGeneratedBlockBid,
+          ...(timezone ? { timezone } : {}),
+        })) as DashboardCourseFollowUpDetailResponse;
+        if (requestId !== detailRequestIdRef.current) {
+          return;
+        }
+        const resolvedDetail = response || EMPTY_FOLLOW_UP_DETAIL;
+        detailCacheRef.current.delete(selectedGeneratedBlockBid);
+        detailCacheRef.current.set(selectedGeneratedBlockBid, resolvedDetail);
+        if (detailCacheRef.current.size > DETAIL_CACHE_LIMIT) {
+          const oldestKey = detailCacheRef.current.keys().next().value;
+          if (oldestKey) {
+            detailCacheRef.current.delete(oldestKey);
+          }
+        }
+        setDetail(resolvedDetail);
+      } catch (err) {
+        if (requestId !== detailRequestIdRef.current) {
+          return;
+        }
+        setDetail(EMPTY_FOLLOW_UP_DETAIL);
+        if (err instanceof ErrorWithCode) {
+          setDetailError({ message: err.message, code: err.code });
+        } else if (err instanceof Error) {
+          setDetailError({ message: err.message });
+        } else {
+          setDetailError({ message: unknownErrorMessage });
+        }
+      } finally {
+        if (requestId === detailRequestIdRef.current) {
+          setDetailLoading(false);
+        }
+      }
+    },
+    [selectedGeneratedBlockBid, shifuBid, timezone, unknownErrorMessage],
+  );
+
+  useEffect(() => {
+    detailCacheRef.current.clear();
+  }, [shifuBid]);
 
   useEffect(() => {
     if (!isInitialized || !isGuest) {
@@ -527,9 +559,11 @@ export default function AdminDashboardCourseFollowUpsPage() {
 
       detailRequestIdRef.current += 1;
       setSelectedGeneratedBlockBid(normalizedGeneratedBlockBid);
-      setDetail(null);
+      setDetail(detailCacheRef.current.get(normalizedGeneratedBlockBid) ?? null);
       setDetailError(null);
-      setDetailLoading(true);
+      setDetailLoading(
+        !detailCacheRef.current.has(normalizedGeneratedBlockBid),
+      );
       setDetailOpen(true);
     },
     [unknownErrorMessage],
@@ -990,7 +1024,7 @@ export default function AdminDashboardCourseFollowUpsPage() {
         contactMode={contactMode}
         defaultUserName={defaultUserName}
         resolveLessonDisplay={resolvePrimaryLessonDisplay}
-        onRetry={fetchFollowUpDetail}
+        onRetry={() => fetchFollowUpDetail({ forceRefresh: true })}
         onOpenChange={handleDetailOpenChange}
       />
     </div>


### PR DESCRIPTION
## Summary
- add a lightweight page-scoped cache for creator dashboard follow-up details keyed by generated block bid
- reuse cached detail payloads when reopening the same follow-up while keeping retry as a forced refresh path
- cover cached reopen and cross-detail fetch behavior with focused follow-up page tests

## Testing
- cd src/cook-web && npm test -- --runTestsByPath "src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx"
- cd src/cook-web && npm run type-check
- cd src/cook-web && npx eslint "src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx" "src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Performance Improvements**
* Follow-up detail views are now cached, making it faster to reopen details for items you’ve already viewed.
* Cache behavior automatically updates when switching dashboard context, and retry now forces a fresh fetch to ensure up-to-date content.

**Test Improvements**
* Expanded follow-up drawer tests to cover repeated open/close behavior and verify that new selections trigger a new detail request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->