### PR TITLE
fix: keep editor onboarding listen target in view

### DIFF
--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -1955,13 +1955,13 @@ export default function ShifuSettingDialog({
                 </div>
 
                 {/* TTS Configuration Section */}
-                <div
-                  className='mb-6'
-                  {...buildOnboardingTargetProps(
-                    ONBOARDING_TARGET_IDS.editorCourseListenMode,
-                  )}
-                >
-                  <div className='flex items-start justify-between mb-4'>
+                <div className='mb-6'>
+                  <div
+                    className='flex items-start justify-between mb-4'
+                    {...buildOnboardingTargetProps(
+                      ONBOARDING_TARGET_IDS.editorCourseListenMode,
+                    )}
+                  >
                     <div className='space-y-1'>
                       <FormLabel className='text-sm font-medium text-foreground'>
                         {t('module.shifuSetting.ttsTitle')}

--- a/src/cook-web/src/hooks/useOnboarding.test.tsx
+++ b/src/cook-web/src/hooks/useOnboarding.test.tsx
@@ -250,4 +250,5 @@ describe('useOnboarding', () => {
       expect(scrollIntoView).toHaveBeenCalledTimes(2);
     });
   });
+
 });

--- a/src/cook-web/src/hooks/useOnboarding.test.tsx
+++ b/src/cook-web/src/hooks/useOnboarding.test.tsx
@@ -250,5 +250,4 @@ describe('useOnboarding', () => {
       expect(scrollIntoView).toHaveBeenCalledTimes(2);
     });
   });
-
 });

--- a/src/cook-web/src/hooks/useOnboarding.test.tsx
+++ b/src/cook-web/src/hooks/useOnboarding.test.tsx
@@ -200,4 +200,54 @@ describe('useOnboarding', () => {
     expect(result.current.targetRect).toBe(firstRect);
     expect(target.getBoundingClientRect).toHaveBeenCalledTimes(1);
   });
+
+  test('re-scrolls panel targets that remain outside the viewport', async () => {
+    const onComplete = jest.fn();
+    const scrollIntoView = jest.fn();
+    const target = document.createElement('div');
+    target.scrollIntoView = scrollIntoView;
+    const offscreenRect = {
+      top: 920,
+      left: 200,
+      width: 120,
+      height: 40,
+      bottom: 960,
+      right: 320,
+      x: 200,
+      y: 920,
+      toJSON: () => ({}),
+    };
+    target.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue(offscreenRect as DOMRect);
+    getOnboardingTargetElement.mockReturnValue(target);
+
+    renderHook(() =>
+      useOnboarding({
+        enabled: true,
+        steps: [
+          {
+            id: 'listen-mode',
+            title: 'Listen mode',
+            description: 'Turn on TTS',
+            targetId: 'editor-course-listen-mode',
+            panel: 'shifu_settings',
+          },
+        ],
+        onComplete,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/cook-web/src/hooks/useOnboarding.ts
+++ b/src/cook-web/src/hooks/useOnboarding.ts
@@ -48,10 +48,7 @@ const rectFitsViewport = (rect: DOMRect) => {
       ? rect.left >= minLeft && rect.right <= maxRight
       : rect.right > minLeft && rect.left < maxRight;
 
-  return (
-    verticallyFits &&
-    horizontallyFits
-  );
+  return verticallyFits && horizontallyFits;
 };
 
 export function useOnboarding({

--- a/src/cook-web/src/hooks/useOnboarding.ts
+++ b/src/cook-web/src/hooks/useOnboarding.ts
@@ -24,18 +24,18 @@ type UseOnboardingOptions = {
   onStepMissing?: (step: OnboardingStep, stepIndex: number) => void;
 };
 
-const rectEquals = (current: DOMRect | null, next: DOMRect | null) => {
-  if (current === next) {
+const VIEWPORT_TARGET_GAP = 16;
+
+const rectFitsViewport = (rect: DOMRect) => {
+  if (typeof window === 'undefined') {
     return true;
   }
-  if (!current || !next) {
-    return false;
-  }
+
   return (
-    current.top === next.top &&
-    current.left === next.left &&
-    current.width === next.width &&
-    current.height === next.height
+    rect.top >= VIEWPORT_TARGET_GAP &&
+    rect.left >= VIEWPORT_TARGET_GAP &&
+    rect.bottom <= window.innerHeight - VIEWPORT_TARGET_GAP &&
+    rect.right <= window.innerWidth - VIEWPORT_TARGET_GAP
   );
 };
 
@@ -174,10 +174,13 @@ export function useOnboarding({
         }
         return false;
       }
-      if (
+      const nextRect = element.getBoundingClientRect();
+      const shouldScrollPanelTarget =
         currentStep.panel &&
-        lastScrolledStepIdRef.current !== currentStep.id
-      ) {
+        (lastScrolledStepIdRef.current !== currentStep.id ||
+          !rectFitsViewport(nextRect));
+
+      if (shouldScrollPanelTarget) {
         element.scrollIntoView({
           block: 'center',
           inline: 'nearest',
@@ -191,7 +194,6 @@ export function useOnboarding({
         setTargetRectStepId(null);
         return false;
       }
-      const nextRect = element.getBoundingClientRect();
       const hasVisibleRect = nextRect.width > 0 && nextRect.height > 0;
       if (!hasVisibleRect) {
         lastMeasuredRect = null;

--- a/src/cook-web/src/hooks/useOnboarding.ts
+++ b/src/cook-web/src/hooks/useOnboarding.ts
@@ -31,11 +31,26 @@ const rectFitsViewport = (rect: DOMRect) => {
     return true;
   }
 
+  const minTop = VIEWPORT_TARGET_GAP;
+  const minLeft = VIEWPORT_TARGET_GAP;
+  const maxBottom = window.innerHeight - VIEWPORT_TARGET_GAP;
+  const maxRight = window.innerWidth - VIEWPORT_TARGET_GAP;
+  const availableHeight = maxBottom - minTop;
+  const availableWidth = maxRight - minLeft;
+
+  const verticallyFits =
+    rect.height <= availableHeight
+      ? rect.top >= minTop && rect.bottom <= maxBottom
+      : rect.bottom > minTop && rect.top < maxBottom;
+
+  const horizontallyFits =
+    rect.width <= availableWidth
+      ? rect.left >= minLeft && rect.right <= maxRight
+      : rect.right > minLeft && rect.left < maxRight;
+
   return (
-    rect.top >= VIEWPORT_TARGET_GAP &&
-    rect.left >= VIEWPORT_TARGET_GAP &&
-    rect.bottom <= window.innerHeight - VIEWPORT_TARGET_GAP &&
-    rect.right <= window.innerWidth - VIEWPORT_TARGET_GAP
+    verticallyFits &&
+    horizontallyFits
   );
 };
 


### PR DESCRIPTION
## Summary
- keep course editor onboarding panel targets scrolled into view until they are actually visible
- narrow the listen-mode onboarding target to the toggle row instead of the full TTS settings section
- add focused onboarding hook coverage for re-scrolling offscreen panel targets

## Testing
- cd src/cook-web && npm test -- --runTestsByPath src/hooks/useOnboarding.test.tsx src/components/shifu-edit/ShifuEdit.test.tsx src/components/onboarding/editorOnboardingSteps.test.ts
- cd src/cook-web && npm run type-check
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding guidance behavior by re-scrolling to keep off-screen onboarding target elements visible when the page is scrolled.
  * Refined onboarding target tracking placement for the TTS configuration panel to ensure guidance aligns with the correct section.
* **Tests**
  * Added coverage to confirm that when onboarding targets are initially off-screen, a subsequent page scroll triggers them to be brought back into view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->