### PR TITLE
refactor: split credit notification config tab state

### DIFF
--- a/docs/exec-plans/active/billing-credit-notifications.md
+++ b/docs/exec-plans/active/billing-credit-notifications.md
@@ -21,8 +21,11 @@
 - [x] 2026-05-21 17:07 CST: Added teacher-facing balance state and softlimit debug blocking on frontend and backend preview/debug paths.
 - [x] 2026-05-21 17:07 CST: Added focused backend/task/frontend tests and ran validation; architecture boundary check is blocked only by unrelated pre-existing untracked route-support files.
 - [x] 2026-05-22 18:35 CST: Extended low-balance notifications with estimated-days thresholds based on finalized daily ledger consumption, structured operator form fields, dry-run details, and focused tests.
-- [ ] 2026-06-19 21:20 CST: Start the follow-up PR on `refactor/billing-credit-notifications`, focused on records/config request-state cleanup, requeue refresh behavior, and config-side experience polish without changing the notification-center core model.
-- [ ] 2026-06-19 21:36 CST: Defer the next-step `CreditNotificationConfigTab.tsx` split (dry-run, template sync, managed-list dialog state isolation) to a separate follow-up PR so the current branch stays scoped to request-state and records-tab polish.
+<<<<<<< HEAD
+- [x] 2026-06-19 21:20 CST: Follow-up work on `refactor/billing-credit-notifications` cleaned up records/config request-state handling, requeue refresh behavior, and config-side experience without changing the notification-center core model.
+- [x] 2026-06-19 21:36 CST: Deferred the next-step `CreditNotificationConfigTab.tsx` split (dry-run, template sync, managed-list dialog state isolation) to a separate follow-up PR so the request-state polish branch stayed reviewable.
+- [x] 2026-06-21 16:10 CST: Follow-up admin refinements split the records overview/filter UI and then moved `CreditNotificationConfigTab` local template/input/managed-list state into a dedicated hook so the config tab stays orchestration-focused without changing backend contracts.
+- [x] 2026-06-21 16:24 CST: Stopped this follow-up round after the local-state extraction; `dry-run` and template-sync deeper hook splits remain explicitly deferred to a later credit-notification follow-up PR to keep the scope reviewable.
 
 ## Surprises & Discoveries
 
@@ -60,6 +63,7 @@ Implemented v1 of the积分通知中心:
 - Low-balance reminders can optionally trigger by estimated remaining days, using finalized daily consume summaries. Fixed-threshold fallback only applies when there is partial valid consumption history; missing or zero daily consumption summaries do not send estimated-days reminders.
 - Billing overview exposes `credit_status`, `debug_allowed`, and `softlimit_threshold`; preview/debug paths enforce softlimit in both frontend and backend.
 - Focused backend, task, and frontend tests cover staging, dedupe, skip, provider retry, scan windows, softlimit, Celery schedule/config, operator page rendering, and frontend preview blocking.
+- Follow-up operator refinements now scope records/config/dry-run errors separately, refresh records plus overview in parallel after requeue, and keep the credit notification config tab maintainable by isolating its local editor and managed-list state in a dedicated frontend hook.
 
 ## Context and Orientation
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -26,9 +26,7 @@ import type {
 } from '../operation-credit-notification-types';
 import { CreditNotificationCreatorListsSection } from './CreditNotificationCreatorListsSection';
 import { CreditNotificationDryRunPanel } from './CreditNotificationDryRunPanel';
-import {
-  CreditNotificationManagedListDialog,
-} from './CreditNotificationManagedListDialog';
+import { CreditNotificationManagedListDialog } from './CreditNotificationManagedListDialog';
 import {
   CreditNotificationTypeConfigCard,
   getTemplateOptionsForType,

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -1,11 +1,10 @@
-import { useState, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import { Button } from '@/components/ui/Button';
-import { toast } from '@/hooks/useToast';
 import { Input } from '@/components/ui/Input';
 import { Label } from '@/components/ui/Label';
 import {
@@ -21,7 +20,6 @@ import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import type {
   AdminOperationCreditNotificationDryRunResponse,
   AdminOperationCreditNotificationPolicy,
-  AdminOperationCreditNotificationPolicyListItem,
   AdminOperationCreditNotificationPolicyResolvedLists,
   AdminOperationCreditNotificationTemplateOption,
   AdminOperationCreditNotificationTemplateSyncResponse,
@@ -30,7 +28,6 @@ import { CreditNotificationCreatorListsSection } from './CreditNotificationCreat
 import { CreditNotificationDryRunPanel } from './CreditNotificationDryRunPanel';
 import {
   CreditNotificationManagedListDialog,
-  type CreditNotificationManagedListType as ManagedListType,
 } from './CreditNotificationManagedListDialog';
 import {
   CreditNotificationTypeConfigCard,
@@ -42,20 +39,15 @@ import {
   CreditNotificationHelpTooltip as HelpTooltip,
 } from './CreditNotificationFormPrimitives';
 import {
-  formatListInput,
   isEstimatedDaysThreshold,
   isFixedThreshold,
   type KnownNotificationType,
   NOTIFICATION_TYPES,
-  normalizeIntegerInput,
-  normalizeListInputCharacters,
-  parseListInput,
-  readNumber,
 } from './creditNotificationUtils';
-
-type UpdatePolicy = (
-  updater: (draft: AdminOperationCreditNotificationPolicy) => void,
-) => void;
+import {
+  type UpdatePolicy,
+  useCreditNotificationConfigTabState,
+} from './useCreditNotificationConfigTabState';
 
 const TIMEZONE_OPTIONS = [
   'Asia/Shanghai',
@@ -66,148 +58,6 @@ const TIMEZONE_OPTIONS = [
   'Asia/Seoul',
   'UTC',
 ];
-const MAX_BLOCKED_CREATOR_IMPORT_COUNT = 50;
-const INVALID_SAMPLE_LIMIT = 5;
-const PHONE_MATCH_PATTERN = /(?:^|\D)(\d{11})(?!\d)/g;
-const EMAIL_MATCH_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
-const EMAIL_TEST_PATTERN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
-const CREATOR_ID_PATTERN = /^[A-Za-z0-9_-]{4,80}$/;
-
-const isSmsMobileIdentifier = (value: string) => {
-  const normalized = value.trim().replace(/^\+/, '');
-  return /^\d{5,20}$/.test(normalized);
-};
-
-const findPhoneIdentifiers = (value: string): string[] => {
-  const matches: string[] = [];
-  const pattern = new RegExp(PHONE_MATCH_PATTERN.source, 'g');
-  let match = pattern.exec(value);
-  while (match) {
-    if (match[1]) {
-      matches.push(match[1]);
-    }
-    match = pattern.exec(value);
-  }
-  return matches;
-};
-
-const findEmailIdentifiers = (value: string): string[] =>
-  Array.from(value.matchAll(EMAIL_MATCH_PATTERN)).map(match =>
-    match[0].toLowerCase(),
-  );
-
-const splitIdentifierTokens = (value: string): string[] =>
-  value
-    .split(/[\s,;|]+/)
-    .map(item => item.trim())
-    .filter(Boolean);
-
-const trimInvalidDisplay = (value: string): string =>
-  value.replace(/^[\s,;|]+|[\s,;|]+$/g, '').trim();
-
-const parseBlockedCreatorInput = (
-  value: string,
-  contactMode: 'email' | 'phone',
-) => {
-  const normalized = normalizeListInputCharacters(value).replace(/\t/g, ' ');
-  const creatorBids: string[] = [];
-  const mobiles: string[] = [];
-  const invalidItems: string[] = [];
-  const addToken = (token: string) => {
-    if (isSmsMobileIdentifier(token)) {
-      mobiles.push(token);
-      return;
-    }
-    if (EMAIL_TEST_PATTERN.test(token)) {
-      creatorBids.push(token.toLowerCase());
-      return;
-    }
-    if (CREATOR_ID_PATTERN.test(token)) {
-      creatorBids.push(token);
-      return;
-    }
-    invalidItems.push(token);
-  };
-
-  normalized.split(/\r?\n/).forEach(rawLine => {
-    const line = trimInvalidDisplay(rawLine);
-    if (!line) {
-      return;
-    }
-    if (/[;,]/.test(line)) {
-      splitIdentifierTokens(line).forEach(addToken);
-      return;
-    }
-    const contactMatches =
-      contactMode === 'email'
-        ? findEmailIdentifiers(line)
-        : findPhoneIdentifiers(line);
-    if (contactMatches.length > 0) {
-      if (contactMode === 'email') {
-        creatorBids.push(...contactMatches);
-        return;
-      }
-      mobiles.push(...contactMatches);
-      return;
-    }
-
-    splitIdentifierTokens(line).forEach(addToken);
-  });
-
-  return {
-    creatorBids: Array.from(new Set(creatorBids)),
-    invalidItems: Array.from(new Set(invalidItems)),
-    mobiles: Array.from(new Set(mobiles)),
-  };
-};
-
-const mergeIdentifierLists = (...lists: string[][]) =>
-  Array.from(
-    new Set(
-      lists.flatMap(list => list.map(item => item.trim()).filter(Boolean)),
-    ),
-  );
-
-const buildListDetails = (
-  identifiers: string[],
-  resolvedItems: AdminOperationCreditNotificationPolicyListItem[] = [],
-) => {
-  const resolvedByIdentifier = new Map(
-    resolvedItems.map(item => [item.identifier, item]),
-  );
-  return identifiers.map(identifier => ({
-    identifier,
-    creator_bid: resolvedByIdentifier.get(identifier)?.creator_bid || '',
-    mobile: resolvedByIdentifier.get(identifier)?.mobile || '',
-    email: resolvedByIdentifier.get(identifier)?.email || '',
-    nickname: resolvedByIdentifier.get(identifier)?.nickname || '',
-  }));
-};
-
-const filterListDetails = (
-  items: AdminOperationCreditNotificationPolicyListItem[],
-  keyword: string,
-  contactMode: 'email' | 'phone',
-) => {
-  const normalized = keyword.trim().toLowerCase();
-  if (!normalized) {
-    return items;
-  }
-  return items.filter(item => {
-    const contactValue =
-      contactMode === 'email'
-        ? item.email || item.identifier
-        : item.mobile || item.identifier;
-    const isContactSearch =
-      contactMode === 'email'
-        ? normalized.includes('@')
-        : /^\d+$/.test(normalized);
-    if (isContactSearch) {
-      return contactValue.toLowerCase() === normalized;
-    }
-    return item.nickname.toLowerCase().includes(normalized);
-  });
-};
 
 function ConfigCard({
   title,
@@ -288,201 +138,45 @@ export function CreditNotificationConfigTab({
     loginMethodsEnabled,
     defaultLoginMethod,
   );
-  const [openTemplatePicker, setOpenTemplatePicker] = useState<
-    Partial<Record<KnownNotificationType, boolean>>
-  >({});
-  const [editingTemplateTypes, setEditingTemplateTypes] = useState<
-    Partial<Record<KnownNotificationType, boolean>>
-  >({});
-  const [templateInputValues, setTemplateInputValues] = useState<
-    Partial<Record<KnownNotificationType, string>>
-  >({});
-  const [listInputValues, setListInputValues] = useState<
-    Partial<Record<string, string>>
-  >({});
-  const [blockedCreatorInput, setBlockedCreatorInput] = useState('');
-  const [integerInputValues, setIntegerInputValues] = useState<
-    Partial<Record<string, string>>
-  >({});
-  const [managedListDialog, setManagedListDialog] =
-    useState<ManagedListType | null>(null);
-  const [managedListSearch, setManagedListSearch] = useState('');
+  const {
+    addBlockedCreators,
+    blockedCreatorIdentifiers,
+    blockedCreatorInput,
+    closeManagedListDialog,
+    editingTemplateTypes,
+    filteredManagedListDetails,
+    finishIntegerInput,
+    finishListInput,
+    getIntegerInputValue,
+    getListInputValue,
+    managedListCanDelete,
+    managedListDialog,
+    managedListSearch,
+    managedListTitle,
+    openManagedListDialog,
+    openTemplatePicker,
+    optedOutCreatorIdentifiers,
+    removeBlockedCreator,
+    setBlockedCreatorInput,
+    setEditingTemplateTypes,
+    setManagedListSearch,
+    setOpenTemplatePicker,
+    setTemplateInputValues,
+    templateInputValues,
+    updateIntegerInput,
+    updateListInput,
+  } = useCreditNotificationConfigTabState({
+    contactMode,
+    policy,
+    resolvedLists,
+    updatePolicy,
+    t,
+  });
   const lowBalanceThresholds = policy.types.low_balance.thresholds || [];
   const fixedLowBalanceThresholds =
     lowBalanceThresholds.filter(isFixedThreshold);
   const estimatedDaysThreshold =
     lowBalanceThresholds.find(isEstimatedDaysThreshold) || null;
-  const blockedCreatorIdentifiers = mergeIdentifierLists(
-    policy.blacklist.creator_bids,
-    policy.blacklist.mobiles,
-  );
-  const optedOutCreatorIdentifiers = mergeIdentifierLists(
-    policy.opt_out.creator_bids,
-    policy.opt_out.mobiles,
-  );
-  const blockedCreatorDetails = buildListDetails(
-    blockedCreatorIdentifiers,
-    resolvedLists.blacklist?.items || [],
-  );
-  const optedOutCreatorDetails = buildListDetails(
-    optedOutCreatorIdentifiers,
-    resolvedLists.opt_out?.items || [],
-  );
-
-  const getListInputValue = (key: string, value: string[]) =>
-    listInputValues[key] ?? formatListInput(value);
-
-  const updateListInput = (
-    key: string,
-    value: string,
-    commit: (normalized: string) => void,
-  ) => {
-    const inputValue = normalizeListInputCharacters(value);
-    setListInputValues(current => ({
-      ...current,
-      [key]: inputValue,
-    }));
-    commit(inputValue);
-  };
-
-  const finishListInput = (key: string, value: string) => {
-    setListInputValues(current => {
-      const next = { ...current };
-      next[key] = formatListInput(parseListInput(value));
-      return next;
-    });
-  };
-
-  const getIntegerInputValue = (key: string, value: number) =>
-    integerInputValues[key] ?? String(value);
-
-  const updateIntegerInput = (
-    key: string,
-    value: string,
-    fallback: number,
-    commit: (value: number) => void,
-  ) => {
-    const normalized = normalizeIntegerInput(value);
-    setIntegerInputValues(current => ({
-      ...current,
-      [key]: normalized,
-    }));
-    commit(readNumber(normalized, fallback));
-  };
-
-  const finishIntegerInput = (key: string, value: number) => {
-    setIntegerInputValues(current => {
-      const next = { ...current };
-      next[key] = String(value);
-      return next;
-    });
-  };
-
-  const openManagedListDialog = (type: ManagedListType) => {
-    setManagedListDialog(type);
-    setManagedListSearch('');
-  };
-
-  const removeBlockedCreator = (identifier: string) => {
-    updatePolicy(draft => {
-      draft.blacklist.creator_bids = draft.blacklist.creator_bids.filter(
-        item => item !== identifier,
-      );
-      draft.blacklist.mobiles = draft.blacklist.mobiles.filter(
-        item => item !== identifier,
-      );
-    });
-  };
-
-  const addBlockedCreators = () => {
-    const normalized = normalizeListInputCharacters(blockedCreatorInput);
-    const { creatorBids, invalidItems, mobiles } = parseBlockedCreatorInput(
-      normalized,
-      contactMode,
-    );
-    if (invalidItems.length > 0) {
-      const sample = invalidItems.slice(0, INVALID_SAMPLE_LIMIT).join(', ');
-      toast({
-        title: t(
-          'module.operationsCreditNotifications.config.listDialog.invalidBlockedCreators',
-          {
-            values:
-              invalidItems.length > INVALID_SAMPLE_LIMIT
-                ? `${sample}...`
-                : sample,
-          },
-        ),
-        variant: 'destructive',
-      });
-      return;
-    }
-    if (creatorBids.length === 0 && mobiles.length === 0) {
-      if (blockedCreatorInput) {
-        setBlockedCreatorInput('');
-      }
-      return;
-    }
-    const existingCreatorBids = new Set(policy.blacklist.creator_bids);
-    const existingMobiles = new Set(policy.blacklist.mobiles);
-    const nextCreatorBids = creatorBids.filter(
-      item => !existingCreatorBids.has(item),
-    );
-    const nextMobiles = mobiles.filter(item => !existingMobiles.has(item));
-    const addedCount = nextCreatorBids.length + nextMobiles.length;
-    if (addedCount > MAX_BLOCKED_CREATOR_IMPORT_COUNT) {
-      toast({
-        title: t(
-          'module.operationsCreditNotifications.config.listDialog.blockedCreatorLimit',
-          { count: MAX_BLOCKED_CREATOR_IMPORT_COUNT },
-        ),
-        variant: 'destructive',
-      });
-      return;
-    }
-    if (addedCount === 0) {
-      setBlockedCreatorInput('');
-      toast({
-        title: t(
-          'module.operationsCreditNotifications.config.listDialog.duplicateBlockedCreators',
-        ),
-      });
-      return;
-    }
-    updatePolicy(draft => {
-      draft.blacklist.creator_bids = Array.from(
-        new Set([...draft.blacklist.creator_bids, ...nextCreatorBids]),
-      );
-      draft.blacklist.mobiles = Array.from(
-        new Set([...draft.blacklist.mobiles, ...nextMobiles]),
-      );
-    });
-    setBlockedCreatorInput('');
-    toast({
-      title: t(
-        'module.operationsCreditNotifications.config.listDialog.addedBlockedCreators',
-        { count: addedCount },
-      ),
-    });
-  };
-
-  const managedListDetails =
-    managedListDialog === 'blocked'
-      ? blockedCreatorDetails
-      : optedOutCreatorDetails;
-  const filteredManagedListDetails = filterListDetails(
-    managedListDetails,
-    managedListSearch,
-    contactMode,
-  );
-  const managedListTitle =
-    managedListDialog === 'blocked'
-      ? t(
-          'module.operationsCreditNotifications.config.fields.blockedCreatorList',
-        )
-      : t(
-          'module.operationsCreditNotifications.config.fields.optedOutCreators',
-        );
-  const managedListCanDelete = managedListDialog === 'blocked';
 
   if (configLoading && !configLoaded) {
     return (
@@ -1019,10 +713,7 @@ export function CreditNotificationConfigTab({
           search={managedListSearch}
           onSearchChange={setManagedListSearch}
           onRemove={removeBlockedCreator}
-          onClose={() => {
-            setManagedListDialog(null);
-            setManagedListSearch('');
-          }}
+          onClose={closeManagedListDialog}
         />
       </div>
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationConfigTabState.ts
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationConfigTabState.ts
@@ -1,0 +1,466 @@
+import { useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import type { TFunction } from 'i18next';
+import { toast } from '@/hooks/useToast';
+import type {
+  AdminOperationCreditNotificationPolicy,
+  AdminOperationCreditNotificationPolicyListItem,
+  AdminOperationCreditNotificationPolicyResolvedLists,
+} from '../operation-credit-notification-types';
+import {
+  formatListInput,
+  normalizeIntegerInput,
+  normalizeListInputCharacters,
+  parseListInput,
+  readNumber,
+  type KnownNotificationType,
+} from './creditNotificationUtils';
+import type { CreditNotificationManagedListType as ManagedListType } from './CreditNotificationManagedListDialog';
+
+export type UpdatePolicy = (
+  updater: (draft: AdminOperationCreditNotificationPolicy) => void,
+) => void;
+
+const MAX_BLOCKED_CREATOR_IMPORT_COUNT = 50;
+const INVALID_SAMPLE_LIMIT = 5;
+const PHONE_MATCH_PATTERN = /(?:^|\D)(\d{11})(?!\d)/g;
+const EMAIL_MATCH_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const EMAIL_TEST_PATTERN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+const CREATOR_ID_PATTERN = /^[A-Za-z0-9_-]{4,80}$/;
+
+const isSmsMobileIdentifier = (value: string) => {
+  const normalized = value.trim().replace(/^\+/, '');
+  return /^\d{5,20}$/.test(normalized);
+};
+
+const findPhoneIdentifiers = (value: string): string[] => {
+  const matches: string[] = [];
+  const pattern = new RegExp(PHONE_MATCH_PATTERN.source, 'g');
+  let match = pattern.exec(value);
+  while (match) {
+    if (match[1]) {
+      matches.push(match[1]);
+    }
+    match = pattern.exec(value);
+  }
+  return matches;
+};
+
+const findEmailIdentifiers = (value: string): string[] =>
+  Array.from(value.matchAll(EMAIL_MATCH_PATTERN)).map(match =>
+    match[0].toLowerCase(),
+  );
+
+const splitIdentifierTokens = (value: string): string[] =>
+  value
+    .split(/[\s,;|]+/)
+    .map(item => item.trim())
+    .filter(Boolean);
+
+const trimInvalidDisplay = (value: string): string =>
+  value.replace(/^[\s,;|]+|[\s,;|]+$/g, '').trim();
+
+const parseBlockedCreatorInput = (
+  value: string,
+  contactMode: 'email' | 'phone',
+) => {
+  const normalized = normalizeListInputCharacters(value).replace(/\t/g, ' ');
+  const creatorBids: string[] = [];
+  const mobiles: string[] = [];
+  const invalidItems: string[] = [];
+  const addToken = (token: string) => {
+    if (isSmsMobileIdentifier(token)) {
+      mobiles.push(token);
+      return;
+    }
+    if (EMAIL_TEST_PATTERN.test(token)) {
+      creatorBids.push(token.toLowerCase());
+      return;
+    }
+    if (CREATOR_ID_PATTERN.test(token)) {
+      creatorBids.push(token);
+      return;
+    }
+    invalidItems.push(token);
+  };
+
+  normalized.split(/\r?\n/).forEach(rawLine => {
+    const line = trimInvalidDisplay(rawLine);
+    if (!line) {
+      return;
+    }
+    if (/[;,]/.test(line)) {
+      splitIdentifierTokens(line).forEach(addToken);
+      return;
+    }
+    const contactMatches =
+      contactMode === 'email'
+        ? findEmailIdentifiers(line)
+        : findPhoneIdentifiers(line);
+    if (contactMatches.length > 0) {
+      if (contactMode === 'email') {
+        creatorBids.push(...contactMatches);
+        return;
+      }
+      mobiles.push(...contactMatches);
+      return;
+    }
+
+    splitIdentifierTokens(line).forEach(addToken);
+  });
+
+  return {
+    creatorBids: Array.from(new Set(creatorBids)),
+    invalidItems: Array.from(new Set(invalidItems)),
+    mobiles: Array.from(new Set(mobiles)),
+  };
+};
+
+const mergeIdentifierLists = (...lists: string[][]) =>
+  Array.from(
+    new Set(
+      lists.flatMap(list => list.map(item => item.trim()).filter(Boolean)),
+    ),
+  );
+
+const buildListDetails = (
+  identifiers: string[],
+  resolvedItems: AdminOperationCreditNotificationPolicyListItem[] = [],
+) => {
+  const resolvedByIdentifier = new Map(
+    resolvedItems.map(item => [item.identifier, item]),
+  );
+  return identifiers.map(identifier => ({
+    identifier,
+    creator_bid: resolvedByIdentifier.get(identifier)?.creator_bid || '',
+    mobile: resolvedByIdentifier.get(identifier)?.mobile || '',
+    email: resolvedByIdentifier.get(identifier)?.email || '',
+    nickname: resolvedByIdentifier.get(identifier)?.nickname || '',
+  }));
+};
+
+const filterListDetails = (
+  items: AdminOperationCreditNotificationPolicyListItem[],
+  keyword: string,
+  contactMode: 'email' | 'phone',
+) => {
+  const normalized = keyword.trim().toLowerCase();
+  if (!normalized) {
+    return items;
+  }
+  return items.filter(item => {
+    const contactValue =
+      contactMode === 'email'
+        ? item.email || item.identifier
+        : item.mobile || item.identifier;
+    const isContactSearch =
+      contactMode === 'email'
+        ? normalized.includes('@')
+        : /^\d+$/.test(normalized);
+    if (isContactSearch) {
+      return contactValue.toLowerCase() === normalized;
+    }
+    return item.nickname.toLowerCase().includes(normalized);
+  });
+};
+
+export function useCreditNotificationConfigTabState({
+  contactMode,
+  policy,
+  resolvedLists,
+  updatePolicy,
+  t,
+}: {
+  contactMode: 'email' | 'phone';
+  policy: AdminOperationCreditNotificationPolicy;
+  resolvedLists: AdminOperationCreditNotificationPolicyResolvedLists;
+  updatePolicy: UpdatePolicy;
+  t: TFunction;
+}) {
+  const [openTemplatePicker, setOpenTemplatePicker] = useState<
+    Partial<Record<KnownNotificationType, boolean>>
+  >({});
+  const [editingTemplateTypes, setEditingTemplateTypes] = useState<
+    Partial<Record<KnownNotificationType, boolean>>
+  >({});
+  const [templateInputValues, setTemplateInputValues] = useState<
+    Partial<Record<KnownNotificationType, string>>
+  >({});
+  const [listInputValues, setListInputValues] = useState<
+    Partial<Record<string, string>>
+  >({});
+  const [blockedCreatorInput, setBlockedCreatorInput] = useState('');
+  const [integerInputValues, setIntegerInputValues] = useState<
+    Partial<Record<string, string>>
+  >({});
+  const [managedListDialog, setManagedListDialog] =
+    useState<ManagedListType | null>(null);
+  const [managedListSearch, setManagedListSearch] = useState('');
+
+  const blockedCreatorIdentifiers = useMemo(
+    () =>
+      mergeIdentifierLists(
+        policy.blacklist.creator_bids,
+        policy.blacklist.mobiles,
+      ),
+    [policy.blacklist.creator_bids, policy.blacklist.mobiles],
+  );
+  const optedOutCreatorIdentifiers = useMemo(
+    () =>
+      mergeIdentifierLists(policy.opt_out.creator_bids, policy.opt_out.mobiles),
+    [policy.opt_out.creator_bids, policy.opt_out.mobiles],
+  );
+  const blockedCreatorDetails = useMemo(
+    () =>
+      buildListDetails(
+        blockedCreatorIdentifiers,
+        resolvedLists.blacklist?.items || [],
+      ),
+    [blockedCreatorIdentifiers, resolvedLists.blacklist?.items],
+  );
+  const optedOutCreatorDetails = useMemo(
+    () =>
+      buildListDetails(
+        optedOutCreatorIdentifiers,
+        resolvedLists.opt_out?.items || [],
+      ),
+    [optedOutCreatorIdentifiers, resolvedLists.opt_out?.items],
+  );
+
+  const getListInputValue = (key: string, value: string[]) =>
+    listInputValues[key] ?? formatListInput(value);
+
+  const updateListInput = (
+    key: string,
+    value: string,
+    commit: (normalized: string) => void,
+  ) => {
+    const inputValue = normalizeListInputCharacters(value);
+    setListInputValues(current => ({
+      ...current,
+      [key]: inputValue,
+    }));
+    commit(inputValue);
+  };
+
+  const finishListInput = (key: string, value: string) => {
+    setListInputValues(current => {
+      const next = { ...current };
+      next[key] = formatListInput(parseListInput(value));
+      return next;
+    });
+  };
+
+  const getIntegerInputValue = (key: string, value: number) =>
+    integerInputValues[key] ?? String(value);
+
+  const updateIntegerInput = (
+    key: string,
+    value: string,
+    fallback: number,
+    commit: (value: number) => void,
+  ) => {
+    const normalized = normalizeIntegerInput(value);
+    setIntegerInputValues(current => ({
+      ...current,
+      [key]: normalized,
+    }));
+    commit(readNumber(normalized, fallback));
+  };
+
+  const finishIntegerInput = (key: string, value: number) => {
+    setIntegerInputValues(current => {
+      const next = { ...current };
+      next[key] = String(value);
+      return next;
+    });
+  };
+
+  const openManagedListDialog = (type: ManagedListType) => {
+    setManagedListDialog(type);
+    setManagedListSearch('');
+  };
+
+  const closeManagedListDialog = () => {
+    setManagedListDialog(null);
+    setManagedListSearch('');
+  };
+
+  const removeBlockedCreator = (identifier: string) => {
+    updatePolicy(draft => {
+      draft.blacklist.creator_bids = draft.blacklist.creator_bids.filter(
+        item => item !== identifier,
+      );
+      draft.blacklist.mobiles = draft.blacklist.mobiles.filter(
+        item => item !== identifier,
+      );
+    });
+  };
+
+  const addBlockedCreators = () => {
+    const normalized = normalizeListInputCharacters(blockedCreatorInput);
+    const { creatorBids, invalidItems, mobiles } = parseBlockedCreatorInput(
+      normalized,
+      contactMode,
+    );
+    if (invalidItems.length > 0) {
+      const sample = invalidItems.slice(0, INVALID_SAMPLE_LIMIT).join(', ');
+      toast({
+        title: t(
+          'module.operationsCreditNotifications.config.listDialog.invalidBlockedCreators',
+          {
+            values:
+              invalidItems.length > INVALID_SAMPLE_LIMIT
+                ? `${sample}...`
+                : sample,
+          },
+        ),
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (creatorBids.length === 0 && mobiles.length === 0) {
+      if (blockedCreatorInput) {
+        setBlockedCreatorInput('');
+      }
+      return;
+    }
+    const existingCreatorBids = new Set(policy.blacklist.creator_bids);
+    const existingMobiles = new Set(policy.blacklist.mobiles);
+    const nextCreatorBids = creatorBids.filter(
+      item => !existingCreatorBids.has(item),
+    );
+    const nextMobiles = mobiles.filter(item => !existingMobiles.has(item));
+    const addedCount = nextCreatorBids.length + nextMobiles.length;
+    if (addedCount > MAX_BLOCKED_CREATOR_IMPORT_COUNT) {
+      toast({
+        title: t(
+          'module.operationsCreditNotifications.config.listDialog.blockedCreatorLimit',
+          { count: MAX_BLOCKED_CREATOR_IMPORT_COUNT },
+        ),
+        variant: 'destructive',
+      });
+      return;
+    }
+    if (addedCount === 0) {
+      setBlockedCreatorInput('');
+      toast({
+        title: t(
+          'module.operationsCreditNotifications.config.listDialog.duplicateBlockedCreators',
+        ),
+      });
+      return;
+    }
+    updatePolicy(draft => {
+      draft.blacklist.creator_bids = Array.from(
+        new Set([...draft.blacklist.creator_bids, ...nextCreatorBids]),
+      );
+      draft.blacklist.mobiles = Array.from(
+        new Set([...draft.blacklist.mobiles, ...nextMobiles]),
+      );
+    });
+    setBlockedCreatorInput('');
+    toast({
+      title: t(
+        'module.operationsCreditNotifications.config.listDialog.addedBlockedCreators',
+        { count: addedCount },
+      ),
+    });
+  };
+
+  const managedListDetails = useMemo(
+    () =>
+      managedListDialog === 'blocked'
+        ? blockedCreatorDetails
+        : optedOutCreatorDetails,
+    [blockedCreatorDetails, managedListDialog, optedOutCreatorDetails],
+  );
+  const filteredManagedListDetails = useMemo(
+    () =>
+      filterListDetails(managedListDetails, managedListSearch, contactMode),
+    [contactMode, managedListDetails, managedListSearch],
+  );
+  const managedListTitle =
+    managedListDialog === 'blocked'
+      ? t(
+          'module.operationsCreditNotifications.config.fields.blockedCreatorList',
+        )
+      : t(
+          'module.operationsCreditNotifications.config.fields.optedOutCreators',
+        );
+  const managedListCanDelete = managedListDialog === 'blocked';
+
+  return {
+    blockedCreatorIdentifiers,
+    blockedCreatorInput,
+    closeManagedListDialog,
+    editingTemplateTypes,
+    filteredManagedListDetails,
+    finishIntegerInput,
+    finishListInput,
+    getIntegerInputValue,
+    getListInputValue,
+    integerInputValues,
+    listInputValues,
+    managedListCanDelete,
+    managedListDialog,
+    managedListSearch,
+    managedListTitle,
+    openManagedListDialog,
+    openTemplatePicker,
+    optedOutCreatorIdentifiers,
+    removeBlockedCreator,
+    setBlockedCreatorInput,
+    setEditingTemplateTypes,
+    setManagedListSearch,
+    setOpenTemplatePicker,
+    setTemplateInputValues,
+    templateInputValues,
+    updateIntegerInput,
+    updateListInput,
+    addBlockedCreators,
+  } satisfies {
+    blockedCreatorIdentifiers: string[];
+    blockedCreatorInput: string;
+    closeManagedListDialog: () => void;
+    editingTemplateTypes: Partial<Record<KnownNotificationType, boolean>>;
+    filteredManagedListDetails: AdminOperationCreditNotificationPolicyListItem[];
+    finishIntegerInput: (key: string, value: number) => void;
+    finishListInput: (key: string, value: string) => void;
+    getIntegerInputValue: (key: string, value: number) => string;
+    getListInputValue: (key: string, value: string[]) => string;
+    integerInputValues: Partial<Record<string, string>>;
+    listInputValues: Partial<Record<string, string>>;
+    managedListCanDelete: boolean;
+    managedListDialog: ManagedListType | null;
+    managedListSearch: string;
+    managedListTitle: string;
+    openManagedListDialog: (type: ManagedListType) => void;
+    openTemplatePicker: Partial<Record<KnownNotificationType, boolean>>;
+    optedOutCreatorIdentifiers: string[];
+    removeBlockedCreator: (identifier: string) => void;
+    setBlockedCreatorInput: Dispatch<SetStateAction<string>>;
+    setEditingTemplateTypes: Dispatch<
+      SetStateAction<Partial<Record<KnownNotificationType, boolean>>>
+    >;
+    setManagedListSearch: Dispatch<SetStateAction<string>>;
+    setOpenTemplatePicker: Dispatch<
+      SetStateAction<Partial<Record<KnownNotificationType, boolean>>>
+    >;
+    setTemplateInputValues: Dispatch<
+      SetStateAction<Partial<Record<KnownNotificationType, string>>>
+    >;
+    templateInputValues: Partial<Record<KnownNotificationType, string>>;
+    updateIntegerInput: (
+      key: string,
+      value: string,
+      fallback: number,
+      commit: (value: number) => void,
+    ) => void;
+    updateListInput: (
+      key: string,
+      value: string,
+      commit: (normalized: string) => void,
+    ) => void;
+    addBlockedCreators: () => void;
+  };
+}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationConfigTabState.ts
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationConfigTabState.ts
@@ -375,8 +375,7 @@ export function useCreditNotificationConfigTabState({
     [blockedCreatorDetails, managedListDialog, optedOutCreatorDetails],
   );
   const filteredManagedListDetails = useMemo(
-    () =>
-      filterListDetails(managedListDetails, managedListSearch, contactMode),
+    () => filterListDetails(managedListDetails, managedListSearch, contactMode),
     [contactMode, managedListDetails, managedListSearch],
   );
   const managedListTitle =


### PR DESCRIPTION
## Summary
- move CreditNotificationConfigTab local editor and managed-list state into a dedicated hook so the config tab stays orchestration-focused
- preserve existing config tab behavior for template picking, integer/list inputs, blocked creator management, and managed-list dialogs
- update the active billing credit notifications ExecPlan to record this follow-up split and defer deeper dry-run/template-sync extraction to a later PR

## Testing
- cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/credit-notifications/page.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npx eslint src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx src/app/admin/operations/credit-notifications/useCreditNotificationConfigTabState.ts src/app/admin/operations/credit-notifications/page.tsx src/app/admin/operations/credit-notifications/page.test.tsx
- python scripts/check_repo_harness.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the credit notifications admin configuration tab by consolidating UI state and related editing logic into a dedicated hook.
  * Simplified template picker/editor and managed-list dialog interactions, keeping the tab focused on orchestration.
* **Documentation**
  * Updated the exec-plan progress notes, including clearer completion status and a refreshed “Outcomes & Retrospective” summary for the follow-up scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->