### PR TITLE
fix: normalize button cursor styles

### DIFF
--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseMetricsCardGrid.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseMetricsCardGrid.tsx
@@ -81,7 +81,7 @@ export default function CourseMetricsCardGrid({
                   key={card.label}
                   type='button'
                   aria-label={card.actionLabel || card.label}
-                  className='group cursor-pointer text-left transition-colors'
+                  className='group text-left transition-colors'
                   onClick={card.onClick}
                 >
                   <AdminCountCard

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.css
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.css
@@ -29,7 +29,6 @@
   box-shadow: var(--shadow-xs-offset-x, 0) var(--shadow-xs-offset-y, 1px)
     var(--shadow-xs-blur-radius, 2px) var(--shadow-xs-spread-radius, 0)
     var(--shadow-xs-color, rgba(0, 0, 0, 0.05));
-  cursor: pointer;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -79,7 +78,6 @@
   border: 0;
   background: rgba(0, 0, 0, 0);
   color: var(--base-muted-foreground, #737373);
-  cursor: pointer;
 }
 .ChatMobileHeader .iconButton:focus-visible {
   outline: 2px solid var(--primary, #0f63ee);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
@@ -39,7 +39,6 @@
     border: 0;
     background: transparent;
     color: var(--base-muted-foreground, #737373);
-    cursor: pointer;
 
     &:focus-visible {
       outline: 2px solid var(--primary, #0f63ee);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.module.css
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.module.css
@@ -275,7 +275,6 @@
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(0, 0, 0, 0.08);
-  cursor: pointer;
   color: #666;
   transition: all 0.3s ease;
   opacity: 0;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatComponents.module.scss
@@ -252,7 +252,6 @@
   align-items: center;
   justify-content: center;
   border: 1px solid rgba(0, 0, 0, 0.08);
-  cursor: pointer;
   color: #666;
   transition: all 0.3s ease;
   opacity: 0;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/GlobalInfoButton.module.css
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/GlobalInfoButton.module.css
@@ -2,7 +2,6 @@
   background: #fff;
   padding: 0;
   margin: 0;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/GlobalInfoButton.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/GlobalInfoButton.module.scss
@@ -2,7 +2,6 @@
   background: #fff;
   padding: 0;
   margin: 0;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonFeedbackInteraction.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonFeedbackInteraction.tsx
@@ -79,7 +79,7 @@ export default function LessonFeedbackInteraction({
                 selected
                   ? 'border-primary bg-primary text-white'
                   : 'border-[var(--border)] bg-[var(--background)] text-[var(--foreground)]',
-                readonly ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                readonly ? 'cursor-not-allowed opacity-60' : '',
               )}
             >
               {score}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -171,7 +171,6 @@
   box-shadow:
     0 12px 28px rgba(15, 23, 42, 0.14),
     0 2px 8px rgba(15, 23, 42, 0.08);
-  cursor: pointer;
   backdrop-filter: blur(16px);
 }
 
@@ -346,7 +345,6 @@
   border-radius: 14px;
   background: color-mix(in srgb, var(--foreground) 3%, transparent);
   color: color-mix(in srgb, var(--foreground) 78%, transparent);
-  cursor: pointer;
   transition:
     background-color 160ms ease,
     border-color 160ms ease,

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.module.css
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.module.css
@@ -38,7 +38,6 @@
   color: #000;
   background: rgba(0, 0, 0, 0);
   border: none;
-  cursor: pointer;
   padding: 0;
   width: 32px;
   height: 32px;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.module.scss
@@ -66,7 +66,6 @@
     color: #000;
     background: transparent;
     border: none;
-    cursor: pointer;
     padding: 0;
     width: 32px;
     height: 32px;

--- a/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.css
+++ b/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.css
@@ -7,7 +7,6 @@
   box-shadow: var(--shadow-xs-offset-x, 0) var(--shadow-xs-offset-y, 1px)
     var(--shadow-xs-blur-radius, 2px) var(--shadow-xs-spread-radius, 0)
     var(--shadow-xs-color, rgba(0, 0, 0, 0.05));
-  cursor: pointer;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;

--- a/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.scss
@@ -25,7 +25,6 @@
   font-weight: var(--font-weight-normal, 400);
   line-height: 14px;
   white-space: nowrap;
-  cursor: pointer;
   appearance: none;
 
   &:focus-visible {

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -125,7 +125,11 @@ body.listen-mode-vh-fallback #root {
     @apply bg-background text-foreground;
   }
   button {
+    cursor: pointer;
     outline: none;
+  }
+  button:disabled {
+    cursor: not-allowed;
   }
   button:focus {
     outline: none;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -115,9 +115,6 @@ body.listen-mode-vh-fallback #root {
   body {
     @apply bg-background text-foreground;
   }
-}
-
-@layer base {
   button {
     cursor: pointer;
     outline: none;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -118,12 +118,6 @@ body.listen-mode-vh-fallback #root {
 }
 
 @layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
   button {
     cursor: pointer;
     outline: none;
@@ -133,6 +127,10 @@ body.listen-mode-vh-fallback #root {
   }
   button:focus {
     outline: none;
+  }
+  button:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
 }
 

--- a/src/cook-web/src/components/audio/AudioPlayer.tsx
+++ b/src/cook-web/src/components/audio/AudioPlayer.tsx
@@ -944,7 +944,7 @@ function AudioPlayerBase(
         'rounded',
         'transition-colors duration-200',
         'hover:bg-gray-100',
-        isButtonDisabled && 'opacity-50 cursor-not-allowed',
+        isButtonDisabled && 'opacity-50',
         className,
       )}
     >

--- a/src/cook-web/src/components/audio/AudioPlayer.tsx
+++ b/src/cook-web/src/components/audio/AudioPlayer.tsx
@@ -945,7 +945,6 @@ function AudioPlayerBase(
         'transition-colors duration-200',
         'hover:bg-gray-100',
         isButtonDisabled && 'opacity-50 cursor-not-allowed',
-        !isButtonDisabled && 'cursor-pointer',
         className,
       )}
     >

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -510,10 +510,7 @@ const Header = ({
                       <DropdownMenuItem
                         asChild
                         disabled={modeDisabled}
-                        className={cn(
-                          'min-w-0 flex-1 bg-transparent px-3 py-2 text-sm focus:bg-transparent',
-                          unavailableLabel ? 'cursor-not-allowed' : '',
-                        )}
+                        className='min-w-0 flex-1 bg-transparent px-3 py-2 text-sm focus:bg-transparent'
                         onSelect={() => {
                           void publish(mode);
                         }}
@@ -521,10 +518,7 @@ const Header = ({
                         <button
                           type='button'
                           disabled={modeDisabled}
-                          className={cn(
-                            'flex min-w-0 items-center gap-2.5 text-left',
-                            unavailableLabel ? 'cursor-not-allowed' : '',
-                          )}
+                          className='flex min-w-0 items-center gap-2.5 text-left'
                         >
                           <ModeIcon className='h-4 w-4 shrink-0 text-muted-foreground/70' />
                           <span className='truncate'>

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -510,7 +510,12 @@ const Header = ({
                       <DropdownMenuItem
                         asChild
                         disabled={modeDisabled}
-                        className='min-w-0 flex-1 bg-transparent px-3 py-2 text-sm focus:bg-transparent'
+                        className={cn(
+                          'min-w-0 flex-1 bg-transparent px-3 py-2 text-sm focus:bg-transparent',
+                          modeDisabled
+                            ? 'cursor-not-allowed'
+                            : 'cursor-pointer',
+                        )}
                         onSelect={() => {
                           void publish(mode);
                         }}

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -275,7 +275,7 @@ const Header = ({
               <button
                 type='button'
                 aria-label={t('component.header.copyLearningLink')}
-                className='flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-blue-600 transition-colors hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300'
+                className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-blue-600 transition-colors hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300'
                 onClick={() => {
                   void copyPublishedUrl(publishedUrl, mode);
                 }}
@@ -512,9 +512,7 @@ const Header = ({
                         disabled={modeDisabled}
                         className={cn(
                           'min-w-0 flex-1 bg-transparent px-3 py-2 text-sm focus:bg-transparent',
-                          unavailableLabel
-                            ? 'cursor-not-allowed'
-                            : 'cursor-pointer',
+                          unavailableLabel ? 'cursor-not-allowed' : '',
                         )}
                         onSelect={() => {
                           void publish(mode);

--- a/src/cook-web/src/components/lesson-preview/VariableList.module.css
+++ b/src/cook-web/src/components/lesson-preview/VariableList.module.css
@@ -39,7 +39,6 @@
   gap: 6px;
   font-size: 14px;
   color: #111827;
-  cursor: pointer;
 }
 .variableList .addButton {
   border: 1px solid #e5e7eb;

--- a/src/cook-web/src/components/lesson-preview/VariableList.module.scss
+++ b/src/cook-web/src/components/lesson-preview/VariableList.module.scss
@@ -52,7 +52,6 @@
     gap: 6px;
     font-size: 14px;
     color: #111827;
-    cursor: pointer;
   }
 
   .addButton {
@@ -95,7 +94,6 @@
     gap: 6px;
     font-size: 13px;
     color: #111827;
-    cursor: pointer;
     border: 1px solid #e5e7eb;
     border-radius: var(--border-radius-rounded-md, 8px);
     background: #fff;
@@ -169,7 +167,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
     opacity: 0;
     transition: opacity 0.15s ease;
     color: var(--muted-foreground, #9ca3af);

--- a/src/cook-web/src/components/ui/Switch.tsx
+++ b/src/cook-web/src/components/ui/Switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Switch.tsx
+++ b/src/cook-web/src/components/ui/Switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Switch.tsx
+++ b/src/cook-web/src/components/ui/Switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Tabs.tsx
+++ b/src/cook-web/src/components/ui/Tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Tabs.tsx
+++ b/src/cook-web/src/components/ui/Tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Tabs.tsx
+++ b/src/cook-web/src/components/ui/Tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Add a global default pointer cursor for native buttons while preserving disabled `not-allowed` behavior.
- Remove redundant explicit pointer cursor declarations from native button-only styles and components so they rely on the global default.
- Keep special cursor declarations for non-button interactive elements, `Button asChild`, custom MarkdownFlow controls, and business-specific disabled semantics.

## Validation
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint`
- `git diff --check`
- pre-commit hooks from `git commit` passed, including Prettier cook-web files and architecture/translation checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized cursor and hover feedback across interactive UI controls for more consistent behavior.
  * Enabled controls now consistently indicate clickability, while disabled controls show a “not allowed” cursor.
  * Improved keyboard focus styling with clearer `:focus-visible` outlines for better accessibility.
  * Refreshed cursor/visual treatment across chat, learning mode, audio/listen controls, lesson preview toggles, and publishing-related UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->