### PR TITLE
fix: stabilize referral reward bootstrap expiry assertions

### DIFF
--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2780,6 +2780,13 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
             return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
 
     monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(user_credits_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        user_credits_module,
+        "_format_operator_datetime",
+        _format_operator_datetime,
+    )
 
     with app.app_context():
         _seed_user(


### PR DESCRIPTION
## Summary
- freeze referral reward bootstrap and credit summary time consistently in the stacking expiry test
- keep operator datetime formatting stable under the fixed test clock so expiry assertions do not depend on wall-clock time

## Testing
- cd src/api && pytest -q tests/service/shifu/test_admin_users.py -k 'grant_operator_user_referral_reward_stacks_bucket_and_expiry or grant_operator_user_referral_reward_extends_empty_active_bucket or grant_operator_user_referral_reward_is_idempotent_for_repeated_request_id'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by enhancing time mocking consistency across datetime formatting and serialization paths in operator referral reward grant tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->