### PR TITLE
chore: bump markdown-flow to 0.2.84

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -126,4 +126,4 @@ zope.event==5.0
 zope.interface==7.1.1
 bcrypt==4.2.1
 --extra-index-url https://pypi.org/simple/
-markdown-flow==0.2.83
+markdown-flow==0.2.84


### PR DESCRIPTION
## Summary
- bump backend markdown-flow dependency from 0.2.83 to 0.2.84
- keep the backend MarkdownFlow pin on a release version for main compatibility

## Validation
- python3 -m pip index versions markdown-flow
- python3 -m pip download --no-deps --dest /tmp/ai-shifu-mdflow-download markdown-flow==0.2.84
- rg -n '^markdown-flow==[0-9]+\.[0-9]+\.[0-9]+$' src/api/requirements.txt
- python3 scripts/check_repo_harness.py
- git diff --check
- lefthook run pre-commit --all-files (failed: local toolchain is missing check-json/check-yaml/check-merge-conflict/check-symlinks/end-of-file-fixer/pretty-format-json/trailing-whitespace, and lefthook could not sync .git/hooks due local permissions; substantive repo checks shown in the run passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a Python package to the latest patch version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->