### PR TITLE
fix: normalize billing renewal event schedule precision

### DIFF
--- a/src/api/flaskr/service/billing/primitives.py
+++ b/src/api/flaskr/service/billing/primitives.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any
 
@@ -189,6 +189,14 @@ def coerce_datetime(value: Any) -> datetime | None:
     if parsed.tzinfo is not None:
         return parsed.astimezone(timezone.utc).replace(tzinfo=None)
     return parsed
+
+
+def normalize_mysql_datetime(value: datetime) -> datetime:
+    """Normalize to MySQL DATETIME(0)'s default fractional-second rounding."""
+
+    if value.microsecond >= 500_000:
+        value = value + timedelta(seconds=1)
+    return value.replace(microsecond=0)
 
 
 def normalize_json_value(value: Any) -> Any:

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -92,6 +92,7 @@ from .queries import (
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
 from .primitives import normalize_json_value as _normalize_json_value
+from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
 from .serializers import serialize_subscription as _serialize_subscription
@@ -2495,12 +2496,6 @@ def _sync_subscription_lifecycle_events(
     )
 
 
-def _normalize_renewal_event_scheduled_at(value: datetime) -> datetime:
-    """Match MySQL DATETIME precision before comparing renewal event boundaries."""
-
-    return value.replace(microsecond=0)
-
-
 def _upsert_subscription_renewal_event(
     app: Flask,
     subscription: BillingSubscription,
@@ -2508,7 +2503,7 @@ def _upsert_subscription_renewal_event(
     event_type: int,
     scheduled_at: datetime,
 ) -> None:
-    normalized_scheduled_at = _normalize_renewal_event_scheduled_at(scheduled_at)
+    normalized_scheduled_at = _normalize_mysql_datetime(scheduled_at)
     payload = _normalize_json_object(
         {
             "subscription_bid": subscription.subscription_bid,

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -2495,6 +2495,12 @@ def _sync_subscription_lifecycle_events(
     )
 
 
+def _normalize_renewal_event_scheduled_at(value: datetime) -> datetime:
+    """Match MySQL DATETIME precision before comparing renewal event boundaries."""
+
+    return value.replace(microsecond=0)
+
+
 def _upsert_subscription_renewal_event(
     app: Flask,
     subscription: BillingSubscription,
@@ -2502,6 +2508,7 @@ def _upsert_subscription_renewal_event(
     event_type: int,
     scheduled_at: datetime,
 ) -> None:
+    normalized_scheduled_at = _normalize_renewal_event_scheduled_at(scheduled_at)
     payload = _normalize_json_object(
         {
             "subscription_bid": subscription.subscription_bid,
@@ -2520,7 +2527,7 @@ def _upsert_subscription_renewal_event(
             BillingRenewalEvent.deleted == 0,
             BillingRenewalEvent.subscription_bid == subscription.subscription_bid,
             BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.scheduled_at == scheduled_at,
+            BillingRenewalEvent.scheduled_at == normalized_scheduled_at,
         )
         .order_by(BillingRenewalEvent.id.desc())
         .first()
@@ -2531,7 +2538,7 @@ def _upsert_subscription_renewal_event(
             subscription_bid=subscription.subscription_bid,
             creator_bid=subscription.creator_bid,
             event_type=event_type,
-            scheduled_at=scheduled_at,
+            scheduled_at=normalized_scheduled_at,
             status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
             attempt_count=0,
             last_error="",
@@ -2550,7 +2557,7 @@ def _upsert_subscription_renewal_event(
     _cancel_stale_subscription_renewal_events(
         subscription.subscription_bid,
         event_type=event_type,
-        keep_scheduled_at=scheduled_at,
+        keep_scheduled_at=normalized_scheduled_at,
     )
 
 

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -44,6 +44,7 @@ from .primitives import credit_decimal_to_number as _credit_decimal_to_number
 from .primitives import is_billing_enabled as _is_billing_enabled
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
+from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import safe_to_positive_int as _safe_to_positive_int
 from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
@@ -363,7 +364,7 @@ def _bootstrap_trial_subscription(
     if valid_days <= 0 or credit_amount <= 0:
         return
 
-    now = now_utc().replace(microsecond=0)
+    now = _normalize_mysql_datetime(now_utc())
     expires_at = now + timedelta(days=valid_days)
     product_bid = str(
         _trial_product_field(product_ref, "product_bid", BILLING_TRIAL_PRODUCT_BID)

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -363,7 +363,7 @@ def _bootstrap_trial_subscription(
     if valid_days <= 0 or credit_amount <= 0:
         return
 
-    now = now_utc()
+    now = now_utc().replace(microsecond=0)
     expires_at = now + timedelta(days=valid_days)
     product_bid = str(
         _trial_product_field(product_ref, "product_bid", BILLING_TRIAL_PRODUCT_BID)

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -57,6 +57,7 @@ from flaskr.service.billing.queries import (
     calculate_self_managed_billing_cycle_end,
     calculate_self_managed_billing_cycle_end_after_boundary,
 )
+from flaskr.service.billing.primitives import normalize_mysql_datetime
 from flaskr.service.billing.subscriptions import (
     ensure_subscription_renewal_order,
     sync_subscription_lifecycle_events,
@@ -491,7 +492,7 @@ def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replaye
 def test_manual_trial_subscription_schedules_and_applies_expire(
     billing_renewal_app: Flask,
 ) -> None:
-    period_end_at = (now_utc() - timedelta(minutes=1)).replace(microsecond=0)
+    period_end_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     with billing_renewal_app.app_context():
         subscription = _create_subscription(
             "sub-trial-expire-1",
@@ -565,7 +566,13 @@ def test_trial_expire_event_sync_reuses_second_precision_scheduled_at(
     billing_renewal_app: Flask,
 ) -> None:
     period_end_at = (now_utc() + timedelta(days=15)).replace(microsecond=654321)
-    stored_period_end_at = period_end_at.replace(microsecond=0)
+    stored_period_end_at = normalize_mysql_datetime(period_end_at)
+    assert stored_period_end_at == period_end_at.replace(microsecond=0) + timedelta(
+        seconds=1
+    )
+    assert normalize_mysql_datetime(
+        period_end_at.replace(microsecond=499999)
+    ) == period_end_at.replace(microsecond=0)
     with billing_renewal_app.app_context():
         subscription = _create_subscription(
             "sub-trial-expire-precision",
@@ -642,7 +649,7 @@ def test_run_billing_renewal_event_applies_downgrade_and_reschedules_renewal(
         assert subscription.product_bid == "bill-product-plan-monthly"
         assert subscription.next_product_bid == ""
         assert renewal_event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
-        assert renewal_event.scheduled_at == next_period_end.replace(microsecond=0)
+        assert renewal_event.scheduled_at == normalize_mysql_datetime(next_period_end)
 
 
 def test_run_billing_downgrade_event_applies_paid_preorder(

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -14,6 +14,7 @@ from flaskr.service.billing.consts import (
     BILLING_INTERVAL_MONTH,
     BILLING_MODE_RECURRING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
@@ -490,7 +491,7 @@ def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replaye
 def test_manual_trial_subscription_schedules_and_applies_expire(
     billing_renewal_app: Flask,
 ) -> None:
-    period_end_at = now_utc() - timedelta(minutes=1)
+    period_end_at = (now_utc() - timedelta(minutes=1)).replace(microsecond=0)
     with billing_renewal_app.app_context():
         subscription = _create_subscription(
             "sub-trial-expire-1",
@@ -560,6 +561,46 @@ def test_manual_trial_subscription_schedules_and_applies_expire(
         assert ledger_entry.amount == Decimal("-100.0000000000")
 
 
+def test_trial_expire_event_sync_reuses_second_precision_scheduled_at(
+    billing_renewal_app: Flask,
+) -> None:
+    period_end_at = (now_utc() + timedelta(days=15)).replace(microsecond=654321)
+    stored_period_end_at = period_end_at.replace(microsecond=0)
+    with billing_renewal_app.app_context():
+        subscription = _create_subscription(
+            "sub-trial-expire-precision",
+            product_bid=BILLING_TRIAL_PRODUCT_BID,
+            billing_provider="manual",
+            provider_subscription_id="",
+            current_period_end_at=period_end_at,
+        )
+        stale_event = _create_renewal_event(
+            "renewal-trial-expire-precision",
+            subscription.subscription_bid,
+            subscription.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+            scheduled_at=stored_period_end_at,
+            status=BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+        )
+        stale_event.processed_at = subscription.current_period_start_at
+        dao.db.session.add(subscription)
+        dao.db.session.add(stale_event)
+        dao.db.session.commit()
+
+        sync_subscription_lifecycle_events(billing_renewal_app, subscription)
+        dao.db.session.commit()
+
+        events = BillingRenewalEvent.query.filter_by(
+            subscription_bid=subscription.subscription_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+        ).all()
+        assert len(events) == 1
+        assert events[0].renewal_event_bid == "renewal-trial-expire-precision"
+        assert events[0].scheduled_at == stored_period_end_at
+        assert events[0].status == BILLING_RENEWAL_EVENT_STATUS_PENDING
+        assert events[0].processed_at is None
+
+
 def test_run_billing_renewal_event_applies_downgrade_and_reschedules_renewal(
     billing_renewal_app: Flask,
 ) -> None:
@@ -601,7 +642,7 @@ def test_run_billing_renewal_event_applies_downgrade_and_reschedules_renewal(
         assert subscription.product_bid == "bill-product-plan-monthly"
         assert subscription.next_product_bid == ""
         assert renewal_event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
-        assert renewal_event.scheduled_at == next_period_end
+        assert renewal_event.scheduled_at == next_period_end.replace(microsecond=0)
 
 
 def test_run_billing_downgrade_event_applies_paid_preorder(

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -201,7 +201,9 @@ def test_trial_bootstrap_creates_manual_order_subscription_and_expire_event_once
         assert subscription.billing_provider == "manual"
         assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
         assert subscription.current_period_start_at == order.paid_at
+        assert subscription.current_period_start_at.microsecond == 0
         assert subscription.current_period_end_at is not None
+        assert subscription.current_period_end_at.microsecond == 0
         assert (
             subscription.current_period_end_at - subscription.current_period_start_at
             == timedelta(days=15)

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -1558,7 +1558,9 @@ class TestBillingWriteRoutes:
                 product,
                 current_period_end,
             )
-            assert downgrade_event.scheduled_at == current_period_end
+            assert downgrade_event.scheduled_at == current_period_end.replace(
+                microsecond=0
+            )
 
     def test_paid_same_plan_preorder_sync_reserves_until_cycle_boundary(
         self, billing_write_client
@@ -1690,7 +1692,9 @@ class TestBillingWriteRoutes:
             assert grant_ledger.consumable_from == current_period_end
             assert grant_ledger.expires_at == expected_cycle_end
             assert downgrade_event is not None
-            assert downgrade_event.scheduled_at == current_period_end
+            assert downgrade_event.scheduled_at == current_period_end.replace(
+                microsecond=0
+            )
 
         upgrade_checkout = client.post(
             "/api/billing/subscriptions/checkout",
@@ -3566,7 +3570,10 @@ class TestBillingWriteRoutes:
                 == 1
             )
             assert renewal_event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
-            assert renewal_event.scheduled_at == subscription.current_period_end_at
+            assert (
+                renewal_event.scheduled_at
+                == subscription.current_period_end_at.replace(microsecond=0)
+            )
 
     def test_cancel_and_resume_subscription_toggle_status(
         self, billing_write_client

--- a/src/api/tests/service/billing/test_billing_write_routes.py
+++ b/src/api/tests/service/billing/test_billing_write_routes.py
@@ -67,6 +67,7 @@ from flaskr.service.billing.provider_state import (
 )
 import flaskr.service.billing.checkout as billing_checkout_module
 from flaskr.service.billing.preorders import mark_preorder_effective_applied
+from flaskr.service.billing.primitives import normalize_mysql_datetime
 from flaskr.service.billing.queries import (
     calculate_self_managed_billing_cycle_end,
     calculate_self_managed_billing_cycle_end_after_boundary,
@@ -1558,8 +1559,8 @@ class TestBillingWriteRoutes:
                 product,
                 current_period_end,
             )
-            assert downgrade_event.scheduled_at == current_period_end.replace(
-                microsecond=0
+            assert downgrade_event.scheduled_at == normalize_mysql_datetime(
+                current_period_end
             )
 
     def test_paid_same_plan_preorder_sync_reserves_until_cycle_boundary(
@@ -1692,8 +1693,8 @@ class TestBillingWriteRoutes:
             assert grant_ledger.consumable_from == current_period_end
             assert grant_ledger.expires_at == expected_cycle_end
             assert downgrade_event is not None
-            assert downgrade_event.scheduled_at == current_period_end.replace(
-                microsecond=0
+            assert downgrade_event.scheduled_at == normalize_mysql_datetime(
+                current_period_end
             )
 
         upgrade_checkout = client.post(
@@ -3570,9 +3571,8 @@ class TestBillingWriteRoutes:
                 == 1
             )
             assert renewal_event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
-            assert (
-                renewal_event.scheduled_at
-                == subscription.current_period_end_at.replace(microsecond=0)
+            assert renewal_event.scheduled_at == normalize_mysql_datetime(
+                subscription.current_period_end_at
             )
 
     def test_cancel_and_resume_subscription_toggle_status(

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -35,6 +35,7 @@ from flaskr.service.billing.referral_plan_rewards import (
     ReferralPlanRewardRequest,
     grant_referral_plan_reward,
 )
+from flaskr.service.billing.primitives import normalize_mysql_datetime
 from flaskr.service.billing.queries import (
     calculate_self_managed_billing_cycle_end_after_boundary,
 )
@@ -148,7 +149,7 @@ def test_referral_plan_reward_creates_manual_paid_order_and_credits(
 def test_referral_plan_reward_defers_active_trial_subscription_until_boundary(
     referral_billing_app: Flask,
 ) -> None:
-    trial_started_at = (now_utc() - timedelta(minutes=5)).replace(microsecond=0)
+    trial_started_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=5))
     trial_ends_at = trial_started_at + timedelta(days=15)
 
     with referral_billing_app.app_context():
@@ -914,7 +915,7 @@ def test_referral_plan_reward_defers_after_higher_paid_subscription(
         expire_event = BillingRenewalEvent.query.filter_by(
             subscription_bid="sub-higher-paid",
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
-            scheduled_at=current_end.replace(microsecond=0),
+            scheduled_at=normalize_mysql_datetime(current_end),
         ).one()
         assert order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL
         assert order.metadata_json["deferred_after_subscription_bid"] == (

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -148,7 +148,7 @@ def test_referral_plan_reward_creates_manual_paid_order_and_credits(
 def test_referral_plan_reward_defers_active_trial_subscription_until_boundary(
     referral_billing_app: Flask,
 ) -> None:
-    trial_started_at = now_utc() - timedelta(minutes=5)
+    trial_started_at = (now_utc() - timedelta(minutes=5)).replace(microsecond=0)
     trial_ends_at = trial_started_at + timedelta(days=15)
 
     with referral_billing_app.app_context():
@@ -914,7 +914,7 @@ def test_referral_plan_reward_defers_after_higher_paid_subscription(
         expire_event = BillingRenewalEvent.query.filter_by(
             subscription_bid="sub-higher-paid",
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
-            scheduled_at=current_end,
+            scheduled_at=current_end.replace(microsecond=0),
         ).one()
         assert order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL
         assert order.metadata_json["deferred_after_subscription_bid"] == (


### PR DESCRIPTION
Summary
- Normalize billing renewal event `scheduled_at` values to second precision before event lookup, insert, and stale-event cleanup.
- Normalize trial bootstrap period boundaries to second precision.
- Add regression coverage for a canceled same-second trial expire event being reused and restored to pending.

Why
- Production MySQL `DATETIME` stores second precision, while Python `now_utc()` carries microseconds.
- A trial expire event could be inserted with a DB-truncated `scheduled_at`, then immediately treated as stale because cleanup compared it with the original microsecond value.
- That left active trial subscriptions with their expire events already canceled, so the dispatcher had nothing pending to execute at expiry.

Verification
- `python3 -m ruff check --fix src/api/flaskr/service/billing/subscriptions.py src/api/flaskr/service/billing/trials.py src/api/tests/service/billing/test_billing_renewal_execution.py src/api/tests/service/billing/test_billing_trial_credits.py`
- `python3 -m ruff format src/api/flaskr/service/billing/subscriptions.py src/api/flaskr/service/billing/trials.py src/api/tests/service/billing/test_billing_renewal_execution.py src/api/tests/service/billing/test_billing_trial_credits.py`
- `git diff --check`
- `cd src/api && pytest tests/service/billing/test_billing_trial_credits.py tests/service/billing/test_billing_renewal_execution.py -q`

Note
- `python scripts/check_dev_tools.py` reports local missing CLI tools (`lefthook`, PATH-visible `ruff`, commitizen/pre-commit-hooks). Targeted checks above passed using `python3 -m ruff`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing timestamp handling so renewal, trial, and referral-related events use consistent second-level precision.
  * Reduced duplicate or missed billing events caused by tiny datetime differences.
  * Trial and renewal dates now align more reliably when subscriptions are created, updated, or synced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->