### PR TITLE
fix: convert admin date filters to UTC bounds

### DIFF
--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Flask, request
 from flaskr.service.common.models import raise_param_error, raise_error
@@ -64,6 +64,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         for datetime_format in (
             "%Y-%m-%d",
             "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M",
             "%Y-%m-%dT%H:%M:%S",
         ):
             try:
@@ -76,7 +77,13 @@ def register_order_handler(app: Flask, path_prefix: str):
                 return parsed
             except ValueError:
                 continue
-        raise_param_error(field_name)
+        try:
+            parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        except ValueError:
+            raise_param_error(field_name)
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
 
     def _parse_admin_pagination():
         page_index = request.args.get("page_index", 1)

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from collections import defaultdict
 import hashlib
@@ -220,6 +220,13 @@ def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
             return parsed
         except ValueError:
             continue
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
     return None
 
 

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Flask, request
 from pydantic import ValidationError
@@ -153,7 +153,13 @@ def _parse_datetime_filter(
             return parsed
         except ValueError:
             continue
-    raise_param_error(field_name)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        raise_param_error(field_name)
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed
 
 
 def _normalize_query_text(raw_value: object) -> str:

--- a/src/api/tests/service/order/test_admin_datetime_filters.py
+++ b/src/api/tests/service/order/test_admin_datetime_filters.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from flaskr.service.order.admin import _parse_datetime
+
+
+def test_parse_admin_order_datetime_normalizes_utc_z_values():
+    assert _parse_datetime("2026-07-01T16:00:00Z") == datetime(2026, 7, 1, 16, 0, 0)
+
+
+def test_parse_admin_order_datetime_normalizes_offset_values_to_utc():
+    assert _parse_datetime("2026-07-02T00:00:00+08:00") == datetime(
+        2026, 7, 1, 16, 0, 0
+    )
+
+
+def test_parse_admin_order_datetime_keeps_legacy_date_only_bounds():
+    assert _parse_datetime("2026-07-02") == datetime(2026, 7, 2, 0, 0, 0)
+    assert _parse_datetime("2026-07-02", is_end=True) == datetime(
+        2026, 7, 2, 23, 59, 59
+    )

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -635,6 +635,49 @@ def test_creator_redemption_code_list_shows_only_owned_course_batches(
     assert all_payload["data"]["items"][0]["ops_states"] == []
 
 
+def test_creator_redemption_code_list_accepts_utc_date_filter_bounds(
+    app, test_client, monkeypatch
+):
+    _mock_creator(monkeypatch, user_id="creator-1")
+    captured_filters = {}
+
+    def fake_list(_app, creator_user_bid, page_index, page_size, filters):
+        captured_filters.update(filters)
+        assert creator_user_bid == "creator-1"
+        assert page_index == 1
+        assert page_size == 20
+        return {
+            "summary": {},
+            "items": [],
+            "page": page_index,
+            "page_size": page_size,
+            "page_count": 0,
+            "total": 0,
+        }
+
+    monkeypatch.setattr(
+        "flaskr.route.order.list_creator_course_redemption_coupons",
+        fake_list,
+    )
+
+    response = test_client.get(
+        "/api/order/admin/orders/redemption-codes",
+        query_string={
+            "page_index": 1,
+            "page_size": 20,
+            "start_time": "2026-07-01T16:00:00Z",
+            "end_time": "2026-07-02T15:59:59Z",
+        },
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] == 0
+    assert captured_filters["start_time"] == datetime(2026, 7, 1, 16, 0, 0)
+    assert captured_filters["end_time"] == datetime(2026, 7, 2, 15, 59, 59)
+
+
 def test_creator_redemption_code_usage_route_requires_owned_course_coupon(
     app, test_client, monkeypatch
 ):

--- a/src/api/tests/service/shifu/test_admin_operation_datetime_filters.py
+++ b/src/api/tests/service/shifu/test_admin_operation_datetime_filters.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from flaskr.service.shifu.admin_operations.route import _parse_datetime_filter
+
+
+def test_parse_datetime_filter_normalizes_utc_z_values():
+    assert _parse_datetime_filter(
+        "2026-07-01T16:00:00Z",
+        field_name="start_time",
+    ) == datetime(2026, 7, 1, 16, 0, 0)
+
+
+def test_parse_datetime_filter_normalizes_offset_values_to_utc():
+    assert _parse_datetime_filter(
+        "2026-07-02T00:00:00+08:00",
+        field_name="start_time",
+    ) == datetime(2026, 7, 1, 16, 0, 0)
+
+
+def test_parse_datetime_filter_keeps_legacy_date_only_bounds():
+    assert _parse_datetime_filter(
+        "2026-07-02",
+        field_name="start_time",
+    ) == datetime(2026, 7, 2, 0, 0, 0)
+    assert _parse_datetime_filter(
+        "2026-07-02",
+        field_name="end_time",
+        is_end=True,
+    ) == datetime(2026, 7, 2, 23, 59, 59)

--- a/src/cook-web/src/app/admin/lib/dateTime.ts
+++ b/src/cook-web/src/app/admin/lib/dateTime.ts
@@ -1,4 +1,6 @@
 export {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
   formatAdminNaiveDateTime,
   formatAdminUtcDateTime,
   parseAdminNaiveDateTime,

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/lib/admin-date-time';
 import { toast } from '@/hooks/useToast';
 import AdminOperationCreditNotificationsPage from './page';
 
@@ -103,6 +107,24 @@ jest.mock('@/components/ErrorDisplay', () => ({
   __esModule: true,
   default: ({ errorMessage }: { errorMessage: string }) => (
     <div>{errorMessage}</div>
+  ),
+}));
+jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    onChange,
+  }: {
+    placeholder: string;
+    onChange: (range: { start: string; end: string }) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid={`date-range-${placeholder}`}
+      onClick={() => onChange({ start: '2026-07-02', end: '2026-07-02' })}
+    >
+      {placeholder}
+    </button>
   ),
 }));
 
@@ -633,6 +655,11 @@ describe('AdminOperationCreditNotificationsPage', () => {
       ),
       { target: { value: '13800138000' } },
     );
+    fireEvent.click(
+      screen.getByTestId(
+        'date-range-module.operationsCreditNotifications.filters.timeRangePlaceholder',
+      ),
+    );
     expect(mockGetRecords).toHaveBeenCalledTimes(1);
 
     fireEvent.click(
@@ -648,6 +675,8 @@ describe('AdminOperationCreditNotificationsPage', () => {
       expect.objectContaining({
         creator_keyword: '13800138000',
         page_index: 1,
+        start_time: formatAdminDateRangeStartUtc('2026-07-02'),
+        end_time: formatAdminDateRangeEndUtc('2026-07-02'),
       }),
     );
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.tsx
@@ -5,6 +5,10 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
 import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import Loading from '@/components/loading';
@@ -274,8 +278,8 @@ export default function AdminOperationCreditNotificationsPage() {
               ? nextFilters.skip_reason.trim()
               : '',
           source_type: nextFilters.source_type.trim(),
-          start_time: nextFilters.start_time.trim(),
-          end_time: nextFilters.end_time.trim(),
+          start_time: formatAdminDateRangeStartUtc(nextFilters.start_time),
+          end_time: formatAdminDateRangeEndUtc(nextFilters.end_time),
         })) as AdminOperationCreditNotificationListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/lib/admin-date-time';
 import CreditOrdersTab from './CreditOrdersTab';
 
 const translationCache = new Map<
@@ -173,8 +177,20 @@ jest.mock('@/components/ui/Select', () => {
 
 jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
   __esModule: true,
-  default: ({ placeholder }: { placeholder: string }) => (
-    <div>{placeholder}</div>
+  default: ({
+    placeholder,
+    onChange,
+  }: {
+    placeholder: string;
+    onChange: (range: { start: string; end: string }) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid={`date-range-${placeholder}`}
+      onClick={() => onChange({ start: '2026-07-02', end: '2026-07-02' })}
+    >
+      {placeholder}
+    </button>
   ),
 }));
 
@@ -605,6 +621,11 @@ describe('CreditOrdersTab', () => {
         target: { value: 'creator-topup-small' },
       },
     );
+    fireEvent.click(
+      screen.getByTestId(
+        'date-range-module.operationsOrder.filters.timeRangePlaceholder',
+      ),
+    );
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -618,6 +639,8 @@ describe('CreditOrdersTab', () => {
           creator_keyword: '13800138000',
           product_keyword: 'creator-topup-small',
           status: 'paid',
+          start_time: formatAdminDateRangeStartUtc('2026-07-02'),
+          end_time: formatAdminDateRangeEndUtc('2026-07-02'),
         }),
       );
     });

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -10,6 +10,10 @@ import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
+import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
   getAdminStickyRightCellClass,
@@ -270,8 +274,8 @@ export default function CreditOrdersTab() {
             ? { has_available_credits: true }
             : {}),
           payment_provider: filters.payment_provider,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         })) as AdminOperationCreditOrderListResponse;
 
         if (requestId !== requestIdRef.current) {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/lib/admin-date-time';
 import LearnOrdersTab from './LearnOrdersTab';
 
 let mockSearchParamsValue = '';
@@ -144,8 +148,20 @@ jest.mock('@/components/ui/Select', () => {
 
 jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
   __esModule: true,
-  default: ({ placeholder }: { placeholder: string }) => (
-    <div>{placeholder}</div>
+  default: ({
+    placeholder,
+    onChange,
+  }: {
+    placeholder: string;
+    onChange: (range: { start: string; end: string }) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid={`date-range-${placeholder}`}
+      onClick={() => onChange({ start: '2026-07-02', end: '2026-07-02' })}
+    >
+      {placeholder}
+    </button>
   ),
 }));
 
@@ -383,6 +399,11 @@ describe('LearnOrdersTab', () => {
         target: { value: 'order-1' },
       },
     );
+    fireEvent.click(
+      screen.getByTestId(
+        'date-range-module.operationsOrder.filters.timeRangePlaceholder',
+      ),
+    );
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -395,6 +416,8 @@ describe('LearnOrdersTab', () => {
         expect.objectContaining({
           user_keyword: '13800138000',
           order_bid: 'order-1',
+          start_time: formatAdminDateRangeStartUtc('2026-07-02'),
+          end_time: formatAdminDateRangeEndUtc('2026-07-02'),
         }),
       );
     });

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -11,6 +11,10 @@ import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
+import {
   formatAdminCount,
   formatAdminNumber,
 } from '@/app/admin/lib/numberFormat';
@@ -296,8 +300,8 @@ export default function LearnOrdersTab() {
           status: filters.status,
           order_source: filters.order_source,
           payment_channel: filters.payment_channel,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         })) as AdminOperationOrderListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/page.test.tsx
@@ -21,6 +21,8 @@ const originalWindow = global.window;
 const RETRY_LABEL = 'retry';
 const MOCK_DIALOG_CLOSE_LABEL = 'mock-dialog-close';
 const mockBrowserTimeZone = jest.fn(() => 'UTC');
+const formatUtcBoundary = (date: Date) =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z');
 const LONG_COURSE_PROMPT =
   'You are a patient course assistant. Help learners build understanding step by step, summarize key ideas clearly, and always connect each answer back to the course context.';
 let mockLanguage = 'en-US';
@@ -1326,6 +1328,12 @@ describe('OperationsPage', () => {
     try {
       await renderAndWaitForLoadedPage();
 
+      const expectedEndDate = new Date();
+      const expectedStartDate = new Date(expectedEndDate);
+      expectedStartDate.setDate(expectedEndDate.getDate() - 6);
+      expectedStartDate.setHours(0, 0, 0, 0);
+      expectedEndDate.setHours(23, 59, 59, 0);
+
       fireEvent.click(
         screen.getByRole('button', {
           name: /module\.operationsCourse\.overview\.metrics\.createdLast7d/i,
@@ -1336,8 +1344,8 @@ describe('OperationsPage', () => {
         expect(mockGetAdminOperationCourses).toHaveBeenLastCalledWith(
           expect.objectContaining({
             quick_filter: 'created_last_7d',
-            start_time: '2026-04-30',
-            end_time: '2026-05-06',
+            start_time: formatUtcBoundary(expectedStartDate),
+            end_time: formatUtcBoundary(expectedEndDate),
           }),
         );
       });

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -15,7 +15,11 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import { ADMIN_TABLE_RESIZE_HANDLE_CLASS } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -395,10 +399,14 @@ const OperationsPage = () => {
           creator_keyword: resolvedFilters.creator_keyword.trim(),
           course_status: resolvedFilters.course_status,
           quick_filter: resolvedQuickFilter,
-          start_time: resolvedFilters.start_time,
-          end_time: resolvedFilters.end_time,
-          updated_start_time: resolvedFilters.updated_start_time,
-          updated_end_time: resolvedFilters.updated_end_time,
+          start_time: formatAdminDateRangeStartUtc(resolvedFilters.start_time),
+          end_time: formatAdminDateRangeEndUtc(resolvedFilters.end_time),
+          updated_start_time: formatAdminDateRangeStartUtc(
+            resolvedFilters.updated_start_time,
+          ),
+          updated_end_time: formatAdminDateRangeEndUtc(
+            resolvedFilters.updated_end_time,
+          ),
         })) as AdminOperationCourseListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/promotions/ReferralCampaignRecordsDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/ReferralCampaignRecordsDialog.tsx
@@ -7,7 +7,11 @@ import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import ReferralRelationsPanel, {
   formatReferralText,
   REFERRAL_PAGE_SIZE,
@@ -219,6 +223,14 @@ function ReferralCampaignInvitationsPanel({
         };
         Object.entries(appliedFilters).forEach(([key, value]) => {
           if (value) {
+            if (key === 'start_time') {
+              params[key] = formatAdminDateRangeStartUtc(value);
+              return;
+            }
+            if (key === 'end_time') {
+              params[key] = formatAdminDateRangeEndUtc(value);
+              return;
+            }
             params[key] = value;
           }
         });

--- a/src/cook-web/src/app/admin/operations/promotions/page.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.tsx
@@ -11,7 +11,11 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import { ADMIN_TABLE_RESIZE_HANDLE_CLASS } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import type {
@@ -319,8 +323,8 @@ export default function AdminOperationPromotionsPage() {
           ops_state: filters.ops_state,
           discount_type: filters.discount_type,
           status: filters.status,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         };
         let response = (await api.getAdminOperationPromotionCoupons(
           requestPayload,
@@ -370,8 +374,8 @@ export default function AdminOperationPromotionsPage() {
           channel: filters.channel.trim(),
           discount_type: filters.discount_type,
           status: filters.status,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         };
         let response = (await api.getAdminOperationPromotionCampaigns(
           requestPayload,
@@ -427,8 +431,8 @@ export default function AdminOperationPromotionsPage() {
           product_type: filters.product_type,
           benefit_type: filters.benefit_type,
           status: filters.status,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         };
         let response = (await api.getAdminBillingCampaigns(requestPayload)) as {
           items: AdminBillingCampaignItem[];
@@ -476,8 +480,8 @@ export default function AdminOperationPromotionsPage() {
           page_size: PAGE_SIZE,
           keyword: filters.keyword.trim(),
           status: filters.status,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         };
         let response = (await api.getAdminOperationPromotionReferralCampaigns(
           requestPayload,

--- a/src/cook-web/src/app/admin/operations/referrals/ReferralRelationsPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/referrals/ReferralRelationsPanel.tsx
@@ -7,7 +7,11 @@ import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import {
   Select,
   SelectContent,
@@ -216,6 +220,14 @@ export default function ReferralRelationsPanel({
           return;
         }
         if (value) {
+          if (key === 'start_time') {
+            params[key] = formatAdminDateRangeStartUtc(value);
+            return;
+          }
+          if (key === 'end_time') {
+            params[key] = formatAdminDateRangeEndUtc(value);
+            return;
+          }
           params[key] = value;
         }
       });

--- a/src/cook-web/src/app/admin/operations/users/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.test.tsx
@@ -18,6 +18,8 @@ const mockGrantDialogPrefix = 'grant-dialog-';
 const mockGrantSuccessLabel = 'mock-grant-success';
 const buildGrantDialogLabel = (userBid: string) =>
   `${mockGrantDialogPrefix}${userBid}`;
+const formatUtcBoundary = (date: Date) =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z');
 let mockLanguage = 'en-US';
 const translationCache = new Map<
   string,
@@ -904,6 +906,12 @@ describe('AdminOperationUsersPage', () => {
     try {
       await renderResolvedPage();
 
+      const expectedEndDate = new Date();
+      const expectedStartDate = new Date(expectedEndDate);
+      expectedStartDate.setDate(expectedEndDate.getDate() - 29);
+      expectedStartDate.setHours(0, 0, 0, 0);
+      expectedEndDate.setHours(23, 59, 59, 0);
+
       fireEvent.click(
         screen.getByRole('button', {
           name: /module\.operationsUser\.overview\.metrics\.newUsers30d/i,
@@ -914,8 +922,8 @@ describe('AdminOperationUsersPage', () => {
         expect(mockGetAdminOperationUsers).toHaveBeenLastCalledWith(
           expect.objectContaining({
             quick_filter: 'created_last_30d',
-            start_time: '2026-04-07',
-            end_time: '2026-05-06',
+            start_time: formatUtcBoundary(expectedStartDate),
+            end_time: formatUtcBoundary(expectedEndDate),
           }),
         );
       });

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -26,6 +26,10 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -536,8 +540,8 @@ export default function AdminOperationUsersPage() {
           user_status: filters.user_status,
           user_role: filters.user_role,
           quick_filter: resolvedQuickFilter,
-          start_time: filters.start_time,
-          end_time: filters.end_time,
+          start_time: formatAdminDateRangeStartUtc(filters.start_time),
+          end_time: formatAdminDateRangeEndUtc(filters.end_time),
         })) as AdminOperationUserListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/voice-clones/page.tsx
+++ b/src/cook-web/src/app/admin/operations/voice-clones/page.tsx
@@ -9,7 +9,11 @@ import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
-import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+  formatAdminUtcDateTime,
+} from '@/app/admin/lib/dateTime';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import {
   getAdminStickyRightCellClass,
@@ -151,6 +155,14 @@ export default function AdminOperationVoiceClonesPage() {
     Object.entries(appliedFilters).forEach(([key, value]) => {
       const normalized = value.trim();
       if (normalized) {
+        if (key === 'start_time') {
+          params[key] = formatAdminDateRangeStartUtc(normalized);
+          return;
+        }
+        if (key === 'end_time') {
+          params[key] = formatAdminDateRangeEndUtc(normalized);
+          return;
+        }
         params[key] = normalized;
       }
     });

--- a/src/cook-web/src/app/admin/orders/page.test.tsx
+++ b/src/cook-web/src/app/admin/orders/page.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/lib/admin-date-time';
 
 import OrdersPage from './page';
 
@@ -82,6 +86,24 @@ jest.mock('@/components/ErrorDisplay', () => ({
 jest.mock('@/components/loading', () => ({
   __esModule: true,
   default: () => <div data-testid='loading-indicator' />,
+}));
+jest.mock('@/app/admin/components/AdminDateRangeFilter', () => ({
+  __esModule: true,
+  default: ({
+    placeholder,
+    onChange,
+  }: {
+    placeholder: string;
+    onChange: (range: { start: string; end: string }) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid={`date-range-${placeholder}`}
+      onClick={() => onChange({ start: '2026-07-02', end: '2026-07-02' })}
+    >
+      {placeholder}
+    </button>
+  ),
 }));
 
 const mockGetAdminOrders = api.getAdminOrders as jest.Mock;
@@ -190,6 +212,40 @@ describe('OrdersPage', () => {
           page_size: 20,
           shifu_bid: '',
           status: '502',
+        }),
+      );
+    });
+  });
+
+  test('converts date filters to UTC bounds when searching orders', async () => {
+    render(<OrdersPage />);
+
+    await waitFor(() => {
+      expect(mockGetAdminOrders).toHaveBeenCalled();
+    });
+
+    mockGetAdminOrders.mockClear();
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.expand',
+      }),
+    );
+    fireEvent.click(
+      screen.getByTestId(
+        'date-range-module.order.filters.dateRangePlaceholder',
+      ),
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.order.filters.search',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetAdminOrders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          start_time: formatAdminDateRangeStartUtc('2026-07-02'),
+          end_time: formatAdminDateRangeEndUtc('2026-07-02'),
         }),
       );
     });

--- a/src/cook-web/src/app/admin/orders/page.tsx
+++ b/src/cook-web/src/app/admin/orders/page.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '@/store';
@@ -444,8 +448,8 @@ const OrdersPage = () => {
           shifu_bid: shifuBidValue,
           status: resolvedFilters.status,
           payment_channel: resolvedFilters.payment_channel,
-          start_time: resolvedFilters.start_time,
-          end_time: resolvedFilters.end_time,
+          start_time: formatAdminDateRangeStartUtc(resolvedFilters.start_time),
+          end_time: formatAdminDateRangeEndUtc(resolvedFilters.end_time),
         })) as OrderListResponse;
 
         const list = response.items || [];

--- a/src/cook-web/src/app/admin/orders/useCreatorRedemptionCodesList.ts
+++ b/src/cook-web/src/app/admin/orders/useCreatorRedemptionCodesList.ts
@@ -2,6 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import api from '@/api';
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
 import type {
   AdminPromotionCouponItem,
   AdminPromotionListResponse,
@@ -60,8 +64,8 @@ export const useCreatorRedemptionCodesList = ({
           ops_state: resolvedFilters.ops_state,
           discount_type: resolvedFilters.discount_type,
           status: resolvedFilters.status,
-          start_time: resolvedFilters.start_time,
-          end_time: resolvedFilters.end_time,
+          start_time: formatAdminDateRangeStartUtc(resolvedFilters.start_time),
+          end_time: formatAdminDateRangeEndUtc(resolvedFilters.end_time),
         })) as AdminPromotionListResponse<AdminPromotionCouponItem>;
 
         if (requestId !== fetchRequestIdRef.current) {

--- a/src/cook-web/src/lib/__tests__/admin-date-time.test.ts
+++ b/src/cook-web/src/lib/__tests__/admin-date-time.test.ts
@@ -1,0 +1,26 @@
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/lib/admin-date-time';
+
+const isoWithoutMilliseconds = (date: Date): string =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+describe('admin date range UTC boundary helpers', () => {
+  test('converts browser-local date start to UTC ISO', () => {
+    expect(formatAdminDateRangeStartUtc('2026-07-02')).toBe(
+      isoWithoutMilliseconds(new Date(2026, 6, 2, 0, 0, 0, 0)),
+    );
+  });
+
+  test('converts browser-local date end to UTC ISO', () => {
+    expect(formatAdminDateRangeEndUtc('2026-07-02')).toBe(
+      isoWithoutMilliseconds(new Date(2026, 6, 2, 23, 59, 59, 0)),
+    );
+  });
+
+  test('rejects invalid date-only values', () => {
+    expect(formatAdminDateRangeStartUtc('2026-02-30')).toBe('');
+    expect(formatAdminDateRangeEndUtc('2026-07-02T00:00:00Z')).toBe('');
+  });
+});

--- a/src/cook-web/src/lib/admin-date-time.ts
+++ b/src/cook-web/src/lib/admin-date-time.ts
@@ -62,6 +62,55 @@ export const formatAdminUtcDateTime = (
   return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
 };
 
+const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const formatUtcIsoWithoutMilliseconds = (date: Date): string =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+const parseAdminDateOnly = (value: string | null | undefined): Date | null => {
+  const normalizedValue = String(value || '').trim();
+  const match = normalizedValue.match(DATE_ONLY_RE);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+};
+
+export const formatAdminDateRangeStartUtc = (
+  value: string | null | undefined,
+): string => {
+  const date = parseAdminDateOnly(value);
+  if (!date) {
+    return '';
+  }
+  date.setHours(0, 0, 0, 0);
+  return formatUtcIsoWithoutMilliseconds(date);
+};
+
+export const formatAdminDateRangeEndUtc = (
+  value: string | null | undefined,
+): string => {
+  const date = parseAdminDateOnly(value);
+  if (!date) {
+    return '';
+  }
+  date.setHours(23, 59, 59, 0);
+  return formatUtcIsoWithoutMilliseconds(date);
+};
+
 export type AdminNaiveDateTimeParts = {
   year: string;
   month: string;


### PR DESCRIPTION
Summary
- Convert admin date-only filter values to browser-local day boundaries before sending UTC ISO query values.
- Apply the boundary conversion across operations course/user/order/promotion/referral/credit-notification/voice-clone surfaces and legacy admin orders/redemption-code lists.
- Normalize timezone-qualified admin order/course query params on the backend while preserving legacy date-only compatibility.
- Add frontend and backend regression coverage for date boundary conversion and UTC normalization.

Why
- Admin datetime display now renders UTC values in the browser timezone, but date filters were still sending `YYYY-MM-DD` strings that backend parsers interpreted as UTC wall-clock days.
- Operators expect a selected date to mean their browser-local calendar day, so the request boundary must be converted to UTC before DB comparisons.

Validation
- `cd src/api && python3 -m ruff check flaskr/service/shifu/admin_operations/route.py flaskr/service/order/admin.py tests/service/shifu/test_admin_operation_datetime_filters.py tests/service/order/test_admin_datetime_filters.py`
- `cd src/api && python3 -m compileall flaskr/service/shifu/admin_operations/route.py flaskr/service/order/admin.py`
- `cd src/api && pytest tests/service/shifu/test_admin_operation_datetime_filters.py tests/service/order/test_admin_datetime_filters.py -q`
- `cd src/api && pytest tests/service/promo/test_admin_promotions.py::test_creator_redemption_code_list_accepts_utc_date_filter_bounds tests/service/order/test_admin_datetime_filters.py tests/service/shifu/test_admin_operation_datetime_filters.py -q`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run test -- --runTestsByPath src/lib/__tests__/admin-date-time.test.ts src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.test.tsx src/app/admin/operations/orders/LearnOrdersTab.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx src/app/admin/operations/promotions/page.test.tsx src/app/admin/operations/referrals/page.test.tsx src/app/admin/operations/credit-notifications/page.test.tsx src/app/admin/orders/page.test.tsx src/app/admin/orders/CreatorRedemptionCodesTab.test.tsx --runInBand`

Notes
- `src/api/app.py` has an unrelated local CORS change and is intentionally excluded from this PR.
- Date-only report/stat semantics remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced admin date filters to support UTC date-range formatting, including date-only inputs and ISO-8601 timestamps with time zone offsets (including `Z`).

* **Bug Fixes**
  * Improved consistency across admin lists and reports by normalizing `start_time`/`end_time` to correct UTC boundaries before requests.
  * Fixed timezone handling so offset-aware inputs are interpreted in UTC.

* **Tests**
  * Added coverage for UTC conversion, offset normalization, and legacy date-only start/end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
