### PR TITLE
Anchor TTS credit multiplier to the shared LLM 1x baseline

### DIFF
--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -24,12 +24,10 @@ from flaskr.util.datetime import now_utc
 from flaskr.common.log import AppLoggerProxy
 from flaskr.i18n import get_current_language
 from flaskr.service.billing.consts import (
-    BILLING_METRIC_LLM_OUTPUT_TOKENS,
     BILLING_METRIC_TTS_OUTPUT_CHARS,
 )
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
-    BILL_USAGE_TYPE_LLM,
     BILL_USAGE_TYPE_TTS,
 )
 
@@ -344,7 +342,7 @@ def _resolve_localized_tts_label(
 
 def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | None:
     try:
-        baseline_cost = _load_default_llm_unit_cost()
+        baseline_cost = _load_tts_multiplier_baseline()
         if baseline_cost is None or baseline_cost <= 0:
             return None
         actual_cost = (
@@ -365,26 +363,22 @@ def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | No
         return None
 
 
-def _resolve_default_llm_rate_identity() -> tuple[str, list[str]]:
-    default_model = str(get_config("DEFAULT_LLM_MODEL", "") or "").strip()
-    if not default_model:
-        return "", [""]
+def _load_tts_multiplier_baseline() -> Decimal | None:
+    # TTS credit multipliers are curated business tiers, not a live ratio to the
+    # default LLM output-token price. The 1x reference is a fixed
+    # credits-per-character anchor (TTS_CREDIT_MULTIPLIER_BASELINE, default
+    # 0.0001 = 1 credit / 10,000 characters), decoupled from the LLM baseline so
+    # the picker shows the intended "Nx" no matter how the default LLM is priced.
     try:
-        from flaskr.api.llm import _resolve_billing_rate_identity
-
-        return _resolve_billing_rate_identity(default_model)
-    except Exception:
-        return "", [default_model]
-
-
-def _load_default_llm_unit_cost() -> Decimal | None:
-    provider, model_candidates = _resolve_default_llm_rate_identity()
-    return _load_usage_rate_unit_cost(
-        usage_type=BILL_USAGE_TYPE_LLM,
-        provider=provider,
-        model_candidates=model_candidates or [""],
-        billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
-    )
+        raw = get_config("TTS_CREDIT_MULTIPLIER_BASELINE", "")
+        if raw is None or str(raw).strip() == "":
+            return None
+        baseline = Decimal(str(raw))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if baseline <= 0:
+        return None
+    return baseline
 
 
 def _load_usage_rate_unit_cost(

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -24,10 +24,12 @@ from flaskr.util.datetime import now_utc
 from flaskr.common.log import AppLoggerProxy
 from flaskr.i18n import get_current_language
 from flaskr.service.billing.consts import (
+    BILLING_METRIC_LLM_OUTPUT_TOKENS,
     BILLING_METRIC_TTS_OUTPUT_CHARS,
 )
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
+    BILL_USAGE_TYPE_LLM,
     BILL_USAGE_TYPE_TTS,
 )
 
@@ -342,43 +344,73 @@ def _resolve_localized_tts_label(
 
 def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | None:
     try:
-        baseline_cost = _load_tts_multiplier_baseline()
+        # One shared 1x anchor for LLM and TTS: the default LLM output-token
+        # price (DeepSeek-V4-Flash). TTS is priced per character, so translate
+        # its per-character cost into the same per-LLM-token dimension using
+        # chars-synthesized-per-token, then take the ratio. The label is
+        # therefore "TTS task consumption / LLM task consumption" on the very
+        # same scale as the LLM model multipliers.
+        baseline_cost = _load_default_llm_unit_cost()
         if baseline_cost is None or baseline_cost <= 0:
             return None
-        actual_cost = (
-            _load_usage_rate_unit_cost(
-                usage_type=BILL_USAGE_TYPE_TTS,
-                provider=provider_name,
-                model_candidates=[model],
-                billing_metric=BILLING_METRIC_TTS_OUTPUT_CHARS,
-                ignore_global_wildcard=True,
-            )
-            or baseline_cost
-        )
-        if actual_cost <= 0:
+        chars_per_token = _load_tts_chars_per_llm_token()
+        if chars_per_token is None or chars_per_token <= 0:
             return None
-        return _format_credit_multiplier_label(actual_cost / baseline_cost)
+        tts_char_cost = _load_usage_rate_unit_cost(
+            usage_type=BILL_USAGE_TYPE_TTS,
+            provider=provider_name,
+            model_candidates=[model],
+            billing_metric=BILLING_METRIC_TTS_OUTPUT_CHARS,
+            ignore_global_wildcard=True,
+        )
+        if tts_char_cost is None or tts_char_cost <= 0:
+            return None
+        multiplier = (tts_char_cost * chars_per_token) / baseline_cost
+        return _format_credit_multiplier_label(multiplier)
     except Exception as exc:
         logger.debug("Skipping TTS credit multiplier label: %s", exc)
         return None
 
 
-def _load_tts_multiplier_baseline() -> Decimal | None:
-    # TTS credit multipliers are curated business tiers, not a live ratio to the
-    # default LLM output-token price. The 1x reference is a fixed
-    # credits-per-character anchor (TTS_CREDIT_MULTIPLIER_BASELINE, default
-    # 0.0001 = 1 credit / 10,000 characters), decoupled from the LLM baseline so
-    # the picker shows the intended "Nx" no matter how the default LLM is priced.
+def _resolve_default_llm_rate_identity() -> tuple[str, list[str]]:
+    default_model = str(get_config("DEFAULT_LLM_MODEL", "") or "").strip()
+    if not default_model:
+        return "", [""]
     try:
-        raw = get_config("TTS_CREDIT_MULTIPLIER_BASELINE", "")
+        from flaskr.api.llm import _resolve_billing_rate_identity
+
+        return _resolve_billing_rate_identity(default_model)
+    except Exception:
+        return "", [default_model]
+
+
+def _load_default_llm_unit_cost() -> Decimal | None:
+    provider, model_candidates = _resolve_default_llm_rate_identity()
+    return _load_usage_rate_unit_cost(
+        usage_type=BILL_USAGE_TYPE_LLM,
+        provider=provider,
+        model_candidates=model_candidates or [""],
+        billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    )
+
+
+def _load_tts_chars_per_llm_token() -> Decimal | None:
+    # TTS is billed per character but the 1x anchor is an LLM output token, so we
+    # need "how many TTS characters one LLM token turns into" to compare them on
+    # one scale. This is omega x 1.6 (TTS-token share of a task x token->char
+    # ratio); see TTS_CHARS_PER_LLM_TOKEN. Keeping it a factor over the shared
+    # LLM baseline (rather than a standalone TTS baseline) means the TTS 1x
+    # tracks the default LLM price automatically.
+    try:
+        raw = get_config("TTS_CHARS_PER_LLM_TOKEN", "")
         if raw is None or str(raw).strip() == "":
             return None
-        baseline = Decimal(str(raw))
+        value = Decimal(str(raw))
     except (InvalidOperation, TypeError, ValueError):
         return None
-    if baseline <= 0:
+    if value <= 0:
         return None
-    return baseline
+    return value
 
 
 def _load_usage_rate_unit_cost(

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1382,17 +1382,17 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         group="tts",
         required=False,
     ),
-    "TTS_CREDIT_MULTIPLIER_BASELINE": EnvVar(
-        name="TTS_CREDIT_MULTIPLIER_BASELINE",
-        default=0.0001,
+    "TTS_CHARS_PER_LLM_TOKEN": EnvVar(
+        name="TTS_CHARS_PER_LLM_TOKEN",
+        default=0.216,
         type=float,
         description=(
-            "Credits-per-character reference that represents the 1x TTS credit "
-            "multiplier shown in the model picker (default 0.0001 = 1 credit per "
-            "10,000 characters). This baseline is intentionally decoupled from the "
-            "default LLM output-token rate: TTS tiers are curated business "
-            "multipliers, so their displayed 'Nx' label is TTS char rate divided "
-            "by this reference, not by the LLM baseline."
+            "TTS characters synthesized per LLM output token in a task, used to "
+            "put TTS (billed per character) and LLM (billed per token) on one "
+            "shared 1x anchor. Default 0.216 = omega(13.5%) x 1.6 chars/token. "
+            "The picker multiplier is TTS char cost x this factor / the default "
+            "LLM output-token cost, so TTS tiers stay on the same scale as LLM "
+            "model multipliers and track the default LLM price automatically."
         ),
         group="tts",
     ),

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1382,6 +1382,20 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         group="tts",
         required=False,
     ),
+    "TTS_CREDIT_MULTIPLIER_BASELINE": EnvVar(
+        name="TTS_CREDIT_MULTIPLIER_BASELINE",
+        default=0.0001,
+        type=float,
+        description=(
+            "Credits-per-character reference that represents the 1x TTS credit "
+            "multiplier shown in the model picker (default 0.0001 = 1 credit per "
+            "10,000 characters). This baseline is intentionally decoupled from the "
+            "default LLM output-token rate: TTS tiers are curated business "
+            "multipliers, so their displayed 'Nx' label is TTS char rate divided "
+            "by this reference, not by the LLM baseline."
+        ),
+        group="tts",
+    ),
     "MINIMAX_TTS_SAMPLE_RATE": EnvVar(
         name="MINIMAX_TTS_SAMPLE_RATE",
         default=24000,

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -95,140 +95,183 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
     }
 
 
-def _baseline_config(baseline: str):
+class _FakeRate:
+    def __init__(self, credits_per_unit, unit_size, provider, model):
+        self.credits_per_unit = credits_per_unit
+        self.unit_size = unit_size
+        self.provider = provider
+        self.model = model
+
+
+def _chars_per_token_config(value: str):
     def _get_config(key, default=None):
-        if key == "TTS_CREDIT_MULTIPLIER_BASELINE":
-            return baseline
+        if key == "TTS_CHARS_PER_LLM_TOKEN":
+            return value
         return default
 
     return _get_config
 
 
-def test_tts_credit_multiplier_uses_tts_baseline_not_llm_rate(monkeypatch):
+def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
-    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
-
-    class FakeRate:
-        def __init__(
-            self,
-            credits_per_unit: str,
-            unit_size: int,
-            provider: str,
-            model: str,
-        ):
-            self.credits_per_unit = credits_per_unit
-            self.unit_size = unit_size
-            self.provider = provider
-            self.model = model
+    from flaskr.service.billing.consts import (
+        BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        BILLING_METRIC_TTS_OUTPUT_CHARS,
+    )
+    from flaskr.service.metering.consts import (
+        BILL_USAGE_TYPE_LLM,
+        BILL_USAGE_TYPE_TTS,
+    )
 
     captured = []
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        captured.append(
-            {
-                "usage_type": usage.usage_type,
-                "provider": usage.provider,
-                "model": usage.model,
-                "billing_metric": billing_metric,
-            }
-        )
+        captured.append((usage.usage_type, usage.provider, usage.model, billing_metric))
+        if (
+            usage.usage_type == BILL_USAGE_TYPE_LLM
+            and usage.provider == "qwen"
+            and usage.model == "deepseek-v4-flash"
+            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ):
+            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")  # 0.0001/token
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and usage.provider == "tencent"
             and usage.model == ""
             and billing_metric == BILLING_METRIC_TTS_OUTPUT_CHARS
         ):
-            return FakeRate("4", 10000, "tencent", "")
+            return _FakeRate("8", 10000, "tencent", "")  # 0.0008/char
         return None
 
-    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
+    monkeypatch.setattr(
+        tts_api,
+        "_resolve_default_llm_rate_identity",
+        lambda: ("qwen", ["deepseek-v4-flash"]),
+    )
+    monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.5"))
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
-    # tencent TTS = 4 credits / 10,000 chars = 0.0004/char; baseline = 0.0001/char
-    # -> 0.0004 / 0.0001 = 4x. The label is decoupled from the LLM rate, so only
-    # the TTS rate is looked up (no BILL_USAGE_TYPE_LLM query).
+    # TTS 0.0008/char x 0.5 chars/token = 0.0004 credits per LLM token; the shared
+    # 1x anchor is the LLM rate 0.0001/token -> 0.0004 / 0.0001 = 4x. Both the LLM
+    # baseline and the TTS rate are looked up (one shared anchor, not a standalone
+    # TTS baseline).
     assert tts_api._resolve_credit_multiplier_label("tencent", "") == "4x"
-    assert captured == [
-        {
-            "usage_type": BILL_USAGE_TYPE_TTS,
-            "provider": "tencent",
-            "model": "",
-            "billing_metric": BILLING_METRIC_TTS_OUTPUT_CHARS,
-        },
-    ]
+    assert (
+        BILL_USAGE_TYPE_LLM,
+        "qwen",
+        "deepseek-v4-flash",
+        BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    ) in captured
+    assert (
+        BILL_USAGE_TYPE_TTS,
+        "tencent",
+        "",
+        BILLING_METRIC_TTS_OUTPUT_CHARS,
+    ) in captured
 
 
-def test_tts_credit_multiplier_scales_with_configured_baseline(monkeypatch):
+def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
-    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
-
-    class FakeRate:
-        def __init__(self, credits_per_unit, unit_size, provider, model):
-            self.credits_per_unit = credits_per_unit
-            self.unit_size = unit_size
-            self.provider = provider
-            self.model = model
+    from flaskr.service.billing.consts import (
+        BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        BILLING_METRIC_TTS_OUTPUT_CHARS,
+    )
+    from flaskr.service.metering.consts import (
+        BILL_USAGE_TYPE_LLM,
+        BILL_USAGE_TYPE_TTS,
+    )
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+        if (
+            usage.usage_type == BILL_USAGE_TYPE_LLM
+            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ):
+            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")  # 0.0001/token
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and billing_metric == BILLING_METRIC_TTS_OUTPUT_CHARS
         ):
-            return FakeRate("22", 10000, "minimax", "speech-2.8-turbo")
+            return _FakeRate("8", 10000, "minimax", "speech-2.8-turbo")  # 0.0008/char
         return None
 
+    monkeypatch.setattr(
+        tts_api,
+        "_resolve_default_llm_rate_identity",
+        lambda: ("qwen", ["deepseek-v4-flash"]),
+    )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
-    # 22 credits / 10,000 chars = 0.0022/char. Halving the baseline doubles the
-    # displayed multiplier, proving the label tracks the configured reference.
-    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
+    # Doubling chars-per-token doubles the TTS consumption per LLM token, so the
+    # multiplier doubles (4x -> 8x). This is the token<->char conversion knob.
+    monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.5"))
     assert (
-        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "22x"
+        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "4x"
     )
-    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.00005"))
+    monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("1.0"))
     assert (
-        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "44x"
+        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "8x"
     )
 
 
-def test_tts_credit_multiplier_falls_back_to_baseline_when_rate_missing(monkeypatch):
+def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
     import flaskr.api.tts as tts_api
+    from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_LLM
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        # No curated TTS rate for this provider/model.
-        return None
+        if (
+            usage.usage_type == BILL_USAGE_TYPE_LLM
+            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ):
+            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
+        return None  # no curated TTS rate
 
-    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
+    monkeypatch.setattr(
+        tts_api,
+        "_resolve_default_llm_rate_identity",
+        lambda: ("qwen", ["deepseek-v4-flash"]),
+    )
+    monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.216"))
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
-    # Missing TTS rate -> actual cost falls back to the baseline -> 1x.
-    assert tts_api._resolve_credit_multiplier_label("unknown", "missing") == "1x"
+    # No TTS rate -> no meaningful multiplier -> no label (not a fabricated 1x).
+    assert tts_api._resolve_credit_multiplier_label("unknown", "missing") is None
 
 
-def test_tts_credit_multiplier_none_when_baseline_unset(monkeypatch):
+def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch):
     import flaskr.api.tts as tts_api
+    from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_LLM
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        return None
+        if (
+            usage.usage_type == BILL_USAGE_TYPE_LLM
+            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ):
+            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
+        return _FakeRate("8", 10000, "tencent", "")
 
-    monkeypatch.setattr(tts_api, "get_config", _baseline_config(""))
+    monkeypatch.setattr(
+        tts_api,
+        "_resolve_default_llm_rate_identity",
+        lambda: ("qwen", ["deepseek-v4-flash"]),
+    )
+    monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config(""))
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
-    # An unset/blank baseline disables the label instead of dividing by zero.
+    # A blank conversion factor disables the label instead of guessing.
     assert tts_api._resolve_credit_multiplier_label("tencent", "") is None
 
 

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -95,16 +95,19 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
     }
 
 
-def test_tts_credit_multiplier_uses_default_llm_output_rate(monkeypatch):
+def _baseline_config(baseline: str):
+    def _get_config(key, default=None):
+        if key == "TTS_CREDIT_MULTIPLIER_BASELINE":
+            return baseline
+        return default
+
+    return _get_config
+
+
+def test_tts_credit_multiplier_uses_tts_baseline_not_llm_rate(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import (
-        BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        BILLING_METRIC_TTS_OUTPUT_CHARS,
-    )
-    from flaskr.service.metering.consts import (
-        BILL_USAGE_TYPE_LLM,
-        BILL_USAGE_TYPE_TTS,
-    )
+    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
     class FakeRate:
         def __init__(
@@ -131,13 +134,6 @@ def test_tts_credit_multiplier_uses_default_llm_output_rate(monkeypatch):
             }
         )
         if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and usage.provider == "qwen"
-            and usage.model == "deepseek-v4-flash"
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
-        if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and usage.provider == "tencent"
             and usage.model == ""
@@ -146,24 +142,17 @@ def test_tts_credit_multiplier_uses_default_llm_output_rate(monkeypatch):
             return FakeRate("4", 10000, "tencent", "")
         return None
 
-    monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
+    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
+    # tencent TTS = 4 credits / 10,000 chars = 0.0004/char; baseline = 0.0001/char
+    # -> 0.0004 / 0.0001 = 4x. The label is decoupled from the LLM rate, so only
+    # the TTS rate is looked up (no BILL_USAGE_TYPE_LLM query).
     assert tts_api._resolve_credit_multiplier_label("tencent", "") == "4x"
     assert captured == [
-        {
-            "usage_type": BILL_USAGE_TYPE_LLM,
-            "provider": "qwen",
-            "model": "deepseek-v4-flash",
-            "billing_metric": BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        },
         {
             "usage_type": BILL_USAGE_TYPE_TTS,
             "provider": "tencent",
@@ -173,25 +162,13 @@ def test_tts_credit_multiplier_uses_default_llm_output_rate(monkeypatch):
     ]
 
 
-def test_tts_credit_multiplier_falls_back_to_default_llm_rate(monkeypatch):
+def test_tts_credit_multiplier_scales_with_configured_baseline(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import (
-        BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        BILLING_METRIC_TTS_OUTPUT_CHARS,
-    )
-    from flaskr.service.metering.consts import (
-        BILL_USAGE_TYPE_LLM,
-        BILL_USAGE_TYPE_TTS,
-    )
+    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
     class FakeRate:
-        def __init__(
-            self,
-            credits_per_unit: str,
-            unit_size: int,
-            provider: str,
-            model: str,
-        ):
+        def __init__(self, credits_per_unit, unit_size, provider, model):
             self.credits_per_unit = credits_per_unit
             self.unit_size = unit_size
             self.provider = provider
@@ -199,30 +176,60 @@ def test_tts_credit_multiplier_falls_back_to_default_llm_rate(monkeypatch):
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
         if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and usage.provider == "qwen"
-            and usage.model == "deepseek-v4-flash"
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
-        if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and billing_metric == BILLING_METRIC_TTS_OUTPUT_CHARS
         ):
-            return FakeRate("100", 10000, "*", "*")
+            return FakeRate("22", 10000, "minimax", "speech-2.8-turbo")
         return None
 
-    monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
+    # 22 credits / 10,000 chars = 0.0022/char. Halving the baseline doubles the
+    # displayed multiplier, proving the label tracks the configured reference.
+    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
+    assert (
+        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "22x"
+    )
+    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.00005"))
+    assert (
+        tts_api._resolve_credit_multiplier_label("minimax", "speech-2.8-turbo") == "44x"
+    )
+
+
+def test_tts_credit_multiplier_falls_back_to_baseline_when_rate_missing(monkeypatch):
+    import flaskr.api.tts as tts_api
+
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+        # No curated TTS rate for this provider/model.
+        return None
+
+    monkeypatch.setattr(tts_api, "get_config", _baseline_config("0.0001"))
+    monkeypatch.setattr(
+        "flaskr.service.billing.charges.load_usage_rate",
+        fake_load_usage_rate,
+    )
+
+    # Missing TTS rate -> actual cost falls back to the baseline -> 1x.
     assert tts_api._resolve_credit_multiplier_label("unknown", "missing") == "1x"
+
+
+def test_tts_credit_multiplier_none_when_baseline_unset(monkeypatch):
+    import flaskr.api.tts as tts_api
+
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+        return None
+
+    monkeypatch.setattr(tts_api, "get_config", _baseline_config(""))
+    monkeypatch.setattr(
+        "flaskr.service.billing.charges.load_usage_rate",
+        fake_load_usage_rate,
+    )
+
+    # An unset/blank baseline disables the label instead of dividing by zero.
+    assert tts_api._resolve_credit_multiplier_label("tencent", "") is None
 
 
 def test_tts_display_name_prefers_request_language(monkeypatch):


### PR DESCRIPTION
## Problem

The TTS model picker shows an **"Nx" credit multiplier**. It must sit on the **same 1x anchor** as the LLM model multipliers so that "Nx" means the same credit-drain speed whether it is an LLM model or a TTS voice — one unified logic, not two separate base units.

The only wrinkle: **LLM is billed per token, TTS per character.** So the shared anchor (default LLM output-token price, DeepSeek-V4-Flash) has to be translated into TTS's character dimension before comparing.

Previously the label divided the TTS char rate by the default LLM **per-token** rate directly — mixing units (char vs token), which produced the wrong magnitude.

## Change

Keep **one shared 1x anchor** (the default LLM output-token cost) and convert:

```
multiplier = TTS_char_cost x TTS_CHARS_PER_LLM_TOKEN / LLM_output_token_cost
```

- New config **`TTS_CHARS_PER_LLM_TOKEN`** (float, default `0.216` = ω 13.5% × 1.6 chars/token) — how many TTS characters one LLM token turns into within a task.
- `_resolve_credit_multiplier_label` uses the shared `_load_default_llm_unit_cost()` (DeepSeek) as the anchor and applies the conversion factor. The TTS 1x therefore **tracks the default LLM price automatically** instead of being a hand-set constant.
- A missing TTS rate now yields **no label** instead of a fabricated `1x`.

This keeps LLM and TTS multipliers on one scale (`multiplier = TTS task consumption ÷ LLM task consumption`), matching the internal pricing doc.

## Tests

`test_tts_config_options.py` rewritten to cover the shared-anchor path (both LLM and TTS rates are queried), conversion-factor scaling (doubling chars/token doubles the multiplier), and the `None` fallbacks (missing TTS rate / unset conversion). `pytest tests/service/tts` (118 passed), `ruff`, and `scripts/check_architecture_boundaries.py` (0 new violations) pass.

## Rollout note

Default `0.216` needs no deploy-config change. The curated TTS rate rows in `credit_usage_rates` (per character) are then set so `char_cost × 0.216 ÷ LLM_baseline` renders the intended tier — billing and display use the same rate (deduct-what-you-show). Deploy the code first, then set the DB rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new TTS configuration setting (`TTS_CHARS_PER_LLM_TOKEN`) to align TTS “credit multiplier” tiers with the LLM token scale.

* **Bug Fixes**
  * Updated the TTS credit multiplier label to compute from a shared LLM reference and the new conversion factor.
  * If pricing inputs or the conversion setting are missing/invalid/non-positive, the multiplier label is now hidden (no fallback).

* **Tests**
  * Updated TTS multiplier label tests for shared-anchor behavior, scaling with the new setting, and disabled-label scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->