### PR TITLE
feat(scripts): add dev-tools doctor and document lefthook setup

### DIFF
--- a/.claude/rules/global/testing-and-commit.md
+++ b/.claude/rules/global/testing-and-commit.md
@@ -33,6 +33,12 @@ duplicating the shared repository guidance already stored in `AGENTS.md`.
 - When Claude is asked for a commit-sized change, run the smallest relevant
   verification first and widen only when shared contracts are affected.
 
+- Before running `git commit`, run `python scripts/check_dev_tools.py` to
+  confirm lefthook and its underlying tools are installed. The lefthook hooks
+  are silently skipped when lefthook is not installed, so if the doctor reports
+  missing tools, surface the printed install commands to the user and pause the
+  commit until they are installed or the user explicitly opts to proceed.
+
 - Keep commit hygiene aligned with the shared repository rule set:
   Conventional Commit subjects, English-only code-facing text, and no skipped
   migration review after backend schema changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ to.
   before creating new abstractions.
 - Use ExecPlans for complex work. `PLANS.md` defines the format, and active
   plans live under `docs/exec-plans/active/`.
+- Before committing, run `python scripts/check_dev_tools.py` to confirm
+  lefthook and its underlying tools are installed; the local checks are
+  silently skipped if lefthook was never installed.
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
@@ -61,6 +64,8 @@ to.
   metadata, and generated harness artifacts.
 - `python scripts/check_architecture_boundaries.py` validates the committed
   frontend/backend boundary baseline and blocks new drift.
+- `python scripts/check_dev_tools.py` verifies lefthook and its underlying
+  tools are installed, so the pre-commit hooks are not silently skipped.
 - `lefthook run pre-commit --all-files` is the repository-wide verification
   gate before a commit-sized change lands.
 

--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -172,6 +172,23 @@ npm run dev
 
 Cook Web (which now serves both the learner experience and authoring console) will be available at `http://localhost:3000`.
 
+#### Step 5.5: Install the Code-Quality Hooks (Contributors)
+
+If you plan to commit changes, install the lefthook git hooks so the same
+pre-commit checks that run in CI also run locally. **Without this step the
+checks are silently skipped on commit.**
+
+```bash
+# From the repository root
+brew install lefthook   # or see https://lefthook.dev for non-macOS installs
+pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0
+(cd src/cook-web && npm ci)   # provides prettier + eslint
+lefthook install
+
+# Verify the toolchain (reports anything missing and how to install it)
+python scripts/check_dev_tools.py
+```
+
 ## Troubleshooting
 
 ### Common Issues
@@ -194,6 +211,10 @@ Cook Web (which now serves both the learner experience and authoring console) wi
    - Ensure Node.js version is 22.16.0
    - Clear node_modules and reinstall: `rm -rf node_modules && npm install`
    - Check for environment variable issues
+
+5. **Pre-commit Hooks Not Running / "command not found"**
+   - Make sure you ran `lefthook install` once in this clone
+   - Run `python scripts/check_dev_tools.py` to see which tools are missing and how to install them
 
 ### Log Files
 

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -33,15 +33,42 @@ FLASK_APP=app.py
 NEXT_PUBLIC_API_URL=http://localhost:5000
 ```
 
+### Local Tooling Setup
+
+Code-quality checks run through **lefthook** (a single Go binary that calls the
+tools already installed on your machine). The git hooks only fire after
+`lefthook install` has wired them into `.git/hooks`, and each hook shells out to
+tools that must already be on `PATH`. One-time setup:
+
+```bash
+brew install lefthook
+pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0
+(cd src/cook-web && npm ci)   # provides prettier + eslint
+lefthook install
+```
+
+> **Important:** if you skip `lefthook install` (or never install lefthook), the
+> pre-commit checks are **silently skipped** on commit — nothing warns you, and
+> the gap only surfaces later in CI. Run `lefthook install` once per clone.
+
+Verify your environment any time (and before committing) with the doctor, which
+reports exactly what is missing and how to install it:
+
+```bash
+python scripts/check_dev_tools.py            # core gaps fail; frontend gaps warn
+python scripts/check_dev_tools.py --strict   # also fail on Cook Web tooling gaps
+```
+
 ## Critical Requirements
 
 ### Must Do Before Any Commit
 
-1. Run the lefthook checks: `lefthook run pre-commit`
-2. Generate a migration for DB changes: `flask db migrate -m "description"`
-3. Test the relevant change surface
-4. Use English for code-facing text
-5. Follow Conventional Commits: `type: description`
+1. Confirm the toolchain is installed: `python scripts/check_dev_tools.py`
+2. Run the lefthook checks: `lefthook run pre-commit`
+3. Generate a migration for DB changes: `flask db migrate -m "description"`
+4. Test the relevant change surface
+5. Use English for code-facing text
+6. Follow Conventional Commits: `type: description`
 
 ### Common Pitfalls To Avoid
 
@@ -464,6 +491,7 @@ When adding a new namespace:
 | Migration not detecting changes | Ensure the model is imported |
 | Frontend cannot connect to API | Check CORS and API URL config |
 | Lefthook checks fail | Run `lefthook install` |
+| Hooks never run, or a tool reports "command not found" | Run `python scripts/check_dev_tools.py` and install what it lists |
 | Tests fail with import errors | Check `PYTHONPATH` and local env |
 | Docker build fails | Ensure required `.env` files exist |
 | TypeScript errors in Cook Web | Run `npm run type-check` |

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -77,7 +77,8 @@ def _hooks_dir() -> Path | None:
             text=True,
         )
         if configured.returncode == 0 and configured.stdout.strip():
-            path = Path(configured.stdout.strip())
+            # git config values may use ~ / ~user; Path() does not expand it.
+            path = Path(configured.stdout.strip()).expanduser()
             return path if path.is_absolute() else (ROOT / path)
 
         resolved = subprocess.run(
@@ -87,10 +88,10 @@ def _hooks_dir() -> Path | None:
             text=True,
             check=True,
         )
+        path = Path(resolved.stdout.strip())
+        return path if path.is_absolute() else (ROOT / path)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
-    path = Path(resolved.stdout.strip())
-    return path if path.is_absolute() else (ROOT / path)
 
 
 def _lefthook_hook_installed() -> bool:

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Doctor for the local lefthook toolchain.
+
+The repository runs its pre-commit / commit-msg checks through lefthook. Those
+git hooks only fire after ``lefthook install`` has wired them into
+``.git/hooks``, and even then each hook shells out to tools that must already be
+on ``PATH`` (ruff, commitizen, the pre-commit-hooks console scripts, and the
+Cook Web prettier binary). If lefthook or any of those tools is missing the
+local checks are silently skipped or fail with a cryptic ``command not found``.
+
+Run this from the repository root before committing to find what is missing and
+exactly how to install it::
+
+    python scripts/check_dev_tools.py
+
+Exit status:
+    0  every required tool is present (Cook Web gaps are warnings by default)
+    1  a required tool, or the installed git hook, is missing
+
+Pass ``--strict`` to also fail when Cook Web (frontend) tooling is missing.
+
+NOTE: the pinned versions in the install hints below mirror ``lefthook.yml``'s
+header (the single source of truth). Keep them in sync when a tool is bumped
+there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Install hints. Versions mirror lefthook.yml's header comment (lines 10-13).
+BREW_INSTALL = "brew install lefthook"
+PIP_INSTALL = "pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0"
+NPM_INSTALL = "cd src/cook-web && npm ci"
+LEFTHOOK_INSTALL = "lefthook install"
+NODE_INSTALL = "install Node.js (see INSTALL_MANUAL.md for the supported version)"
+
+# Console scripts provided by the pre-commit-hooks pip package and invoked by
+# lefthook.yml's pre-commit hook.
+PRE_COMMIT_HOOKS_SCRIPTS = (
+    "check-yaml",
+    "check-json",
+    "check-merge-conflict",
+    "check-symlinks",
+    "end-of-file-fixer",
+    "trailing-whitespace-fixer",
+    "pretty-format-json",
+    "requirements-txt-fixer",
+)
+
+# Cook Web prettier is installed locally, not on PATH (see lefthook.yml).
+COOK_WEB_PRETTIER = ROOT / "src" / "cook-web" / "node_modules" / ".bin" / "prettier"
+
+
+class Check:
+    """A single tool/state check and the command that fixes it."""
+
+    def __init__(self, name: str, ok: bool, fix: str, *, required: bool = True):
+        self.name = name
+        self.ok = ok
+        self.fix = fix
+        self.required = required
+
+
+def _hooks_dir() -> Path | None:
+    """Return the directory git uses for hooks, honoring core.hooksPath."""
+    try:
+        configured = subprocess.run(
+            ["git", "config", "--get", "core.hooksPath"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if configured.returncode == 0 and configured.stdout.strip():
+            path = Path(configured.stdout.strip())
+            return path if path.is_absolute() else (ROOT / path)
+
+        resolved = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    path = Path(resolved.stdout.strip())
+    return path if path.is_absolute() else (ROOT / path)
+
+
+def _lefthook_hook_installed() -> bool:
+    """True when ``lefthook install`` has wired the pre-commit hook in."""
+    hooks_dir = _hooks_dir()
+    if hooks_dir is None:
+        return False
+    pre_commit = hooks_dir / "pre-commit"
+    if not pre_commit.is_file():
+        return False
+    try:
+        return "lefthook" in pre_commit.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def collect_checks() -> tuple[list[Check], list[Check]]:
+    """Return (core_checks, frontend_checks)."""
+    lefthook_present = shutil.which("lefthook") is not None
+
+    core: list[Check] = [
+        Check("lefthook", lefthook_present, BREW_INSTALL),
+        # Only meaningful once the binary exists; surface the install step
+        # regardless so a half-finished setup is obvious.
+        Check(
+            "lefthook git hooks (lefthook install)",
+            lefthook_present and _lefthook_hook_installed(),
+            LEFTHOOK_INSTALL,
+        ),
+        Check("ruff", shutil.which("ruff") is not None, PIP_INSTALL),
+        Check("cz (commitizen)", shutil.which("cz") is not None, PIP_INSTALL),
+    ]
+    for script in PRE_COMMIT_HOOKS_SCRIPTS:
+        core.append(Check(script, shutil.which(script) is not None, PIP_INSTALL))
+
+    frontend: list[Check] = [
+        Check("node", shutil.which("node") is not None, NODE_INSTALL, required=False),
+        Check("npm", shutil.which("npm") is not None, NODE_INSTALL, required=False),
+        Check(
+            "Cook Web prettier (node_modules)",
+            COOK_WEB_PRETTIER.is_file(),
+            NPM_INSTALL,
+            required=False,
+        ),
+    ]
+    return core, frontend
+
+
+def _report(title: str, checks: list[Check]) -> None:
+    print(title)
+    for check in checks:
+        mark = "OK  " if check.ok else "MISS"
+        print(f"  [{mark}] {check.name}")
+
+
+def _fix_lines(missing: list[Check]) -> list[str]:
+    """Unique fix commands, preserving first-seen order."""
+    seen: list[str] = []
+    for check in missing:
+        if check.fix not in seen:
+            seen.append(check.fix)
+    return seen
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat missing Cook Web (frontend) tooling as a failure too",
+    )
+    args = parser.parse_args()
+
+    core, frontend = collect_checks()
+
+    _report("Core lefthook toolchain:", core)
+    print()
+    _report("Cook Web (frontend) toolchain:", frontend)
+    print()
+
+    missing_core = [c for c in core if not c.ok]
+    missing_frontend = [c for c in frontend if not c.ok]
+
+    if missing_core:
+        print("Missing required tooling. Install with:")
+        for line in _fix_lines(missing_core):
+            print(f"  {line}")
+        print()
+
+    if missing_frontend:
+        label = (
+            "Missing Cook Web tooling"
+            if args.strict
+            else (
+                "Cook Web tooling missing (warning; needed before committing "
+                "frontend changes)"
+            )
+        )
+        print(f"{label}. Install with:")
+        for line in _fix_lines(missing_frontend):
+            print(f"  {line}")
+        print()
+
+    failed = bool(missing_core) or (bool(missing_frontend) and args.strict)
+    if failed:
+        print("Dev tooling check FAILED. See the commands above.")
+        return 1
+
+    if missing_frontend:
+        print("Core tooling OK (Cook Web gaps reported as warnings).")
+    else:
+        print("All dev tooling present. Local lefthook checks will run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Background

We migrated code-quality checks from pre-commit/pre-commit.ci to **lefthook**.
But lefthook's git hooks only fire after `lefthook install` has wired them into
`.git/hooks`, and each hook shells out to tools that must already be on `PATH`
(ruff, commitizen, the pre-commit-hooks console scripts, and the Cook Web
prettier binary).

Two gaps this causes:

1. **Silent bypass** — a contributor who never installed lefthook (or never ran
   `lefthook install`) commits with **no checks at all**; nothing warns them and
   the gap only surfaces later in CI.
2. **Cryptic errors** — lefthook installed but a tool missing → `command not
   found`.

A git hook can't detect "lefthook isn't installed" (if it isn't, no hook runs),
so the check has to live outside the hook.

## What this adds

- **`scripts/check_dev_tools.py`** — a stdlib "doctor". Detects the lefthook
  binary, whether `lefthook install` ran (honoring `core.hooksPath`), and every
  underlying tool, then prints per-ecosystem install commands and exits non-zero
  when a required tool is missing. Cook Web (frontend) gaps are warnings unless
  `--strict`.
- **Docs** — one-time setup + the doctor in `docs/engineering-baseline.md`
  (new "Local Tooling Setup" section, pre-commit step, troubleshooting row) and
  `INSTALL_MANUAL.md` (Step 5.5 + troubleshooting). Root `AGENTS.md` gains the
  command in Commands/Do.
- **Claude commit routing** — `.claude/rules/global/testing-and-commit.md` now
  tells Claude to run the doctor before `git commit` and pause when tools are
  missing.

> Note: the doctor is intentionally **not** added to `lefthook.yml`'s
> pre-commit. It can't help the "not installed at all" case (no hook runs), and
> would falsely block backend-only commits made without Cook Web deps installed.
> It's a pre-commit / troubleshooting tool plus the Claude self-check.

## Verification

- `python scripts/check_dev_tools.py` — all present → exit 0; restricted PATH →
  precise missing list + deduped install commands → exit 1.
- `python scripts/generate_ai_collab_docs.py` → no mirror drift.
- `python scripts/check_repo_harness.py` → passed.
- `lefthook run pre-commit` (staged) and the real commit hooks → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local toolchain verification command to confirm required commit-hook and formatting tools are installed before committing.
  * The check reports core and optional frontend readiness and provides suggested install commands.
* **Documentation**
  * Expanded contributor setup and “must do before any commit” guidance to include the new verification step.
  * Updated troubleshooting sections to direct users to run the verification command when hooks aren’t running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->