### PR TITLE
fix: restore valid Prometheus image tag

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -159,21 +159,21 @@ jobs:
 
           # 1. Node.js/npm projects - Look for package.json files
           echo "🔍 Scanning for Node.js/npm projects..."
-          find . -name "package.json" -not -path "./node_modules/*" -not -path "./.git/*" | while read -r file; do
+          while read -r file; do
             if [ -f "$file" ]; then
               update_json_version "$file"
               UPDATED_FILES+=("$file")
             fi
-          done
+          done < <(find . -name "package.json" -not -path "./node_modules/*" -not -path "./.git/*")
 
           # 2. Python pyproject.toml projects
           echo "🔍 Scanning for Python pyproject.toml projects..."
-          find . -name "pyproject.toml" -not -path "./.git/*" | while read -r file; do
+          while read -r file; do
             if [ -f "$file" ] && grep -q "version.*=" "$file"; then
               update_toml_version "$file"
               UPDATED_FILES+=("$file")
             fi
-          done
+          done < <(find . -name "pyproject.toml" -not -path "./.git/*")
 
           # 3. Python setup.py projects
           echo "🔍 Scanning for Python setup.py projects..."
@@ -188,37 +188,37 @@ jobs:
 
           # 4. Python __init__.py version files
           echo "🔍 Scanning for Python __init__.py version files..."
-          find . -name "__init__.py" -not -path "./.git/*" | while read -r file; do
+          while read -r file; do
             if grep -q "__version__\|VERSION" "$file" 2>/dev/null; then
               update_python_version "$file"
               UPDATED_FILES+=("$file")
             fi
-          done
+          done < <(find . -name "__init__.py" -not -path "./.git/*")
 
           # 5. Cargo.toml for Rust projects
           echo "🔍 Scanning for Rust Cargo.toml projects..."
-          find . -name "Cargo.toml" -not -path "./.git/*" | while read -r file; do
+          while read -r file; do
             if [ -f "$file" ]; then
               update_toml_version "$file"
               UPDATED_FILES+=("$file")
             fi
-          done
+          done < <(find . -name "Cargo.toml" -not -path "./.git/*")
 
           # 6. Docker Compose files (AI-Shifu release images only)
           echo "🔍 Scanning for Docker Compose files..."
-          find . \( -name "docker-compose*.yml" -o -name "docker-compose*.yaml" \) -not -path "./.git/*" | while read -r file; do
+          while read -r file; do
             if [ -f "$file" ]; then
               before_hash=$(sha256sum "$file" | cut -d' ' -f1)
               echo "  → Updating AI-Shifu Docker image tags in $file..."
               # Keep third-party image tags (Prometheus, Grafana, MySQL, Redis, etc.) unchanged.
-              sed -i.bak -E "s|image: aishifu/(ai-shifu-api|ai-shifu-cook-web):[^[:space:]]+|image: aishifu/\1:$TAG_NAME|g" "$file"
+              sed -i.bak -E "s#image: aishifu/(ai-shifu-api|ai-shifu-cook-web):[^[:space:]]+#image: aishifu/\1:$TAG_NAME#g" "$file"
               rm -f "$file.bak"
               after_hash=$(sha256sum "$file" | cut -d' ' -f1)
               if [ "$before_hash" != "$after_hash" ]; then
                 UPDATED_FILES+=("$file")
               fi
             fi
-          done
+          done < <(find . \( -name "docker-compose*.yml" -o -name "docker-compose*.yaml" \) -not -path "./.git/*")
 
           # Guard against accidental third-party image tag changes in release PRs.
           if git diff --unified=0 -- 'docker/docker-compose*.yml' 'docker/docker-compose*.yaml' \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -204,17 +204,30 @@ jobs:
             fi
           done
 
-          # 6. Docker Compose files (project-specific, should be customized)
+          # 6. Docker Compose files (AI-Shifu release images only)
           echo "🔍 Scanning for Docker Compose files..."
-          find . -name "docker-compose*.yml" -o -name "docker-compose*.yaml" | while read -r file; do
+          find . \( -name "docker-compose*.yml" -o -name "docker-compose*.yaml" \) -not -path "./.git/*" | while read -r file; do
             if [ -f "$file" ]; then
-              echo "  → Updating Docker image tags in $file..."
-              # Generic pattern - update any image tags that look like versions
-              sed -i.bak -E "s|image: ([^:]+):v[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]*|image: \1:$TAG_NAME|g" "$file"
+              before_hash=$(sha256sum "$file" | cut -d' ' -f1)
+              echo "  → Updating AI-Shifu Docker image tags in $file..."
+              # Keep third-party image tags (Prometheus, Grafana, MySQL, Redis, etc.) unchanged.
+              sed -i.bak -E "s|image: aishifu/(ai-shifu-api|ai-shifu-cook-web):[^[:space:]]+|image: aishifu/\1:$TAG_NAME|g" "$file"
               rm -f "$file.bak"
-              UPDATED_FILES+=("$file")
+              after_hash=$(sha256sum "$file" | cut -d' ' -f1)
+              if [ "$before_hash" != "$after_hash" ]; then
+                UPDATED_FILES+=("$file")
+              fi
             fi
           done
+
+          # Guard against accidental third-party image tag changes in release PRs.
+          if git diff --unified=0 -- 'docker/docker-compose*.yml' 'docker/docker-compose*.yaml' \
+            | grep -E '^[+-][[:space:]]*image: ' \
+            | grep -Ev '^[+-][[:space:]]*image: aishifu/(ai-shifu-api|ai-shifu-cook-web):' \
+            | grep -Ev '^(---|\+\+\+)' ; then
+            echo "❌ Release version bump changed a third-party Docker image tag. Refusing to continue."
+            exit 1
+          fi
 
           # 7. Version files (VERSION, version.txt, etc.)
           echo "🔍 Scanning for version files..."

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -153,7 +153,7 @@ services:
       - ./observability/otel-collector-config.yml:/etc/otel-collector-config.yml
 
   ai-shifu-prometheus:
-    image: prom/prometheus:v2.2.4
+    image: prom/prometheus:v2.54.1
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus


### PR DESCRIPTION
## Summary
- restore the dev compose Prometheus image tag from the invalid `prom/prometheus:v2.2.4` to `prom/prometheus:v2.54.1`
- limit the release workflow's Docker Compose version bump to AI-Shifu-owned images only
- add a release-workflow guard that refuses accidental third-party image tag changes

## Verification
- `docker-compose -f docker-compose.dev.yml config`
- `docker manifest inspect prom/prometheus:v2.54.1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development monitoring stack to use a newer Prometheus image for improved stability and performance.
  * Improved release automation for Docker Compose updates by applying a dedicated AI-Shifu image tag pattern, verifying that only intended changes occur, and failing the workflow if unrelated image tags are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->