### PR TITLE
chore: align operations users and orders UTC time display coverage

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -71,17 +71,12 @@ offset.
 - Until those fields are migrated to timezone-qualified ISO strings, the
   frontend should preserve the returned wall-clock time with the naive
   formatter helpers instead of applying browser-timezone conversion.
-- Current exceptions:
-  - operator user record `created_at` / `updated_at`
-  - operator user activity `last_login_at` / `last_learning_at`
-  - operator user credit ledger `created_at`
-  - operator user credit usage detail `created_at`
-  - operator learn order metadata `created_at`
-  - operator credit order metadata `created_at`
-  - operator order detail metadata `created_at` / `updated_at`
+- No known wall-clock exceptions remain in the migrated operations users,
+  orders, or course surfaces listed below.
 
-The following operator course fields have been migrated to the UTC ISO payload
-contract and must use browser-timezone rendering with `formatAdminUtcDateTime`:
+The following operator fields have been migrated to the UTC ISO payload contract
+and must use browser-timezone rendering with `formatAdminUtcDateTime` or its
+operator alias `formatOperatorUtcDateTime`:
 
 - course metadata `basic_info.created_at` / `basic_info.updated_at`
 - course list metadata `created_at` / `updated_at`
@@ -92,6 +87,14 @@ contract and must use browser-timezone rendering with `formatAdminUtcDateTime`:
 - course follow-up detail `basic_info.created_at` / timeline `created_at`
 - course ratings `rated_at` / `latest_rated_at`
 - chapter metadata `updated_at`
+- user record `created_at` / `updated_at`
+- user activity `last_login_at` / `last_learning_at`
+- user credits expiry `credits_expire_at`
+- user credit ledger `created_at` / `expires_at` / `consumable_from`
+- user credit usage detail `created_at`
+- learn order metadata `created_at`
+- credit order metadata `created_at` / `paid_at` / `failed_at` / `refunded_at`
+- order detail metadata `created_at` / `updated_at`
 
 Other event timestamps that are already backed by correct timezone-qualified
 payloads should continue to use the browser-timezone rendering flow.

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -14,6 +14,7 @@ const TRANSLATION_OVERRIDES: Record<string, string> = {
   'module.operationsOrder.creditOrders.productNameFormat': 'Yearly - Advanced',
 };
 let mockLanguage = 'en-US';
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
 
 const baseTranslation = (namespace?: string | string[]) => {
   const ns = Array.isArray(namespace) ? namespace[0] : namespace;
@@ -65,6 +66,10 @@ jest.mock('@/api', () => ({
     getAdminOperationCreditOrders: jest.fn(),
     getAdminOperationCreditOrderDetail: jest.fn(),
   },
+}));
+
+jest.mock('@/lib/browser-timezone', () => ({
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 jest.mock('@/lib/request', () => ({
@@ -200,6 +205,7 @@ describe('CreditOrdersTab', () => {
     mockGetAdminOperationCreditOrders.mockReset();
     mockGetAdminOperationCreditOrderDetail.mockReset();
     mockLanguage = 'en-US';
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     window.localStorage.clear();
     mockGetAdminOperationCreditOrdersOverview.mockResolvedValue({
       total_order_count: 12,
@@ -241,7 +247,7 @@ describe('CreditOrdersTab', () => {
           provider_reference_id: 'charge_1',
           failure_code: '',
           failure_message: '',
-          created_at: '2026-04-27T09:00:00+08:00',
+          created_at: '2026-04-27T09:00:00Z',
           paid_at: '2026-04-27T10:00:00Z',
           failed_at: null,
           refunded_at: null,
@@ -312,7 +318,7 @@ describe('CreditOrdersTab', () => {
         provider_reference_id: 'charge_1',
         failure_code: '',
         failure_message: '',
-        created_at: '2026-04-27T09:00:00+08:00',
+        created_at: '2026-04-27T09:00:00Z',
         paid_at: '2026-04-27T10:00:00Z',
         failed_at: null,
         refunded_at: null,
@@ -352,8 +358,8 @@ describe('CreditOrdersTab', () => {
     });
 
     expect(await screen.findByText('bill-order-1')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-27 09:00:00')).toBeInTheDocument();
-    expect(screen.queryByText('2026-04-27 01:00:00')).not.toBeInTheDocument();
+    expect(screen.getByText('2026-04-27 02:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-04-27 09:00:00')).not.toBeInTheDocument();
     expect(
       screen.queryByText('module.operationsOrder.overview.activeFilter'),
     ).not.toBeInTheDocument();
@@ -635,10 +641,10 @@ describe('CreditOrdersTab', () => {
         'module.operationsOrder.creditOrders.detail.title',
       ),
     ).toBeInTheDocument();
-    expect(screen.getAllByText('2026-04-27 09:00:00').length).toBeGreaterThan(
+    expect(screen.queryAllByText('2026-04-27 02:00:00').length).toBeGreaterThan(
       0,
     );
-    expect(screen.queryByText('2026-04-27 01:00:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-04-27 09:00:00')).not.toBeInTheDocument();
   });
 
   test('shows detail error state when detail request fails', async () => {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -62,8 +62,10 @@ jest.mock('@/c-store', () => ({
     }),
 }));
 
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
+
 jest.mock('@/lib/browser-timezone', () => ({
-  getBrowserTimeZone: () => 'UTC',
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -156,6 +158,7 @@ describe('LearnOrdersTab', () => {
     mockSearchParamsValue = '';
     mockGetAdminOperationOrdersOverview.mockReset();
     mockGetAdminOperationOrders.mockReset();
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     window.localStorage.clear();
     mockGetAdminOperationOrdersOverview.mockResolvedValue({
       total_order_count: 10,
@@ -185,8 +188,8 @@ describe('LearnOrdersTab', () => {
           order_source: 'user_purchase',
           order_source_key: 'module.operationsOrder.source.userPurchase',
           coupon_codes: ['FREE100'],
-          created_at: '2026-04-23T10:00:00+08:00',
-          updated_at: '2026-04-23T11:00:00+08:00',
+          created_at: '2026-04-23T10:00:00Z',
+          updated_at: '2026-04-23T11:00:00Z',
         },
       ],
       page: 1,
@@ -217,7 +220,7 @@ describe('LearnOrdersTab', () => {
     });
 
     expect(await screen.findByText('order-1')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-23 02:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-23 03:00:00')).toBeInTheDocument();
     expect(screen.queryByText('2026-04-23 10:00:00')).not.toBeInTheDocument();
     expect(
       screen.queryByText('module.operationsOrder.overview.activeFilter'),

--- a/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx
@@ -15,8 +15,10 @@ const baseTranslation = (namespace?: string | string[]) => {
   return translationCache.get(cacheKey)!;
 };
 
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
+
 jest.mock('@/lib/browser-timezone', () => ({
-  getBrowserTimeZone: () => 'UTC',
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 jest.mock('@/api', () => ({
@@ -85,6 +87,7 @@ const mockGetAdminOperationOrderDetail =
 describe('OperatorOrderDetailSheet', () => {
   beforeEach(() => {
     mockGetAdminOperationOrderDetail.mockReset();
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
   });
 
   test('renders translated source label and hides activities section when empty', async () => {
@@ -107,8 +110,8 @@ describe('OperatorOrderDetailSheet', () => {
         order_source: '',
         order_source_key: '',
         coupon_codes: ['FREE100'],
-        created_at: '2026-04-23T10:00:00+08:00',
-        updated_at: '2026-04-23T11:00:00+08:00',
+        created_at: '2026-04-23T10:00:00Z',
+        updated_at: '2026-04-23T11:00:00Z',
       },
       payment: {
         payment_channel: 'manual',
@@ -149,8 +152,8 @@ describe('OperatorOrderDetailSheet', () => {
       await screen.findByText('module.operationsOrder.detail.title'),
     ).toBeInTheDocument();
     expect(screen.getByText('order-1')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-23 02:00:00')).toBeInTheDocument();
     expect(screen.getByText('2026-04-23 03:00:00')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-23 04:00:00')).toBeInTheDocument();
     expect(screen.queryByText('2026-04-23 10:00:00')).not.toBeInTheDocument();
     expect(
       screen.getByText('module.operationsOrder.source.importActivation'),


### PR DESCRIPTION
Summary

- Align admin time display docs so operations users and orders are no longer listed as wall-clock exceptions.
- Update operations order tests to use UTC `Z` payloads and verify browser-timezone rendering with a non-UTC mocked timezone.
- Confirm existing users/orders production code already uses the shared admin/operator UTC datetime formatters.

Validation

- `cd src/cook-web && npm test -- --runInBand --runTestsByPath src/app/admin/operations/orders/LearnOrdersTab.test.tsx src/app/admin/operations/orders/OperatorOrderDetailSheet.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx src/app/admin/operations/users/page.test.tsx 'src/app/admin/operations/users/[user_bid]/page.test.tsx' src/app/admin/operations/users/UserCreditGrantDialog.test.tsx`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified admin datetime display guidance for migrated operations and expanded the list of timestamps that should render in the browser’s local timezone.
  * Updated the wording to reflect the current handling of operator-facing date and time fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->