### PR TITLE
fix: persist the caller's value in update_config instead of the cached one

### DIFF
--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -255,13 +255,6 @@ def update_config(
         if has_explicit_env_override(key):
             return False
         cache_key = _get_config_cache_key(app, key)
-        cache = redis.get(cache_key)
-        if cache:
-            cache_config = ConfigCache.model_validate_json(cache)
-            if cache_config.is_encrypted:
-                value = _decrypt_config(app, cache_config.value)
-            else:
-                value = cache_config.value
         if value:
             if is_secret:
                 value = _encrypt_config(app, value)

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -781,7 +781,7 @@ class TestUpdateConfig:
     @patch("flaskr.service.config.funcs.Config")
     @patch("flaskr.service.config.funcs._decrypt_config")
     @patch("flaskr.service.config.funcs._encrypt_config")
-    def test_update_config_from_cache_encrypted(
+    def test_update_config_ignores_cache_encrypted(
         self,
         mock_encrypt,
         mock_decrypt,
@@ -791,7 +791,9 @@ class TestUpdateConfig:
         mock_get_config_from_common,
         app,
     ):
-        """Test that update_config uses cached encrypted value if exists."""
+        """update_config must persist the caller's new value, not a stale cached
+        one, even when the cache is warm (regression: a warm cache used to
+        overwrite the new value and re-persist the old one)."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -800,7 +802,6 @@ class TestUpdateConfig:
                 is_encrypted=True, value="cached-encrypted"
             ).model_dump_json()
             mock_redis.get.return_value = cache_data
-            mock_decrypt.return_value = "cached-decrypted"
             mock_encrypt.return_value = "re-encrypted-value"
 
             # Mock database query
@@ -816,10 +817,11 @@ class TestUpdateConfig:
             mock_config_class.query = mock_query
 
             result = update_config(app, "test_key", "new_value", is_secret=True)
-            # Should use cached decrypted value instead of new_value
-            mock_decrypt.assert_called_once_with(app, "cached-encrypted")
-            # Should encrypt the cached value
-            mock_encrypt.assert_called_once_with(app, "cached-decrypted")
+            # The cached value must be ignored entirely.
+            mock_decrypt.assert_not_called()
+            # The new value is what gets encrypted and written.
+            mock_encrypt.assert_called_once_with(app, "new_value")
+            assert mock_config_record.value == "re-encrypted-value"
             assert result is True
 
     @patch("flaskr.service.config.funcs.get_config_from_common")
@@ -827,7 +829,7 @@ class TestUpdateConfig:
     @patch("flaskr.service.config.funcs.db")
     @patch("flaskr.service.config.funcs.Config")
     @patch("flaskr.service.config.funcs._encrypt_config")
-    def test_update_config_from_cache_plain(
+    def test_update_config_ignores_cache_plain(
         self,
         mock_encrypt,
         mock_config_class,
@@ -836,7 +838,8 @@ class TestUpdateConfig:
         mock_get_config_from_common,
         app,
     ):
-        """Test that update_config uses cached plain value if exists."""
+        """update_config must persist the caller's new plain value, not a stale
+        cached one, even when the cache is warm."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             mock_get_config_from_common.return_value = None
@@ -858,8 +861,9 @@ class TestUpdateConfig:
             mock_config_class.query = mock_query
 
             result = update_config(app, "test_key", "new_value", is_secret=False)
-            # Should use cached value instead of new_value
+            # The new value is written verbatim; the cached value is ignored.
             mock_encrypt.assert_not_called()
+            assert mock_config_record.value == "new_value"
             assert result is True
 
     @patch("flaskr.service.config.funcs.get_config_from_common")


### PR DESCRIPTION
## Problem

`update_config` reads the Redis cache for the key and, on a **cache hit**, overwrites the caller-supplied `value` with the cached value before writing it back to the DB:

```python
cache = redis.get(cache_key)
if cache:
    cache_config = ConfigCache.model_validate_json(cache)
    ...
    else:
        value = cache_config.value   # caller's new value is discarded
...
config.value = value                 # the stale cached value is re-persisted
```

So whenever the key's cache is warm, `update_config` **cannot change the value** — it rewrites the old cached value and refreshes the cache with it. `add_config` does **not** have this block (it correctly writes the passed value), so the two diverged.

### Real-world impact (found while operating prod)

`flask console update_demo_shifu` stores a `DEMO_SHIFU_HASH` marker via `update_config` to skip re-import when the demo JSON is unchanged. Because the marker's cache was warm, every `update_config(hash, new_hash)` re-wrote the **old** hash. Observed in production: after re-importing the updated CN demo course, `DEMO_SHIFU_HASH` stayed at the old value `560b8d98…` (file hash was `941caf3e…`), so the command re-imports the whole course on **every** run instead of skipping. More generally, **any** code path that updates a config value while its cache is warm was silently a no-op.

## Fix

Drop the cache-read/overwrite block. `update_config` now writes the caller's `value` and then refreshes the cache with it — same contract as `add_config`. `cache_key` is still computed for the trailing `redis.set`.

## Tests

Two existing tests literally asserted the buggy behavior (`test_update_config_from_cache_*`, docstrings "uses cached value"). Rewrote them as `test_update_config_ignores_cache_*` to assert the cached value is ignored and the **new** value is persisted (mirroring the existing `test_add_config_from_cache_*`). Full `tests/service/config/test_funcs.py` — 41 passed; ruff clean.

## Follow-up (ops, not code)

After this deploys, the stuck prod `DEMO_SHIFU_HASH` self-corrects on the next `flask console update_demo_shifu` run (it re-imports once, then writes the correct hash and skips thereafter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)