### PR TITLE
fix: add configurable home_url redirect for entitlement custom domains

### DIFF
--- a/src/api/flaskr/service/billing/entitlements.py
+++ b/src/api/flaskr/service/billing/entitlements.py
@@ -104,6 +104,7 @@ def grant_creator_manual_entitlement(
     branding_enabled: bool | None = None,
     custom_domain_enabled: bool | None = None,
     branding: dict[str, Any] | None = None,
+    home_url: str | None = None,
     commit: bool = True,
 ) -> CreatorEntitlementState:
     """Upsert a manual entitlement snapshot for a creator (operator action).
@@ -111,8 +112,10 @@ def grant_creator_manual_entitlement(
     Reuses a single open manual snapshot per creator instead of stacking new
     rows, so repeated grants stay idempotent. ``branding`` keys (e.g.
     ``logo_wide_url``) are merged into ``feature_payload.branding`` and only
-    overwrite existing values when not ``None``. Returns the freshly resolved
-    entitlement state for verification.
+    overwrite existing values when not ``None``. ``home_url`` is stored at
+    the top level of ``feature_payload`` (not under branding) so it can drive
+    root-path redirects independently of ``branding_enabled``. Returns the
+    freshly resolved entitlement state for verification.
     """
 
     normalized_creator_bid = _normalize_bid(creator_bid)
@@ -165,6 +168,13 @@ def grant_creator_manual_entitlement(
             {key: value for key, value in branding.items() if value is not None}
         )
         payload["branding"] = merged_branding
+        row.feature_payload = payload
+    if home_url is not None:
+        payload = dict(row.feature_payload or {})
+        if home_url.strip():
+            payload["home_url"] = home_url.strip()
+        else:
+            payload.pop("home_url", None)
         row.feature_payload = payload
 
     if commit:

--- a/src/api/flaskr/service/billing/runtime_config.py
+++ b/src/api/flaskr/service/billing/runtime_config.py
@@ -137,6 +137,6 @@ def _build_branding_payload(
         logo_wide_url=pick("logo_wide_url", "logoWideUrl"),
         logo_square_url=pick("logo_square_url", "logoSquareUrl"),
         favicon_url=pick("favicon_url", "faviconUrl"),
-        home_url=pick("home_url", "homeUrl") or home_url_from_feature,
+        home_url=pick("home_url", "homeUrl"),
         contact_us_url=pick("contact_us_url", "contactUsUrl"),
     )

--- a/src/api/flaskr/service/billing/runtime_config.py
+++ b/src/api/flaskr/service/billing/runtime_config.py
@@ -101,6 +101,23 @@ def _build_branding_payload(
     entitlement_state,
 ) -> RuntimeBillingBrandingDTO:
     normalized_feature_payload = entitlement_state.feature_payload.to_metadata_json()
+
+    def _pick_feature_str(key: str) -> str | None:
+        value = normalized_feature_payload.get(key)
+        normalized_value = str(value or "").strip()
+        return normalized_value or None
+
+    home_url_from_feature = _pick_feature_str("home_url")
+
+    if not bool(entitlement_state.branding_enabled):
+        return RuntimeBillingBrandingDTO(
+            logo_wide_url=None,
+            logo_square_url=None,
+            favicon_url=None,
+            home_url=home_url_from_feature,
+            contact_us_url=None,
+        )
+
     branding_payload = normalized_feature_payload.get("branding")
     normalized_branding_payload = (
         branding_payload if isinstance(branding_payload, dict) else {}
@@ -116,19 +133,10 @@ def _build_branding_payload(
                 return normalized_value
         return None
 
-    if not bool(entitlement_state.branding_enabled):
-        return RuntimeBillingBrandingDTO(
-            logo_wide_url=None,
-            logo_square_url=None,
-            favicon_url=None,
-            home_url=None,
-            contact_us_url=None,
-        )
-
     return RuntimeBillingBrandingDTO(
         logo_wide_url=pick("logo_wide_url", "logoWideUrl"),
         logo_square_url=pick("logo_square_url", "logoSquareUrl"),
         favicon_url=pick("favicon_url", "faviconUrl"),
-        home_url=pick("home_url", "homeUrl"),
+        home_url=pick("home_url", "homeUrl") or home_url_from_feature,
         contact_us_url=pick("contact_us_url", "contactUsUrl"),
     )

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -12,8 +12,23 @@ export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
 
   const pathname = window.location.pathname || '/';
   const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/+$/, '');
-  const shouldRedirect = normalizedPath === '/' || normalizedPath === '/c';
 
+  const normalizedHome = homeUrl.replace(/\/+$/, '');
+  if (normalizedHome === '' || normalizedHome === '/c') {
+    return false;
+  }
+
+  if (
+    normalizedHome ===
+    (window.location.origin + (pathname === '/' ? '' : pathname)).replace(
+      /\/+$/,
+      '',
+    )
+  ) {
+    return false;
+  }
+
+  const shouldRedirect = normalizedPath === '/' || normalizedPath === '/c';
   if (shouldRedirect) {
     window.location.replace(homeUrl);
     return true;

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -12,27 +12,28 @@ export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
 
   const pathname = window.location.pathname || '/';
   const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/+$/, '');
-
-  const normalizedHome = homeUrl.replace(/\/+$/, '');
-  if (normalizedHome === '' || normalizedHome === '/c') {
-    return false;
-  }
-
-  if (
-    normalizedHome ===
-    (window.location.origin + (pathname === '/' ? '' : pathname)).replace(
-      /\/+$/,
-      '',
-    )
-  ) {
-    return false;
-  }
-
   const shouldRedirect = normalizedPath === '/' || normalizedPath === '/c';
-  if (shouldRedirect) {
-    window.location.replace(homeUrl);
-    return true;
+  if (!shouldRedirect) {
+    return false;
   }
 
-  return false;
+  try {
+    const currentUrl = new URL(window.location.href);
+    const targetUrl = new URL(homeUrl, window.location.href);
+
+    const currentPath = currentUrl.pathname.replace(/\/+$/, '') || '/';
+    const targetPath = targetUrl.pathname.replace(/\/+$/, '') || '/';
+
+    if (
+      currentUrl.origin === targetUrl.origin &&
+      (targetPath === '/' || targetPath === '/c' || currentPath === targetPath)
+    ) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  window.location.replace(homeUrl);
+  return true;
 };


### PR DESCRIPTION
## Summary

Fixes the infinite loop when accessing a custom domain at root path, and adds configurable redirect via `bill_entitlements.feature_payload.home_url`.

## Root Cause

When `homeUrl` defaults to `"/"` (no HOME_URL config, no entitlement branding), `redirectToHomeUrlIfRootPath` redirects `/` to `/`, causing an infinite loop.

## Changes

### Frontend (1 file)
- **`src/cook-web/src/lib/utils.ts`**: Skip same-origin redirects in `redirectToHomeUrlIfRootPath` — return false when `homeUrl` resolves to `"/"` or `"/c"`, or matches the current page URL exactly.

### Backend (2 files)
- **`src/api/flaskr/service/billing/runtime_config.py`**: `_build_branding_payload` now reads `home_url` from `feature_payload.home_url` at the top level regardless of `branding_enabled`, so custom domain redirects work independently of branding.
- **`src/api/flaskr/service/billing/entitlements.py`**: `grant_creator_manual_entitlement` accepts optional `home_url` parameter and persists it to `feature_payload.home_url`.

## Behavior

| Scenario | Result |
|----------|--------|
| `feature_payload.home_url` set (e.g. `https://my-site.com`) | Redirect `/` → target URL |
| No `home_url` configured | Stay on `/` page (no more infinite loop) |
| Ingress-level redirect (e.g. `app.ai-shifu.cn`) | Unaffected (nginx handles it first) |
| Non-entitlement domains | Unaffected |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable Home URL, stored independently of branding so redirect behavior remains consistent even when branding is disabled.

* **Bug Fixes**
  * Improved redirect handling to prevent unnecessary/duplicate redirects and to safely handle URL parsing.
  * Home URLs are now normalized more reliably (e.g., trimming trailing slashes and ignoring empty values).

* **Refactor**
  * Updated billing branding configuration handling to consistently preserve and use Home URL data across entitlement states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->