### PR TITLE
fix: keep listen follow-up above subtitles

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -402,12 +402,16 @@
   .slide-ask-overlay,
 .listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
   .listen-slide-root:not(.slide--browser-fullscreen)
-  .slide-interaction-overlay,
+  .slide-interaction-overlay {
+  --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);
+  z-index: 90;
+}
+
 .listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
   .listen-slide-root:not(.slide--browser-fullscreen)
   .slide-subtitle-overlay {
   --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);
-  z-index: 90;
+  z-index: 89;
 }
 
 .listen-reveal-wrapper.mobile


### PR DESCRIPTION
Summary
- Adjust listen-mode overlay stacking so the follow-up ask panel renders above subtitles.
- Keep subtitle overlays above the player controls while lowering them below the ask/interaction overlay layer.

Root Cause
- The follow-up ask overlay and subtitle overlay shared the same z-index in the non-fullscreen listen-mode layout, so DOM paint order allowed subtitles to cover the ask panel.

Validation
- `git diff --check`
- `cd src/cook-web && npm run lint` (passes with existing warnings)

Manual Regression
- Open learner listen mode.
- Enable subtitles.
- Open follow-up ask.
- Confirm the ask panel remains visible and usable above the subtitle overlay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated overlay styling so the interaction overlay now appears above the subtitle overlay.
  * Improved layout consistency by applying the slide player offset more explicitly to both overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->