### PR TITLE
fix: hide preview read audio controls

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -306,8 +306,11 @@ export const NewChatComponents = ({
   }`;
   const [settledPromptContextKey, setSettledPromptContextKey] =
     useState(promptContextKey);
+  const isPreviewReadMode = previewMode && learningMode === 'read';
   const shouldShowAudioAction =
-    !isClassroomMode && (previewMode || isListenModeActive);
+    !isClassroomMode &&
+    (previewMode || isListenModeActive) &&
+    !isPreviewReadMode;
   const { requestExclusive, releaseExclusive } = useExclusiveAudio();
   const isPromptContextSettled = settledPromptContextKey === promptContextKey;
   const ensureLessonScope = useAskStateStore(state => state.ensureLessonScope);


### PR DESCRIPTION
## Summary
- hide per-block audio controls only for preview links in read mode
- keep existing audio controls for preview listen mode and non-preview listen flows

## Testing
- cd src/cook-web && npm run type-check
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio action visibility in preview read mode. Audio actions now correctly remain disabled in this mode while continuing to function normally in listen mode and other preview variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->