### PR TITLE
style: add dashed underline to save timestamp

### DIFF
--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -421,7 +421,9 @@ const Header = ({
                         title={historyTooltip}
                       >
                         <History className='mr-2 h-4 w-4 shrink-0' />
-                        <span>{lessonHistoryText}</span>
+                        <span className={s.lessonHistoryText}>
+                          {lessonHistoryText}
+                        </span>
                       </Link>
                     </TooltipTrigger>
                     <TooltipContent>{historyTooltip}</TooltipContent>

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -421,7 +421,7 @@ const Header = ({
                         title={historyTooltip}
                       >
                         <History className='mr-2 h-4 w-4 shrink-0' />
-                        <span className={s.lessonHistoryText}>
+                        <span className='underline decoration-dashed decoration-1 underline-offset-[3px]'>
                           {lessonHistoryText}
                         </span>
                       </Link>

--- a/src/cook-web/src/components/header/header.module.scss
+++ b/src/cook-web/src/components/header/header.module.scss
@@ -21,10 +21,3 @@
 .archived {
   @extend .statusBadge;
 }
-
-.lessonHistoryText {
-  text-decoration-line: underline;
-  text-decoration-style: dashed;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-}

--- a/src/cook-web/src/components/header/header.module.scss
+++ b/src/cook-web/src/components/header/header.module.scss
@@ -21,3 +21,10 @@
 .archived {
   @extend .statusBadge;
 }
+
+.lessonHistoryText {
+  text-decoration-line: underline;
+  text-decoration-style: dashed;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}


### PR DESCRIPTION
## Summary
- Apply a dashed underline to the course editor header save timestamp text.
- Use Tailwind text-decoration utilities directly in `Header.tsx`, leaving the history icon and link behavior unchanged.

## Review follow-up
- Replaced the custom SCSS module class with utility classes after review feedback.
- Kept the full localized save-time display string underlined (`Last updated: {relativeTime}` / `本节最后修改：{relativeTime}`), matching the product request.
- Resolved the 4 outdated review threads after the follow-up commit.

## Validation
- `python3 scripts/check_dev_tools.py`
- `git diff --check`
- `cd src/cook-web && npm run lint-file -- src/components/header/Header.tsx` (passes with existing `@next/next/no-img-element` warning)
- `cd src/cook-web && npm run type-check`
- Commit hooks: pre-commit and commit-msg passed
- Posted `/gemini review`; Gemini reported no feedback on commit `20346c75c6aa9afea443cae893df90c29a453a57`

## Notes
- Local visual QA attempted against `http://127.0.0.1:3020/shifu/shifu-1?lessonid=lesson-1`, but the page redirected to `/login`, so the authenticated editor header was not visible locally.