### PR TITLE
ci: fix lint workflow checkout for fork PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Check out PR branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          # Same-repo PRs: check out the head branch so auto-fixes can be pushed
+          # back. Fork PRs: head_ref does not exist in this repo, so fall back to
+          # the default PR merge ref (read-only; fork fixes are never pushed).
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
           fetch-depth: 0
           # Do not leave the write-capable token in .git/config while
           # PR-controlled tooling (npm ci, linters) runs. The push step


### PR DESCRIPTION
## Problem

The `Lint` workflow (`autofix` job) added in #1992 checks out `ref: github.head_ref`. For **fork PRs**, that branch does not exist in the base repo, so checkout fails with `A branch or tag with the name '<branch>' could not be found` and the whole job errors out before any linting runs.

Because `autofix` is now a **required status check** on `main`, this blocked every fork PR (e.g. #1991).

## Fix

Check out the head branch only for same-repo PRs (so auto-fixes can be pushed back); for fork PRs fall back to the default PR merge ref (read-only — fork fixes are never pushed anyway, and the workflow already fails fork PRs that need fixes with guidance to run lefthook locally).

```yaml
ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
```

## Verification

- Same-repo path unchanged (this PR is same-repo and exercises it).
- Fork path: will be confirmed by re-running #1991's `autofix` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request handling in automated checks so same-repository PRs can receive fix-up commits, while forked PRs continue to run safely in read-only mode.
  * Reduced checkout issues in the workflow by choosing the appropriate PR source based on where the change originated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->