### PR TITLE
chore: codify commit message guidance

### DIFF
--- a/.claude/rules/global/testing-and-commit.md
+++ b/.claude/rules/global/testing-and-commit.md
@@ -39,9 +39,9 @@ duplicating the shared repository guidance already stored in `AGENTS.md`.
   missing tools, surface the printed install commands to the user and pause the
   commit until they are installed or the user explicitly opts to proceed.
 
-- Keep commit hygiene aligned with the shared repository rule set:
-  Conventional Commit subjects, English-only code-facing text, and no skipped
-  migration review after backend schema changes.
+- Keep commit hygiene aligned with
+  `docs/engineering-baseline.md#commit-message-policy`; do not duplicate the
+  detailed commit-format policy in Claude-only rules.
 
 - If a task changes only docs or AI-instruction files, the minimum
   verification target is `python scripts/check_repo_harness.py`.

--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -37,6 +37,10 @@ alwaysApply: true
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
+- Follow the canonical commit-message policy in
+  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
+  rule files pointing there instead of duplicating the policy.
+
 - Keep generated knowledge artifacts in sync by running
   `python scripts/build_repo_knowledge_index.py` after docs structure or
   metadata changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,10 @@
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
+- Follow the canonical commit-message policy in
+  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
+  rule files pointing there instead of duplicating the policy.
+
 - Regenerate repository knowledge indexes with
   `python scripts/build_repo_knowledge_index.py` after moving docs or changing
   required metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@ to.
 - Before committing, run `python scripts/check_dev_tools.py` to confirm
   lefthook and its underlying tools are installed; the local checks are
   silently skipped if lefthook was never installed.
+- Follow the canonical commit-message policy in
+  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
+  rule files pointing there instead of duplicating the policy.
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -68,7 +68,37 @@ python scripts/check_dev_tools.py --strict   # also fail on Cook Web tooling gap
 3. Generate a migration for DB changes: `flask db migrate -m "description"`
 4. Test the relevant change surface
 5. Use English for code-facing text
-6. Follow Conventional Commits: `type: description`
+6. For human-authored and coding-agent-authored commits, follow the
+   [Commit Message Policy](#commit-message-policy)
+
+### Commit Message Policy
+
+This policy applies to human-authored and coding-agent-authored commits.
+Existing workflow-generated bot commits are exempt unless the workflow is being
+updated for this policy. The local `commit-msg` hook remains a baseline
+Conventional Commits syntax check; use this section as the source of truth for
+requirements the hook cannot validate.
+
+- Subject: use English Conventional Commits without scope parentheses, such as
+  `type: summary`; do not use `type(scope): summary`.
+- Body: include exactly two sections, `Changed:` and `Benefit:`.
+- Classification: use `chore` for repository-maintenance-only instruction or
+  generated guidance updates like this file.
+- Runtime prompt, template, and system-prompt changes affect product behavior:
+  use `feat` when adding capability and `fix` when correcting behavior; do not
+  use `docs`.
+
+Example:
+
+```text
+chore: codify commit message guidance
+
+Changed:
+Codified commit message requirements across repository guidance files.
+
+Benefit:
+Contributors can write commit history that is easier to review and audit.
+```
 
 ### Common Pitfalls To Avoid
 

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1670,6 +1670,10 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
+                "Follow the canonical commit-message policy in "
+                "`docs/engineering-baseline.md#commit-message-policy`; keep "
+                "agent-specific rule files pointing there instead of "
+                "duplicating the policy.",
                 "Keep generated knowledge artifacts in sync by running "
                 "`python scripts/build_repo_knowledge_index.py` after docs "
                 "structure or metadata changes.",
@@ -1832,6 +1836,10 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
+                "Follow the canonical commit-message policy in "
+                "`docs/engineering-baseline.md#commit-message-policy`; keep "
+                "agent-specific rule files pointing there instead of "
+                "duplicating the policy.",
                 "Regenerate repository knowledge indexes with "
                 "`python scripts/build_repo_knowledge_index.py` after moving docs "
                 "or changing required metadata.",


### PR DESCRIPTION
## Summary
- Centralize the detailed commit message policy in docs/engineering-baseline.md.
- Point AGENTS, Claude, Cursor, and Copilot rule files to that single policy instead of duplicating commit-format details.
- Require human/coding-agent commits to use no-scope Conventional Commit subjects plus Changed/Benefit bodies.
- Clarify classification: repository-maintenance-only instruction/generated guidance updates use chore; runtime prompt/template/system-prompt changes use feat or fix based on product behavior impact.
- Exempt existing workflow-generated bot commits and document that the commit-msg hook is only the baseline syntax check.

## Verification
- python3 scripts/generate_ai_collab_docs.py
- python3 scripts/check_repo_harness.py
- git diff --check
- python3 scripts/check_dev_tools.py
- lefthook pre-commit and commit-msg hooks via git commit --amend