### PR TITLE
fix(billing): treat reference-less pending orders as unpaid instead of orderNotFound

### DIFF
--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2094,10 +2094,22 @@ def _sync_pingxx_order(
     app: Flask,
     order: BillingOrder,
 ) -> BillingOrderProviderUpdateResult:
-    provider = get_payment_provider("pingxx")
     if not order.provider_reference_id:
-        raise_error("server.order.orderNotFound")
+        # No pingxx charge was ever created for this order (e.g. a subscription
+        # renewal preorder whose charge creation never happened). Treat it as
+        # still unpaid instead of raising orderNotFound so callers such as the
+        # pending-order timeout scan can expire it normally.
+        return _apply_billing_order_provider_update(
+            order,
+            provider="pingxx",
+            event_type="manual_sync",
+            source="sync",
+            payload={},
+            provider_reference_id="",
+            target_status=BILLING_ORDER_STATUS_PENDING,
+        )
 
+    provider = get_payment_provider("pingxx")
     sync_result = provider.sync_reference(
         provider_reference=order.provider_reference_id,
         reference_type="charge",
@@ -2142,10 +2154,21 @@ def _sync_native_order(
     order: BillingOrder,
 ) -> BillingOrderProviderUpdateResult:
     provider_name = _normalize_bid(order.payment_provider)
-    provider = get_payment_provider(provider_name)
     if not order.provider_reference_id:
-        raise_error("server.order.orderNotFound")
+        # Same as pingxx: no native trade was ever created for this order, so
+        # treat it as still unpaid instead of raising orderNotFound and let the
+        # caller (e.g. the pending-order timeout scan) expire it normally.
+        return _apply_billing_order_provider_update(
+            order,
+            provider=provider_name,
+            event_type="manual_sync",
+            source="sync",
+            payload={},
+            provider_reference_id="",
+            target_status=BILLING_ORDER_STATUS_PENDING,
+        )
 
+    provider = get_payment_provider(provider_name)
     sync_result = provider.sync_reference(
         provider_reference=order.provider_reference_id,
         reference_type="payment",

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -952,6 +952,80 @@ def test_expire_pending_orders_task_includes_legacy_orders_without_expires_at(
     assert payload["timeout_count"] == 1
 
 
+def test_sync_pingxx_order_without_reference_does_not_raise(
+    billing_task_integration_app: Flask,
+) -> None:
+    from flaskr.service.billing.checkout import _sync_pingxx_order
+
+    with billing_task_integration_app.app_context():
+        order = BillingOrder(
+            bill_order_bid="bill-order-refless-pingxx-unit",
+            creator_bid="creator-refless-unit",
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+            product_bid="bill-product-plan-monthly",
+            subscription_bid="sub-refless-unit",
+            currency="CNY",
+            payable_amount=990,
+            paid_amount=0,
+            payment_provider="pingxx",
+            provider_reference_id="",
+            status=BILLING_ORDER_STATUS_PENDING,
+            metadata_json={},
+        )
+        # No pingxx charge was ever created: must not raise orderNotFound and
+        # must keep the order pending so the caller can expire it.
+        result = _sync_pingxx_order(billing_task_integration_app, order)
+
+    assert result is not None
+    assert int(order.status) == BILLING_ORDER_STATUS_PENDING
+
+
+def test_sync_billing_order_expires_reference_less_pingxx_order(
+    billing_task_integration_app: Flask,
+) -> None:
+    from flaskr.service.billing.checkout import sync_billing_order
+
+    now = datetime(2026, 6, 9, 12, 0, 0)
+    with billing_task_integration_app.app_context():
+        dao.db.session.add(
+            BillingOrder(
+                bill_order_bid="bill-order-refless-pingxx-expire",
+                creator_bid="creator-refless-expire",
+                order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+                product_bid="bill-product-plan-monthly",
+                subscription_bid="sub-refless-expire",
+                currency="CNY",
+                payable_amount=990,
+                paid_amount=0,
+                payment_provider="pingxx",
+                channel="alipay_qr",
+                provider_reference_id="",
+                status=BILLING_ORDER_STATUS_PENDING,
+                expires_at=now - timedelta(minutes=1),
+                metadata_json={},
+                created_at=now - timedelta(minutes=30),
+                updated_at=now - timedelta(minutes=30),
+            )
+        )
+        dao.db.session.commit()
+
+    # Reference-less pending order past expiry must be expired (TIMEOUT), not
+    # raise orderNotFound as it did before (the source of the alert storm).
+    result = sync_billing_order(
+        billing_task_integration_app,
+        "creator-refless-expire",
+        "bill-order-refless-pingxx-expire",
+        {},
+    )
+    assert result is not None
+
+    with billing_task_integration_app.app_context():
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="bill-order-refless-pingxx-expire"
+        ).one()
+        assert int(order.status) == BILLING_ORDER_STATUS_TIMEOUT
+
+
 def test_reconcile_provider_reference_task_delegates_to_reconcile_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
`_sync_pingxx_order` / `_sync_native_order` raised `orderNotFound` whenever an order had no `provider_reference_id`. A subscription **renewal preorder whose provider charge was never created** hits exactly this case: no reference yet means **unpaid**, not **not found**.

Because the raise happened inside `sync_billing_order` *before* `_expire_pending_billing_order_if_due`, such orders could never be expired. The `billing.expire_pending_orders` timeout scan (runs every minute) kept re-syncing them, raising, and logging at ERROR level — flooding the ops alert channel and leaving the orders stuck `PENDING` forever.

## Fix
A reference-less order now returns a no-op "still pending" provider update (checking the reference *before* instantiating the provider), so `sync_billing_order` proceeds to `_expire_pending_billing_order_if_due` and expires the order normally once it is past due. Applied to both pingxx and native (alipay/wechatpay) sync paths.

## Incident context
Surfaced on 2026-07-06 when the billing renewal dispatcher (`BILL_RENEWAL_TASK_CONFIG.enabled=1`) was enabled on CN prod: 10 pingxx renewal preorders were created with empty `provider_reference_id`, and `expire_pending_orders` began raising `orderNotFound` ~10x/min into the alert group. Mitigated live by cancelling those 10 zero-charge orphan preorders; this PR removes the root cause. The dispatcher is currently paused (`enabled=0`) pending this fix.

## Tests
- `test_sync_pingxx_order_without_reference_does_not_raise` — reference-less order returns without raising and stays PENDING.
- `test_sync_billing_order_expires_reference_less_pingxx_order` — a past-due reference-less pingxx order is expired to TIMEOUT instead of raising.
- `cd src/api && pytest tests/service/billing -q` → 393 passed.

## Follow-ups (not in this PR)
- Renewal task concurrency `IntegrityError (autoflush)` / `Lock wait timeout` on `bill_orders` — wrap the relevant renewal queries in `no_autoflush` (same class as #2005/#1920).
- Consider not generating RENEWAL events for `manual`-provider subscriptions (they can never auto-renew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing orders without a provider reference now remain in a pending state instead of failing with an error during sync.
  * Reference-less pending orders can now expire correctly and move to timeout after their expiry time.
* **Tests**
  * Added coverage for billing sync behavior when no provider reference is available, including pending and timeout outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->