### PR TITLE
docs: codify the read-side UTC serialization contract in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,15 @@ to.
   `default=now_utc` / `onupdate=now_utc`. The DB session is pinned to UTC in
   `src/api/flaskr/dao/__init__.py`; treat that as a safety net, not a license
   to write local time.
+- Serialize timestamps as UTC ISO-8601 with a trailing `Z` on the read side.
+  Prefer leaving DTO datetime fields as raw `datetime | None` and letting the
+  single serialization sink `fmt()` in `src/api/flaskr/route/common.py` emit
+  them (it treats naive values as UTC and converts aware values to UTC). When
+  you must serialize by hand, use `to_utc_iso()` in
+  `src/api/flaskr/util/datetime.py`; return `null` for missing times rather
+  than `""` or a pre-formatted string. Display-time timezone conversion is a
+  pure frontend concern: the browser renders UTC via helpers such as
+  `formatAdminUtcDateTime`, so the API must not localize by request timezone.
 - In Chinese user-facing text and Chinese docs, do not use `创作者` as a
   generic product term. Use `老师` for the general course-building or teacher
   account role; use `课程负责人` or, inside an existing course context,
@@ -63,6 +72,13 @@ to.
   `CURRENT_TIMESTAMP` defaults and naked `datetime.now()` / `datetime.utcnow()`
   for stored times. They depend on the DB session or process time zone and
   reintroduce the UTC-vs-local drift; use `now_utc()` instead.
+- Do not bypass the read-side UTC contract: avoid emitting API datetimes with a
+  naive `datetime.isoformat()` / `strftime(...)` (no `Z`), do not localize
+  display times server-side from a request/browser `?timezone=` param, and do
+  not compare timestamps that carry different serialization contracts (naive
+  vs offset-aware, or string vs string) — normalize both to UTC before
+  comparing. These are exactly the drifts that reappear when new code lands in
+  modules the UTC sweep has not yet reached.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- add a read-side UTC serialization rule to `AGENTS.md` (Prefer + Avoid), closing the gap that let #2001/#2003 reintroduce timezone drifts #1995 had already removed
- regenerate the AI-collaboration mirror docs; `check_repo_harness.py` passes

## Why
The existing timestamp rule in `AGENTS.md` only covered the **write side** (store via `now_utc()`). It said nothing about how datetimes must be **serialized back to clients**. #1995 established that contract (the `fmt()` sink in `src/api/flaskr/route/common.py`, `to_utc_iso()`, "display-time conversion is a pure frontend concern", no request `?timezone=`) but only in code and commit messages — never in the rules.

As a result, follow-up work in the `learn` module (which #1995 did not sweep) reintroduced the exact drifts #1995 removed, and only AI review caught them:
- naive `isoformat()` / `strftime()` strings without a `Z` (bypassing the `fmt()` sink)
- request/browser `?timezone=` server-side localization
- comparing timestamps across mismatched serialization contracts (naive vs offset-aware), which flips ordering outside the server timezone

## What changed
- **Prefer**: API datetimes are UTC ISO-8601 with a trailing `Z`; keep DTO fields as raw `datetime | None` and let the `fmt()` sink serialize them, or use `to_utc_iso()` when serializing by hand; return `null` for missing times; display-time conversion is a pure frontend concern.
- **Avoid**: no naive `isoformat()`/`strftime()` for API datetimes, no server-side localization from a request `?timezone=`, no cross-contract timestamp comparison without normalizing to UTC first.

## Notes
- docs-only change; per `AGENTS.md` the minimum gate for instruction-file changes is `python scripts/check_repo_harness.py`, which passes.
- Pre-existing `learn`-module instances of the same class of bug (`lesson_feedback.py` naive `strftime`, `runscript_v2.py` shadow `fmt()`) are **out of scope** here and left for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified UTC timestamp serialization rules for contributions and integrations.
  * Reinforced that date-time values should be emitted in UTC ISO-8601 format with a trailing `Z`.
  * Added guidance to use the standard serialization path and UTC conversion for manual formatting.
  * Expanded best practices to avoid naive timestamps, timezone-based server-side display changes, and comparing timestamps without normalizing to UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->