### PR TITLE
fix: harden Feishu notify response handling

### DIFF
--- a/src/api/flaskr/api/doc/feishu.py
+++ b/src/api/flaskr/api/doc/feishu.py
@@ -23,6 +23,25 @@ def send_notify(app: Flask, title, msgs):
             [{"tag": "text", "text": msg}]
         )
 
-    r = requests.post(url, headers=headers, data=json.dumps(data))
-    app.logger.info("send_notify:" + str(r.json()))
-    return r.json()
+    try:
+        response = requests.post(url, headers=headers, data=json.dumps(data), timeout=10)
+    except requests.RequestException:
+        app.logger.exception("send_notify request failed")
+        return None
+
+    response_text = response.text or ""
+    if response.status_code < 200 or response.status_code >= 300:
+        app.logger.warning(
+            "send_notify failed: status_code=%s response=%s",
+            response.status_code,
+            response_text[:1000],
+        )
+        return None
+
+    try:
+        result = response.json()
+    except ValueError:
+        result = {"status_code": response.status_code, "text": response_text[:1000]}
+
+    app.logger.info("send_notify:%s", result)
+    return result

--- a/src/api/flaskr/api/doc/feishu.py
+++ b/src/api/flaskr/api/doc/feishu.py
@@ -24,7 +24,9 @@ def send_notify(app: Flask, title, msgs):
         )
 
     try:
-        response = requests.post(url, headers=headers, data=json.dumps(data), timeout=10)
+        response = requests.post(
+            url, headers=headers, data=json.dumps(data), timeout=10
+        )
     except requests.RequestException:
         app.logger.exception("send_notify request failed")
         return None

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -1,0 +1,82 @@
+import requests
+
+from flaskr.api.doc import feishu
+
+
+class _Logger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+        self.exceptions = []
+
+    def info(self, *args, **kwargs):
+        self.infos.append(args)
+
+    def warning(self, *args, **kwargs):
+        self.warnings.append(args)
+
+    def exception(self, *args, **kwargs):
+        self.exceptions.append(args)
+
+
+class _App:
+    def __init__(self):
+        self.logger = _Logger()
+
+
+class _Response:
+    def __init__(self, status_code=200, text="", json_value=None, json_exc=None):
+        self.status_code = status_code
+        self.text = text
+        self._json_value = json_value
+        self._json_exc = json_exc
+
+    def json(self):
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._json_value
+
+
+def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypatch):
+    app = _App()
+    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+    monkeypatch.setattr(
+        feishu.requests,
+        "post",
+        lambda *args, **kwargs: _Response(status_code=200, text="ok", json_exc=ValueError("not json")),
+    )
+
+    result = feishu.send_notify(app, "标题", ["消息"])
+
+    assert result == {"status_code": 200, "text": "ok"}
+    assert app.logger.warnings == []
+
+
+def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
+    app = _App()
+    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+    monkeypatch.setattr(
+        feishu.requests,
+        "post",
+        lambda *args, **kwargs: _Response(status_code=400, text="bad request"),
+    )
+
+    result = feishu.send_notify(app, "标题", ["消息"])
+
+    assert result is None
+    assert app.logger.warnings
+
+
+def test_send_notify_returns_none_for_request_error(monkeypatch):
+    app = _App()
+    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+
+    def _raise(*args, **kwargs):
+        raise requests.RequestException("network down")
+
+    monkeypatch.setattr(feishu.requests, "post", _raise)
+
+    result = feishu.send_notify(app, "标题", ["消息"])
+
+    assert result is None
+    assert app.logger.exceptions

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -39,11 +39,15 @@ class _Response:
 
 def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypatch):
     app = _App()
-    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+    monkeypatch.setattr(
+        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+    )
     monkeypatch.setattr(
         feishu.requests,
         "post",
-        lambda *args, **kwargs: _Response(status_code=200, text="ok", json_exc=ValueError("not json")),
+        lambda *args, **kwargs: _Response(
+            status_code=200, text="ok", json_exc=ValueError("not json")
+        ),
     )
 
     result = feishu.send_notify(app, "标题", ["消息"])
@@ -54,7 +58,9 @@ def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypat
 
 def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
     app = _App()
-    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+    monkeypatch.setattr(
+        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+    )
     monkeypatch.setattr(
         feishu.requests,
         "post",
@@ -69,7 +75,9 @@ def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
 
 def test_send_notify_returns_none_for_request_error(monkeypatch):
     app = _App()
-    monkeypatch.setattr(feishu, "get_config", lambda key, default=None: "https://example.test/webhook")
+    monkeypatch.setattr(
+        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+    )
 
     def _raise(*args, **kwargs):
         raise requests.RequestException("network down")


### PR DESCRIPTION
## 来源

运维保障群 2026-06-25 02:00 报错：

- `/api/open-api/v1/order/revoke` 在调用 `send_revoke_feishu -> send_notify` 后执行 `r.json()`
- Feishu webhook 返回了非 JSON/空响应，触发 `requests.exceptions.JSONDecodeError`
- 结果导致订单撤销接口本身被通知链路异常带崩

## 修复

- 为 `send_notify` 增加 10s timeout，避免 webhook 请求无限等待
- 捕获 `requests.RequestException`，通知请求失败时记录日志并返回 `None`
- 对非 2xx 响应记录 warning 并返回 `None`
- 对 2xx 但非 JSON 的响应不再抛异常，返回包含 `status_code/text` 的结果，避免业务主流程因日志/通知响应格式异常失败
- 增加单测覆盖：成功但非 JSON、非 2xx、请求异常三类情况

## 验证

- ✅ `python3 -m py_compile src/api/flaskr/api/doc/feishu.py src/api/tests/api/doc/test_feishu_notify.py`
- ⚠️ `PYTHONPATH=src/api /opt/homebrew/Caskroom/miniconda/base/bin/python -m pytest src/api/tests/api/doc/test_feishu_notify.py -q` 未完成：当前本机环境缺少 `prometheus_client`，在加载 `src/api/tests/conftest.py` 时失败。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery reliability by adding request timeouts and error handling.
  * Non-success responses now return no result and are logged clearly.
  * If a response can’t be read as JSON, the app now falls back to a readable summary instead of failing.
  * Added coverage for successful, failed, and request-error notification responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->