### PR TITLE
fix: keep classroom title placeholder and add tips

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -306,7 +306,60 @@ describe('ListenModeSlideRenderer', () => {
     );
   });
 
-  it('skips the leading section-title placeholder in classroom mode', () => {
+  it('shows classroom paging tips on the empty title placeholder', () => {
+    render(
+      <ListenModeSlideRenderer
+        variant='classroom'
+        items={[]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        sectionTitle='Section title'
+      />,
+    );
+
+    const classroomSlideProps = getMockSlide().mock.calls[0]?.[0] as
+      | { elementList?: Array<Record<string, unknown>>; showPlayer?: boolean }
+      | undefined;
+    expect(classroomSlideProps?.elementList?.[0]?.blockBid).toBe('empty-ppt');
+    expect(classroomSlideProps?.showPlayer).toBe(false);
+
+    const { unmount: unmountClassroomPlaceholder } = render(
+      classroomSlideProps?.elementList?.[0]?.content as React.ReactElement,
+    );
+    expect(screen.getByText('Section title')).toBeInTheDocument();
+    expect(
+      screen.getByText('module.chat.classroomTitlePlaceholderTips'),
+    ).toBeInTheDocument();
+    unmountClassroomPlaceholder();
+  });
+
+  it('does not prepend the classroom title placeholder once a slide is available', () => {
+    render(
+      <ListenModeSlideRenderer
+        variant='classroom'
+        items={[
+          {
+            type: 'content',
+            content: '<section>First slide</section>',
+            element_bid: 'first-slide',
+            element_type: 'html',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        sectionTitle='Section title'
+      />,
+    );
+
+    const classroomSlideProps = getMockSlide().mock.calls[0]?.[0] as
+      | { elementList?: Array<Record<string, unknown>> }
+      | undefined;
+    expect(classroomSlideProps?.elementList).toHaveLength(1);
+    expect(classroomSlideProps?.elementList?.[0]?.blockBid).toBe('first-slide');
+  });
+
+  it('keeps listen leading text placeholder without classroom tips', () => {
     const items: ChatContentItem[] = [
       {
         type: 'content',
@@ -324,29 +377,6 @@ describe('ListenModeSlideRenderer', () => {
       },
     ];
 
-    const { unmount } = render(
-      <ListenModeSlideRenderer
-        variant='classroom'
-        items={items}
-        mobileStyle={false}
-        chatRef={createChatRef()}
-        sectionTitle='Section title'
-      />,
-    );
-
-    const classroomSlideProps = getMockSlide().mock.calls[0]?.[0] as
-      | { elementList?: Array<Record<string, unknown>> }
-      | undefined;
-    expect(
-      classroomSlideProps?.elementList?.some(
-        element => element.blockBid === 'empty-ppt',
-      ),
-    ).toBe(false);
-    expect(classroomSlideProps?.elementList?.[0]?.blockBid).toBe('intro-text');
-
-    unmount();
-    getMockSlide().mockClear();
-
     render(
       <ListenModeSlideRenderer
         items={items}
@@ -360,9 +390,16 @@ describe('ListenModeSlideRenderer', () => {
       | { elementList?: Array<Record<string, unknown>> }
       | undefined;
     expect(listenSlideProps?.elementList?.[0]?.blockBid).toBe('empty-ppt');
+    const { unmount: unmountListenPlaceholder } = render(
+      listenSlideProps?.elementList?.[0]?.content as React.ReactElement,
+    );
+    expect(
+      screen.queryByText('module.chat.classroomTitlePlaceholderTips'),
+    ).not.toBeInTheDocument();
+    unmountListenPlaceholder();
   });
 
-  it('strips audio data and disables loading overlay in classroom mode', async () => {
+  it('omits audio data and disables loading overlay in classroom mode', async () => {
     const requestFullscreen = jest
       .fn()
       .mockRejectedValue(new Error('fullscreen blocked'));
@@ -379,6 +416,7 @@ describe('ListenModeSlideRenderer', () => {
             type: 'content',
             content: 'Slide',
             element_bid: 'content-1',
+            element_type: 'html',
             is_speakable: true,
             audio_url: '/tts.mp3',
             audio_segments: [

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -500,12 +500,18 @@ const getListenPlaybackSequenceActive = ({
 
 const createEmptyStateElement = (
   sectionTitle: string | undefined,
+  sectionPlaceholderTips?: string,
 ): ListenSlideElement => ({
   sequence_number: 1,
   type: 'slot',
   content: (
-    <div className='flex h-full w-full items-center justify-center text-center text-[40px] font-bold leading-[1.3] text-primary'>
-      {sectionTitle}
+    <div className='flex h-full w-full flex-col items-center justify-center text-center text-primary'>
+      <div className='text-[40px] font-bold leading-[1.3]'>{sectionTitle}</div>
+      {sectionPlaceholderTips ? (
+        <div className='mt-4 text-[18px] font-normal leading-7 text-primary/65'>
+          {sectionPlaceholderTips}
+        </div>
+      ) : null}
     </div>
   ),
   is_marker: true,
@@ -519,6 +525,7 @@ const buildSlideElementList = ({
   items,
   askListByAnchorElementBid,
   sectionTitle,
+  sectionPlaceholderTips,
   interactionInputMap,
   lastInteractionBid,
   lastItemIsInteraction,
@@ -529,6 +536,7 @@ const buildSlideElementList = ({
   items: ChatContentItem[];
   askListByAnchorElementBid: Map<string, AskMessage[]>;
   sectionTitle?: string;
+  sectionPlaceholderTips?: string;
   interactionInputMap: Record<string, string>;
   lastInteractionBid: string | null;
   lastItemIsInteraction: boolean;
@@ -632,7 +640,7 @@ const buildSlideElementList = ({
   });
 
   if (!elementList.length) {
-    return [createEmptyStateElement(sectionTitle)];
+    return [createEmptyStateElement(sectionTitle, sectionPlaceholderTips)];
   }
 
   // Keep a leading placeholder when the first content payload is text.
@@ -680,6 +688,10 @@ const ListenModeSlideRenderer = ({
     disableLoadingOverlay,
     playerClassName,
   } = presentationProfile;
+  const sectionPlaceholderTips =
+    variant === 'classroom'
+      ? t('module.chat.classroomTitlePlaceholderTips')
+      : undefined;
   const renderSequenceByStreamKeyRef = useRef<Map<string, number>>(new Map());
   const audioListenerCleanupMapRef = useRef<Map<HTMLAudioElement, () => void>>(
     new Map(),
@@ -863,6 +875,7 @@ const ListenModeSlideRenderer = ({
       items,
       askListByAnchorElementBid,
       sectionTitle,
+      sectionPlaceholderTips,
       interactionInputMap,
       lastInteractionBid,
       lastItemIsInteraction,
@@ -887,6 +900,7 @@ const ListenModeSlideRenderer = ({
     lastInteractionBid,
     lastItemIsInteraction,
     sectionTitle,
+    sectionPlaceholderTips,
     showLeadingTextPlaceholder,
   ]);
   const markerStepCount = useMemo(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
@@ -199,6 +199,13 @@ describe('chatUiModeProjection', () => {
         is_renderable: true,
       },
       {
+        type: ChatContentItemType.CONTENT,
+        element_bid: 'video-slide-1',
+        element_type: 'video' as ChatContentItem['element_type'],
+        content: '<iframe data-tag="video" src="/lesson.mp4"></iframe>',
+        is_renderable: true,
+      },
+      {
         type: ChatContentItemType.INTERACTION,
         element_bid: 'interaction-1',
         content: '?[%{{choice}} A | B]',
@@ -225,6 +232,7 @@ describe('chatUiModeProjection', () => {
     expect(projectedItems.map(item => item.element_bid)).toEqual([
       'slide-1',
       'image-slide-1',
+      'video-slide-1',
       'interaction-1',
     ]);
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
@@ -31,6 +31,7 @@ const CLASSROOM_VISUAL_ELEMENT_TYPES = new Set<string>([
   'diff',
   'img',
   'image',
+  'video',
 ]);
 
 const projectContentButton = ({

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -731,6 +731,7 @@ export type I18nKey =
   | 'module.chat.askContent'
   | 'module.chat.audioLoading'
   | 'module.chat.classroomEnterFullscreen'
+  | 'module.chat.classroomTitlePlaceholderTips'
   | 'module.chat.closeCatalog'
   | 'module.chat.generating'
   | 'module.chat.learningModeClassroom'

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -5,6 +5,7 @@
   "askContent": "Please enter your follow-up question",
   "audioLoading": "Loading audio...",
   "classroomEnterFullscreen": "Fullscreen",
+  "classroomTitlePlaceholderTips": "Classroom mode only shows slides; press F to toggle fullscreen, and use arrow keys or Space to change slides.",
   "closeCatalog": "Close catalog",
   "generating": "Generating diagram...",
   "learningModeClassroom": "Classroom",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -5,6 +5,7 @@
   "askContent": "Veuillez saisir votre question de suivi",
   "audioLoading": "Chargement de l'audio…",
   "classroomEnterFullscreen": "Plein écran",
+  "classroomTitlePlaceholderTips": "Le mode classe affiche uniquement les diapositives ; appuyez sur F pour passer en plein écran, puis utilisez les touches fléchées ou Espace pour changer de diapositive.",
   "closeCatalog": "Fermer le catalogue",
   "generating": "Génération du diagramme…",
   "learningModeClassroom": "Classe",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -5,6 +5,7 @@
   "askContent": "请输入你想追问的问题",
   "audioLoading": "音频加载中...",
   "classroomEnterFullscreen": "全屏",
+  "classroomTitlePlaceholderTips": "课堂模式只展示幻灯片；按 F 切换全屏，按方向键或空格翻页。",
   "closeCatalog": "关闭目录",
   "generating": "插图生成中...",
   "learningModeClassroom": "课堂模式",


### PR DESCRIPTION
## Summary

- Keep classroom mode on the normal slide projection path: text-only content is filtered before rendering, so the renderer naturally receives an empty slide list until visual content arrives.
- Show the lesson title placeholder with classroom-only keyboard tips when the projected classroom slide list is empty.
- Stop inserting a classroom title placeholder once a visual slide is available; the renderer now treats placeholder tips as an optional display prop.
- Keep zh-CN, en-US, and fr-FR i18n keys aligned, and include video as a classroom visual projection type.

## Validation

- npm run test -- --runInBand --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
- npm run test -- --runInBand --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/NewChatComp.test.tsx
- npm run type-check
- npm run lint -- --quiet
- pre-commit hooks during amend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Classroom mode now shows helpful keyboard tips on empty title placeholders.
  * Video content is now included in classroom slide projections alongside other visual items.

* **Bug Fixes**
  * Improved placeholder behavior so the right empty-state content appears only when needed.
  * Updated related checks to keep classroom and listen modes displaying the expected slide list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->