### PR TITLE
ci: add manual markdown-flow version bump workflow

### DIFF
--- a/.github/workflows/bump-markdown-flow.yml
+++ b/.github/workflows/bump-markdown-flow.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Commit and push
         env:
           MF_VERSION: ${{ inputs.version }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           if git diff --quiet -- src/api/requirements.txt; then
             echo "No change: requirements already pin markdown-flow==${MF_VERSION}."
@@ -129,15 +130,16 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/api/requirements.txt
           git commit -m "chore: bump markdown-flow to ${MF_VERSION}"
-          git push origin HEAD:${{ github.ref_name }}
+          git push origin "HEAD:${BRANCH_NAME}"
 
       - name: Summary
         env:
           MF_VERSION: ${{ inputs.version }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           {
             echo "## Pinned \`markdown-flow==${MF_VERSION}\`"
             echo ""
-            echo "- Branch: \`${{ github.ref_name }}\`"
+            echo "- Branch: \`${BRANCH_NAME}\`"
             echo "- File: \`src/api/requirements.txt\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bump-markdown-flow.yml
+++ b/.github/workflows/bump-markdown-flow.yml
@@ -1,0 +1,143 @@
+name: Bump markdown-flow
+
+# Manually update the markdown-flow dependency pin in src/api/requirements.txt
+# on a feature branch, then commit & push the bump back to that branch.
+#
+# Use this after publishing a new markdown-flow build from
+# https://github.com/ai-shifu/markdown-flow-agent-py so this project picks it up.
+#
+# How to run:
+#   Actions -> Bump markdown-flow -> Run workflow
+#     - "Use workflow from": pick the feature branch to update (NOT main)
+#     - version: the markdown-flow version to pin, e.g. 0.2.83 or 0.2.83.dev1
+#
+# The workflow refuses to run on the default branch (main).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "markdown-flow version to pin, e.g. 0.2.83 or 0.2.83.dev1"
+        required: true
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # allow pushing the bump commit back to the branch
+
+    steps:
+      # Never bump the pin directly on the protected default branch.
+      - name: Guard against running on main
+        if: github.ref_name == 'main'
+        run: |
+          echo "::error::Do not bump markdown-flow on 'main'. Run this workflow from a feature branch, then PR the change in."
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tooling
+        run: pip install --upgrade packaging
+
+      - name: Validate version exists on PyPI
+        env:
+          MF_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          from packaging.version import InvalidVersion, Version
+
+          version = os.environ["MF_VERSION"].strip()
+
+          try:
+              Version(version)
+          except InvalidVersion:
+              print(f"::error::Invalid version '{version}': not a valid PEP 440 version.")
+              sys.exit(1)
+
+          url = "https://pypi.org/pypi/markdown-flow/json"
+          try:
+              with urllib.request.urlopen(url, timeout=30) as resp:
+                  data = json.load(resp)
+          except Exception as exc:  # noqa: BLE001 - network/parse errors are all fatal here
+              print(f"::error::Failed to query PyPI: {exc}")
+              sys.exit(1)
+
+          if version not in data.get("releases", {}):
+              print(
+                  f"::error::markdown-flow=={version} was not found on PyPI. "
+                  "Publish it first from markdown-flow-agent-py (run its Publish action), then retry."
+              )
+              sys.exit(1)
+
+          print(f"OK: markdown-flow=={version} exists on PyPI.")
+          PY
+
+      - name: Update requirements pin
+        env:
+          MF_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          import sys
+
+          path = "src/api/requirements.txt"
+          version = os.environ["MF_VERSION"].strip()
+
+          with open(path, encoding="utf-8") as f:
+              content = f.read()
+
+          new_content, count = re.subn(
+              r"(?m)^markdown-flow==.*$",
+              f"markdown-flow=={version}",
+              content,
+          )
+          if count != 1:
+              print(f"::error::Expected exactly 1 'markdown-flow==' pin in {path}, found {count}.")
+              sys.exit(1)
+
+          with open(path, "w", encoding="utf-8") as f:
+              f.write(new_content)
+          print(f"Pinned markdown-flow=={version} in {path}")
+          PY
+
+      - name: Commit and push
+        env:
+          MF_VERSION: ${{ inputs.version }}
+        run: |
+          if git diff --quiet -- src/api/requirements.txt; then
+            echo "No change: requirements already pin markdown-flow==${MF_VERSION}."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/api/requirements.txt
+          git commit -m "chore: bump markdown-flow to ${MF_VERSION}"
+          git push origin HEAD:${{ github.ref_name }}
+
+      - name: Summary
+        env:
+          MF_VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "## Pinned \`markdown-flow==${MF_VERSION}\`"
+            echo ""
+            echo "- Branch: \`${{ github.ref_name }}\`"
+            echo "- File: \`src/api/requirements.txt\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-markdown-flow-release.yml
+++ b/.github/workflows/check-markdown-flow-release.yml
@@ -1,0 +1,67 @@
+name: Check markdown-flow release pin
+
+# Gate for PRs into main: the markdown-flow pin in src/api/requirements.txt
+# must be a RELEASE version (X.Y.Z), never a pre-release/dev build
+# (e.g. X.Y.Z.devN, X.Y.ZrcN). dev builds are for feature branches only.
+#
+# To actually block merges, add this check as a required status check in the
+# branch protection rules for `main`.
+#
+# No `paths:` filter on purpose: required checks with path filters get stuck
+# "pending" on PRs that don't touch the filtered files. This runs on every PR
+# into main and validates whatever pin main would end up with — cheap and safe.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tooling
+        run: pip install --upgrade packaging
+
+      - name: Ensure markdown-flow pin is a release version
+        run: |
+          python - <<'PY'
+          import re
+          import sys
+
+          from packaging.version import InvalidVersion, Version
+
+          path = "src/api/requirements.txt"
+          with open(path, encoding="utf-8") as f:
+              text = f.read()
+
+          match = re.search(r"(?m)^markdown-flow==(.+)$", text)
+          if not match:
+              print(f"::error::No 'markdown-flow==' pin found in {path}.")
+              sys.exit(1)
+
+          raw = match.group(1).strip()
+          try:
+              version = Version(raw)
+          except InvalidVersion:
+              print(f"::error::Invalid markdown-flow version '{raw}' in {path}.")
+              sys.exit(1)
+
+          if version.is_prerelease or version.is_devrelease:
+              print(
+                  f"::error::markdown-flow=={raw} is a pre-release/dev build and cannot be "
+                  "merged into main. Pin a release version (X.Y.Z) first — publish a release "
+                  "build from markdown-flow-agent-py, then update the pin."
+              )
+              sys.exit(1)
+
+          print(f"OK: markdown-flow=={raw} is a release version.")
+          PY

--- a/.github/workflows/check-markdown-flow-release.yml
+++ b/.github/workflows/check-markdown-flow-release.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@ To try a `markdown-flow` change against this project:
      version. It validates the version exists on PyPI, updates the pin, and
      pushes the bump back to the branch. It refuses to run on `main`.
 
+`main` must always pin a **release** version of `markdown-flow`. The
+**Check markdown-flow release pin** workflow runs on every PR into `main` and
+fails if the pin is a pre-release/dev build (e.g. `X.Y.Z.devN`). Pin a release
+version before merging.
+
 ## Tests
 
 - Run the smallest relevant backend, frontend, or script checks first, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,25 @@ to.
 - `pre-commit run -a` is the repository-wide verification gate before a
   commit-sized change lands.
 
+## markdown-flow dependency
+
+`markdown-flow` is the core MarkdownFlow engine, pinned in
+`src/api/requirements.txt` (the `markdown-flow==<version>` line). It is published
+from <https://github.com/ai-shifu/markdown-flow-agent-py>.
+
+To try a `markdown-flow` change against this project:
+
+1. In `markdown-flow-agent-py`, on your branch, run its **Publish** action to
+   release a build (use `dev` for a throwaway `X.Y.Z.devN` test package). Wait
+   for the run to pass — the version is now on PyPI.
+2. Point this project at that version:
+   - **Locally (uncommitted)**: edit the `markdown-flow==` line in
+     `src/api/requirements.txt`.
+   - **On an already-pushed feature branch**: run the **Bump markdown-flow**
+     action (`.github/workflows/bump-markdown-flow.yml`) with the published
+     version. It validates the version exists on PyPI, updates the pin, and
+     pushes the bump back to the branch. It refuses to run on `main`.
+
 ## Tests
 
 - Run the smallest relevant backend, frontend, or script checks first, then


### PR DESCRIPTION
## What

Two related additions for managing the `markdown-flow` dependency, plus root `AGENTS.md` docs:

1. **`.github/workflows/bump-markdown-flow.yml`** — manually-triggered (`workflow_dispatch`) workflow to update the `markdown-flow` pin in `src/api/requirements.txt` on a feature branch, then commit & push the bump back.
2. **`.github/workflows/check-markdown-flow-release.yml`** — `pull_request` check (target `main`) that fails when the pin is a pre-release/dev build.

## Why

`markdown-flow` is published from `ai-shifu/markdown-flow-agent-py`. After publishing a build there, this project needs its pin updated — for already-pushed branches, the bump workflow does it from the GitHub UI. And `main` must only ever pin a stable release, so the check gate blocks dev pins from merging.

## Bump workflow

- Input `version` (e.g. `0.2.83` or `0.2.83.dev1`).
- Guard: refuses to run on `main`.
- Validates the version exists on PyPI (fails fast pointing back to the Publish action in `markdown-flow-agent-py`).
- Rewrites the single `markdown-flow==` line, commits `chore: bump markdown-flow to <version>`, pushes to the branch.

## Release-pin check

- Runs on every PR into `main` (no `paths:` filter, so it never gets stuck pending as a required check).
- Fails on `X.Y.Z.devN` / `rcN` / `aN` / `bN`; passes on `X.Y.Z` (and `.postN`).
- **To block merges, add this check as a required status check in `main` branch protection.**

## Notes

- Root `AGENTS.md` is a hand-authored source file (not generated); `python scripts/check_repo_harness.py` passes.
- The `workflow_dispatch` button only appears once the bump workflow is on the default branch (`main`) — hence this PR targets `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow to update the pinned `markdown-flow` version and push the change back to the current branch.
  * Added a pull request check that verifies the pinned `markdown-flow` version is a valid release before merging to `main`.

* **Documentation**
  * Expanded repository guidance with steps for testing `markdown-flow` updates and rules for release-only version pins on `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->