### PR TITLE
fix(api): harden runtime errors from ops alerts

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -730,7 +730,9 @@ def get_generated_content(
         )
 
 
-def _resolve_runtime_tts_voice_id(app: Flask, provider: str, voice_id: str) -> str:
+def _resolve_runtime_tts_voice_id(
+    app: Flask, provider: str, voice_id: str, *, shifu_bid: str
+) -> str:
     """Return a voice id that is safe to send to the provider at runtime.
 
     MiniMax accepts user-defined clone IDs that share the same character shape as
@@ -754,15 +756,22 @@ def _resolve_runtime_tts_voice_id(app: Flask, provider: str, voice_id: str) -> s
     if normalized_voice_id in built_in_voice_ids:
         return normalized_voice_id
 
+    # Only accept a cloned voice that belongs to THIS shifu and is ready.
+    # Scoping by shifu_bid keeps a stale/misconfigured voice id from resolving to
+    # another shifu's clone, and filtering status in the query prevents a newer
+    # non-ready duplicate from hiding an older ready row.
+    normalized_shifu_bid = (shifu_bid or "").strip()
     cloned_voice = (
         TTSMiniMaxClonedVoice.query.filter(
             TTSMiniMaxClonedVoice.voice_id == normalized_voice_id,
+            TTSMiniMaxClonedVoice.shifu_bid == normalized_shifu_bid,
+            TTSMiniMaxClonedVoice.status == TTS_MINIMAX_CLONE_STATUS_READY,
             TTSMiniMaxClonedVoice.deleted == 0,
         )
         .order_by(TTSMiniMaxClonedVoice.id.desc())
         .first()
     )
-    if cloned_voice and cloned_voice.status == TTS_MINIMAX_CLONE_STATUS_READY:
+    if cloned_voice:
         return normalized_voice_id
 
     default_voice_settings = get_default_voice_settings(normalized_provider)
@@ -818,6 +827,7 @@ def _resolve_shifu_tts_settings(
         app,
         validated.provider,
         validated.voice_id,
+        shifu_bid=shifu_bid,
     )
 
     voice_settings = get_default_voice_settings(validated.provider)

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -81,6 +81,7 @@ from flaskr.service.shifu.utils import get_shifu_res_url
 from flaskr.api.tts import (
     get_default_audio_settings,
     get_default_voice_settings,
+    get_tts_provider,
     is_tts_configured,
     synthesize_text,
 )
@@ -98,7 +99,12 @@ from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
 )
-from flaskr.service.tts.models import AUDIO_STATUS_COMPLETED, LearnGeneratedAudio
+from flaskr.service.tts.models import (
+    AUDIO_STATUS_COMPLETED,
+    LearnGeneratedAudio,
+    TTSMiniMaxClonedVoice,
+    TTS_MINIMAX_CLONE_STATUS_READY,
+)
 from flaskr.service.tts.pipeline import split_text_for_tts
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.service.tts.validation import validate_tts_settings_strict
@@ -724,6 +730,53 @@ def get_generated_content(
         )
 
 
+def _resolve_runtime_tts_voice_id(app: Flask, provider: str, voice_id: str) -> str:
+    """Return a voice id that is safe to send to the provider at runtime.
+
+    MiniMax accepts user-defined clone IDs that share the same character shape as
+    historical built-in voices. A stale DB value can therefore pass local shape
+    validation and fail only after the external API call with `2054 - voice id not
+    exist`. For learner-facing audio generation, fall back to the provider's
+    default voice when the MiniMax voice is neither a current built-in voice nor a
+    ready cloned voice tracked by our system.
+    """
+    normalized_provider = (provider or "").strip().lower()
+    normalized_voice_id = (voice_id or "").strip()
+    if normalized_provider != "minimax" or not normalized_voice_id:
+        return normalized_voice_id
+
+    provider_config = get_tts_provider(normalized_provider).get_provider_config()
+    built_in_voice_ids = {
+        (voice.get("value") or "").strip()
+        for voice in (provider_config.voices or [])
+        if (voice.get("value") or "").strip()
+    }
+    if normalized_voice_id in built_in_voice_ids:
+        return normalized_voice_id
+
+    cloned_voice = (
+        TTSMiniMaxClonedVoice.query.filter(
+            TTSMiniMaxClonedVoice.voice_id == normalized_voice_id,
+            TTSMiniMaxClonedVoice.deleted == 0,
+        )
+        .order_by(TTSMiniMaxClonedVoice.id.desc())
+        .first()
+    )
+    if cloned_voice and cloned_voice.status == TTS_MINIMAX_CLONE_STATUS_READY:
+        return normalized_voice_id
+
+    default_voice_settings = get_default_voice_settings(normalized_provider)
+    fallback_voice_id = (getattr(default_voice_settings, "voice_id", "") or "").strip()
+    if not fallback_voice_id and built_in_voice_ids:
+        fallback_voice_id = sorted(built_in_voice_ids)[0]
+    app.logger.warning(
+        "MiniMax TTS voice_id %s is not a current built-in voice or ready cloned voice; falling back to %s",
+        normalized_voice_id,
+        fallback_voice_id,
+    )
+    return fallback_voice_id or normalized_voice_id
+
+
 def _resolve_shifu_tts_settings(
     app: Flask,
     *,
@@ -761,8 +814,14 @@ def _resolve_shifu_tts_settings(
         emotion=emotion,
     )
 
+    runtime_voice_id = _resolve_runtime_tts_voice_id(
+        app,
+        validated.provider,
+        validated.voice_id,
+    )
+
     voice_settings = get_default_voice_settings(validated.provider)
-    voice_settings.voice_id = validated.voice_id
+    voice_settings.voice_id = runtime_voice_id
     voice_settings.speed = validated.speed
     voice_settings.pitch = validated.pitch
     voice_settings.emotion = validated.emotion

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+import flaskr.dao as dao
+
+if dao.db is None:
+    _test_app = Flask("test-runtime-tts-voice-id")
+    _test_app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    _db = SQLAlchemy()
+    _db.init_app(_test_app)
+    dao.db = _db
+
+if not hasattr(dao, "redis_client"):
+    dao.redis_client = None
+
+
+class _Col:
+    """Stand-in for a SQLAlchemy column expression used in filter/order_by."""
+
+    def desc(self):
+        return self
+
+    def __eq__(self, other):
+        return False
+
+
+class _FakeQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+def _make_fake_clone_model(first_result):
+    return type(
+        "_FakeCloneModel",
+        (),
+        {
+            "voice_id": _Col(),
+            "deleted": _Col(),
+            "id": _Col(),
+            "query": _FakeQuery(first_result),
+        },
+    )
+
+
+def _fake_app():
+    return SimpleNamespace(
+        logger=SimpleNamespace(warning=lambda *args, **kwargs: None)
+    )
+
+
+def _patch_provider(monkeypatch, built_in_values, default_voice_id="default-voice"):
+    provider_config = SimpleNamespace(
+        voices=[{"value": value} for value in built_in_values]
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.get_tts_provider",
+        lambda _provider: SimpleNamespace(
+            get_provider_config=lambda: provider_config
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.learn.learn_funcs.get_default_voice_settings",
+        lambda _provider: SimpleNamespace(voice_id=default_voice_id),
+    )
+
+
+def test_non_minimax_provider_returns_voice_id_unchanged(monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    # Non-MiniMax providers are trusted as-is; no provider/DB lookups happen.
+    assert (
+        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "tencent", "any-voice")
+        == "any-voice"
+    )
+
+
+def test_minimax_builtin_voice_is_kept(monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    _patch_provider(monkeypatch, ["builtin-1", "builtin-2"])
+    assert (
+        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "MiniMax", "builtin-1")
+        == "builtin-1"
+    )
+
+
+def test_minimax_ready_cloned_voice_is_kept(monkeypatch):
+    from flaskr.service.learn import learn_funcs
+    from flaskr.service.tts.models import TTS_MINIMAX_CLONE_STATUS_READY
+
+    _patch_provider(monkeypatch, ["builtin-1"])
+    monkeypatch.setattr(
+        learn_funcs,
+        "TTSMiniMaxClonedVoice",
+        _make_fake_clone_model(
+            SimpleNamespace(status=TTS_MINIMAX_CLONE_STATUS_READY)
+        ),
+    )
+    assert (
+        learn_funcs._resolve_runtime_tts_voice_id(
+            _fake_app(), "minimax", "clone-ready"
+        )
+        == "clone-ready"
+    )
+
+
+def test_minimax_stale_voice_falls_back_to_default(monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    _patch_provider(monkeypatch, ["builtin-1"], default_voice_id="default-voice")
+    # Not a built-in voice and no ready clone tracked -> fall back to default.
+    monkeypatch.setattr(
+        learn_funcs,
+        "TTSMiniMaxClonedVoice",
+        _make_fake_clone_model(None),
+    )
+    assert (
+        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "stale-voice")
+        == "default-voice"
+    )
+
+
+def test_minimax_empty_voice_id_returns_empty(monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    assert learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "") == ""

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -57,9 +57,7 @@ def _make_fake_clone_model(first_result):
 
 
 def _fake_app():
-    return SimpleNamespace(
-        logger=SimpleNamespace(warning=lambda *args, **kwargs: None)
-    )
+    return SimpleNamespace(logger=SimpleNamespace(warning=lambda *args, **kwargs: None))
 
 
 def _patch_provider(monkeypatch, built_in_values, default_voice_id="default-voice"):
@@ -68,9 +66,7 @@ def _patch_provider(monkeypatch, built_in_values, default_voice_id="default-voic
     )
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.get_tts_provider",
-        lambda _provider: SimpleNamespace(
-            get_provider_config=lambda: provider_config
-        ),
+        lambda _provider: SimpleNamespace(get_provider_config=lambda: provider_config),
     )
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.get_default_voice_settings",
@@ -106,14 +102,10 @@ def test_minimax_ready_cloned_voice_is_kept(monkeypatch):
     monkeypatch.setattr(
         learn_funcs,
         "TTSMiniMaxClonedVoice",
-        _make_fake_clone_model(
-            SimpleNamespace(status=TTS_MINIMAX_CLONE_STATUS_READY)
-        ),
+        _make_fake_clone_model(SimpleNamespace(status=TTS_MINIMAX_CLONE_STATUS_READY)),
     )
     assert (
-        learn_funcs._resolve_runtime_tts_voice_id(
-            _fake_app(), "minimax", "clone-ready"
-        )
+        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "clone-ready")
         == "clone-ready"
     )
 

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -1,69 +1,40 @@
 from types import SimpleNamespace
 
+import pytest
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 
 import flaskr.dao as dao
+from flaskr.service.tts.models import (
+    TTSMiniMaxClonedVoice,
+    TTS_MINIMAX_CLONE_STATUS_FAILED,
+    TTS_MINIMAX_CLONE_STATUS_READY,
+)
 
-if dao.db is None:
-    _test_app = Flask("test-runtime-tts-voice-id")
-    _test_app.config.update(
+
+@pytest.fixture
+def voice_app():
+    app = Flask(__name__)
+    app.testing = True
+    app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_BINDS={
+            "ai_shifu_saas": "sqlite:///:memory:",
+            "ai_shifu_admin": "sqlite:///:memory:",
+        },
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
-
-
-class _Col:
-    """Stand-in for a SQLAlchemy column expression used in filter/order_by."""
-
-    def desc(self):
-        return self
-
-    def __eq__(self, other):
-        return False
+    dao.db.init_app(app)
+    with app.app_context():
+        dao.db.create_all()
+        yield app
+        dao.db.session.remove()
+        dao.db.drop_all()
 
 
-class _FakeQuery:
-    def __init__(self, result):
-        self._result = result
-
-    def filter(self, *args, **kwargs):
-        return self
-
-    def order_by(self, *args, **kwargs):
-        return self
-
-    def first(self):
-        return self._result
-
-
-def _make_fake_clone_model(first_result):
-    return type(
-        "_FakeCloneModel",
-        (),
-        {
-            "voice_id": _Col(),
-            "deleted": _Col(),
-            "id": _Col(),
-            "query": _FakeQuery(first_result),
-        },
-    )
-
-
-def _fake_app():
-    return SimpleNamespace(logger=SimpleNamespace(warning=lambda *args, **kwargs: None))
-
-
-def _patch_provider(monkeypatch, built_in_values, default_voice_id="default-voice"):
-    provider_config = SimpleNamespace(
-        voices=[{"value": value} for value in built_in_values]
-    )
+def _patch_provider(
+    monkeypatch, built_in=("builtin-1",), default_voice_id="default-voice"
+):
+    provider_config = SimpleNamespace(voices=[{"value": value} for value in built_in])
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.get_tts_provider",
         lambda _provider: SimpleNamespace(get_provider_config=lambda: provider_config),
@@ -74,59 +45,112 @@ def _patch_provider(monkeypatch, built_in_values, default_voice_id="default-voic
     )
 
 
-def test_non_minimax_provider_returns_voice_id_unchanged(monkeypatch):
+def _add_clone(shifu_bid, voice_id, status, voice_bid):
+    dao.db.session.add(
+        TTSMiniMaxClonedVoice(
+            voice_bid=voice_bid,
+            shifu_bid=shifu_bid,
+            voice_id=voice_id,
+            status=status,
+            deleted=0,
+        )
+    )
+    dao.db.session.commit()
+
+
+def test_non_minimax_provider_returns_voice_id_unchanged(voice_app):
     from flaskr.service.learn import learn_funcs
 
-    # Non-MiniMax providers are trusted as-is; no provider/DB lookups happen.
-    assert (
-        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "tencent", "any-voice")
-        == "any-voice"
-    )
+    with voice_app.app_context():
+        # Non-MiniMax providers are trusted as-is; no provider/DB lookups happen.
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "tencent", "any-voice", shifu_bid="shifu-1"
+            )
+            == "any-voice"
+        )
 
 
-def test_minimax_builtin_voice_is_kept(monkeypatch):
+def test_minimax_empty_voice_id_returns_empty(voice_app):
     from flaskr.service.learn import learn_funcs
 
-    _patch_provider(monkeypatch, ["builtin-1", "builtin-2"])
-    assert (
-        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "MiniMax", "builtin-1")
-        == "builtin-1"
-    )
+    with voice_app.app_context():
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "minimax", "", shifu_bid="shifu-1"
+            )
+            == ""
+        )
 
 
-def test_minimax_ready_cloned_voice_is_kept(monkeypatch):
-    from flaskr.service.learn import learn_funcs
-    from flaskr.service.tts.models import TTS_MINIMAX_CLONE_STATUS_READY
-
-    _patch_provider(monkeypatch, ["builtin-1"])
-    monkeypatch.setattr(
-        learn_funcs,
-        "TTSMiniMaxClonedVoice",
-        _make_fake_clone_model(SimpleNamespace(status=TTS_MINIMAX_CLONE_STATUS_READY)),
-    )
-    assert (
-        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "clone-ready")
-        == "clone-ready"
-    )
-
-
-def test_minimax_stale_voice_falls_back_to_default(monkeypatch):
+def test_minimax_builtin_voice_is_kept(voice_app, monkeypatch):
     from flaskr.service.learn import learn_funcs
 
-    _patch_provider(monkeypatch, ["builtin-1"], default_voice_id="default-voice")
-    # Not a built-in voice and no ready clone tracked -> fall back to default.
-    monkeypatch.setattr(
-        learn_funcs,
-        "TTSMiniMaxClonedVoice",
-        _make_fake_clone_model(None),
-    )
-    assert (
-        learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "stale-voice")
-        == "default-voice"
-    )
+    _patch_provider(monkeypatch)
+    with voice_app.app_context():
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "MiniMax", "builtin-1", shifu_bid="shifu-1"
+            )
+            == "builtin-1"
+        )
 
 
-def test_minimax_empty_voice_id_returns_empty(monkeypatch):
+def test_minimax_ready_clone_of_same_shifu_is_kept(voice_app, monkeypatch):
     from flaskr.service.learn import learn_funcs
 
-    assert learn_funcs._resolve_runtime_tts_voice_id(_fake_app(), "minimax", "") == ""
+    _patch_provider(monkeypatch)
+    with voice_app.app_context():
+        _add_clone("shifu-1", "AiShifu_clone_1", TTS_MINIMAX_CLONE_STATUS_READY, "vb-1")
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "minimax", "AiShifu_clone_1", shifu_bid="shifu-1"
+            )
+            == "AiShifu_clone_1"
+        )
+
+
+def test_minimax_ready_clone_of_other_shifu_falls_back(voice_app, monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    _patch_provider(monkeypatch)
+    with voice_app.app_context():
+        # Ready clone exists but belongs to a different shifu -> must not leak.
+        _add_clone("shifu-2", "AiShifu_clone_1", TTS_MINIMAX_CLONE_STATUS_READY, "vb-2")
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "minimax", "AiShifu_clone_1", shifu_bid="shifu-1"
+            )
+            == "default-voice"
+        )
+
+
+def test_minimax_non_ready_clone_of_same_shifu_falls_back(voice_app, monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    _patch_provider(monkeypatch)
+    with voice_app.app_context():
+        # Clone belongs to this shifu but is not ready -> fall back.
+        _add_clone(
+            "shifu-1", "AiShifu_clone_1", TTS_MINIMAX_CLONE_STATUS_FAILED, "vb-3"
+        )
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "minimax", "AiShifu_clone_1", shifu_bid="shifu-1"
+            )
+            == "default-voice"
+        )
+
+
+def test_minimax_unknown_voice_falls_back_to_default(voice_app, monkeypatch):
+    from flaskr.service.learn import learn_funcs
+
+    _patch_provider(monkeypatch)
+    with voice_app.app_context():
+        # Not a built-in voice and no clone tracked at all -> fall back.
+        assert (
+            learn_funcs._resolve_runtime_tts_voice_id(
+                voice_app, "minimax", "stale-voice", shifu_bid="shifu-1"
+            )
+            == "default-voice"
+        )


### PR DESCRIPTION
## 来源

运维保障群 2026-06-26 18:00 至 2026-06-27 18:00 AI-Shifu 报错巡检：

- `learn_lesson_feedbacks.idx_learn_lesson_feedback_unique_active` 重复键，lesson-feedback 接口并发写入触发 SQLAlchemy autoflush IntegrityError（2 条）。
- `get_config` 释放 Redis lock 时 `LockNotOwnedError: Cannot release a lock that's no longer owned`，影响课程详情、mdflow、draft-meta 等接口（4 条）。
- `run_script` 中 `_get_current_attend` 相关路径为空时触发 `TypeError: 'NoneType' object is not iterable`（多条重复）。
- generated-block TTS 调用 MiniMax 返回 `2054 - voice id not exist`；生产只读库核对到对应课程发布配置使用了历史/失效音色 `female-shu`，会在外部 API 调用阶段失败（7 条）。

## 修复内容

- `get_config`：释放 Redis lock 失败时降级为 warning，不再带崩业务接口。
- lesson feedback：generated-block 同步查询包裹 `no_autoflush`，让重复键竞态进入既有 IntegrityError 恢复逻辑。
- run context：当 parent outline path 缺失时返回既有 lesson-not-found 应用错误，避免原始 TypeError。
- TTS：MiniMax 运行时音色如果既不是当前内置音色，也不是系统内 ready 状态的克隆音色，则回退到 provider 默认音色并打 warning，避免历史失效音色导致学习端音频生成失败。

## 验证

- `python3 -m py_compile src/api/flaskr/service/config/funcs.py src/api/flaskr/service/learn/lesson_feedback.py src/api/flaskr/service/learn/context_v2.py src/api/flaskr/service/learn/learn_funcs.py` 通过。
- 本机 system Python 缺少 `pytest`，目标 pytest 未执行。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech voice selection so lessons are less likely to fail when a saved cloned voice is no longer valid.
  * Added automatic fallback to a safe default voice when the selected voice can’t be used.
  * Kept valid built-in and ready cloned voices unchanged at playback time.
* **Tests**
  * Added coverage for voice selection behavior across built-in, cloned, stale, and empty voice ID cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->