### PR TITLE
fix: fallback current outline in runscript context

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1384,7 +1384,10 @@ class RunScriptContextV2:
         self._shifu_info = shifu_info
         self.shifu_ids = []
         self.outline_item_ids = []
-        self.current_outline_item = None
+        # Default to the request outline dto so helper methods can still
+        # operate when the cached history tree does not contain this outline
+        # yet (for example, a stale/partial history snapshot during runtime).
+        self._current_outline_item = outline_item_info
         self._run_type = RunType.INPUT
         self._can_continue = True
         self._stop_event = stop_event
@@ -1744,14 +1747,15 @@ class RunScriptContextV2:
     # outline is a node when has outline item as children
     # outline is a leaf when has no children
     def _is_leaf_outline_item(self, outline_item_info: ShifuOutlineItemDto) -> bool:
-        if outline_item_info.children:
-            if outline_item_info.children[0].type == "block":
+        children = getattr(outline_item_info, "children", []) or []
+        if children:
+            if children[0].type == "block":
                 return True
-            if outline_item_info.children[0].type == "outline":
+            if children[0].type == "outline":
                 return False
-        if outline_item_info.type == "outline":
+        if getattr(outline_item_info, "type", "") == "outline":
             return True
-        return False
+        return not children
 
     def _get_current_outline_block_count(self) -> int:
         """
@@ -1766,8 +1770,8 @@ class RunScriptContextV2:
             return 0
 
         history_block_count = max(
-            len(self._current_outline_item.children),
-            self._current_outline_item.child_count,
+            len(getattr(self._current_outline_item, "children", []) or []),
+            int(getattr(self._current_outline_item, "child_count", 0) or 0),
         )
         if not self._is_leaf_outline_item(self._current_outline_item):
             return history_block_count
@@ -1785,7 +1789,7 @@ class RunScriptContextV2:
                 self.app,
                 outline_bid,
                 self._preview_mode,
-                outline_item_id=int(self._current_outline_item.id or 0),
+                outline_item_id=int(getattr(self._current_outline_item, "id", 0) or 0),
             )
             block_count = len(
                 MdflowContextV2(document=outline_item_info.mdflow).get_all_blocks()

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -1286,6 +1286,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
                     bid="outline-1",
                     shifu_bid="shifu-1",
                     title="Lesson",
+                    children=[],
                 ),
                 user_info=types.SimpleNamespace(user_id="user-1"),
                 is_paid=True,
@@ -1294,6 +1295,56 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         self.assertIs(captured["client"], sentinel_client)
         self.assertEqual(captured["trace_payload"]["id"], "req-trace-1")
+
+    def test_runtime_context_falls_back_to_request_outline_when_struct_misses_it(self):
+        app = Flask("runtime-outline-fallback")
+        struct = HistoryItem(
+            bid="shifu-1",
+            id=1,
+            type="shifu",
+            children=[
+                HistoryItem(
+                    bid="other-outline",
+                    id=2,
+                    type="outline",
+                    children=[],
+                    child_count=0,
+                )
+            ],
+        )
+        outline_item_info = types.SimpleNamespace(
+            bid="outline-1",
+            shifu_bid="shifu-1",
+            title="Lesson",
+            children=[],
+        )
+
+        with (
+            patch(
+                "flaskr.service.learn.context_v2.get_langfuse_client",
+                return_value=object(),
+            ),
+            patch(
+                "flaskr.service.learn.context_v2.get_request_trace_id",
+                return_value="req-trace-1",
+            ),
+            patch(
+                "flaskr.service.learn.context_v2.create_trace_with_root_span",
+                return_value=(_FakeLangfuseTrace(), _FakeLangfuseSpan()),
+            ),
+        ):
+            ctx = RunScriptContextV2(
+                app=app,
+                shifu_info=types.SimpleNamespace(),
+                struct=struct,
+                outline_item_info=outline_item_info,
+                user_info=types.SimpleNamespace(user_id="user-1"),
+                is_paid=True,
+                preview_mode=False,
+            )
+
+        self.assertIs(ctx._current_outline_item, outline_item_info)
+        self.assertEqual(ctx._get_current_outline_block_count(), 0)
 
     def test_set_input_normalizes_structured_value_for_trace(self):
         ctx = _make_context()


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-07-01 14:35 连续告警：

- `/api/learn/shifu/5450f218bcaa41688e146266c8ca3e21/run/ed49e9def9714a9e9bdaf12a00ba72db`
- `run_script error`
- `AttributeError: 'RunScriptContextV2' object has no attribute '_current_outline_item'`
- traceback 指向 `context_v2.py:_get_current_outline_block_count()` 访问 `self._current_outline_item`

## 修复内容

- 初始化 `RunScriptContextV2._current_outline_item` 时先默认使用请求中的 `outline_item_info`。
- 如果历史结构树中能找到对应 outline，再继续用树中的 `HistoryItem` 覆盖。
- 让 `_is_leaf_outline_item()`、`_get_current_outline_block_count()` 兼容 fallback outline DTO，避免历史结构树缺失/滞后时直接 AttributeError。
- 补充单测覆盖「struct 缺少当前 outline 时 fallback 到请求 outline」场景。

## 验证

- ✅ `python3.13 -m py_compile src/api/flaskr/service/learn/context_v2.py src/api/tests/service/learn/test_context_v2.py`
- ⚠️ `cd src/api && python3.13 -m pytest tests/service/learn/test_context_v2.py -q` 未能在本机启动：环境缺少 `prometheus_client`（`ModuleNotFoundError: No module named 'prometheus_client'`）。等待 CI 在完整依赖环境验证。

## 跳过项

同一巡检窗口内另有 `/api/order/reqiure-to-pay` 的 `pingpp.error.APIError: 系统出现了些问题,请稍后再试。`，判断为第三方支付网关返回的瞬时错误/外部依赖异常，当前缺少稳定复现与业务侧错误码映射需求，未在本 PR 修改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outline handling in runtime scripts so processing continues smoothly even when cached history data is incomplete or missing.
  * Made outline item detection more reliable for empty or partially loaded structures, reducing unexpected failures and count mismatches.

* **Tests**
  * Added coverage for cases where the current outline is provided by the request but not present in the stored structure.
  * Updated existing runtime context coverage to better reflect empty-child outline items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->