### PR TITLE
fix: show cloned voice display names without suffix

### DIFF
--- a/src/i18n/en-US/modules/shifu-setting.json
+++ b/src/i18n/en-US/modules/shifu-setting.json
@@ -142,7 +142,7 @@
   "minimaxCloneSubmitReasonSubmitting": "Submitting. Please wait.",
   "minimaxCloneVoiceId": "Voice ID",
   "minimaxCloneVoiceIdPlaceholder": "Optional custom MiniMax voice_id",
-  "minimaxCloneVoiceOptionLabel": "{name} voice clone",
+  "minimaxCloneVoiceOptionLabel": "{name}",
   "minimaxManualVoiceApply": "Use",
   "minimaxManualVoiceBadge": "Custom",
   "minimaxManualVoiceInvalid": "Enter a valid MiniMax custom voice ID",

--- a/src/i18n/fr-FR/modules/shifu-setting.json
+++ b/src/i18n/fr-FR/modules/shifu-setting.json
@@ -142,7 +142,7 @@
   "minimaxCloneSubmitReasonSubmitting": "Envoi en cours. Veuillez patienter.",
   "minimaxCloneVoiceId": "Voice ID",
   "minimaxCloneVoiceIdPlaceholder": "voice_id MiniMax personnalisé facultatif",
-  "minimaxCloneVoiceOptionLabel": "Clone vocal {name}",
+  "minimaxCloneVoiceOptionLabel": "{name}",
   "minimaxManualVoiceApply": "Utiliser",
   "minimaxManualVoiceBadge": "Perso.",
   "minimaxManualVoiceInvalid": "Saisissez un ID de voix MiniMax personnalisé valide",

--- a/src/i18n/zh-CN/modules/shifu-setting.json
+++ b/src/i18n/zh-CN/modules/shifu-setting.json
@@ -142,7 +142,7 @@
   "minimaxCloneSubmitReasonSubmitting": "正在提交，请稍候。",
   "minimaxCloneVoiceId": "Voice ID",
   "minimaxCloneVoiceIdPlaceholder": "可选，填写自定义 MiniMax voice_id",
-  "minimaxCloneVoiceOptionLabel": "{name} 语音clone 音色",
+  "minimaxCloneVoiceOptionLabel": "{name}",
   "minimaxManualVoiceApply": "使用",
   "minimaxManualVoiceBadge": "自定义",
   "minimaxManualVoiceInvalid": "请输入合法的 MiniMax 自定义音色 ID",


### PR DESCRIPTION
## Summary
- show MiniMax cloned voice options using only the saved display name
- keep zh-CN, en-US, and fr-FR labels aligned

## Root Cause
The cloned voice option label i18n value appended a voice-clone descriptor to the saved voice name, so the course settings dropdown showed extra text such as `语音clone 音色` even when the stored voice name was clean.

## Validation
- `python3 scripts/check_dev_tools.py`
- `npm run test -- src/components/shifu-setting/minimax-voice-clone.test.ts`
- pre-commit translation checks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the voice-clone option label across supported languages so it now shows only the selected name, reducing clutter in the settings UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->