### PR TITLE
fix: harden Feishu log delivery

### DIFF
--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -4,6 +4,7 @@ from flask import Flask, request
 import uuid
 from logging.handlers import TimedRotatingFileHandler
 import socket
+import threading
 import time
 from datetime import datetime
 import pytz
@@ -81,8 +82,13 @@ class FeishuLogHandler(logging.Handler):
     def __init__(self, webhook_url):
         super().__init__(level=logging.ERROR)
         self.webhook_url = webhook_url
-        self._internal_logger = logging.getLogger("ai_shifu.feishu_log_handler")
-        self._internal_logger.propagate = False
+        # This handler is attached to app.logger, so reporting a webhook
+        # delivery failure through the same logger would loop straight back
+        # into emit() and re-hit the webhook. A thread-local re-entrancy guard
+        # breaks that loop while still letting the failure surface through the
+        # standard file/console handlers (unlike silencing it on a
+        # non-propagating logger).
+        self._delivering = threading.local()
 
     def _build_message_text(self, log_entry: str) -> str:
         text = f"师傅出错啦！\n{log_entry}\n"
@@ -92,7 +98,19 @@ class FeishuLogHandler(logging.Handler):
         suffix = f"\n...[truncated {omitted} chars to fit Feishu webhook limit]"
         return text[: self.MAX_TEXT_LENGTH - len(suffix)] + suffix
 
+    def _report_delivery_failure(self, exc: Exception) -> None:
+        message = "Failed to send log to Feishu webhook: %s"
+        try:
+            from flask import current_app
+
+            current_app.logger.warning(message, exc, exc_info=True)
+        except Exception:
+            logging.getLogger(__name__).warning(message, exc, exc_info=True)
+
     def emit(self, record):
+        if getattr(self._delivering, "active", False):
+            return
+        self._delivering.active = True
         try:
             log_entry = self.format(record)
             payload = {
@@ -101,12 +119,12 @@ class FeishuLogHandler(logging.Handler):
             }
             response = requests.post(self.webhook_url, json=payload, timeout=5)
             response.raise_for_status()
-        except requests.exceptions.RequestException:
-            self._internal_logger.warning(
-                "Failed to send log to Feishu webhook", exc_info=True
-            )
+        except requests.exceptions.RequestException as exc:
+            self._report_delivery_failure(exc)
         except Exception:
             self.handleError(record)
+        finally:
+            self._delivering.active = False
 
 
 class ColoredRequestFormatter(RequestFormatter, colorlog.ColoredFormatter):

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -76,23 +76,37 @@ class RequestFormatter(logging.Formatter):
 
 
 class FeishuLogHandler(logging.Handler):
+    MAX_TEXT_LENGTH = 18000
+
     def __init__(self, webhook_url):
         super().__init__(level=logging.ERROR)
         self.webhook_url = webhook_url
+        self._internal_logger = logging.getLogger("ai_shifu.feishu_log_handler")
+        self._internal_logger.propagate = False
+
+    def _build_message_text(self, log_entry: str) -> str:
+        text = f"师傅出错啦！\n{log_entry}\n"
+        if len(text) <= self.MAX_TEXT_LENGTH:
+            return text
+        omitted = len(text) - self.MAX_TEXT_LENGTH
+        suffix = f"\n...[truncated {omitted} chars to fit Feishu webhook limit]"
+        return text[: self.MAX_TEXT_LENGTH - len(suffix)] + suffix
 
     def emit(self, record):
-        log_entry = self.format(record)
-        payload = {
-            "msg_type": "text",
-            "content": {"text": f"师傅出错啦！\n{log_entry}\n"},
-        }
         try:
-            response = requests.post(self.webhook_url, json=payload)
+            log_entry = self.format(record)
+            payload = {
+                "msg_type": "text",
+                "content": {"text": self._build_message_text(log_entry)},
+            }
+            response = requests.post(self.webhook_url, json=payload, timeout=5)
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            from flask import current_app
-
-            current_app.logger.error(f"Failed to send log to Feishu: {e}")
+        except requests.exceptions.RequestException:
+            self._internal_logger.warning(
+                "Failed to send log to Feishu webhook", exc_info=True
+            )
+        except Exception:
+            self.handleError(record)
 
 
 class ColoredRequestFormatter(RequestFormatter, colorlog.ColoredFormatter):

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -1,0 +1,65 @@
+import logging
+
+import requests
+
+from flaskr.common.log import FeishuLogHandler
+
+
+class _FailingResponse:
+    def raise_for_status(self):
+        raise requests.exceptions.HTTPError("400 Client Error")
+
+
+def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FailingResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    handler = FeishuLogHandler("https://open.feishu.cn/open-apis/bot/v2/hook/test")
+    record = logging.LogRecord(
+        name="app",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="original application error",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    assert len(calls) == 1
+    assert calls[0][1]["timeout"] == 5
+
+
+def test_feishu_log_handler_truncates_oversized_payload(monkeypatch):
+    captured = {}
+
+    def fake_post(_url, *, json, timeout):
+        captured["payload"] = json
+        captured["timeout"] = timeout
+        return type("Response", (), {"raise_for_status": lambda self: None})()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    handler = FeishuLogHandler("https://open.feishu.cn/open-apis/bot/v2/hook/test")
+    record = logging.LogRecord(
+        name="app",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="x" * (handler.MAX_TEXT_LENGTH + 1000),
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    text = captured["payload"]["content"]["text"]
+    assert len(text) <= handler.MAX_TEXT_LENGTH
+    assert "truncated" in text
+    assert captured["timeout"] == 5

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -19,7 +19,7 @@ def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
 
     monkeypatch.setattr(requests, "post", fake_post)
 
-    handler = FeishuLogHandler("https://open.feishu.cn/open-apis/bot/v2/hook/test")
+    handler = FeishuLogHandler("https://example.invalid/open-apis/bot/v2/hook/test")
     record = logging.LogRecord(
         name="app",
         level=logging.ERROR,
@@ -36,6 +36,64 @@ def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
     assert calls[0][1]["timeout"] == 5
 
 
+def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
+    monkeypatch, caplog
+):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FailingResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    handler = FeishuLogHandler("https://example.invalid/open-apis/bot/v2/hook/test")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    # Attach the handler to a real logger so that reporting the delivery
+    # failure would re-enter emit() if the re-entrancy guard were missing.
+    logger = logging.getLogger("test_feishu_recursion")
+    logger.handlers = [handler]
+    logger.setLevel(logging.ERROR)
+    logger.propagate = False
+
+    with caplog.at_level(logging.WARNING, logger="flaskr.common.log"):
+        logger.error("original application error")
+
+    # The webhook is attempted exactly once: the delivery-failure report does
+    # not loop back into the handler.
+    assert len(calls) == 1
+    # The failure is still visible in the standard logs, not silently dropped.
+    assert "Failed to send log to Feishu webhook" in caplog.text
+
+
+def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        return type("Response", (), {"raise_for_status": lambda self: None})()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    handler = FeishuLogHandler("https://example.invalid/open-apis/bot/v2/hook/test")
+    record = logging.LogRecord(
+        name="app",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="nested emit",
+        args=(),
+        exc_info=None,
+    )
+
+    # Simulate being already inside emit() on this thread (as happens when the
+    # delivery-failure report flows back through app.logger).
+    handler._delivering.active = True
+    handler.emit(record)
+
+    assert calls == []
+
+
 def test_feishu_log_handler_truncates_oversized_payload(monkeypatch):
     captured = {}
 
@@ -46,7 +104,7 @@ def test_feishu_log_handler_truncates_oversized_payload(monkeypatch):
 
     monkeypatch.setattr(requests, "post", fake_post)
 
-    handler = FeishuLogHandler("https://open.feishu.cn/open-apis/bot/v2/hook/test")
+    handler = FeishuLogHandler("https://example.invalid/open-apis/bot/v2/hook/test")
     record = logging.LogRecord(
         name="app",
         level=logging.ERROR,


### PR DESCRIPTION
## 来源

运维保障群 2026-06-24 18:00 巡检，最近 24h 中同一批 TTS 报错后出现多条：

- `Failed to send log to Feishu: 400 Client Error: Bad Request for url: https://open.feishu.cn/open-apis/bot/v2/hook/...`

这些报错来自 `FeishuLogHandler.emit()` 在 webhook 发送失败后又调用 `current_app.logger.error(...)`，会被同一个 Error 级别 Feishu handler 再次处理，放大告警噪音。

## 修复

- `FeishuLogHandler` 发送 webhook 增加 5s timeout，避免日志发送阻塞请求线程。
- Feishu webhook 失败时改用不向上冒泡的内部 logger 记录，避免递归/二次推送到 Feishu。
- 对 Feishu 文本 payload 做长度上限截断，降低长 traceback 被 webhook 400 拒绝的概率。
- 增加单元测试覆盖：webhook 失败不重复发送、超长 payload 会截断。

## 验证

- `python3 -m py_compile src/api/flaskr/common/log.py src/api/tests/common/test_log.py` ✅
- `python3 -m pytest src/api/tests/common/test_log.py -q` 未能运行：当前本机 Python 环境未安装 pytest（`No module named pytest`）。

## 其他巡检结论

- TTS `No speakable text elements available for TTS synthesis`：已有 open PR #1908 / #1961 覆盖，避免重复修。
- outline reorder `TypeError: 'NoneType' object is not iterable`：已有 open PR #1926 覆盖，仍待合并/部署。
- MiniMax `2054 - voice id not exist`：定位为课程/试听中传入 MiniMax 不存在的 voice_id（如生产库可见部分草稿使用 `female-calm-default`、`standard-female-voice` 等非内置值），涉及数据/产品校验策略，未在本 PR 中硬改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log messages sent to Feishu are now automatically shortened when they exceed the platform’s message limit.
  * Webhook requests now use a 5-second timeout and handle send failures more gracefully, reducing noisy error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->