### PR TITLE
chore(api): bump markdown-flow to 0.2.86 to render fence-wrapped HTML

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -126,4 +126,4 @@ zope.event==5.0
 zope.interface==7.1.1
 bcrypt==4.2.1
 --extra-index-url https://pypi.org/simple/
-markdown-flow==0.2.84
+markdown-flow==0.2.86


### PR DESCRIPTION
## Problem

In listen/learn content, an infographic (block-level HTML + SVG) intermittently rendered as **raw source code** instead of the intended visual. Root cause: the LLM sometimes wraps otherwise-renderable output in an **untagged** code fence (a bare ``` with no language, sometimes unclosed). CommonMark turns that region into a code block, so `format_content` classified the whole thing as a single `code` element and the client showed the source.

Confirmed against production learning records: the same infographic is emitted as bare HTML in some regenerations (renders) and wrapped in a bare ``` in others (shows source) — matching the intermittent reports.

## Change

Bump `markdown-flow` `0.2.84` → `0.2.86`.

`0.2.86` makes `format_content` strip untagged (language-less) code fences **by default** before classification, so:

- Bare-fence-wrapped HTML/SVG is classified as `html` / `svg` with **fence-free** element content → the client renders it.
- **Language-tagged fences are untouched** (` ```html ` source display, ` ```mermaid `, ` ```python ` …), preserving the deliberate "show source" convention.

The listen backfill path (`listen_element_mdflow_backfill._emit_content_group`) already calls `format_content(content)`, so **no application code change is required** — the fix arrives with the dependency bump. It is the only `format_content` consumer in the API.

## Validation

- Installed `0.2.86` in the `ai-shifu` env and ran the exact `_emit_content_group` call on the real production content: the infographic now yields `html` elements with no bare fences; narrative yields `text`; ` ```html ` stays `code`.
- markdown-flow side: https://github.com/ai-shifu/markdown-flow-agent-py/pull/70

## Notes

- This fixes the **history/revisit render path** (the reported case), which goes through `format_content`. The live first-generation streaming path computes element types with its own classifier (`stream_element_type`); if it also shows source during live streaming, that is a separate follow-up.
- Already-stored bad records are not retroactively rewritten; they render correctly on re-fetch because `format_content` runs at emit time.
- Deploy note (CN prod): dependency-only change, no DB migration.