### PR TITLE
chore: bump markdown-flow to 0.2.83

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -126,4 +126,4 @@ zope.event==5.0
 zope.interface==7.1.1
 bcrypt==4.2.1
 --extra-index-url https://pypi.org/simple/
-markdown-flow==0.2.82
+markdown-flow==0.2.83


### PR DESCRIPTION
## Summary
- Bump the backend `markdown-flow` pin in `src/api/requirements.txt` from `0.2.82` to `0.2.83`.
- Keep the pin on a release version so the main-branch release-pin check remains mergeable.

## Validation
- `python3 -c '...Version(raw)...'` confirms `markdown-flow==0.2.83` is not a dev/pre-release build.
- `git diff --check`
- `python3 scripts/check_repo_harness.py`

Note: `lefthook run pre-commit --all-files` was attempted locally but could not complete because this checkout's hook/tooling environment is not ready: missing `pre-commit-hooks` console scripts such as `check-json` / `check-yaml`, and lefthook could not replace stale `.git/hooks` files in the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a third-party package to the latest pinned version to improve stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->