### PR TITLE
test: cover trial subscription expiration lifecycle

### DIFF
--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -490,16 +490,36 @@ def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replaye
 def test_manual_trial_subscription_schedules_and_applies_expire(
     billing_renewal_app: Flask,
 ) -> None:
+    period_end_at = now_utc() - timedelta(minutes=1)
     with billing_renewal_app.app_context():
         subscription = _create_subscription(
             "sub-trial-expire-1",
             product_bid=BILLING_TRIAL_PRODUCT_BID,
             billing_provider="manual",
             provider_subscription_id="",
-            current_period_end_at=now_utc() - timedelta(minutes=1),
+            current_period_end_at=period_end_at,
+        )
+        wallet = _create_wallet(
+            subscription.creator_bid,
+            available_credits="100.0000000000",
         )
         dao.db.session.add(subscription)
+        dao.db.session.add(wallet)
         dao.db.session.flush()
+        dao.db.session.add(
+            _create_bucket(
+                wallet.wallet_bid,
+                subscription.creator_bid,
+                "bucket-trial-expire-1",
+                available_credits="100.0000000000",
+                source_bid=subscription.subscription_bid,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                effective_from=period_end_at - timedelta(days=15),
+                effective_to=period_end_at,
+                created_at=period_end_at - timedelta(days=15),
+            )
+        )
         sync_subscription_lifecycle_events(billing_renewal_app, subscription)
         dao.db.session.commit()
 
@@ -522,7 +542,22 @@ def test_manual_trial_subscription_schedules_and_applies_expire(
         subscription = BillingSubscription.query.filter_by(
             subscription_bid="sub-trial-expire-1"
         ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid=subscription.creator_bid
+        ).one()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-trial-expire-1"
+        ).one()
+        ledger_entry = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid="bucket-trial-expire-1",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        ).one()
         assert subscription.status == BILLING_SUBSCRIPTION_STATUS_EXPIRED
+        assert wallet.available_credits == Decimal("0E-10")
+        assert bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+        assert bucket.available_credits == Decimal("0")
+        assert bucket.expired_credits == Decimal("100.0000000000")
+        assert ledger_entry.amount == Decimal("-100.0000000000")
 
 
 def test_run_billing_renewal_event_applies_downgrade_and_reschedules_renewal(

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -23,6 +23,7 @@ from flaskr.service.billing.consts import (
     BILLING_PRODUCT_STATUS_ACTIVE,
     BILLING_PRODUCT_TYPE_PLAN,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_TRIAL_PRODUCT_BID,
     CREDIT_BUCKET_CATEGORY_FREE,
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,
@@ -802,6 +803,65 @@ class TestBillingRoutes:
         with app.app_context():
             subscription = BillingSubscription.query.filter_by(
                 subscription_bid="sub-stale-active"
+            ).one()
+            assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+
+    def test_overview_marks_stale_active_trial_subscription_expired(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+        with app.app_context():
+            dao.db.session.add(
+                CreditWallet(
+                    wallet_bid="wallet-stale-trial",
+                    creator_bid="creator-stale-trial",
+                    available_credits=Decimal("0"),
+                    reserved_credits=Decimal("0"),
+                    lifetime_granted_credits=Decimal("100.0000000000"),
+                    lifetime_consumed_credits=Decimal("100.0000000000"),
+                    created_at=datetime(2026, 3, 1, 0, 0, 0),
+                    updated_at=datetime(2026, 4, 5, 0, 0, 0),
+                )
+            )
+            dao.db.session.add(
+                BillingSubscription(
+                    subscription_bid="sub-stale-trial",
+                    creator_bid="creator-stale-trial",
+                    product_bid=BILLING_TRIAL_PRODUCT_BID,
+                    status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                    billing_provider="manual",
+                    provider_subscription_id="",
+                    provider_customer_id="",
+                    current_period_start_at=datetime(2026, 3, 1, 0, 0, 0),
+                    current_period_end_at=datetime(2026, 3, 16, 0, 0, 0),
+                    cancel_at_period_end=0,
+                    next_product_bid="",
+                    metadata_json={"trial_bootstrap": True},
+                    created_at=datetime(2026, 3, 1, 0, 0, 0),
+                    updated_at=datetime(2026, 3, 1, 0, 0, 0),
+                )
+            )
+            dao.db.session.commit()
+
+        response = billing_test_client.get(
+            "/api/billing/overview",
+            headers={"X-User-Id": "creator-stale-trial"},
+        )
+        payload = response.get_json(force=True)
+
+        assert payload["code"] == 0
+        assert payload["data"]["subscription"]["subscription_bid"] == (
+            "sub-stale-trial"
+        )
+        assert payload["data"]["subscription"]["product_bid"] == (
+            BILLING_TRIAL_PRODUCT_BID
+        )
+        assert payload["data"]["subscription"]["status"] == "expired"
+        assert payload["data"]["trial_offer"]["status"] == "granted"
+        assert payload["data"]["trial_offer"]["expires_at"] is not None
+        with app.app_context():
+            subscription = BillingSubscription.query.filter_by(
+                subscription_bid="sub-stale-trial"
             ).one()
             assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
 

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -679,6 +679,70 @@ class TestBillingWriteRoutes:
             assert new_subscription.status == BILLING_SUBSCRIPTION_STATUS_DRAFT
             assert order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_START
 
+    def test_subscription_checkout_allows_paid_plan_after_stale_active_trial(
+        self, billing_write_client
+    ) -> None:
+        client = billing_write_client["client"]
+        app = billing_write_client["app"]
+        now = now_utc()
+
+        with app.app_context():
+            dao.db.session.add(
+                BillingSubscription(
+                    subscription_bid="sub-stale-trial-checkout",
+                    creator_bid="creator-stale-trial-checkout",
+                    product_bid=BILLING_TRIAL_PRODUCT_BID,
+                    status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                    billing_provider="manual",
+                    provider_subscription_id="",
+                    provider_customer_id="",
+                    current_period_start_at=now - timedelta(days=45),
+                    current_period_end_at=now - timedelta(days=30),
+                    cancel_at_period_end=0,
+                    next_product_bid="",
+                    metadata_json={"trial_bootstrap": True},
+                    created_at=now - timedelta(days=45),
+                    updated_at=now - timedelta(days=45),
+                )
+            )
+            dao.db.session.commit()
+
+        response = client.post(
+            "/api/billing/subscriptions/checkout",
+            json={
+                "product_bid": "bill-product-plan-monthly-pro",
+                "payment_provider": "stripe",
+            },
+            headers={"X-User-Id": "creator-stale-trial-checkout"},
+        )
+        payload = response.get_json(force=True)
+
+        assert payload["code"] == 0
+        assert payload["data"]["checkout_type"] == "subscription"
+        with app.app_context():
+            stale_trial = BillingSubscription.query.filter_by(
+                subscription_bid="sub-stale-trial-checkout"
+            ).one()
+            new_subscription = (
+                BillingSubscription.query.filter(
+                    BillingSubscription.creator_bid
+                    == "creator-stale-trial-checkout",
+                    BillingSubscription.subscription_bid
+                    != "sub-stale-trial-checkout",
+                )
+                .order_by(BillingSubscription.id.desc())
+                .one()
+            )
+            order = BillingOrder.query.filter_by(
+                creator_bid="creator-stale-trial-checkout",
+                subscription_bid=new_subscription.subscription_bid,
+            ).one()
+
+            assert stale_trial.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+            assert new_subscription.product_bid == "bill-product-plan-monthly-pro"
+            assert new_subscription.status == BILLING_SUBSCRIPTION_STATUS_DRAFT
+            assert order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_START
+
     def test_subscription_checkout_supports_daily_stripe_recurring_interval(
         self, billing_write_client
     ) -> None:

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -725,10 +725,8 @@ class TestBillingWriteRoutes:
             ).one()
             new_subscription = (
                 BillingSubscription.query.filter(
-                    BillingSubscription.creator_bid
-                    == "creator-stale-trial-checkout",
-                    BillingSubscription.subscription_bid
-                    != "sub-stale-trial-checkout",
+                    BillingSubscription.creator_bid == "creator-stale-trial-checkout",
+                    BillingSubscription.subscription_bid != "sub-stale-trial-checkout",
                 )
                 .order_by(BillingSubscription.id.desc())
                 .one()


### PR DESCRIPTION
Summary
- Add regression coverage that trial expire events move subscriptions to expired and expire the related wallet bucket through the ledger path.
- Add billing overview coverage for stale active trial subscriptions returning expired without mutating DB state.
- Add checkout coverage that an expired/stale trial does not block starting a paid subscription.

Why
- Production had historical trial subscriptions left as active after expiry because lifecycle jobs had not advanced persisted state.
- The current code path already schedules and applies expire events; this PR locks that behavior down with focused tests.

Verification
- `git diff --check`
- `cd src/api && pytest tests/service/billing/test_billing_trial_credits.py tests/service/billing/test_billing_renewal_execution.py::test_manual_trial_subscription_schedules_and_applies_expire tests/service/billing/test_billing_routes.py::TestBillingRoutes::test_overview_marks_stale_active_trial_subscription_expired tests/service/billing/test_billing_write_routes.py::TestBillingWriteRoutes::test_subscription_checkout_allows_paid_plan_after_stale_active_trial -q`
- `cd src/api && pytest tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_billing_routes.py tests/service/billing/test_billing_write_routes.py -q`

Note
- Full `cd src/api && pytest tests/service/billing/ -q` currently has unrelated local-environment failures because `celery` is not installed and fallback task functions do not expose `apply_async`; the touched tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded billing coverage for trial subscription expiration and renewal handling, including wallet and bucket credit/ledger balance assertions.
  * Added coverage for billing overview behavior for stale active trial subscriptions (response shows expired, stored status remains unchanged).
  * Added coverage for checkout after a stale active trial, confirming paid plan sign-up creates the expected draft subscription and billing order while the stale trial remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->