### PR TITLE
refactor: add admin filter field builders

### DIFF
--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  createDateRangeFilterItem,
+  createSelectFilterItem,
+  createTextFilterItem,
+} from './adminFilterFieldBuilders';
+
+jest.mock('@/components/ui/Select', () => ({
+  Select: ({ children }: { children: ReactNode }) => (
+    <div data-testid='select-root'>{children}</div>
+  ),
+  SelectTrigger: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <button data-testid='select-trigger' className={className}>
+      {children}
+    </button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: ReactNode;
+    value: string;
+  }) => <div data-value={value}>{children}</div>,
+}));
+
+describe('adminFilterFieldBuilders', () => {
+  test('builds text filter item with clearable input', () => {
+    const item = createTextFilterItem({
+      key: 'keyword',
+      label: 'Keyword',
+      value: 'abc',
+      placeholder: 'Search keyword',
+      clearLabel: 'Clear',
+      onChange: jest.fn(),
+    });
+
+    render(item.component);
+    expect(screen.getByPlaceholderText('Search keyword')).toHaveValue('abc');
+  });
+
+  test('builds select filter item with provided options', () => {
+    const item = createSelectFilterItem({
+      key: 'status',
+      label: 'Status',
+      value: '__all__',
+      placeholder: 'Choose status',
+      options: [
+        { value: '__all__', label: 'All' },
+        { value: 'active', label: 'Active' },
+      ],
+      onChange: jest.fn(),
+    });
+
+    render(item.component);
+    expect(screen.getByText('Choose status')).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  test('builds date range filter item with trigger placeholder', () => {
+    const item = createDateRangeFilterItem({
+      key: 'date_range',
+      label: 'Date',
+      startValue: '',
+      endValue: '',
+      placeholder: 'Start ~ End',
+      resetLabel: 'Reset',
+      clearLabel: 'Clear',
+      onChange: jest.fn(),
+    });
+
+    render(item.component);
+    expect(
+      screen.getByRole('button', { name: 'Start ~ End' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
   createDateRangeFilterItem,
   createSelectFilterItem,
@@ -37,17 +37,27 @@ jest.mock('@/components/ui/Select', () => ({
 
 describe('adminFilterFieldBuilders', () => {
   test('builds text filter item with clearable input', () => {
+    const onChange = jest.fn();
+    const onSubmit = jest.fn();
     const item = createTextFilterItem({
       key: 'keyword',
       label: 'Keyword',
       value: 'abc',
       placeholder: 'Search keyword',
       clearLabel: 'Clear',
-      onChange: jest.fn(),
+      onChange,
+      onSubmit,
     });
 
     render(item.component);
-    expect(screen.getByPlaceholderText('Search keyword')).toHaveValue('abc');
+    const input = screen.getByPlaceholderText('Search keyword');
+    expect(input).toHaveValue('abc');
+
+    fireEvent.change(input, { target: { value: 'abcd' } });
+    expect(onChange).toHaveBeenCalledWith('abcd');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   test('builds select filter item with provided options', () => {

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.test.tsx
@@ -17,7 +17,10 @@ jest.mock('@/components/ui/Select', () => ({
     children: ReactNode;
     className?: string;
   }) => (
-    <button data-testid='select-trigger' className={className}>
+    <button
+      data-testid='select-trigger'
+      className={className}
+    >
       {children}
     </button>
   ),
@@ -27,13 +30,9 @@ jest.mock('@/components/ui/Select', () => ({
   SelectContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  SelectItem: ({
-    children,
-    value,
-  }: {
-    children: ReactNode;
-    value: string;
-  }) => <div data-value={value}>{children}</div>,
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <div data-value={value}>{children}</div>
+  ),
 }));
 
 describe('adminFilterFieldBuilders', () => {

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
@@ -1,0 +1,159 @@
+import type { ReactNode } from 'react';
+import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
+import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
+import type { AdminFilterItem } from '@/app/admin/components/AdminFilter';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+
+export type AdminFilterSelectOption = {
+  value: string;
+  label: ReactNode;
+};
+
+type CreateTextFilterItemParams = {
+  key: string;
+  label: ReactNode;
+  value?: string | null;
+  placeholder: string;
+  clearLabel: string;
+  onChange: (value: string) => void;
+  onSubmit?: () => void;
+  contentClassName?: string;
+  itemClassName?: string;
+  labelClassName?: string;
+  inputClassName?: string;
+};
+
+type CreateSelectFilterItemParams = {
+  key: string;
+  label: ReactNode;
+  value: string;
+  placeholder: string;
+  options: AdminFilterSelectOption[];
+  onChange: (value: string) => void;
+  contentClassName?: string;
+  itemClassName?: string;
+  labelClassName?: string;
+  triggerClassName?: string;
+  itemClassNameOverride?: string;
+  indicatorClassName?: string;
+};
+
+type CreateDateRangeFilterItemParams = {
+  key: string;
+  label: ReactNode;
+  startValue: string;
+  endValue: string;
+  placeholder: string;
+  resetLabel: string;
+  clearLabel: string;
+  onChange: (range: { start: string; end: string }) => void;
+  contentClassName?: string;
+  itemClassName?: string;
+  labelClassName?: string;
+};
+
+export const createTextFilterItem = ({
+  key,
+  label,
+  value,
+  placeholder,
+  clearLabel,
+  onChange,
+  onSubmit,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+  inputClassName,
+}: CreateTextFilterItemParams): AdminFilterItem => ({
+  key,
+  label,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+  component: (
+    <AdminClearableInput
+      value={value}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      placeholder={placeholder}
+      clearLabel={clearLabel}
+      className={inputClassName}
+    />
+  ),
+});
+
+export const createSelectFilterItem = ({
+  key,
+  label,
+  value,
+  placeholder,
+  options,
+  onChange,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+  triggerClassName,
+  itemClassNameOverride,
+  indicatorClassName,
+}: CreateSelectFilterItemParams): AdminFilterItem => ({
+  key,
+  label,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+  component: (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className={triggerClassName || 'h-9'}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map(option => (
+          <SelectItem
+            key={option.value}
+            value={option.value}
+            className={itemClassNameOverride}
+            indicatorClassName={indicatorClassName}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ),
+});
+
+export const createDateRangeFilterItem = ({
+  key,
+  label,
+  startValue,
+  endValue,
+  placeholder,
+  resetLabel,
+  clearLabel,
+  onChange,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+}: CreateDateRangeFilterItemParams): AdminFilterItem => ({
+  key,
+  label,
+  contentClassName,
+  itemClassName,
+  labelClassName,
+  component: (
+    <AdminDateRangeFilter
+      startValue={startValue}
+      endValue={endValue}
+      onChange={onChange}
+      placeholder={placeholder}
+      resetLabel={resetLabel}
+      clearLabel={clearLabel}
+    />
+  ),
+});

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
@@ -41,7 +41,7 @@ type CreateSelectFilterItemParams = {
   itemClassName?: string;
   labelClassName?: string;
   triggerClassName?: string;
-  itemClassNameOverride?: string;
+  selectItemClassName?: string;
   indicatorClassName?: string;
 };
 
@@ -100,7 +100,7 @@ export const createSelectFilterItem = ({
   itemClassName,
   labelClassName,
   triggerClassName,
-  itemClassNameOverride,
+  selectItemClassName,
   indicatorClassName,
 }: CreateSelectFilterItemParams): AdminFilterItem => ({
   key,
@@ -121,7 +121,7 @@ export const createSelectFilterItem = ({
           <SelectItem
             key={option.value}
             value={option.value}
-            className={itemClassNameOverride}
+            className={selectItemClassName}
             indicatorClassName={indicatorClassName}
           >
             {option.label}

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
@@ -108,7 +108,10 @@ export const createSelectFilterItem = ({
   itemClassName,
   labelClassName,
   component: (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value}
+      onValueChange={onChange}
+    >
       <SelectTrigger className={triggerClassName || 'h-9'}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>

--- a/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
+++ b/src/cook-web/src/app/admin/components/adminFilterFieldBuilders.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/Select';
+import { cn } from '@/lib/utils';
 
 export type AdminFilterSelectOption = {
   value: string;
@@ -112,7 +113,7 @@ export const createSelectFilterItem = ({
       value={value}
       onValueChange={onChange}
     >
-      <SelectTrigger className={triggerClassName || 'h-9'}>
+      <SelectTrigger className={cn('h-9', triggerClassName)}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
@@ -95,7 +95,7 @@ export default function CreatorRedemptionCodesFilterPanel({
         value: toSelectValue(option.value),
         label: option.label,
       })),
-      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+      selectItemClassName: SINGLE_SELECT_ITEM_CLASS,
       indicatorClassName: SINGLE_SELECT_INDICATOR_CLASS,
     });
 

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
@@ -153,9 +153,7 @@ export default function CreatorRedemptionCodesFilterPanel({
         onFilterChange('start_time', range.start);
         onFilterChange('end_time', range.end);
       },
-      placeholder: `${t('module.order.filters.startTime')} ~ ${t(
-        'module.order.filters.endTime',
-      )}`,
+      placeholder: t('module.order.filters.dateRangePlaceholder'),
       resetLabel: t('module.order.filters.reset'),
       clearLabel: t('common.core.close'),
     }),

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
@@ -1,27 +1,20 @@
 'use client';
 
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo } from 'react';
-import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
-import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
-import { Button } from '@/components/ui/Button';
+import type { AdminFilterItem } from '@/app/admin/components/AdminFilter';
+import AdminFilter from '@/app/admin/components/AdminFilter';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/Select';
+  createDateRangeFilterItem,
+  createSelectFilterItem,
+  createTextFilterItem,
+} from '@/app/admin/components/adminFilterFieldBuilders';
 import { COUPON_OPS_STATE_OPTIONS } from '@/app/admin/operations/promotions/promotionPageShared';
-import { cn } from '@/lib/utils';
 import {
-  FILTER_LABEL_CLASS,
   SINGLE_SELECT_INDICATOR_CLASS,
   SINGLE_SELECT_ITEM_CLASS,
   fromSelectValue,
   toSelectValue,
   type RedemptionCodeFilters,
-  type RedemptionFilterItem,
 } from './creatorRedemptionCodeShared';
 
 type TranslationFn = (key: string, options?: Record<string, unknown>) => string;
@@ -85,227 +78,114 @@ export default function CreatorRedemptionCodesFilterPanel({
     [t, tPromotion],
   );
 
-  const filterItems: RedemptionFilterItem[] = [
-    {
+  const buildSelectItem = (
+    key: keyof RedemptionCodeFilters,
+    label: string,
+    placeholder: string,
+    value: string,
+    options: Array<{ value: string; label: string }>,
+  ): AdminFilterItem =>
+    createSelectFilterItem({
+      key,
+      label,
+      value: toSelectValue(value),
+      onChange: nextValue => onFilterChange(key, fromSelectValue(nextValue)),
+      placeholder,
+      options: options.map(option => ({
+        value: toSelectValue(option.value),
+        label: option.label,
+      })),
+      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+      indicatorClassName: SINGLE_SELECT_INDICATOR_CLASS,
+    });
+
+  const filterItems: AdminFilterItem[] = [
+    createTextFilterItem({
       key: 'name',
       label: tPromotion('filters.name'),
-      component: (
-        <AdminClearableInput
-          value={filters.name}
-          onChange={value => onFilterChange('name', value)}
-          placeholder={tPromotion('filters.namePlaceholder')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
-    {
+      value: filters.name,
+      onChange: value => onFilterChange('name', value),
+      placeholder: tPromotion('filters.namePlaceholder'),
+      clearLabel: t('common.core.close'),
+    }),
+    createTextFilterItem({
       key: 'course_query',
       label: tPromotion('filters.courseId'),
-      component: (
-        <AdminClearableInput
-          value={filters.course_query}
-          onChange={value => onFilterChange('course_query', value)}
-          placeholder={tPromotion('filters.courseIdPlaceholder')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
-    {
-      key: 'usage_type',
-      label: tPromotion('filters.usageType'),
-      component: (
-        <Select
-          value={toSelectValue(filters.usage_type)}
-          onValueChange={value =>
-            onFilterChange('usage_type', fromSelectValue(value))
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue placeholder={tPromotion('filters.usageType')} />
-          </SelectTrigger>
-          <SelectContent>
-            {usageTypeOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={toSelectValue(option.value)}
-                className={SINGLE_SELECT_ITEM_CLASS}
-                indicatorClassName={SINGLE_SELECT_INDICATOR_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
-      key: 'status',
-      label: tPromotion('filters.status'),
-      component: (
-        <Select
-          value={toSelectValue(filters.status)}
-          onValueChange={value =>
-            onFilterChange('status', fromSelectValue(value))
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue placeholder={tPromotion('filters.status')} />
-          </SelectTrigger>
-          <SelectContent>
-            {statusOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={toSelectValue(option.value)}
-                className={SINGLE_SELECT_ITEM_CLASS}
-                indicatorClassName={SINGLE_SELECT_INDICATOR_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
-      key: 'ops_state',
-      label: t('module.order.redemptionCodes.opsState'),
-      component: (
-        <Select
-          value={toSelectValue(filters.ops_state)}
-          onValueChange={value =>
-            onFilterChange('ops_state', fromSelectValue(value))
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue
-              placeholder={t('module.order.redemptionCodes.opsState')}
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {opsStateOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={toSelectValue(option.value)}
-                className={SINGLE_SELECT_ITEM_CLASS}
-                indicatorClassName={SINGLE_SELECT_INDICATOR_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
-      key: 'discount_type',
-      label: tPromotion('filters.discountType'),
-      component: (
-        <Select
-          value={toSelectValue(filters.discount_type)}
-          onValueChange={value =>
-            onFilterChange('discount_type', fromSelectValue(value))
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue placeholder={tPromotion('filters.discountType')} />
-          </SelectTrigger>
-          <SelectContent>
-            {discountTypeOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={toSelectValue(option.value)}
-                className={SINGLE_SELECT_ITEM_CLASS}
-                indicatorClassName={SINGLE_SELECT_INDICATOR_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
+      value: filters.course_query,
+      onChange: value => onFilterChange('course_query', value),
+      placeholder: tPromotion('filters.courseIdPlaceholder'),
+      clearLabel: t('common.core.close'),
+    }),
+    buildSelectItem(
+      'usage_type',
+      tPromotion('filters.usageType'),
+      tPromotion('filters.usageType'),
+      filters.usage_type,
+      usageTypeOptions,
+    ),
+    buildSelectItem(
+      'status',
+      tPromotion('filters.status'),
+      tPromotion('filters.status'),
+      filters.status,
+      statusOptions,
+    ),
+    buildSelectItem(
+      'ops_state',
+      t('module.order.redemptionCodes.opsState'),
+      t('module.order.redemptionCodes.opsState'),
+      filters.ops_state,
+      opsStateOptions,
+    ),
+    buildSelectItem(
+      'discount_type',
+      tPromotion('filters.discountType'),
+      tPromotion('filters.discountType'),
+      filters.discount_type,
+      discountTypeOptions,
+    ),
+    createDateRangeFilterItem({
       key: 'date_range',
       label: tPromotion('filters.activeTime'),
-      component: (
-        <AdminDateRangeFilter
-          startValue={filters.start_time}
-          endValue={filters.end_time}
-          onChange={range => {
-            onFilterChange('start_time', range.start);
-            onFilterChange('end_time', range.end);
-          }}
-          placeholder={`${t('module.order.filters.startTime')} ~ ${t(
-            'module.order.filters.endTime',
-          )}`}
-          resetLabel={t('module.order.filters.reset')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
-    {
+      startValue: filters.start_time,
+      endValue: filters.end_time,
+      onChange: range => {
+        onFilterChange('start_time', range.start);
+        onFilterChange('end_time', range.end);
+      },
+      placeholder: `${t('module.order.filters.startTime')} ~ ${t(
+        'module.order.filters.endTime',
+      )}`,
+      resetLabel: t('module.order.filters.reset'),
+      clearLabel: t('common.core.close'),
+    }),
+    createTextFilterItem({
       key: 'keyword',
       label: tPromotion('filters.keyword'),
-      component: (
-        <AdminClearableInput
-          value={filters.keyword}
-          onChange={value => onFilterChange('keyword', value)}
-          placeholder={tPromotion('filters.keywordPlaceholder')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
+      value: filters.keyword,
+      onChange: value => onFilterChange('keyword', value),
+      placeholder: tPromotion('filters.keywordPlaceholder'),
+      clearLabel: t('common.core.close'),
+    }),
   ];
-  const visibleFilterItems = expanded ? filterItems : filterItems.slice(0, 4);
 
   return (
-    <div className='w-full bg-white'>
-      <div className='grid min-w-0 grid-cols-1 gap-x-7 gap-y-4 xl:grid-cols-4'>
-        {visibleFilterItems.map(item => (
-          <div
-            key={item.key}
-            className='flex min-w-0 items-center gap-3 md:[&>span]:text-right'
-          >
-            <span className={cn(FILTER_LABEL_CLASS, 'w-24')}>{item.label}</span>
-            <div className='min-w-0 flex-1'>{item.component}</div>
-          </div>
-        ))}
-      </div>
-      <div className='mt-5 flex items-center justify-end'>
-        <div className='flex shrink-0 items-center justify-end'>
-          <Button
-            size='sm'
-            type='button'
-            variant='outline'
-            className='px-4'
-            onClick={onReset}
-          >
-            {t('module.order.filters.reset')}
-          </Button>
-          <Button
-            size='sm'
-            type='button'
-            className='ml-2 px-4'
-            onClick={onSearch}
-          >
-            {t('module.order.filters.search')}
-          </Button>
-          <Button
-            size='sm'
-            type='button'
-            variant='ghost'
-            className='ml-4 gap-1 px-2 text-[var(--base-foreground,#0A0A0A)] hover:text-[var(--base-foreground,#0A0A0A)]'
-            onClick={() => onExpandedChange(!expanded)}
-          >
-            {expanded ? t('common.core.collapse') : t('common.core.expand')}
-            {expanded ? (
-              <ChevronUp className='h-4 w-4' />
-            ) : (
-              <ChevronDown className='h-4 w-4' />
-            )}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <AdminFilter
+      items={filterItems}
+      expanded={expanded}
+      onExpandedChange={onExpandedChange}
+      onReset={onReset}
+      onSearch={onSearch}
+      resetLabel={t('module.order.filters.reset')}
+      searchLabel={t('module.order.filters.search')}
+      expandLabel={t('common.core.expand')}
+      collapseLabel={t('common.core.collapse')}
+      collapsedCount={4}
+      labelClassName='w-24'
+      contentClassName='min-w-0'
+      collapsedGridClassName='gap-x-7 xl:grid-cols-4'
+      expandedGridClassName='gap-x-7 xl:grid-cols-4'
+      showToggle
+    />
   );
 }

--- a/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
@@ -4,8 +4,12 @@ import { useMemo } from 'react';
 import { Check, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
-import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
+import {
+  createDateRangeFilterItem,
+  createSelectFilterItem,
+  createTextFilterItem,
+} from '@/app/admin/components/adminFilterFieldBuilders';
 import Loading from '@/components/loading';
 import { Button } from '@/components/ui/Button';
 import {
@@ -14,13 +18,6 @@ import {
   PopoverTrigger,
 } from '@/components/ui/Popover';
 import { ScrollArea } from '@/components/ui/ScrollArea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/Select';
 import { cn } from '@/lib/utils';
 import type { Shifu } from '@/types/shifu';
 import type { OrderFilters } from './ordersPageShared';
@@ -122,18 +119,14 @@ export default function OrdersFilterPanel({
   }, [courseSearch, courses]);
 
   const filterItems = [
-    {
+    createTextFilterItem({
       key: 'user_bid',
       label: userBidPlaceholder,
-      component: (
-        <AdminClearableInput
-          value={filters.user_bid}
-          onChange={value => onFilterChange('user_bid', value)}
-          placeholder={userBidPlaceholder}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
+      value: filters.user_bid,
+      onChange: value => onFilterChange('user_bid', value),
+      placeholder: userBidPlaceholder,
+      clearLabel: t('common.core.close'),
+    }),
     {
       key: 'shifu_bids',
       label: t('module.order.filters.shifuBid'),
@@ -225,94 +218,58 @@ export default function OrdersFilterPanel({
         </Popover>
       ),
     },
-    {
+    createSelectFilterItem({
       key: 'status',
       label: t('module.order.filters.status'),
-      component: (
-        <Select
-          value={displayStatusValue}
-          onValueChange={value =>
-            onFilterChange('status', value === ALL_OPTION_VALUE ? '' : value)
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue placeholder={t('module.order.filters.status')} />
-          </SelectTrigger>
-          <SelectContent>
-            {statusOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={option.value || ALL_OPTION_VALUE}
-                className={SINGLE_SELECT_ITEM_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
+      value: displayStatusValue,
+      onChange: value =>
+        onFilterChange('status', value === ALL_OPTION_VALUE ? '' : value),
+      placeholder: t('module.order.filters.status'),
+      options: statusOptions.map(option => ({
+        value: option.value || ALL_OPTION_VALUE,
+        label: option.label,
+      })),
+      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+    }),
+    createSelectFilterItem({
       key: 'payment_channel',
       label: t('module.order.filters.channel'),
-      component: (
-        <Select
-          value={displayChannelValue}
-          onValueChange={value =>
-            onFilterChange(
-              'payment_channel',
-              value === ALL_OPTION_VALUE ? '' : value,
-            )
-          }
-        >
-          <SelectTrigger className='h-9'>
-            <SelectValue placeholder={t('module.order.filters.channel')} />
-          </SelectTrigger>
-          <SelectContent>
-            {channelOptions.map(option => (
-              <SelectItem
-                key={option.value || 'all'}
-                value={option.value || ALL_OPTION_VALUE}
-                className={SINGLE_SELECT_ITEM_CLASS}
-              >
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ),
-    },
-    {
+      value: displayChannelValue,
+      onChange: value =>
+        onFilterChange(
+          'payment_channel',
+          value === ALL_OPTION_VALUE ? '' : value,
+        ),
+      placeholder: t('module.order.filters.channel'),
+      options: channelOptions.map(option => ({
+        value: option.value || ALL_OPTION_VALUE,
+        label: option.label,
+      })),
+      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+    }),
+    createDateRangeFilterItem({
       key: 'date_range',
       label: t('module.order.table.createdAt'),
-      component: (
-        <AdminDateRangeFilter
-          startValue={filters.start_time}
-          endValue={filters.end_time}
-          onChange={range => {
-            onFilterChange('start_time', range.start);
-            onFilterChange('end_time', range.end);
-          }}
-          placeholder={`${t('module.order.filters.startTime')} ~ ${t(
-            'module.order.filters.endTime',
-          )}`}
-          resetLabel={t('module.order.filters.reset')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
-    {
+      startValue: filters.start_time,
+      endValue: filters.end_time,
+      onChange: range => {
+        onFilterChange('start_time', range.start);
+        onFilterChange('end_time', range.end);
+      },
+      placeholder: `${t('module.order.filters.startTime')} ~ ${t(
+        'module.order.filters.endTime',
+      )}`,
+      resetLabel: t('module.order.filters.reset'),
+      clearLabel: t('common.core.close'),
+    }),
+    createTextFilterItem({
       key: 'order_bid',
       label: t('module.order.filters.orderBid'),
-      component: (
-        <AdminClearableInput
-          value={filters.order_bid}
-          onChange={value => onFilterChange('order_bid', value)}
-          placeholder={t('module.order.filters.orderBid')}
-          clearLabel={t('common.core.close')}
-        />
-      ),
-    },
+      value: filters.order_bid,
+      onChange: value => onFilterChange('order_bid', value),
+      placeholder: t('module.order.filters.orderBid'),
+      clearLabel: t('common.core.close'),
+    }),
   ];
 
   return (

--- a/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
@@ -256,9 +256,7 @@ export default function OrdersFilterPanel({
         onFilterChange('start_time', range.start);
         onFilterChange('end_time', range.end);
       },
-      placeholder: `${t('module.order.filters.startTime')} ~ ${t(
-        'module.order.filters.endTime',
-      )}`,
+      placeholder: t('module.order.filters.dateRangePlaceholder'),
       resetLabel: t('module.order.filters.reset'),
       clearLabel: t('common.core.close'),
     }),

--- a/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
@@ -229,7 +229,7 @@ export default function OrdersFilterPanel({
         value: option.value || ALL_OPTION_VALUE,
         label: option.label,
       })),
-      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+      selectItemClassName: SINGLE_SELECT_ITEM_CLASS,
     }),
     createSelectFilterItem({
       key: 'payment_channel',
@@ -245,7 +245,7 @@ export default function OrdersFilterPanel({
         value: option.value || ALL_OPTION_VALUE,
         label: option.label,
       })),
-      itemClassNameOverride: SINGLE_SELECT_ITEM_CLASS,
+      selectItemClassName: SINGLE_SELECT_ITEM_CLASS,
     }),
     createDateRangeFilterItem({
       key: 'date_range',

--- a/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
+++ b/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react';
-
 export const PAGE_SIZE = 20;
 export const USAGE_PROGRESS_SEPARATOR = '/';
 export const ALL_OPTION_VALUE = '__all__';
@@ -19,12 +17,6 @@ export type RedemptionCodeFilters = {
   status: string;
   start_time: string;
   end_time: string;
-};
-
-export type RedemptionFilterItem = {
-  key: string;
-  label: ReactNode;
-  component: ReactNode;
 };
 
 export const createDefaultFilters = (): RedemptionCodeFilters => ({

--- a/src/i18n/en-US/modules/order.json
+++ b/src/i18n/en-US/modules/order.json
@@ -52,6 +52,7 @@
   "filters": {
     "all": "All",
     "channel": "Payment Channel",
+    "dateRangePlaceholder": "Start Date ~ End Date",
     "endTime": "End Date",
     "orderBid": "Order ID",
     "reset": "Reset",

--- a/src/i18n/fr-FR/modules/order.json
+++ b/src/i18n/fr-FR/modules/order.json
@@ -52,6 +52,7 @@
   "filters": {
     "all": "Tous",
     "channel": "Canal de paiement",
+    "dateRangePlaceholder": "Date de début ~ Date de fin",
     "endTime": "Date de fin",
     "orderBid": "ID de commande",
     "reset": "Réinitialiser",

--- a/src/i18n/zh-CN/modules/order.json
+++ b/src/i18n/zh-CN/modules/order.json
@@ -52,6 +52,7 @@
   "filters": {
     "all": "全部",
     "channel": "支付渠道",
+    "dateRangePlaceholder": "开始日期 ~ 结束日期",
     "endTime": "结束日期",
     "orderBid": "订单 ID",
     "reset": "重置",


### PR DESCRIPTION
## Summary
- add shared admin filter field builders for text, select, and date-range inputs
- refactor the orders filter panel and creator redemption-code filter panel to use the shared builders while keeping the course multi-select popover custom
- add focused builder coverage and remove the obsolete redemption filter item type

## Testing
- `cd src/cook-web && npm test -- --runInBand src/app/admin/components/adminFilterFieldBuilders.test.tsx`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint-file -- src/app/admin/components/adminFilterFieldBuilders.tsx`
- `cd src/cook-web && npm run lint-file -- src/app/admin/components/adminFilterFieldBuilders.test.tsx`
- `cd src/cook-web && npm run lint-file -- src/app/admin/orders/OrdersFilterPanel.tsx`
- `cd src/cook-web && npm run lint-file -- src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx`
- `cd src/cook-web && npm run lint-file -- src/app/admin/orders/creatorRedemptionCodeShared.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin order and redemption-code filter panels now use a more consistent, reusable filter experience with unified text, select, and date-range controls.
  * Improved date-range placeholder text across languages (“Start Date ~ End Date”, “Date de début ~ Date de fin”, “开始日期 ~ 结束日期”).
* **Tests**
  * Added Jest/React Testing Library coverage for the new filter field builders, verifying rendering and interactions for text, select, and date-range filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->