### PR TITLE
feat: ide referral invite surfaces without campaign

### DIFF
--- a/src/api/flaskr/service/referral/dtos.py
+++ b/src/api/flaskr/service/referral/dtos.py
@@ -24,9 +24,29 @@ class InviteProfileDTO:
     reward_queue_summary: dict[str, int] = field(default_factory=dict)
     reward_queue: list[dict[str, Any]] = field(default_factory=list)
     rules_copy_i18n_key: str = ""
+    available: bool = True
+
+    @classmethod
+    def unavailable(cls) -> "InviteProfileDTO":
+        return cls(
+            campaign_bid="",
+            campaign_code="",
+            invite_code="",
+            invite_url="",
+            reward_product_code="",
+            reward_cycle_count=0,
+            reward_credit_amount=None,
+            reward_credit_validity_days=None,
+            reward_cap_scope="",
+            reward_cap_count=None,
+            reward_granted_count=0,
+            reward_remaining_count=None,
+            available=False,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "available": self.available,
             "campaign_bid": self.campaign_bid,
             "campaign_code": self.campaign_code,
             "invite_code": self.invite_code,

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -390,10 +390,10 @@ def build_invite_profile(app: Flask, *, inviter_user_bid: str) -> InviteProfileD
             raise ValueError("inviter_user_bid is required")
         campaign = load_active_campaign()
         if campaign is None:
-            raise ValueError("no active referral campaign")
+            return InviteProfileDTO.unavailable()
         rule = select_reward_rule(campaign)
         if rule is None:
-            raise ValueError("no active referral reward rule")
+            return InviteProfileDTO.unavailable()
 
         invite_code = _load_active_invite_code(
             campaign_bid=campaign.campaign_bid,

--- a/src/api/tests/service/referral/test_referral_service.py
+++ b/src/api/tests/service/referral/test_referral_service.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 
-from flask import Flask
+from flask import Flask, request
 
 from flaskr.dao import db
 from flaskr.service.referral.routes import register_referral_routes
@@ -148,6 +149,64 @@ def test_invite_profile_lazily_creates_stable_campaign_scoped_code(
         assert first.reward_cap_count == 12
         assert first.reward_granted_count == 0
         assert first.reward_remaining_count == 12
+
+
+def test_invite_profile_route_returns_unavailable_without_campaign(
+    referral_app,
+) -> None:
+    register_referral_routes(referral_app, "/api/referral")
+
+    @referral_app.before_request
+    def _inject_request_user() -> None:
+        request.user = SimpleNamespace(user_id="inviter-no-campaign")
+
+    response = referral_app.test_client().get("/api/referral/invite-profile")
+    payload = response.get_json(force=True)["data"]
+
+    assert response.status_code == 200
+    assert payload == {
+        "available": False,
+        "campaign_bid": "",
+        "campaign_code": "",
+        "invite_code": "",
+        "invite_url": "",
+        "reward_product_code": "",
+        "reward_cycle_count": 0,
+        "reward_credit_amount": None,
+        "reward_credit_validity_days": None,
+        "reward_cap_scope": "",
+        "reward_cap_count": None,
+        "reward_granted_count": 0,
+        "reward_remaining_count": None,
+        "reward_queue_summary": {},
+        "reward_queue": [],
+        "rules_copy_i18n_key": "",
+    }
+    assert ReferralInviteCode.query.count() == 0
+
+
+def test_invite_profile_route_returns_unavailable_without_reward_rule(
+    referral_app,
+) -> None:
+    register_referral_routes(referral_app, "/api/referral")
+
+    @referral_app.before_request
+    def _inject_request_user() -> None:
+        request.user = SimpleNamespace(user_id="inviter-no-rule")
+
+    with referral_app.app_context():
+        _campaign, rule = _seed_campaign(campaign_bid="ref-campaign-no-rule")
+        rule.deleted = 1
+        db.session.commit()
+
+    response = referral_app.test_client().get("/api/referral/invite-profile")
+    payload = response.get_json(force=True)["data"]
+
+    assert response.status_code == 200
+    assert payload["available"] is False
+    assert payload["campaign_bid"] == ""
+    assert payload["invite_url"] == ""
+    assert ReferralInviteCode.query.count() == 0
 
 
 def test_invite_profile_includes_creator_reward_queue(

--- a/src/cook-web/src/app/admin/admin-menu.test.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.test.tsx
@@ -14,6 +14,17 @@ describe('buildAdminMenuItems', () => {
     ]);
   });
 
+  test('excludes referral invite entry when referral is unavailable', () => {
+    const options = { t, isOperator: false, showReferralInvite: false };
+    const menuItems = buildAdminMenuItems(options);
+
+    expect(menuItems.map(item => item.href)).toEqual([
+      '/admin',
+      '/admin/orders',
+      '/admin/dashboard',
+    ]);
+  });
+
   test('includes operations entry for operators', () => {
     const menuItems = buildAdminMenuItems({ t, isOperator: true });
 
@@ -52,6 +63,11 @@ describe('buildAdminMenuItems', () => {
           id: 'operations-credit-notification',
           label: 'common.core.creditNotificationManagement',
           href: '/admin/operations/credit-notifications',
+        },
+        {
+          id: 'operations-voice-clone',
+          label: 'common.core.voiceCloneManagement',
+          href: '/admin/operations/voice-clones',
         },
         {
           id: 'operations-profile-onboarding',

--- a/src/cook-web/src/app/admin/admin-menu.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.tsx
@@ -19,11 +19,13 @@ export type AdminMenuItem = {
 type BuildAdminMenuItemsOptions = {
   t: (key: string) => string;
   isOperator: boolean;
+  showReferralInvite?: boolean;
 };
 
 export const buildAdminMenuItems = ({
   t,
   isOperator,
+  showReferralInvite = true,
 }: BuildAdminMenuItemsOptions): AdminMenuItem[] => {
   const items: AdminMenuItem[] = [
     {
@@ -44,13 +46,16 @@ export const buildAdminMenuItems = ({
       label: t('module.dashboard.title'),
       href: '/admin/dashboard',
     },
-    {
+  ];
+
+  if (showReferralInvite) {
+    items.push({
       id: 'referral',
       icon: <UserPlusIcon className='w-4 h-4' />,
       label: t('common.core.referralInvitation'),
       href: '/admin/referral',
-    },
-  ];
+    });
+  }
 
   if (isOperator) {
     items.push({

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import api from '@/api';
 import { useBillingOverview } from '@/hooks/useBillingData';
 import { CONTACT_RAIL_I18N_KEY } from '@/components/contact/ContactSideRail';
 import { buildAdminMenuItems } from './admin-menu';
@@ -50,6 +51,14 @@ jest.mock('react-i18next', () => ({
       language: 'en-US',
     },
   }),
+}));
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    completeCreatorOnboarding: jest.fn(),
+    getReferralInviteProfile: jest.fn(),
+  },
 }));
 
 jest.mock('@/components/contact/ContactSideRail', () => ({
@@ -188,6 +197,7 @@ jest.mock('@/hooks/useOnboarding', () => ({
 
 const mockUseBillingOverview = useBillingOverview as jest.Mock;
 const mockMutateBillingOverview = jest.fn();
+const mockGetReferralInviteProfile = api.getReferralInviteProfile as jest.Mock;
 
 describe('SidebarContent', () => {
   const t = (key: string) => key;
@@ -417,6 +427,10 @@ describe('AdminLayout', () => {
       search: '',
     });
     mockMutateBillingOverview.mockReset();
+    mockGetReferralInviteProfile.mockReset();
+    mockGetReferralInviteProfile.mockResolvedValue({
+      available: false,
+    });
     mockUseBillingOverview.mockReturnValue({
       data: buildBillingOverview({}),
       error: undefined,
@@ -629,6 +643,45 @@ describe('AdminLayout', () => {
     expect(
       screen.queryByText('module.billing.sidebar.cta'),
     ).not.toBeInTheDocument();
+  });
+
+  test('hides referral invite navigation when campaign is unavailable', async () => {
+    mockGetReferralInviteProfile.mockResolvedValueOnce({
+      available: false,
+    });
+
+    render(
+      <AdminLayout>
+        <div data-testid='child-content' />
+      </AdminLayout>,
+    );
+
+    await waitFor(() =>
+      expect(mockGetReferralInviteProfile).toHaveBeenCalledTimes(1),
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'common.core.referralInvitation' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows referral invite navigation when campaign is available', async () => {
+    mockGetReferralInviteProfile.mockResolvedValueOnce({
+      available: true,
+      invite_url: 'https://app.example.com/invite/AB12CD34',
+    });
+
+    render(
+      <AdminLayout>
+        <div data-testid='child-content' />
+      </AdminLayout>,
+    );
+
+    expect(
+      await screen.findByRole('link', {
+        name: 'common.core.referralInvitation',
+      }),
+    ).toHaveAttribute('href', '/admin/referral');
   });
 
   test('hides the credits section when available credits are zero', () => {

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -18,6 +18,7 @@ import { ContactSideRail } from '@/components/contact/ContactSideRail';
 import { OnboardingOverlay } from '@/components/onboarding/OnboardingOverlay';
 import { buildAdminHomeOnboardingSteps } from '@/components/onboarding/onboardingSteps';
 import { applyCreatorBranding } from '@/lib/initializeEnvData';
+import type { ReferralInviteProfile } from '@/types/referral';
 import { buildAdminMenuItems } from './admin-menu';
 import { SidebarContent } from './SidebarContent';
 import { getCourseCreatorUrl } from '@/c-utils/urlUtils';
@@ -107,9 +108,42 @@ const MainInterface = ({
     [closeDesktopMenu],
   );
 
+  const [showReferralInvite, setShowReferralInvite] = React.useState(false);
+
+  useEffect(() => {
+    if (!menuReady) {
+      setShowReferralInvite(false);
+      return;
+    }
+
+    let isActive = true;
+    setShowReferralInvite(false);
+
+    api
+      .getReferralInviteProfile({})
+      .then(response => {
+        if (!isActive) {
+          return;
+        }
+        const profile = response as ReferralInviteProfile;
+        setShowReferralInvite(
+          profile.available !== false && Boolean(profile.invite_url),
+        );
+      })
+      .catch(() => {
+        if (isActive) {
+          setShowReferralInvite(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [currentUserId, menuReady]);
+
   const menuItems = useMemo(
-    () => buildAdminMenuItems({ t, isOperator }),
-    [isOperator, t],
+    () => buildAdminMenuItems({ t, isOperator, showReferralInvite }),
+    [isOperator, showReferralInvite, t],
   );
 
   const { data: billingOverview, isLoading: billingOverviewLoading } =

--- a/src/cook-web/src/app/admin/referral/page.test.tsx
+++ b/src/cook-web/src/app/admin/referral/page.test.tsx
@@ -119,4 +119,38 @@ describe('AdminReferralPage', () => {
       screen.queryByText('creator.ledgerStates.reserved'),
     ).not.toBeInTheDocument();
   });
+
+  test('hides invite page content when referral campaign is unavailable', async () => {
+    (api.getReferralInviteProfile as jest.Mock).mockResolvedValueOnce({
+      available: false,
+      campaign_bid: '',
+      campaign_code: '',
+      invite_code: '',
+      invite_url: '',
+      reward_product_code: '',
+      reward_cycle_count: 0,
+      reward_credit_amount: null,
+      reward_credit_validity_days: null,
+      reward_cap_scope: '',
+      reward_cap_count: null,
+      reward_granted_count: 0,
+      reward_remaining_count: null,
+      reward_queue_summary: {},
+      reward_queue: [],
+      rules_copy_i18n_key: '',
+    });
+
+    const { container } = render(<AdminReferralPage />);
+
+    await waitFor(() =>
+      expect(api.getReferralInviteProfile).toHaveBeenCalledTimes(1),
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('creator.title')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('creator.inviteCardTitle'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('error')).not.toBeInTheDocument();
+  });
 });

--- a/src/cook-web/src/app/admin/referral/page.tsx
+++ b/src/cook-web/src/app/admin/referral/page.tsx
@@ -144,6 +144,10 @@ export default function AdminReferralPage() {
     );
   }
 
+  if (profile?.available === false) {
+    return null;
+  }
+
   return (
     <div className='flex min-h-0 flex-col'>
       <AdminTitle

--- a/src/cook-web/src/types/referral.ts
+++ b/src/cook-web/src/types/referral.ts
@@ -21,6 +21,7 @@ export type ReferralRewardQueueItem = {
 };
 
 export type ReferralInviteProfile = {
+  available?: boolean;
   campaign_bid: string;
   campaign_code: string;
   invite_code: string;


### PR DESCRIPTION
## Summary

- Return a normal unavailable referral invite profile when there is no active campaign or reward rule instead of raising `ValueError`.
- Hide the creator referral invite page when `invite-profile` reports `available: false`.
- Hide the admin sidebar referral invitation entry unless the invite profile is available and has an invite URL.
- Add backend, page, menu, and layout regressions for empty campaign/rule states and hidden invite UI.

## Root cause

`/api/referral/invite-profile` called `build_invite_profile()`, which treated missing referral campaign configuration as an exceptional state. In environments with no active referral campaign, that raised `ValueError("no active referral campaign")` and the route returned a server error instead of disabling the invite UI.

## Validation

- `cd src/api && pytest tests/service/referral -q`
- `cd src/api && python -m ruff check flaskr/service/referral/dtos.py flaskr/service/referral/service.py tests/service/referral/test_referral_service.py`
- `cd src/cook-web && PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm test -- src/app/admin/admin-menu.test.tsx --runInBand`
- `cd src/cook-web && PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm test -- src/app/admin/layout.test.tsx --runInBand`
- `cd src/cook-web && PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm test -- src/app/admin/referral/page.test.tsx --runInBand`
- `cd src/cook-web && PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm run type-check`
- `cd src/cook-web && PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm run lint` (passes with existing warnings)
- `/opt/homebrew/bin/python3 scripts/generate_languages.py && git diff --exit-code -- src/i18n/locales.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Referral invite availability is now surfaced in the app, allowing the UI to show or hide referral invite access based on current status.
  * Admin navigation now adapts dynamically when referral invites are not available.

* **Bug Fixes**
  * Referral invite pages now stay hidden instead of showing errors when referral access is unavailable.
  * Admin invite/profile screens no longer render empty or broken content for unavailable referral states.

* **Tests**
  * Added coverage for unavailable referral scenarios in both backend and admin UI flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->