### PR TITLE
fix: localize learner system interaction buttons

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -117,6 +117,14 @@ jest.mock('@/c-utils/lesson-feedback-interaction', () => ({
 jest.mock('@/c-utils/system-interaction', () => ({
   isSystemInteractionContent: (content?: string) =>
     content?.includes('_sys_') ?? false,
+  localizeSystemInteractionContent: (
+    content: string,
+    translate: (key: string) => string,
+  ) =>
+    content.replace(
+      '?[' + 'Next//_sys_next_chapter]',
+      `?[${translate('server.learn.nextChapterButton')}//_sys_next_chapter]`,
+    ),
 }));
 
 jest.mock('@/c-api/studyV2', () => ({

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -23,7 +23,10 @@ import {
 import { lessonFeedbackInteractionDefaultValueOptions } from '@/c-utils/lesson-feedback-interaction-defaults';
 import { resolveInteractionSubmission } from '@/c-utils/interaction-user-input';
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
-import { isSystemInteractionContent } from '@/c-utils/system-interaction';
+import {
+  isSystemInteractionContent,
+  localizeSystemInteractionContent,
+} from '@/c-utils/system-interaction';
 import { type OnSendContentParams } from 'markdown-flow-ui/renderer';
 import {
   Slide,
@@ -532,6 +535,7 @@ const buildSlideElementList = ({
   includeAudio,
   showLeadingTextPlaceholder,
   resolveRenderSequence,
+  localizeSystemContent,
 }: {
   items: ChatContentItem[];
   askListByAnchorElementBid: Map<string, AskMessage[]>;
@@ -543,6 +547,7 @@ const buildSlideElementList = ({
   includeAudio: boolean;
   showLeadingTextPlaceholder: boolean;
   resolveRenderSequence: ResolveRenderSequence;
+  localizeSystemContent: (content: string) => string;
 }) => {
   let pageCursor = 0;
   let sequenceNumber = 0;
@@ -623,7 +628,7 @@ const buildSlideElementList = ({
         fallbackSequence: sequenceNumber,
       }),
       type: 'interaction',
-      content: item.content || '',
+      content: localizeSystemContent(item.content || ''),
       is_marker: item.is_marker ?? true,
       is_renderable: item.is_renderable ?? true,
       is_new: item.is_new ?? true,
@@ -882,6 +887,8 @@ const ListenModeSlideRenderer = ({
       includeAudio,
       showLeadingTextPlaceholder,
       resolveRenderSequence,
+      localizeSystemContent: content =>
+        localizeSystemInteractionContent(content, t),
     });
 
     for (const streamKey of Array.from(sequenceMap.keys())) {
@@ -902,6 +909,7 @@ const ListenModeSlideRenderer = ({
     sectionTitle,
     sectionPlaceholderTips,
     showLeadingTextPlaceholder,
+    t,
   ]);
   const markerStepCount = useMemo(
     () => elementList.filter(element => Boolean(element.is_marker)).length,

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenPlayer.tsx
@@ -11,7 +11,10 @@ import {
 import styles from './ListenPlayer.module.scss';
 import { cn } from '@/lib/utils';
 import { lessonFeedbackInteractionDefaultValueOptions } from '@/c-utils/lesson-feedback-interaction-defaults';
-import { isPaySystemInteractionContent } from '@/c-utils/system-interaction';
+import {
+  isPaySystemInteractionContent,
+  localizeSystemInteractionContent,
+} from '@/c-utils/system-interaction';
 import type { ChatContentItem } from './useChatLogicHook';
 import {
   ContentRender,
@@ -161,7 +164,10 @@ const ListenPlayer = ({
             >
               <ContentRender
                 enableTypewriter={false}
-                content={effectiveInteraction.content || ''}
+                content={localizeSystemInteractionContent(
+                  effectiveInteraction.content || '',
+                  t,
+                )}
                 customRenderBar={effectiveInteraction.customRenderBar}
                 userInput={resolvedInteractionUserInput}
                 interactionDefaultValueOptions={

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -104,18 +104,18 @@ const ContentBlock = memo(
       item.element_type === 'text';
     const isRichContentElement =
       item.type === ChatContentItemType.CONTENT && item.element_type !== 'text';
-    const shouldRenderExternalCustomButton =
-      isRichContentElement && hasCustomButtonAfterContent(item.content);
     const localizedContent = localizeSystemInteractionContent(
       item.content || '',
       t,
     );
+    const shouldRenderExternalCustomButton =
+      isRichContentElement && hasCustomButtonAfterContent(localizedContent);
     const renderedContent =
       shouldEnableTypewriter || shouldRenderExternalCustomButton
         ? (stripCustomButtonAfterContent(localizedContent) ?? '')
         : localizedContent;
     const externalCustomButtonInnerHtml = shouldRenderExternalCustomButton
-      ? extractCustomButtonAfterContentInnerHtml(item.content)
+      ? extractCustomButtonAfterContentInnerHtml(localizedContent)
       : '';
     const handleTypeFinished = useCallback(() => {
       onTypeFinished?.(blockBid, renderedContent);

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback } from 'react';
 import { useLongPress } from 'react-use';
 import { ContentRender } from 'markdown-flow-ui/renderer';
+import { useTranslation } from 'react-i18next';
 import { lessonFeedbackInteractionDefaultValueOptions } from '@/c-utils/lesson-feedback-interaction-defaults';
 import type { OnSendContentParams } from 'markdown-flow-ui/renderer';
 import { cn } from '@/lib/utils';
@@ -16,7 +17,10 @@ import {
   stripCustomButtonAfterContent,
 } from '@/app/c/[[...id]]/Components/ChatUi/chatUiUtils';
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
-import { isPaySystemInteractionContent } from '@/c-utils/system-interaction';
+import {
+  isPaySystemInteractionContent,
+  localizeSystemInteractionContent,
+} from '@/c-utils/system-interaction';
 import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 
 interface ContentBlockProps {
@@ -57,6 +61,7 @@ const ContentBlock = memo(
     onTypeFinished,
     enableStreamingTypewriter = false,
   }: ContentBlockProps) => {
+    const { t } = useTranslation();
     const handleClick = useCallback(() => {
       onClickCustomButtonAfterContent?.(blockBid);
     }, [blockBid, onClickCustomButtonAfterContent]);
@@ -101,10 +106,14 @@ const ContentBlock = memo(
       item.type === ChatContentItemType.CONTENT && item.element_type !== 'text';
     const shouldRenderExternalCustomButton =
       isRichContentElement && hasCustomButtonAfterContent(item.content);
+    const localizedContent = localizeSystemInteractionContent(
+      item.content || '',
+      t,
+    );
     const renderedContent =
       shouldEnableTypewriter || shouldRenderExternalCustomButton
-        ? (stripCustomButtonAfterContent(item.content) ?? '')
-        : item.content || '';
+        ? (stripCustomButtonAfterContent(localizedContent) ?? '')
+        : localizedContent;
     const externalCustomButtonInnerHtml = shouldRenderExternalCustomButton
       ? extractCustomButtonAfterContentInnerHtml(item.content)
       : '';

--- a/src/cook-web/src/c-utils/system-interaction.test.ts
+++ b/src/cook-web/src/c-utils/system-interaction.test.ts
@@ -1,0 +1,48 @@
+jest.mock('@/c-api/studyV2', () => ({
+  SYS_INTERACTION_TYPE: {
+    NEXT_CHAPTER: '_sys_next_chapter',
+    PAY: '_sys_pay',
+    LOGIN: '_sys_login',
+  },
+}));
+
+import { localizeSystemInteractionContent } from './system-interaction';
+
+const translate = (key: string) =>
+  ({
+    'server.learn.nextChapterButton': '下一节',
+    'server.order.checkout': '去支付',
+    'server.user.login': '登录',
+  })[key] ?? key;
+
+describe('localizeSystemInteractionContent', () => {
+  it('localizes persisted next-chapter labels from the runtime language', () => {
+    expect(
+      localizeSystemInteractionContent('?[Next//_sys_next_chapter]', translate),
+    ).toBe('?[下一节//_sys_next_chapter]');
+  });
+
+  it('keeps the system action while replacing only the label', () => {
+    expect(
+      localizeSystemInteractionContent(
+        'before ?[Suivant//_sys_next_chapter] after',
+        translate,
+      ),
+    ).toBe('before ?[下一节//_sys_next_chapter] after');
+  });
+
+  it('does not rewrite non-system interactions', () => {
+    expect(
+      localizeSystemInteractionContent('?[Next//custom_action]', translate),
+    ).toBe('?[Next//custom_action]');
+  });
+
+  it('localizes persisted pay and login system labels from the runtime language', () => {
+    expect(
+      localizeSystemInteractionContent('?[Pay//_sys_pay]', translate),
+    ).toBe('?[去支付//_sys_pay]');
+    expect(
+      localizeSystemInteractionContent('?[Login//_sys_login]', translate),
+    ).toBe('?[登录//_sys_login]');
+  });
+});

--- a/src/cook-web/src/c-utils/system-interaction.ts
+++ b/src/cook-web/src/c-utils/system-interaction.ts
@@ -1,6 +1,8 @@
 import { SYS_INTERACTION_TYPE } from '@/c-api/studyV2';
 
 const SYSTEM_INTERACTION_TYPES = Object.values(SYS_INTERACTION_TYPE);
+type SystemInteractionType =
+  (typeof SYS_INTERACTION_TYPE)[keyof typeof SYS_INTERACTION_TYPE];
 
 export const isSystemInteractionContent = (content?: string | null) =>
   typeof content === 'string' &&
@@ -10,3 +12,37 @@ export const isSystemInteractionContent = (content?: string | null) =>
 
 export const isPaySystemInteractionContent = (content?: string | null) =>
   typeof content === 'string' && content.includes(SYS_INTERACTION_TYPE.PAY);
+
+const SYSTEM_INTERACTION_LABEL_KEYS: Partial<
+  Record<SystemInteractionType, string>
+> = {
+  [SYS_INTERACTION_TYPE.NEXT_CHAPTER]: 'server.learn.nextChapterButton',
+  [SYS_INTERACTION_TYPE.PAY]: 'server.order.checkout',
+  [SYS_INTERACTION_TYPE.LOGIN]: 'server.user.login',
+};
+
+const SYSTEM_INTERACTION_REGEX = /\?\[([^\]]*?)\/\/(_sys_[a-z_]+)\]/g;
+
+export const localizeSystemInteractionContent = (
+  content: string | undefined | null,
+  translate: (key: string) => string,
+) => {
+  if (!content) {
+    return content ?? '';
+  }
+
+  return content.replace(SYSTEM_INTERACTION_REGEX, (match, _label, action) => {
+    const labelKey =
+      SYSTEM_INTERACTION_LABEL_KEYS[action as SystemInteractionType];
+    if (!labelKey) {
+      return match;
+    }
+
+    const localizedLabel = translate(labelKey);
+    if (!localizedLabel || localizedLabel === labelKey) {
+      return match;
+    }
+
+    return `?[${localizedLabel}//${action}]`;
+  });
+};

--- a/src/cook-web/src/c-utils/system-interaction.ts
+++ b/src/cook-web/src/c-utils/system-interaction.ts
@@ -21,7 +21,7 @@ const SYSTEM_INTERACTION_LABEL_KEYS: Partial<
   [SYS_INTERACTION_TYPE.LOGIN]: 'server.user.login',
 };
 
-const SYSTEM_INTERACTION_REGEX = /\?\[([^\]]*?)\/\/(_sys_[a-z_]+)\]/g;
+const SYSTEM_INTERACTION_REGEX = /\?\[([^\]]*?)\/\/(_sys_[a-zA-Z0-9_]+)\]/g;
 
 export const localizeSystemInteractionContent = (
   content: string | undefined | null,


### PR DESCRIPTION
## Summary
- Localize learner system interaction button labels at render time based on the current frontend language.
- Covers persisted MarkdownFlow system actions for next lesson, payment, and login: `_sys_next_chapter`, `_sys_pay`, and `_sys_login`.
- Applies the localization in read mode, listen/classroom slide mode, and the listen player interaction overlay so historical blocks like `?[Next//_sys_next_chapter]` render correctly in Chinese as `下一节` without changing the underlying action.

## Root Cause
System interaction labels were persisted as part of MarkdownFlow content, for example `?[Next//_sys_next_chapter]`. If the backend language at generation time was English, the label stayed English even when the learner UI was later in Chinese. The action value is stable and language-independent, so rendering should localize by action instead of trusting the stored label.

## Validation
- `cd src/cook-web && npm run test -- --runTestsByPath src/c-utils/system-interaction.test.ts 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx'`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint`
- `git diff --check`

## Notes
- `pre-commit run -a` cannot run in this checkout because `.pre-commit-config.yaml` is not present at repo root; local self-review was generated and the only hard failure was that missing config file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized system action prompts now render in the user’s selected language across listen/chat views.

* **Bug Fixes**
  * Fixed “next chapter,” “pay,” and “login” labels showing in the default language.
  * Preserved system action markers while updating only the user-visible text.

* **Tests**
  * Added unit tests covering localized system interaction content behavior, including unchanged non-system text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->