### PR TITLE
chore: align billing legacy orders UTC coverage

### DIFF
--- a/docs/admin-time-display.md
+++ b/docs/admin-time-display.md
@@ -95,6 +95,10 @@ operator alias `formatOperatorUtcDateTime`:
 - learn order metadata `created_at`
 - credit order metadata `created_at` / `paid_at` / `failed_at` / `refunded_at`
 - order detail metadata `created_at` / `updated_at`
+- legacy admin order metadata `created_at`
+- legacy redemption-code metadata `created_at` / `updated_at`
+- legacy redemption-code time ranges `start_at` / `end_at`
+- legacy redemption-code usage timestamps `used_at` / `updated_at`
 - promotion coupon/campaign metadata `created_at` / `updated_at`
 - promotion coupon/campaign time ranges `start_at` / `end_at`
 - promotion coupon/campaign record timestamps `applied_at` / `used_at`
@@ -103,6 +107,12 @@ operator alias `formatOperatorUtcDateTime`:
 - referral relation and reward timestamps `bound_at` / `effective_at` / `expires_at`
 - credit notification records `created_at` / `updated_at` / `requested_at` / `attempted_at` / `sent_at`
 - credit notification template sync `last_synced_at`
+- billing subscription period timestamps `current_period_start_at` / `current_period_end_at` / `grace_period_end_at`
+- billing renewal event timestamps `scheduled_at` / `processed_at`
+- billing order metadata `created_at` / `paid_at` / `failed_at` / `refunded_at`
+- billing entitlement time ranges `effective_from` / `effective_to`
+- billing domain verification timestamp `last_verified_at`
+- billing report windows `window_started_at` / `window_ended_at`
 
 Other event timestamps that are already backed by correct timezone-qualified
 payloads should continue to use the browser-timezone rendering flow.

--- a/src/cook-web/src/app/admin/billing/admin/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/admin/page.test.tsx
@@ -33,9 +33,11 @@ jest.mock('@/c-store', () => ({
     selector(mockEnvState),
 }));
 
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
+
 jest.mock('@/lib/browser-timezone', () => ({
   __esModule: true,
-  getBrowserTimeZone: () => 'Asia/Shanghai',
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 jest.mock('@/api', () => ({
@@ -69,6 +71,7 @@ const mockGetAdminBillingOrders = api.getAdminBillingOrders as jest.Mock;
 describe('AdminBillingConsolePage', () => {
   beforeEach(() => {
     mockReplace.mockReset();
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockEnvState.billingEnabled = 'true';
     mockEnvState.runtimeConfigLoaded = true;
     mockAdjustAdminBillingLedger.mockReset();
@@ -355,6 +358,10 @@ describe('AdminBillingConsolePage', () => {
       page_size: 10,
     });
     expect(await screen.findByText('sub-past-due')).toBeInTheDocument();
+    expect(screen.getAllByText('2026-03-31 17:00:00').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText('2026-04-01T00:00:00Z')).not.toBeInTheDocument();
     expect(
       screen.getByText('module.billing.renewal.eventType.retry'),
     ).toBeInTheDocument();
@@ -371,6 +378,7 @@ describe('AdminBillingConsolePage', () => {
     });
 
     expect(await screen.findByText('order-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-04-03 00:55:00')).toBeInTheDocument();
     expect(
       screen.getByText('module.billing.admin.orders.title'),
     ).toBeInTheDocument();
@@ -388,6 +396,9 @@ describe('AdminBillingConsolePage', () => {
     ).toBeInTheDocument();
     expect(screen.getAllByText('creator-2').length).toBeGreaterThan(0);
     expect(screen.getByText('Card was declined')).toBeInTheDocument();
+    expect(screen.getAllByText('2026-03-31 17:00:00').length).toBeGreaterThan(
+      0,
+    );
 
     await act(async () => {
       await user.click(
@@ -436,6 +447,9 @@ describe('AdminBillingConsolePage', () => {
     expect(
       screen.getByText('module.billing.reports.metric.llmOutputTokens'),
     ).toBeInTheDocument();
+    expect(
+      screen.getAllByText('2026-04-05 17:00:00 → 2026-04-06 17:00:00').length,
+    ).toBeGreaterThan(0);
   });
 
   test('submits a manual ledger adjustment and revalidates admin billing data', async () => {

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx
@@ -9,6 +9,12 @@ import {
 import api from '@/api';
 import CreatorRedemptionCodesTab from './CreatorRedemptionCodesTab';
 
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
+
+jest.mock('@/lib/browser-timezone', () => ({
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
+}));
+
 jest.mock('@/api', () => ({
   __esModule: true,
   default: {
@@ -202,14 +208,14 @@ const createListResponse = (
       scope_type: 'single_course',
       shifu_bid: 'course-1',
       course_name: 'Course A',
-      start_at: '2026-05-01 00:00:00',
-      end_at: '2026-06-01 23:59:59',
+      start_at: '2026-05-01T00:00:00Z',
+      end_at: '2026-06-01T23:59:59Z',
       total_count: 20,
       used_count: 3,
       computed_status: 'active',
       computed_status_key: 'module.operationsPromotion.status.active',
-      created_at: '2026-05-01 12:00:00',
-      updated_at: '2026-05-01 12:00:00',
+      created_at: '2026-05-01T12:00:00Z',
+      updated_at: '2026-05-01T12:00:00Z',
     },
   ],
   page: 1,
@@ -221,6 +227,7 @@ const createListResponse = (
 
 describe('CreatorRedemptionCodesTab', () => {
   beforeEach(() => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
     mockToast.mockReset();
     mockGetCreatorCourseRedemptionCodes.mockReset();
     mockGetCreatorCourseRedemptionCodeDetail.mockReset();
@@ -242,14 +249,14 @@ describe('CreatorRedemptionCodesTab', () => {
           scope_type: 'single_course',
           shifu_bid: 'course-1',
           course_name: 'Course A',
-          start_at: '2026-05-01 00:00:00',
-          end_at: '2026-06-01 23:59:59',
+          start_at: '2026-05-01T00:00:00Z',
+          end_at: '2026-06-01T23:59:59Z',
           total_count: 20,
           used_count: 3,
           computed_status: 'active',
           computed_status_key: 'module.operationsPromotion.status.active',
-          created_at: '2026-05-01 12:00:00',
-          updated_at: '2026-05-01 12:00:00',
+          created_at: '2026-05-01T12:00:00Z',
+          updated_at: '2026-05-01T12:00:00Z',
         },
         {
           coupon_bid: 'coupon-2',
@@ -263,14 +270,14 @@ describe('CreatorRedemptionCodesTab', () => {
           scope_type: 'single_course',
           shifu_bid: 'course-2',
           course_name: 'Course B',
-          start_at: '2026-05-01 00:00:00',
-          end_at: '2026-06-01 23:59:59',
+          start_at: '2026-05-01T00:00:00Z',
+          end_at: '2026-06-01T23:59:59Z',
           total_count: 30,
           used_count: 0,
           computed_status: 'active',
           computed_status_key: 'module.operationsPromotion.status.active',
-          created_at: '2026-05-01 12:00:00',
-          updated_at: '2026-05-01 12:00:00',
+          created_at: '2026-05-01T12:00:00Z',
+          updated_at: '2026-05-01T12:00:00Z',
         },
       ],
       page: 1,
@@ -298,8 +305,8 @@ describe('CreatorRedemptionCodesTab', () => {
           payable_price: '99.00',
           discount_amount: '10.00',
           paid_price: '89.00',
-          used_at: '2026-05-02 12:00:00',
-          updated_at: '2026-05-02 12:00:00',
+          used_at: '2026-05-02T12:00:00Z',
+          updated_at: '2026-05-02T12:00:00Z',
         },
       ],
       page: 1,
@@ -321,7 +328,7 @@ describe('CreatorRedemptionCodesTab', () => {
           user_nickname: '',
           order_bid: '',
           used_at: '',
-          updated_at: '2026-05-02 12:00:00',
+          updated_at: '2026-05-02T12:00:00Z',
         },
       ],
       page: 1,
@@ -343,14 +350,14 @@ describe('CreatorRedemptionCodesTab', () => {
         scope_type: 'single_course',
         shifu_bid: 'course-1',
         course_name: 'Course A',
-        start_at: '2026-05-01 00:00:00',
-        end_at: '2026-06-01 23:59:59',
+        start_at: '2026-05-01T00:00:00Z',
+        end_at: '2026-06-01T23:59:59Z',
         total_count: 20,
         used_count: 3,
         computed_status: 'active',
         computed_status_key: 'module.operationsPromotion.status.active',
-        created_at: '2026-05-01 12:00:00',
-        updated_at: '2026-05-01 12:00:00',
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-01T12:00:00Z',
       },
     });
     mockUpdateCreatorCourseRedemptionCodeStatus.mockResolvedValue({
@@ -382,6 +389,13 @@ describe('CreatorRedemptionCodesTab', () => {
     expect(screen.getByText('3/20')).toBeInTheDocument();
     expect(screen.getByText('Batch B')).toBeInTheDocument();
     expect(screen.getAllByText('table.codesEntry').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('2026-04-30 17:00:00 ~ 2026-06-01 16:59:59').length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText('2026-05-01 05:00:00').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText('2026-05-01T00:00:00Z')).not.toBeInTheDocument();
 
     const actionHeader = screen.getByText('table.actions').closest('th');
     expect(actionHeader).toHaveClass('sticky');
@@ -414,6 +428,8 @@ describe('CreatorRedemptionCodesTab', () => {
     expect(await screen.findByText('coupon.usages')).toBeInTheDocument();
     expect(screen.getAllByText('CODE-A').length).toBeGreaterThan(0);
     expect(screen.getByText('order-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-05-02 05:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-05-02T12:00:00Z')).not.toBeInTheDocument();
   });
 
   test('opens and exports single-use sub-codes', async () => {

--- a/src/cook-web/src/app/admin/orders/OrdersTable.test.tsx
+++ b/src/cook-web/src/app/admin/orders/OrdersTable.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import OrdersTable from './OrdersTable';
+import type { OrderSummary } from '@/components/order/order-types';
+
+const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
+
+jest.mock('@/lib/browser-timezone', () => ({
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('@/app/admin/components/AdminTooltipText', () => ({
+  __esModule: true,
+  default: ({ text, emptyValue }: { text?: string; emptyValue?: string }) => (
+    <span>{text || emptyValue || ''}</span>
+  ),
+}));
+
+const getColumnStyle = () => ({ width: 120 });
+const getResizeHandleProps = () => ({
+  onMouseDown: jest.fn(),
+  'aria-hidden': true as const,
+});
+
+const order: OrderSummary = {
+  order_bid: 'order-1',
+  shifu_bid: 'course-1',
+  shifu_name: 'Course One',
+  user_bid: 'user-1',
+  user_mobile: '',
+  user_email: 'learner@example.com',
+  user_nickname: 'Learner One',
+  payable_price: '99.00',
+  paid_price: '89.00',
+  discount_amount: '10.00',
+  status: 502,
+  status_key: 'server.order.orderStatusPaid',
+  payment_channel: 'stripe',
+  payment_channel_key: 'module.order.paymentChannel.stripe',
+  coupon_codes: [],
+  created_at: '2026-05-01T12:00:00Z',
+  updated_at: '2026-05-01T12:00:00Z',
+};
+
+describe('OrdersTable', () => {
+  beforeEach(() => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+  });
+
+  test('formats order created_at with the admin browser-timezone rule', () => {
+    render(
+      <OrdersTable
+        orders={[order]}
+        loading={false}
+        total={1}
+        pageIndex={1}
+        pageCount={1}
+        isEmailMode
+        defaultUserName='-'
+        getColumnStyle={getColumnStyle}
+        getResizeHandleProps={getResizeHandleProps}
+        formatMoney={value => `¥${value || '0'}`}
+        resolveStatusLabel={item => item.status_key}
+        onPageChange={jest.fn()}
+        onViewDetail={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('2026-05-01 05:00:00')).toBeInTheDocument();
+    expect(screen.queryByText('2026-05-01T12:00:00Z')).not.toBeInTheDocument();
+  });
+});

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -10,6 +10,7 @@ import {
   hasBillingProductBonusCampaign,
   extractBillingPingxxQrCode,
   formatBillingCompactDateTime,
+  formatBillingDate,
   formatBillingDateTime,
   parseBillingDateValue,
   resolveBillingLedgerUsageType,
@@ -495,10 +496,18 @@ describe('billing datetime display helpers', () => {
     );
   });
 
-  test('normalizes date-only fallback values before datetime display', () => {
-    expect(formatBillingDateTime('2026-04-14', 'zh-CN')).toBe(
-      '2026-04-14 08:00:00',
-    );
+  test('rejects date-only values for datetime display', () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+
+    expect(formatBillingDateTime('2026-04-14', 'zh-CN')).toBe('');
+    expect(formatBillingCompactDateTime('2026-04-14Z', 'zh-CN')).toBe('');
+  });
+
+  test('formats date-only values without browser timezone shifting', () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+
+    expect(formatBillingDate('2026-04-14', 'en-US')).toBe('Apr 14, 2026');
+    expect(formatBillingDate('2026-04-14Z', 'en-US')).toBe('Apr 14, 2026');
   });
 });
 

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -21,8 +21,10 @@ import {
 import type { BillingLedgerItem, BillingPlan } from '@/types/billing';
 import type { BillingCheckoutResult } from '@/types/billing';
 
+const mockBrowserTimeZone = jest.fn(() => 'Asia/Shanghai');
+
 jest.mock('@/lib/browser-timezone', () => ({
-  getBrowserTimeZone: () => 'Asia/Shanghai',
+  getBrowserTimeZone: () => mockBrowserTimeZone(),
 }));
 
 const monthlyPlan: BillingPlan = {
@@ -411,6 +413,9 @@ describe('resolveBillingLedgerUsageType', () => {
 });
 
 describe('parseBillingDateValue', () => {
+  beforeEach(() => {
+    mockBrowserTimeZone.mockReturnValue('Asia/Shanghai');
+  });
   test('treats offsetless billing instants as UTC', () => {
     expect(parseBillingDateValue('2026-04-14T07:32:00')?.toISOString()).toBe(
       '2026-04-14T07:32:00.000Z',
@@ -447,6 +452,9 @@ describe('parseBillingDateValue', () => {
 });
 
 describe('billing datetime display helpers', () => {
+  beforeEach(() => {
+    mockBrowserTimeZone.mockReturnValue('Asia/Shanghai');
+  });
   test('formats legacy offsetless billing timestamps as UTC before applying the admin browser-timezone rule', () => {
     expect(formatBillingDateTime('2026-04-14T07:32:00', 'zh-CN')).toBe(
       '2026-04-14 15:32:00',
@@ -455,6 +463,14 @@ describe('billing datetime display helpers', () => {
   test('formats UTC billing timestamps with the admin browser-timezone rule', () => {
     expect(formatBillingDateTime('2026-04-14T07:32:00Z', 'zh-CN')).toBe(
       '2026-04-14 15:32:00',
+    );
+  });
+
+  test('uses the browser timezone rather than the locale for billing datetime display', () => {
+    mockBrowserTimeZone.mockReturnValue('America/Los_Angeles');
+
+    expect(formatBillingDateTime('2026-04-14T07:32:00Z', 'zh-CN')).toBe(
+      '2026-04-14 00:32:00',
     );
   });
 
@@ -479,8 +495,10 @@ describe('billing datetime display helpers', () => {
     );
   });
 
-  test('rejects date-only values for datetime display', () => {
-    expect(formatBillingDateTime('2026-04-14', 'zh-CN')).toBe('');
+  test('normalizes date-only fallback values before datetime display', () => {
+    expect(formatBillingDateTime('2026-04-14', 'zh-CN')).toBe(
+      '2026-04-14 08:00:00',
+    );
   });
 });
 

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -321,7 +321,7 @@ function normalizeBillingDateTimeValue(
 
   const billingDateOnlyMatch = normalizedValue.match(BILLING_DATE_ONLY_RE);
   if (billingDateOnlyMatch) {
-    return `${billingDateOnlyMatch[1]}T00:00:00Z`;
+    return billingDateOnlyMatch[1];
   }
   const billingDateTimeMatch = normalizedValue.match(BILLING_DATETIME_RE);
   if (!billingDateTimeMatch) {
@@ -506,6 +506,18 @@ export function formatBillingDate(
   value: string | null | undefined,
   locale: string,
 ): string {
+  const dateOnlyMatch = String(value || '')
+    .trim()
+    .match(BILLING_DATE_ONLY_RE);
+  if (dateOnlyMatch) {
+    return new Intl.DateTimeFormat(locale, {
+      timeZone: 'UTC',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(`${dateOnlyMatch[1]}T00:00:00Z`));
+  }
+
   const date = parseBillingDateValue(value);
   if (!date) {
     return '';
@@ -522,7 +534,11 @@ export function formatBillingDateTime(
   locale: string,
 ): string {
   void locale;
-  return formatAdminUtcDateTime(normalizeBillingDateTimeValue(value));
+  const normalizedValue = normalizeBillingDateTimeValue(value);
+  if (normalizedValue?.match(BILLING_DATE_ONLY_RE)) {
+    return '';
+  }
+  return formatAdminUtcDateTime(normalizedValue);
 }
 
 export function formatBillingCompactDateTime(
@@ -530,9 +546,11 @@ export function formatBillingCompactDateTime(
   locale: string,
 ): string {
   void locale;
-  const formattedValue = formatAdminUtcDateTime(
-    normalizeBillingDateTimeValue(value),
-  );
+  const normalizedValue = normalizeBillingDateTimeValue(value);
+  if (normalizedValue?.match(BILLING_DATE_ONLY_RE)) {
+    return '';
+  }
+  const formattedValue = formatAdminUtcDateTime(normalizedValue);
   return formattedValue ? formattedValue.slice(0, 16) : '';
 }
 


### PR DESCRIPTION
Summary
- Document billing and legacy admin order fields that follow the UTC Z payload + browser-timezone admin display contract.
- Add regression coverage for billing admin timestamps, billing date-only fallback behavior, legacy order timestamps, and redemption-code time ranges/usages.
- Keep `stat_date` and query-boundary semantics out of scope for this display-only pass.

Validation
- `cd src/cook-web && npm test -- --runInBand --runTestsByPath src/lib/__tests__/billing.test.ts src/app/admin/billing/admin/page.test.tsx src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx src/app/admin/orders/OrdersTable.test.tsx`
- `cd src/cook-web && npm run type-check`
- `git diff --check`
- `cd src/cook-web && npm run lint` (passes with existing warnings)

Notes
- Local unrelated `src/api/app.py` changes were not included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin billing, orders, and redemption-code timestamps now display in the viewer’s local time zone more consistently.
  * Date-only billing values are now shown as dates without unwanted time shifts.

* **Bug Fixes**
  * Fixed several admin views and reports that could show raw UTC timestamps instead of readable local times.
  * Improved handling of date-only values so they no longer appear as invalid or misleading date-time strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->