### PR TITLE
fix: allow operator creators into onboarding rollout

### DIFF
--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -106,8 +106,6 @@ def _resolve_user_segment(user: UserEntity | None) -> str:
         return USER_SEGMENT_INELIGIBLE
     if not bool(getattr(user, "is_creator", 0)):
         return USER_SEGMENT_INELIGIBLE
-    if bool(getattr(user, "is_operator", 0)):
-        return USER_SEGMENT_INELIGIBLE
 
     threshold = _parse_rollout_threshold(get_dynamic_config(ROLLOUT_CONFIG_KEY, ""))
     eligible_at = getattr(user, "created_at", None)

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -118,7 +118,7 @@ def test_onboarding_status_returns_eligible_creator_scene_state(
     assert payload["data"]["guide_course"]["language"] == "zh-CN"
 
 
-def test_onboarding_status_excludes_operator_and_marks_scenes_ineligible(
+def test_onboarding_status_allows_operator_creator_when_new_creator_gate_matches(
     app, test_client, monkeypatch
 ):
     user_bid = uuid.uuid4().hex[:32]
@@ -127,7 +127,7 @@ def test_onboarding_status_excludes_operator_and_marks_scenes_ineligible(
             user_bid=user_bid,
             is_creator=True,
             is_operator=True,
-            created_at=datetime(2026, 6, 1, 12, 0, 0),
+            created_at=datetime(2026, 6, 17, 12, 0, 0),
         )
         db.session.commit()
         token = generate_token(app, user_bid)
@@ -152,11 +152,14 @@ def test_onboarding_status_excludes_operator_and_marks_scenes_ineligible(
     assert response.status_code == 200
     payload = response.get_json(force=True)
     assert payload["code"] == 0
-    assert payload["data"]["eligible"] is False
-    assert payload["data"]["user_segment"] == "ineligible"
-    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is False
-    assert payload["data"]["scenes"]["admin_home_onboarding"]["variant"] is None
-    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is False
+    assert payload["data"]["eligible"] is True
+    assert payload["data"]["user_segment"] == "new_creator"
+    assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is True
+    assert (
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
+        == "trial_credit"
+    )
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
 
 
 def test_onboarding_status_treats_old_user_newly_activated_as_existing_rollout(

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -156,8 +156,7 @@ def test_onboarding_status_allows_operator_creator_when_new_creator_gate_matches
     assert payload["data"]["user_segment"] == "new_creator"
     assert payload["data"]["scenes"]["admin_home_onboarding"]["eligible"] is True
     assert (
-        payload["data"]["scenes"]["admin_home_onboarding"]["variant"]
-        == "trial_credit"
+        payload["data"]["scenes"]["admin_home_onboarding"]["variant"] == "trial_credit"
     )
     assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
 

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -158,7 +158,9 @@ def test_onboarding_status_allows_operator_creator_when_new_creator_gate_matches
     assert (
         payload["data"]["scenes"]["admin_home_onboarding"]["variant"] == "trial_credit"
     )
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["completed"] is False
     assert payload["data"]["scenes"]["course_editor_onboarding"]["eligible"] is True
+    assert payload["data"]["scenes"]["course_editor_onboarding"]["variant"] is None
 
 
 def test_onboarding_status_treats_old_user_newly_activated_as_existing_rollout(


### PR DESCRIPTION
## Summary
- allow operator users who are also creators to reuse the existing creator onboarding eligibility rules
- keep course editor onboarding owner-only by leaving frontend editor gating unchanged
- update user onboarding route coverage for eligible operator creators

## Testing
- cd src/api && pytest -q tests/service/user/test_onboarding_routes.py
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated onboarding eligibility logic so operator users are no longer automatically marked ineligible.
  * When a user matches the new creator gate, onboarding status is now eligible and returns the correct `user_segment`.
  * Scene-level onboarding results now align with the expected eligibility, including proper variants for admin home onboarding (and correct handling for course editor onboarding).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->