### PR TITLE
chore: bump markdown-flow-ui to 0.1.128

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "^0.1.127",
+        "markdown-flow-ui": "0.1.128",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13560,9 +13560,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.1.127",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.127.tgz",
-      "integrity": "sha512-YNIexzyAnTJbI3qzvz22zzqH7DPcuMYKKSIjyuj1Jgho84vlGjalxpP/B6z7wSy7SaWK/F8Mt990qn/yqtKbdg==",
+      "version": "0.1.128",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.128.tgz",
+      "integrity": "sha512-I41Bi114IHnzrtoMuw8PSWGet/jG7ecPpARN+DWMx9rz4pQ82VE35bfIA9YDDRf08nIEvHDGpxjbRVvsI8v4EQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "^0.1.127",
+    "markdown-flow-ui": "0.1.128",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- Upgrade `markdown-flow-ui` from `0.1.127` to the latest release `0.1.128`.
- Pin the frontend dependency exactly and update the lockfile tarball/integrity entry.

## Verification
- `python3 scripts/check_dev_tools.py`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint`
- `cd src/cook-web && npx --yes npm@10.9.2 ci --dry-run --ignore-scripts`
- `git diff --check`

## Notes
- Local npm dry-run emitted the existing Node engine warning because this shell is on Node `v26.4.0`; the project declares Node `22.16.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a frontend dependency to the latest available version and pinned it for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->