### PR TITLE
chore(deps): bump frontend runtime deps for security advisories

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -8839,7 +8839,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8883,13 +8885,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
-      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "6.0.0"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/echarts-for-react": {
@@ -13222,11 +13224,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -18195,7 +18201,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -18627,9 +18635,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
-      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -127,5 +127,8 @@
     "sass": "^1.89.2",
     "tailwindcss": "^4.1.13",
     "typescript": "^5"
+  },
+  "overrides": {
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
## What

Bump direct frontend runtime dependencies in `src/cook-web` to their latest patched releases to clear open Dependabot security advisories. Fourth of the grouped dependency-remediation PRs (frontend direct deps).

| Package | From | To | Advisories cleared |
|---|---|---|---|
| dompurify | 3.2.6 | 3.4.11 | Multiple XSS advisories in the HTML sanitizer |
| echarts | 6.0.0 | 6.1.0 | Lines-series tooltip XSS |
| lodash | 4.17.21 | 4.18.1 | Code injection via `_.template` imports key names |
| lodash-es | 4.17.21 | 4.18.1 | Same lodash code-injection advisory (transitive) |
| uuid | 11.1.0 | 11.1.1 | — (patch within advisory range) |

## The lodash-es override

`lodash-es` is transitive (pulled by `mermaid` → `chevrotain`). `chevrotain` pins it to an **exact** `4.17.21`, so the security patch cannot be resolved through normal range bumps. It is forced to `4.18.1` via an npm `overrides` entry. `4.18.1` is a backward-compatible security release of the 4.17.x line, so this is safe. All `lodash-es` instances in the lockfile now resolve to 4.18.1.

## Scope

All four direct deps already allow the target versions via their existing `^` ranges, so `package.json` changes only add the `overrides` block; the runtime version bumps live in `package-lock.json` (6 version lines).

## Testing

Verified locally on the pinned toolchain:

- `npm install` resolves all targets (every `lodash-es` instance at 4.18.1).
- `next build`: compiles successfully, 29/29 static pages generated.
- `next lint`: passes with only pre-existing warnings.
- Note: the repo's jest unit tests have pre-existing failures caused by unrelated `next/navigation` mock gaps (tests that render components using `usePathname` without mocking it, plus a few stale assertions). Those tests do not import any of the bumped packages and jest is not part of the CI gating (lint / prettier / build / e2e), so they are out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to pin a specific version of `lodash-es` for more consistent builds and installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->