### PR TITLE
fix: restrict owner-only course actions

### DIFF
--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -35,12 +35,23 @@ from flaskr.service.shifu.shifu_draft_funcs import (
     get_shifu_draft_list,
     get_shifu_published_list,
 )
+from flaskr.service.shifu.utils import get_shifu_creator_bid
 
 
 def register_order_handler(app: Flask, path_prefix: str):
     def _require_creator():
         if not request.user.is_creator:
             raise_error("server.shifu.noPermission")
+
+    def _require_shifu_owner(shifu_bid: str) -> str:
+        _require_creator()
+        user_id = request.user.user_id
+        creator_bid = get_shifu_creator_bid(app, shifu_bid)
+        if not creator_bid:
+            raise_error("server.shifu.shifuNotFound")
+        if creator_bid != user_id:
+            raise_error("server.shifu.noPermission")
+        return user_id
 
     def _parse_datetime_filter(
         value: str, field_name: str, *, is_end: bool = False
@@ -622,7 +633,6 @@ def register_order_handler(app: Flask, path_prefix: str):
                                         order_bid:
                                             type: string
         """
-        _require_creator()
         payload = request.get_json() or {}
         lines = payload.get("lines")
         course_id = str(payload.get("course_id", "")).strip()
@@ -633,6 +643,7 @@ def register_order_handler(app: Flask, path_prefix: str):
             raise_param_error("course_id")
         if contact_type not in {"phone", "email"}:
             raise_param_error("contact_type")
+        _require_shifu_owner(course_id)
 
         contact_label = "email" if contact_type == "email" else "mobile"
 

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -85,9 +85,7 @@ def test_admin_import_activation_rejects_shared_permission_user(
     assert payload["code"] == 401
 
 
-def test_admin_import_activation_allows_owner(
-    monkeypatch, test_client, app
-):
+def test_admin_import_activation_allows_owner(monkeypatch, test_client, app):
     shifu_bid = "import-permission-course-2"
     owner_bid = "owner-import-2"
     _seed_shifu(app, shifu_bid, owner_bid)

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -1,0 +1,124 @@
+from decimal import Decimal
+from types import SimpleNamespace
+import json
+
+import flaskr.dao as dao
+
+
+def _seed_shifu(app, shifu_bid: str, owner_bid: str) -> None:
+    from flaskr.service.shifu.models import DraftShifu, AiCourseAuth
+
+    with app.app_context():
+        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
+        AiCourseAuth.query.filter_by(course_id=shifu_bid).delete()
+
+        dao.db.session.add(
+            DraftShifu(
+                shifu_bid=shifu_bid,
+                title="Import Activation Course",
+                description="desc",
+                avatar_res_bid="res",
+                keywords="test",
+                llm="gpt",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                price=Decimal("0"),
+                created_user_bid=owner_bid,
+                updated_user_bid=owner_bid,
+            )
+        )
+        dao.db.session.commit()
+
+
+def _add_shared_permission(app, shifu_bid: str, user_id: str) -> None:
+    from flaskr.service.shifu.models import AiCourseAuth
+
+    with app.app_context():
+        dao.db.session.add(
+            AiCourseAuth(
+                course_auth_id=f"auth-{shifu_bid}-{user_id}",
+                course_id=shifu_bid,
+                user_id=user_id,
+                auth_type=json.dumps(["edit"]),
+                status=1,
+            )
+        )
+        dao.db.session.commit()
+
+
+def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = True):
+    dummy_user = SimpleNamespace(
+        user_id=user_id,
+        is_creator=is_creator,
+        language="en-US",
+    )
+    monkeypatch.setattr(
+        "flaskr.route.user.validate_user",
+        lambda _app, _token: dummy_user,
+        raising=False,
+    )
+    return dummy_user
+
+
+def test_admin_import_activation_rejects_shared_permission_user(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "import-permission-course-1"
+    owner_bid = "owner-import-1"
+    shared_bid = "shared-import-1"
+    _seed_shifu(app, shifu_bid, owner_bid)
+    _add_shared_permission(app, shifu_bid, shared_bid)
+    _mock_user(monkeypatch, shared_bid, is_creator=True)
+
+    response = test_client.post(
+        "/api/order/admin/orders/import-activation",
+        json={
+            "mobile": "13800138000",
+            "course_id": shifu_bid,
+            "contact_type": "phone",
+        },
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 401
+
+
+def test_admin_import_activation_allows_owner(
+    monkeypatch, test_client, app
+):
+    shifu_bid = "import-permission-course-2"
+    owner_bid = "owner-import-2"
+    _seed_shifu(app, shifu_bid, owner_bid)
+    _mock_user(monkeypatch, owner_bid, is_creator=True)
+
+    monkeypatch.setattr(
+        "flaskr.route.order.get_shifu_info",
+        lambda _app, _shifu_bid, _preview: SimpleNamespace(price=Decimal("0")),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.route.order.import_activation_orders",
+        lambda _app, _mobiles, _course_id, _user_nick_name, contact_type="phone": {
+            "success": [{"mobile": "13800138000", "order_bid": "order-1"}],
+            "failed": [],
+            "contact_type": contact_type,
+        },
+        raising=False,
+    )
+
+    response = test_client.post(
+        "/api/order/admin/orders/import-activation",
+        json={
+            "mobile": "13800138000",
+            "course_id": shifu_bid,
+            "contact_type": "phone",
+        },
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["success"][0]["order_bid"] == "order-1"

--- a/src/cook-web/src/app/admin/page.test.tsx
+++ b/src/cook-web/src/app/admin/page.test.tsx
@@ -94,6 +94,10 @@ jest.mock('@/lib/onboardingTargets', () => ({
 
 jest.mock('@/lib/shifu-permissions', () => ({
   canManageArchive: () => true,
+  canManageOwnerCourseAction: (
+    shifu: { created_user_bid?: string } | null | undefined,
+    currentUserId: string,
+  ) => shifu?.created_user_bid === currentUserId,
 }));
 
 jest.mock('react-i18next', () => ({
@@ -400,5 +404,45 @@ describe('AdminPage', () => {
       },
       { timeout: 500 },
     );
+  });
+
+  test('does not show owner-only course actions for shared-permission courses', async () => {
+    mockGetShifuList.mockResolvedValue({
+      items: [
+        {
+          bid: 'course-shared-1',
+          name: 'Shared Course',
+          description: 'Shared course description',
+          archived: false,
+          avatar: '',
+          is_favorite: false,
+          created_user_bid: 'owner-1',
+          can_manage_permissions: false,
+        },
+      ],
+    });
+
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared Course')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.more',
+      }),
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'module.order.importActivation.action',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'module.order.redemptionCodes.action',
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -41,7 +41,10 @@ import { useUserStore } from '@/store';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import { getCourseCreatorUrl } from '@/c-utils/urlUtils';
 import { useCreatorOnboardingStatus } from '@/hooks/useOnboarding';
-import { canManageArchive as canManageArchiveForShifu } from '@/lib/shifu-permissions';
+import {
+  canManageArchive as canManageArchiveForShifu,
+  canManageOwnerCourseAction,
+} from '@/lib/shifu-permissions';
 import {
   buildGuideCourseTargetId,
   buildOnboardingTargetProps,
@@ -827,11 +830,15 @@ const ScriptManagementPage = () => {
                   canManagePermissions={canManagePermissions(shifu)}
                   onArchiveRequest={() => handleArchiveRequest(shifu)}
                   onPermissionRequest={() => handlePermissionRequest(shifu)}
-                  onImportActivationRequest={() =>
-                    handleImportActivationRequest(shifu)
+                  onImportActivationRequest={
+                    canManageOwnerCourseAction(shifu, currentUserId)
+                      ? () => handleImportActivationRequest(shifu)
+                      : undefined
                   }
-                  onRedemptionCodeRequest={() =>
-                    handleRedemptionCodeRequest(shifu)
+                  onRedemptionCodeRequest={
+                    canManageOwnerCourseAction(shifu, currentUserId)
+                      ? () => handleRedemptionCodeRequest(shifu)
+                      : undefined
                   }
                   onboardingTargetId={
                     shifu.bid === onboardingStatus?.guide_course.bid

--- a/src/cook-web/src/lib/shifu-permissions.ts
+++ b/src/cook-web/src/lib/shifu-permissions.ts
@@ -15,3 +15,15 @@ export const canManageArchive = (
   }
   return !shifu.readonly;
 };
+
+export const canManageOwnerCourseAction = (
+  shifu: Shifu | null | undefined,
+  currentUserId: string,
+): boolean => {
+  if (!shifu?.bid || !currentUserId) {
+    return false;
+  }
+  return (
+    Boolean(shifu.created_user_bid) && shifu.created_user_bid === currentUserId
+  );
+};


### PR DESCRIPTION
## Summary
- hide course-card import activation and redemption code actions for shared-permission users
- keep owner-only gating consistent by reusing a shared frontend permission helper
- enforce owner-only import activation on the backend and cover it with route tests

## Testing
- npx jest --runInBand --runTestsByPath src/app/admin/page.test.tsx src/app/admin/orders/CreatorRedemptionCodeDialog.test.tsx
- pytest tests/service/order/test_import_activation_permissions.py -q
- npm run type-check
- pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner-scoped admin actions now appear only for users who own the course, improving permission-based visibility in the admin area.

* **Bug Fixes**
  * Fixed import-activation access so shared-course users can no longer run owner-only admin actions.
  * Updated backend checks to return clearer permission failures when a course is missing or not owned by the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->