### PR TITLE
fix(shifu): log summary worker-shutdown race as warning, not error

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -232,7 +232,22 @@ def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None)
         apply_shifu_context_snapshot(shifu_context_snapshot)
         get_shifu_summary(app, shifu_id)
     except Exception as e:
-        app.logger.error(f"Failed to generate shifu summary for {shifu_id}: {str(e)}")
+        message = str(e)
+        if "cannot schedule new futures after shutdown" in message:
+            # Summary generation runs in a fire-and-forget daemon thread. When
+            # the worker/process is recycled mid-LLM-call (e.g. a deploy),
+            # litellm's fallback tries to schedule on an executor that is already
+            # shutting down. This is an expected shutdown race, not a real
+            # failure, so log at warning level to avoid paging ops on deploys.
+            app.logger.warning(
+                "Skipped shifu summary for %s due to worker shutdown race: %s",
+                shifu_id,
+                message,
+            )
+        else:
+            app.logger.error(
+                f"Failed to generate shifu summary for {shifu_id}: {message}"
+            )
 
 
 def get_shifu_summary(app, shifu_id: str):

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -246,7 +246,8 @@ def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None)
             )
         else:
             app.logger.error(
-                f"Failed to generate shifu summary for {shifu_id}: {message}"
+                f"Failed to generate shifu summary for {shifu_id}: {message}",
+                exc_info=True,
             )
 
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -163,6 +163,55 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch):
     assert trace.updated["output"] == "summary result"
 
 
+def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
+    from unittest.mock import MagicMock
+    from flaskr.service.shifu import shifu_publish_funcs as module
+
+    monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
+
+    def _raise_shutdown(*_a, **_k):
+        raise RuntimeError(
+            "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
+            "cannot schedule new futures after shutdown"
+        )
+
+    monkeypatch.setattr(module, "get_shifu_summary", _raise_shutdown)
+
+    app = Flask("shifu-summary-shutdown")
+    warning_mock = MagicMock()
+    error_mock = MagicMock()
+    monkeypatch.setattr(app.logger, "warning", warning_mock)
+    monkeypatch.setattr(app.logger, "error", error_mock)
+
+    module._run_summary_with_error_handling(app, "shifu-1")
+
+    warning_mock.assert_called_once()
+    error_mock.assert_not_called()
+
+
+def test_run_summary_logs_error_for_other_failures(monkeypatch):
+    from unittest.mock import MagicMock
+    from flaskr.service.shifu import shifu_publish_funcs as module
+
+    monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
+
+    def _raise_other(*_a, **_k):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(module, "get_shifu_summary", _raise_other)
+
+    app = Flask("shifu-summary-error")
+    warning_mock = MagicMock()
+    error_mock = MagicMock()
+    monkeypatch.setattr(app.logger, "warning", warning_mock)
+    monkeypatch.setattr(app.logger, "error", error_mock)
+
+    module._run_summary_with_error_handling(app, "shifu-1")
+
+    error_mock.assert_called_once()
+    warning_mock.assert_not_called()
+
+
 def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
     from flaskr.service.shifu import shifu_publish_funcs as module
 


### PR DESCRIPTION
## Summary
Shifu summary generation runs in a fire-and-forget **daemon thread** (`_run_summary_with_error_handling`, spawned from `publish`). When a worker/pod is recycled mid-LLM-call (e.g. a deploy), litellm's mid-stream fallback tries to schedule on an executor that is already shutting down and raises `OpenAIException - cannot schedule new futures after shutdown`.

The publish itself already succeeded (the summary is best-effort/async), so this is an **expected shutdown race, not a real failure** — but it was logged at ERROR and paged ops on every deploy that happened to overlap a publish (observed live 2026-07-06 during a burst of deploys).

## Fix
Downgrade that one specific case (message contains `cannot schedule new futures after shutdown`) from `error` to `warning`. All other summary failures still log at `error`.

## Tests
- `test_run_summary_downgrades_shutdown_race_to_warning` — shutdown-race message → `logger.warning`, not `error`.
- `test_run_summary_logs_error_for_other_failures` — any other exception → `logger.error`, not `warning`.
- `pytest tests/service/shifu/test_shifu_publish_funcs.py -q` -> 4 passed.

## Follow-up (not in this PR)
The robust fix is to move summary generation from a daemon thread to a Celery task (survives worker recycling, retryable) — noted for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of summary generation failures during shutdown races, so these interruptions are now logged as warnings instead of errors.
  * Normal failures still appear as errors, making real issues easier to spot while reducing noisy error logs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->