### PR TITLE
chore(deps): bump pillow and pytest to clear Dependabot alerts

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -76,7 +76,7 @@ orjson==3.11.6
 oss2==2.18.6
 packaging==23.2
 pandas==2.2.3
-pillow==10.4.0
+pillow==12.2.0
 pingpp==2.7.2
 prometheus-client==0.22.1
 pydub>=0.25.1
@@ -90,7 +90,7 @@ pydantic-settings==2.6.1
 pydantic_core==2.27.2
 PyJWT==2.13.0
 PyMySQL==1.1.1
-pytest==8.3.5
+pytest==9.0.3
 pytest-env==1.1.5
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2


### PR DESCRIPTION
## What

Batch **B4** of the backend Dependabot remediation: the two major-version bumps deferred from B3.

| Package | From | To | Max severity | Scope |
|---|---|---|---|---|
| pillow | 10.4.0 | 12.2.0 | high | runtime |
| pytest | 8.3.5 | 9.0.3 | medium | dev/test only |

### pillow 10 → 12
The only first-party PIL usage is the captcha renderer (`flaskr/service/user/captcha.py`). It already uses the modern, Pillow-12-safe APIs: `ImageDraw.textbbox` (not the removed `textsize`), `Image.Resampling` accessed via `getattr` fallback, and `Image.rotate(resample=...)`. No deprecated/removed API in use.

### pytest 8 → 9
Test-only dependency (not in the production runtime). The full suite is green on 9.0.3, and `pytest-testmon` 2.2.0 — which CI installs and runs via `pytest --testmon` — works correctly under pytest 9.

## Verification

In a clean Python 3.11 venv:
- `pip check` → no broken requirements
- Full backend suite: **1847 passed, 6 skipped**
- Contract tests: **pass**

The one test that flips under `--testmon` run ordering (`test_listen_elements::test_listen_run_emits_visual_before_blocking_tts_finalize`) is a **pre-existing, order-dependent flaky** (noted in earlier batches): it passes in isolation and when its file runs alone, and does not import pillow or anything touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python package versions to newer releases, including image handling and test tooling dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->