### PR TITLE
fix: improve listen-mode interaction hint copy

### DIFF
--- a/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
@@ -41,7 +41,7 @@ describe('ContentBlock pay interaction overrides', () => {
         item={
           {
             type: 'interaction',
-            content: '提交以下内容后继续学习\n?[去支付//_sys_pay]',
+            content: '先完成这一步，再继续听课\n?[去支付//_sys_pay]',
             element_bid: 'pay-block',
             readonly: true,
             user_input: '_sys_pay',

--- a/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
@@ -41,7 +41,7 @@ describe('ContentBlock pay interaction overrides', () => {
         item={
           {
             type: 'interaction',
-            content: '先完成这一步，再继续听课\n?[去支付//_sys_pay]',
+            content: 'Pay interaction\n?[Pay//_sys_pay]',
             element_bid: 'pay-block',
             readonly: true,
             user_input: '_sys_pay',

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "Please choose a score from 1 to 5.",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
   "listenAudioBackfillFailed": "Audio generation failed. Please retry or keep reading.",
-  "listenInteractionHint": "Submit the following to continue learning",
+  "listenInteractionHint": "Complete this step to continue the lesson",
   "listenModeTtsDisabled": "Listen mode is not enabled for this course.",
   "listenPlaybackSpeedAriaLabel": "Playback speed: {speed}",
   "listenPlaybackSpeedLabel": "Playback speed",

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "Please choose a score from 1 to 5.",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
   "listenAudioBackfillFailed": "Audio generation failed. Please retry or keep reading.",
-  "listenInteractionHint": "Complete this step to continue the lesson",
+  "listenInteractionHint": "Complete this step to continue the course",
   "listenModeTtsDisabled": "Listen mode is not enabled for this course.",
   "listenPlaybackSpeedAriaLabel": "Playback speed: {speed}",
   "listenPlaybackSpeedLabel": "Playback speed",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "Veuillez choisir une note de 1 à 5.",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
   "listenAudioBackfillFailed": "La génération audio a échoué. Veuillez réessayer ou continuer la lecture.",
-  "listenInteractionHint": "Envoyez ce qui suit pour continuer l’apprentissage",
+  "listenInteractionHint": "Terminez cette étape pour continuer le cours",
   "listenModeTtsDisabled": "Le mode écoute n’est pas activé pour ce cours.",
   "listenPlaybackSpeedAriaLabel": "Vitesse de lecture : {speed}",
   "listenPlaybackSpeedLabel": "Vitesse de lecture",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "请选择1-5分后再提交",
   "lessonFeedbackSubmitted": "感谢你的反馈",
   "listenAudioBackfillFailed": "音频生成失败，请重试或继续阅读",
-  "listenInteractionHint": "提交以下内容后继续学习",
+  "listenInteractionHint": "先完成这一步，再继续听课",
   "listenModeTtsDisabled": "当前课程未开启听课模式，无法使用该模式",
   "listenPlaybackSpeedAriaLabel": "播放倍速：{speed}",
   "listenPlaybackSpeedLabel": "播放倍速",


### PR DESCRIPTION
## Summary
- Update the listen-mode interaction hint copy in zh-CN, en-US, and fr-FR.
- Use course-context wording in English and French instead of literal "listening" phrasing.
- Keep the existing i18n key and component behavior unchanged.

## Verification
- `python3 scripts/check_dev_tools.py`
- `npm test -- content-block-pay-interaction.test.tsx`
- `git diff --check`
- pre-commit hooks during `git commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the lesson continuation hint text in multiple languages to use clearer, more natural wording.
  * Refreshed the pay/continue prompt so users see improved guidance before proceeding.
* **Tests**
  * Updated the related test fixture to reflect the changed user-facing instruction text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->