### PR TITLE
chore: centralize commit message requirements

### DIFF
--- a/.claude/rules/global/testing-and-commit.md
+++ b/.claude/rules/global/testing-and-commit.md
@@ -39,9 +39,9 @@ duplicating the shared repository guidance already stored in `AGENTS.md`.
   missing tools, surface the printed install commands to the user and pause the
   commit until they are installed or the user explicitly opts to proceed.
 
-- Keep commit hygiene aligned with
-  `docs/engineering-baseline.md#commit-message-policy`; do not duplicate the
-  detailed commit-format policy in Claude-only rules.
+- For git commit message title, body, and classification requirements, read the
+  root `AGENTS.md#git-commit-message-requirements`; do not duplicate the
+  detailed commit-message policy in Claude-only rules.
 
 - If a task changes only docs or AI-instruction files, the minimum
   verification target is `python scripts/check_repo_harness.py`.

--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -37,9 +37,9 @@ alwaysApply: true
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
-- Follow the canonical commit-message policy in
-  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
-  rule files pointing there instead of duplicating the policy.
+- For git commit message title, body, and classification requirements, read
+  `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
+  from duplicating the detailed commit-message policy.
 
 - Keep generated knowledge artifacts in sync by running
   `python scripts/build_repo_knowledge_index.py` after docs structure or

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,9 +32,9 @@
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
-- Follow the canonical commit-message policy in
-  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
-  rule files pointing there instead of duplicating the policy.
+- For git commit message title, body, and classification requirements, read
+  `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
+  from duplicating the detailed commit-message policy.
 
 - Regenerate repository knowledge indexes with
   `python scripts/build_repo_knowledge_index.py` after moving docs or changing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@ to.
 - Before committing, run `python scripts/check_dev_tools.py` to confirm
   lefthook and its underlying tools are installed; the local checks are
   silently skipped if lefthook was never installed.
-- Follow the canonical commit-message policy in
-  `docs/engineering-baseline.md#commit-message-policy`; keep agent-specific
-  rule files pointing there instead of duplicating the policy.
+- For git commit message title, body, and classification requirements, use
+  [Git Commit Message Requirements](#git-commit-message-requirements); keep
+  agent-specific rule files pointing there instead of duplicating the policy.
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
@@ -82,6 +82,39 @@ to.
   vs offset-aware, or string vs string) — normalize both to UTC before
   comparing. These are exactly the drifts that reappear when new code lands in
   modules the UTC sweep has not yet reached.
+
+## Git Commit Message Requirements
+
+All git commit message requirements live in this section. Other docs and
+agent-specific rule files may point here for title, body, and classification
+rules, but must not duplicate or redefine them.
+
+- Human-authored and coding-agent-authored commit messages must follow the
+  policy below. Existing workflow-generated bot commits are exempt unless the
+  workflow is being updated for this policy.
+- The local `commit-msg` hook is only a baseline Conventional Commits syntax
+  check. It does not enforce the `Changed:` / `Benefit:` body or the
+  classification rules below.
+- Subject: use English Conventional Commits without scope parentheses, such as
+  `type: summary`; do not use `type(scope): summary`.
+- Body: include exactly two sections, `Changed:` and `Benefit:`.
+- Classification: use `chore` for repository-maintenance-only instruction or
+  generated guidance updates like this file.
+- Runtime prompt, template, and system-prompt changes affect product behavior:
+  use `feat` when adding capability and `fix` when correcting behavior; do not
+  use `docs`.
+
+Example:
+
+```text
+chore: centralize commit message requirements
+
+Changed:
+Moved repository commit message requirements into the root AGENTS.md file.
+
+Benefit:
+Contributors have one place to check the required commit title and body format.
+```
 
 ## Commands
 

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -68,37 +68,9 @@ python scripts/check_dev_tools.py --strict   # also fail on Cook Web tooling gap
 3. Generate a migration for DB changes: `flask db migrate -m "description"`
 4. Test the relevant change surface
 5. Use English for code-facing text
-6. For human-authored and coding-agent-authored commits, follow the
-   [Commit Message Policy](#commit-message-policy)
-
-### Commit Message Policy
-
-This policy applies to human-authored and coding-agent-authored commits.
-Existing workflow-generated bot commits are exempt unless the workflow is being
-updated for this policy. The local `commit-msg` hook remains a baseline
-Conventional Commits syntax check; use this section as the source of truth for
-requirements the hook cannot validate.
-
-- Subject: use English Conventional Commits without scope parentheses, such as
-  `type: summary`; do not use `type(scope): summary`.
-- Body: include exactly two sections, `Changed:` and `Benefit:`.
-- Classification: use `chore` for repository-maintenance-only instruction or
-  generated guidance updates like this file.
-- Runtime prompt, template, and system-prompt changes affect product behavior:
-  use `feat` when adding capability and `fix` when correcting behavior; do not
-  use `docs`.
-
-Example:
-
-```text
-chore: codify commit message guidance
-
-Changed:
-Codified commit message requirements across repository guidance files.
-
-Benefit:
-Contributors can write commit history that is easier to review and audit.
-```
+6. For human-authored and coding-agent-authored commits, follow the git commit
+   message requirements in
+   [`AGENTS.md`](../AGENTS.md#git-commit-message-requirements)
 
 ### Common Pitfalls To Avoid
 

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1670,10 +1670,11 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
-                "Follow the canonical commit-message policy in "
-                "`docs/engineering-baseline.md#commit-message-policy`; keep "
-                "agent-specific rule files pointing there instead of "
-                "duplicating the policy.",
+                "For git commit message title, body, and classification "
+                "requirements, read "
+                "`AGENTS.md#git-commit-message-requirements`; keep "
+                "agent-specific rule files from duplicating the detailed "
+                "commit-message policy.",
                 "Keep generated knowledge artifacts in sync by running "
                 "`python scripts/build_repo_knowledge_index.py` after docs "
                 "structure or metadata changes.",
@@ -1836,10 +1837,11 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
-                "Follow the canonical commit-message policy in "
-                "`docs/engineering-baseline.md#commit-message-policy`; keep "
-                "agent-specific rule files pointing there instead of "
-                "duplicating the policy.",
+                "For git commit message title, body, and classification "
+                "requirements, read "
+                "`AGENTS.md#git-commit-message-requirements`; keep "
+                "agent-specific rule files from duplicating the detailed "
+                "commit-message policy.",
                 "Regenerate repository knowledge indexes with "
                 "`python scripts/build_repo_knowledge_index.py` after moving docs "
                 "or changing required metadata.",


### PR DESCRIPTION
## Summary
- Move git commit message title, body, and classification requirements into root AGENTS.md
- Keep engineering-baseline commit workflow steps in place while pointing message-format details to AGENTS.md
- Update generated Claude, Cursor, and Copilot instruction mirrors to reference the new AGENTS.md anchor

## Verification
- python3 scripts/generate_ai_collab_docs.py
- python3 -m py_compile scripts/generate_ai_collab_docs.py
- python3 scripts/check_repo_harness.py
- python3 scripts/check_dev_tools.py
- lefthook run pre-commit --all-files
- git diff --check