### PR TITLE
feat: open course editor in the same tab from admin card

### DIFF
--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -121,8 +121,6 @@ const ShifuCard = ({
     >
       <Link
         href={`/shifu/${id}`}
-        target='_blank'
-        rel='noopener noreferrer'
         className='block w-full h-full'
       >
         <Card


### PR DESCRIPTION
## What & Why

In the admin console course list, clicking a course card opened the course editor (`/shifu/{id}`) in a **new browser tab**. This changes it to open in the **current tab**, which matches the more common expectation for back-office navigation.

## Change

- `src/cook-web/src/app/admin/page.tsx` — remove `target='_blank'` and the now-meaningless `rel='noopener noreferrer'` from the `ShifuCard` `<Link href={/shifu/${id}}>`.
- Without `target='_blank'`, the Next.js `<Link>` falls back to its default **client-side, same-tab navigation** (no full page reload).
- Deletion-only change: 2 lines removed, no new logic added.

## Scope note

This is the only course card that navigates to the course editor. The operations table (`CourseTableSection`) links to `/admin/operations/{shifu_bid}` (the operations detail page), which is a different feature and is out of scope here.

## Verification

- All local pre-commit hooks passed: eslint, prettier, check-architecture-boundaries, check-shared-translations, commitizen, etc.
- Confirmed no test asserts the new-tab behavior of this card, so the change does not affect existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)