### PR TITLE
fix: avoid ops alerts for handled run script errors

### DIFF
--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -440,6 +440,32 @@ def _to_sse_chunk(payload: object) -> str:
     )
 
 
+def _log_run_script_stream_error(app: Flask, stream_error: Exception) -> None:
+    error_traceback = "".join(
+        traceback.format_exception(
+            type(stream_error),
+            stream_error,
+            stream_error.__traceback__,
+        )
+    )
+    error_info = {
+        "name": type(stream_error).__name__,
+        "description": str(stream_error),
+        "traceback": error_traceback,
+    }
+
+    if isinstance(stream_error, AppException):
+        # AppException is already a handled, user-facing business error (for example,
+        # a stale lesson URL after a course republish). Keep it out of ERROR-level
+        # operational alerts while preserving enough context for diagnostics.
+        app.logger.info("run_script handled app exception")
+        app.logger.info(error_info)
+        return
+
+    app.logger.error("run_script error")
+    app.logger.error(error_info)
+
+
 def _make_terminal_event(
     *,
     outline_bid: str,
@@ -769,26 +795,10 @@ def run_script(
 
             if stream_error and not client_disconnected:
                 if isinstance(stream_error, Exception):
-                    app.logger.error("run_script error")
-                    app.logger.error(stream_error)
-                    error_traceback = "".join(
-                        traceback.format_exception(
-                            type(stream_error),
-                            stream_error,
-                            stream_error.__traceback__,
-                        )
-                    )
-                    error_info = {
-                        "name": type(stream_error).__name__,
-                        "description": str(stream_error),
-                        "traceback": error_traceback,
-                    }
-
+                    _log_run_script_stream_error(app, stream_error)
                     if isinstance(stream_error, AppException):
-                        app.logger.info(error_info)
                         error_content = str(stream_error)
                     else:
-                        app.logger.error(error_info)
                         error_content = str(_("server.common.unknownError"))
                     yield _to_sse_chunk(
                         _make_terminal_event(

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -441,6 +441,12 @@ def _to_sse_chunk(payload: object) -> str:
 
 
 def _log_run_script_stream_error(app: Flask, stream_error: Exception) -> None:
+    """Log a run-script stream error, keeping handled AppExceptions off ERROR.
+
+    Unexpected errors are logged at ERROR for operational alerting, while a
+    handled, user-facing AppException is logged at INFO so it stays out of the
+    alert stream but remains diagnosable.
+    """
     error_traceback = "".join(
         traceback.format_exception(
             type(stream_error),

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -590,12 +590,12 @@ def test_log_run_script_stream_error_does_not_error_for_app_exception():
     app.logger.error = lambda *args, **kwargs: error_calls.append(args)
 
     runscript_v2._log_run_script_stream_error(
-        app, AppException("大纲单元不存在", status_code=1001)
+        app, AppException("outline unit does not exist", status_code=1001)
     )
 
     assert error_calls == []
     assert info_calls[0] == ("run_script handled app exception",)
-    assert info_calls[1][0]["description"] == "大纲单元不存在"
+    assert info_calls[1][0]["description"] == "outline unit does not exist"
 
 
 def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -6,6 +6,7 @@ import pytest
 from flask import Flask, has_app_context
 
 from flaskr.service.learn import runscript_v2
+from flaskr.service.common.models import AppException
 from flaskr.service.learn.learn_dtos import (
     ElementDTO,
     ElementType,
@@ -579,6 +580,36 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
         GeneratedType.CONTENT,
         GeneratedType.BREAK,
     ]
+
+
+def test_log_run_script_stream_error_does_not_error_for_app_exception():
+    app = Flask(__name__)
+    info_calls = []
+    error_calls = []
+    app.logger.info = lambda *args, **kwargs: info_calls.append(args)
+    app.logger.error = lambda *args, **kwargs: error_calls.append(args)
+
+    runscript_v2._log_run_script_stream_error(
+        app, AppException("大纲单元不存在", status_code=1001)
+    )
+
+    assert error_calls == []
+    assert info_calls[0] == ("run_script handled app exception",)
+    assert info_calls[1][0]["description"] == "大纲单元不存在"
+
+
+def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():
+    app = Flask(__name__)
+    info_calls = []
+    error_calls = []
+    app.logger.info = lambda *args, **kwargs: info_calls.append(args)
+    app.logger.error = lambda *args, **kwargs: error_calls.append(args)
+
+    runscript_v2._log_run_script_stream_error(app, RuntimeError("boom"))
+
+    assert info_calls == []
+    assert error_calls[0] == ("run_script error",)
+    assert error_calls[1][0]["description"] == "boom"
 
 
 def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):


### PR DESCRIPTION
## 来源
- 运维保障群 2026-06-20 16:59 连续告警：`/api/learn/shifu/0efa4e2811444e77b01c45ddd1e8c8b3/run/573a7dcaa2d54c4e865343c13e80fb77` 返回 `run_script error` / `大纲单元不存在`。
- 排查生产只读库：该 outline bid 已被最新发布版本删除，同位置已有新的 published outline bid；属于课程重发布后旧学习页/旧 outline 请求触发的业务异常。

## 修复
- 将 `run_script` 中已处理的 `AppException` 从 ERROR 级别降为 INFO，保留异常结构化信息。
- 未预期异常仍维持 ERROR 级别并返回通用错误文案。
- 避免 stale outline 这类用户可见业务异常继续触发运维报错群噪音。

## 验证
- `python3 -m py_compile src/api/flaskr/service/learn/runscript_v2.py src/api/tests/service/learn/test_runscript_v2_lock.py`
- 本机未安装可用 pytest：`pytest` command not found，workspace venv Python 指向缺失/无权限解释器，未能跑完整 pytest。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined error handling and logging logic for improved error reporting consistency.

* **Tests**
  * Added validation tests for error logging behavior in run script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->