### PR TITLE
test: cover get_config LockNotOwnedError-on-release handling (follow-up to #2028)

### DIFF
--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -282,6 +282,46 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.get_config_from_common")
     @patch("flaskr.service.config.funcs.redis")
     @patch("flaskr.service.config.funcs.Config")
+    @patch("flaskr.service.config.funcs._decrypt_config")
+    def test_get_config_ignores_lock_not_owned_error_on_release(
+        self,
+        mock_decrypt,
+        mock_config_class,
+        mock_redis,
+        mock_get_config_from_common,
+        app,
+    ):
+        """get_config still returns the DB value if lock.release() raises
+        LockNotOwnedError (the 1s lock TTL elapsed before release)."""
+        from redis.exceptions import LockNotOwnedError
+
+        with app.app_context():
+            app.config["REDIS_KEY_PREFIX"] = "test:"
+            mock_get_config_from_common.return_value = None
+            mock_redis.get.return_value = None
+            mock_lock = MagicMock()
+            mock_lock.acquire.return_value = True
+            mock_lock.release.side_effect = LockNotOwnedError("lock expired")
+            mock_redis.lock.return_value = mock_lock
+
+            mock_config_instance = MagicMock()
+            mock_config_instance.value = "db-value"
+            mock_config_instance.is_encrypted = 0
+            mock_config_instance.created_at = datetime.now()
+            mock_query = MagicMock()
+            mock_query.filter.return_value.order_by.return_value.first.return_value = (
+                mock_config_instance
+            )
+            mock_config_class.query = mock_query
+
+            # Must not propagate the LockNotOwnedError from release().
+            result = get_config("test_key")
+            assert result == "db-value"
+            mock_lock.release.assert_called_once()
+
+    @patch("flaskr.service.config.funcs.get_config_from_common")
+    @patch("flaskr.service.config.funcs.redis")
+    @patch("flaskr.service.config.funcs.Config")
     def test_get_config_queries_database_when_default_is_explicit_empty_string(
         self, mock_config_class, mock_redis, mock_get_config_from_common, app
     ):


### PR DESCRIPTION
## Summary
Follow-up test for #2028 (already merged), which made `get_config()` tolerate `LockNotOwnedError` from `lock.release()` when the 1s lock TTL elapses before release. #2028 merged without a regression test (Copilot review flagged this); this PR adds it.

## Test
`test_get_config_ignores_lock_not_owned_error_on_release` — mocks `lock.release()` to raise `LockNotOwnedError`, cache miss + DB hit, and asserts `get_config()` returns the DB value without propagating the error.

`cd src/api && pytest tests/service/config/test_funcs.py -q` -> 42 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for a config retrieval case where a cache lock expires before it can be released.
  * Confirmed the app still returns the stored database value and does not surface the lock release error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->