### PR TITLE
fix(learn): skip outline update when current item is missing

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1912,6 +1912,12 @@ class RunScriptContextV2:
 
     # get the outline items to start or complete
     def _get_next_outline_item(self) -> list[OutlineItemUpdateDTO]:
+        if not self._current_outline_item:
+            self.app.logger.warning(
+                "Skip outline progress update because current outline item is missing"
+            )
+            return []
+
         res = []
         q = queue.Queue()
         q.put(self._struct)

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -430,6 +430,17 @@ class CompletionTailInteractionTests(unittest.TestCase):
 
 
 class RuntimeOutlineBlockCountTests(unittest.TestCase):
+    def test_get_next_outline_item_skips_missing_current_outline_item(self):
+        ctx = _make_context()
+        ctx.app = Flask("missing-current-outline-tests")
+        ctx._current_outline_item = None
+        ctx._current_attend = types.SimpleNamespace(
+            block_position=1,
+            status=LEARN_STATUS_IN_PROGRESS,
+        )
+
+        self.assertEqual(ctx._get_next_outline_item(), [])
+
     def test_get_next_outline_item_uses_runtime_block_count_for_leaf_outline(self):
         ctx = _make_context()
         ctx.app = Flask("runtime-outline-block-count-tests")


### PR DESCRIPTION
## Source

Daily ops scan of 「运维保障群」 for 2026-07-07 18:00 ~ 2026-07-08 18:00 found repeated AI-Shifu learn run errors:

- Service: `new-shifu-api`
- Endpoint: `/api/learn/shifu/*/run/*`
- Error: `AttributeError: 'NoneType' object has no attribute 'children'`
- Stack: `_get_next_outline_item -> _mark_sub_node_completed -> _is_leaf_outline_item`

The error appears when runtime tries to calculate outline progress while `self._current_outline_item` is missing.

## Fix

- Guard `_get_next_outline_item` when the current outline item is absent.
- Log a warning and skip outline progress updates instead of raising during the streaming run.
- Add regression coverage for the missing-current-outline case.

## Validation

- `python3 -m py_compile src/api/flaskr/service/learn/context_v2.py src/api/tests/service/learn/test_context_v2.py` ✅
- `python3.13 -m pytest src/api/tests/service/learn/test_context_v2.py::RuntimeOutlineBlockCountTests -q` blocked: local Python env has no `pytest` installed.
- `PYTHONPATH=src/api python3.13 -m unittest ...` blocked: local Python env missing `dotenv`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an error when learning progress is evaluated without a current outline item.
  * The app now safely returns no update instead of continuing with incomplete state, improving stability during outline navigation.

* **Tests**
  * Added coverage for the missing-outline-item case to ensure the behavior stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->