### PR TITLE
fix: show lesson history time for readonly courses

### DIFF
--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1456,7 +1456,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         path_prefix + "/shifus/<shifu_bid>/draft-meta",
         methods=["GET"],
     )
-    @ShifuTokenValidation(ShifuPermission.EDIT)
+    @ShifuTokenValidation(ShifuPermission.VIEW)
     def get_draft_meta_api(shifu_bid: str):
         """
         get draft meta

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -28,7 +28,7 @@ def test_alembic_migrations_have_single_head():
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
 
-    assert heads == ["d4e5f6a7b8c9"]
+    assert heads == ["e7f1a2b3c4d5"]
 
 
 def _get_base_mysql_uri() -> str:

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -74,6 +74,20 @@ def _mock_route_user(monkeypatch, user_id: str):
     return dummy_user
 
 
+def _mock_route_permission(monkeypatch, permission_map: dict[str, bool]):
+    from flaskr.service.shifu import route
+
+    def _has_permission(_app, _user_id, _shifu_bid, permission: str):
+        return permission_map.get(permission, False)
+
+    monkeypatch.setattr(
+        route,
+        "shifu_permission_verification",
+        _has_permission,
+        raising=False,
+    )
+
+
 def test_save_shifu_draft_info_keeps_existing_price_when_input_is_none(
     app, monkeypatch
 ):
@@ -222,3 +236,46 @@ def test_get_draft_meta_route_serializes_utc_timestamp(app, test_client, monkeyp
     assert response.status_code == 200
     assert payload["code"] == 0
     assert payload["data"]["updated_at"] == "2026-06-30T05:37:42Z"
+
+
+def test_get_draft_meta_route_allows_view_only_permission(
+    app, test_client, monkeypatch
+):
+    from flaskr.service.shifu.models import DraftOutlineItem
+
+    shifu_bid = "test-draft-meta-view-only"
+    owner_bid = "owner-draft-meta-view-only"
+    shared_user_bid = "shared-draft-meta-view-only"
+    outline_bid = "lesson-draft-meta-view-only"
+    _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.00"))
+    _mock_route_user(monkeypatch, shared_user_bid)
+    _mock_route_permission(monkeypatch, {"view": True, "edit": False})
+
+    with app.app_context():
+        DraftOutlineItem.query.filter_by(
+            shifu_bid=shifu_bid,
+            outline_item_bid=outline_bid,
+        ).delete()
+        dao.db.session.add(
+            DraftOutlineItem(
+                shifu_bid=shifu_bid,
+                outline_item_bid=outline_bid,
+                title="Lesson",
+                content="content",
+                updated_user_bid=owner_bid,
+                created_user_bid=owner_bid,
+                updated_at=datetime(2026, 7, 2, 10, 0, 0),
+                created_at=datetime(2026, 7, 2, 10, 0, 0),
+            )
+        )
+        dao.db.session.commit()
+
+    response = test_client.get(
+        f"/api/shifu/shifus/{shifu_bid}/draft-meta?outline_bid={outline_bid}",
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert payload["data"]["updated_at"] == "2026-07-02T10:00:00Z"

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -407,6 +407,27 @@ describe('ShifuEdit draft conflict checks', () => {
     });
   });
 
+  test('still loads draft meta for readonly lessons without starting draft sync', async () => {
+    setLessonNode();
+    mockShifuState.currentShifu = {
+      bid: 'shifu-1',
+      readonly: true,
+      name: 'Course',
+    };
+    mockLoadDraftMeta.mockResolvedValue({
+      revision: 3,
+      updated_at: '2026-07-02T10:00:00Z',
+      updated_user: null,
+    });
+
+    render(<ScriptEditor id='shifu-1' />);
+
+    await waitFor(() => {
+      expect(mockLoadDraftMeta).toHaveBeenCalledWith('shifu-1', 'lesson-1');
+    });
+    expect(baseActions.loadMdflow).not.toHaveBeenCalled();
+  });
+
   test('auto-syncs latest lesson content without opening conflict dialog when there are no local edits', async () => {
     setLessonNode();
     mockShifuState.baseRevision = 1;

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -756,12 +756,9 @@ const ScriptEditor = ({
   }, [currentShifu?.bid, resetDraftConflictState, shouldSkipConflictCheck]);
 
   useEffect(() => {
-    if (shouldSkipConflictCheck) {
-      return;
-    }
     const shifuBid = currentShifu?.bid;
     const outlineBid = currentNode?.bid;
-    if (!shifuBid || !outlineBid) {
+    if (!shifuBid || !outlineBid || !isLessonNode) {
       return;
     }
 
@@ -776,6 +773,9 @@ const ScriptEditor = ({
       ) {
         return;
       }
+      if (shouldSkipConflictCheck) {
+        return;
+      }
       await syncDraftFromRemote(shifuBid, outlineBid, meta, {
         showNotice: false,
         mode: resolveDraftConflictMode(meta),
@@ -788,6 +788,7 @@ const ScriptEditor = ({
   }, [
     currentNode?.bid,
     currentShifu?.bid,
+    isLessonNode,
     resetDraftConflictState,
     resolveDraftConflictMode,
     shouldSkipConflictCheck,


### PR DESCRIPTION
## Summary
- load lesson draft meta for readonly lessons so the header can show the last modified time
- keep draft conflict sync disabled for readonly lessons
- allow view-only users to read draft meta and cover it with frontend/backend tests

## Verification
- cd src/cook-web && npm run type-check
- cd src/cook-web && npx jest --runInBand --runTestsByPath src/components/shifu-edit/ShifuEdit.test.tsx
- cd src/cook-web && npm run lint-file -- src/components/shifu-edit/ShifuEdit.tsx src/components/shifu-edit/ShifuEdit.test.tsx
- cd src/api && pytest tests/service/shifu/test_shifu_draft_info.py -q
- python -m py_compile src/api/flaskr/service/shifu/route.py src/api/tests/service/shifu/test_shifu_draft_info.py

## Notes
- frontend focused lint still reports pre-existing warnings in ShifuEdit.tsx and a pre-existing jsx literal warning in ShifuEdit.test.tsx; no new lint errors were introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Users with view-only access can now open draft metadata for a shifu (GET draft-meta).
  * Read-only lessons still load draft details, but draft syncing and content loading no longer start.
  * Draft-sync initialization now runs only in the correct lesson context and avoids unnecessary conflict-check processing.
* **Tests**
  * Added/updated coverage to verify the view-vs-edit permission behavior and draft-sync load behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->