### PR TITLE
fix: Rebase onboarding migration onto production head

### DIFF
--- a/src/api/migrations/versions/c6a4f8d9b2e1_add_user_onboarding_states.py
+++ b/src/api/migrations/versions/c6a4f8d9b2e1_add_user_onboarding_states.py
@@ -1,7 +1,7 @@
 """add user onboarding states
 
 Revision ID: c6a4f8d9b2e1
-Revises: 5a6b7c8d9e10
+Revises: 8c2d4e6f1a9b
 Create Date: 2026-06-17 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "c6a4f8d9b2e1"
-down_revision = "5a6b7c8d9e10"
+down_revision = "8c2d4e6f1a9b"
 branch_labels = None
 depends_on = None
 

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -23,6 +23,14 @@ def _get_expected_head() -> str:
     return ScriptDirectory.from_config(config).get_current_head()
 
 
+def test_alembic_migrations_have_single_head():
+    config = Config(str(API_ROOT / "migrations" / "alembic.ini"))
+    config.set_main_option("script_location", str(API_ROOT / "migrations"))
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert heads == ["d4e5f6a7b8c9"]
+
+
 def _get_base_mysql_uri() -> str:
     if os.getenv(SMOKE_FLAG) != "1":
         pytest.skip(f"Set {SMOKE_FLAG}=1 to run the fresh-MySQL migration smoke test.")


### PR DESCRIPTION
## Summary

- Rebase the user onboarding Alembic migration onto the production migration head `8c2d4e6f1a9b`.
- Keep the creator admin home migration as the single current Alembic head, `d4e5f6a7b8c9`.
- Add a lightweight migration graph test so future multi-head drift is caught without requiring a database.

## Production / deploy comparison

- Live production `new-shifu-api` pods are running `registry.cn-beijing.aliyuncs.com/agix/ai-shifu-api:20260622-85989a7`.
- Live production `new-shifu-celery-worker` is also running `20260622-85989a7`; `new-shifu-celery-beat` is on `20260622-3b2a6dc`.
- The migration graph at app commit `85989a7` has a single head: `8c2d4e6f1a9b`.
- Latest `upstream/main` had two heads before this patch: `8c2d4e6f1a9b` and `d4e5f6a7b8c9`.

## Validation

- Red check before fix: `pytest -q tests/migrations/test_fresh_mysql_upgrade.py::test_alembic_migrations_have_single_head` failed with heads `8c2d4e6f1a9b` and `d4e5f6a7b8c9`.
- `pytest -q tests/migrations/test_fresh_mysql_upgrade.py` -> `1 passed, 1 skipped`.
- Alembic API check -> `heads= ['d4e5f6a7b8c9']`, `current_head= d4e5f6a7b8c9`.
- `pre-commit run --files src/api/migrations/versions/c6a4f8d9b2e1_add_user_onboarding_states.py src/api/tests/migrations/test_fresh_mysql_upgrade.py` -> passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration metadata for consistency.

* **Tests**
  * Added validation test for database migration integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->