### PR TITLE
feat: rollout onboarding for existing creators

### DIFF
--- a/docs/exec-plans/active/onboarding-existing-creator-rollout.md
+++ b/docs/exec-plans/active/onboarding-existing-creator-rollout.md
@@ -1,0 +1,186 @@
+# Existing Creator Onboarding Rollout
+
+## Purpose / Big Picture
+
+Extend the creator onboarding rollout to a targeted existing-creator cohort
+ after `#1931` (admin home onboarding) and `#1933` (course editor onboarding)
+ are already merged on `main`. The rollout must show the admin-home onboarding
+ once on the first `/admin` entry and the editor onboarding once on the first
+ owner editor entry, while keeping the old-user billing copy free of expired
+ trial-credit messaging. The implementation must preserve the existing
+ onboarding storage model and event names, and only widen eligibility and copy
+ selection.
+
+## Progress
+
+- [x] 2026-06-23 14:45 CST: Confirmed `main` now includes `#1933` and aligned
+      the old-user rollout scope with the merged admin-home and editor
+      onboarding baseline.
+- [x] 2026-06-23 14:55 CST: Finalize the backend eligibility contract for the
+      existing-creator rollout segment and scene-level flags.
+- [x] 2026-06-23 15:05 CST: Implement admin-home variant switching so old-user
+      billing guidance uses generic balance/package copy instead of trial-credit
+      copy.
+- [x] 2026-06-23 15:15 CST: Wire editor onboarding to the new scene-level
+      eligibility while keeping source parameters as tracking-only metadata.
+- [x] 2026-06-23 15:25 CST: Add focused backend/frontend coverage and verify
+      the expanded tracking payload.
+
+## Surprises & Discoveries
+
+- `#1933` already changed editor onboarding to support direct editor entry, so
+  this rollout no longer needs course-count heuristics to make skills-created
+  courses reachable.
+- The current admin-home billing step always renders trial-credit messaging
+  from `trial_offer`; that is incorrect for existing creators whose historical
+  onboarding credits have already expired.
+- Existing onboarding persistence is already scene-based and idempotent. The
+  safest rollout path is to extend the status payload instead of adding a new
+  completion table or bumping the onboarding version.
+
+## Decision Log
+
+- Decision: Keep onboarding completion on `version=v1` and use new eligibility
+  metadata instead of introducing `v2`.
+  - Why: a version bump would replay onboarding for users who already completed
+    the new-creator flow, which is not the product intent.
+- Decision: Model old-user rollout as a user-segment eligibility expansion, not
+  as a course-count gate inside the editor page.
+  - Why: skills can create multiple courses before the user first re-enters the
+    admin/editor surfaces, so first-editor-entry should not depend on owning
+    exactly one course.
+- Decision: Keep current Umami event names and add `user_segment` while
+  preserving `trigger_source`.
+  - Why: existing dashboards keep working, while the rollout can still be
+    split between `new_creator` and `existing_creator_rollout`.
+- Decision: Keep old-user rollout scope configurable through dynamic config
+  keys first, instead of hardcoding more audience rules into code.
+  - Why: rollout scope is product policy, not a schema concern. Small changes
+    such as new time windows, enable flags, or limited cohorts should be
+    adjustable without migrations or redeploys.
+
+## Outcomes & Retrospective
+
+- Implemented the rollout contract without a version bump. Existing creators
+  can now be targeted by config, while already-completed `v1` scenes remain
+  untouched.
+- The admin-home billing card now switches between trial-credit copy and a
+  generic balance/package message based on backend-provided variant metadata.
+- Both admin-home and editor onboarding tracking payloads now include
+  `user_segment`, keeping existing event names intact for dashboards.
+
+## Context and Orientation
+
+- Backend owner paths:
+  - `src/api/flaskr/service/user/onboarding.py`
+  - `src/api/flaskr/route/user.py`
+  - `src/api/tests/service/user/test_onboarding_routes.py`
+- Frontend owner paths:
+  - `src/cook-web/src/app/admin/layout.tsx`
+  - `src/cook-web/src/components/onboarding/onboardingSteps.ts`
+  - `src/cook-web/src/components/shifu-edit/ShifuEdit.tsx`
+  - `src/cook-web/src/types/onboarding.ts`
+- Translation owner paths:
+  - `src/i18n/zh-CN/modules/onboarding.json`
+  - `src/i18n/en-US/modules/onboarding.json`
+  - `src/i18n/fr-FR/modules/onboarding.json`
+
+## Plan of Work
+
+1. Extend the onboarding status contract with segment-aware, scene-level
+   eligibility and billing-copy variants for old creators.
+2. Update admin-home and editor onboarding consumers to use the new contract,
+   keeping source parameters only for tracking metadata.
+3. Add rollout-aware tracking payload fields and focused backend/frontend
+   verification.
+
+## Concrete Steps
+
+1. Backend contract
+   - Add an existing-creator rollout config gate.
+   - Return `user_segment` from onboarding status.
+   - Return scene-level `eligible` flags for:
+     - `admin_home_onboarding`
+     - `course_editor_onboarding`
+   - Return `admin_home_onboarding.variant` with:
+     - `trial_credit`
+     - `generic_billing`
+2. Admin home rollout
+   - Read scene-level eligibility in the admin layout instead of relying only on
+     the top-level creator eligibility boolean.
+   - Switch the billing-card copy by variant so the old-user rollout uses a
+     generic “check balance / buy or upgrade packages” message.
+   - Keep the blank-create and lobster steps unchanged.
+3. Editor rollout
+   - Gate editor onboarding with:
+     - owner-only access
+     - scene completion false
+     - scene-level eligibility true
+     - non-history editor view
+   - Keep `manual_create`, `lobster_create`, `skills_create`, and
+     `editor_entry` as `trigger_source` values only.
+4. Tracking
+   - Keep existing event names:
+     - `creator_onboarding_started`
+     - `creator_onboarding_step_viewed`
+     - `creator_onboarding_completed`
+     - `creator_onboarding_complete_failed`
+   - Add `user_segment` to all onboarding event payloads.
+   - Keep `trigger_source=admin_entry` for admin-home events.
+5. Verification
+   - Backend tests for new segment/scene/variant combinations.
+   - Frontend tests for variant-based admin-home copy and editor eligibility
+     gating.
+   - Type-check and focused lint/test runs.
+
+## Validation and Acceptance
+
+- A rollout-eligible existing creator who has not completed admin-home
+  onboarding sees it once on the first `/admin` entry.
+- The admin-home billing step for existing creators does not claim new trial
+  credits were granted.
+- A rollout-eligible existing creator who has not completed editor onboarding
+  sees it once on the first entry to any owner course editor.
+- Skills-created courses can trigger editor onboarding on first editor entry
+  even if more than one course already exists.
+- Shared-permission users still do not see the owner editor onboarding.
+- Existing event names remain unchanged and now include `user_segment`.
+- Users who already completed either scene under `v1` do not replay that scene.
+
+## Idempotence and Recovery
+
+- Scene completion remains idempotent through the existing
+  `(user_bid, scene_key, version)` uniqueness.
+- If rollout config is disabled, scene-level eligibility must fall back to
+  `false` without breaking the existing payload shape.
+- If the variant field is absent or malformed on the frontend, admin-home
+  billing copy should safely fall back to the current trial-credit behavior for
+  new creators and never block rendering.
+
+## Interfaces and Dependencies
+
+- API:
+  - `GET /api/user/onboarding/status`
+  - `POST /api/user/onboarding/complete`
+- Dynamic config:
+  - `ADMIN_ONBOARDING_ENABLED_FROM`
+  - `ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM`
+- Tracking:
+  - `creator_onboarding_started`
+  - `creator_onboarding_step_viewed`
+  - `creator_onboarding_completed`
+  - `creator_onboarding_complete_failed`
+
+## Follow-up Expansion Guidance
+
+- Near-term audience expansion should continue through dynamic config, not
+  migrations. Preferred examples:
+  - enable/disable switch for existing-creator rollout
+  - site or locale-specific rollout keys
+  - whitelist or limited-cohort keys
+  - percentage or staged rollout keys
+- If old-user targeting rules grow beyond a few independent keys, consolidate
+  them into one structured config payload rather than adding many parallel
+  scalar keys.
+- Only introduce a dedicated config table or admin management UI when rollout
+  policy becomes high-frequency operational work with audit/history needs.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -15,6 +15,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Creator Dashboard Ratings SQL Optimization](./active/creator-dashboard-ratings-sql-optimization.md)
 - [Creator Dashboard Request Splitting](./active/creator-dashboard-request-splitting.md)
 - [Observability Artifacts, Consistency Probes, and Frontend Trace IDs](./active/observability-artifacts-consistency-frontend-trace.md)
+- [Existing Creator Onboarding Rollout](./active/onboarding-existing-creator-rollout.md)
 - [ExecPlan: Operator Credit Grant Package](./active/operator-credit-grant-package.md)
 - [ExecPlan: Operator Promotion Ops State Rules](./active/operator-promotion-ops-state-rules.md)
 - [ExecPlan: Package Campaigns](./active/package-campaigns.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -29,6 +29,7 @@
 | `docs/exec-plans/active/creator-dashboard-ratings-sql-optimization.md` | Creator Dashboard Ratings SQL Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-dashboard-request-splitting.md` | Creator Dashboard Request Splitting | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/observability-artifacts-consistency-frontend-trace.md` | Observability Artifacts, Consistency Probes, and Frontend Trace IDs | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/onboarding-existing-creator-rollout.md` | Existing Creator Onboarding Rollout | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/operator-credit-grant-package.md` | ExecPlan: Operator Credit Grant Package | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/operator-promotion-ops-state-rules.md` | ExecPlan: Operator Promotion Ops State Rules | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/package-campaigns.md` | ExecPlan: Package Campaigns | `exec-plan-active` | `active` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `10`
 - Product specs: `10`
 - References: `3`
-- Active ExecPlans: `13`
+- Active ExecPlans: `14`
 - Completed ExecPlans: `6`
 
 ## Boundary Baseline

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -31,9 +31,7 @@ SUPPORTED_TRIGGER_SOURCES = {
 }
 STATUS_COMPLETED = "completed"
 ROLLOUT_CONFIG_KEY = "ADMIN_ONBOARDING_ENABLED_FROM"
-EXISTING_CREATOR_ROLLOUT_CONFIG_KEY = (
-    "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM"
-)
+EXISTING_CREATOR_ROLLOUT_CONFIG_KEY = "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM"
 USER_SEGMENT_NEW_CREATOR = "new_creator"
 USER_SEGMENT_EXISTING_CREATOR_ROLLOUT = "existing_creator_rollout"
 USER_SEGMENT_INELIGIBLE = "ineligible"
@@ -124,10 +122,7 @@ def _resolve_user_segment(user: UserEntity | None) -> str:
     now = datetime.utcnow()
 
     if threshold is None:
-        if (
-            existing_rollout_threshold is not None
-            and now >= existing_rollout_threshold
-        ):
+        if existing_rollout_threshold is not None and now >= existing_rollout_threshold:
             return USER_SEGMENT_EXISTING_CREATOR_ROLLOUT
         return USER_SEGMENT_INELIGIBLE
 

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -11,7 +11,6 @@ from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.config.funcs import get_config as get_dynamic_config
 from flaskr.service.shifu.dtos import resolve_demo_course_for_language
-from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
 
@@ -144,13 +143,12 @@ def _build_scene_status(
     scene_key: str,
     states: dict[str, UserOnboardingState],
     user_segment: str,
-    has_preexisting_course: bool,
 ) -> OnboardingSceneStatus:
     row = states.get(scene_key)
-    is_eligible = user_segment == USER_SEGMENT_NEW_CREATOR or (
-        user_segment == USER_SEGMENT_EXISTING_CREATOR_ROLLOUT
-        and not has_preexisting_course
-    )
+    is_eligible = user_segment in {
+        USER_SEGMENT_NEW_CREATOR,
+        USER_SEGMENT_EXISTING_CREATOR_ROLLOUT,
+    }
     variant = None
     if scene_key == SCENE_ADMIN_HOME and is_eligible:
         variant = (
@@ -169,43 +167,12 @@ def _build_scene_status(
     )
 
 
-def _has_preexisting_owned_course(
-    user_bid: str,
-    new_creator_threshold: datetime | None,
-) -> bool:
-    normalized_user_bid = str(user_bid or "").strip()
-    if not normalized_user_bid or new_creator_threshold is None:
-        return False
-
-    for model in (DraftShifu, PublishedShifu):
-        exists = (
-            db.session.query(model.id)
-            .filter(
-                model.created_user_bid == normalized_user_bid,
-                model.deleted == 0,
-                model.created_at < new_creator_threshold,
-            )
-            .first()
-        )
-        if exists is not None:
-            return True
-
-    return False
-
-
 def build_onboarding_status(
     app: Flask, user_bid: str, language: str | None
 ) -> dict[str, Any]:
     with app.app_context():
         user = _load_user_entity(user_bid)
         user_segment = _resolve_user_segment(user)
-        new_creator_threshold = _parse_rollout_threshold(
-            get_dynamic_config(ROLLOUT_CONFIG_KEY, "")
-        )
-        has_preexisting_course = _has_preexisting_owned_course(
-            str(user_bid or "").strip(),
-            new_creator_threshold,
-        )
         normalized_language = _normalize_language(
             language or getattr(user, "language", "")
         )
@@ -223,13 +190,11 @@ def build_onboarding_status(
                 scene_key=SCENE_ADMIN_HOME,
                 states=states,
                 user_segment=user_segment,
-                has_preexisting_course=has_preexisting_course,
             ).__dict__,
             SCENE_COURSE_EDITOR: _build_scene_status(
                 scene_key=SCENE_COURSE_EDITOR,
                 states=states,
                 user_segment=user_segment,
-                has_preexisting_course=has_preexisting_course,
             ).__dict__,
         }
 

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -11,6 +11,7 @@ from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.config.funcs import get_config as get_dynamic_config
 from flaskr.service.shifu.dtos import resolve_demo_course_for_language
+from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
 
@@ -143,12 +144,13 @@ def _build_scene_status(
     scene_key: str,
     states: dict[str, UserOnboardingState],
     user_segment: str,
+    has_preexisting_course: bool,
 ) -> OnboardingSceneStatus:
     row = states.get(scene_key)
-    is_eligible = user_segment in {
-        USER_SEGMENT_NEW_CREATOR,
-        USER_SEGMENT_EXISTING_CREATOR_ROLLOUT,
-    }
+    is_eligible = user_segment == USER_SEGMENT_NEW_CREATOR or (
+        user_segment == USER_SEGMENT_EXISTING_CREATOR_ROLLOUT
+        and not has_preexisting_course
+    )
     variant = None
     if scene_key == SCENE_ADMIN_HOME and is_eligible:
         variant = (
@@ -167,12 +169,43 @@ def _build_scene_status(
     )
 
 
+def _has_preexisting_owned_course(
+    user_bid: str,
+    new_creator_threshold: datetime | None,
+) -> bool:
+    normalized_user_bid = str(user_bid or "").strip()
+    if not normalized_user_bid or new_creator_threshold is None:
+        return False
+
+    for model in (DraftShifu, PublishedShifu):
+        exists = (
+            db.session.query(model.id)
+            .filter(
+                model.created_user_bid == normalized_user_bid,
+                model.deleted == 0,
+                model.created_at < new_creator_threshold,
+            )
+            .first()
+        )
+        if exists is not None:
+            return True
+
+    return False
+
+
 def build_onboarding_status(
     app: Flask, user_bid: str, language: str | None
 ) -> dict[str, Any]:
     with app.app_context():
         user = _load_user_entity(user_bid)
         user_segment = _resolve_user_segment(user)
+        new_creator_threshold = _parse_rollout_threshold(
+            get_dynamic_config(ROLLOUT_CONFIG_KEY, "")
+        )
+        has_preexisting_course = _has_preexisting_owned_course(
+            str(user_bid or "").strip(),
+            new_creator_threshold,
+        )
         normalized_language = _normalize_language(
             language or getattr(user, "language", "")
         )
@@ -185,22 +218,26 @@ def build_onboarding_status(
             ).all()
         }
 
+        scenes = {
+            SCENE_ADMIN_HOME: _build_scene_status(
+                scene_key=SCENE_ADMIN_HOME,
+                states=states,
+                user_segment=user_segment,
+                has_preexisting_course=has_preexisting_course,
+            ).__dict__,
+            SCENE_COURSE_EDITOR: _build_scene_status(
+                scene_key=SCENE_COURSE_EDITOR,
+                states=states,
+                user_segment=user_segment,
+                has_preexisting_course=has_preexisting_course,
+            ).__dict__,
+        }
+
         return {
-            "eligible": user_segment != USER_SEGMENT_INELIGIBLE,
+            "eligible": any(scene["eligible"] for scene in scenes.values()),
             "user_segment": user_segment,
             "version": ONBOARDING_VERSION,
-            "scenes": {
-                SCENE_ADMIN_HOME: _build_scene_status(
-                    scene_key=SCENE_ADMIN_HOME,
-                    states=states,
-                    user_segment=user_segment,
-                ).__dict__,
-                SCENE_COURSE_EDITOR: _build_scene_status(
-                    scene_key=SCENE_COURSE_EDITOR,
-                    states=states,
-                    user_segment=user_segment,
-                ).__dict__,
-            },
+            "scenes": scenes,
             "guide_course": guide_course,
         }
 

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -27,15 +27,26 @@ SUPPORTED_TRIGGER_SOURCES = {
     "editor_entry",
     "manual_create",
     "lobster_create",
+    "skills_create",
 }
 STATUS_COMPLETED = "completed"
 ROLLOUT_CONFIG_KEY = "ADMIN_ONBOARDING_ENABLED_FROM"
+EXISTING_CREATOR_ROLLOUT_CONFIG_KEY = (
+    "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM"
+)
+USER_SEGMENT_NEW_CREATOR = "new_creator"
+USER_SEGMENT_EXISTING_CREATOR_ROLLOUT = "existing_creator_rollout"
+USER_SEGMENT_INELIGIBLE = "ineligible"
+BILLING_VARIANT_TRIAL_CREDIT = "trial_credit"
+BILLING_VARIANT_GENERIC_BILLING = "generic_billing"
 
 
 @dataclass(frozen=True)
 class OnboardingSceneStatus:
     completed: bool
     completed_at: str | None
+    eligible: bool
+    variant: str | None
 
 
 def _serialize_datetime(value: datetime | None) -> str | None:
@@ -92,25 +103,73 @@ def _load_user_entity(user_bid: str) -> UserEntity | None:
     ).first()
 
 
-def _is_user_eligible(user: UserEntity | None) -> bool:
+def _resolve_user_segment(user: UserEntity | None) -> str:
     if user is None:
-        return False
+        return USER_SEGMENT_INELIGIBLE
     if not bool(getattr(user, "is_creator", 0)):
-        return False
+        return USER_SEGMENT_INELIGIBLE
     if bool(getattr(user, "is_operator", 0)):
-        return False
+        return USER_SEGMENT_INELIGIBLE
 
     threshold = _parse_rollout_threshold(get_dynamic_config(ROLLOUT_CONFIG_KEY, ""))
-    eligible_at = getattr(user, "creator_activated_at", None) or getattr(
-        user, "created_at", None
-    )
-    if threshold is None:
-        return True
+    eligible_at = getattr(user, "created_at", None)
     if eligible_at is None:
-        return False
+        return USER_SEGMENT_INELIGIBLE
     if getattr(eligible_at, "tzinfo", None) is not None:
         eligible_at = eligible_at.astimezone(timezone.utc).replace(tzinfo=None)
-    return eligible_at >= threshold
+
+    existing_rollout_threshold = _parse_rollout_threshold(
+        get_dynamic_config(EXISTING_CREATOR_ROLLOUT_CONFIG_KEY, "")
+    )
+    now = datetime.utcnow()
+
+    if threshold is None:
+        if (
+            existing_rollout_threshold is not None
+            and now >= existing_rollout_threshold
+        ):
+            return USER_SEGMENT_EXISTING_CREATOR_ROLLOUT
+        return USER_SEGMENT_INELIGIBLE
+
+    if eligible_at >= threshold:
+        return USER_SEGMENT_NEW_CREATOR
+
+    if existing_rollout_threshold is None:
+        return USER_SEGMENT_INELIGIBLE
+
+    if now >= existing_rollout_threshold:
+        return USER_SEGMENT_EXISTING_CREATOR_ROLLOUT
+
+    return USER_SEGMENT_INELIGIBLE
+
+
+def _build_scene_status(
+    *,
+    scene_key: str,
+    states: dict[str, UserOnboardingState],
+    user_segment: str,
+) -> OnboardingSceneStatus:
+    row = states.get(scene_key)
+    is_eligible = user_segment in {
+        USER_SEGMENT_NEW_CREATOR,
+        USER_SEGMENT_EXISTING_CREATOR_ROLLOUT,
+    }
+    variant = None
+    if scene_key == SCENE_ADMIN_HOME and is_eligible:
+        variant = (
+            BILLING_VARIANT_TRIAL_CREDIT
+            if user_segment == USER_SEGMENT_NEW_CREATOR
+            else BILLING_VARIANT_GENERIC_BILLING
+        )
+
+    return OnboardingSceneStatus(
+        completed=row is not None and row.status == STATUS_COMPLETED,
+        completed_at=_serialize_datetime(
+            getattr(row, "completed_at", None) if row else None
+        ),
+        eligible=is_eligible,
+        variant=variant,
+    )
 
 
 def build_onboarding_status(
@@ -118,6 +177,7 @@ def build_onboarding_status(
 ) -> dict[str, Any]:
     with app.app_context():
         user = _load_user_entity(user_bid)
+        user_segment = _resolve_user_segment(user)
         normalized_language = _normalize_language(
             language or getattr(user, "language", "")
         )
@@ -130,21 +190,21 @@ def build_onboarding_status(
             ).all()
         }
 
-        def build_scene_status(scene_key: str) -> OnboardingSceneStatus:
-            row = states.get(scene_key)
-            return OnboardingSceneStatus(
-                completed=row is not None and row.status == STATUS_COMPLETED,
-                completed_at=_serialize_datetime(
-                    getattr(row, "completed_at", None) if row else None
-                ),
-            )
-
         return {
-            "eligible": _is_user_eligible(user),
+            "eligible": user_segment != USER_SEGMENT_INELIGIBLE,
+            "user_segment": user_segment,
             "version": ONBOARDING_VERSION,
             "scenes": {
-                SCENE_ADMIN_HOME: build_scene_status(SCENE_ADMIN_HOME).__dict__,
-                SCENE_COURSE_EDITOR: build_scene_status(SCENE_COURSE_EDITOR).__dict__,
+                SCENE_ADMIN_HOME: _build_scene_status(
+                    scene_key=SCENE_ADMIN_HOME,
+                    states=states,
+                    user_segment=user_segment,
+                ).__dict__,
+                SCENE_COURSE_EDITOR: _build_scene_status(
+                    scene_key=SCENE_COURSE_EDITOR,
+                    states=states,
+                    user_segment=user_segment,
+                ).__dict__,
             },
             "guide_course": guide_course,
         }
@@ -174,7 +234,7 @@ def complete_onboarding_scene(
 
     with app.app_context():
         user = _load_user_entity(normalized_user_bid)
-        if not _is_user_eligible(user):
+        if _resolve_user_segment(user) == USER_SEGMENT_INELIGIBLE:
             raise_error("server.user.userNotPermission")
 
         existing = UserOnboardingState.query.filter(

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -306,6 +306,13 @@ def test_onboarding_status_uses_conservative_fallback_when_new_creator_gate_miss
         db.session.commit()
         token = generate_token(app, user_bid)
 
+    class _MockDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return cls(2026, 6, 23, 10, 0, 0)
+
+    monkeypatch.setattr("flaskr.service.user.onboarding.datetime", _MockDateTime)
+
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
         lambda key, default="": {

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -104,14 +104,22 @@ def test_onboarding_status_returns_eligible_creator_scene_state(
     payload = response.get_json(force=True)
     assert payload["code"] == 0
     assert payload["data"]["eligible"] is True
+    assert payload["data"]["user_segment"] == "new_creator"
     assert payload["data"]["version"] == "v1"
     assert payload["data"]["scenes"]["admin_home_onboarding"]["completed"] is True
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is True
+    assert (
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
+        == "trial_credit"
+    )
     assert payload["data"]["scenes"]["course_editor_onboarding"]["completed"] is False
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["variant"] is None
     assert payload["data"]["guide_course"]["bid"] == "demo-zh-course"
     assert payload["data"]["guide_course"]["language"] == "zh-CN"
 
 
-def test_onboarding_status_excludes_operator_and_old_creator(
+def test_onboarding_status_excludes_operator_and_marks_scenes_ineligible(
     app, test_client, monkeypatch
 ):
     user_bid = uuid.uuid4().hex[:32]
@@ -146,9 +154,13 @@ def test_onboarding_status_excludes_operator_and_old_creator(
     payload = response.get_json(force=True)
     assert payload["code"] == 0
     assert payload["data"]["eligible"] is False
+    assert payload["data"]["user_segment"] == "ineligible"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["variant"] is None
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
 
 
-def test_onboarding_status_includes_old_user_newly_activated_as_creator(
+def test_onboarding_status_treats_old_user_newly_activated_as_existing_rollout(
     app, test_client, monkeypatch
 ):
     user_bid = uuid.uuid4().hex[:32]
@@ -169,6 +181,7 @@ def test_onboarding_status_includes_old_user_newly_activated_as_creator(
         "flaskr.service.user.onboarding.get_dynamic_config",
         lambda key, default="": {
             "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-20 00:00:00",
             "DEMO_SHIFU_BID": "demo-zh-course",
         }.get(key, default),
     )
@@ -186,6 +199,177 @@ def test_onboarding_status_includes_old_user_newly_activated_as_creator(
     payload = response.get_json(force=True)
     assert payload["code"] == 0
     assert payload["data"]["eligible"] is True
+    assert payload["data"]["user_segment"] == "existing_creator_rollout"
+    assert (
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
+        == "generic_billing"
+    )
+
+
+def test_onboarding_status_includes_existing_creator_rollout_segment(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+    created_at = datetime(2026, 5, 1, 12, 0, 0)
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=created_at,
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-20 00:00:00",
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is True
+    assert payload["data"]["user_segment"] == "existing_creator_rollout"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is True
+    assert (
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
+        == "generic_billing"
+    )
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
+
+
+def test_onboarding_status_excludes_existing_creator_before_rollout_switch(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=datetime(2026, 5, 1, 12, 0, 0),
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2099-01-01 00:00:00",
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is False
+    assert payload["data"]["user_segment"] == "ineligible"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
+
+
+def test_onboarding_status_uses_conservative_fallback_when_new_creator_gate_missing(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=datetime(2026, 4, 8, 11, 2, 6),
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-20 00:00:00",
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is True
+    assert payload["data"]["user_segment"] == "existing_creator_rollout"
+    assert (
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
+        == "generic_billing"
+    )
+
+
+def test_onboarding_status_stays_ineligible_when_all_rollout_gates_missing(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=datetime(2026, 6, 21, 11, 0, 0),
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is False
+    assert payload["data"]["user_segment"] == "ineligible"
 
 
 def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch):
@@ -197,7 +381,9 @@ def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch):
 
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": default,
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+        }.get(key, default),
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.demo_courses.get_dynamic_config",
@@ -245,7 +431,9 @@ def test_complete_course_editor_onboarding_accepts_direct_editor_entry(
 
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": default,
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+        }.get(key, default),
     )
 
     response = test_client.post(
@@ -273,6 +461,47 @@ def test_complete_course_editor_onboarding_accepts_direct_editor_entry(
         assert row.trigger_source == "editor_entry"
 
 
+def test_complete_course_editor_onboarding_accepts_skills_create(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+    with app.app_context():
+        _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+        }.get(key, default),
+    )
+
+    response = test_client.post(
+        "/api/user/onboarding/complete",
+        json={
+            "scene_key": "course_editor_onboarding",
+            "version": "v1",
+            "trigger_source": "skills_create",
+        },
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["completed"] is True
+
+    with app.app_context():
+        row = UserOnboardingState.query.filter(
+            UserOnboardingState.user_bid == user_bid,
+            UserOnboardingState.scene_key == "course_editor_onboarding",
+            UserOnboardingState.version == "v1",
+        ).first()
+        assert row is not None
+        assert row.trigger_source == "skills_create"
+
+
 def test_complete_onboarding_scene_handles_integrity_error(
     app, test_client, monkeypatch
 ):
@@ -296,7 +525,9 @@ def test_complete_onboarding_scene_handles_integrity_error(
 
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": default,
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-10 00:00:00",
+        }.get(key, default),
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.demo_courses.get_dynamic_config",

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -35,6 +35,8 @@ def _create_user(
     )
     db.session.add(user)
     return user
+
+
 def test_serialize_datetime_emits_explicit_utc_suffix():
     assert _serialize_datetime(None) is None
     assert _serialize_datetime(datetime(2026, 6, 17, 12, 5, 0)) == (

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -6,7 +6,6 @@ import uuid
 from sqlalchemy.exc import IntegrityError
 
 from flaskr.dao import db
-from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.onboarding import _serialize_datetime
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
@@ -36,44 +35,6 @@ def _create_user(
     )
     db.session.add(user)
     return user
-
-
-def _create_draft_course(
-    *,
-    shifu_bid: str,
-    user_bid: str,
-    created_at: datetime,
-) -> DraftShifu:
-    course = DraftShifu(
-        shifu_bid=shifu_bid,
-        title="Draft Course",
-        created_user_bid=user_bid,
-        created_at=created_at,
-        updated_at=created_at,
-        updated_user_bid=user_bid,
-    )
-    db.session.add(course)
-    return course
-
-
-def _create_published_course(
-    *,
-    shifu_bid: str,
-    user_bid: str,
-    created_at: datetime,
-) -> PublishedShifu:
-    course = PublishedShifu(
-        shifu_bid=shifu_bid,
-        title="Published Course",
-        created_user_bid=user_bid,
-        created_at=created_at,
-        updated_at=created_at,
-        updated_user_bid=user_bid,
-    )
-    db.session.add(course)
-    return course
-
-
 def test_serialize_datetime_emits_explicit_utc_suffix():
     assert _serialize_datetime(None) is None
     assert _serialize_datetime(datetime(2026, 6, 17, 12, 5, 0)) == (
@@ -286,98 +247,6 @@ def test_onboarding_status_includes_existing_creator_rollout_segment(
         == "generic_billing"
     )
     assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
-
-
-def test_onboarding_status_excludes_existing_creator_with_preexisting_draft_course(
-    app, test_client, monkeypatch
-):
-    user_bid = uuid.uuid4().hex[:32]
-
-    with app.app_context():
-        _create_user(
-            user_bid=user_bid,
-            is_creator=True,
-            created_at=datetime(2026, 5, 1, 12, 0, 0),
-        )
-        _create_draft_course(
-            shifu_bid=uuid.uuid4().hex[:32],
-            user_bid=user_bid,
-            created_at=datetime(2026, 6, 1, 12, 0, 0),
-        )
-        db.session.commit()
-        token = generate_token(app, user_bid)
-
-    monkeypatch.setattr(
-        "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": {
-            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-22 00:00:00",
-            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-23 00:00:00",
-            "DEMO_SHIFU_BID": "demo-zh-course",
-        }.get(key, default),
-    )
-    monkeypatch.setattr(
-        "flaskr.service.shifu.demo_courses.get_dynamic_config",
-        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
-    )
-
-    response = test_client.get(
-        "/api/user/onboarding/status",
-        headers={"Token": token},
-    )
-
-    assert response.status_code == 200
-    payload = response.get_json(force=True)
-    assert payload["code"] == 0
-    assert payload["data"]["eligible"] is False
-    assert payload["data"]["user_segment"] == "existing_creator_rollout"
-    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
-    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
-
-
-def test_onboarding_status_excludes_existing_creator_with_preexisting_published_course(
-    app, test_client, monkeypatch
-):
-    user_bid = uuid.uuid4().hex[:32]
-
-    with app.app_context():
-        _create_user(
-            user_bid=user_bid,
-            is_creator=True,
-            created_at=datetime(2026, 5, 1, 12, 0, 0),
-        )
-        _create_published_course(
-            shifu_bid=uuid.uuid4().hex[:32],
-            user_bid=user_bid,
-            created_at=datetime(2026, 6, 5, 12, 0, 0),
-        )
-        db.session.commit()
-        token = generate_token(app, user_bid)
-
-    monkeypatch.setattr(
-        "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": {
-            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-22 00:00:00",
-            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-23 00:00:00",
-            "DEMO_SHIFU_BID": "demo-zh-course",
-        }.get(key, default),
-    )
-    monkeypatch.setattr(
-        "flaskr.service.shifu.demo_courses.get_dynamic_config",
-        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
-    )
-
-    response = test_client.get(
-        "/api/user/onboarding/status",
-        headers={"Token": token},
-    )
-
-    assert response.status_code == 200
-    payload = response.get_json(force=True)
-    assert payload["code"] == 0
-    assert payload["data"]["eligible"] is False
-    assert payload["data"]["user_segment"] == "existing_creator_rollout"
-    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
-    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
 
 
 def test_onboarding_status_excludes_existing_creator_before_rollout_switch(

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -109,8 +109,7 @@ def test_onboarding_status_returns_eligible_creator_scene_state(
     assert payload["data"]["scenes"]["admin_home_onboarding"]["completed"] is True
     assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is True
     assert (
-        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
-        == "trial_credit"
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"] == "trial_credit"
     )
     assert payload["data"]["scenes"]["course_editor_onboarding"]["completed"] is False
     assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -6,6 +6,7 @@ import uuid
 from sqlalchemy.exc import IntegrityError
 
 from flaskr.dao import db
+from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.onboarding import _serialize_datetime
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
@@ -35,6 +36,42 @@ def _create_user(
     )
     db.session.add(user)
     return user
+
+
+def _create_draft_course(
+    *,
+    shifu_bid: str,
+    user_bid: str,
+    created_at: datetime,
+) -> DraftShifu:
+    course = DraftShifu(
+        shifu_bid=shifu_bid,
+        title="Draft Course",
+        created_user_bid=user_bid,
+        created_at=created_at,
+        updated_at=created_at,
+        updated_user_bid=user_bid,
+    )
+    db.session.add(course)
+    return course
+
+
+def _create_published_course(
+    *,
+    shifu_bid: str,
+    user_bid: str,
+    created_at: datetime,
+) -> PublishedShifu:
+    course = PublishedShifu(
+        shifu_bid=shifu_bid,
+        title="Published Course",
+        created_user_bid=user_bid,
+        created_at=created_at,
+        updated_at=created_at,
+        updated_user_bid=user_bid,
+    )
+    db.session.add(course)
+    return course
 
 
 def test_serialize_datetime_emits_explicit_utc_suffix():
@@ -249,6 +286,98 @@ def test_onboarding_status_includes_existing_creator_rollout_segment(
         == "generic_billing"
     )
     assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
+
+
+def test_onboarding_status_excludes_existing_creator_with_preexisting_draft_course(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=datetime(2026, 5, 1, 12, 0, 0),
+        )
+        _create_draft_course(
+            shifu_bid=uuid.uuid4().hex[:32],
+            user_bid=user_bid,
+            created_at=datetime(2026, 6, 1, 12, 0, 0),
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-22 00:00:00",
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-23 00:00:00",
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is False
+    assert payload["data"]["user_segment"] == "existing_creator_rollout"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
+
+
+def test_onboarding_status_excludes_existing_creator_with_preexisting_published_course(
+    app, test_client, monkeypatch
+):
+    user_bid = uuid.uuid4().hex[:32]
+
+    with app.app_context():
+        _create_user(
+            user_bid=user_bid,
+            is_creator=True,
+            created_at=datetime(2026, 5, 1, 12, 0, 0),
+        )
+        _create_published_course(
+            shifu_bid=uuid.uuid4().hex[:32],
+            user_bid=user_bid,
+            created_at=datetime(2026, 6, 5, 12, 0, 0),
+        )
+        db.session.commit()
+        token = generate_token(app, user_bid)
+
+    monkeypatch.setattr(
+        "flaskr.service.user.onboarding.get_dynamic_config",
+        lambda key, default="": {
+            "ADMIN_ONBOARDING_ENABLED_FROM": "2026-06-22 00:00:00",
+            "ADMIN_EXISTING_CREATOR_ONBOARDING_ENABLED_FROM": "2026-06-23 00:00:00",
+            "DEMO_SHIFU_BID": "demo-zh-course",
+        }.get(key, default),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.demo_courses.get_dynamic_config",
+        lambda key, default="": {"DEMO_SHIFU_BID": "demo-zh-course"}.get(key, default),
+    )
+
+    response = test_client.get(
+        "/api/user/onboarding/status",
+        headers={"Token": token},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)
+    assert payload["code"] == 0
+    assert payload["data"]["eligible"] is False
+    assert payload["data"]["user_segment"] == "existing_creator_rollout"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
 
 
 def test_onboarding_status_excludes_existing_creator_before_rollout_switch(

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -152,10 +152,21 @@ jest.mock('@/hooks/useOnboarding', () => ({
   useCreatorOnboardingStatus: () => ({
     data: {
       eligible: false,
+      user_segment: 'ineligible',
       version: 'v1',
       scenes: {
-        admin_home_onboarding: { completed: true, completed_at: null },
-        course_editor_onboarding: { completed: true, completed_at: null },
+        admin_home_onboarding: {
+          completed: true,
+          completed_at: null,
+          eligible: false,
+          variant: null,
+        },
+        course_editor_onboarding: {
+          completed: true,
+          completed_at: null,
+          eligible: false,
+          variant: null,
+        },
       },
       guide_course: {
         bid: '',

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -146,7 +146,7 @@ const MainInterface = ({
     pathname === '/admin' &&
     menuReady &&
     adminHomeSceneStatus?.eligible === true &&
-    adminHomeSceneStatus.completed === false &&
+    adminHomeSceneStatus?.completed === false &&
     (!billingEnabled || !billingOverviewLoading);
 
   const {

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -119,6 +119,7 @@ const MainInterface = ({
   );
   const { data: onboardingStatus, mutate: mutateOnboardingStatus } =
     useCreatorOnboardingStatus(menuReady);
+  const adminHomeSceneStatus = onboardingStatus?.scenes.admin_home_onboarding;
   const courseCreatorUrl = useMemo(() => getCourseCreatorUrl(), []);
 
   const adminHomeSteps = useMemo(
@@ -129,8 +130,10 @@ const MainInterface = ({
         trialOffer: billingOverview?.trial_offer,
         courseCreatorUrl,
         locale: currentLanguage || i18n.language,
+        variant: adminHomeSceneStatus?.variant,
       }),
     [
+      adminHomeSceneStatus?.variant,
       billingEnabled,
       courseCreatorUrl,
       billingOverview?.trial_offer,
@@ -142,8 +145,8 @@ const MainInterface = ({
   const shouldShowAdminHomeOnboarding =
     pathname === '/admin' &&
     menuReady &&
-    Boolean(onboardingStatus?.eligible) &&
-    onboardingStatus?.scenes.admin_home_onboarding.completed === false &&
+    adminHomeSceneStatus?.eligible === true &&
+    adminHomeSceneStatus.completed === false &&
     (!billingEnabled || !billingOverviewLoading);
 
   const {
@@ -160,6 +163,7 @@ const MainInterface = ({
       trackEvent('creator_onboarding_step_viewed', {
         scene_key: 'admin_home_onboarding',
         version: onboardingStatus?.version || 'v1',
+        user_segment: onboardingStatus?.user_segment || 'ineligible',
         step_id: step.id,
         step_index: stepIndex + 1,
         trigger_source: 'admin_entry',
@@ -178,6 +182,7 @@ const MainInterface = ({
         trackEvent('creator_onboarding_completed', {
           scene_key: 'admin_home_onboarding',
           version,
+          user_segment: onboardingStatus?.user_segment || 'ineligible',
           trigger_source: 'admin_entry',
           language,
         });
@@ -185,6 +190,7 @@ const MainInterface = ({
         trackEvent('creator_onboarding_complete_failed', {
           scene_key: 'admin_home_onboarding',
           version,
+          user_segment: onboardingStatus?.user_segment || 'ineligible',
           trigger_source: 'admin_entry',
           language,
         });
@@ -198,6 +204,7 @@ const MainInterface = ({
           scenes: {
             ...current.scenes,
             admin_home_onboarding: {
+              ...current.scenes.admin_home_onboarding,
               completed: true,
               completed_at: new Date().toISOString(),
             },
@@ -216,6 +223,7 @@ const MainInterface = ({
     trackEvent('creator_onboarding_started', {
       scene_key: 'admin_home_onboarding',
       version: onboardingStatus?.version || 'v1',
+      user_segment: onboardingStatus?.user_segment || 'ineligible',
       trigger_source: 'admin_entry',
       language: currentLanguage || i18n.language,
     });
@@ -223,6 +231,7 @@ const MainInterface = ({
     adminHomeOnboardingOpen,
     currentLanguage,
     i18n.language,
+    onboardingStatus?.user_segment,
     onboardingStatus?.version,
     trackEvent,
   ]);

--- a/src/cook-web/src/components/onboarding/onboardingSteps.test.ts
+++ b/src/cook-web/src/components/onboarding/onboardingSteps.test.ts
@@ -5,6 +5,8 @@ import React from 'react';
 
 const t = (key: string) => {
   const translations: Record<string, string> = {
+    'adminHome.billingCard.descriptionGeneric':
+      'Check balance or buy and upgrade plans',
     'adminHome.billingCard.descriptionWithExpiry':
       'Trial {credits} expires on {expiresAt}',
     'adminHome.billingCard.descriptionWithDays':
@@ -89,5 +91,16 @@ describe('buildAdminHomeOnboardingSteps', () => {
     expect(steps[1].id).toBe('lobster_course_creation');
     expect(steps[1].actionHref).toBeUndefined();
     expect(steps[1].actionLabel).toBeUndefined();
+  });
+
+  test('uses generic billing copy for rollout creators', () => {
+    const steps = buildAdminHomeOnboardingSteps({
+      t,
+      billingEnabled: true,
+      trialOffer,
+      variant: 'generic_billing',
+    });
+
+    expect(steps[2].description).toBe('Check balance or buy and upgrade plans');
   });
 });

--- a/src/cook-web/src/components/onboarding/onboardingSteps.test.ts
+++ b/src/cook-web/src/components/onboarding/onboardingSteps.test.ts
@@ -103,4 +103,20 @@ describe('buildAdminHomeOnboardingSteps', () => {
 
     expect(steps[2].description).toBe('Check balance or buy and upgrade plans');
   });
+
+  test('uses generic billing copy when trial credits are not actually granted', () => {
+    const steps = buildAdminHomeOnboardingSteps({
+      t,
+      billingEnabled: true,
+      trialOffer: {
+        ...trialOffer,
+        status: 'eligible',
+        granted_at: null,
+        expires_at: null,
+      },
+      variant: 'trial_credit',
+    });
+
+    expect(steps[2].description).toBe('Check balance or buy and upgrade plans');
+  });
 });

--- a/src/cook-web/src/components/onboarding/onboardingSteps.ts
+++ b/src/cook-web/src/components/onboarding/onboardingSteps.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { BillingTrialOffer } from '@/types/billing';
+import type { CreatorOnboardingBillingVariant } from '@/types/onboarding';
 import { ONBOARDING_TARGET_IDS } from '@/lib/onboardingTargets';
 import { formatBillingDate } from '@/lib/billing';
 import type { OnboardingStep } from './onboardingTypes';
@@ -21,13 +22,19 @@ type BuildAdminHomeStepsOptions = {
   trialOffer?: BillingTrialOffer | null;
   courseCreatorUrl?: string | null;
   locale?: string;
+  variant?: CreatorOnboardingBillingVariant | null;
 };
 
 const buildBillingDescription = (
   t: Translate,
   trialOffer: BillingTrialOffer | null | undefined,
   locale?: string,
+  variant?: CreatorOnboardingBillingVariant | null,
 ) => {
+  if (variant === 'generic_billing') {
+    return t('adminHome.billingCard.descriptionGeneric');
+  }
+
   const credits = trialOffer?.credit_amount || 0;
   const expiresAt = formatBillingDate(
     trialOffer?.expires_at,
@@ -83,6 +90,7 @@ export function buildAdminHomeOnboardingSteps({
   trialOffer,
   courseCreatorUrl,
   locale,
+  variant,
 }: BuildAdminHomeStepsOptions): OnboardingStep[] {
   const steps: OnboardingStep[] = [
     {
@@ -105,7 +113,7 @@ export function buildAdminHomeOnboardingSteps({
     steps.push({
       id: 'billing_card',
       title: t('adminHome.billingCard.title'),
-      description: buildBillingDescription(t, trialOffer, locale),
+      description: buildBillingDescription(t, trialOffer, locale, variant),
       targetId: ONBOARDING_TARGET_IDS.billingCard,
       skipWhenTargetMissing: true,
       highlightPadding: 4,

--- a/src/cook-web/src/components/onboarding/onboardingSteps.ts
+++ b/src/cook-web/src/components/onboarding/onboardingSteps.ts
@@ -36,7 +36,7 @@ const buildBillingDescription = (
   locale?: string,
   variant?: CreatorOnboardingBillingVariant | null,
 ) => {
-  if (variant === 'generic_billing') {
+  if (variant === 'generic_billing' || trialOffer?.status !== 'granted') {
     return t('adminHome.billingCard.descriptionGeneric');
   }
 

--- a/src/cook-web/src/components/onboarding/onboardingSteps.ts
+++ b/src/cook-web/src/components/onboarding/onboardingSteps.ts
@@ -5,6 +5,11 @@ import { ONBOARDING_TARGET_IDS } from '@/lib/onboardingTargets';
 import { formatBillingDate } from '@/lib/billing';
 import type { OnboardingStep } from './onboardingTypes';
 
+/*
+ * Translation usage markers for scripts/check_translation_usage.py:
+ * - 'module.onboarding.adminHome.billingCard.descriptionGeneric'
+ */
+
 const replaceTemplate = (
   template: string,
   values: Record<string, string | number>,

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -325,7 +325,7 @@ const ScriptEditor = ({
     !isHistoryPage &&
     editorOnboardingReady &&
     courseEditorSceneStatus?.eligible === true &&
-    courseEditorSceneStatus.completed === false &&
+    courseEditorSceneStatus?.completed === false &&
     isCourseOwner;
   const actionsRef = useRef(actions);
   const baseRevisionRef = useRef<number | null>(null);

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -306,6 +306,8 @@ const ScriptEditor = ({
   );
   const { data: onboardingStatus, mutate: mutateOnboardingStatus } =
     useCreatorOnboardingStatus(Boolean(currentUserId));
+  const courseEditorSceneStatus =
+    onboardingStatus?.scenes.course_editor_onboarding;
   const editorOnboardingSteps = useMemo(
     () =>
       buildCourseEditorOnboardingSteps({
@@ -322,8 +324,8 @@ const ScriptEditor = ({
   const shouldShowCourseEditorOnboarding =
     !isHistoryPage &&
     editorOnboardingReady &&
-    Boolean(onboardingStatus?.eligible) &&
-    onboardingStatus?.scenes.course_editor_onboarding.completed === false &&
+    courseEditorSceneStatus?.eligible === true &&
+    courseEditorSceneStatus.completed === false &&
     isCourseOwner;
   const actionsRef = useRef(actions);
   const baseRevisionRef = useRef<number | null>(null);
@@ -351,6 +353,7 @@ const ScriptEditor = ({
       trackEvent('creator_onboarding_step_viewed', {
         scene_key: 'course_editor_onboarding',
         version: onboardingStatus?.version || 'v1',
+        user_segment: onboardingStatus?.user_segment || 'ineligible',
         step_id: step.id,
         step_index: stepIndex + 1,
         trigger_source: editorOnboardingTriggerSource,
@@ -369,6 +372,7 @@ const ScriptEditor = ({
         trackEvent('creator_onboarding_completed', {
           scene_key: 'course_editor_onboarding',
           version,
+          user_segment: onboardingStatus?.user_segment || 'ineligible',
           trigger_source: editorOnboardingTriggerSource,
           language,
         });
@@ -376,6 +380,7 @@ const ScriptEditor = ({
         trackEvent('creator_onboarding_complete_failed', {
           scene_key: 'course_editor_onboarding',
           version,
+          user_segment: onboardingStatus?.user_segment || 'ineligible',
           trigger_source: editorOnboardingTriggerSource,
           language,
         });
@@ -389,6 +394,7 @@ const ScriptEditor = ({
           scenes: {
             ...current.scenes,
             course_editor_onboarding: {
+              ...current.scenes.course_editor_onboarding,
               completed: true,
               completed_at: new Date().toISOString(),
             },
@@ -439,12 +445,14 @@ const ScriptEditor = ({
     trackEvent('creator_onboarding_started', {
       scene_key: 'course_editor_onboarding',
       version: onboardingStatus?.version || 'v1',
+      user_segment: onboardingStatus?.user_segment || 'ineligible',
       trigger_source: editorOnboardingTriggerSource,
       language: profile?.language || i18n.language,
     });
   }, [
     courseEditorOnboardingOpen,
     editorOnboardingTriggerSource,
+    onboardingStatus?.user_segment,
     onboardingStatus?.version,
     profile?.language,
     trackEvent,

--- a/src/cook-web/src/types/onboarding.ts
+++ b/src/cook-web/src/types/onboarding.ts
@@ -14,8 +14,8 @@ export type CreatorOnboardingBillingVariant =
 export type CreatorOnboardingSceneStatus = {
   completed: boolean;
   completed_at: string | null;
-  eligible?: boolean;
-  variant?: CreatorOnboardingBillingVariant | null;
+  eligible: boolean;
+  variant: CreatorOnboardingBillingVariant | null;
 };
 
 export type CreatorOnboardingStatus = {

--- a/src/cook-web/src/types/onboarding.ts
+++ b/src/cook-web/src/types/onboarding.ts
@@ -2,13 +2,25 @@ export type CreatorOnboardingSceneKey =
   | 'admin_home_onboarding'
   | 'course_editor_onboarding';
 
+export type CreatorOnboardingUserSegment =
+  | 'new_creator'
+  | 'existing_creator_rollout'
+  | 'ineligible';
+
+export type CreatorOnboardingBillingVariant =
+  | 'trial_credit'
+  | 'generic_billing';
+
 export type CreatorOnboardingSceneStatus = {
   completed: boolean;
   completed_at: string | null;
+  eligible?: boolean;
+  variant?: CreatorOnboardingBillingVariant | null;
 };
 
 export type CreatorOnboardingStatus = {
   eligible: boolean;
+  user_segment: CreatorOnboardingUserSegment;
   version: string;
   scenes: Record<CreatorOnboardingSceneKey, CreatorOnboardingSceneStatus>;
   guide_course: {

--- a/src/i18n/en-US/modules/onboarding.json
+++ b/src/i18n/en-US/modules/onboarding.json
@@ -2,6 +2,7 @@
   "__namespace__": "module.onboarding",
   "adminHome": {
     "billingCard": {
+      "descriptionGeneric": "Check your credit balance here, or buy and upgrade plans when needed.",
       "descriptionWithDays": "We have added {credits} trial credits to your account for {days} days. Check your credit balance here, or buy and upgrade plans when needed.",
       "descriptionWithExpiry": "We have added {credits} trial credits to your account, valid until {expiresAt}. Check your credit balance here, or buy and upgrade plans when needed.",
       "title": "Check credits and buy plans here"

--- a/src/i18n/fr-FR/modules/onboarding.json
+++ b/src/i18n/fr-FR/modules/onboarding.json
@@ -2,6 +2,7 @@
   "__namespace__": "module.onboarding",
   "adminHome": {
     "billingCard": {
+      "descriptionGeneric": "Consultez ici votre solde de crédits, ou achetez et mettez votre offre à niveau si nécessaire.",
       "descriptionWithDays": "Nous avons ajouté {credits} crédits d'essai à votre compte, valables pendant {days} jours. Consultez ici votre solde de crédits, ou achetez et mettez votre offre à niveau si nécessaire.",
       "descriptionWithExpiry": "Nous avons ajouté {credits} crédits d'essai à votre compte, valables jusqu'au {expiresAt}. Consultez ici votre solde de crédits, ou achetez et mettez votre offre à niveau si nécessaire.",
       "title": "Consultez vos crédits et achetez une offre ici"

--- a/src/i18n/zh-CN/modules/onboarding.json
+++ b/src/i18n/zh-CN/modules/onboarding.json
@@ -2,6 +2,7 @@
   "__namespace__": "module.onboarding",
   "adminHome": {
     "billingCard": {
+      "descriptionGeneric": "你可以在这里查看积分余额，也可以购买或升级套餐。",
       "descriptionWithDays": "系统已为你发放 {credits} 体验积分，有效期 {days} 天。你可以在这里查看积分余额，也可以购买或升级套餐。",
       "descriptionWithExpiry": "系统已为你发放 {credits} 体验积分，有效期至 {expiresAt}。你可以在这里查看积分余额，也可以购买或升级套餐。",
       "title": "这里查看积分和购买套餐"

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -215,7 +215,7 @@
       "validityPreset": "有效期"
     },
     "confirmTitle": "确认发放积分",
-    "description": "用于运营后台给老师或运营发放积分或套餐。",
+    "description": "用于运营后台给创作者或运营发放积分或套餐。",
     "fields": {
       "amount": "积分",
       "mode": "发放类型",
@@ -304,7 +304,7 @@
   "overview": {
     "activeFilter": "快捷筛选",
     "metrics": {
-      "creators": "老师数",
+      "creators": "创作者数",
       "guests": "游客数",
       "learners": "学习者数",
       "learningActive30d": "近30天活跃学习用户",
@@ -318,7 +318,7 @@
     "staleData": "数据概览刷新失败，当前展示最近一次成功加载的数据。",
     "title": "数据概览",
     "tooltips": {
-      "creators": "老师数量",
+      "creators": "创作者数量",
       "guests": "游客状态用户数量",
       "learners": "有学习记录的用户数量",
       "learningActive30d": "近 30 天有学习行为的用户数量",
@@ -339,7 +339,7 @@
     "wechat": "微信"
   },
   "roleLabels": {
-    "creator": "老师",
+    "creator": "创作者",
     "learner": "学员",
     "operator": "运营",
     "regular": "普通用户",

--- a/src/i18n/zh-CN/modules/operations-user.json
+++ b/src/i18n/zh-CN/modules/operations-user.json
@@ -215,7 +215,7 @@
       "validityPreset": "有效期"
     },
     "confirmTitle": "确认发放积分",
-    "description": "用于运营后台给创作者或运营发放积分或套餐。",
+    "description": "用于运营后台给老师或运营发放积分或套餐。",
     "fields": {
       "amount": "积分",
       "mode": "发放类型",
@@ -304,7 +304,7 @@
   "overview": {
     "activeFilter": "快捷筛选",
     "metrics": {
-      "creators": "创作者数",
+      "creators": "老师数",
       "guests": "游客数",
       "learners": "学习者数",
       "learningActive30d": "近30天活跃学习用户",
@@ -318,7 +318,7 @@
     "staleData": "数据概览刷新失败，当前展示最近一次成功加载的数据。",
     "title": "数据概览",
     "tooltips": {
-      "creators": "创作者数量",
+      "creators": "老师数量",
       "guests": "游客状态用户数量",
       "learners": "有学习记录的用户数量",
       "learningActive30d": "近 30 天有学习行为的用户数量",
@@ -339,7 +339,7 @@
     "wechat": "微信"
   },
   "roleLabels": {
-    "creator": "创作者",
+    "creator": "老师",
     "learner": "学员",
     "operator": "运营",
     "regular": "普通用户",


### PR DESCRIPTION
## Summary
- extend creator onboarding status with `user_segment`, scene-level eligibility, and admin billing copy variants
- roll out admin-home and course-editor onboarding to existing creators behind dynamic config gates, while still keeping completed v1 scenes one-time only
- keep admin-home billing copy split by user segment: new creators see trial-credit copy, existing creators see generic billing copy

## Testing
- `cd src/api && pytest tests/service/user/test_onboarding_routes.py -q`
- `cd src/cook-web && npm test -- --runInBand src/components/onboarding/onboardingSteps.test.ts src/app/admin/layout.test.tsx`
- `cd src/cook-web && npm run type-check`
