### PR TITLE
ci: add markdown-flow-ui bump + release-pin check (frontend)

### DIFF
--- a/.github/workflows/bump-markdown-flow-ui.yml
+++ b/.github/workflows/bump-markdown-flow-ui.yml
@@ -12,8 +12,8 @@ name: Bump markdown-flow-ui
 #     - version: the markdown-flow-ui version to pin, e.g. 0.1.128 or 0.1.128-dev.1
 #
 # Pins an EXACT version (drops any ^ range) so dev builds can be locked for
-# debugging. Note: only package.json is updated — run your package manager
-# locally to refresh the lockfile. Refuses to run on the default branch (main).
+# debugging, and refreshes package-lock.json so CI's `npm ci` stays green.
+# Refuses to run on the default branch (main).
 
 on:
   workflow_dispatch:
@@ -105,18 +105,24 @@ jobs:
           console.log(`Pinned markdown-flow-ui ${version} (exact) in ${path}`);
           NODE
 
+      # Keep package-lock.json in sync so CI's `npm ci` (e.g. prettier-check,
+      # runtime-harness) doesn't fail on a mismatched lockfile.
+      - name: Update lockfile
+        working-directory: src/cook-web
+        run: npm install --package-lock-only --ignore-scripts
+
       - name: Commit and push
         env:
           MF_UI_VERSION: ${{ inputs.version }}
           BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          if git diff --quiet -- src/cook-web/package.json; then
+          if git diff --quiet -- src/cook-web/package.json src/cook-web/package-lock.json; then
             echo "No change: already pins markdown-flow-ui ${MF_UI_VERSION}."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/cook-web/package.json
+          git add src/cook-web/package.json src/cook-web/package-lock.json
           git commit -m "chore: bump markdown-flow-ui to ${MF_UI_VERSION}"
           git push origin "HEAD:${BRANCH_NAME}"
 
@@ -129,6 +135,5 @@ jobs:
             echo "## Pinned \`markdown-flow-ui@${MF_UI_VERSION}\`"
             echo ""
             echo "- Branch: \`${BRANCH_NAME}\`"
-            echo "- File: \`src/cook-web/package.json\`"
-            echo "- Note: lockfile not updated — run your package manager locally."
+            echo "- Files: \`src/cook-web/package.json\` + \`package-lock.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bump-markdown-flow-ui.yml
+++ b/.github/workflows/bump-markdown-flow-ui.yml
@@ -1,0 +1,134 @@
+name: Bump markdown-flow-ui
+
+# Manually update the markdown-flow-ui dependency pin in src/cook-web/package.json
+# on a feature branch, then commit & push the bump back to that branch.
+#
+# Use this after publishing a new markdown-flow-ui build from
+# https://github.com/ai-shifu/markdown-flow-ui so this project picks it up.
+#
+# How to run:
+#   Actions -> Bump markdown-flow-ui -> Run workflow
+#     - "Use workflow from": pick the feature branch to update (NOT main)
+#     - version: the markdown-flow-ui version to pin, e.g. 0.1.128 or 0.1.128-dev.1
+#
+# Pins an EXACT version (drops any ^ range) so dev builds can be locked for
+# debugging. Note: only package.json is updated — run your package manager
+# locally to refresh the lockfile. Refuses to run on the default branch (main).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "markdown-flow-ui version to pin, e.g. 0.1.128 or 0.1.128-dev.1"
+        required: true
+        type: string
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # allow pushing the bump commit back to the branch
+
+    steps:
+      # Never bump the pin directly on the protected default branch.
+      - name: Guard against running on main
+        if: github.ref_name == 'main'
+        run: |
+          echo "::error::Do not bump markdown-flow-ui on 'main'. Run this workflow from a feature branch, then PR the change in."
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Validate version exists on npm
+        env:
+          MF_UI_VERSION: ${{ inputs.version }}
+        run: |
+          node <<'NODE'
+          const cp = require("child_process");
+
+          const version = (process.env.MF_UI_VERSION || "").trim();
+          if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+            console.error(`::error::Invalid version '${version}'.`);
+            process.exit(1);
+          }
+
+          let versions = [];
+          try {
+            const out = cp.execSync("npm view markdown-flow-ui versions --json", { encoding: "utf8" });
+            const parsed = JSON.parse(out);
+            versions = Array.isArray(parsed) ? parsed : [parsed];
+          } catch (e) {
+            console.error(`::error::Failed to query npm: ${e.message}`);
+            process.exit(1);
+          }
+
+          if (!versions.includes(version)) {
+            console.error(
+              `::error::markdown-flow-ui@${version} was not found on npm. ` +
+                "Publish it first from markdown-flow-ui (run its Publish action), then retry.",
+            );
+            process.exit(1);
+          }
+
+          console.log(`OK: markdown-flow-ui@${version} exists on npm.`);
+          NODE
+
+      - name: Update package.json pin
+        env:
+          MF_UI_VERSION: ${{ inputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const path = "src/cook-web/package.json";
+          const version = (process.env.MF_UI_VERSION || "").trim();
+
+          let content = fs.readFileSync(path, "utf8");
+          const re = /("markdown-flow-ui"\s*:\s*")[^"]*(")/;
+          if (!re.test(content)) {
+            console.error(`::error::No 'markdown-flow-ui' dependency found in ${path}.`);
+            process.exit(1);
+          }
+
+          content = content.replace(re, `$1${version}$2`);
+          fs.writeFileSync(path, content);
+          console.log(`Pinned markdown-flow-ui ${version} (exact) in ${path}`);
+          NODE
+
+      - name: Commit and push
+        env:
+          MF_UI_VERSION: ${{ inputs.version }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet -- src/cook-web/package.json; then
+            echo "No change: already pins markdown-flow-ui ${MF_UI_VERSION}."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/cook-web/package.json
+          git commit -m "chore: bump markdown-flow-ui to ${MF_UI_VERSION}"
+          git push origin "HEAD:${BRANCH_NAME}"
+
+      - name: Summary
+        env:
+          MF_UI_VERSION: ${{ inputs.version }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## Pinned \`markdown-flow-ui@${MF_UI_VERSION}\`"
+            echo ""
+            echo "- Branch: \`${BRANCH_NAME}\`"
+            echo "- File: \`src/cook-web/package.json\`"
+            echo "- Note: lockfile not updated — run your package manager locally."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-markdown-flow-ui-release.yml
+++ b/.github/workflows/check-markdown-flow-ui-release.yml
@@ -1,0 +1,57 @@
+name: Check markdown-flow-ui release pin
+
+# Gate for PRs into main: the markdown-flow-ui pin in src/cook-web/package.json
+# must resolve to a RELEASE version (X.Y.Z), never a pre-release/dev build
+# (e.g. X.Y.Z-dev.N). dev builds are for feature branches only.
+#
+# To actually block merges, add this check as a required status check in the
+# branch protection / ruleset for `main`.
+#
+# No `paths:` filter on purpose: required checks with path filters get stuck
+# "pending" on PRs that don't touch the filtered files.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Ensure markdown-flow-ui pin is a release version
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const path = "src/cook-web/package.json";
+          const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+          const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+          const raw = deps["markdown-flow-ui"];
+
+          if (!raw) {
+            console.error(`::error::No 'markdown-flow-ui' dependency found in ${path}.`);
+            process.exit(1);
+          }
+
+          // Strip any range prefix (^, ~, >=, spaces, ...) to get the core version.
+          const core = raw.replace(/^[^\d]*/, "");
+
+          // semver pre-release = anything after a hyphen (e.g. 0.1.128-dev.1)
+          if (core.includes("-")) {
+            console.error(
+              `::error::markdown-flow-ui ${raw} is a pre-release/dev build and cannot be ` +
+                "merged into main. Pin a release version (X.Y.Z) first — publish a release " +
+                "build from markdown-flow-ui, then update the pin.",
+            );
+            process.exit(1);
+          }
+
+          console.log(`OK: markdown-flow-ui ${raw} is a release version.`);
+          NODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,8 @@ prod**.
      **Bump markdown-flow** (`bump-markdown-flow.yml`) or **Bump markdown-flow-ui**
      (`bump-markdown-flow-ui.yml`). Each validates the version is published,
      updates the pin, and pushes the bump back to the branch. Both refuse to run
-     on `main`. (The frontend bump pins an exact version and does **not** refresh
-     the lockfile — run your package manager locally to sync it.)
+     on `main`. (The frontend bump pins an exact version and refreshes
+     `src/cook-web/package-lock.json` so CI's `npm ci` stays green.)
 
 ### Rule: `main` must pin RELEASE versions of both libraries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,29 +64,43 @@ to.
 - `pre-commit run -a` is the repository-wide verification gate before a
   commit-sized change lands.
 
-## markdown-flow dependency
+## MarkdownFlow component libraries
 
-`markdown-flow` is the core MarkdownFlow engine, pinned in
-`src/api/requirements.txt` (the `markdown-flow==<version>` line). It is published
-from <https://github.com/ai-shifu/markdown-flow-agent-py>.
+ai-shifu consumes two MarkdownFlow component libraries. Changing either is
+usually done in order to use it here, so the overall flow is: **change the
+library → publish a build → point ai-shifu at it → debug locally / on test / in
+prod**.
 
-To try a `markdown-flow` change against this project:
+| Library            | Kind             | Pinned in                                            | Published from                                                            |
+| ------------------ | ---------------- | ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| `markdown-flow`    | Python (backend) | `src/api/requirements.txt` (`markdown-flow==<ver>`)  | [markdown-flow-agent-py](https://github.com/ai-shifu/markdown-flow-agent-py) (PyPI) |
+| `markdown-flow-ui` | npm (frontend)   | `src/cook-web/package.json` (`"markdown-flow-ui"`)   | [markdown-flow-ui](https://github.com/ai-shifu/markdown-flow-ui) (npm)    |
 
-1. In `markdown-flow-agent-py`, on your branch, run its **Publish** action to
-   release a build (use `dev` for a throwaway `X.Y.Z.devN` test package). Wait
-   for the run to pass — the version is now on PyPI.
+### Trying a library change against this project
+
+1. In the library repo, on your branch, run its **Publish** action to release a
+   build — use a `dev` build (`X.Y.Z.devN` on PyPI, `X.Y.Z-dev.N` on npm) for a
+   throwaway test package. Wait for the run to pass; the version is now published.
 2. Point this project at that version:
-   - **Locally (uncommitted)**: edit the `markdown-flow==` line in
-     `src/api/requirements.txt`.
-   - **On an already-pushed feature branch**: run the **Bump markdown-flow**
-     action (`.github/workflows/bump-markdown-flow.yml`) with the published
-     version. It validates the version exists on PyPI, updates the pin, and
-     pushes the bump back to the branch. It refuses to run on `main`.
+   - **Locally (uncommitted)**: edit the pin in `src/api/requirements.txt`
+     (backend) or `src/cook-web/package.json` (frontend).
+   - **On an already-pushed feature branch**: run the matching bump action —
+     **Bump markdown-flow** (`bump-markdown-flow.yml`) or **Bump markdown-flow-ui**
+     (`bump-markdown-flow-ui.yml`). Each validates the version is published,
+     updates the pin, and pushes the bump back to the branch. Both refuse to run
+     on `main`. (The frontend bump pins an exact version and does **not** refresh
+     the lockfile — run your package manager locally to sync it.)
 
-`main` must always pin a **release** version of `markdown-flow`. The
-**Check markdown-flow release pin** workflow runs on every PR into `main` and
-fails if the pin is a pre-release/dev build (e.g. `X.Y.Z.devN`). Pin a release
-version before merging.
+### Rule: `main` must pin RELEASE versions of both libraries
+
+dev builds are for feature-branch / cross-repo testing only. `main` must always
+pin **release** versions (`X.Y.Z`) of both libraries. Two CI checks enforce this
+on every PR into `main` and fail on a pre-release/dev pin:
+
+- **Check markdown-flow release pin** (`check-markdown-flow-release.yml`) — backend.
+- **Check markdown-flow-ui release pin** (`check-markdown-flow-ui-release.yml`) — frontend.
+
+Pin release versions of both before merging.
 
 ## Tests
 


### PR DESCRIPTION
## What

Mirrors the existing backend `markdown-flow` tooling for the **frontend** `markdown-flow-ui` dependency (`src/cook-web/package.json`):

1. **`bump-markdown-flow-ui.yml`** — `workflow_dispatch` to pin an exact published npm version on a feature branch (validates it exists on npm via `npm view`), commit & push the bump back. Refuses `main`. Drops the `^` range to pin exact (so dev builds lock cleanly); lockfile is not refreshed (run your package manager locally).
2. **`check-markdown-flow-ui-release.yml`** — `pull_request` gate (target `main`) that fails when the `markdown-flow-ui` pin resolves to a pre-release/dev build (strips `^`/`~` range prefixes, then blocks on `-`).

Plus an `AGENTS.md` rewrite of the dependency section to cover **both** libraries (backend + frontend), the publish→bump→apply flow, and the rule that `main` pins release versions of both.

## Why

`markdown-flow-ui` is the frontend half of the MarkdownFlow stack (the backend `markdown-flow` already had bump + check). A change there is usually made to be used in ai-shifu, and `main` must only ever carry release pins of both libraries.

## Verified

- check logic: `^0.1.127`/`~0.1.127`/`0.1.128` pass; `^0.1.128-dev.1`/`0.1.128-rc.0` blocked.
- bump replace: `"markdown-flow-ui": "^0.1.127"` → `"markdown-flow-ui": "0.1.128-dev.1"` (exact, formatting preserved).
- `python scripts/check_repo_harness.py` passes (root AGENTS.md is hand-authored).

## Follow-up

Add **Check markdown-flow-ui release pin** (and the existing backend check) as required status checks for `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow to pin `markdown-flow-ui` to a specific npm release version on a branch and push updates automatically.
  * Added a pull request check that ensures `markdown-flow-ui` is pinned to a release-only version (no pre-release/dev suffix).

* **Documentation**
  * Expanded component library guidance to cover both `markdown-flow` and `markdown-flow-ui`, including updated bump-and-validation steps and pinning rules.

* **Bug Fixes**
  * Ensures the frontend lockfile is refreshed when bumping, helping keep CI `npm ci` runs passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->