### PR TITLE
fix: normalize residual backend timestamp writes

### DIFF
--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -1,7 +1,6 @@
 #  ilivedata
 #  https://docs.ilivedata.com/textcheck/sync/check/
 
-import datetime
 import base64
 import hmac
 import json
@@ -9,6 +8,8 @@ from hashlib import sha256 as sha256
 from urllib.request import Request, urlopen
 from urllib.error import URLError
 from flask import Flask
+from flaskr.util.datetime import now_utc
+
 from .dto import (
     CheckResultDTO,
     CHECK_RESULT_PASS,
@@ -71,7 +72,7 @@ def ilivedata_check(
             raw_data={},
         )
 
-    now_date = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_date = now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
     params = {"content": text, "userId": user_id, "sessionId": data_id}
     query_body = json.dumps(params)
     parameter = "POST\n"

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -18,6 +18,7 @@ from flaskr.api.langfuse import (
     resolve_langfuse_trace_id,
 )
 from flaskr.service.config import get_config
+from flaskr.util.datetime import now_utc
 from flaskr.service.common.models import raise_error_with_args
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_OUTPUT_TOKENS,
@@ -1117,7 +1118,7 @@ def _attach_credit_multipliers(
 
     try:
         rows = _load_llm_output_rate_rows(app)
-        now = datetime.now()
+        now = now_utc()
         default_provider, default_model_candidates = _resolve_billing_rate_identity(
             default_model
         )

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -14,13 +14,13 @@ The provider can be selected per-Shifu configuration.
 import logging
 import os
 import json
-from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 from flask import has_request_context, request
 
 from flaskr.common.config import get_config
+from flaskr.util.datetime import now_utc
 from flaskr.common.log import AppLoggerProxy
 from flaskr.i18n import get_current_language
 from flaskr.service.billing.consts import (
@@ -401,9 +401,8 @@ def _load_usage_rate_unit_cost(
     normalized_models = [str(model or "").strip() for model in model_candidates]
     if not normalized_models:
         normalized_models = [""]
-    # Match the UTC settlement window used by billing rate selection
-    # (billing/charges.py defaults settlement_at to datetime.utcnow()).
-    settlement_at = datetime.utcnow()
+    # Match the UTC settlement window used by billing rate selection.
+    settlement_at = now_utc()
     for model in normalized_models:
         rate = load_usage_rate(
             usage=BillUsageRecord(

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -28,6 +28,8 @@ from .consts import (
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from .models import CreditUsageRate
+from flaskr.util.datetime import now_utc
+
 from .primitives import (
     credit_decimal_to_number,
     decimal_to_number,
@@ -322,7 +324,7 @@ def resolve_credit_multiplier_label(
     if not metrics:
         return None
 
-    at = settlement_at or datetime.utcnow()
+    at = settlement_at or now_utc()
     usage = BillUsageRecord(
         usage_type=int(usage_type),
         provider=str(provider or "").strip(),

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, case, false, or_
 from sqlalchemy.orm import aliased
 
 from flaskr.dao import db
+from flaskr.util.datetime import now_utc
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.dashboard.dtos import (
     DashboardCourseDetailBasicInfoDTO,
@@ -2676,7 +2677,7 @@ def build_dashboard_course_detail(
                 LearnProgressRecord.shifu_bid == normalized_shifu_bid,
                 LearnProgressRecord.deleted == 0,
                 LearnProgressRecord.status != LEARN_STATUS_RESET,
-                LearnProgressRecord.updated_at >= datetime.utcnow() - timedelta(days=7),
+                LearnProgressRecord.updated_at >= now_utc() - timedelta(days=7),
             )
             .scalar()
             or 0
@@ -2716,7 +2717,7 @@ def build_dashboard_course_detail(
         new_learner_count_last_7_days = sum(
             1
             for joined_at in joined_at_map.values()
-            if joined_at >= datetime.utcnow() - timedelta(days=7)
+            if joined_at >= now_utc() - timedelta(days=7)
         )
         learning_learner_count = sum(
             1

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 from flask import Flask
 
 from flaskr.common.public_urls import build_stripe_learner_result_url
+from flaskr.util.datetime import now_utc
 from flaskr.service.config import get_config
 from flaskr.common.swagger import register_schema_to_swagger
 from flaskr.i18n import _
@@ -1816,7 +1817,7 @@ def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
                 if not pingxx_order:
                     lock.release()
                     return None
-                pingxx_order.update = datetime.datetime.now()
+                pingxx_order.update = now_utc()
                 pingxx_order.status = 1
                 pingxx_order.charge_object = json.dumps(body)
                 if pingxx_order:

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import defer
 from flaskr.common.umami_client import get_course_visit_count_30d
 from flaskr.i18n import _
 from flaskr.dao import db
+from flaskr.util.datetime import now_utc
 from flaskr.service.billing.bucket_categories import (
     resolve_wallet_bucket_runtime_category,
     wallet_bucket_requires_active_subscription,
@@ -1566,7 +1567,7 @@ def _load_operator_user_credit_summary_map(
     if not normalized_user_bids:
         return {}
 
-    now = datetime.now()
+    now = now_utc()
     active_subscription_end_map = _load_active_subscription_end_map(
         normalized_user_bids,
         as_of=now,

--- a/src/api/flaskr/service/shifu/admin_operations/courses.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses.py
@@ -5519,7 +5519,9 @@ def _list_operator_courses_legacy(
                 == COURSE_STATUS_PUBLISHED
             ]
         elif quick_filter == COURSE_QUICK_FILTER_CREATED_LAST_7D:
-            created_window_start, created_window_end = _resolve_created_last_7d_window()
+            created_window_start, created_window_end = _resolve_created_last_7d_window(
+                now_utc()
+            )
             merged_courses = [
                 course
                 for course in merged_courses
@@ -5657,7 +5659,7 @@ def list_operator_courses(
                 )
             elif quick_filter == COURSE_QUICK_FILTER_CREATED_LAST_7D:
                 created_window_start, created_window_end = (
-                    _resolve_created_last_7d_window()
+                    _resolve_created_last_7d_window(now_utc())
                 )
                 query = query.filter(
                     candidate_subquery.c.created_at >= created_window_start,

--- a/src/api/flaskr/service/shifu/admin_operations/courses.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses.py
@@ -16,6 +16,7 @@ from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_key_prefix
 from flaskr.common.umami_client import get_course_visit_count_30d
 from flaskr.i18n import _
+from flaskr.util.datetime import now_utc
 from flaskr.dao import db
 from flaskr.service.billing.consts import (
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
@@ -2378,7 +2379,7 @@ def _update_course_creator_bid(
     published_values = {PublishedShifu.created_user_bid: creator_user_bid}
     normalized_updated_user_bid = str(updated_user_bid or "").strip()
     if normalized_updated_user_bid:
-        updated_at = datetime.now()
+        updated_at = now_utc()
         draft_values[DraftShifu.updated_user_bid] = normalized_updated_user_bid
         draft_values[DraftShifu.updated_at] = updated_at
         published_values[PublishedShifu.updated_user_bid] = normalized_updated_user_bid
@@ -2489,7 +2490,7 @@ def copy_operator_course(
             raise_error("server.shifu.copyCourseDemoNotAllowed")
 
         action_user_bid = normalized_operator_user_bid
-        now = datetime.now()
+        now = now_utc()
         new_shifu_bid = generate_id(app)
         resolved_new_course_name = _resolve_course_copy_title(
             source_draft.title,
@@ -5267,7 +5268,7 @@ def _build_operator_course_overview(app: Flask) -> AdminOperationCourseOverviewD
     if candidate_query is None:
         return AdminOperationCourseOverviewDTO()
     candidate_subquery = candidate_query.subquery("operator_course_overview_candidates")
-    now = datetime.now()
+    now = now_utc()
     created_window_start, created_window_end = _resolve_created_last_7d_window(now)
     recent_activity_window_start = now - timedelta(days=30)
     aggregate_row = db.session.query(
@@ -5383,7 +5384,7 @@ def _build_operator_course_overview_legacy(
     if total_course_count == 0:
         return AdminOperationCourseOverviewDTO()
 
-    now = datetime.now()
+    now = now_utc()
     created_window_start, created_window_end = _resolve_created_last_7d_window(now)
     recent_activity_window_start = now - timedelta(days=30)
     visible_shifu_bids = [
@@ -5533,12 +5534,12 @@ def _list_operator_courses_legacy(
             ]
             if quick_filter == COURSE_QUICK_FILTER_LEARNING_ACTIVE_30D:
                 matched_shifu_bids = _load_recent_learning_active_course_bids(
-                    since=datetime.now() - timedelta(days=30),
+                    since=now_utc() - timedelta(days=30),
                     shifu_bids=visible_shifu_bids,
                 )
             else:
                 matched_shifu_bids = _load_recent_paid_order_course_bids(
-                    since=datetime.now() - timedelta(days=30),
+                    since=now_utc() - timedelta(days=30),
                     shifu_bids=visible_shifu_bids,
                 )
             merged_courses = [
@@ -5670,7 +5671,7 @@ def list_operator_courses(
                         LearnProgressRecord.deleted == 0,
                         LearnProgressRecord.status != LEARN_STATUS_RESET,
                         LearnProgressRecord.created_at
-                        >= datetime.now() - timedelta(days=30),
+                        >= now_utc() - timedelta(days=30),
                     )
                     query = query.filter(
                         candidate_subquery.c.shifu_bid.in_(active_course_query)
@@ -5679,7 +5680,7 @@ def list_operator_courses(
                     paid_course_query = db.session.query(Order.shifu_bid).filter(
                         Order.deleted == 0,
                         Order.status == ORDER_STATUS_SUCCESS,
-                        Order.created_at >= datetime.now() - timedelta(days=30),
+                        Order.created_at >= now_utc() - timedelta(days=30),
                     )
                     query = query.filter(
                         candidate_subquery.c.shifu_bid.in_(paid_course_query)

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -15,6 +15,7 @@ from flask import Flask
 from ...dao import db
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from datetime import datetime
+from flaskr.util.datetime import now_utc
 from .dtos import ShifuDto, ShifuDetailDto
 from ...util import generate_id
 from .consts import (
@@ -244,7 +245,7 @@ def create_shifu_draft(
         ShifuDto: Shifu dto
     """
     with app.app_context():
-        now_time = datetime.now()
+        now_time = now_utc()
 
         shifu_id = generate_id(app)
 
@@ -646,7 +647,7 @@ def save_shifu_draft_info(
             if use_learner_language is not None:
                 new_shifu_draft.use_learner_language = 1 if use_learner_language else 0
             new_shifu_draft.updated_user_bid = user_id
-            new_shifu_draft.updated_at = datetime.now()
+            new_shifu_draft.updated_at = now_utc()
             if shifu_system_prompt is not None:
                 new_shifu_draft.llm_system_prompt = shifu_system_prompt
             if not new_shifu_draft.eq(shifu_draft):
@@ -918,7 +919,7 @@ def _set_shifu_archive_state(app, user_id: str, shifu_id: str, archived: bool):
             raise_error("server.shifu.noPermission")
 
         new_flag = 1 if archived else 0
-        now = datetime.now()
+        now = now_utc()
         existing = ShifuUserArchive.query.filter(
             ShifuUserArchive.shifu_bid == shifu_id,
             ShifuUserArchive.user_bid == user_id,

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -44,7 +44,7 @@ from flaskr.dao import db
 from flaskr.util import generate_id
 from flaskr.util.datetime import to_utc_iso
 import queue
-from datetime import datetime
+from flaskr.util.datetime import now_utc
 import re
 from flaskr.service.user.models import UserInfo
 
@@ -257,7 +257,7 @@ def __save_shifu_history(
     Returns:
         None
     """
-    now = datetime.now()
+    now = now_utc()
     shifu_history = LogDraftStruct(
         struct_bid=generate_id(app),
         shifu_bid=shifu_bid,

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -34,7 +34,7 @@ from .shifu_history_manager import (
     delete_outline_history,
 )
 from .shifu_mdflow_funcs import cleanup_outline_history_versions
-from datetime import datetime
+from flaskr.util.datetime import now_utc
 from markdown_flow import MarkdownFlow
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
@@ -264,7 +264,7 @@ def create_outline(
         SimpleOutlineDto: Outline dto
     """
     with app.app_context():
-        now_time = datetime.now()
+        now_time = now_utc()
         # generate new outline id
         outline_bid = generate_id(app)
 
@@ -375,7 +375,7 @@ def reorder_outline_tree(
         app.logger.info(
             f"reorder outline tree, user_id: {user_id}, shifu_id: {shifu_id}"
         )
-        now_time = datetime.now()
+        now_time = now_utc()
 
         # get existing outlines
         existing_items = __get_existing_outline_items(shifu_id)
@@ -506,7 +506,7 @@ def modify_unit(
     """
     with app.app_context():
         app.logger.info(f"modify unit: {unit_id}, name: {unit_name}")
-        now_time = datetime.now()
+        now_time = now_utc()
         # find existing unit
         existing_unit = (
             DraftOutlineItem.query.filter(
@@ -586,7 +586,7 @@ def delete_unit(app, user_id: str, unit_id: str):
         bool: True if deleted, False otherwise
     """
     with app.app_context():
-        now_time = datetime.now()
+        now_time = now_utc()
         # find the unit to delete
         unit_to_delete = (
             DraftOutlineItem.query.filter(

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -24,7 +24,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.shifu_struct_manager import get_shifu_outline_tree
 from flaskr.util import generate_id
-from datetime import datetime
+from flaskr.util.datetime import now_utc
 import threading
 import queue
 from flaskr.service.shifu.shifu_struct_manager import ShifuInfoDto
@@ -105,7 +105,7 @@ def publish_shifu_draft(
         str: Shifu published URL
     """
     with app.app_context():
-        now_time = datetime.now()
+        now_time = now_utc()
         shifu_draft = get_latest_shifu_draft(shifu_id)
         if not shifu_draft:
             raise_error("server.shifu.shifuNotFound")

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -32,7 +32,10 @@ from flaskr.service.billing.models import (
     CreditWallet,
     CreditWalletBucket,
 )
-from flaskr.service.billing.charges import build_usage_metric_charges
+from flaskr.service.billing.charges import (
+    build_usage_metric_charges,
+    resolve_credit_multiplier_label,
+)
 from flaskr.service.billing.settlement import (
     backfill_bill_usage_settlement,
     replay_bill_usage_settlement,
@@ -1475,3 +1478,30 @@ def test_build_usage_metric_charges_uses_public_charge_module(
         assert len(charges) == 1
         assert charges[0]["billing_metric"] == BILLING_METRIC_LLM_INPUT_TOKENS
         assert charges[0]["raw_amount"] == 1200
+
+
+def test_resolve_credit_multiplier_label_uses_utc_default_settlement(monkeypatch):
+    from flaskr.service.billing import charges
+
+    utc_sentinel = datetime(2026, 1, 1, 0, 0, 0)
+    captured = []
+
+    monkeypatch.setattr(charges, "now_utc", lambda: utc_sentinel)
+
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+        captured.append(settlement_at)
+        return None
+
+    monkeypatch.setattr(charges, "load_usage_rate", fake_load_usage_rate)
+
+    assert (
+        resolve_credit_multiplier_label(
+            usage_type=BILL_USAGE_TYPE_TTS,
+            provider="minimax",
+            model="speech-01-turbo",
+        )
+        is None
+    )
+
+    assert captured
+    assert set(captured) == {utc_sentinel}

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -11,6 +11,7 @@ from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import AppException
 from flaskr.service.shifu import admin as admin_module
+from flaskr.service.shifu.admin_operations import courses as admin_courses_module
 from flaskr.service.shifu.admin import (
     _load_latest_shifus,
     _build_operator_course_overview,
@@ -739,6 +740,7 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(admin_courses_module, "now_utc", lambda: FixedDateTime.now())
 
     app = Flask(__name__)
     recent_course = DummyCourse(
@@ -879,6 +881,7 @@ def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(admin_courses_module, "now_utc", lambda: FixedDateTime.now())
 
     draft_only_bid = uuid.uuid4().hex[:32]
     published_only_bid = uuid.uuid4().hex[:32]

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2784,6 +2784,9 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
     )
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
     monkeypatch.setattr(
+        admin_module, "now_utc", lambda: datetime(2026, 4, 21, 0, 0, 0)
+    )
+    monkeypatch.setattr(
         user_credits_module, "now_utc", lambda: datetime(2026, 4, 21, 0, 0, 0)
     )
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2783,9 +2783,7 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
         lambda: datetime(2026, 4, 21, 0, 0, 0),
     )
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
-    monkeypatch.setattr(
-        admin_module, "now_utc", lambda: datetime(2026, 4, 21, 0, 0, 0)
-    )
+    monkeypatch.setattr(admin_module, "now_utc", lambda: datetime(2026, 4, 21, 0, 0, 0))
     monkeypatch.setattr(
         user_credits_module, "now_utc", lambda: datetime(2026, 4, 21, 0, 0, 0)
     )

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 
 import pytest
@@ -16,6 +17,12 @@ def _get_archive_funcs():
     from flaskr.service.shifu import shifu_draft_funcs
 
     return shifu_draft_funcs.archive_shifu, shifu_draft_funcs.unarchive_shifu
+
+
+def _get_draft_module():
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    return shifu_draft_funcs
 
 
 def _seed_shifu(app, shifu_bid: str, owner_bid: str):
@@ -44,10 +51,15 @@ def _seed_shifu(app, shifu_bid: str, owner_bid: str):
         dao.db.session.commit()
 
 
-def test_archive_then_unarchive_updates_both_tables(app):
+def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
     shifu_bid = "test-archive-toggle"
     owner_bid = "owner-123"
     _seed_shifu(app, shifu_bid, owner_bid)
+
+    archived_at = datetime(2026, 4, 21, 0, 0, 0)
+    unarchived_at = datetime(2026, 4, 22, 0, 0, 0)
+    draft_module = _get_draft_module()
+    monkeypatch.setattr(draft_module, "now_utc", lambda: archived_at)
 
     archive_shifu, unarchive_shifu = _get_archive_funcs()
     archive_shifu(app, owner_bid, shifu_bid)
@@ -66,8 +78,11 @@ def test_archive_then_unarchive_updates_both_tables(app):
         assert draft is not None
         assert archive is not None
         assert archive.archived == 1
-        assert archive.archived_at is not None
+        assert archive.created_at == archived_at
+        assert archive.updated_at == archived_at
+        assert archive.archived_at == archived_at
 
+    monkeypatch.setattr(draft_module, "now_utc", lambda: unarchived_at)
     unarchive_shifu(app, owner_bid, shifu_bid)
 
     with app.app_context():
@@ -84,7 +99,50 @@ def test_archive_then_unarchive_updates_both_tables(app):
         assert draft is not None
         assert archive is not None
         assert archive.archived == 0
+        assert archive.created_at == archived_at
+        assert archive.updated_at == unarchived_at
         assert archive.archived_at is None
+
+
+def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypatch):
+    created_at = datetime(2026, 4, 21, 0, 0, 0)
+    owner_bid = "owner-create-utc"
+    draft_module = _get_draft_module()
+    DraftShifu, _ = _get_models()
+
+    monkeypatch.setattr(draft_module, "now_utc", lambda: created_at)
+    monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-create-utc")
+    monkeypatch.setattr(
+        draft_module,
+        "check_text_with_risk_control",
+        lambda *_args, **_kwargs: None,
+    )
+    from flaskr.service.shifu import shifu_outline_funcs
+
+    monkeypatch.setattr(
+        shifu_outline_funcs,
+        "check_text_with_risk_control",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = draft_module.create_shifu_draft(
+        app,
+        user_id=owner_bid,
+        shifu_name="UTC Draft",
+        shifu_description="description",
+        shifu_image="res",
+        shifu_keywords=["utc"],
+        shifu_model="gpt-test",
+        shifu_temperature=0.3,
+        shifu_price=0,
+    )
+
+    with app.app_context():
+        draft = DraftShifu.query.filter_by(shifu_bid=result.bid).first()
+
+        assert draft is not None
+        assert draft.created_at == created_at
+        assert draft.updated_at == created_at
 
 
 def test_archive_requires_creator_permission(app):

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -318,18 +318,8 @@ def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch):
     from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
     utc_sentinel = datetime(2026, 1, 1, 0, 0, 0)
-    local_sentinel = datetime(2026, 1, 1, 8, 0, 0)
 
-    class _FakeDateTime:
-        @staticmethod
-        def utcnow():
-            return utc_sentinel
-
-        @staticmethod
-        def now():
-            return local_sentinel
-
-    monkeypatch.setattr(tts_api, "datetime", _FakeDateTime)
+    monkeypatch.setattr(tts_api, "now_utc", lambda: utc_sentinel)
 
     captured = {}
 


### PR DESCRIPTION
Summary
- Normalize remaining high-confidence backend timestamp writes and business comparisons to the shared `now_utc()` helper.
- Align billing/TTS/LLM rate-selection defaults, shifu draft/history/publish writes, operator course recent-activity windows, legacy Ping++ snapshot updates, and ilivedata request timestamps.
- Keep date-only/reporting windows, explicit policy timezone decisions, provider signature timestamps, and elapsed timers out of scope.

Validation
- `cd src/api && python3 -m pytest tests/service/tts/test_tts_config_options.py::test_usage_rate_unit_cost_uses_utc_settlement tests/service/billing/test_usage_settlement.py::test_resolve_credit_multiplier_label_uses_utc_default_settlement tests/service/shifu/test_archive.py tests/service/shifu/test_transfer_creator.py tests/service/shifu/test_admin_courses.py tests/service/shifu/test_shifu_draft_list.py tests/service/shifu/test_shifu_publish_funcs.py tests/service/dashboard tests/test_llm.py tests/test_order.py -q`
- `cd src/api && python3 -m ruff check flaskr/api/check/ilivedata.py flaskr/api/llm/__init__.py flaskr/api/tts/__init__.py flaskr/service/billing/charges.py flaskr/service/dashboard/funcs.py flaskr/service/order/funs.py flaskr/service/shifu/admin.py flaskr/service/shifu/admin_operations/courses.py flaskr/service/shifu/shifu_draft_funcs.py flaskr/service/shifu/shifu_history_manager.py flaskr/service/shifu/shifu_outline_funcs.py flaskr/service/shifu/shifu_publish_funcs.py tests/service/billing/test_usage_settlement.py tests/service/shifu/test_admin_courses.py tests/service/tts/test_tts_config_options.py`
- `cd src/api && python3 -m compileall flaskr/api/check/ilivedata.py flaskr/api/llm/__init__.py flaskr/api/tts/__init__.py flaskr/service/billing/charges.py flaskr/service/dashboard/funcs.py flaskr/service/order/funs.py flaskr/service/shifu/admin.py flaskr/service/shifu/admin_operations/courses.py flaskr/service/shifu/shifu_draft_funcs.py flaskr/service/shifu/shifu_history_manager.py flaskr/service/shifu/shifu_outline_funcs.py flaskr/service/shifu/shifu_publish_funcs.py tests/service/billing/test_usage_settlement.py tests/service/shifu/test_admin_courses.py tests/service/tts/test_tts_config_options.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized time-based calculations to use UTC for billing, credits/usage settlement, order snapshots, dashboards, course activity windows, and content draft/publish timestamps.
  * Improved consistency and reliability of “current time” driven filtering and updates, reducing mismatches caused by local/naive time references.

* **Tests**
  * Added and updated unit tests to ensure UTC settlement/default timestamps are used, including time-mocking adjustments for deterministic verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->