### PR TITLE
fix: finish legacy listen TTS for non-speakable blocks

### DIFF
--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1469,10 +1469,17 @@ def stream_generated_block_audio(
                 # from the raw block text instead of failing.
                 cleaned_fallback_text = preprocess_for_tts(raw_text)
                 if not cleaned_fallback_text or len(cleaned_fallback_text.strip()) < 2:
-                    raise_error_with_args(
-                        "server.common.paramsError",
-                        param_message="No speakable text elements available for TTS synthesis",
+                    app.logger.info(
+                        "skip listen-mode TTS for non-speakable generated block | shifu_bid=%s | generated_block_bid=%s | user_bid=%s",
+                        shifu_bid,
+                        generated_block_bid,
+                        user_bid,
                     )
+                    yield _build_tts_done_message(
+                        outline_bid=generated_block.outline_item_bid or "",
+                        generated_block_bid=generated_block_bid,
+                    )
+                    return
 
                 def _generate_legacy_audio():
                     yield from _yield_run_tts_audio_events(

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -599,6 +599,57 @@ class TestGeneratedBlockListenTtsElementFirst:
         assert [event.content.position for event in audio_complete_events] == [0]
         assert events[-1].type == GeneratedType.DONE
 
+    def test_stream_generated_block_audio_listen_finishes_non_speakable_legacy_block(
+        self, monkeypatch
+    ):
+        from flaskr.dao import db
+        from flaskr.service.learn.learn_dtos import GeneratedType
+        from flaskr.service.learn.learn_funcs import stream_generated_block_audio
+
+        user_bid = "user-legacy-non-speakable"
+        shifu_bid = "shifu-legacy-non-speakable"
+        generated_block_bid = "gen-legacy-non-speakable"
+
+        with self.app.app_context():
+            db.session.query(self.LearnGeneratedAudio).delete()
+            db.session.query(self.LearnGeneratedElement).delete()
+            db.session.query(self.LearnGeneratedBlock).delete()
+            db.session.commit()
+
+            db.session.add(
+                self.LearnGeneratedBlock(
+                    generated_block_bid=generated_block_bid,
+                    progress_record_bid="progress-legacy-non-speakable",
+                    user_bid=user_bid,
+                    block_bid="block-legacy-non-speakable",
+                    outline_item_bid="outline-legacy-non-speakable",
+                    shifu_bid=shifu_bid,
+                    type=1,
+                    role=1,
+                    generated_content="<svg><text>visual only</text></svg>",
+                    position=0,
+                    block_content_conf="",
+                    status=1,
+                )
+            )
+            db.session.commit()
+
+        synthesized_texts = _patch_run_tts_processor(monkeypatch)
+
+        events = list(
+            stream_generated_block_audio(
+                self.app,
+                shifu_bid=shifu_bid,
+                generated_block_bid=generated_block_bid,
+                user_bid=user_bid,
+                preview_mode=False,
+                listen=True,
+            )
+        )
+
+        assert synthesized_texts == []
+        assert [event.type for event in events] == [GeneratedType.DONE]
+
     def test_stream_generated_block_audio_preview_listen_falls_back_to_block_tts_without_final_elements(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Source

运维保障群 2026-07-04 20:15~20:41（Asia/Shanghai）多次告警：`/api/learn/shifu/ca3265b045e84774b8d845a4c3c5b0a3/generated-blocks/*/tts` 在 listen 模式下抛出 `Params Error No speakable text elements available for TTS synthesis`。

## Changes

- When listen-mode generated blocks have no final speakable elements and legacy raw block text also preprocesses to no speakable text, emit a `DONE` TTS event instead of raising `AppException`.
- Add regression coverage for non-speakable legacy SVG-only blocks.

## Validation

- `git diff --check`
- `python3 -m compileall -q src/api/flaskr/service/learn/learn_funcs.py src/api/tests/service/learn/test_generated_block_tts_av_mode.py`

Note: local `python3 -m pytest tests/service/learn/test_generated_block_tts_av_mode.py -q` could not run because this host Python does not have `pytest` installed (`No module named pytest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio streaming in listen mode for content that can’t be converted into speech.
  * Instead of failing on non-speakable or too-short fallback content, the stream now ends cleanly with a completion event.
  * Added coverage for legacy generated blocks containing only non-speakable content to ensure no speech synthesis is attempted and the stream completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->