### PR TITLE
feat: show more credit usage entries per page

### DIFF
--- a/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
+++ b/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
@@ -151,18 +151,15 @@ export function AdminBillingPageClient({
           </TabsContent>
 
           <TabsContent
-            className='mt-0 min-h-0 flex-1'
+            className='mt-0'
             value='details'
             data-testid='admin-billing-details-panel'
           >
-            <div className='flex h-full min-h-0 flex-col gap-8 pb-6'>
+            <div className='space-y-8 pb-6'>
               <BillingCreditDetailsPanel
                 onUpgrade={() => updateTab('packages')}
               />
-              <BillingRecentActivitySection
-                className='flex-1'
-                stretchToFill
-              />
+              <BillingRecentActivitySection />
             </div>
           </TabsContent>
         </Tabs>

--- a/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
+++ b/src/cook-web/src/app/admin/billing/AdminBillingPageClient.tsx
@@ -106,13 +106,13 @@ export function AdminBillingPageClient({
 
   return (
     <div
-      className='h-full min-h-0 overscroll-none p-0'
+      className='overscroll-none p-0'
       data-testid='admin-billing-page'
     >
-      <div className='flex h-full min-h-0 flex-col px-1 pb-6'>
+      <div className='px-1 pb-6'>
         <h1 className='sr-only'>{pageHeading}</h1>
         <Tabs
-          className='flex min-h-0 flex-1 flex-col'
+          className='flex flex-col'
           value={activeTab}
           onValueChange={v => updateTab(v as BillingTab)}
         >
@@ -141,7 +141,7 @@ export function AdminBillingPageClient({
           />
 
           <TabsContent
-            className='mt-0 min-h-0'
+            className='mt-0'
             value='packages'
             data-testid='admin-billing-packages-panel'
           >

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -466,6 +466,13 @@ describe('BillingRecentActivitySection', () => {
     expect(skeletonRows[0].querySelector('td:last-child > div')).toHaveClass(
       'ml-auto',
     );
+    expect(
+      screen.getByRole('navigation', { name: 'pagination' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '2' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
 
     await act(async () => {
       resolveSecondPage?.({

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -83,7 +83,7 @@ describe('BillingRecentActivitySection', () => {
           page: 2,
           page_count: 2,
           page_size,
-          total: 11,
+          total: 21,
         });
       }
 
@@ -143,7 +143,7 @@ describe('BillingRecentActivitySection', () => {
         page: 1,
         page_count: 2,
         page_size,
-        total: 11,
+        total: 21,
       });
     });
   });
@@ -154,7 +154,7 @@ describe('BillingRecentActivitySection', () => {
     await waitFor(() => {
       expect(mockGetBillingLedger).toHaveBeenCalledWith({
         page_index: 1,
-        page_size: 10,
+        page_size: 20,
       });
     });
 
@@ -238,7 +238,7 @@ describe('BillingRecentActivitySection', () => {
     await waitFor(() => {
       expect(mockGetBillingLedger).toHaveBeenCalledWith({
         page_index: 2,
-        page_size: 10,
+        page_size: 20,
       });
     });
 
@@ -250,13 +250,13 @@ describe('BillingRecentActivitySection', () => {
 
   test('keeps one full page height when a full usage page is available', async () => {
     mockGetBillingLedger.mockResolvedValueOnce({
-      items: Array.from({ length: 10 }, (_, index) =>
+      items: Array.from({ length: 20 }, (_, index) =>
         createLedgerItem(index + 1),
       ),
       page: 1,
       page_count: 3,
-      page_size: 10,
-      total: 30,
+      page_size: 20,
+      total: 60,
     });
 
     renderSection({ stretchToFill: true });
@@ -264,9 +264,9 @@ describe('BillingRecentActivitySection', () => {
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
     expect(scrollContainer).toHaveClass('flex-1');
-    expect(scrollContainer.style.minHeight).toBe('570px');
+    expect(scrollContainer.style.minHeight).toBe('1100px');
     expect(scrollContainer.parentElement).toHaveStyle({
-      minHeight: '570px',
+      minHeight: '1100px',
     });
   });
 
@@ -293,7 +293,7 @@ describe('BillingRecentActivitySection', () => {
       ],
       page: 1,
       page_count: 1,
-      page_size: 10,
+      page_size: 20,
       total: 1,
     });
 
@@ -321,7 +321,7 @@ describe('BillingRecentActivitySection', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('keeps a full 10-row skeleton height while the next ledger page is loading', async () => {
+  test('keeps a full 20-row skeleton height while the next ledger page is loading', async () => {
     const user = userEvent.setup();
     let resolveSecondPage:
       | ((value: {
@@ -386,7 +386,7 @@ describe('BillingRecentActivitySection', () => {
         page: 1,
         page_count: 2,
         page_size,
-        total: 11,
+        total: 21,
       });
     });
 
@@ -410,7 +410,7 @@ describe('BillingRecentActivitySection', () => {
     const skeleton = await screen.findByTestId('billing-usage-table-skeleton');
     expect(skeleton).toBeInTheDocument();
     const skeletonRows = screen.getAllByTestId('billing-usage-skeleton-row');
-    expect(skeletonRows).toHaveLength(10);
+    expect(skeletonRows).toHaveLength(20);
     expect(skeletonRows[0]).toHaveClass('hover:!bg-transparent');
     expect(skeletonRows[0].querySelector('td:last-child > div')).toHaveClass(
       'ml-auto',
@@ -436,8 +436,8 @@ describe('BillingRecentActivitySection', () => {
         ],
         page: 2,
         page_count: 2,
-        page_size: 10,
-        total: 11,
+        page_size: 20,
+        total: 21,
       });
     });
 

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -250,7 +250,7 @@ describe('BillingRecentActivitySection', () => {
     expect(await screen.findByText('+5.00')).toBeInTheDocument();
   });
 
-  test('keeps one full page height when a full usage page is available', async () => {
+  test('renders a full usage page without fixed vertical scrolling', async () => {
     mockGetBillingLedger.mockResolvedValueOnce({
       items: Array.from({ length: 20 }, (_, index) =>
         createLedgerItem(index + 1),
@@ -267,8 +267,8 @@ describe('BillingRecentActivitySection', () => {
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
     expect(scrollContainer).not.toHaveClass('flex-1');
     expect(scrollContainer).toHaveClass('overflow-x-auto');
-    expect(scrollContainer.style.minHeight).toBe('1100px');
-    expect(scrollContainer.parentElement).toHaveStyle({
+    expect(scrollContainer.style.minHeight).toBe('');
+    expect(scrollContainer.parentElement).not.toHaveStyle({
       minHeight: '1100px',
     });
   });

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -198,7 +198,8 @@ describe('BillingRecentActivitySection', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '1' })).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
-    expect(scrollContainer).toHaveClass('overflow-visible');
+    expect(scrollContainer).toHaveClass('overflow-x-auto');
+    expect(scrollContainer).not.toHaveClass('overflow-visible');
     expect(scrollContainer).not.toHaveClass('overflow-auto');
     const columns = Array.from(container.querySelectorAll('col'));
     expect(columns.map(column => column.className)).toEqual([
@@ -265,7 +266,7 @@ describe('BillingRecentActivitySection', () => {
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
     expect(scrollContainer).not.toHaveClass('flex-1');
-    expect(scrollContainer).toHaveClass('overflow-visible');
+    expect(scrollContainer).toHaveClass('overflow-x-auto');
     expect(scrollContainer.style.minHeight).toBe('1100px');
     expect(scrollContainer.parentElement).toHaveStyle({
       minHeight: '1100px',
@@ -285,7 +286,7 @@ describe('BillingRecentActivitySection', () => {
 
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
-    expect(scrollContainer).toHaveClass('overflow-visible');
+    expect(scrollContainer).toHaveClass('overflow-x-auto');
     expect(scrollContainer).not.toHaveClass('flex-1');
     expect(scrollContainer.style.minHeight).toBe('');
     expect(scrollContainer.parentElement).not.toHaveClass('flex-1');

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -198,7 +198,8 @@ describe('BillingRecentActivitySection', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '1' })).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
-    expect(scrollContainer).toHaveClass('overflow-auto');
+    expect(scrollContainer).toHaveClass('overflow-visible');
+    expect(scrollContainer).not.toHaveClass('overflow-auto');
     const columns = Array.from(container.querySelectorAll('col'));
     expect(columns.map(column => column.className)).toEqual([
       'w-[64%]',
@@ -259,40 +260,19 @@ describe('BillingRecentActivitySection', () => {
       total: 60,
     });
 
-    renderSection({ stretchToFill: false });
+    renderSection();
 
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
     expect(scrollContainer).not.toHaveClass('flex-1');
+    expect(scrollContainer).toHaveClass('overflow-visible');
     expect(scrollContainer.style.minHeight).toBe('1100px');
     expect(scrollContainer.parentElement).toHaveStyle({
       minHeight: '1100px',
     });
   });
 
-  test('omits the fixed page height when the usage table stretches to fill', async () => {
-    mockGetBillingLedger.mockResolvedValueOnce({
-      items: Array.from({ length: 20 }, (_, index) =>
-        createLedgerItem(index + 1),
-      ),
-      page: 1,
-      page_count: 3,
-      page_size: 20,
-      total: 60,
-    });
-
-    renderSection({ stretchToFill: true });
-
-    expect(await screen.findByText('+1.00')).toBeInTheDocument();
-    const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
-    expect(scrollContainer).toHaveClass('flex-1');
-    expect(scrollContainer.style.minHeight).toBe('');
-    expect(scrollContainer.parentElement).not.toHaveStyle({
-      minHeight: '1100px',
-    });
-  });
-
-  test('keeps the stretch layout when a usage page has fewer rows', async () => {
+  test('does not force page height when a usage page has fewer rows', async () => {
     mockGetBillingLedger.mockResolvedValueOnce({
       items: [createLedgerItem(1)],
       page: 2,
@@ -301,13 +281,14 @@ describe('BillingRecentActivitySection', () => {
       total: 21,
     });
 
-    renderSection({ stretchToFill: true });
+    renderSection();
 
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
-    expect(scrollContainer).toHaveClass('flex-1');
+    expect(scrollContainer).toHaveClass('overflow-visible');
+    expect(scrollContainer).not.toHaveClass('flex-1');
     expect(scrollContainer.style.minHeight).toBe('');
-    expect(scrollContainer.parentElement).toHaveClass('flex-1');
+    expect(scrollContainer.parentElement).not.toHaveClass('flex-1');
   });
 
   test('does not render an empty pagination footer for a single page result', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -63,6 +63,10 @@ describe('BillingRecentActivitySection', () => {
     HTMLElement.prototype,
     'scrollIntoView',
   );
+  const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    'matchMedia',
+  );
 
   beforeEach(() => {
     mockGetBillingLedger.mockReset();
@@ -168,6 +172,11 @@ describe('BillingRecentActivitySection', () => {
       );
     } else {
       Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+    }
+    if (originalMatchMediaDescriptor) {
+      Object.defineProperty(window, 'matchMedia', originalMatchMediaDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'matchMedia');
     }
   });
 
@@ -275,6 +284,41 @@ describe('BillingRecentActivitySection', () => {
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       behavior: 'smooth',
+      block: 'start',
+    });
+  });
+
+  test('does not smooth scroll when reduced motion is preferred', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    renderSection();
+
+    expect(
+      await screen.findByText(
+        'module.billing.ledger.usageScene.tts - Published Course 1 - learner@example.com',
+      ),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getByRole('link', { name: '2' }));
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'auto',
       block: 'start',
     });
   });

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -288,6 +288,11 @@ describe('BillingRecentActivitySection', () => {
       behavior: 'smooth',
       block: 'start',
     });
+    expect(
+      screen.getByRole('heading', {
+        name: 'module.billing.details.usageTable.title',
+      }),
+    ).toHaveFocus();
   });
 
   test('does not smooth scroll when reduced motion is preferred', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -288,11 +288,11 @@ describe('BillingRecentActivitySection', () => {
       behavior: 'smooth',
       block: 'start',
     });
-    expect(
-      screen.getByRole('heading', {
-        name: 'module.billing.details.usageTable.title',
-      }),
-    ).toHaveFocus();
+    const usageHeading = screen.getByRole('heading', {
+      name: 'module.billing.details.usageTable.title',
+    });
+    expect(usageHeading).toHaveFocus();
+    expect(usageHeading).toHaveClass('focus:outline-none');
   });
 
   test('does not smooth scroll when reduced motion is preferred', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@/api', () => ({
 }));
 
 const mockGetBillingLedger = api.getBillingLedger as jest.Mock;
+const scrollIntoViewMock = jest.fn();
 
 const createLedgerItem = (index: number) => ({
   ledger_bid: `ledger-${index}`,
@@ -60,6 +61,8 @@ function renderSection(
 describe('BillingRecentActivitySection', () => {
   beforeEach(() => {
     mockGetBillingLedger.mockReset();
+    scrollIntoViewMock.mockClear();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
 
     mockGetBillingLedger.mockImplementation(({ page_index, page_size }) => {
       if (page_index === 2) {
@@ -232,6 +235,7 @@ describe('BillingRecentActivitySection', () => {
         'module.billing.ledger.usageScene.tts - Published Course 1 - learner@example.com',
       ),
     ).toBeInTheDocument();
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
 
     await act(async () => {
       await user.click(screen.getByRole('link', { name: '2' }));
@@ -248,6 +252,8 @@ describe('BillingRecentActivitySection', () => {
       await screen.findByText('module.billing.ledger.source.topup'),
     ).toBeInTheDocument();
     expect(await screen.findByText('+5.00')).toBeInTheDocument();
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'start' });
   });
 
   test('renders a full usage page without fixed vertical scrolling', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -59,12 +59,18 @@ function renderSection(
 }
 
 describe('BillingRecentActivitySection', () => {
-  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollIntoView',
+  );
 
   beforeEach(() => {
     mockGetBillingLedger.mockReset();
     scrollIntoViewMock.mockClear();
-    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
 
     mockGetBillingLedger.mockImplementation(({ page_index, page_size }) => {
       if (page_index === 2) {
@@ -154,7 +160,15 @@ describe('BillingRecentActivitySection', () => {
   });
 
   afterEach(() => {
-    Element.prototype.scrollIntoView = originalScrollIntoView;
+    if (originalScrollIntoViewDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollIntoView',
+        originalScrollIntoViewDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+    }
   });
 
   test('renders the credit usage details table from recent ledger entries', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -259,7 +259,10 @@ describe('BillingRecentActivitySection', () => {
     ).toBeInTheDocument();
     expect(await screen.findByText('+5.00')).toBeInTheDocument();
     expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'start' });
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
   });
 
   test('renders a full usage page without fixed vertical scrolling', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -292,7 +292,12 @@ describe('BillingRecentActivitySection', () => {
       name: 'module.billing.details.usageTable.title',
     });
     expect(usageHeading).toHaveFocus();
-    expect(usageHeading).toHaveClass('focus:outline-none');
+    expect(usageHeading).toHaveClass(
+      'focus-visible:outline-none',
+      'focus-visible:ring-2',
+      'focus-visible:ring-primary/20',
+      'focus-visible:ring-offset-2',
+    );
   });
 
   test('does not smooth scroll when reduced motion is preferred', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -281,7 +281,9 @@ describe('BillingRecentActivitySection', () => {
       await screen.findByText('module.billing.ledger.source.topup'),
     ).toBeInTheDocument();
     expect(await screen.findByText('+5.00')).toBeInTheDocument();
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'start',
@@ -316,7 +318,9 @@ describe('BillingRecentActivitySection', () => {
       await user.click(screen.getByRole('link', { name: '2' }));
     });
 
-    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
     expect(scrollIntoViewMock).toHaveBeenCalledWith({
       behavior: 'auto',
       block: 'start',

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -59,6 +59,8 @@ function renderSection(
 }
 
 describe('BillingRecentActivitySection', () => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
   beforeEach(() => {
     mockGetBillingLedger.mockReset();
     scrollIntoViewMock.mockClear();
@@ -149,6 +151,10 @@ describe('BillingRecentActivitySection', () => {
         total: 21,
       });
     });
+  });
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
   });
 
   test('renders the credit usage details table from recent ledger entries', async () => {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -259,13 +259,35 @@ describe('BillingRecentActivitySection', () => {
       total: 60,
     });
 
+    renderSection({ stretchToFill: false });
+
+    expect(await screen.findByText('+1.00')).toBeInTheDocument();
+    const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
+    expect(scrollContainer).not.toHaveClass('flex-1');
+    expect(scrollContainer.style.minHeight).toBe('1100px');
+    expect(scrollContainer.parentElement).toHaveStyle({
+      minHeight: '1100px',
+    });
+  });
+
+  test('omits the fixed page height when the usage table stretches to fill', async () => {
+    mockGetBillingLedger.mockResolvedValueOnce({
+      items: Array.from({ length: 20 }, (_, index) =>
+        createLedgerItem(index + 1),
+      ),
+      page: 1,
+      page_count: 3,
+      page_size: 20,
+      total: 60,
+    });
+
     renderSection({ stretchToFill: true });
 
     expect(await screen.findByText('+1.00')).toBeInTheDocument();
     const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
     expect(scrollContainer).toHaveClass('flex-1');
-    expect(scrollContainer.style.minHeight).toBe('1100px');
-    expect(scrollContainer.parentElement).toHaveStyle({
+    expect(scrollContainer.style.minHeight).toBe('');
+    expect(scrollContainer.parentElement).not.toHaveStyle({
       minHeight: '1100px',
     });
   });

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.test.tsx
@@ -292,6 +292,24 @@ describe('BillingRecentActivitySection', () => {
     });
   });
 
+  test('keeps the stretch layout when a usage page has fewer rows', async () => {
+    mockGetBillingLedger.mockResolvedValueOnce({
+      items: [createLedgerItem(1)],
+      page: 2,
+      page_count: 2,
+      page_size: 20,
+      total: 21,
+    });
+
+    renderSection({ stretchToFill: true });
+
+    expect(await screen.findByText('+1.00')).toBeInTheDocument();
+    const scrollContainer = screen.getByTestId('billing-usage-table-scroll');
+    expect(scrollContainer).toHaveClass('flex-1');
+    expect(scrollContainer.style.minHeight).toBe('');
+    expect(scrollContainer.parentElement).toHaveClass('flex-1');
+  });
+
   test('does not render an empty pagination footer for a single page result', async () => {
     mockGetBillingLedger.mockResolvedValueOnce({
       items: [

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -31,7 +31,6 @@ const USAGE_TABLE_PAGE_MIN_HEIGHT =
 
 type BillingRecentActivitySectionProps = {
   className?: string;
-  stretchToFill?: boolean;
 };
 
 function formatSignedCredits(value: number, locale: string): string {
@@ -80,7 +79,6 @@ function UsageTableSkeleton() {
 
 export function BillingRecentActivitySection({
   className,
-  stretchToFill = false,
 }: BillingRecentActivitySectionProps) {
   const { t, i18n } = useTranslation();
   registerBillingTranslationUsage(t);
@@ -107,9 +105,8 @@ export function BillingRecentActivitySection({
   const currentPage = Number(ledgerData?.page || pageIndex);
   const shouldUsePageHeight =
     ledgerLoading || ledgerItems.length >= RECENT_ITEMS_LIMIT;
-  const shouldStretchTable = stretchToFill;
   const usageTablePageStyle: React.CSSProperties | undefined =
-    shouldUsePageHeight && !stretchToFill
+    shouldUsePageHeight
       ? {
           minHeight: USAGE_TABLE_PAGE_MIN_HEIGHT,
         }
@@ -118,10 +115,7 @@ export function BillingRecentActivitySection({
   return (
     <section
       id='billing-recent-orders'
-      className={cn(
-        stretchToFill ? 'flex min-h-0 flex-col gap-6' : 'space-y-6',
-        className,
-      )}
+      className={cn('space-y-6', className)}
       data-testid='billing-usage-table-section'
     >
       <div>
@@ -140,11 +134,7 @@ export function BillingRecentActivitySection({
           isEmpty={!ledgerLoading && ledgerItems.length === 0}
           emptyContent={t('module.billing.ledger.empty')}
           emptyColSpan={3}
-          containerClassName={cn(stretchToFill && 'min-h-0 flex-1')}
-          tableWrapperClassName={cn(
-            'overflow-hidden rounded-[var(--border-radius-rounded-lg,10px)] [&_tbody_tr[data-admin-skeleton-row]:hover]:!bg-transparent [&_tbody_tr[data-admin-skeleton-row]:hover_td]:!bg-transparent',
-            shouldStretchTable && 'flex min-h-0 flex-1 flex-col',
-          )}
+          tableWrapperClassName='overflow-hidden rounded-[var(--border-radius-rounded-lg,10px)] [&_tbody_tr[data-admin-skeleton-row]:hover]:!bg-transparent [&_tbody_tr[data-admin-skeleton-row]:hover_td]:!bg-transparent'
           tableWrapperStyle={usageTablePageStyle}
           footerClassName='px-0'
           pagination={
@@ -169,10 +159,7 @@ export function BillingRecentActivitySection({
           }
           table={emptyRow => (
             <div
-              className={cn(
-                'overflow-auto',
-                shouldStretchTable && 'min-h-0 flex-1',
-              )}
+              className='overflow-visible'
               style={usageTablePageStyle}
               data-testid='billing-usage-table-scroll'
             >

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -78,6 +78,7 @@ export function BillingRecentActivitySection({
 }: BillingRecentActivitySectionProps) {
   const { t, i18n } = useTranslation();
   registerBillingTranslationUsage(t);
+  const sectionRef = React.useRef<HTMLElement | null>(null);
   const [pageIndex, setPageIndex] = React.useState(1);
 
   const {
@@ -99,9 +100,20 @@ export function BillingRecentActivitySection({
   const ledgerItems = ledgerData?.items || [];
   const pageCount = Number(ledgerData?.page_count || 1);
   const currentPage = Number(ledgerData?.page || pageIndex);
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      if (nextPage === pageIndex) {
+        return;
+      }
+      setPageIndex(nextPage);
+      sectionRef.current?.scrollIntoView({ block: 'start' });
+    },
+    [pageIndex],
+  );
 
   return (
     <section
+      ref={sectionRef}
       id='billing-recent-orders'
       className={cn('space-y-6', className)}
       data-testid='billing-usage-table-section'
@@ -129,7 +141,7 @@ export function BillingRecentActivitySection({
               ? {
                   pageIndex: currentPage,
                   pageCount,
-                  onPageChange: setPageIndex,
+                  onPageChange: handlePageChange,
                   prevLabel: t('module.order.paginationPrev'),
                   nextLabel: t('module.order.paginationNext'),
                   prevAriaLabel: t(

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -80,6 +80,7 @@ export function BillingRecentActivitySection({
   registerBillingTranslationUsage(t);
   const sectionRef = React.useRef<HTMLElement | null>(null);
   const lastPageCountRef = React.useRef(1);
+  const lastPageIndexRef = React.useRef(1);
   const [pageIndex, setPageIndex] = React.useState(1);
 
   const {
@@ -107,8 +108,11 @@ export function BillingRecentActivitySection({
       lastPageCountRef.current = ledgerPageCount;
     }
   }, [ledgerData, ledgerPageCount]);
-  const handlePageChange = React.useCallback((nextPage: number) => {
-    setPageIndex(nextPage);
+  React.useEffect(() => {
+    if (lastPageIndexRef.current === pageIndex) {
+      return;
+    }
+    lastPageIndexRef.current = pageIndex;
     const prefersReducedMotion =
       typeof window !== 'undefined' &&
       typeof window.matchMedia === 'function' &&
@@ -117,6 +121,9 @@ export function BillingRecentActivitySection({
       behavior: prefersReducedMotion ? 'auto' : 'smooth',
       block: 'start',
     });
+  }, [pageIndex]);
+  const handlePageChange = React.useCallback((nextPage: number) => {
+    setPageIndex(nextPage);
   }, []);
 
   return (

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -138,7 +138,10 @@ export function BillingRecentActivitySection({
         <h2
           ref={headingRef}
           tabIndex={-1}
-          className={cn(BILLING_SUBSECTION_TITLE_CLASS, 'focus:outline-none')}
+          className={cn(
+            BILLING_SUBSECTION_TITLE_CLASS,
+            'rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2',
+          )}
         >
           {t('module.billing.details.usageTable.title')}
         </h2>

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -23,7 +23,7 @@ import {
   resolveBillingLedgerReasonLabel,
 } from '@/lib/billing';
 
-const RECENT_ITEMS_LIMIT = 10;
+const RECENT_ITEMS_LIMIT = 20;
 const USAGE_TABLE_HEADER_HEIGHT = 40;
 const USAGE_TABLE_ROW_HEIGHT = 53;
 const USAGE_TABLE_PAGE_MIN_HEIGHT =

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -100,16 +100,10 @@ export function BillingRecentActivitySection({
   const ledgerItems = ledgerData?.items || [];
   const pageCount = Number(ledgerData?.page_count || 1);
   const currentPage = Number(ledgerData?.page || pageIndex);
-  const handlePageChange = React.useCallback(
-    (nextPage: number) => {
-      if (nextPage === pageIndex) {
-        return;
-      }
-      setPageIndex(nextPage);
-      sectionRef.current?.scrollIntoView?.({ block: 'start' });
-    },
-    [pageIndex],
-  );
+  const handlePageChange = React.useCallback((nextPage: number) => {
+    setPageIndex(nextPage);
+    sectionRef.current?.scrollIntoView?.({ block: 'start' });
+  }, []);
 
   return (
     <section

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -79,6 +79,7 @@ export function BillingRecentActivitySection({
   const { t, i18n } = useTranslation();
   registerBillingTranslationUsage(t);
   const sectionRef = React.useRef<HTMLElement | null>(null);
+  const headingRef = React.useRef<HTMLHeadingElement | null>(null);
   const lastPageCountRef = React.useRef(1);
   const lastPageIndexRef = React.useRef(1);
   const [pageIndex, setPageIndex] = React.useState(1);
@@ -121,6 +122,7 @@ export function BillingRecentActivitySection({
       behavior: prefersReducedMotion ? 'auto' : 'smooth',
       block: 'start',
     });
+    headingRef.current?.focus({ preventScroll: true });
   }, [pageIndex]);
   const handlePageChange = React.useCallback((nextPage: number) => {
     setPageIndex(nextPage);
@@ -134,7 +136,11 @@ export function BillingRecentActivitySection({
       data-testid='billing-usage-table-section'
     >
       <div>
-        <h2 className={BILLING_SUBSECTION_TITLE_CLASS}>
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className={BILLING_SUBSECTION_TITLE_CLASS}
+        >
           {t('module.billing.details.usageTable.title')}
         </h2>
       </div>

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -139,7 +139,7 @@ export function BillingRecentActivitySection({
         <h2
           ref={headingRef}
           tabIndex={-1}
-          className={BILLING_SUBSECTION_TITLE_CLASS}
+          className={cn(BILLING_SUBSECTION_TITLE_CLASS, 'focus:outline-none')}
         >
           {t('module.billing.details.usageTable.title')}
         </h2>

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -79,6 +79,7 @@ export function BillingRecentActivitySection({
   const { t, i18n } = useTranslation();
   registerBillingTranslationUsage(t);
   const sectionRef = React.useRef<HTMLElement | null>(null);
+  const lastPageCountRef = React.useRef(1);
   const [pageIndex, setPageIndex] = React.useState(1);
 
   const {
@@ -98,8 +99,14 @@ export function BillingRecentActivitySection({
   );
 
   const ledgerItems = ledgerData?.items || [];
-  const pageCount = Number(ledgerData?.page_count || 1);
+  const ledgerPageCount = Number(ledgerData?.page_count || 1);
+  const pageCount = ledgerData ? ledgerPageCount : lastPageCountRef.current;
   const currentPage = Number(ledgerData?.page || pageIndex);
+  React.useEffect(() => {
+    if (ledgerData) {
+      lastPageCountRef.current = ledgerPageCount;
+    }
+  }, [ledgerData, ledgerPageCount]);
   const handlePageChange = React.useCallback((nextPage: number) => {
     setPageIndex(nextPage);
     sectionRef.current?.scrollIntoView?.({

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -107,7 +107,7 @@ export function BillingRecentActivitySection({
   const currentPage = Number(ledgerData?.page || pageIndex);
   const shouldUsePageHeight =
     ledgerLoading || ledgerItems.length >= RECENT_ITEMS_LIMIT;
-  const shouldStretchTable = stretchToFill && shouldUsePageHeight;
+  const shouldStretchTable = stretchToFill;
   const usageTablePageStyle: React.CSSProperties | undefined =
     shouldUsePageHeight && !stretchToFill
       ? {

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -109,8 +109,12 @@ export function BillingRecentActivitySection({
   }, [ledgerData, ledgerPageCount]);
   const handlePageChange = React.useCallback((nextPage: number) => {
     setPageIndex(nextPage);
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     sectionRef.current?.scrollIntoView?.({
-      behavior: 'smooth',
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
       block: 'start',
     });
   }, []);

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -106,7 +106,7 @@ export function BillingRecentActivitySection({
         return;
       }
       setPageIndex(nextPage);
-      sectionRef.current?.scrollIntoView({ block: 'start' });
+      sectionRef.current?.scrollIntoView?.({ block: 'start' });
     },
     [pageIndex],
   );

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -109,7 +109,7 @@ export function BillingRecentActivitySection({
     ledgerLoading || ledgerItems.length >= RECENT_ITEMS_LIMIT;
   const shouldStretchTable = stretchToFill && shouldUsePageHeight;
   const usageTablePageStyle: React.CSSProperties | undefined =
-    shouldUsePageHeight
+    shouldUsePageHeight && !stretchToFill
       ? {
           minHeight: USAGE_TABLE_PAGE_MIN_HEIGHT,
         }

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -24,10 +24,6 @@ import {
 } from '@/lib/billing';
 
 const RECENT_ITEMS_LIMIT = 20;
-const USAGE_TABLE_HEADER_HEIGHT = 40;
-const USAGE_TABLE_ROW_HEIGHT = 53;
-const USAGE_TABLE_PAGE_MIN_HEIGHT =
-  USAGE_TABLE_HEADER_HEIGHT + RECENT_ITEMS_LIMIT * USAGE_TABLE_ROW_HEIGHT;
 
 type BillingRecentActivitySectionProps = {
   className?: string;
@@ -103,14 +99,6 @@ export function BillingRecentActivitySection({
   const ledgerItems = ledgerData?.items || [];
   const pageCount = Number(ledgerData?.page_count || 1);
   const currentPage = Number(ledgerData?.page || pageIndex);
-  const shouldUsePageHeight =
-    ledgerLoading || ledgerItems.length >= RECENT_ITEMS_LIMIT;
-  const usageTablePageStyle: React.CSSProperties | undefined =
-    shouldUsePageHeight
-      ? {
-          minHeight: USAGE_TABLE_PAGE_MIN_HEIGHT,
-        }
-      : undefined;
 
   return (
     <section
@@ -135,7 +123,6 @@ export function BillingRecentActivitySection({
           emptyContent={t('module.billing.ledger.empty')}
           emptyColSpan={3}
           tableWrapperClassName='overflow-hidden rounded-[var(--border-radius-rounded-lg,10px)] [&_tbody_tr[data-admin-skeleton-row]:hover]:!bg-transparent [&_tbody_tr[data-admin-skeleton-row]:hover_td]:!bg-transparent'
-          tableWrapperStyle={usageTablePageStyle}
           footerClassName='px-0'
           pagination={
             pageCount > 1
@@ -160,7 +147,6 @@ export function BillingRecentActivitySection({
           table={emptyRow => (
             <div
               className='overflow-x-auto'
-              style={usageTablePageStyle}
               data-testid='billing-usage-table-scroll'
             >
               <Table

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -159,7 +159,7 @@ export function BillingRecentActivitySection({
           }
           table={emptyRow => (
             <div
-              className='overflow-visible'
+              className='overflow-x-auto'
               style={usageTablePageStyle}
               data-testid='billing-usage-table-scroll'
             >

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -102,7 +102,10 @@ export function BillingRecentActivitySection({
   const currentPage = Number(ledgerData?.page || pageIndex);
   const handlePageChange = React.useCallback((nextPage: number) => {
     setPageIndex(nextPage);
-    sectionRef.current?.scrollIntoView?.({ block: 'start' });
+    sectionRef.current?.scrollIntoView?.({
+      behavior: 'smooth',
+      block: 'start',
+    });
   }, []);
 
   return (

--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -80,9 +80,9 @@ export function BillingRecentActivitySection({
   registerBillingTranslationUsage(t);
   const sectionRef = React.useRef<HTMLElement | null>(null);
   const headingRef = React.useRef<HTMLHeadingElement | null>(null);
-  const lastPageCountRef = React.useRef(1);
-  const lastPageIndexRef = React.useRef(1);
   const [pageIndex, setPageIndex] = React.useState(1);
+  const [pageCount, setPageCount] = React.useState(1);
+  const lastPageIndexRef = React.useRef(pageIndex);
 
   const {
     data: ledgerData,
@@ -102,11 +102,10 @@ export function BillingRecentActivitySection({
 
   const ledgerItems = ledgerData?.items || [];
   const ledgerPageCount = Number(ledgerData?.page_count || 1);
-  const pageCount = ledgerData ? ledgerPageCount : lastPageCountRef.current;
   const currentPage = Number(ledgerData?.page || pageIndex);
   React.useEffect(() => {
     if (ledgerData) {
-      lastPageCountRef.current = ledgerPageCount;
+      setPageCount(ledgerPageCount);
     }
   }, [ledgerData, ledgerPageCount]);
   React.useEffect(() => {

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -461,7 +461,7 @@ describe('AdminBillingPage', () => {
       await screen.findByTestId('billing-usage-table-section'),
     ).toHaveClass('space-y-6');
     expect(screen.getByTestId('billing-usage-table-scroll')).toHaveClass(
-      'overflow-visible',
+      'overflow-x-auto',
     );
     expect(mockGetBillingCatalog).toHaveBeenCalledWith({});
   });

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -241,7 +241,7 @@ describe('AdminBillingPage', () => {
       ],
       page: 1,
       page_count: 1,
-      page_size: 4,
+      page_size: 20,
       total: 1,
     });
     mockUseBillingOverview.mockReturnValue({
@@ -417,7 +417,7 @@ describe('AdminBillingPage', () => {
     });
     expect(mockGetBillingLedger).toHaveBeenCalledWith({
       page_index: 1,
-      page_size: 10,
+      page_size: 20,
     });
 
     expect(

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -453,8 +453,15 @@ describe('AdminBillingPage', () => {
         name: 'module.billing.page.title · module.billing.page.tabs.ledger',
       }),
     ).toHaveClass('sr-only');
-    expect(screen.getByTestId('admin-billing-details-panel')).toHaveClass(
-      'mt-0',
+    const detailsPanel = screen.getByTestId('admin-billing-details-panel');
+    expect(detailsPanel).toHaveClass('mt-0');
+    expect(detailsPanel).not.toHaveClass('flex-1');
+    expect(detailsPanel.firstElementChild).toHaveClass('space-y-8');
+    expect(
+      await screen.findByTestId('billing-usage-table-section'),
+    ).toHaveClass('space-y-6');
+    expect(screen.getByTestId('billing-usage-table-scroll')).toHaveClass(
+      'overflow-visible',
     );
     expect(mockGetBillingCatalog).toHaveBeenCalledWith({});
   });

--- a/src/cook-web/src/app/admin/billing/page.test.tsx
+++ b/src/cook-web/src/app/admin/billing/page.test.tsx
@@ -290,7 +290,10 @@ describe('AdminBillingPage', () => {
     expect(screen.getByTestId('admin-billing-page')).toHaveClass(
       'overscroll-none',
     );
+    expect(screen.getByTestId('admin-billing-page')).not.toHaveClass('h-full');
+    expect(screen.getByTestId('admin-billing-page')).not.toHaveClass('min-h-0');
     expect(packagesPanel).toHaveClass('mt-0');
+    expect(packagesPanel).not.toHaveClass('min-h-0');
     expect(
       within(tabs).getByRole('tab', {
         name: 'module.billing.page.tabs.plans',


### PR DESCRIPTION
## Summary

- Increased the billing credit usage detail page size from 10 to 20 entries.
- Removed the nested stretch-to-fill ledger scroller so all loaded entries render in the page flow.
- Updated the recent activity component tests and billing page integration test for the new page size.

## Impact

Teachers can scan every loaded credit consumption entry before moving to the next ledger page, using the admin page's normal vertical scroll instead of a nested table scroller.

## Verification

- `python3 scripts/check_dev_tools.py`
- `npm run test -- src/app/admin/billing/components/BillingRecentActivitySection.test.tsx src/app/admin/billing/page.test.tsx`
- `git diff --check`
- Commit hooks: architecture boundary check, translation checks, ESLint, generated language check, Prettier, whitespace checks, and commit message validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The billing activity view now displays more ledger items per page, reducing the frequency of pagination.

* **Bug Fixes**
  * Updated the billing “details” and “recent activity” layout for more consistent spacing and sizing.
  * Refreshed loading, skeleton, and scroll/container styling to align with the new pagination behavior.

* **Tests**
  * Updated billing page and recent activity unit tests to reflect the new page size, pagination calls, and updated layout/overflow expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->