### PR TITLE
ci: give the markdown-flow release-pin checks unique job names

### DIFF
--- a/.github/workflows/check-markdown-flow-release.yml
+++ b/.github/workflows/check-markdown-flow-release.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  check-markdown-flow-release:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/check-markdown-flow-ui-release.yml
+++ b/.github/workflows/check-markdown-flow-ui-release.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  check-markdown-flow-ui-release:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
Both `check-markdown-flow-release` and `check-markdown-flow-ui-release` used the job id `check`, producing two status checks both named `check` — ambiguous for required-status-check configuration. Renames each job to match its workflow, so they have distinct contexts and can both be wired up as required on `main`. No behavior change.