### PR TITLE
fix(tts): scope MiniMax RPM gate per model and treat queue timeout as backpressure

### DIFF
--- a/src/api/error_codes.json
+++ b/src/api/error_codes.json
@@ -54,6 +54,7 @@
   "server.shifu.shifuNotFound": 4008,
   "server.shifu.outlineItemNotFound": 4009,
   "server.shifu.outlineStructureBroken": 4010,
+  "server.learn.ttsRateLimited": 4011,
   "server.pay.payChannelNotSupport": 5001,
   "server.pay.wechatOpenIdRequired": 5002,
   "server.billing.creditInsufficient": 7101,

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -134,6 +134,65 @@ def _coerce_float_config(name: str, default: float) -> float:
         return default
 
 
+# Per-tier default RPM quotas for MiniMax synchronous speech synthesis, matching
+# MiniMax's published per-model limits (turbo tier vs hd tier). MiniMax enforces
+# these per model, so the RPM gate must resolve a limit per model rather than
+# applying one global number to every model.
+MINIMAX_TTS_RPM_TIER_DEFAULTS = {"turbo": 200, "hd": 20}
+
+
+def _minimax_model_tier(model: str) -> str:
+    normalized = (model or "").strip().lower()
+    if normalized.endswith("-hd"):
+        return "hd"
+    if normalized.endswith("-turbo"):
+        return "turbo"
+    return ""
+
+
+def _parse_minimax_rpm_overrides() -> Dict[str, int]:
+    """Parse the optional MINIMAX_TTS_RPM_LIMITS JSON map (model -> rpm)."""
+    raw = get_config("MINIMAX_TTS_RPM_LIMITS")
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        candidate = raw
+    else:
+        try:
+            candidate = json.loads(raw)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid MINIMAX_TTS_RPM_LIMITS JSON: %r", raw)
+            return {}
+    if not isinstance(candidate, dict):
+        logger.warning("Ignoring non-object MINIMAX_TTS_RPM_LIMITS: %r", raw)
+        return {}
+    overrides: Dict[str, int] = {}
+    for key, value in candidate.items():
+        try:
+            overrides[str(key).strip()] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return overrides
+
+
+def _resolve_minimax_rpm_limit(model: str) -> int:
+    """Resolve the RPM limit for a MiniMax TTS model.
+
+    Resolution order:
+    1. Explicit per-model override in the MINIMAX_TTS_RPM_LIMITS JSON map.
+    2. The tier default (turbo vs hd) derived from the model suffix.
+    3. The global MINIMAX_TTS_RPM_LIMIT fallback (0 disables gating).
+    """
+    normalized = (model or "").strip()
+    overrides = _parse_minimax_rpm_overrides()
+    if normalized in overrides:
+        return overrides[normalized]
+    tier = _minimax_model_tier(normalized)
+    if tier in MINIMAX_TTS_RPM_TIER_DEFAULTS:
+        return MINIMAX_TTS_RPM_TIER_DEFAULTS[tier]
+    return _coerce_int_config("MINIMAX_TTS_RPM_LIMIT", 0)
+
+
 @dataclass
 class MinimaxHTTPStreamChunk:
     """One parsed MiniMax HTTP streaming response event."""
@@ -408,10 +467,11 @@ class MinimaxTTSProvider(BaseTTSProvider):
         acquire_tts_rpm_slot(
             provider="minimax",
             api_key=api_key,
-            rpm_limit=_coerce_int_config("MINIMAX_TTS_RPM_LIMIT", 0),
+            rpm_limit=_resolve_minimax_rpm_limit(tts_model),
             max_wait_seconds=_coerce_float_config(
                 "MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS", 10.0
             ),
+            model=tts_model,
         )
 
         logger.debug(

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional, Callable, Dict, List, Type
@@ -76,6 +77,31 @@ class EnvVar:
             return list(value)
         else:
             return str(value)
+
+
+def _is_valid_rpm_limits_json(value: Any) -> bool:
+    """Validate the MINIMAX_TTS_RPM_LIMITS override map.
+
+    Empty is allowed (no overrides). A non-empty value must be a JSON object
+    whose values are integer-coercible RPM limits.
+    """
+    if not value:
+        return True
+    if isinstance(value, dict):
+        candidate = value
+    else:
+        try:
+            candidate = json.loads(value)
+        except (TypeError, ValueError):
+            return False
+    if not isinstance(candidate, dict):
+        return False
+    for rpm in candidate.values():
+        try:
+            int(rpm)
+        except (TypeError, ValueError):
+            return False
+    return True
 
 
 # Environment variable registry
@@ -1389,6 +1415,7 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
             'the per-tier defaults (e.g. {"speech-2.8-hd": 20})'
         ),
         group="tts",
+        validator=_is_valid_rpm_limits_json,
     ),
     "MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS": EnvVar(
         name="MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS",

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1374,7 +1374,20 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         name="MINIMAX_TTS_RPM_LIMIT",
         default=0,
         type=int,
-        description="MiniMax TTS RPM queue limit; 0 disables queue gating",
+        description=(
+            "Fallback MiniMax TTS RPM queue limit for models without a known "
+            "tier or explicit override; 0 disables queue gating"
+        ),
+        group="tts",
+    ),
+    "MINIMAX_TTS_RPM_LIMITS": EnvVar(
+        name="MINIMAX_TTS_RPM_LIMITS",
+        default="",
+        type=str,
+        description=(
+            "Optional JSON map of MiniMax TTS model -> RPM limit that overrides "
+            'the per-tier defaults (e.g. {"speech-2.8-hd": 20})'
+        ),
         group="tts",
     ),
     "MINIMAX_TTS_QUEUE_MAX_WAIT_SECONDS": EnvVar(

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -106,6 +106,7 @@ from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_READY,
 )
 from flaskr.service.tts.pipeline import split_text_for_tts
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.service.tts.validation import validate_tts_settings_strict
 from flaskr.util import generate_id
@@ -996,6 +997,13 @@ def _yield_with_tts_error_mapping(
         yield from body()
     except ValueError as exc:
         raise_error_with_args("server.common.paramsError", param_message=str(exc))
+    except TTSRpmQueueTimeout as exc:
+        # The TTS provider's RPM quota is saturated. This is expected
+        # backpressure, not a crash: log at WARNING (so it does not page ops as
+        # an ERROR) and surface a retryable message instead of a generic
+        # unknown error.
+        app.logger.warning("%s: %s", unknown_error_log, exc)
+        raise_error("server.learn.ttsRateLimited")
     except Exception:
         app.logger.error(unknown_error_log, exc_info=True)
         raise_error("server.common.unknownError")

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -86,7 +86,7 @@ from flaskr.api.tts import (
     synthesize_text,
 )
 from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
-from flaskr.service.tts.api import create_streaming_tts_processor
+from flaskr.service.tts.api import create_streaming_tts_processor, TTSRpmQueueTimeout
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
     get_audio_duration_ms,
@@ -106,7 +106,6 @@ from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_READY,
 )
 from flaskr.service.tts.pipeline import split_text_for_tts
-from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.service.tts.validation import validate_tts_settings_strict
 from flaskr.util import generate_id

--- a/src/api/flaskr/service/tts/api.py
+++ b/src/api/flaskr/service/tts/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flaskr.service.tts.pipeline import build_av_segmentation_contract
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
 from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
@@ -38,4 +39,5 @@ __all__ = [
     "run_minimax_voice_clone",
     "serialize_minimax_cloned_voice",
     "submit_minimax_voice_clone",
+    "TTSRpmQueueTimeout",
 ]

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -170,7 +170,12 @@ def _get_redis_client():
 
 def _scope_key(*, provider: str, api_key: str, model: str = "") -> str:
     normalized_provider = (provider or "default").strip().lower() or "default"
-    key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:24]
+    # Fingerprint the API key so the raw secret never appears in Redis keys.
+    # This is a namespacing digest, not password storage, so a fast hash is
+    # appropriate (usedforsecurity=False documents that intent).
+    key_hash = hashlib.sha256(
+        (api_key or "").encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:24]
     normalized_model = (model or "").strip().lower()
     if normalized_model:
         return f"{normalized_provider}:{key_hash}:{normalized_model}"

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -39,10 +39,15 @@ def acquire_tts_rpm_slot(
     api_key: str,
     rpm_limit: int | float,
     max_wait_seconds: int | float,
+    model: str = "",
     now_fn: Callable[[], float] = time.time,
     sleep_fn: Callable[[float], None] = time.sleep,
 ) -> TTSRpmGateResult:
-    """Reserve one smoothed RPM slot for a provider/API-key pair.
+    """Reserve one smoothed RPM slot for a provider/API-key/model tuple.
+
+    Provider RPM quotas are per-model (e.g. MiniMax turbo vs hd tiers), so the
+    queue is scoped by model as well as provider/API key: each model smooths
+    against its own limit instead of sharing a single global queue.
 
     The Redis path coordinates all workers. When Redis is not configured or is
     unreachable, the local process path still protects a single worker so the
@@ -56,7 +61,7 @@ def acquire_tts_rpm_slot(
 
     wait_cap = max(float(max_wait_seconds or 0), 0.0)
     interval = 60.0 / limit
-    scope_key = _scope_key(provider=provider, api_key=api_key)
+    scope_key = _scope_key(provider=provider, api_key=api_key, model=model)
     start = now_fn()
     deadline = start + wait_cap
 
@@ -163,9 +168,12 @@ def _get_redis_client():
     return redis_client
 
 
-def _scope_key(*, provider: str, api_key: str) -> str:
+def _scope_key(*, provider: str, api_key: str, model: str = "") -> str:
     normalized_provider = (provider or "default").strip().lower() or "default"
     key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:24]
+    normalized_model = (model or "").strip().lower()
+    if normalized_model:
+        return f"{normalized_provider}:{key_hash}:{normalized_model}"
     return f"{normalized_provider}:{key_hash}"
 
 

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -61,7 +61,7 @@ def acquire_tts_rpm_slot(
 
     wait_cap = max(float(max_wait_seconds or 0), 0.0)
     interval = 60.0 / limit
-    scope_key = _scope_key(provider=provider, api_key=api_key, model=model)
+    scope_key = _model_scope_key(provider=provider, api_key=api_key, model=model)
     start = now_fn()
     deadline = start + wait_cap
 
@@ -168,18 +168,21 @@ def _get_redis_client():
     return redis_client
 
 
-def _scope_key(*, provider: str, api_key: str, model: str = "") -> str:
+def _scope_key(*, provider: str, api_key: str) -> str:
     normalized_provider = (provider or "default").strip().lower() or "default"
-    # Fingerprint the API key so the raw secret never appears in Redis keys.
-    # This is a namespacing digest, not password storage, so a fast hash is
-    # appropriate (usedforsecurity=False documents that intent).
-    key_hash = hashlib.sha256(
-        (api_key or "").encode("utf-8"), usedforsecurity=False
-    ).hexdigest()[:24]
+    key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:24]
+    return f"{normalized_provider}:{key_hash}"
+
+
+def _model_scope_key(*, provider: str, api_key: str, model: str) -> str:
+    # Extend the provider/api-key scope with the model so each model smooths
+    # against its own queue. Kept separate from _scope_key so that function
+    # stays byte-identical to its original single-scope form.
+    base = _scope_key(provider=provider, api_key=api_key)
     normalized_model = (model or "").strip().lower()
     if normalized_model:
-        return f"{normalized_provider}:{key_hash}:{normalized_model}"
-    return f"{normalized_provider}:{key_hash}"
+        return f"{base}:{normalized_model}"
+    return base
 
 
 def _parse_timestamp(

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -1,0 +1,49 @@
+import logging
+
+import pytest
+
+from flaskr.service.common.models import AppException, ERROR_CODE
+from flaskr.service.learn.learn_funcs import _yield_with_tts_error_mapping
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+
+
+def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
+    def _body():
+        raise TTSRpmQueueTimeout("TTS RPM queue wait exceeded 10.00s")
+        yield  # pragma: no cover
+
+    with app.app_context():
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(AppException) as exc_info:
+                list(
+                    _yield_with_tts_error_mapping(
+                        app,
+                        unknown_error_log="AV TTS synthesis failed",
+                        body=_body,
+                    )
+                )
+
+    # Backpressure surfaces as the dedicated retryable code, not a generic 500.
+    assert exc_info.value.code == ERROR_CODE["server.learn.ttsRateLimited"]
+    assert exc_info.value.code != ERROR_CODE["server.common.unknownError"]
+    # It is not escalated to ERROR (which would page ops via the Feishu handler).
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_unexpected_error_still_maps_to_unknown_error(app, caplog):
+    def _body():
+        raise RuntimeError("tts worker crashed")
+        yield  # pragma: no cover
+
+    with app.app_context():
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(AppException) as exc_info:
+                list(
+                    _yield_with_tts_error_mapping(
+                        app,
+                        unknown_error_log="AV TTS synthesis failed",
+                        body=_body,
+                    )
+                )
+
+    assert exc_info.value.code == ERROR_CODE["server.common.unknownError"]

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -113,7 +113,11 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     assert chunks[-1].word_count == 2
     assert chunks[-1].usage_characters == 6
     assert chunks[-1].subtitles[0]["text"] == "First."
-    assert gate_calls[0]["rpm_limit"] == 60
+    # speech-2.8-turbo resolves to its turbo-tier quota (200), overriding the
+    # global MINIMAX_TTS_RPM_LIMIT fallback, and the model is passed through so
+    # the gate queues per model.
+    assert gate_calls[0]["rpm_limit"] == 200
+    assert gate_calls[0]["model"] == "speech-2.8-turbo"
     assert post_calls[0][0].endswith("GroupId=test-group")
     assert post_calls[0][1]["stream"] is True
     assert post_calls[0][1]["json"]["stream"] is True

--- a/src/api/tests/service/tts/test_minimax_rpm_limit.py
+++ b/src/api/tests/service/tts/test_minimax_rpm_limit.py
@@ -1,0 +1,46 @@
+from flaskr.api.tts import minimax_provider
+
+
+def _set_config(monkeypatch, mapping):
+    monkeypatch.setattr(
+        minimax_provider,
+        "get_config",
+        lambda name, default=None: mapping.get(name, default),
+    )
+
+
+def test_resolve_rpm_turbo_tier_default(monkeypatch):
+    _set_config(monkeypatch, {})
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-01-turbo") == 200
+
+
+def test_resolve_rpm_hd_tier_default(monkeypatch):
+    _set_config(monkeypatch, {})
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-hd") == 20
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-02-hd") == 20
+
+
+def test_resolve_rpm_json_override_takes_precedence(monkeypatch):
+    _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMITS": '{"speech-2.8-hd": 15}'})
+    # Explicit override wins over the tier default.
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-hd") == 15
+    # Models not in the override map still use their tier default.
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
+
+
+def test_resolve_rpm_invalid_override_json_is_ignored(monkeypatch):
+    _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMITS": "not-json"})
+    assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
+
+
+def test_resolve_rpm_unknown_model_falls_back_to_global(monkeypatch):
+    _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMIT": 42})
+    # No tier suffix and no override -> global fallback.
+    assert minimax_provider._resolve_minimax_rpm_limit("some-future-model") == 42
+
+
+def test_resolve_rpm_unknown_model_without_global_disables_gating(monkeypatch):
+    _set_config(monkeypatch, {})
+    # Global default is 0 which disables gating for unknown models.
+    assert minimax_provider._resolve_minimax_rpm_limit("some-future-model") == 0

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -108,6 +108,63 @@ def test_rpm_gate_uses_independent_queues_for_different_api_keys(monkeypatch):
     assert second.waited_seconds == 0
 
 
+def test_rpm_gate_uses_independent_queues_for_different_models(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
+    now_fn, sleep_fn = _clock()
+
+    first = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        model="speech-2.8-turbo",
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+    second = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        model="speech-2.8-hd",
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    # Per-model quotas: different models smooth against independent queues.
+    assert first.waited_seconds == 0
+    assert second.waited_seconds == 0
+
+
+def test_rpm_gate_smooths_same_model(monkeypatch):
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
+    now_fn, sleep_fn = _clock()
+
+    first = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        model="speech-2.8-hd",
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+    second = rpm_gate.acquire_tts_rpm_slot(
+        provider="minimax",
+        api_key="api-key-a",
+        rpm_limit=60,
+        max_wait_seconds=10,
+        model="speech-2.8-hd",
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert first.waited_seconds == 0
+    assert second.waited_seconds == pytest.approx(1.0)
+
+
 def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch):
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)

--- a/src/i18n/en-US/modules/backend/learn.json
+++ b/src/i18n/en-US/modules/backend/learn.json
@@ -7,6 +7,7 @@
     "invalidAction": "Invalid action",
     "lessonFeedbackCommentPlaceholder": "Optional: leave your feedback",
     "nextChapterButton": "Next",
-    "outputInProgress": "Content is still generating. Please wait before retrying."
+    "outputInProgress": "Content is still generating. Please wait before retrying.",
+    "ttsRateLimited": "The voice service is busy right now. Please try again in a moment."
   }
 }

--- a/src/i18n/fr-FR/modules/backend/learn.json
+++ b/src/i18n/fr-FR/modules/backend/learn.json
@@ -7,6 +7,7 @@
     "invalidAction": "Action non valide",
     "lessonFeedbackCommentPlaceholder": "Facultatif : laissez votre commentaire",
     "nextChapterButton": "Suivant",
-    "outputInProgress": "Le contenu est encore en cours de génération. Veuillez patienter avant de réessayer."
+    "outputInProgress": "Le contenu est encore en cours de génération. Veuillez patienter avant de réessayer.",
+    "ttsRateLimited": "Le service vocal est actuellement occupé. Veuillez réessayer dans un instant."
   }
 }

--- a/src/i18n/zh-CN/modules/backend/learn.json
+++ b/src/i18n/zh-CN/modules/backend/learn.json
@@ -7,6 +7,7 @@
     "invalidAction": "无效的操作",
     "lessonFeedbackCommentPlaceholder": "选填：告诉我们你的建议",
     "nextChapterButton": "下一节",
-    "outputInProgress": "正在有内容输出中，请等待输出结束后再重试"
+    "outputInProgress": "正在有内容输出中，请等待输出结束后再重试",
+    "ttsRateLimited": "语音服务当前繁忙，请稍后重试"
   }
 }


### PR DESCRIPTION
## Problem

Production alert (2026-07-07 10:23):
`TTSRpmQueueTimeout: TTS RPM queue wait exceeded 10.00s`, logged at ERROR as
"AV TTS synthesis failed" and paged to Feishu; the user received a generic
`unknownError`.

Root cause: MiniMax enforces RPM quotas **per model** (per their docs, turbo
tiers = 200 RPM, hd tiers = 20 RPM), but the TTS RPM gate applied a single
global limit keyed only by `provider + api_key`. All MiniMax models therefore
shared one 200-RPM queue. When one course generated a burst of TTS requests
(a live PPT classroom session), the shared queue saturated and requests were
shed with `TTSRpmQueueTimeout` — expected backpressure, but reported as a crash.

## Changes

- **Per-model queue scope** (`rpm_gate.py`): `acquire_tts_rpm_slot` takes a
  `model` and includes it in the scope key, so each model smooths against its
  own limit instead of a single shared queue.
- **Per-model limit resolution** (`minimax_provider.py`): resolve the RPM limit
  per model. Order: `MINIMAX_TTS_RPM_LIMITS` JSON override → per-tier default
  (turbo 200 / hd 20, from the model suffix) → global `MINIMAX_TTS_RPM_LIMIT`
  fallback (0 disables gating). The resolved model is passed to the gate.
- **Config** (`config.py`): add `MINIMAX_TTS_RPM_LIMITS` (optional JSON map) and
  reword `MINIMAX_TTS_RPM_LIMIT` as the fallback for unknown-tier models.
- **De-noise** (`learn_funcs.py`): `_yield_with_tts_error_mapping` now maps
  `TTSRpmQueueTimeout` to a new retryable `server.learn.ttsRateLimited` error,
  logged at WARNING (no ERROR page) instead of `unknownError`, with en/zh/fr
  messages.

## Behavior notes

- Turbo models (incl. the default `speech-01-turbo`) keep a 200 limit, so the
  common case is unchanged. `hd` models drop to their real 20-RPM quota (they
  were previously under-throttled by the loose global 200). Ops can override any
  model via `MINIMAX_TTS_RPM_LIMITS` from deploy-config without a code change.
- The global `MINIMAX_TTS_RPM_LIMIT=200` in the CN configmap now acts as the
  unknown-tier fallback; no configmap change is required for this PR to help,
  but per-model overrides can be added later if a tier's quota changes.

## Tests

- `test_tts_rpm_gate.py`: independent queues per model; same-model smoothing.
- `test_minimax_rpm_limit.py`: tier defaults, JSON override precedence, invalid
  JSON ignored, unknown-model global fallback.
- `test_tts_error_mapping.py`: `TTSRpmQueueTimeout` -> `ttsRateLimited` (not
  `unknownError`, not ERROR-level); other exceptions still map to `unknownError`.
- Updated `test_minimax_http_streaming.py` for the per-model limit + model arg.

All TTS/learn suites pass locally (123 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-model (tier-aware) request rate limiting for voice synthesis, so different models have separate throttling.
  * Added an optional configuration to override rate limits for specific voice models.
  * Added a user-facing message indicating the voice service is temporarily busy and to try again shortly.
* **Bug Fixes**
  * Improved error handling so voice rate-limit timeouts now surface the dedicated “try again shortly” error instead of a generic failure.
  * Updated throttling behavior to apply independently per voice model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->