### PR TITLE
fix: clarify follow-up knowledge source label

### DIFF
--- a/src/i18n/zh-CN/modules/shifu-setting.json
+++ b/src/i18n/zh-CN/modules/shifu-setting.json
@@ -87,7 +87,7 @@
   "askProviderSelect": "选择追问方式",
   "askTemperature": "追问温度",
   "askTemperatureHint": "控制回答问题的发散程度（取值范围 0-2，建议用 0）",
-  "askTitle": "追问设置",
+  "askTitle": "追问的知识来源",
   "debugDisabledBySoftLimit": "积分余额已低于提醒阈值，暂不能使用调试预览。",
   "draftConflictDescription": "课程已被 {phone} 修改，请加载最新内容获取最新记录",
   "draftConflictRefresh": "加载最新内容",


### PR DESCRIPTION
## Summary
- Update the Chinese follow-up settings heading from `追问设置` to `追问的知识来源`.
- Keep the provider option wording from the current base branch, where `LLM` is already shown as `内置模型`.

## Issue / Motivation
The settings panel should make it clear that the selector controls the knowledge source used for learner follow-up answers.

## Verification
- `python3 scripts/check_dev_tools.py`
- `python3 scripts/check_translations.py`
- `python3 scripts/check_translation_usage.py --fail-on-unused`
- `jq empty src/i18n/zh-CN/modules/shifu-setting.json`
- `git diff --check`
- `../../.venv/bin/python -m pytest tests/service/shifu/test_ask_config_route.py -q`

## Dependencies
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Chinese translation for the “askTitle” label to better match the intended wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->