### PR TITLE
fix: serialize backend metadata timestamps as UTC

### DIFF
--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -17,7 +17,7 @@ from flaskr.i18n import get_current_language, set_language
 from flaskr.service.user.models import UserConversion
 from flaskr.service.user.repository import load_user_aggregate
 from flaskr.util.timezone import format_with_app_timezone
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 
 from .consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -185,7 +185,7 @@ def stage_subscription_purchase_sms_for_paid_order(
     if current_status:
         return False
 
-    now = datetime.now().isoformat()
+    now = to_utc_iso(now_utc())
     payload["status"] = "pending"
     payload["requested_at"] = now
     payload["updated_at"] = now
@@ -222,7 +222,7 @@ def stage_billing_paid_feishu_for_paid_order(
     if current_status:
         return False
 
-    now = datetime.now().isoformat()
+    now = to_utc_iso(now_utc())
     payload["status"] = "pending"
     payload["requested_at"] = now
     payload["updated_at"] = now
@@ -607,10 +607,10 @@ def _finalize_billing_paid_feishu_notification(
 ) -> None:
     payload = _read_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY)
     payload["status"] = status
-    payload["updated_at"] = now.isoformat()
-    payload["processed_at"] = now.isoformat()
+    payload["updated_at"] = to_utc_iso(now)
+    payload["processed_at"] = to_utc_iso(now)
     if status == "sent":
-        payload["sent_at"] = now.isoformat()
+        payload["sent_at"] = to_utc_iso(now)
         payload.pop("error_code", None)
         payload.pop("error_message", None)
     else:
@@ -631,10 +631,10 @@ def _finalize_notification(
 ) -> None:
     payload = _read_notification_payload(order)
     payload["status"] = status
-    payload["updated_at"] = now.isoformat()
-    payload["processed_at"] = now.isoformat()
+    payload["updated_at"] = to_utc_iso(now)
+    payload["processed_at"] = to_utc_iso(now)
     if status == "sent":
-        payload["sent_at"] = now.isoformat()
+        payload["sent_at"] = to_utc_iso(now)
         payload.pop("error_code", None)
         payload.pop("error_message", None)
     else:
@@ -729,8 +729,8 @@ def deliver_billing_paid_feishu(
         )
         now = now_utc()
         payload["status"] = "processing"
-        payload["attempted_at"] = now.isoformat()
-        payload["updated_at"] = now.isoformat()
+        payload["attempted_at"] = to_utc_iso(now)
+        payload["updated_at"] = to_utc_iso(now)
         _write_notification_payload_by_key(order, _BILLING_PAID_FEISHU_KEY, payload)
         db.session.add(order)
         db.session.commit()
@@ -869,8 +869,8 @@ def deliver_subscription_purchase_sms(
             )
 
         payload["status"] = "processing"
-        payload["attempted_at"] = now.isoformat()
-        payload["updated_at"] = now.isoformat()
+        payload["attempted_at"] = to_utc_iso(now)
+        payload["updated_at"] = to_utc_iso(now)
         _write_notification_payload(order, payload)
         db.session.add(order)
         db.session.commit()

--- a/src/api/flaskr/service/billing/preorders.py
+++ b/src/api/flaskr/service/billing/preorders.py
@@ -12,7 +12,7 @@ from .consts import (
 from .models import BillingOrder, BillingProduct, BillingSubscription
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 
 CHECKOUT_ACTION_PREORDER = "preorder"
 CHECKOUT_ACTION_UPGRADE_IMMEDIATE = "upgrade_immediate"
@@ -111,12 +111,12 @@ def build_preorder_order_metadata(
             "current_product_bid": current_product.product_bid,
             "target_product_bid": target_product.product_bid,
             "preorder_target_product_bid": target_product.product_bid,
-            "preorder_effective_at": effective_at.isoformat(),
+            "preorder_effective_at": to_utc_iso(effective_at),
             "preorder_source_subscription_bid": subscription.subscription_bid,
             "absorbed_by_bill_order_bid": None,
             "absorbed_at": None,
-            "renewal_cycle_start_at": effective_at.isoformat(),
-            "renewal_cycle_end_at": cycle_end_at.isoformat(),
+            "renewal_cycle_start_at": to_utc_iso(effective_at),
+            "renewal_cycle_end_at": to_utc_iso(cycle_end_at),
             "subscription_bid": subscription.subscription_bid,
             "product_bid": target_product.product_bid,
             "provider_reference_type": "charge",
@@ -179,7 +179,7 @@ def mark_preorder_absorbed_by_upgrade(
             {
                 "preorder_state": PREORDER_STATE_ABSORBED_BY_UPGRADE,
                 "absorbed_by_bill_order_bid": upgrade_order_bid,
-                "absorbed_at": now.isoformat(),
+                "absorbed_at": to_utc_iso(now),
             }
         )
     )
@@ -200,7 +200,7 @@ def mark_preorder_effective_applied(order: BillingOrder) -> None:
         _normalize_json_object(
             {
                 "preorder_state": PREORDER_STATE_EFFECTIVE_APPLIED,
-                "effective_applied_at": datetime.now().isoformat(),
+                "effective_applied_at": to_utc_iso(now_utc()),
             }
         )
     )

--- a/src/api/flaskr/service/billing/primitives.py
+++ b/src/api/flaskr/service/billing/primitives.py
@@ -15,6 +15,7 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_SCENE_PROD,
 )
+from flaskr.util.datetime import to_utc_iso
 
 from .consts import BILL_CONFIG_KEY_CREDIT_PRECISION, BILL_CONFIG_KEY_ENABLED
 from .value_objects import JsonObjectMap
@@ -194,7 +195,7 @@ def normalize_json_value(value: Any) -> Any:
     if isinstance(value, Decimal):
         return decimal_to_number(value)
     if isinstance(value, datetime):
-        return value.isoformat()
+        return to_utc_iso(value)
     if isinstance(value, list):
         return [normalize_json_value(item) for item in value]
     if isinstance(value, JsonObjectMap):

--- a/src/api/flaskr/service/common/profile_onboarding.py
+++ b/src/api/flaskr/service/common/profile_onboarding.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
 from typing import Any
 
 from flask import Flask
 
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.config.funcs import add_config, get_config
+from flaskr.util.datetime import now_utc, to_utc_iso
 
 
 PROFILE_ONBOARDING_CONFIG_KEY = "PROFILE_ONBOARDING_FLOW"
@@ -23,7 +23,7 @@ _INTERACTION_VARIABLE_PATTERN = re.compile(r"%\{\{\s*([^}\s]+)\s*\}\}")
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return to_utc_iso(now_utc().replace(microsecond=0)) or ""
 
 
 def _default_config_payload() -> dict[str, Any]:

--- a/src/api/flaskr/service/profile/onboarding.py
+++ b/src/api/flaskr/service/profile/onboarding.py
@@ -19,13 +19,12 @@ from flaskr.service.profile.funcs import (
     save_user_profiles,
 )
 from flaskr.service.profile.models import VariableValue
+from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 
 
 def _now_iso() -> str:
-    from datetime import datetime, timezone
-
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return to_utc_iso(now_utc().replace(microsecond=0)) or ""
 
 
 def _has_onboarding_state(user_id: str) -> bool:

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -14,7 +14,7 @@ from urllib.parse import urlsplit, urlunsplit
 from flask import Flask, has_app_context, has_request_context, request
 from sqlalchemy import func
 
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 from sqlalchemy.exc import IntegrityError
 
 from flaskr.common.config import get_config as get_common_config
@@ -675,7 +675,7 @@ def _mark_reward_grant_failed(
     reward.billing_artifacts = {
         **artifacts,
         "grant_error": str(error)[:500],
-        "last_failed_at": now_utc().isoformat() + "Z",
+        "last_failed_at": to_utc_iso(now_utc()),
     }
     db.session.add(reward)
     db.session.commit()

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.dao import db
 from flaskr.util import generate_id
+from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.service.common.models import raise_error
 from flaskr.service.shifu.models import DraftShifu, DraftOutlineItem
 from flaskr.service.shifu.shifu_draft_funcs import (
@@ -78,7 +79,7 @@ def export_shifu(app: Flask, shifu_id: str, file_path: str) -> str:
         # Build export data
         export_data = {
             "version": "1.0",
-            "exported_at": datetime.now().isoformat(),
+            "exported_at": to_utc_iso(now_utc()),
             "shifu": {
                 "shifu_bid": shifu_draft.shifu_bid,
                 "title": shifu_draft.title,

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -2,7 +2,6 @@ import json
 import os
 from flask import Flask
 from werkzeug.datastructures import FileStorage
-from datetime import datetime
 from decimal import Decimal
 from typing import Dict, Optional
 
@@ -180,7 +179,7 @@ def import_shifu(
         structure_data = import_data.get("structure")
         ask_provider_config = _extract_import_ask_provider_config(shifu_data)
 
-        now_time = datetime.now()
+        now_time = now_utc()
 
         # Determine shifu_bid
         shifu_bid = shifu_id

--- a/src/api/tests/service/billing/test_billing_primitives.py
+++ b/src/api/tests/service/billing/test_billing_primitives.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from flaskr.service.billing.primitives import coerce_datetime
+from flaskr.service.billing.primitives import coerce_datetime, normalize_json_object
 
 
 def test_coerce_datetime_normalizes_epoch_to_utc_naive():
@@ -17,3 +17,11 @@ def test_coerce_datetime_normalizes_offset_iso_to_utc_naive():
         2025, 12, 31, 16, 0, 0
     )
     assert coerce_datetime("2026-01-01T00:00:00Z") == datetime(2026, 1, 1, 0, 0, 0)
+
+
+def test_normalize_json_object_serializes_datetimes_as_utc_z():
+    payload = normalize_json_object(
+        {"metadata_time": datetime(2026, 1, 1, 0, 0, 0)}
+    ).to_metadata_json()
+
+    assert payload["metadata_time"] == "2026-01-01T00:00:00Z"

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -317,7 +317,7 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
         order = BillingOrder.query.filter_by(bill_order_bid="billing-sync-sms-1").one()
         notification = order.metadata_json["notifications"]["subscription_purchase_sms"]
         assert notification["status"] == "pending"
-        assert notification["requested_at"] is not None
+        assert notification["requested_at"].endswith("Z")
 
 
 def test_stripe_subscription_webhook_enqueues_subscription_purchase_sms_once(
@@ -487,7 +487,7 @@ def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
         assert notification["status"] == "pending"
-        assert notification["requested_at"] is not None
+        assert notification["requested_at"].endswith("Z")
 
 
 def test_pingxx_topup_webhook_enqueues_billing_paid_feishu_once(
@@ -719,7 +719,7 @@ def test_send_billing_paid_feishu_task_marks_sent(
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
         assert notification["status"] == "sent"
-        assert notification["sent_at"] is not None
+        assert notification["sent_at"].endswith("Z")
 
 
 def test_send_billing_paid_feishu_task_raises_retryable_error_on_provider_failure(
@@ -807,7 +807,7 @@ def test_send_billing_paid_feishu_task_retries_failed_provider_notification(
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
         assert notification["status"] == "sent"
-        assert notification["sent_at"] is not None
+        assert notification["sent_at"].endswith("Z")
 
 
 def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
@@ -870,7 +870,7 @@ def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
         order = BillingOrder.query.filter_by(bill_order_bid="billing-task-sent-1").one()
         notification = order.metadata_json["notifications"]["subscription_purchase_sms"]
         assert notification["status"] == "sent"
-        assert notification["sent_at"] is not None
+        assert notification["sent_at"].endswith("Z")
 
 
 def test_deliver_subscription_purchase_sms_skips_when_creator_has_no_mobile(

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -87,7 +87,7 @@ from flaskr.service.order.payment_providers import (
 )
 from flaskr.service.user.consts import USER_STATE_REGISTERED
 from flaskr.service.user.repository import create_user_entity
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 from tests.common.fixtures.bill_products import build_bill_products
 from tests.service.billing.route_loader import (
     load_billing_routes_module,
@@ -1016,7 +1016,7 @@ class TestBillingWriteRoutes:
             assert order.metadata_json["preorder_state"] == "pending_effective"
             assert (
                 order.metadata_json["renewal_cycle_start_at"]
-                == current_period_end.isoformat()
+                == to_utc_iso(current_period_end)
             )
 
     @pytest.mark.parametrize(

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -1014,9 +1014,8 @@ class TestBillingWriteRoutes:
             assert order.status == BILLING_ORDER_STATUS_PENDING
             assert order.metadata_json["checkout_type"] == "subscription_preorder"
             assert order.metadata_json["preorder_state"] == "pending_effective"
-            assert (
-                order.metadata_json["renewal_cycle_start_at"]
-                == to_utc_iso(current_period_end)
+            assert order.metadata_json["renewal_cycle_start_at"] == to_utc_iso(
+                current_period_end
             )
 
     @pytest.mark.parametrize(

--- a/src/api/tests/service/referral/test_referral_service.py
+++ b/src/api/tests/service/referral/test_referral_service.py
@@ -546,6 +546,7 @@ def test_post_auth_preserves_reward_when_billing_grant_fails_then_repairs(
         ).one()
         assert relation.relation_status == REFERRAL_RELATION_STATUS_REGISTERED
         assert reward.billing_artifacts["grant_error"] == "billing offline"
+        assert reward.billing_artifacts["last_failed_at"].endswith("Z")
 
         dry_run = retry_pending_referral_rewards(referral_app, dry_run=True)
         assert dry_run == [

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -57,6 +57,7 @@ def test_profile_onboarding_config_roundtrip(app, monkeypatch):
         "sys_user_style",
         "sys_user_background",
     ]
+    assert result["updated_at"].endswith("Z")
     assert saved_payloads[0][1] == "operator-1"
 
 


### PR DESCRIPTION
Summary
- Serialize backend metadata/payload timestamps that bypass the API `fmt()` sink as UTC `Z` strings.
- Align billing notification/preorder metadata, billing JSON datetime normalization, profile onboarding timestamps, shifu export metadata, and referral reward failure timestamps with the admin timezone rules.
- Keep date-only report/query-boundary behavior out of scope.

Validation
- `cd src/api && python3 -m ruff check flaskr/service/billing/primitives.py flaskr/service/billing/notifications.py flaskr/service/billing/preorders.py flaskr/service/profile/onboarding.py flaskr/service/common/profile_onboarding.py flaskr/service/shifu/shifu_import_export_funcs.py flaskr/service/referral/service.py tests/service/billing/test_billing_primitives.py tests/service/billing/test_billing_subscription_sms.py tests/service/billing/test_billing_write_routes.py tests/service/user/test_profile_onboarding.py tests/service/referral/test_referral_service.py`
- `cd src/api && pytest tests/service/billing/test_billing_primitives.py tests/service/billing/test_billing_subscription_sms.py tests/service/billing/test_billing_write_routes.py tests/service/billing/test_billing_renewal_execution.py tests/service/user/test_profile_onboarding.py tests/service/referral/test_referral_service.py -k 'not requeue_subscription_purchase_sms_enqueues_failed_provider_order' -q`
- `cd src/api && python3 -m compileall flaskr/service/billing/primitives.py flaskr/service/billing/notifications.py flaskr/service/billing/preorders.py flaskr/service/profile/onboarding.py flaskr/service/common/profile_onboarding.py flaskr/service/shifu/shifu_import_export_funcs.py flaskr/service/referral/service.py`

Notes
- The deselected billing SMS test still requires local `celery`; this is an existing local-environment limitation, not a code failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized stored and exported timestamps across billing notifications, preorder metadata, onboarding updates, referral reward failures, and Shifu import/export to use consistent UTC ISO-8601 formatting (including the `Z` suffix).
  * Improved datetime serialization for JSON normalization so dates are reliably written in UTC ISO format.
* **Tests**
  * Tightened assertions to validate UTC `Z`-suffixed timestamp strings and added coverage for UTC datetime serialization behavior.
* **Documentation**
  * None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->