### PR TITLE
fix: prevent listen footer overlap

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -156,7 +156,7 @@
   &.mobile {
     width: 100%;
     // padding-top: 80px;
-    // padding-bottom: 40px;
+    // padding-bottom: var(--chat-footer-height);
     overflow: hidden;
     .chatComponents {
       padding-top: 0;
@@ -178,15 +178,13 @@
       calc(var(--app-viewport-block-unit, 1dvh) * 100) - var(
           --mobile-chat-header-height,
           44px
-        ) -
-        40px
+        ) - var(--chat-footer-height)
     );
     max-height: calc(
       calc(var(--app-viewport-block-unit, 1dvh) * 100) - var(
           --mobile-chat-header-height,
           44px
-        ) -
-        40px
+        ) - var(--chat-footer-height)
     );
     min-height: 0;
     flex-direction: column;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -1,4 +1,7 @@
 .ChatUi {
+  --chat-footer-height: 40px;
+  --listen-player-footer-gap: 12px;
+
   position: relative;
   flex: 1;
   min-width: 0;
@@ -86,7 +89,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    height: 40px;
+    height: var(--chat-footer-height);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -129,14 +129,14 @@
   background: var(--color-slide-desktop-bg);
 }
 
-.listen-reveal-wrapper:not(.mobile) .listen-slide-player.slide-player {
+.listen-reveal-wrapper:not(.mobile) .listen-slide-player {
   bottom: calc(
     var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
   );
   z-index: 30;
 }
 
-.listen-reveal-wrapper.mobile .listen-slide-player.slide-player {
+.listen-reveal-wrapper.mobile .listen-slide-player {
   z-index: 30;
 }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -376,7 +376,9 @@
 }
 
 .slide-ask-overlay {
-  --slide-player-bottom-offset: calc(var(--chat-footer-height, 40px) + 24px);
+  --slide-player-bottom-offset: calc(
+    var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
+  );
   --slide-player-height: 80px;
   --slide-interaction-gap: 16px;
   position: absolute;
@@ -474,7 +476,7 @@
 }
 
 @media (max-width: 640px) {
-  .slide-ask-overlay {
+  .listen-reveal-wrapper.mobile .slide-ask-overlay {
     --slide-player-bottom-offset: 0px;
   }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -408,7 +408,7 @@
 }
 
 .slide-ask-overlay--standalone {
-  bottom: 24px;
+  bottom: var(--slide-player-bottom-offset);
 }
 
 .slide-player__ask-card {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -129,10 +129,14 @@
   background: var(--color-slide-desktop-bg);
 }
 
-.listen-reveal-wrapper:not(.mobile) .listen-slide-player {
-  bottom: calc(
+.listen-reveal-wrapper:not(.mobile) {
+  --listen-slide-player-bottom-offset: calc(
     var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
   );
+}
+
+.listen-reveal-wrapper:not(.mobile) .listen-slide-player {
+  bottom: var(--listen-slide-player-bottom-offset);
   z-index: 30;
 }
 
@@ -376,8 +380,11 @@
 }
 
 .slide-ask-overlay {
-  --slide-player-bottom-offset: calc(
-    var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
+  --slide-player-bottom-offset: var(
+    --listen-slide-player-bottom-offset,
+    calc(
+      var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
+    )
   );
   --slide-player-height: 80px;
   --slide-interaction-gap: 16px;
@@ -390,6 +397,12 @@
 
 .listen-reveal-wrapper:not(.mobile) .slide-interaction-overlay {
   --slide-player-notes-arrow-offset: 168px;
+}
+
+.listen-reveal-wrapper:not(.mobile) .slide-interaction-overlay,
+.listen-reveal-wrapper:not(.mobile) .slide-subtitle-overlay {
+  --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);
+  z-index: 90;
 }
 
 .listen-reveal-wrapper.mobile

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -129,13 +129,15 @@
   background: var(--color-slide-desktop-bg);
 }
 
-.listen-reveal-wrapper:not(.mobile) {
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom) {
   --listen-slide-player-bottom-offset: calc(
     var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
   );
 }
 
-.listen-reveal-wrapper:not(.mobile) .listen-slide-player {
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
+  .listen-slide-root:not(.slide--browser-fullscreen)
+  .listen-slide-player {
   bottom: var(--listen-slide-player-bottom-offset);
   z-index: 30;
 }
@@ -380,12 +382,7 @@
 }
 
 .slide-ask-overlay {
-  --slide-player-bottom-offset: var(
-    --listen-slide-player-bottom-offset,
-    calc(
-      var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
-    )
-  );
+  --slide-player-bottom-offset: 24px;
   --slide-player-height: 80px;
   --slide-interaction-gap: 16px;
   position: absolute;
@@ -399,8 +396,18 @@
   --slide-player-notes-arrow-offset: 168px;
 }
 
-.listen-reveal-wrapper:not(.mobile) .slide-interaction-overlay,
-.listen-reveal-wrapper:not(.mobile) .slide-subtitle-overlay {
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
+  .listen-slide-shell
+  > .slide-ask-overlay,
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
+  .listen-slide-root:not(.slide--browser-fullscreen)
+  .slide-ask-overlay,
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
+  .listen-slide-root:not(.slide--browser-fullscreen)
+  .slide-interaction-overlay,
+.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
+  .listen-slide-root:not(.slide--browser-fullscreen)
+  .slide-subtitle-overlay {
   --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);
   z-index: 90;
 }

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -129,6 +129,17 @@
   background: var(--color-slide-desktop-bg);
 }
 
+.listen-reveal-wrapper:not(.mobile) .listen-slide-player.slide-player {
+  bottom: calc(
+    var(--chat-footer-height, 40px) + var(--listen-player-footer-gap, 12px)
+  );
+  z-index: 30;
+}
+
+.listen-reveal-wrapper.mobile .listen-slide-player.slide-player {
+  z-index: 30;
+}
+
 .classroom-slide-player {
   display: none !important;
 }
@@ -365,7 +376,7 @@
 }
 
 .slide-ask-overlay {
-  --slide-player-bottom-offset: 24px;
+  --slide-player-bottom-offset: calc(var(--chat-footer-height, 40px) + 24px);
   --slide-player-height: 80px;
   --slide-interaction-gap: 16px;
   position: absolute;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -68,11 +68,15 @@ jest.mock('markdown-flow-ui/slide', () => {
   return {
     Slide: jest.fn(
       (props: {
+        playerClassName?: string;
         playerCustomActions?:
           | React.ReactNode
           | ((context: typeof slideCustomActionContext) => React.ReactNode);
       }) => (
-        <div data-testid='mock-slide'>
+        <div
+          data-player-class-name={props.playerClassName ?? ''}
+          data-testid='mock-slide'
+        >
           <audio data-testid='slide-audio' />
           <div data-testid='slide-custom-actions'>
             {typeof props.playerCustomActions === 'function'
@@ -219,6 +223,32 @@ describe('ListenModeSlideRenderer', () => {
         position: 0,
       }),
     ]);
+  });
+
+  it('passes a stable listen player class for footer-safe positioning', () => {
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Hello',
+            element_bid: 'content-1',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+      />,
+    );
+
+    const slideProps = getMockSlide().mock.calls[0]?.[0] as
+      | { playerClassName?: string }
+      | undefined;
+
+    expect(slideProps?.playerClassName ?? '').toContain('listen-slide-player');
+    expect(slideProps?.playerClassName ?? '').not.toContain(
+      'classroom-slide-player',
+    );
   });
 
   it('passes selected interaction user input to the slide during playback', () => {
@@ -487,6 +517,9 @@ describe('ListenModeSlideRenderer', () => {
     expect(slideProps?.showPlayer).toBe(true);
     expect(slideProps?.playerClassName ?? '').toContain(
       'classroom-slide-player',
+    );
+    expect(slideProps?.playerClassName ?? '').not.toContain(
+      'listen-slide-player',
     );
     expect(slideProps?.className ?? '').toContain('listen-slide-root');
     expect(slideProps?.className ?? '').not.toContain('classroom-slide-root');

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -86,6 +86,9 @@ jest.mock('markdown-flow-ui/slide', () => {
   };
 });
 
+const getClassTokens = (className?: string) =>
+  (className ?? '').split(/\s+/).filter(Boolean);
+
 jest.mock('./useChatLogicHook', () => ({
   ChatContentItemType: {
     ASK: 'ask',
@@ -242,10 +245,10 @@ describe('ListenModeSlideRenderer', () => {
       | { playerClassName?: string }
       | undefined;
 
-    expect(slideProps?.playerClassName ?? '').toContain('listen-slide-player');
-    expect(slideProps?.playerClassName ?? '').not.toContain(
-      'classroom-slide-player',
-    );
+    const playerClassTokens = getClassTokens(slideProps?.playerClassName);
+
+    expect(playerClassTokens).toContain('listen-slide-player');
+    expect(playerClassTokens).not.toContain('classroom-slide-player');
   });
 
   it('passes selected interaction user input to the slide during playback', () => {
@@ -512,12 +515,10 @@ describe('ListenModeSlideRenderer', () => {
     expect(slideProps?.playerCustomActions).toBeNull();
     expect(slideProps?.disableLoadingOverlay).toBe(true);
     expect(slideProps?.showPlayer).toBe(true);
-    expect(slideProps?.playerClassName ?? '').toContain(
-      'classroom-slide-player',
-    );
-    expect(slideProps?.playerClassName ?? '').not.toContain(
-      'listen-slide-player',
-    );
+    const playerClassTokens = getClassTokens(slideProps?.playerClassName);
+
+    expect(playerClassTokens).toContain('classroom-slide-player');
+    expect(playerClassTokens).not.toContain('listen-slide-player');
     expect(slideProps?.className ?? '').toContain('listen-slide-root');
     expect(slideProps?.className ?? '').not.toContain('classroom-slide-root');
     expect(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -73,10 +73,7 @@ jest.mock('markdown-flow-ui/slide', () => {
           | React.ReactNode
           | ((context: typeof slideCustomActionContext) => React.ReactNode);
       }) => (
-        <div
-          data-player-class-name={props.playerClassName ?? ''}
-          data-testid='mock-slide'
-        >
+        <div data-testid='mock-slide'>
           <audio data-testid='slide-audio' />
           <div data-testid='slide-custom-actions'>
             {typeof props.playerCustomActions === 'function'

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -523,7 +523,7 @@ describe('ListenModeSlideRenderer', () => {
     expect(slideProps?.className ?? '').not.toContain('classroom-slide-root');
     expect(
       screen.getByTestId('mock-slide').closest('.listen-reveal-wrapper'),
-    ).not.toHaveClass('listen-reveal-wrapper--classroom');
+    ).toHaveClass('listen-reveal-wrapper--classroom');
     expect(
       screen.queryByRole('button', {
         name: 'module.chat.listenPlaybackSpeedAriaLabel',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1896,6 +1896,7 @@ const ListenModeSlideRenderer = ({
       className={cn(
         'listen-reveal-wrapper',
         previewMode && !mobileStyle && 'listen-reveal-wrapper--preview',
+        variant === 'classroom' && 'listen-reveal-wrapper--classroom',
         mobileStyle ? 'mobile bg-white' : 'bg-[var(--color-slide-desktop-bg)]',
       )}
       ref={chatRef}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1858,6 +1858,8 @@ const ListenModeSlideRenderer = ({
     showAskOverlays && isMobileAskPanelMounted && !shouldRenderEmptyPpt;
   const shouldRenderManualFullscreenButton =
     showManualFullscreenButton && !isClassroomFullscreenActive;
+  const listenPlayerClassName =
+    variant === 'listen' ? 'listen-slide-player' : '';
 
   const desktopAskOverlay = shouldRenderDesktopAskOverlay ? (
     <div
@@ -1990,6 +1992,7 @@ const ListenModeSlideRenderer = ({
           onSend={handleInteractionSend}
           onMobileViewModeChange={handleMobileViewModeChange}
           playerClassName={cn(
+            listenPlayerClassName,
             mobileStyle ? 'listen-slide-player-mobile' : '',
             playerClassName,
           )}


### PR DESCRIPTION
## Summary
- add a stable listen-mode player class so AI-Shifu can target the MarkdownFlow Slide player directly
- raise the desktop listen player and ask/interaction overlays above the fixed Chat UI footer
- scope the footer-safe offsets to non-fullscreen listen slides so browser fullscreen keeps the MarkdownFlow player placement
- mark classroom wrappers and exclude classroom overlays from listen-player footer offsets
- cover the listen/classroom player class contract with regression tests

## Root Cause
The listen-mode Slide player was positioned at the viewport bottom while the AI-Shifu footer was also fixed at the bottom. Because the Slide player did not have a stable listen-specific class, AI-Shifu could not reliably reserve footer-safe space for the player. Follow-up review also found that the footer-safe selector was too broad for browser fullscreen and classroom mode, where the fixed Chat UI footer or listen player is not present.

## Validation
- python3 scripts/check_dev_tools.py
- git diff --check
- ./node_modules/.bin/prettier --check targeted ChatUi files
- npm run test -- --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
- npm run lint -- --quiet --file src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx --file src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
- npm run type-check
- git commit pre-commit hook: architecture boundaries, translation checks, lint-file, prettier-cook-web, and whitespace checks

## Review Follow-up
- resolved PRRT_kwDOMZ_AH86N351h by excluding `.slide--browser-fullscreen` from footer-safe player/overlay rules
- resolved PRRT_kwDOMZ_AH86N351p by adding a classroom wrapper modifier and excluding classroom overlays from listen offsets
- posted `/gemini review`; Gemini could not generate a review for these file types
- CodeRabbit finished the latest run with no actionable comments

## Browser QA
Confirmed the footer-safe CSS rules are compiled into the local dev page. Full player screenshot validation on the local /c route was blocked by the existing dev-server error: Cannot assign to read only property params of object.