### PR TITLE
fix: polish billing details page copy

### DIFF
--- a/src/cook-web/SKILL.md
+++ b/src/cook-web/SKILL.md
@@ -21,7 +21,7 @@
 - 积分详情页的“积分消耗明细”表格优先复用 `src/app/admin/components/AdminTableShell.tsx` 和标准 `Table` 组件；分页走 `AdminTableShell.pagination`，不要在 billing 组件里另写卡片表格和独立分页外壳。
 - 仅服务后台路由且依赖 `src/app/admin/components/*` 的 billing 组件，应放在 `src/app/admin/billing/components/` 这类同路由作用域下；`src/components/*` 里的共享组件不要直接 import `src/app/*` 的 route-internal 实现，避免触发架构边界校验。
 - `AdminTableShell` 内的表头默认保持左对齐；如果某些 body 单元格需要右对齐，只在 body 内容层处理，不要把表头也右对齐。自定义骨架屏行放进 `AdminTableShell` 时要禁用 hover 背景，避免加载翻页时出现整行灰色条。
-- 账户余额、可用积分、侧边会员卡余额这类“积分余额”展示统一只保留整数部分且不加千分位分隔；套餐赠送额度、购买额度、消耗量等非余额数字继续使用通用积分格式化方法，避免把两类数字口径混用。
+- 账户余额、可用积分、侧边会员卡余额这类“积分余额”展示统一只保留整数部分；套餐赠送额度、购买额度、消耗量等非余额数字继续使用通用积分格式化方法，避免把两类数字口径混用。
 - 当产品要求把套餐赠送积分数、免费体验积分和积分包额度也统一成整数展示时，优先复用 `src/lib/billing.ts` 的共享积分数量格式化方法，确保套餐卡、免费卡、积分包卡和对应测试口径一致。
 - 积分消耗明细表格迁移到 `AdminTableShell` 后，列宽优先让“消耗项”占最大宽度，时间列居中偏右，数量列贴近最右侧对齐；不要在时间列保留旧版 grid 表格里的 `text-right`、`justify-end` 或 `ml-auto` 残留，数量列如需靠右可只在该列内容层使用 `justify-end`/`ml-auto`。加载骨架屏行需要同时禁用 `tr:hover` 和 `td:hover` 背景，避免翻页 loading 时出现整行灰色条。
 - admin 侧边会员卡如果改成双层信息布局，保持整卡点击跳转 `packages`、底部“查看详情”独立跳转 `details`，并把积分余额与到期时间放在同一信息层；卡片整体内边距优先保持 `py-14px / pl-16px`，右侧需要贴设计微调时可收敛成 `pr-12px`。若设计稿要求顶部“积分 + 升级”这一整行整体左收 `4px`，优先给这一行的外层容器补 `padding-right`，不要误加到升级按钮本身；`查看详情` 默认不要额外补右侧内边距。头部与信息层之间优先用弱分隔线 `rgba(0,0,0,0.05)`，分隔线下余额行 `pt-3`、到期/详情行 `pt-2.5`，正文颜色优先复用 `--base-card-foreground` 和既有 `text-sm` typography token。

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -167,6 +167,12 @@ describe('BillingRecentActivitySection', () => {
       screen.getByText('module.billing.details.usageTable.title'),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'module.billing.details.usageTable.title',
+      }),
+    ).toHaveClass('text-xl');
+    expect(
       await screen.findByText(
         'module.billing.ledger.usageScene.tts - Published Course 1 - learner@example.com',
       ),
@@ -176,7 +182,7 @@ describe('BillingRecentActivitySection', () => {
         'module.billing.ledger.usageScene.debug - Debug Course 1 - 15811237246',
       ),
     ).toBeInTheDocument();
-    const dateCells = await screen.findAllByText(/Apr 6, 2026/);
+    const dateCells = await screen.findAllByText(/^2026-04-06 /);
     expect(dateCells).toHaveLength(2);
     expect(dateCells[0].tagName).toBe('TD');
     const amountValue = await screen.findByText('-2.50');

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/Table';
 import { cn } from '@/lib/utils';
 import type { BillingLedgerItem, BillingPagedResponse } from '@/types/billing';
-import { BILLING_SECTION_TITLE_CLASS } from '@/components/billing/billingSectionTitleClass';
+import { BILLING_SUBSECTION_TITLE_CLASS } from '@/components/billing/billingSectionTitleClass';
 import {
   buildBillingSwrKey,
   formatBillingCreditDetail,
@@ -125,7 +125,7 @@ export function BillingRecentActivitySection({
       data-testid='billing-usage-table-section'
     >
       <div>
-        <h2 className={BILLING_SECTION_TITLE_CLASS}>
+        <h2 className={BILLING_SUBSECTION_TITLE_CLASS}>
           {t('module.billing.details.usageTable.title')}
         </h2>
       </div>

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -444,8 +444,11 @@ describe('AdminBillingPage', () => {
       }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByText('module.billing.details.title'),
+      await screen.findByText('module.billing.details.totalCreditsLabel'),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('module.billing.details.title'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
         level: 1,
@@ -473,7 +476,10 @@ describe('AdminBillingPage', () => {
       }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByText('module.billing.details.title'),
+      await screen.findByText('module.billing.details.totalCreditsLabel'),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText('module.billing.details.title'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -446,9 +446,7 @@ describe('AdminBillingPage', () => {
     expect(
       await screen.findByText('module.billing.details.totalCreditsLabel'),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('module.billing.details.title'),
-    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
     expect(
       screen.getByRole('heading', {
         level: 1,
@@ -478,8 +476,6 @@ describe('AdminBillingPage', () => {
     expect(
       await screen.findByText('module.billing.details.totalCreditsLabel'),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('module.billing.details.title'),
-    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
   });
 });

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -126,7 +126,10 @@ describe('BillingCreditDetailsPanel', () => {
     render(<BillingCreditDetailsPanel onUpgrade={onUpgrade} />);
 
     expect(
-      screen.getByText('module.billing.details.title'),
+      screen.queryByText('module.billing.details.title'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('module.billing.details.totalCreditsLabel'),
     ).toBeInTheDocument();
     expect(screen.getByText('1,110')).toBeInTheDocument();
     expect(
@@ -137,8 +140,8 @@ describe('BillingCreditDetailsPanel', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('100.00')).toBeInTheDocument();
     expect(screen.getByText('1,000.00')).toBeInTheDocument();
-    expect(screen.getByText('2026年10月12日 23:59')).toBeInTheDocument();
-    expect(screen.getByText('2026年10月20日 23:59')).toBeInTheDocument();
+    expect(screen.getByText('2026-10-13 07:59')).toBeInTheDocument();
+    expect(screen.getByText('2026-10-21 07:59')).toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', {
@@ -241,7 +244,7 @@ describe('BillingCreditDetailsPanel', () => {
       within(subscriptionRow as HTMLElement).getByText('120.00'),
     ).toBeInTheDocument();
     expect(
-      within(subscriptionRow as HTMLElement).getByText('2026年05月06日 07:59'),
+      within(subscriptionRow as HTMLElement).getByText('2026-05-06 15:59'),
     ).toBeInTheDocument();
   });
 
@@ -324,9 +327,7 @@ describe('BillingCreditDetailsPanel', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      within(subscriptionRow as HTMLElement).queryByText(
-        '2026年05月06日 07:59',
-      ),
+      within(subscriptionRow as HTMLElement).queryByText('2026-05-06 15:59'),
     ).not.toBeInTheDocument();
   });
 

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -16,6 +16,11 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+jest.mock('@/lib/browser-timezone', () => ({
+  __esModule: true,
+  getBrowserTimeZone: () => 'Asia/Shanghai',
+}));
+
 jest.mock('@/hooks/useBillingData', () => ({
   __esModule: true,
   useBillingOverview: jest.fn(),

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -131,7 +131,10 @@ describe('BillingCreditDetailsPanel', () => {
     render(<BillingCreditDetailsPanel onUpgrade={onUpgrade} />);
 
     expect(
-      screen.queryByText('module.billing.details.title'),
+      within(screen.getByTestId('billing-credit-details-panel')).queryByRole(
+        'heading',
+        { level: 1 },
+      ),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText('module.billing.details.totalCreditsLabel'),

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -10,7 +10,6 @@ import {
   CardTitle,
 } from '@/components/ui/Card';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { BILLING_SECTION_TITLE_CLASS } from './billingSectionTitleClass';
 import {
   Tooltip,
   TooltipContent,
@@ -219,12 +218,6 @@ export function BillingCreditDetailsPanel({
       className='space-y-6'
       data-testid='billing-credit-details-panel'
     >
-      <div>
-        <h1 className={BILLING_SECTION_TITLE_CLASS}>
-          {t('module.billing.details.title')}
-        </h1>
-      </div>
-
       <Card className='gap-[var(--spacing-6,24px)] overflow-hidden rounded-[var(--border-radius-rounded-lg,10px)] border border-[var(--base-border,#E5E5E5)] bg-[#F6FAFF] shadow-[var(--shadow-xs-offset-x,0)_var(--shadow-xs-offset-y,1px)_var(--shadow-xs-blur-radius,2px)_var(--shadow-xs-spread-radius,0)_var(--shadow-xs-color,rgba(0,0,0,0.05))]'>
         <CardHeader className='gap-6 px-6 pb-0 pt-6 md:flex-row md:items-start md:justify-between'>
           <div className='space-y-1.5'>

--- a/src/cook-web/src/components/billing/billingSectionTitleClass.ts
+++ b/src/cook-web/src/components/billing/billingSectionTitleClass.ts
@@ -1,5 +1,2 @@
-export const BILLING_SECTION_TITLE_CLASS =
-  'text-2xl font-semibold tracking-tight text-slate-950 md:text-3xl';
-
 export const BILLING_SUBSECTION_TITLE_CLASS =
   'text-xl font-semibold leading-7 tracking-normal text-[var(--base-foreground,#0A0A0A)]';

--- a/src/cook-web/src/components/billing/billingSectionTitleClass.ts
+++ b/src/cook-web/src/components/billing/billingSectionTitleClass.ts
@@ -1,2 +1,5 @@
 export const BILLING_SECTION_TITLE_CLASS =
   'text-2xl font-semibold tracking-tight text-slate-950 md:text-3xl';
+
+export const BILLING_SUBSECTION_TITLE_CLASS =
+  'text-xl font-semibold leading-7 tracking-normal text-[var(--base-foreground,#0A0A0A)]';

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -439,7 +439,6 @@ export type I18nKey =
   | 'module.billing.details.table.balance'
   | 'module.billing.details.table.creditType'
   | 'module.billing.details.table.validUntil'
-  | 'module.billing.details.title'
   | 'module.billing.details.topupAvailabilityLabel'
   | 'module.billing.details.topupAvailabilityTooltip'
   | 'module.billing.details.totalCreditsDescription'

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -355,7 +355,6 @@
       "creditType": "Type",
       "validUntil": "Valid until"
     },
-    "title": "Details",
     "topupAvailabilityLabel": "No expiration",
     "topupAvailabilityTooltip": "An active subscription is required to use credit packs.",
     "totalCreditsDescription": "Plan credits are used first, then credit packs.",

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -353,18 +353,18 @@
     "table": {
       "balance": "Balance",
       "creditType": "Type",
-      "validUntil": "Expires on"
+      "validUntil": "Valid until"
     },
-    "title": "Credits Overview",
-    "topupAvailabilityLabel": "No expiry",
-    "topupAvailabilityTooltip": "An active subscription is required before credit packs can be used",
-    "totalCreditsDescription": "Credits are consumed in priority order: plan credits > credit packs",
-    "totalCreditsLabel": "Credit balance",
+    "title": "Details",
+    "topupAvailabilityLabel": "No expiration",
+    "topupAvailabilityTooltip": "An active subscription is required to use credit packs.",
+    "totalCreditsDescription": "Plan credits are used first, then credit packs.",
+    "totalCreditsLabel": "Balance",
     "usageTable": {
       "columns": {
         "scene": "Usage item"
       },
-      "title": "Credit usage details"
+      "title": "Usage details"
     }
   },
   "domains": {

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -355,7 +355,6 @@
       "creditType": "Type",
       "validUntil": "Valide jusqu’au"
     },
-    "title": "Détails",
     "topupAvailabilityLabel": "Aucune expiration",
     "topupAvailabilityTooltip": "Un abonnement actif est requis pour utiliser les packs de crédits.",
     "totalCreditsDescription": "Les crédits du forfait sont utilisés en premier, puis les packs de crédits.",

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -353,18 +353,18 @@
     "table": {
       "balance": "Solde",
       "creditType": "Type",
-      "validUntil": "Expire le"
+      "validUntil": "Valide jusqu’au"
     },
-    "title": "Crédits Vue d’ensemble",
-    "topupAvailabilityLabel": "Sans expiration",
-    "topupAvailabilityTooltip": "Un abonnement actif est requis pour utiliser les packs de crédits",
-    "totalCreditsDescription": "Les crédits sont consommés par ordre de priorité : crédits du forfait > packs de crédits",
-    "totalCreditsLabel": "Solde de crédits",
+    "title": "Détails",
+    "topupAvailabilityLabel": "Aucune expiration",
+    "topupAvailabilityTooltip": "Un abonnement actif est requis pour utiliser les packs de crédits.",
+    "totalCreditsDescription": "Les crédits du forfait sont utilisés en premier, puis les packs de crédits.",
+    "totalCreditsLabel": "Solde",
     "usageTable": {
       "columns": {
         "scene": "Élément d’utilisation"
       },
-      "title": "Crédit usage details"
+      "title": "Détail des consommations"
     }
   },
   "domains": {

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -355,7 +355,6 @@
       "creditType": "类型",
       "validUntil": "有效期至"
     },
-    "title": "详情",
     "topupAvailabilityLabel": "无限期",
     "topupAvailabilityTooltip": "需开通任一有效套餐后才可使用",
     "totalCreditsDescription": "优先使用套餐积分，再使用积分包",

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -353,18 +353,18 @@
     "table": {
       "balance": "余额",
       "creditType": "类型",
-      "validUntil": "有效期到"
+      "validUntil": "有效期至"
     },
-    "title": "积分总览",
+    "title": "详情",
     "topupAvailabilityLabel": "无限期",
-    "topupAvailabilityTooltip": "必须有任意激活套餐才可使用",
-    "totalCreditsDescription": "按照套餐积分>积分包的顺序优先扣减",
-    "totalCreditsLabel": "积分余额",
+    "topupAvailabilityTooltip": "需开通任一有效套餐后才可使用",
+    "totalCreditsDescription": "优先使用套餐积分，再使用积分包",
+    "totalCreditsLabel": "余额",
     "usageTable": {
       "columns": {
         "scene": "消耗项"
       },
-      "title": "积分消耗明细"
+      "title": "消耗明细"
     }
   },
   "domains": {


### PR DESCRIPTION
## Summary
- Remove the redundant visible credits overview heading from the billing details tab.
- Rename visible balance and usage detail copy across zh-CN, en-US, and fr-FR.
- Lower the usage details section title styling and keep balance formatting and ledger reason formatting unchanged.
- Update the cook-web billing guidance to avoid any thousand-separator rule.

## Verification
- `npm run test -- src/components/billing/BillingCreditDetailsPanel.test.tsx src/app/admin/billing/components/BillingRecentActivitySection.test.tsx src/app/admin/billing/page.test.tsx`
- `npm run type-check`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_dev_tools.py`
- pre-commit hooks via `git commit`