### PR TITLE
fix: prevent homepage redirect loop and course page SSR crash on fresh deploy

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -1,11 +1,11 @@
 import styles from './ChatUi.module.scss';
 
 import { memo, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { useShallow } from 'zustand/react/shallow';
 import { useTranslation } from 'react-i18next';
 
-import ChatComponents from './NewChatComp';
 import UserSettings from '../Settings/UserSettings';
 import { FRAME_LAYOUT_MOBILE } from '@/c-constants/uiConstants';
 import { useSystemStore } from '@/c-store/useSystemStore';
@@ -15,6 +15,10 @@ import type { ListenMobileViewModeChangeHandler } from './listenModeTypes';
 import CourseHeaderSummary from '../CourseHeaderSummary';
 import LearningModeSwitch from '../LearningModeSwitch';
 import PreviewHeaderBanner from '../PreviewHeaderBanner';
+
+const ChatComponents = dynamic(() => import('./NewChatComp'), {
+  ssr: false,
+});
 
 interface ChatUiProps {
   chapterId: string;

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -1,0 +1,46 @@
+import { redirectToHomeUrlIfRootPath } from './utils';
+
+const setLocation = (href: string) => {
+  const url = new URL(href);
+
+  window.location.href = url.toString();
+  window.location.pathname = url.pathname;
+  window.location.search = url.search;
+  window.location.hash = url.hash;
+  window.location.origin = url.origin;
+  window.location.protocol = url.protocol;
+  window.location.host = url.host;
+  window.location.hostname = url.hostname;
+  window.location.port = url.port;
+};
+
+describe('redirectToHomeUrlIfRootPath', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setLocation('http://localhost:3000/');
+  });
+
+  it('does not redirect when the root home URL resolves to the current URL', () => {
+    expect(redirectToHomeUrlIfRootPath('/')).toBe(false);
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects the root page to a configured course page', () => {
+    expect(redirectToHomeUrlIfRootPath('/c/course-1')).toBe(true);
+    expect(window.location.replace).toHaveBeenCalledWith('/c/course-1');
+  });
+
+  it('does not redirect a concrete course page', () => {
+    setLocation('http://localhost:3000/c/course-1');
+
+    expect(redirectToHomeUrlIfRootPath('/c/course-2')).toBe(false);
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when /c resolves to /c/', () => {
+    setLocation('http://localhost:3000/c/');
+
+    expect(redirectToHomeUrlIfRootPath('/c')).toBe(false);
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+});

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -6,18 +6,42 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
-  if (typeof window === 'undefined' || !homeUrl) {
+  const trimmedHomeUrl = homeUrl?.trim();
+  if (typeof window === 'undefined' || !trimmedHomeUrl) {
     return false;
   }
 
-  const pathname = window.location.pathname || '/';
-  const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/+$/, '');
+  const currentUrl = new URL(window.location.href);
+  const normalizedPath =
+    currentUrl.pathname === '/'
+      ? '/'
+      : currentUrl.pathname.replace(/\/+$/, '');
   const shouldRedirect = normalizedPath === '/' || normalizedPath === '/c';
 
-  if (shouldRedirect) {
-    window.location.replace(homeUrl);
-    return true;
+  if (!shouldRedirect) {
+    return false;
   }
 
-  return false;
+  const targetUrl = new URL(trimmedHomeUrl, currentUrl.origin);
+  const normalizedTargetPath =
+    targetUrl.pathname === '/'
+      ? '/'
+      : targetUrl.pathname.replace(/\/+$/, '');
+  const isSameUrl =
+    targetUrl.origin === currentUrl.origin &&
+    normalizedTargetPath === normalizedPath &&
+    targetUrl.search === currentUrl.search &&
+    targetUrl.hash === currentUrl.hash;
+
+  if (isSameUrl) {
+    return false;
+  }
+
+  const sameOriginTarget =
+    targetUrl.origin === currentUrl.origin
+      ? `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`
+      : targetUrl.toString();
+
+  window.location.replace(sameOriginTarget);
+  return true;
 };


### PR DESCRIPTION
## What

Two issues prevent a fresh self-hosted deployment (default config, no `DEFAULT_COURSE_ID` / `HOME_URL`) from opening the web app.

### 1. Homepage redirect loop (root path keeps reloading)
`redirectToHomeUrlIfRootPath()` always calls `window.location.replace(homeUrl)` when on `/` or `/c`. With the default `HOME_URL="/"`, the target equals the current URL, so the root page redirects to itself forever — the page visibly flickers/reloads and never settles.

**Fix:** skip the redirect when the resolved target URL equals the current URL (origin + normalized path + search + hash). Cross-origin targets and real course pages still redirect as before.

> Related to #1451, which targets the same loop but is a large, long-open branch. This PR is a small, isolated fix with unit tests.

### 2. Course page SSR crash: `document is not defined`
`NewChatComp` pulls in the MarkdownFlow browser renderer, which references `document` at render time and throws during server-side rendering of `/c/[[...id]]`.

**Fix:** load `NewChatComp` via `next/dynamic` with `ssr: false`, matching the existing pattern used for the payment component in #1446.

## Tests
Added `src/cook-web/src/lib/utils.test.ts` covering the redirect boundaries: root → same URL (no-op), root → course (redirect), concrete course page (no-op), `/c` → `/c` (no-op).

## Verification
- `next build` passes.
- `jest src/lib/utils.test.ts` passes (4/4).
- Manual: visiting `/` now lands on the configured course page immediately with no reload loop and no console errors; the frontend container log no longer shows `document is not defined`.

## Reproduce (before this PR)
1. `cd docker && docker compose -f docker-compose.latest.yml up -d` with a default `.env` (one LLM key, `DEFAULT_COURSE_ID`/`HOME_URL` left empty).
2. Open the web root → the page flickers/reloads indefinitely; the course page errors with `document is not defined` during SSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the chat UI to load the chat component client-side only.
* **Bug Fixes**
  * Improved root/course redirect handling by trimming and validating configuration, normalizing paths (including trailing slashes), and adding safeguards to avoid redirects when the target matches the current URL or when browser location is unavailable.
* **Tests**
  * Added Jest tests covering redirect behavior across root, course, and trailing-slash scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->