### PR TITLE
fix: clarify publish success action label

### DIFF
--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -169,7 +169,7 @@ const Header = () => {
   ) => {
     alert.showAlert({
       title: t('component.header.publishSuccess'),
-      cancelText: t('component.header.close'),
+      cancelText: t('component.header.publishSuccessDone'),
       showConfirm: false,
       descriptionAsChild: true,
       description: (

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -169,7 +169,7 @@ const Header = () => {
   ) => {
     alert.showAlert({
       title: t('component.header.publishSuccess'),
-      cancelText: t('component.header.publishSuccessDone'),
+      confirmText: t('component.header.publishSuccessDone'),
       showConfirm: false,
       descriptionAsChild: true,
       description: (

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -100,6 +100,7 @@ export type I18nKey =
   | 'component.header.publishSuccess'
   | 'component.header.publishSuccessAudienceDescription'
   | 'component.header.publishSuccessDescription'
+  | 'component.header.publishSuccessDone'
   | 'component.header.publishSuccessDraftHelp'
   | 'component.header.readonly'
   | 'component.header.saved'

--- a/src/i18n/en-US/components/header.json
+++ b/src/i18n/en-US/components/header.json
@@ -17,6 +17,7 @@
   "publishSuccess": "Published Successfully",
   "publishSuccessAudienceDescription": "Students can use the link below to learn, and teachers can use the same link to teach in Classroom mode.",
   "publishSuccessDescription": "The latest draft version has been published.",
+  "publishSuccessDone": "Done",
   "publishSuccessDraftHelp": "The admin view saves multiple draft versions, and you can publish them as needed.",
   "readonly": "Readonly",
   "saved": "Saved"

--- a/src/i18n/fr-FR/components/header.json
+++ b/src/i18n/fr-FR/components/header.json
@@ -17,6 +17,7 @@
   "publishSuccess": "Publication réussie",
   "publishSuccessAudienceDescription": "Les élèves peuvent utiliser le lien ci-dessous pour apprendre, et les enseignants peuvent utiliser le même lien pour enseigner en mode classe.",
   "publishSuccessDescription": "La dernière version du brouillon a été publiée.",
+  "publishSuccessDone": "Terminé",
   "publishSuccessDraftHelp": "L'administration conserve plusieurs versions du brouillon, que vous pouvez publier selon vos besoins.",
   "readonly": "Lecture seule",
   "saved": "Enregistré"

--- a/src/i18n/zh-CN/components/header.json
+++ b/src/i18n/zh-CN/components/header.json
@@ -17,6 +17,7 @@
   "publishSuccess": "发布成功",
   "publishSuccessAudienceDescription": "学生可通过下面链接学习，老师可用同一链接进入课堂模式授课",
   "publishSuccessDescription": "已将草稿的最新版发布",
+  "publishSuccessDone": "完成",
   "publishSuccessDraftHelp": "后台会保存草稿的多个版本，可以按需发布",
   "readonly": "只读",
   "saved": "已保存"


### PR DESCRIPTION
## Summary
- Use a publish-success-specific action label instead of the shared Close label.
- Add localized Done/完成/Terminé strings and regenerate i18n key types.

## Validation
- npm run i18n:keys
- npm run type-check
- git diff --check
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the publish success confirmation dialog button label when users complete a publish action. Enhanced with complete multi-language support including English, French, and Chinese translations for consistent global user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->