### PR TITLE
fix(api): harden runtime error paths from ops alerts

### DIFF
--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -167,7 +167,12 @@ def get_config(key: str, default: str = None) -> str:
                     )
                     return value
                 finally:
-                    lock.release()
+                    try:
+                        lock.release()
+                    except Exception as exc:
+                        app.logger.warning(
+                            "Failed to release get_config lock for %s: %s", key, exc
+                        )
             return default
         except (SQLAlchemyError, RuntimeError) as exc:
             app.logger.warning("Database not ready for get_config(%s): %s", key, exc)

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1719,6 +1719,8 @@ class RunScriptContextV2:
                 ):
                     raise UserNotLoginException()
             parent_path = find_node_with_parents(self._struct, outline_bid)
+            if not parent_path:
+                raise_error("server.shifu.lessonNotFoundInCourse")
             attend_info = None
             for item in parent_path:
                 if item.type == "outline":

--- a/src/api/flaskr/service/learn/lesson_feedback.py
+++ b/src/api/flaskr/service/learn/lesson_feedback.py
@@ -166,14 +166,15 @@ def submit_lesson_feedback(
             )
             db.session.add(feedback_record)
 
-        _sync_feedback_to_generated_block(
-            user_bid,
-            shifu_bid,
-            outline_bid,
-            normalized_score,
-            normalized_comment,
-        )
         try:
+            with db.session.no_autoflush:
+                _sync_feedback_to_generated_block(
+                    user_bid,
+                    shifu_bid,
+                    outline_bid,
+                    normalized_score,
+                    normalized_comment,
+                )
             db.session.commit()
         except IntegrityError:
             # Handle race on unique active row: re-read and update instead of failing.


### PR DESCRIPTION
## Summary
- From the 运维保障群 2026-06-26 alerts: `/api/runtime-config` and shifu outline routes failed with `redis.exceptions.LockNotOwnedError` while releasing `get_config` locks. The release path now logs and suppresses release failures so config reads do not fail after the value has already been resolved.
- From lesson feedback alerts: duplicate active feedback rows could autoflush during generated-block sync before the existing IntegrityError recovery path. The sync query now runs under `no_autoflush`, allowing commit-time race handling to update the existing row.
- From run_script alerts: missing outline path produced a raw `TypeError: NoneType object is not iterable`. It now raises the existing lesson-not-found application error when the outline path cannot be found.

## Validation
- `python3 -m py_compile src/api/flaskr/service/config/funcs.py src/api/flaskr/service/learn/lesson_feedback.py src/api/flaskr/service/learn/context_v2.py`
- Attempted `PYTHONPATH=src/api /opt/homebrew/Caskroom/miniconda/base/bin/python -m pytest src/api/tests/service/learn/test_lesson_feedback.py -q`, but local environment is missing `prometheus_client` while loading `tests/conftest.py`.
- Attempted `PYTHONPATH=src/api python3 -m unittest src/api/tests/service/learn/test_lesson_feedback.py`, but local system Python is missing `pytest` imported by `src/api/tests/__init__.py`.

## Alert source
运维保障群, recent 24h AI-Shifu error巡检 on 2026-06-26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when loading configuration, reducing the chance of unexpected errors during startup or settings access.
  * Fixed a lesson-progress issue so invalid course paths now return a clear “lesson not found” response instead of continuing with incomplete data.
  * Improved lesson feedback submission handling to reduce database-related failures and make save behavior more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->