### PR TITLE
fix: standardize clickable cursors

### DIFF
--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -24,7 +24,9 @@ applyTo: "src/cook-web/**/*.ts,src/cook-web/**/*.tsx,src/cook-web/**/*.js,src/co
   clicks, mark the actual clickable target with `data-clickable="true"` and
   preserve disabled states with `disabled`, `aria-disabled="true"`, or
   `data-disabled`. Do not rely on page-local cursor styles or broad
-  `* { cursor: pointer; }` rules.
+  `* { cursor: pointer; }` rules. Full-screen onboarding/backdrop advance
+  surfaces are the exception: keep their large background or card hit areas on
+  the default cursor so the whole page does not read as a button.
 
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -23,7 +23,8 @@ applyTo: "src/cook-web/**/*.ts,src/cook-web/**/*.tsx,src/cook-web/**/*.js,src/co
   shared Radix/shadcn primitives. If a non-semantic element must handle
   clicks, mark the actual clickable target with `data-clickable="true"` and
   preserve disabled states with `disabled`, `aria-disabled="true"`, or
-  `data-disabled`.
+  `data-disabled`. Do not rely on page-local cursor styles or broad
+  `* { cursor: pointer; }` rules.
 
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -19,6 +19,12 @@ applyTo: "src/cook-web/**/*.ts,src/cook-web/**/*.tsx,src/cook-web/**/*.js,src/co
 - Keep user-facing strings in shared i18n JSON under `src/i18n/` and preserve
   the unified business-code handling path.
 
+- For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
+  shared Radix/shadcn primitives. If a non-semantic element must handle
+  clicks, mark the actual clickable target with `data-clickable="true"` and
+  preserve disabled states with `disabled`, `aria-disabled="true"`, or
+  `data-disabled`.
+
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a
   deliberate migration removes them.

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1807,7 +1807,8 @@ def build_documents() -> dict[Path, str]:
                 "non-semantic element must handle clicks, mark the actual "
                 'clickable target with `data-clickable="true"` and preserve '
                 'disabled states with `disabled`, `aria-disabled="true"`, or '
-                "`data-disabled`.",
+                "`data-disabled`. Do not rely on page-local cursor styles or "
+                "broad `* { cursor: pointer; }` rules.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a planned migration removes them.",
@@ -1932,7 +1933,8 @@ def build_documents() -> dict[Path, str]:
                 "non-semantic element must handle clicks, mark the actual "
                 'clickable target with `data-clickable="true"` and preserve '
                 'disabled states with `disabled`, `aria-disabled="true"`, or '
-                "`data-disabled`.",
+                "`data-disabled`. Do not rely on page-local cursor styles or "
+                "broad `* { cursor: pointer; }` rules.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a deliberate migration removes them.",

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1802,6 +1802,12 @@ def build_documents() -> dict[Path, str]:
                 "path or ad-hoc component fetch logic.",
                 "Keep user-facing strings in shared i18n JSON under `src/i18n/` "
                 "and preserve the unified request/business-code handling flow.",
+                "For clickable UI, prefer semantic elements (`button`, `a`, "
+                "`summary`) or shared Radix/shadcn primitives. If a "
+                "non-semantic element must handle clicks, mark the actual "
+                'clickable target with `data-clickable="true"` and preserve '
+                'disabled states with `disabled`, `aria-disabled="true"`, or '
+                "`data-disabled`.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a planned migration removes them.",
@@ -1921,6 +1927,12 @@ def build_documents() -> dict[Path, str]:
                 "implementations or ad-hoc component fetch logic.",
                 "Keep user-facing strings in shared i18n JSON under `src/i18n/` "
                 "and preserve the unified business-code handling path.",
+                "For clickable UI, prefer semantic elements (`button`, `a`, "
+                "`summary`) or shared Radix/shadcn primitives. If a "
+                "non-semantic element must handle clicks, mark the actual "
+                'clickable target with `data-clickable="true"` and preserve '
+                'disabled states with `disabled`, `aria-disabled="true"`, or '
+                "`data-disabled`.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a deliberate migration removes them.",

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1808,7 +1808,10 @@ def build_documents() -> dict[Path, str]:
                 'clickable target with `data-clickable="true"` and preserve '
                 'disabled states with `disabled`, `aria-disabled="true"`, or '
                 "`data-disabled`. Do not rely on page-local cursor styles or "
-                "broad `* { cursor: pointer; }` rules.",
+                "broad `* { cursor: pointer; }` rules. Full-screen "
+                "onboarding/backdrop advance surfaces are the exception: keep "
+                "their large background or card hit areas on the default "
+                "cursor so the whole page does not read as a button.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a planned migration removes them.",
@@ -1934,7 +1937,10 @@ def build_documents() -> dict[Path, str]:
                 'clickable target with `data-clickable="true"` and preserve '
                 'disabled states with `disabled`, `aria-disabled="true"`, or '
                 "`data-disabled`. Do not rely on page-local cursor styles or "
-                "broad `* { cursor: pointer; }` rules.",
+                "broad `* { cursor: pointer; }` rules. Full-screen "
+                "onboarding/backdrop advance surfaces are the exception: keep "
+                "their large background or card hit areas on the default "
+                "cursor so the whole page does not read as a button.",
                 "Keep route-entry behavior in `page.tsx`, `layout.tsx`, and "
                 "`route.ts`, and treat legacy `c-*` directories as active "
                 "compatibility surfaces until a deliberate migration removes them.",

--- a/src/cook-web/.cursor/rules/cook-web.mdc
+++ b/src/cook-web/.cursor/rules/cook-web.mdc
@@ -25,7 +25,8 @@ alwaysApply: false
   shared Radix/shadcn primitives. If a non-semantic element must handle
   clicks, mark the actual clickable target with `data-clickable="true"` and
   preserve disabled states with `disabled`, `aria-disabled="true"`, or
-  `data-disabled`.
+  `data-disabled`. Do not rely on page-local cursor styles or broad
+  `* { cursor: pointer; }` rules.
 
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a

--- a/src/cook-web/.cursor/rules/cook-web.mdc
+++ b/src/cook-web/.cursor/rules/cook-web.mdc
@@ -21,6 +21,12 @@ alwaysApply: false
 - Keep user-facing strings in shared i18n JSON under `src/i18n/` and preserve
   the unified request/business-code handling flow.
 
+- For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
+  shared Radix/shadcn primitives. If a non-semantic element must handle
+  clicks, mark the actual clickable target with `data-clickable="true"` and
+  preserve disabled states with `disabled`, `aria-disabled="true"`, or
+  `data-disabled`.
+
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a
   planned migration removes them.

--- a/src/cook-web/.cursor/rules/cook-web.mdc
+++ b/src/cook-web/.cursor/rules/cook-web.mdc
@@ -26,7 +26,9 @@ alwaysApply: false
   clicks, mark the actual clickable target with `data-clickable="true"` and
   preserve disabled states with `disabled`, `aria-disabled="true"`, or
   `data-disabled`. Do not rely on page-local cursor styles or broad
-  `* { cursor: pointer; }` rules.
+  `* { cursor: pointer; }` rules. Full-screen onboarding/backdrop advance
+  surfaces are the exception: keep their large background or card hit areas on
+  the default cursor so the whole page does not read as a button.
 
 - Keep route-entry behavior in `page.tsx`, `layout.tsx`, and `route.ts`, and
   treat legacy `c-*` directories as active compatibility surfaces until a

--- a/src/cook-web/AGENTS.md
+++ b/src/cook-web/AGENTS.md
@@ -25,6 +25,12 @@ hard frontend constraints close to `src/cook-web/`.
   local Docker dev stack.
 - Treat legacy `c-*` directories as maintained compatibility surfaces until a
   planned migration removes them.
+- For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
+  shared Radix/shadcn primitives. If a non-semantic element must handle clicks,
+  mark the actual clickable target with `data-clickable="true"` and preserve
+  disabled states with `disabled`, `aria-disabled="true"`, or `data-disabled`.
+  Do not rely on page-local cursor styles or broad `* { cursor: pointer; }`
+  rules.
 
 ## Avoid
 

--- a/src/cook-web/AGENTS.md
+++ b/src/cook-web/AGENTS.md
@@ -30,7 +30,9 @@ hard frontend constraints close to `src/cook-web/`.
   mark the actual clickable target with `data-clickable="true"` and preserve
   disabled states with `disabled`, `aria-disabled="true"`, or `data-disabled`.
   Do not rely on page-local cursor styles or broad `* { cursor: pointer; }`
-  rules.
+  rules. Full-screen onboarding/backdrop advance surfaces are the exception:
+  keep their large background or card hit areas on the default cursor so the
+  whole page does not read as a button.
 
 ## Avoid
 

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDetailSheet.tsx
@@ -384,7 +384,7 @@ export function CreditNotificationDetailSheet({
               </Section>
 
               <details className='rounded-lg border border-border bg-white p-4'>
-                <summary className='cursor-pointer text-sm font-semibold text-foreground'>
+                <summary className='text-sm font-semibold text-foreground'>
                   {t(
                     'module.operationsCreditNotifications.detail.sections.diagnostics',
                   )}

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationDryRunPanel.tsx
@@ -83,7 +83,7 @@ export function CreditNotificationDryRunPanel({
       ) : null}
       {dryRunResult ? (
         <details className='rounded-md border border-border bg-white p-3 text-xs text-muted-foreground'>
-          <summary className='cursor-pointer text-foreground'>
+          <summary className='text-foreground'>
             {t('module.operationsCreditNotifications.dryRun.rawResult')}
           </summary>
           <pre className='mt-3 max-h-[220px] overflow-auto rounded-md bg-muted p-3'>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationTemplateSyncPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationTemplateSyncPanel.tsx
@@ -132,7 +132,7 @@ export function CreditNotificationPlaceholderGuide({
 
   return (
     <details className='group rounded-md border border-border bg-white px-3 py-2'>
-      <summary className='flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-medium text-muted-foreground marker:hidden'>
+      <summary className='flex list-none items-center justify-between gap-3 text-xs font-medium text-muted-foreground marker:hidden'>
         <span className='flex min-w-0 items-center gap-2'>
           <Info className='h-3.5 w-3.5 shrink-0' />
           <span>

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrderDetailDialog.tsx
@@ -409,7 +409,7 @@ export default function CreditOrderDetailDialog({
 
               {metadata ? (
                 <details className='rounded-xl border border-border bg-white p-4'>
-                  <summary className='cursor-pointer text-sm font-semibold text-foreground'>
+                  <summary className='text-sm font-semibold text-foreground'>
                     {tOperationsOrder('creditOrders.detail.sections.metadata')}
                   </summary>
                   <pre className='mt-3 overflow-x-auto rounded-lg bg-slate-50 p-3 text-xs leading-6 text-slate-700'>

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.module.scss
@@ -127,6 +127,9 @@
 .mobileOverlay {
   position: fixed;
   inset: 0;
+  padding: 0;
+  border: 0;
+  appearance: none;
   background: rgba(0, 0, 0, 0.35);
   z-index: 1200;
 }

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.module.scss
@@ -127,9 +127,6 @@
 .mobileOverlay {
   position: fixed;
   inset: 0;
-  padding: 0;
-  border: 0;
-  appearance: none;
   background: rgba(0, 0, 0, 0.35);
   z-index: 1200;
 }

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -589,6 +589,18 @@ export default function AskBlock({
     [onToggleAskExpanded, element_bid, expanded, mobileStyle],
   );
 
+  const handleTitleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
+      event.preventDefault();
+      handleClickTitle(index);
+    },
+    [handleClickTitle],
+  );
+
   const renderMessages = ({
     extraClass,
     messages = messagesToShow,
@@ -619,14 +631,23 @@ export default function AskBlock({
           // if (message.type === BLOCK_TYPE.ANSWER) {
           //   console.log('message', message, shouldEnableMessageTypewriter);
           // }
+          const isMessageClickable = index === 0 && !expanded && mobileStyle;
           return (
             <div
               key={messageRenderKey}
-              data-clickable={
-                index === 0 && !expanded && mobileStyle ? 'true' : undefined
-              }
+              data-clickable={isMessageClickable ? 'true' : undefined}
+              role={isMessageClickable ? 'button' : undefined}
+              tabIndex={isMessageClickable ? 0 : undefined}
+              aria-label={isMessageClickable ? t('module.chat.ask') : undefined}
               className={cn(styles.messageWrapper)}
-              onClick={() => handleClickTitle(index)}
+              onClick={
+                isMessageClickable ? () => handleClickTitle(index) : undefined
+              }
+              onKeyDown={
+                isMessageClickable
+                  ? event => handleTitleKeyDown(event, index)
+                  : undefined
+              }
               style={{
                 justifyContent:
                   message.type === BLOCK_TYPE.ASK ? 'flex-end' : 'flex-start',
@@ -710,9 +731,10 @@ export default function AskBlock({
         {!expanded && renderMessages()}
         {(expanded || hasStreamingAnswerTypewriterMessage) && (
           <>
-            <div
+            <button
+              type='button'
               className={styles.mobileOverlay}
-              data-clickable='true'
+              aria-label='Close'
               onClick={handleClose}
               style={expanded ? undefined : { display: 'none' }}
             />

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -589,18 +589,6 @@ export default function AskBlock({
     [onToggleAskExpanded, element_bid, expanded, mobileStyle],
   );
 
-  const handleTitleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>, index: number) => {
-      if (event.key !== 'Enter' && event.key !== ' ') {
-        return;
-      }
-
-      event.preventDefault();
-      handleClickTitle(index);
-    },
-    [handleClickTitle],
-  );
-
   const renderMessages = ({
     extraClass,
     messages = messagesToShow,
@@ -631,23 +619,14 @@ export default function AskBlock({
           // if (message.type === BLOCK_TYPE.ANSWER) {
           //   console.log('message', message, shouldEnableMessageTypewriter);
           // }
-          const isMessageClickable = index === 0 && !expanded && mobileStyle;
           return (
             <div
               key={messageRenderKey}
-              data-clickable={isMessageClickable ? 'true' : undefined}
-              role={isMessageClickable ? 'button' : undefined}
-              tabIndex={isMessageClickable ? 0 : undefined}
-              aria-label={isMessageClickable ? t('module.chat.ask') : undefined}
+              data-clickable={
+                index === 0 && !expanded && mobileStyle ? 'true' : undefined
+              }
               className={cn(styles.messageWrapper)}
-              onClick={
-                isMessageClickable ? () => handleClickTitle(index) : undefined
-              }
-              onKeyDown={
-                isMessageClickable
-                  ? event => handleTitleKeyDown(event, index)
-                  : undefined
-              }
+              onClick={() => handleClickTitle(index)}
               style={{
                 justifyContent:
                   message.type === BLOCK_TYPE.ASK ? 'flex-end' : 'flex-start',
@@ -731,10 +710,9 @@ export default function AskBlock({
         {!expanded && renderMessages()}
         {(expanded || hasStreamingAnswerTypewriterMessage) && (
           <>
-            <button
-              type='button'
+            <div
               className={styles.mobileOverlay}
-              aria-label='Close'
+              data-clickable='true'
               onClick={handleClose}
               style={expanded ? undefined : { display: 'none' }}
             />

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -622,6 +622,9 @@ export default function AskBlock({
           return (
             <div
               key={messageRenderKey}
+              data-clickable={
+                index === 0 && !expanded && mobileStyle ? 'true' : undefined
+              }
               className={cn(styles.messageWrapper)}
               onClick={() => handleClickTitle(index)}
               style={{
@@ -709,6 +712,7 @@ export default function AskBlock({
           <>
             <div
               className={styles.mobileOverlay}
+              data-clickable='true'
               onClick={handleClose}
               style={expanded ? undefined : { display: 'none' }}
             />

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -1295,7 +1295,7 @@ export const NewChatComponents = ({
                   )}
                   onClick={handleRetakeButtonClick}
                   disabled={isRetakingCurrentLesson}
-                  className='inline-flex h-auto min-h-0 cursor-pointer items-baseline rounded px-0.5 py-0 font-semibold text-amber-950 underline decoration-amber-700/35 underline-offset-[3px] transition-colors hover:bg-amber-100/80 hover:text-amber-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50 disabled:cursor-not-allowed disabled:opacity-60'
+                  className='inline-flex h-auto min-h-0 items-baseline rounded px-0.5 py-0 font-semibold text-amber-950 underline decoration-amber-700/35 underline-offset-[3px] transition-colors hover:bg-amber-100/80 hover:text-amber-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50 disabled:cursor-not-allowed disabled:opacity-60'
                 />
               ),
             }}

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.module.scss
@@ -2,7 +2,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0;
+  border: 0;
   background-color: transparent;
+  appearance: none;
 
   &:active {
     background-color: var(--color-9);

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.module.scss
@@ -2,10 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0;
-  border: 0;
   background-color: transparent;
-  appearance: none;
 
   &:active {
     background-color: var(--color-9);

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
@@ -14,7 +14,7 @@ export const IconButton = ({
 }) => {
   const [isHover, setIsHover] = useState(false);
   const [isActive, setIsActive] = useState(false);
-  const topRef = useRef<HTMLDivElement>(null);
+  const topRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const onMouseEnter = () => {
@@ -65,9 +65,9 @@ export const IconButton = ({
   }, [icon, activeIcon, hoverIcon, selectedIcon, isActive, isHover, selected]);
 
   return (
-    <div
+    <button
+      type='button'
       ref={topRef}
-      data-clickable='true'
       className={styles.IconButton}
       style={{
         width: `${width}px`,
@@ -81,7 +81,7 @@ export const IconButton = ({
         alt=''
         className={styles.innerIcon}
       />
-    </div>
+    </button>
   );
 };
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
@@ -67,6 +67,7 @@ export const IconButton = ({
   return (
     <div
       ref={topRef}
+      data-clickable='true'
       className={styles.IconButton}
       style={{
         width: `${width}px`,

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
@@ -7,6 +7,7 @@ export const IconButton = ({
   hoverIcon = '',
   activeIcon = '',
   selectedIcon = '',
+  ariaLabel = 'Icon button',
   width = 36,
   borderRadius = 10,
   selected = false,
@@ -69,6 +70,7 @@ export const IconButton = ({
       type='button'
       ref={topRef}
       className={styles.IconButton}
+      aria-label={ariaLabel}
       style={{
         width: `${width}px`,
         height: `${width}px`,

--- a/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/IconButton/IconButton.tsx
@@ -7,7 +7,6 @@ export const IconButton = ({
   hoverIcon = '',
   activeIcon = '',
   selectedIcon = '',
-  ariaLabel = 'Icon button',
   width = 36,
   borderRadius = 10,
   selected = false,
@@ -15,7 +14,7 @@ export const IconButton = ({
 }) => {
   const [isHover, setIsHover] = useState(false);
   const [isActive, setIsActive] = useState(false);
-  const topRef = useRef<HTMLButtonElement>(null);
+  const topRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const onMouseEnter = () => {
@@ -66,11 +65,10 @@ export const IconButton = ({
   }, [icon, activeIcon, hoverIcon, selectedIcon, isActive, isHover, selected]);
 
   return (
-    <button
-      type='button'
+    <div
       ref={topRef}
+      data-clickable='true'
       className={styles.IconButton}
-      aria-label={ariaLabel}
       style={{
         width: `${width}px`,
         height: `${width}px`,
@@ -83,7 +81,7 @@ export const IconButton = ({
         alt=''
         className={styles.innerIcon}
       />
-    </button>
+    </div>
   );
 };
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
@@ -663,6 +663,7 @@ export const PayModal = ({
                         {isStripeAvailable ? (
                           <div className={styles.stripeSelector}>
                             <div
+                              data-clickable='true'
                               onClick={() =>
                                 onPayChannelSelectChange({
                                   channel: PAY_CHANNEL_STRIPE,

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
@@ -649,6 +649,7 @@ export const PayModalM = ({
                                     payChannel === PAY_CHANNEL_WECHAT_JSAPI &&
                                       styles.selected,
                                   )}
+                                  data-clickable='true'
                                   onClick={onPayChannelWechatClick}
                                 >
                                   <div className={styles.payChannelBasic}>
@@ -674,6 +675,7 @@ export const PayModalM = ({
                                     payChannel === PAY_CHANNEL_ZHIFUBAO &&
                                       styles.selected,
                                   )}
+                                  data-clickable='true'
                                   onClick={onPayChannelZhifubaoClick}
                                 >
                                   <div className={styles.payChannelBasic}>

--- a/src/cook-web/src/app/c/[[...id]]/Components/Settings/SettingSelectElement.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Settings/SettingSelectElement.tsx
@@ -14,6 +14,7 @@ export const SettingSelectElement = ({
   return (
     <div
       className={clsx(styles.settingSelect, className)}
+      data-clickable='true'
       onClick={onClick}
     >
       <div className={styles.title}>{value && title}</div>

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -134,7 +134,9 @@ body.listen-mode-vh-fallback #root {
   button {
     outline: none;
   }
-  :where(:disabled, [aria-disabled='true'], [data-disabled]) {
+  :disabled,
+  [aria-disabled='true'],
+  [data-disabled] {
     cursor: not-allowed;
   }
   button:focus {

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -137,7 +137,7 @@ body.listen-mode-vh-fallback #root {
   :disabled,
   [aria-disabled='true'],
   [data-disabled] {
-    cursor: not-allowed;
+    cursor: not-allowed !important;
   }
   button:focus {
     outline: none;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -206,10 +206,18 @@ body.listen-mode-vh-fallback #root {
     background: var(--base-background, #fff);
     color: var(--base-foreground, #0a0a0a);
     opacity: 1;
-    cursor: pointer;
     box-shadow: var(--shadow-xs-offset-x, 0) var(--shadow-xs-offset-y, 1px)
       var(--shadow-xs-blur-radius, 2px) var(--shadow-xs-spread-radius, 0)
       var(--shadow-xs-color, rgba(0, 0, 0, 0.05));
+  }
+
+  .content-render .single-select-container button:not(:disabled),
+  .content-render .single-select-container .select {
+    cursor: pointer;
+  }
+
+  .content-render .single-select-container button:disabled {
+    cursor: not-allowed;
   }
 }
 

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -118,6 +118,9 @@ body.listen-mode-vh-fallback #root {
   :where(
     a[href],
     button,
+    input[type='button'],
+    input[type='submit'],
+    input[type='reset'],
     summary,
     [role='button'],
     [role='link'],
@@ -137,6 +140,7 @@ body.listen-mode-vh-fallback #root {
     outline: none;
   }
   :disabled,
+  [disabled],
   [aria-disabled='true'],
   [data-disabled]:not([data-disabled='false']) {
     cursor: not-allowed !important;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -115,11 +115,26 @@ body.listen-mode-vh-fallback #root {
   body {
     @apply bg-background text-foreground;
   }
-  button {
+  :where(
+    a[href],
+    button,
+    summary,
+    [role='button'],
+    [role='link'],
+    [role='tab'],
+    [role='menuitem'],
+    [role='option'],
+    [role='checkbox'],
+    [role='radio'],
+    [role='switch'],
+    [data-clickable='true']
+  ) {
     cursor: pointer;
+  }
+  button {
     outline: none;
   }
-  button:disabled {
+  :where(:disabled, [aria-disabled='true'], [data-disabled]) {
     cursor: not-allowed;
   }
   button:focus {

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -121,6 +121,8 @@ body.listen-mode-vh-fallback #root {
     input[type='button'],
     input[type='submit'],
     input[type='reset'],
+    input[type='checkbox'],
+    input[type='radio'],
     summary,
     [role='button'],
     [role='link'],
@@ -219,13 +221,8 @@ body.listen-mode-vh-fallback #root {
       var(--shadow-xs-color, rgba(0, 0, 0, 0.05));
   }
 
-  .content-render .single-select-container button:not(:disabled),
   .content-render .single-select-container .select {
     cursor: pointer;
-  }
-
-  .content-render .single-select-container button:disabled {
-    cursor: not-allowed;
   }
 }
 

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -123,6 +123,8 @@ body.listen-mode-vh-fallback #root {
     [role='link'],
     [role='tab'],
     [role='menuitem'],
+    [role='menuitemcheckbox'],
+    [role='menuitemradio'],
     [role='option'],
     [role='checkbox'],
     [role='radio'],
@@ -136,7 +138,7 @@ body.listen-mode-vh-fallback #root {
   }
   :disabled,
   [aria-disabled='true'],
-  [data-disabled] {
+  [data-disabled]:not([data-disabled='false']) {
     cursor: not-allowed !important;
   }
   button:focus {

--- a/src/cook-web/src/components/billing/BillingSidebarCard.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.tsx
@@ -63,7 +63,7 @@ export function BillingSidebarCard({
       data-href={BILLING_PACKAGES_HREF}
       onClick={handleCardClick}
       onKeyDown={handleCardKeyDown}
-      className='mt-4 block cursor-pointer rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] py-[14px] pl-4 pr-3 shadow-[0_10px_24px_rgba(15,23,42,0.06)] transition-colors hover:border-[var(--base-border-hover,#D4D4D4)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400'
+      className='mt-4 block rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] py-[14px] pl-4 pr-3 shadow-[0_10px_24px_rgba(15,23,42,0.06)] transition-colors hover:border-[var(--base-border-hover,#D4D4D4)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400'
       data-testid='admin-billing-sidebar-card'
       {...buildOnboardingTargetProps(ONBOARDING_TARGET_IDS.billingCard)}
     >

--- a/src/cook-web/src/components/contact/ContactSideRail.tsx
+++ b/src/cook-web/src/components/contact/ContactSideRail.tsx
@@ -48,7 +48,7 @@ export function ContactSideRail({ className, label }: ContactSideRailProps) {
           });
         }}
         title={resolvedLabel}
-        className='pointer-events-auto group relative ml-auto flex h-10 w-10 cursor-pointer items-center justify-start overflow-hidden rounded-l-md bg-primary text-primary-foreground shadow-lg shadow-black/15 transition-[width] duration-200 hover:w-auto focus-visible:w-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
+        className='pointer-events-auto group relative ml-auto flex h-10 w-10 items-center justify-start overflow-hidden rounded-l-md bg-primary text-primary-foreground shadow-lg shadow-black/15 transition-[width] duration-200 hover:w-auto focus-visible:w-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
       >
         <span
           className='flex h-10 w-10 shrink-0 items-center justify-center'

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
@@ -80,6 +80,12 @@
   pointer-events: auto;
 }
 
+.dnd-sortable-tree_simple_disable-interaction
+  > .dnd-sortable-tree_simple_tree-item[data-disabled='true']
+  * {
+  pointer-events: none;
+}
+
 .dnd-sortable-tree_folder_tree-item-collapse_button {
   border: 0;
   width: 20px;

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
@@ -75,6 +75,11 @@
   pointer-events: none;
 }
 
+.dnd-sortable-tree_simple_disable-interaction
+  > .dnd-sortable-tree_simple_tree-item[data-disabled='true'] {
+  pointer-events: auto;
+}
+
 .dnd-sortable-tree_folder_tree-item-collapse_button {
   border: 0;
   width: 20px;

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
@@ -102,7 +102,6 @@
   justify-content: center;
   padding: 0;
   margin: 0 8px;
-  cursor: pointer;
   width: 20px;
   height: 20px;
 }

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.css
@@ -75,17 +75,6 @@
   pointer-events: none;
 }
 
-.dnd-sortable-tree_simple_disable-interaction
-  > .dnd-sortable-tree_simple_tree-item[data-disabled='true'] {
-  pointer-events: auto;
-}
-
-.dnd-sortable-tree_simple_disable-interaction
-  > .dnd-sortable-tree_simple_tree-item[data-disabled='true']
-  * {
-  pointer-events: none;
-}
-
 .dnd-sortable-tree_folder_tree-item-collapse_button {
   border: 0;
   width: 20px;

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -97,7 +97,9 @@ export const SimpleTreeItemWrapper = forwardRef<
           'dnd-sortable-tree_simple_tree-item group',
           contentClassName,
         )}
-        data-clickable={handleWrapperClick ? 'true' : undefined}
+        data-clickable={
+          handleWrapperClick && !disableInteraction ? 'true' : undefined
+        }
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={handleWrapperClick}

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -64,12 +64,6 @@ export const SimpleTreeItemWrapper = forwardRef<
   const handleWrapperClick =
     shouldHandleCollapse || hasCustomItemClick
       ? (event: React.MouseEvent<HTMLDivElement>) => {
-          if (disableInteraction) {
-            event.preventDefault();
-            event.stopPropagation();
-            return;
-          }
-
           onItemClick?.(event);
 
           if (event.defaultPrevented) {
@@ -104,7 +98,6 @@ export const SimpleTreeItemWrapper = forwardRef<
           contentClassName,
         )}
         data-clickable={handleWrapperClick ? 'true' : undefined}
-        data-disabled={disableInteraction ? 'true' : undefined}
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={handleWrapperClick}

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -97,6 +97,7 @@ export const SimpleTreeItemWrapper = forwardRef<
           'dnd-sortable-tree_simple_tree-item group',
           contentClassName,
         )}
+        data-clickable={handleWrapperClick ? 'true' : undefined}
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={handleWrapperClick}

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -98,6 +98,9 @@ export const SimpleTreeItemWrapper = forwardRef<
           contentClassName,
         )}
         data-clickable={handleWrapperClick ? 'true' : undefined}
+        data-disabled={
+          handleWrapperClick && disableInteraction ? 'true' : undefined
+        }
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={handleWrapperClick}

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -104,9 +104,7 @@ export const SimpleTreeItemWrapper = forwardRef<
           contentClassName,
         )}
         data-clickable={handleWrapperClick ? 'true' : undefined}
-        data-disabled={
-          handleWrapperClick && disableInteraction ? 'true' : undefined
-        }
+        data-disabled={disableInteraction ? 'true' : undefined}
         ref={ref}
         {...(manualDrag ? undefined : handleProps)}
         onClick={handleWrapperClick}

--- a/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
+++ b/src/cook-web/src/components/dnd-kit-sortable-tree/ui/simple/SimpleTreeItemWrapper.tsx
@@ -64,6 +64,12 @@ export const SimpleTreeItemWrapper = forwardRef<
   const handleWrapperClick =
     shouldHandleCollapse || hasCustomItemClick
       ? (event: React.MouseEvent<HTMLDivElement>) => {
+          if (disableInteraction) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
+
           onItemClick?.(event);
 
           if (event.defaultPrevented) {

--- a/src/cook-web/src/components/onboarding/OnboardingCard.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingCard.tsx
@@ -9,6 +9,7 @@ type OnboardingCardProps = {
   actionLabel?: React.ReactNode;
   actionHref?: string;
   skipLabel?: React.ReactNode;
+  onAdvance: () => void;
   onSkip?: () => void;
 };
 
@@ -21,6 +22,7 @@ export function OnboardingCard({
   actionLabel,
   actionHref,
   skipLabel,
+  onAdvance,
   onSkip,
 }: OnboardingCardProps) {
   const progressLabel = `${stepIndex + 1} / ${totalSteps}`;
@@ -39,21 +41,23 @@ export function OnboardingCard({
           href={actionHref}
           target='_blank'
           rel='noopener noreferrer'
-          onClick={event => event.stopPropagation()}
           className='mt-3 inline-flex text-sm font-medium leading-6 text-blue-600 underline-offset-4 transition-colors hover:text-blue-700 hover:underline'
         >
           {actionLabel}
         </a>
       ) : null}
       <div className='mt-4 flex items-center justify-between gap-3'>
-        <p className='text-xs font-medium uppercase tracking-[0.12em] text-slate-400'>
+        <button
+          type='button'
+          onClick={onAdvance}
+          className='text-xs font-medium uppercase tracking-[0.12em] text-blue-600 underline-offset-4 transition-colors hover:text-blue-700 hover:underline'
+        >
           {continueLabel}
-        </p>
+        </button>
         {skipLabel ? (
           <button
             type='button'
-            onClick={event => {
-              event.stopPropagation();
+            onClick={() => {
               onSkip?.();
             }}
             className='shrink-0 text-xs font-medium text-slate-400 underline-offset-4 transition-colors hover:text-slate-600 hover:underline'

--- a/src/cook-web/src/components/onboarding/OnboardingCard.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingCard.tsx
@@ -9,7 +9,6 @@ type OnboardingCardProps = {
   actionLabel?: React.ReactNode;
   actionHref?: string;
   skipLabel?: React.ReactNode;
-  onAdvance: () => void;
   onSkip?: () => void;
 };
 
@@ -22,7 +21,6 @@ export function OnboardingCard({
   actionLabel,
   actionHref,
   skipLabel,
-  onAdvance,
   onSkip,
 }: OnboardingCardProps) {
   const progressLabel = `${stepIndex + 1} / ${totalSteps}`;
@@ -41,23 +39,21 @@ export function OnboardingCard({
           href={actionHref}
           target='_blank'
           rel='noopener noreferrer'
+          onClick={event => event.stopPropagation()}
           className='mt-3 inline-flex text-sm font-medium leading-6 text-blue-600 underline-offset-4 transition-colors hover:text-blue-700 hover:underline'
         >
           {actionLabel}
         </a>
       ) : null}
       <div className='mt-4 flex items-center justify-between gap-3'>
-        <button
-          type='button'
-          onClick={onAdvance}
-          className='text-xs font-medium uppercase tracking-[0.12em] text-blue-600 underline-offset-4 transition-colors hover:text-blue-700 hover:underline'
-        >
+        <p className='text-xs font-medium uppercase tracking-[0.12em] text-slate-400'>
           {continueLabel}
-        </button>
+        </p>
         {skipLabel ? (
           <button
             type='button'
-            onClick={() => {
+            onClick={event => {
+              event.stopPropagation();
               onSkip?.();
             }}
             className='shrink-0 text-xs font-medium text-slate-400 underline-offset-4 transition-colors hover:text-slate-600 hover:underline'

--- a/src/cook-web/src/components/onboarding/OnboardingCard.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingCard.tsx
@@ -56,7 +56,7 @@ export function OnboardingCard({
               event.stopPropagation();
               onSkip?.();
             }}
-            className='shrink-0 cursor-pointer text-xs font-medium text-slate-400 underline-offset-4 transition-colors hover:text-slate-600 hover:underline'
+            className='shrink-0 text-xs font-medium text-slate-400 underline-offset-4 transition-colors hover:text-slate-600 hover:underline'
           >
             {skipLabel}
           </button>

--- a/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
@@ -216,11 +216,13 @@ export function OnboardingOverlay({
       )}
       <div
         ref={cardRef}
+        data-clickable='true'
         className='pointer-events-auto absolute z-20'
         style={{
           ...cardStyle,
           visibility: isCardMeasured ? 'visible' : 'hidden',
         }}
+        onClick={onAdvance}
       >
         <OnboardingCard
           title={title}
@@ -231,7 +233,6 @@ export function OnboardingOverlay({
           actionLabel={actionLabel}
           actionHref={actionHref}
           skipLabel={skipLabel}
-          onAdvance={onAdvance}
           onSkip={onSkip}
         />
       </div>

--- a/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
@@ -216,13 +216,11 @@ export function OnboardingOverlay({
       )}
       <div
         ref={cardRef}
-        data-clickable='true'
         className='pointer-events-auto absolute z-20'
         style={{
           ...cardStyle,
           visibility: isCardMeasured ? 'visible' : 'hidden',
         }}
-        onClick={onAdvance}
       >
         <OnboardingCard
           title={title}
@@ -233,6 +231,7 @@ export function OnboardingOverlay({
           actionLabel={actionLabel}
           actionHref={actionHref}
           skipLabel={skipLabel}
+          onAdvance={onAdvance}
           onSkip={onSkip}
         />
       </div>

--- a/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
@@ -191,7 +191,7 @@ export function OnboardingOverlay({
             type='button'
             aria-label={advanceAriaLabel}
             onClick={onAdvance}
-            className='absolute inset-0 z-10'
+            className='absolute inset-0 z-10 cursor-default'
           />
           <div
             className='pointer-events-none absolute border border-white/70'
@@ -210,14 +210,13 @@ export function OnboardingOverlay({
           type='button'
           aria-label={advanceAriaLabel}
           onClick={onAdvance}
-          className='absolute inset-0 z-10'
+          className='absolute inset-0 z-10 cursor-default'
           style={{ backgroundColor: OVERLAY_BG }}
         />
       )}
       <div
         ref={cardRef}
-        data-clickable='true'
-        className='pointer-events-auto absolute z-20'
+        className='pointer-events-auto absolute z-20 cursor-default'
         style={{
           ...cardStyle,
           visibility: isCardMeasured ? 'visible' : 'hidden',

--- a/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/cook-web/src/components/onboarding/OnboardingOverlay.tsx
@@ -216,6 +216,7 @@ export function OnboardingOverlay({
       )}
       <div
         ref={cardRef}
+        data-clickable='true'
         className='pointer-events-auto absolute z-20'
         style={{
           ...cardStyle,

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -30,7 +30,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -88,7 +88,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -104,7 +104,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -128,7 +128,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -37,14 +37,16 @@ const DropdownMenuSubTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
     inset?: boolean;
   }
->(({ className, inset, children, ...props }, ref) => (
+>(({ className, disabled, inset, children, onClick, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
+    disabled={disabled}
     className={cn(
       'flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
+    onClick={disabled ? preventDisabledMenuClick : onClick}
     {...props}
   >
     {children}

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -21,6 +21,43 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
+const handleDisabledMenuClick = (
+  disabled: boolean | undefined,
+  onClick: React.MouseEventHandler<HTMLElement> | undefined,
+): React.MouseEventHandler<HTMLElement> | undefined => {
+  if (!disabled && !onClick) {
+    return undefined;
+  }
+
+  return event => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+};
+
+const handleDisabledMenuSelect = (
+  disabled: boolean | undefined,
+  onSelect: ((event: Event) => void) | undefined,
+): ((event: Event) => void) | undefined => {
+  if (!disabled && !onSelect) {
+    return undefined;
+  }
+
+  return event => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    onSelect?.(event);
+  };
+};
+
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
@@ -30,7 +67,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -84,9 +121,12 @@ const DropdownMenuItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
   }
->(({ className, inset, ...props }, ref) => (
+>(({ className, disabled, inset, onClick, onSelect, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
+    disabled={disabled}
+    onClick={handleDisabledMenuClick(disabled, onClick)}
+    onSelect={handleDisabledMenuSelect(disabled, onSelect)}
     className={cn(
       'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
@@ -100,37 +140,48 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
-      className,
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className='h-4 w-4' />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-));
+>(
+  (
+    { className, children, checked, disabled, onClick, onSelect, ...props },
+    ref,
+  ) => (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      disabled={disabled}
+      className={cn(
+        'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+        className,
+      )}
+      checked={checked}
+      onClick={handleDisabledMenuClick(disabled, onClick)}
+      onSelect={handleDisabledMenuSelect(disabled, onSelect)}
+      {...props}
+    >
+      <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className='h-4 w-4' />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  ),
+);
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, disabled, onClick, onSelect, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
+    disabled={disabled}
     className={cn(
       'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
+    onClick={handleDisabledMenuClick(disabled, onClick)}
+    onSelect={handleDisabledMenuSelect(disabled, onSelect)}
     {...props}
   >
     <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -42,7 +42,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     ref={ref}
     disabled={disabled}
     className={cn(
-      'flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -104,7 +104,7 @@ const DropdownMenuItem = React.forwardRef<
     onClick={disabled ? preventDisabledMenuClick : onClick}
     onSelect={disabled ? preventDisabledMenuSelect : onSelect}
     className={cn(
-      'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -125,7 +125,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       ref={ref}
       disabled={disabled}
       className={cn(
-        'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+        'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
       checked={checked}
@@ -153,7 +153,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     ref={ref}
     disabled={disabled}
     className={cn(
-      'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
     onClick={disabled ? preventDisabledMenuClick : onClick}

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -88,7 +88,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -104,7 +104,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -128,7 +128,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -30,7 +30,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -88,7 +88,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -104,7 +104,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
@@ -128,7 +128,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -21,41 +21,15 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const handleDisabledMenuClick = (
-  disabled: boolean | undefined,
-  onClick: React.MouseEventHandler<HTMLElement> | undefined,
-): React.MouseEventHandler<HTMLElement> | undefined => {
-  if (!disabled && !onClick) {
-    return undefined;
-  }
-
-  return event => {
-    if (disabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
-    onClick?.(event);
-  };
+const preventDisabledMenuClick: React.MouseEventHandler<
+  HTMLElement
+> = event => {
+  event.preventDefault();
+  event.stopPropagation();
 };
 
-const handleDisabledMenuSelect = (
-  disabled: boolean | undefined,
-  onSelect: ((event: Event) => void) | undefined,
-): ((event: Event) => void) | undefined => {
-  if (!disabled && !onSelect) {
-    return undefined;
-  }
-
-  return event => {
-    if (disabled) {
-      event.preventDefault();
-      return;
-    }
-
-    onSelect?.(event);
-  };
+const preventDisabledMenuSelect = (event: Event) => {
+  event.preventDefault();
 };
 
 const DropdownMenuSubTrigger = React.forwardRef<
@@ -125,8 +99,8 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     disabled={disabled}
-    onClick={handleDisabledMenuClick(disabled, onClick)}
-    onSelect={handleDisabledMenuSelect(disabled, onSelect)}
+    onClick={disabled ? preventDisabledMenuClick : onClick}
+    onSelect={disabled ? preventDisabledMenuSelect : onSelect}
     className={cn(
       'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
@@ -153,8 +127,8 @@ const DropdownMenuCheckboxItem = React.forwardRef<
         className,
       )}
       checked={checked}
-      onClick={handleDisabledMenuClick(disabled, onClick)}
-      onSelect={handleDisabledMenuSelect(disabled, onSelect)}
+      onClick={disabled ? preventDisabledMenuClick : onClick}
+      onSelect={disabled ? preventDisabledMenuSelect : onSelect}
       {...props}
     >
       <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
@@ -180,8 +154,8 @@ const DropdownMenuRadioItem = React.forwardRef<
       'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
-    onClick={handleDisabledMenuClick(disabled, onClick)}
-    onSelect={handleDisabledMenuSelect(disabled, onSelect)}
+    onClick={disabled ? preventDisabledMenuClick : onClick}
+    onSelect={disabled ? preventDisabledMenuSelect : onSelect}
     {...props}
   >
     <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -21,32 +21,19 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const preventDisabledMenuClick: React.MouseEventHandler<
-  HTMLElement
-> = event => {
-  event.preventDefault();
-  event.stopPropagation();
-};
-
-const preventDisabledMenuSelect = (event: Event) => {
-  event.preventDefault();
-};
-
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
     inset?: boolean;
   }
->(({ className, disabled, inset, children, onClick, ...props }, ref) => (
+>(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
-    disabled={disabled}
     className={cn(
       'flex gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
-    onClick={disabled ? preventDisabledMenuClick : onClick}
     {...props}
   >
     {children}
@@ -97,12 +84,9 @@ const DropdownMenuItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
   }
->(({ className, disabled, inset, onClick, onSelect, ...props }, ref) => (
+>(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
-    disabled={disabled}
-    onClick={disabled ? preventDisabledMenuClick : onClick}
-    onSelect={disabled ? preventDisabledMenuSelect : onSelect}
     className={cn(
       'relative flex select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
@@ -116,48 +100,37 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(
-  (
-    { className, children, checked, disabled, onClick, onSelect, ...props },
-    ref,
-  ) => (
-    <DropdownMenuPrimitive.CheckboxItem
-      ref={ref}
-      disabled={disabled}
-      className={cn(
-        'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
-        className,
-      )}
-      checked={checked}
-      onClick={disabled ? preventDisabledMenuClick : onClick}
-      onSelect={disabled ? preventDisabledMenuSelect : onSelect}
-      {...props}
-    >
-      <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Check className='h-4 w-4' />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.CheckboxItem>
-  ),
-);
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className='h-4 w-4' />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, disabled, onClick, onSelect, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
-    disabled={disabled}
     className={cn(
       'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
-    onClick={disabled ? preventDisabledMenuClick : onClick}
-    onSelect={disabled ? preventDisabledMenuSelect : onSelect}
     {...props}
   >
     <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>

--- a/src/cook-web/src/components/ui/MarkdownFlowLink.tsx
+++ b/src/cook-web/src/components/ui/MarkdownFlowLink.tsx
@@ -25,7 +25,7 @@ export const MarkdownFlowLink: React.FC<MarkdownFlowLinkProps> = ({
   targetUrl = 'https://markdownflow.ai/',
 }) => {
   const defaultLinkClass =
-    'underline hover:opacity-80 transition-opacity duration-200 cursor-pointer';
+    'underline hover:opacity-80 transition-opacity duration-200';
 
   // Build content parts array and filter out empty elements
   const contentParts: React.ReactNode[] = [

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
+      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -111,48 +111,34 @@ type SelectItemProps = React.ComponentPropsWithoutRef<
   indicatorClassName?: string;
 };
 
-const preventDisabledSelectItemClick: React.MouseEventHandler<
-  HTMLDivElement
-> = event => {
-  event.preventDefault();
-  event.stopPropagation();
-};
-
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   SelectItemProps
->(
-  (
-    { className, children, disabled, indicatorClassName, onClick, ...props },
-    ref,
-  ) => (
-    <SelectPrimitive.Item
-      ref={ref}
-      disabled={disabled}
+>(({ className, children, indicatorClassName, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}
+  >
+    <span
       className={cn(
-        'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
-        className,
+        'absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
+        indicatorClassName,
       )}
-      onClick={disabled ? preventDisabledSelectItemClick : onClick}
-      {...props}
     >
-      <span
-        className={cn(
-          'absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
-          indicatorClassName,
-        )}
-      >
-        <SelectPrimitive.ItemIndicator>
-          <Check className='h-4 w-4' />
-        </SelectPrimitive.ItemIndicator>
-      </span>
+      <SelectPrimitive.ItemIndicator>
+        <Check className='h-4 w-4' />
+      </SelectPrimitive.ItemIndicator>
+    </span>
 
-      <SelectPrimitive.ItemText asChild>
-        <span className='flex min-w-0 flex-1'>{children}</span>
-      </SelectPrimitive.ItemText>
-    </SelectPrimitive.Item>
-  ),
-);
+    <SelectPrimitive.ItemText asChild>
+      <span className='flex min-w-0 flex-1'>{children}</span>
+    </SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -111,23 +111,11 @@ type SelectItemProps = React.ComponentPropsWithoutRef<
   indicatorClassName?: string;
 };
 
-const handleDisabledSelectItemClick = (
-  disabled: boolean | undefined,
-  onClick: React.MouseEventHandler<HTMLDivElement> | undefined,
-): React.MouseEventHandler<HTMLDivElement> | undefined => {
-  if (!disabled && !onClick) {
-    return undefined;
-  }
-
-  return event => {
-    if (disabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-
-    onClick?.(event);
-  };
+const preventDisabledSelectItemClick: React.MouseEventHandler<
+  HTMLDivElement
+> = event => {
+  event.preventDefault();
+  event.stopPropagation();
 };
 
 const SelectItem = React.forwardRef<
@@ -145,7 +133,7 @@ const SelectItem = React.forwardRef<
         'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
-      onClick={handleDisabledSelectItemClick(disabled, onClick)}
+      onClick={disabled ? preventDisabledSelectItemClick : onClick}
       {...props}
     >
       <span

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
       className,
     )}
     {...props}

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -130,7 +130,7 @@ const SelectItem = React.forwardRef<
       ref={ref}
       disabled={disabled}
       className={cn(
-        'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+        'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
       onClick={disabled ? preventDisabledSelectItemClick : onClick}

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -111,34 +111,60 @@ type SelectItemProps = React.ComponentPropsWithoutRef<
   indicatorClassName?: string;
 };
 
+const handleDisabledSelectItemClick = (
+  disabled: boolean | undefined,
+  onClick: React.MouseEventHandler<HTMLDivElement> | undefined,
+): React.MouseEventHandler<HTMLDivElement> | undefined => {
+  if (!disabled && !onClick) {
+    return undefined;
+  }
+
+  return event => {
+    if (disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    onClick?.(event);
+  };
+};
+
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   SelectItemProps
->(({ className, children, indicatorClassName, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
-      className,
-    )}
-    {...props}
-  >
-    <span
+>(
+  (
+    { className, children, disabled, indicatorClassName, onClick, ...props },
+    ref,
+  ) => (
+    <SelectPrimitive.Item
+      ref={ref}
+      disabled={disabled}
       className={cn(
-        'absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
-        indicatorClassName,
+        'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+        className,
       )}
+      onClick={handleDisabledSelectItemClick(disabled, onClick)}
+      {...props}
     >
-      <SelectPrimitive.ItemIndicator>
-        <Check className='h-4 w-4' />
-      </SelectPrimitive.ItemIndicator>
-    </span>
+      <span
+        className={cn(
+          'absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
+          indicatorClassName,
+        )}
+      >
+        <SelectPrimitive.ItemIndicator>
+          <Check className='h-4 w-4' />
+        </SelectPrimitive.ItemIndicator>
+      </span>
 
-    <SelectPrimitive.ItemText asChild>
-      <span className='flex min-w-0 flex-1'>{children}</span>
-    </SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
+      <SelectPrimitive.ItemText asChild>
+        <span className='flex min-w-0 flex-1'>{children}</span>
+      </SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  ),
+);
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<


### PR DESCRIPTION
## Summary
- Add a sitewide clickable cursor contract in src/cook-web/src/app/globals.css for semantic elements, common interactive roles, and data-clickable="true".
- Preserve disabled cursor affordance for :disabled, aria-disabled="true", and data-disabled values other than false.
- Mark confirmed legacy non-semantic click targets with data-clickable="true".
- Normalize shared dropdown/select item cursor classes to rely on the global cursor contract while preserving disabled pointer-event guards.
- Keep full-screen onboarding/backdrop advance surfaces on the default cursor so the whole page or card does not read as a button.
- Document the convention and onboarding exception in src/cook-web/AGENTS.md and mirrored generated frontend instructions.
- Remove redundant cursor-pointer classes from elements already covered by the global selector.

## Scope
This PR is intentionally cursor-only. Behavior and accessibility refactors identified during review, including semantic button conversions, keyboard semantics, and disabled event guard rewrites, were reverted or deferred and should be handled in separate follow-up PRs if product wants them.

## Validation
- python3 scripts/check_dev_tools.py
- python3 scripts/check_repo_harness.py
- git diff --check
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint
- cd src/cook-web && npm test -- src/components/ui/Select.test.tsx
- cd src/cook-web && npm test -- --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx

## Notes
- cd src/cook-web && npm run test:e2e was not run; this correction did not touch the browser harness, and the local full e2e backend/login harness was not started.