### PR TITLE
fix(tts): cap concurrent block-audio synthesis to prevent RPM bursts

### DIFF
--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1424,6 +1424,16 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         description="Maximum seconds a MiniMax TTS request waits in the RPM queue",
         group="tts",
     ),
+    "MAX_PARALLEL_TTS_SYNTH_COUNT": EnvVar(
+        name="MAX_PARALLEL_TTS_SYNTH_COUNT",
+        default=6,
+        type=int,
+        description=(
+            "Max concurrent block-audio TTS syntheses per (user, outline); "
+            "0 disables the concurrency cap"
+        ),
+        group="tts",
+    ),
     # Volcengine TTS Configuration (shared by WebSocket + HTTP providers)
     "VOLCENGINE_TTS_APP_KEY": EnvVar(
         name="VOLCENGINE_TTS_APP_KEY",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1008,6 +1008,151 @@ def _yield_with_tts_error_mapping(
         raise_error("server.common.unknownError")
 
 
+# --- Per-(user, outline) TTS synthesis concurrency gate --------------------
+#
+# A client that enters listen mode may fan out block-audio synthesis for a whole
+# lesson at once, which can saturate the shared provider RPM gate. This counting
+# semaphore caps how many block-audio syntheses a single learner runs in parallel
+# for one outline. It mirrors the ask semaphore in runscript_v2 (Redis Lua
+# counter, TTL leak-protection, fail-open when Redis is unavailable).
+
+DEFAULT_MAX_PARALLEL_TTS_SYNTH_COUNT = 6
+# Leak protection: the counter self-expires this long after the last acquire, in
+# case a release is ever missed (the finally block normally releases far sooner).
+TTS_SYNTH_SEM_TTL_SECONDS = 300
+
+_LUA_ACQUIRE_TTS_SYNTH_SLOT = """
+local key = KEYS[1]
+local max_count = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+local current = tonumber(redis.call('get', key) or '0')
+if current < max_count then
+    redis.call('set', key, current + 1, 'EX', ttl)
+    return 1
+end
+return 0
+"""
+
+_LUA_RELEASE_TTS_SYNTH_SLOT = """
+local key = KEYS[1]
+local current = tonumber(redis.call('get', key) or '0')
+if current > 0 then
+    redis.call('decr', key)
+end
+return 1
+"""
+
+
+def _get_max_parallel_tts_synth_count(app: Flask) -> int:
+    try:
+        return int(
+            app.config.get(
+                "MAX_PARALLEL_TTS_SYNTH_COUNT",
+                DEFAULT_MAX_PARALLEL_TTS_SYNTH_COUNT,
+            )
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_PARALLEL_TTS_SYNTH_COUNT
+
+
+def _get_tts_synth_sem_key(app: Flask, user_bid: str, outline_bid: str) -> str:
+    return (
+        app.config.get("REDIS_KEY_PREFIX", "")
+        + ":tts_synth_sem:"
+        + user_bid
+        + ":"
+        + outline_bid
+    )
+
+
+def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
+    """Try to reserve a TTS-synthesis slot. Returns True if acquired.
+
+    Fails open (returns True) when the cap is disabled, the key is incomplete, or
+    Redis is unavailable, so audio synthesis is never blocked by the limiter
+    itself.
+    """
+    max_count = _get_max_parallel_tts_synth_count(app)
+    if max_count <= 0 or not user_bid or not outline_bid:
+        return True
+    try:
+        from flaskr.dao import redis_client
+
+        if redis_client is None:
+            return True  # fail open when Redis is unavailable
+        result = redis_client.eval(
+            _LUA_ACQUIRE_TTS_SYNTH_SLOT,
+            1,
+            _get_tts_synth_sem_key(app, user_bid, outline_bid),
+            str(max_count),
+            str(TTS_SYNTH_SEM_TTL_SECONDS),
+        )
+        return bool(result)
+    except Exception as exc:
+        app.logger.warning(
+            "tts_synth_sem_acquire failed, failing open: user_bid=%s outline_bid=%s error=%s",
+            user_bid,
+            outline_bid,
+            repr(exc),
+        )
+        return True  # fail open
+
+
+def _tts_synth_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
+    """Release a TTS-synthesis slot (no-op when the cap is disabled)."""
+    if _get_max_parallel_tts_synth_count(app) <= 0 or not user_bid or not outline_bid:
+        return
+    try:
+        from flaskr.dao import redis_client
+
+        if redis_client is None:
+            return
+        redis_client.eval(
+            _LUA_RELEASE_TTS_SYNTH_SLOT,
+            1,
+            _get_tts_synth_sem_key(app, user_bid, outline_bid),
+        )
+    except Exception as exc:
+        app.logger.warning(
+            "tts_synth_sem_release failed: user_bid=%s outline_bid=%s error=%s",
+            user_bid,
+            outline_bid,
+            repr(exc),
+        )
+
+
+def _yield_tts_synthesis(
+    app: Flask,
+    *,
+    user_bid: str,
+    outline_bid: str,
+    unknown_error_log: str,
+    body,
+):
+    """Run a TTS synthesis body under a per-(user, outline) concurrency slot.
+
+    Cache-hit paths never reach here, so they do not consume a slot. When the
+    per-(user, outline) cap is already full, the request is shed (yields nothing
+    and returns) instead of piling onto the shared provider RPM queue; the client
+    treats the block as having no audio yet and retries later.
+    """
+    if not _tts_synth_sem_acquire(app, user_bid, outline_bid):
+        app.logger.warning(
+            "tts synthesis concurrency limit reached; shedding request | user_bid=%s outline_bid=%s",
+            user_bid,
+            outline_bid,
+        )
+        return
+    try:
+        yield from _yield_with_tts_error_mapping(
+            app,
+            unknown_error_log=unknown_error_log,
+            body=body,
+        )
+    finally:
+        _tts_synth_sem_release(app, user_bid, outline_bid)
+
+
 def _record_stream_segment_usage(
     app: Flask,
     usage_context: UsageContext,
@@ -1480,8 +1625,10 @@ def stream_generated_block_audio(
                     preview_mode=preview_mode,
                 )
 
-            yield from _yield_with_tts_error_mapping(
+            yield from _yield_tts_synthesis(
                 app,
+                user_bid=user_bid,
+                outline_bid=generated_block.outline_item_bid or "",
                 unknown_error_log="TTS streaming synthesis failed",
                 body=_generate_single_audio,
             )
@@ -1571,8 +1718,10 @@ def stream_generated_block_audio(
                     subtitle_cues=subtitle_cues,
                 )
 
-            yield from _yield_with_tts_error_mapping(
+            yield from _yield_tts_synthesis(
                 app,
+                user_bid=user_bid,
+                outline_bid=generated_block.outline_item_bid or "",
                 unknown_error_log="Preview listen fallback TTS synthesis failed",
                 body=_generate_preview_audio,
             )
@@ -1639,8 +1788,10 @@ def stream_generated_block_audio(
                         position=0,
                     )
 
-                yield from _yield_with_tts_error_mapping(
+                yield from _yield_tts_synthesis(
                     app,
+                    user_bid=user_bid,
+                    outline_bid=generated_block.outline_item_bid or "",
                     unknown_error_log="Legacy listen TTS synthesis failed",
                     body=_generate_legacy_audio,
                 )
@@ -1746,8 +1897,10 @@ def stream_generated_block_audio(
                         stream_element_type=_audio_stream_element_type(element),
                     )
 
-            yield from _yield_with_tts_error_mapping(
+            yield from _yield_tts_synthesis(
                 app,
+                user_bid=user_bid,
+                outline_bid=generated_block.outline_item_bid or "",
                 unknown_error_log="AV TTS synthesis failed",
                 body=_generate_av_audio,
             )

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1065,21 +1065,31 @@ def _get_tts_synth_sem_key(app: Flask, user_bid: str, outline_bid: str) -> str:
     )
 
 
-def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
-    """Try to reserve a TTS-synthesis slot. Returns True if acquired.
+# Outcomes of a TTS-synthesis slot acquisition.
+_TTS_SLOT_ACQUIRED = "acquired"  # a real Redis slot was reserved -> must release
+_TTS_SLOT_FULL = "full"  # cap reached -> shed the request
+_TTS_SLOT_BYPASS = "bypass"  # limiter inactive -> proceed, nothing to release
 
-    Fails open (returns True) when the cap is disabled, the key is incomplete, or
-    Redis is unavailable, so audio synthesis is never blocked by the limiter
-    itself.
+
+def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> str:
+    """Try to reserve a TTS-synthesis slot.
+
+    Returns one of:
+    - ``_TTS_SLOT_ACQUIRED``: a Redis slot was actually reserved; the caller must
+      release it.
+    - ``_TTS_SLOT_FULL``: the cap is reached; the caller should shed the request.
+    - ``_TTS_SLOT_BYPASS``: the limiter is inactive (disabled, incomplete key, or
+      Redis unavailable/erroring); proceed without a slot and do NOT release, so a
+      fail-open acquire can never decrement a slot it did not reserve.
     """
     max_count = _get_max_parallel_tts_synth_count(app)
     if max_count <= 0 or not user_bid or not outline_bid:
-        return True
+        return _TTS_SLOT_BYPASS
     try:
         from flaskr.dao import redis_client
 
         if redis_client is None:
-            return True  # fail open when Redis is unavailable
+            return _TTS_SLOT_BYPASS  # fail open when Redis is unavailable
         result = redis_client.eval(
             _LUA_ACQUIRE_TTS_SYNTH_SLOT,
             1,
@@ -1087,7 +1097,7 @@ def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
             str(max_count),
             str(TTS_SYNTH_SEM_TTL_SECONDS),
         )
-        return bool(result)
+        return _TTS_SLOT_ACQUIRED if bool(result) else _TTS_SLOT_FULL
     except Exception as exc:
         app.logger.warning(
             "tts_synth_sem_acquire failed, failing open: user_bid=%s outline_bid=%s error=%s",
@@ -1095,7 +1105,7 @@ def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
             outline_bid,
             repr(exc),
         )
-        return True  # fail open
+        return _TTS_SLOT_BYPASS  # fail open
 
 
 def _tts_synth_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
@@ -1136,7 +1146,8 @@ def _yield_tts_synthesis(
     and returns) instead of piling onto the shared provider RPM queue; the client
     treats the block as having no audio yet and retries later.
     """
-    if not _tts_synth_sem_acquire(app, user_bid, outline_bid):
+    slot = _tts_synth_sem_acquire(app, user_bid, outline_bid)
+    if slot == _TTS_SLOT_FULL:
         app.logger.warning(
             "tts synthesis concurrency limit reached; shedding request | user_bid=%s outline_bid=%s",
             user_bid,
@@ -1150,7 +1161,10 @@ def _yield_tts_synthesis(
             body=body,
         )
     finally:
-        _tts_synth_sem_release(app, user_bid, outline_bid)
+        # Only release a slot we actually reserved; a fail-open bypass never
+        # incremented the counter, so it must not decrement it.
+        if slot == _TTS_SLOT_ACQUIRED:
+            _tts_synth_sem_release(app, user_bid, outline_bid)
 
 
 def _record_stream_segment_usage(

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -1,4 +1,9 @@
 from flaskr.service.learn import learn_funcs
+from flaskr.service.learn.learn_funcs import (
+    _TTS_SLOT_ACQUIRED,
+    _TTS_SLOT_BYPASS,
+    _TTS_SLOT_FULL,
+)
 
 
 class FakeRedis:
@@ -26,31 +31,51 @@ class FakeRedis:
         return 1
 
 
+class ExplodingRedis:
+    """Redis stub whose .eval always raises, to exercise the fail-open path."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def eval(self, *_args, **_kwargs):
+        self.calls += 1
+        raise RuntimeError("redis down")
+
+
 def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
     fake = FakeRedis()
     monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 2
 
-    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
-    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
-    # third over the cap -> busy
-    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is False
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") == _TTS_SLOT_ACQUIRED
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") == _TTS_SLOT_ACQUIRED
+    # third over the cap -> full
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") == _TTS_SLOT_FULL
 
     # releasing one frees a slot
     learn_funcs._tts_synth_sem_release(app, "u1", "o1")
-    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") == _TTS_SLOT_ACQUIRED
 
     # a different outline has its own independent counter
-    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o2") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o2") == _TTS_SLOT_ACQUIRED
 
 
-def test_tts_synth_semaphore_fail_open_without_redis(app, monkeypatch):
+def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch):
     monkeypatch.setattr("flaskr.dao.redis_client", None, raising=False)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    # Redis unavailable -> never block synthesis (fail open, no cap enforced)
-    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
-    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+    # Redis unavailable -> bypass (never blocks synthesis, no cap enforced)
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
+
+
+def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch):
+    boom = ExplodingRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", boom, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
+    assert boom.calls == 1
 
 
 def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
@@ -58,7 +83,7 @@ def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
     monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 0
 
-    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
     # disabled cap does not touch Redis at all
     assert fake.counters == {}
 
@@ -68,9 +93,9 @@ def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
     monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    # Missing user/outline -> fail open, no counter created
-    assert learn_funcs._tts_synth_sem_acquire(app, "", "o") is True
-    assert learn_funcs._tts_synth_sem_acquire(app, "u", "") is True
+    # Missing user/outline -> bypass, no counter created
+    assert learn_funcs._tts_synth_sem_acquire(app, "", "o") == _TTS_SLOT_BYPASS
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "") == _TTS_SLOT_BYPASS
     assert fake.counters == {}
 
 
@@ -86,7 +111,7 @@ def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
         yield "chunk"
 
     # occupy the only slot
-    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_ACQUIRED
 
     out = list(
         learn_funcs._yield_tts_synthesis(
@@ -129,3 +154,30 @@ def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch):
     # slot released after the generator is exhausted
     key = learn_funcs._get_tts_synth_sem_key(app, "u", "o")
     assert fake.counters.get(key, 0) == 0
+
+
+def test_yield_tts_synthesis_bypass_does_not_release(app, monkeypatch):
+    # Redis errors on acquire -> bypass (fail open); the finally must NOT call
+    # release, otherwise it would decrement a slot that was never reserved and
+    # could steal another request's slot.
+    boom = ExplodingRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", boom, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    def _body():
+        yield "a"
+
+    with app.app_context():
+        out = list(
+            learn_funcs._yield_tts_synthesis(
+                app,
+                user_bid="u",
+                outline_bid="o",
+                unknown_error_log="x",
+                body=_body,
+            )
+        )
+
+    assert out == ["a"]
+    # exactly one eval (the failing acquire); no release eval was attempted
+    assert boom.calls == 1

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -1,0 +1,131 @@
+from flaskr.service.learn import learn_funcs
+
+
+class FakeRedis:
+    """Minimal Redis .eval stub implementing the counter-semaphore Lua.
+
+    Distinguishes acquire (key, max, ttl) from release (key) by arg count.
+    """
+
+    def __init__(self):
+        self.counters: dict[str, int] = {}
+
+    def eval(self, _script, _numkeys, *args):
+        key = args[0]
+        if len(args) >= 3:  # acquire: key, max_count, ttl
+            max_count = int(args[1])
+            current = self.counters.get(key, 0)
+            if current < max_count:
+                self.counters[key] = current + 1
+                return 1
+            return 0
+        # release: key only
+        current = self.counters.get(key, 0)
+        if current > 0:
+            self.counters[key] = current - 1
+        return 1
+
+
+def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 2
+
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
+    # third over the cap -> busy
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is False
+
+    # releasing one frees a slot
+    learn_funcs._tts_synth_sem_release(app, "u1", "o1")
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") is True
+
+    # a different outline has its own independent counter
+    assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o2") is True
+
+
+def test_tts_synth_semaphore_fail_open_without_redis(app, monkeypatch):
+    monkeypatch.setattr("flaskr.dao.redis_client", None, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    # Redis unavailable -> never block synthesis (fail open, no cap enforced)
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+
+
+def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 0
+
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+    # disabled cap does not touch Redis at all
+    assert fake.counters == {}
+
+
+def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    # Missing user/outline -> fail open, no counter created
+    assert learn_funcs._tts_synth_sem_acquire(app, "", "o") is True
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "") is True
+    assert fake.counters == {}
+
+
+def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    body_calls = {"n": 0}
+
+    def _body():
+        body_calls["n"] += 1
+        yield "chunk"
+
+    # occupy the only slot
+    assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") is True
+
+    out = list(
+        learn_funcs._yield_tts_synthesis(
+            app,
+            user_bid="u",
+            outline_bid="o",
+            unknown_error_log="x",
+            body=_body,
+        )
+    )
+
+    # shed: no events yielded, body never invoked, occupied slot untouched
+    assert out == []
+    assert body_calls["n"] == 0
+    key = learn_funcs._get_tts_synth_sem_key(app, "u", "o")
+    assert fake.counters.get(key) == 1
+
+
+def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
+
+    def _body():
+        yield "a"
+        yield "b"
+
+    with app.app_context():
+        out = list(
+            learn_funcs._yield_tts_synthesis(
+                app,
+                user_bid="u",
+                outline_bid="o",
+                unknown_error_log="x",
+                body=_body,
+            )
+        )
+
+    assert out == ["a", "b"]
+    # slot released after the generator is exhausted
+    key = learn_funcs._get_tts_synth_sem_key(app, "u", "o")
+    assert fake.counters.get(key, 0) == 0

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@/lib/utils';
+import { runWithConcurrency } from '@/lib/runWithConcurrency';
 import { getDocumentFullscreenElement } from '@/c-utils/browserFullscreen';
 import { stopActiveLessonStream } from '@/app/c/[[...id]]/events';
 import { AppContext } from '../AppContext';
@@ -81,6 +82,12 @@ import {
 import { findLastVisibleLessonFeedbackElementBid } from './lessonFeedbackPromptState';
 
 const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
+
+// Max concurrent listen-mode audio backfill requests. Entering listen mode used
+// to fire TTS synthesis for every missing block at once (Promise.all), which
+// could burst past the provider RPM limit; a small bounded pool keeps the
+// instantaneous request rate well under it.
+const LISTEN_AUDIO_BACKFILL_CONCURRENCY = 3;
 
 interface NewChatComponentsProps {
   className?: string;
@@ -749,25 +756,40 @@ export const NewChatComponents = ({
 
     listenAudioBackfillLessonIdRef.current = lessonIdAtRequest;
 
-    const backfillPromises = missingAudioBlockBids.map(blockBid =>
-      requestListenAudioBackfillForBlock(blockBid, lessonIdAtRequest)
-        .then(result => {
-          if (listenAudioBackfillLessonIdRef.current !== lessonIdAtRequest) {
-            return null;
-          }
-
-          return result;
-        })
-        .catch(() => null),
+    // Prioritise blocks that will actually be played (non-history) so the first
+    // playable block is synthesised before history blocks, which auto-play
+    // skips. Otherwise the bounded pool could spend its slots on leading history
+    // blocks and delay first playback.
+    const historyBlockBidSet = new Set(
+      readyBackfillCandidateItems
+        .filter(item => item.isHistory)
+        .map(item => item.element_bid),
     );
+    const prioritizedBlockBids = [
+      ...missingAudioBlockBids.filter(bid => !historyBlockBidSet.has(bid)),
+      ...missingAudioBlockBids.filter(bid => historyBlockBidSet.has(bid)),
+    ];
 
-    void Promise.all(backfillPromises).then(results => {
+    void runWithConcurrency(
+      prioritizedBlockBids,
+      LISTEN_AUDIO_BACKFILL_CONCURRENCY,
+      blockBid =>
+        requestListenAudioBackfillForBlock(blockBid, lessonIdAtRequest)
+          .then(result => {
+            if (listenAudioBackfillLessonIdRef.current !== lessonIdAtRequest) {
+              return null;
+            }
+
+            return result;
+          })
+          .catch(() => null),
+    ).then(results => {
       if (listenAudioBackfillLessonIdRef.current !== lessonIdAtRequest) {
         return;
       }
 
       const hasGeneratedAudio = results.some(Boolean);
-      const failedBlockBids = missingAudioBlockBids.filter(
+      const failedBlockBids = prioritizedBlockBids.filter(
         (_, index) => !results[index],
       );
       failedBlockBids.forEach(blockBid => {

--- a/src/cook-web/src/lib/runWithConcurrency.test.ts
+++ b/src/cook-web/src/lib/runWithConcurrency.test.ts
@@ -1,0 +1,55 @@
+import { runWithConcurrency } from './runWithConcurrency';
+
+describe('runWithConcurrency', () => {
+  it('returns results index-aligned to the input order', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await runWithConcurrency(items, 2, async n => n * 10);
+    expect(results).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await runWithConcurrency(items, 3, async i => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      active -= 1;
+      return i;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it('records null for a rejected worker without aborting the batch', async () => {
+    const items = [1, 2, 3, 4];
+    const results = await runWithConcurrency(items, 2, async n => {
+      if (n === 2) {
+        throw new Error('boom');
+      }
+      return n;
+    });
+    expect(results).toEqual([1, null, 3, 4]);
+  });
+
+  it('handles an empty list', async () => {
+    const results = await runWithConcurrency([], 3, async n => n);
+    expect(results).toEqual([]);
+  });
+
+  it('clamps limits below 1 to a single worker', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const items = [1, 2, 3];
+    await runWithConcurrency(items, 0, async i => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise(resolve => setTimeout(resolve, 1));
+      active -= 1;
+      return i;
+    });
+    expect(maxActive).toBe(1);
+  });
+});

--- a/src/cook-web/src/lib/runWithConcurrency.ts
+++ b/src/cook-web/src/lib/runWithConcurrency.ts
@@ -19,7 +19,10 @@ export async function runWithConcurrency<T, R>(
     return results;
   }
 
-  const effectiveLimit = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+  const effectiveLimit = Math.max(
+    1,
+    Math.min(Math.floor(limit) || 1, items.length),
+  );
   let nextIndex = 0;
 
   const runOne = async (): Promise<void> => {

--- a/src/cook-web/src/lib/runWithConcurrency.ts
+++ b/src/cook-web/src/lib/runWithConcurrency.ts
@@ -1,0 +1,44 @@
+/**
+ * Run an async `worker` over `items` with a bounded number of concurrent tasks.
+ *
+ * Uses a dynamic worker pool (complete one, start the next) rather than fixed
+ * batches, so the pool stays saturated and there is no barrier between chunks.
+ *
+ * Guarantees:
+ * - At most `limit` workers run at any time.
+ * - Results are returned index-aligned to `items` (order preserved).
+ * - A rejected worker yields `null` for that slot and never aborts the batch.
+ */
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<(R | null)[]> {
+  const results: (R | null)[] = new Array(items.length).fill(null);
+  if (items.length === 0) {
+    return results;
+  }
+
+  const effectiveLimit = Math.max(1, Math.min(Math.floor(limit) || 1, items.length));
+  let nextIndex = 0;
+
+  const runOne = async (): Promise<void> => {
+    // Each runner pulls the next unclaimed index until the queue drains.
+    for (;;) {
+      const current = nextIndex;
+      nextIndex += 1;
+      if (current >= items.length) {
+        return;
+      }
+      try {
+        results[current] = await worker(items[current], current);
+      } catch {
+        results[current] = null;
+      }
+    }
+  };
+
+  const runners = Array.from({ length: effectiveLimit }, () => runOne());
+  await Promise.all(runners);
+  return results;
+}


### PR DESCRIPTION
## Problem

Production alert `TTSRpmQueueTimeout: TTS RPM queue wait exceeded 10.00s`. Root
cause (confirmed from `bill_usage` at the alert second): a teacher opened one
lesson (a "PPT classroom" version) in the learner/prod path, and the client fired
TTS synthesis for **all ~35 blocks of the lesson at once** (`Promise.all`).
Instantaneous rate ~350/min blew past MiniMax turbo's 200/min smoothing, so the
shared RPM gate's 10s wait cap overflowed and one request was shed. It was a
**concurrency burst from a single lesson**, not high volume — only 1 course / 1
user / 1 outline active at that moment, so the per-model gate from #2070 cannot
help (nothing to separate).

## Fix — cap concurrent synthesis (frontend + backend, dual gate)

### Frontend (root cause) — `NewChatComp.tsx`, `lib/runWithConcurrency.ts`
- Replace the unbounded `missingAudioBlockBids.map(...) + Promise.all` in the
  listen-mode audio backfill with a **bounded dynamic pool** (`runWithConcurrency`,
  limit **3**, complete-one-start-next, order-preserving, reject → null).
- **First-block priority**: stable-partition so non-history blocks (the ones
  `autoPlayTargetBlockBid` actually plays) run before leading history blocks —
  otherwise the cap could spend its slots on history blocks and delay first
  playback.
- Keep the existing per-block in-flight dedup and the post-settle failure toast.

### Backend (defense-in-depth) — `learn_funcs.py`, `config.py`
- Add a **per-(user, outline) TTS-synthesis counting semaphore** (Redis Lua
  counter + TTL leak-protection + fail-open when Redis is down), capped by new
  config **`MAX_PARALLEL_TTS_SYNTH_COUNT` (default 6)**. Mirrors the ask semaphore
  in `runscript_v2`.
- Gate real synthesis inside `stream_generated_block_audio` via a
  `_yield_tts_synthesis` wrapper around the single `_yield_with_tts_error_mapping`
  choke point that all four synthesis paths funnel through. **Cache-hit paths
  never reach it, so they never consume a slot.** On full, the request is shed
  (yields nothing) instead of piling onto the RPM queue; the client treats the
  block as not-yet-ready and retries.

## Not affected
- **Mode switching stays instant** — switching is a pure state change decoupled
  from audio (verified); smoothness comes from the typewriter cache, not eager
  parallel backfill.
- **classroom mode** does not run this backfill (listen only).
- rpm_gate global smoothing is unchanged (still the final global backstop). This
  is complementary to #2070 (per-model fairness + hd limits + de-noise).

## Tests
- Backend (`tests/service/learn/test_tts_synth_concurrency.py`): semaphore caps at
  limit & releases, fail-open without Redis, disabled at 0, incomplete key
  ignored, `_yield_tts_synthesis` sheds when full (body not called, slot
  untouched) and releases the slot after a normal run.
- Frontend (`lib/runWithConcurrency.test.ts`): order-aligned results, never
  exceeds limit, reject → null without aborting, empty list, clamps limit < 1.
- `python -m pytest tests/service/learn tests/service/tts` green; `ruff` +
  architecture-boundary check clean; frontend `type-check` + `lint` +
  `runWithConcurrency` jest green.

## Verify end-to-end
Enter listen mode on a lesson with many blocks → DevTools Network shows ≤ 3
concurrent `/tts` SSE, no `TTSRpmQueueTimeout`; first block still starts promptly;
read↔listen↔classroom switching stays instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable cap on parallel TTS synthesis per user/outline to improve reliability during heavy listen-mode activity.
  * Listen-mode audio backfill now uses bounded concurrency (and prioritizes likely-to-play blocks first).

* **Bug Fixes**
  * When the TTS cap is reached, requests are shed instead of causing bursts; audio continues to work via safe fallback when limits can’t be enforced.

* **Tests**
  * Added/expanded tests for TTS concurrency, including release behavior and fail-open cases.
  * Added unit tests for the new bounded-concurrency utility (ordering, clamping, and failure handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->