### PR TITLE
refactor: isolate credit notification config actions

### DIFF
--- a/docs/exec-plans/active/billing-credit-notifications.md
+++ b/docs/exec-plans/active/billing-credit-notifications.md
@@ -21,11 +21,11 @@
 - [x] 2026-05-21 17:07 CST: Added teacher-facing balance state and softlimit debug blocking on frontend and backend preview/debug paths.
 - [x] 2026-05-21 17:07 CST: Added focused backend/task/frontend tests and ran validation; architecture boundary check is blocked only by unrelated pre-existing untracked route-support files.
 - [x] 2026-05-22 18:35 CST: Extended low-balance notifications with estimated-days thresholds based on finalized daily ledger consumption, structured operator form fields, dry-run details, and focused tests.
-<<<<<<< HEAD
 - [x] 2026-06-19 21:20 CST: Follow-up work on `refactor/billing-credit-notifications` cleaned up records/config request-state handling, requeue refresh behavior, and config-side experience without changing the notification-center core model.
 - [x] 2026-06-19 21:36 CST: Deferred the next-step `CreditNotificationConfigTab.tsx` split (dry-run, template sync, managed-list dialog state isolation) to a separate follow-up PR so the request-state polish branch stayed reviewable.
 - [x] 2026-06-21 16:10 CST: Follow-up admin refinements split the records overview/filter UI and then moved `CreditNotificationConfigTab` local template/input/managed-list state into a dedicated hook so the config tab stays orchestration-focused without changing backend contracts.
 - [x] 2026-06-21 16:24 CST: Stopped this follow-up round after the local-state extraction; `dry-run` and template-sync deeper hook splits remain explicitly deferred to a later credit-notification follow-up PR to keep the scope reviewable.
+- [x] 2026-06-21 17:05 CST: A config-tab follow-up extracted `dry-run` and template-sync state into dedicated frontend hooks so their errors stay local to the config area instead of reusing page-level state.
 
 ## Surprises & Discoveries
 
@@ -63,7 +63,7 @@ Implemented v1 of the积分通知中心:
 - Low-balance reminders can optionally trigger by estimated remaining days, using finalized daily consume summaries. Fixed-threshold fallback only applies when there is partial valid consumption history; missing or zero daily consumption summaries do not send estimated-days reminders.
 - Billing overview exposes `credit_status`, `debug_allowed`, and `softlimit_threshold`; preview/debug paths enforce softlimit in both frontend and backend.
 - Focused backend, task, and frontend tests cover staging, dedupe, skip, provider retry, scan windows, softlimit, Celery schedule/config, operator page rendering, and frontend preview blocking.
-- Follow-up operator refinements now scope records/config/dry-run errors separately, refresh records plus overview in parallel after requeue, and keep the credit notification config tab maintainable by isolating its local editor and managed-list state in a dedicated frontend hook.
+- Follow-up operator refinements now scope records/config/dry-run errors separately, refresh records plus overview in parallel after requeue, keep the credit notification config tab maintainable by isolating its local editor and managed-list state in a dedicated frontend hook, and move `dry-run` plus template-sync state into dedicated frontend hooks so config actions stay local to the config experience without changing contracts or records-tab behavior.
 
 ## Context and Orientation
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -88,6 +88,7 @@ export function CreditNotificationConfigTab({
   configError,
   dryRunResult,
   dryRunError,
+  templateSyncError,
   templateSyncResults,
   templateSyncLoading,
   templateOptions,
@@ -107,6 +108,7 @@ export function CreditNotificationConfigTab({
   configError: string;
   dryRunResult: AdminOperationCreditNotificationDryRunResponse | null;
   dryRunError: string;
+  templateSyncError: string;
   templateSyncResults: Partial<
     Record<
       KnownNotificationType,
@@ -233,6 +235,11 @@ export function CreditNotificationConfigTab({
             'module.operationsCreditNotifications.config.sections.types',
           )}
         >
+          {templateSyncError ? (
+            <div className='mb-3 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive'>
+              {templateSyncError}
+            </div>
+          ) : null}
           <div className='space-y-3'>
             {NOTIFICATION_TYPES.map(type => (
               <CreditNotificationTypeConfigCard

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -1261,8 +1261,11 @@ describe('AdminOperationCreditNotificationsPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows dry-run failures inside config without polluting records error state', async () => {
-    mockDryRun.mockRejectedValueOnce(new Error('dry run unavailable'));
+  it('shows dry-run failures inside the config tab without reusing records errors', async () => {
+    mockDryRun.mockRejectedValueOnce({
+      message: 'dry-run failed',
+      code: 5001,
+    });
 
     render(<AdminOperationCreditNotificationsPage />);
 
@@ -1275,9 +1278,13 @@ describe('AdminOperationCreditNotificationsPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('dry run unavailable')).toBeInTheDocument();
+      expect(mockDryRun).toHaveBeenCalledWith({
+        notification_type: '',
+        creator_bid: '',
+      });
     });
-    expect(mockGetRecords).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByText('dry-run failed')).toBeInTheDocument();
     expect(
       screen.queryByText('module.operationsCreditNotifications.loadError'),
     ).not.toBeInTheDocument();

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -209,8 +209,7 @@ export default function AdminOperationCreditNotificationsPage() {
     templateSyncLoading,
     templateSyncResults,
   } = useCreditNotificationTemplateSyncState({
-    getTemplateCode: notificationType =>
-      policy.types[notificationType].template_code,
+    policyTypes: policy.types,
     setTemplateOptions,
     t,
   });

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -55,6 +55,8 @@ import {
   type NotificationFilters,
   type PageTab,
 } from './creditNotificationUtils';
+import { useCreditNotificationDryRun } from './useCreditNotificationDryRun';
+import { useCreditNotificationTemplateSyncState } from './useCreditNotificationTemplateSyncState';
 
 const normalizeResolvedPolicyLists = (
   payload: unknown,
@@ -114,20 +116,6 @@ export default function AdminOperationCreditNotificationsPage() {
   const [configError, setConfigError] = React.useState('');
   const [configLoaded, setConfigLoaded] = React.useState(false);
   const [configLoading, setConfigLoading] = React.useState(false);
-  const [dryRunResult, setDryRunResult] =
-    React.useState<AdminOperationCreditNotificationDryRunResponse | null>(null);
-  const [dryRunError, setDryRunError] = React.useState('');
-  const [templateSyncResults, setTemplateSyncResults] = React.useState<
-    Partial<
-      Record<
-        KnownNotificationType,
-        AdminOperationCreditNotificationTemplateSyncResponse
-      >
-    >
-  >({});
-  const [templateSyncLoading, setTemplateSyncLoading] = React.useState<
-    Partial<Record<KnownNotificationType, boolean>>
-  >({});
   const [templateOptions, setTemplateOptions] = React.useState<
     AdminOperationCreditNotificationTemplateOption[]
   >([]);
@@ -211,6 +199,24 @@ export default function AdminOperationCreditNotificationsPage() {
     },
     [],
   );
+
+  const {
+    dryRunError,
+    dryRunResult,
+    runDryRun,
+  } = useCreditNotificationDryRun(t);
+  const {
+    clearTemplateSyncResult,
+    syncTemplate,
+    templateSyncError,
+    templateSyncLoading,
+    templateSyncResults,
+  } = useCreditNotificationTemplateSyncState({
+    getTemplateCode: notificationType =>
+      policy.types[notificationType].template_code,
+    setTemplateOptions,
+    t,
+  });
 
   const fetchConfig = React.useCallback(async () => {
     const response = await api.getAdminOperationCreditNotificationConfig({});
@@ -551,113 +557,9 @@ export default function AdminOperationCreditNotificationsPage() {
       document.removeEventListener('click', handleDocumentClick, true);
   }, [activeTab, isConfigDirty]);
 
-  const syncTemplate = React.useCallback(
-    async (
-      notificationType: KnownNotificationType,
-      templateCodeOverride?: string,
-    ) => {
-      const templateCode = (
-        templateCodeOverride ?? policy.types[notificationType].template_code
-      ).trim();
-      if (!templateCode) {
-        setConfigError(
-          t(
-            'module.operationsCreditNotifications.config.templateSync.templateCodeRequired',
-          ),
-        );
-        return false;
-      }
-      setTemplateSyncLoading(current => ({
-        ...current,
-        [notificationType]: true,
-      }));
-      try {
-        const response =
-          (await api.syncAdminOperationCreditNotificationTemplate({
-            notification_type: notificationType,
-            template_code: templateCode,
-          })) as AdminOperationCreditNotificationTemplateSyncResponse;
-        setTemplateSyncResults(current => ({
-          ...current,
-          [notificationType]: response,
-        }));
-        setTemplateOptions(current => {
-          const nextOption: AdminOperationCreditNotificationTemplateOption = {
-            notification_template_bid: response.notification_template_bid,
-            channel: response.channel,
-            provider: response.provider,
-            template_code: response.template_code,
-            template_name: response.template_name,
-            template_content: response.template_content,
-            template_status: response.template_status,
-            template_type: response.template_type,
-            sync_status: response.sync_status,
-            error_code: response.error_code,
-            error_message: response.error_message,
-            placeholders: response.placeholders,
-            compatible_notification_types: response.compatible
-              ? [notificationType]
-              : [],
-            last_synced_at: response.last_synced_at,
-            source: 'local',
-          };
-          return [
-            nextOption,
-            ...current.filter(
-              option => option.template_code !== response.template_code,
-            ),
-          ];
-        });
-        setConfigError('');
-        return Boolean(response.compatible);
-      } catch (requestError) {
-        const resolvedError = requestError as ErrorWithCode;
-        setConfigError(
-          resolvedError.message ||
-            t(
-              'module.operationsCreditNotifications.config.templateSync.syncFailed',
-            ),
-        );
-        return false;
-      } finally {
-        setTemplateSyncLoading(current => ({
-          ...current,
-          [notificationType]: false,
-        }));
-      }
-    },
-    [policy.types, t],
-  );
-
-  const clearTemplateSyncResult = React.useCallback(
-    (notificationType: KnownNotificationType) => {
-      setTemplateSyncResults(current => {
-        if (current[notificationType] === undefined) {
-          return current;
-        }
-        return {
-          ...current,
-          [notificationType]: undefined,
-        };
-      });
-    },
-    [],
-  );
-
   const dryRun = React.useCallback(async () => {
-    try {
-      setDryRunError('');
-      const response = (await api.dryRunAdminOperationCreditNotifications({
-        notification_type: draftFilters.notification_type.trim(),
-        creator_bid: '',
-      })) as AdminOperationCreditNotificationDryRunResponse;
-      setDryRunResult(response);
-    } catch (requestError) {
-      const resolvedError = requestError as ErrorWithCode;
-      setDryRunResult(null);
-      setDryRunError(resolvedError.message || t('common.core.submitFailed'));
-    }
-  }, [draftFilters.notification_type, t]);
+    await runDryRun(draftFilters.notification_type);
+  }, [draftFilters.notification_type, runDryRun]);
 
   const requeue = React.useCallback(
     async (notificationBid: string) => {
@@ -781,6 +683,7 @@ export default function AdminOperationCreditNotificationsPage() {
             configError={configError}
             dryRunResult={dryRunResult}
             dryRunError={dryRunError}
+            templateSyncError={templateSyncError}
             templateSyncResults={templateSyncResults}
             templateSyncLoading={templateSyncLoading}
             templateOptions={templateOptions}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -200,11 +200,8 @@ export default function AdminOperationCreditNotificationsPage() {
     [],
   );
 
-  const {
-    dryRunError,
-    dryRunResult,
-    runDryRun,
-  } = useCreditNotificationDryRun(t);
+  const { dryRunError, dryRunResult, runDryRun } =
+    useCreditNotificationDryRun(t);
   const {
     clearTemplateSyncResult,
     syncTemplate,

--- a/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationDryRun.ts
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationDryRun.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { TFunction } from 'i18next';
+import api from '@/api';
+import { ErrorWithCode } from '@/lib/request';
+import type { AdminOperationCreditNotificationDryRunResponse } from '../operation-credit-notification-types';
+
+export function useCreditNotificationDryRun(t: TFunction) {
+  const [dryRunResult, setDryRunResult] =
+    React.useState<AdminOperationCreditNotificationDryRunResponse | null>(null);
+  const [dryRunError, setDryRunError] = React.useState('');
+
+  const runDryRun = React.useCallback(
+    async (notificationType: string) => {
+      try {
+        const response = (await api.dryRunAdminOperationCreditNotifications({
+          notification_type: notificationType.trim(),
+          creator_bid: '',
+        })) as AdminOperationCreditNotificationDryRunResponse;
+        setDryRunResult(response);
+        setDryRunError('');
+        return true;
+      } catch (requestError) {
+        const resolvedError = requestError as ErrorWithCode;
+        setDryRunResult(null);
+        setDryRunError(resolvedError.message || t('common.core.submitFailed'));
+        return false;
+      }
+    },
+    [t],
+  );
+
+  return {
+    dryRunError,
+    dryRunResult,
+    runDryRun,
+  };
+}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationTemplateSyncState.ts
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationTemplateSyncState.ts
@@ -1,0 +1,135 @@
+import React from 'react';
+import type { TFunction } from 'i18next';
+import api from '@/api';
+import { ErrorWithCode } from '@/lib/request';
+import type {
+  AdminOperationCreditNotificationTemplateOption,
+  AdminOperationCreditNotificationTemplateSyncResponse,
+} from '../operation-credit-notification-types';
+import type { KnownNotificationType } from './creditNotificationUtils';
+
+export function useCreditNotificationTemplateSyncState({
+  getTemplateCode,
+  setTemplateOptions,
+  t,
+}: {
+  getTemplateCode: (notificationType: KnownNotificationType) => string;
+  setTemplateOptions: React.Dispatch<
+    React.SetStateAction<AdminOperationCreditNotificationTemplateOption[]>
+  >;
+  t: TFunction;
+}) {
+  const [templateSyncResults, setTemplateSyncResults] = React.useState<
+    Partial<
+      Record<
+        KnownNotificationType,
+        AdminOperationCreditNotificationTemplateSyncResponse
+      >
+    >
+  >({});
+  const [templateSyncLoading, setTemplateSyncLoading] = React.useState<
+    Partial<Record<KnownNotificationType, boolean>>
+  >({});
+  const [templateSyncError, setTemplateSyncError] = React.useState('');
+
+  const syncTemplate = React.useCallback(
+    async (
+      notificationType: KnownNotificationType,
+      templateCodeOverride?: string,
+    ) => {
+      const templateCode = (
+        templateCodeOverride ?? getTemplateCode(notificationType)
+      ).trim();
+      if (!templateCode) {
+        setTemplateSyncError(
+          t(
+            'module.operationsCreditNotifications.config.templateSync.templateCodeRequired',
+          ),
+        );
+        return false;
+      }
+      setTemplateSyncLoading(current => ({
+        ...current,
+        [notificationType]: true,
+      }));
+      try {
+        const response =
+          (await api.syncAdminOperationCreditNotificationTemplate({
+            notification_type: notificationType,
+            template_code: templateCode,
+          })) as AdminOperationCreditNotificationTemplateSyncResponse;
+        setTemplateSyncResults(current => ({
+          ...current,
+          [notificationType]: response,
+        }));
+        setTemplateOptions(current => {
+          const nextOption: AdminOperationCreditNotificationTemplateOption = {
+            notification_template_bid: response.notification_template_bid,
+            channel: response.channel,
+            provider: response.provider,
+            template_code: response.template_code,
+            template_name: response.template_name,
+            template_content: response.template_content,
+            template_status: response.template_status,
+            template_type: response.template_type,
+            sync_status: response.sync_status,
+            error_code: response.error_code,
+            error_message: response.error_message,
+            placeholders: response.placeholders,
+            compatible_notification_types: response.compatible
+              ? [notificationType]
+              : [],
+            last_synced_at: response.last_synced_at,
+            source: 'local',
+          };
+          return [
+            nextOption,
+            ...current.filter(
+              option => option.template_code !== response.template_code,
+            ),
+          ];
+        });
+        setTemplateSyncError('');
+        return Boolean(response.compatible);
+      } catch (requestError) {
+        const resolvedError = requestError as ErrorWithCode;
+        setTemplateSyncError(
+          resolvedError.message ||
+            t(
+              'module.operationsCreditNotifications.config.templateSync.syncFailed',
+            ),
+        );
+        return false;
+      } finally {
+        setTemplateSyncLoading(current => ({
+          ...current,
+          [notificationType]: false,
+        }));
+      }
+    },
+    [getTemplateCode, setTemplateOptions, t],
+  );
+
+  const clearTemplateSyncResult = React.useCallback(
+    (notificationType: KnownNotificationType) => {
+      setTemplateSyncResults(current => {
+        if (current[notificationType] === undefined) {
+          return current;
+        }
+        return {
+          ...current,
+          [notificationType]: undefined,
+        };
+      });
+    },
+    [],
+  );
+
+  return {
+    clearTemplateSyncResult,
+    syncTemplate,
+    templateSyncError,
+    templateSyncLoading,
+    templateSyncResults,
+  };
+}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationTemplateSyncState.ts
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/useCreditNotificationTemplateSyncState.ts
@@ -9,11 +9,11 @@ import type {
 import type { KnownNotificationType } from './creditNotificationUtils';
 
 export function useCreditNotificationTemplateSyncState({
-  getTemplateCode,
+  policyTypes,
   setTemplateOptions,
   t,
 }: {
-  getTemplateCode: (notificationType: KnownNotificationType) => string;
+  policyTypes: Record<KnownNotificationType, { template_code: string }>;
   setTemplateOptions: React.Dispatch<
     React.SetStateAction<AdminOperationCreditNotificationTemplateOption[]>
   >;
@@ -38,7 +38,7 @@ export function useCreditNotificationTemplateSyncState({
       templateCodeOverride?: string,
     ) => {
       const templateCode = (
-        templateCodeOverride ?? getTemplateCode(notificationType)
+        templateCodeOverride ?? policyTypes[notificationType].template_code
       ).trim();
       if (!templateCode) {
         setTemplateSyncError(
@@ -85,7 +85,11 @@ export function useCreditNotificationTemplateSyncState({
           return [
             nextOption,
             ...current.filter(
-              option => option.template_code !== response.template_code,
+              option =>
+                option.template_code !== response.template_code ||
+                !option.compatible_notification_types?.includes(
+                  notificationType,
+                ),
             ),
           ];
         });
@@ -107,7 +111,7 @@ export function useCreditNotificationTemplateSyncState({
         }));
       }
     },
-    [getTemplateCode, setTemplateOptions, t],
+    [policyTypes, setTemplateOptions, t],
   );
 
   const clearTemplateSyncResult = React.useCallback(


### PR DESCRIPTION
## Summary
- move credit notification dry-run state and template-sync state into dedicated hooks to keep config-tab actions local
- keep dry-run failures inside the config area instead of reusing page-level records errors
- update the active billing credit notifications ExecPlan to record this config follow-up extraction

## Testing
- cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/credit-notifications/page.test.tsx
- cd src/cook-web && npm run type-check
- cd src/cook-web && npx eslint src/app/admin/operations/credit-notifications/page.tsx src/app/admin/operations/credit-notifications/page.test.tsx src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx src/app/admin/operations/credit-notifications/useCreditNotificationDryRun.ts src/app/admin/operations/credit-notifications/useCreditNotificationTemplateSyncState.ts
- python scripts/check_repo_harness.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for dry-run and template sync operations in the credit notifications configuration tab; errors are now isolated to the relevant configuration section for better clarity.

* **Tests**
  * Updated dry-run failure test to verify correct error message display in the configuration interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->