### PR TITLE
fix: align operator admin page spacing

### DIFF
--- a/src/cook-web/src/app/admin/operations/profile-onboarding/page.tsx
+++ b/src/cook-web/src/app/admin/operations/profile-onboarding/page.tsx
@@ -152,7 +152,7 @@ export default function ProfileOnboardingAdminPage() {
   }
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col px-8 py-6'>
+    <>
       <AdminBreadcrumb
         items={[
           {
@@ -321,6 +321,6 @@ export default function ProfileOnboardingAdminPage() {
           ) : null}
         </aside>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/cook-web/src/app/admin/operations/voice-clones/page.tsx
+++ b/src/cook-web/src/app/admin/operations/voice-clones/page.tsx
@@ -576,7 +576,7 @@ export default function AdminOperationVoiceClonesPage() {
   }
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col px-8 py-6'>
+    <>
       <AdminBreadcrumb
         items={[{ label: t('module.operationsVoiceClone.title') }]}
       />
@@ -945,7 +945,7 @@ export default function AdminOperationVoiceClonesPage() {
           ) : null}
         </SheetContent>
       </Sheet>
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Issue / Motivation:
The operator menu pages for voice clone management and profile onboarding had an extra page-level padding wrapper, so their spacing did not match the other operator admin pages that rely on the shared /admin layout content container.

Summary:
- Remove the extra page-level wrapper from the voice clone operations page.
- Remove the extra page-level wrapper from the profile onboarding operations page.
- Let both pages use the shared admin layout content container directly.

Dependencies:
- None.

Verification:
- python3 scripts/check_dev_tools.py
- npm run test -- src/app/admin/operations/profile-onboarding/page.test.tsx
- npm run type-check
- npm run lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the layout structure of two admin operation pages to simplify the top-level wrapper, without changing visible UI or functionality.
  * Kept the existing onboarding and voice clone management experience intact, including navigation, dialogs, filtering, tables, and detail sheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->