### PR TITLE
fix: serialize learn timestamps as UTC

### DIFF
--- a/src/api/flaskr/service/learn/lesson_feedback.py
+++ b/src/api/flaskr/service/learn/lesson_feedback.py
@@ -17,6 +17,7 @@ from flaskr.service.learn.models import (
 from flaskr.service.order.consts import LEARN_STATUS_RESET
 from flaskr.service.shifu.consts import BLOCK_TYPE_MDINTERACTION_VALUE
 from flaskr.util import generate_id
+from flaskr.util.datetime import to_utc_iso
 
 _FEEDBACK_COMMENT_MAX_LENGTH = 1000
 _VALID_MODES = {"read", "listen"}
@@ -258,12 +259,8 @@ def list_lesson_feedbacks(
                     "score": row.score,
                     "comment": row.comment,
                     "mode": row.mode,
-                    "created_at": row.created_at.strftime("%Y-%m-%d %H:%M:%S")
-                    if row.created_at
-                    else "",
-                    "updated_at": row.updated_at.strftime("%Y-%m-%d %H:%M:%S")
-                    if row.updated_at
-                    else "",
+                    "created_at": to_utc_iso(row.created_at),
+                    "updated_at": to_utc_iso(row.updated_at),
                 }
                 for row in rows
             ],

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -4,6 +4,7 @@ import queue
 import threading
 import time
 import traceback
+from datetime import datetime
 from typing import Any, Generator, Optional
 
 from flask import Flask
@@ -35,7 +36,6 @@ from flaskr.service.order.models import Order
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 from flaskr.service.learn.listen_elements import ListenElementRunAdapter
-import datetime
 from flaskr.common.log import thread_local as log_thread_local
 from flaskr.service.learn.exceptions import BreakException
 from flaskr.i18n import get_current_language, set_language
@@ -43,6 +43,7 @@ from flaskr.common.shifu_context import (
     get_shifu_context_snapshot,
     apply_shifu_context_snapshot,
 )
+from flaskr.util.datetime import to_utc_iso
 
 RUN_SCRIPT_TIMEOUT_SECONDS = 5 * 60
 RUN_SCRIPT_STATUS_REFRESH_SECONDS = 30
@@ -426,10 +427,9 @@ def run_script_inner(
 
 
 def fmt(o):
-    if isinstance(o, datetime.datetime):
-        return o.isoformat()
-    else:
-        return o.__json__()
+    if isinstance(o, datetime):
+        return to_utc_iso(o)
+    return o.__json__()
 
 
 def _to_sse_chunk(payload: object) -> str:

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -139,12 +139,8 @@ class LessonFeedbackTests(unittest.TestCase):
         )
 
         self.assertEqual(result["total"], 1)
-        self.assertEqual(
-            result["items"][0]["created_at"], "2026-06-30T11:57:03Z"
-        )
-        self.assertEqual(
-            result["items"][0]["updated_at"], "2026-06-30T12:08:09Z"
-        )
+        self.assertEqual(result["items"][0]["created_at"], "2026-06-30T11:57:03Z")
+        self.assertEqual(result["items"][0]["updated_at"], "2026-06-30T12:08:09Z")
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -1,11 +1,13 @@
 import json
 import unittest
+from datetime import datetime
 
 from flask import Flask
 import flaskr.dao as dao
 
 from flaskr.service.learn.lesson_feedback import (
     build_lesson_feedback_interaction_md,
+    list_lesson_feedbacks,
     submit_lesson_feedback,
 )
 from flaskr.service.learn.models import (
@@ -110,6 +112,39 @@ class LessonFeedbackTests(unittest.TestCase):
         synced_generated_content = json.loads(synced_block.generated_content)
         self.assertEqual(synced_generated_content.get("score"), 3)
         self.assertEqual(synced_generated_content.get("comment"), "Need more examples")
+
+    def test_list_feedback_serializes_timestamps_as_utc_iso_z(self):
+        feedback = LearnLessonFeedback(
+            bid="feedback-1",
+            lesson_feedback_bid="feedback-1",
+            shifu_bid="shifu-1",
+            outline_item_bid="outline-1",
+            progress_record_bid="progress-1",
+            user_bid="user-1",
+            score=4,
+            comment="Useful",
+            mode="read",
+            deleted=0,
+            created_at=datetime(2026, 6, 30, 11, 57, 3),
+            updated_at=datetime(2026, 6, 30, 12, 8, 9),
+        )
+        dao.db.session.add(feedback)
+        dao.db.session.commit()
+
+        result = list_lesson_feedbacks(
+            self.app,
+            shifu_bid="shifu-1",
+            page_index=1,
+            page_size=20,
+        )
+
+        self.assertEqual(result["total"], 1)
+        self.assertEqual(
+            result["items"][0]["created_at"], "2026-06-30T11:57:03Z"
+        )
+        self.assertEqual(
+            result["items"][0]["updated_at"], "2026-06-30T12:08:09Z"
+        )
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -121,7 +121,11 @@ def _make_test_app() -> Flask:
 
 def test_sse_chunk_serializes_datetime_as_utc_iso_z():
     chunk = runscript_v2._to_sse_chunk(
-        {"created_at": datetime(2026, 6, 30, 19, 57, 3, tzinfo=timezone(timedelta(hours=8)))}
+        {
+            "created_at": datetime(
+                2026, 6, 30, 19, 57, 3, tzinfo=timezone(timedelta(hours=8))
+            )
+        }
     )
 
     events = _parse_sse_events([chunk])

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -116,6 +117,16 @@ def _make_test_app() -> Flask:
     app.config["REDIS_KEY_PREFIX"] = "test"
     app.config["SSE_HEARTBEAT_INTERVAL"] = 0
     return app
+
+
+def test_sse_chunk_serializes_datetime_as_utc_iso_z():
+    chunk = runscript_v2._to_sse_chunk(
+        {"created_at": datetime(2026, 6, 30, 19, 57, 3, tzinfo=timezone(timedelta(hours=8)))}
+    )
+
+    events = _parse_sse_events([chunk])
+
+    assert events == [{"created_at": "2026-06-30T11:57:03Z"}]
 
 
 def _patch_fake_element_adapter(monkeypatch):


### PR DESCRIPTION
Summary
- Serialize lesson feedback list `created_at` and `updated_at` values with UTC ISO `Z` output.
- Align runscript SSE datetime JSON serialization with the shared UTC timestamp helper.
- Add focused learn tests for lesson feedback timestamp output and SSE datetime conversion.

Why
- Learn payloads still had two legacy read-side timestamp paths that emitted ambiguous local or offsetless datetime strings.
- This keeps the backend read contract aligned with the UTC `Z` rule introduced by the admin timezone cleanup series.

Validation
- `python scripts/check_dev_tools.py` (fails locally: missing lefthook/commitizen/pre-commit-hooks tooling; no frontend changes)
- `cd src/api && python3 -m ruff check flaskr/service/learn/lesson_feedback.py flaskr/service/learn/runscript_v2.py tests/service/learn/test_lesson_feedback.py tests/service/learn/test_runscript_v2_lock.py`
- `cd src/api && python3 -m compileall flaskr/service/learn/lesson_feedback.py flaskr/service/learn/runscript_v2.py`
- `cd src/api && pytest tests/service/learn/test_lesson_feedback.py tests/service/learn/test_runscript_v2_lock.py -q`
- `cd src/api && pytest tests/service/learn/ -q -k 'not transform_expands_interaction_without_adjacent_users'`

Notes
- The deselected learn test depends on a local `markdown-flow` private helper that is not present in this environment and is unrelated to this timestamp change.
- Existing `server_default=func.now()` defaults in `learn/models.py` are not changed in this PR; they are tracked separately as residual DB-default cleanup risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date and time values in lesson feedback and run-script responses are now consistently returned in UTC ISO-8601 format with a `Z` suffix.
  * Timestamps from different time zones are normalized before being sent to the client, improving consistency across views and streamed updates.

* **Tests**
  * Added coverage for UTC timestamp serialization in lesson feedback listings.
  * Added coverage for datetime conversion in streamed run-script output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->