### PR TITLE
fix(learn): preserve no-variable interaction choice in rebuilt context

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -559,17 +559,30 @@ class MdflowContextV2:
                     }
                 )
             elif generated_block.type == BLOCK_TYPE_MDINTERACTION_VALUE:
-                # Hand the raw interaction syntax to markdown-flow as an
-                # assistant message. Its _transform_context_messages expands
-                # ?[%{{var}}...] into {user: <value>} + {assistant: "ok"}
-                # using `variables`, instead of us crudely flattening the
-                # input into a bare user message.
-                message_list.append(
-                    {
-                        "role": "assistant",
-                        "content": block.content or "",
-                    }
-                )
+                interaction = InteractionParser().parse(block.content or "")
+                if interaction.get("variable"):
+                    # Variable interaction (e.g. ?[%{{var}} A | B]): hand the
+                    # raw syntax to markdown-flow, whose
+                    # _transform_context_messages expands it into
+                    # {user: <value>} + {assistant: "ok"} using `variables`.
+                    message_list.append(
+                        {
+                            "role": "assistant",
+                            "content": block.content or "",
+                        }
+                    )
+                else:
+                    # No-variable interaction (e.g. plain button choice
+                    # ?[A | B | C]): markdown-flow has no variable to recover
+                    # the learner's choice from and would collapse the turn
+                    # into {user: "ok"} + {assistant: "ok"}, dropping the
+                    # actual selection. Use the selection captured in
+                    # generated_content instead; if it is empty, skip the turn
+                    # rather than fabricate an "ok".
+                    user_content = (generated_block.generated_content or "").strip()
+                    if user_content:
+                        message_list.append({"role": "user", "content": user_content})
+                        message_list.append({"role": "assistant", "content": "ok"})
         return message_list
 
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2143,5 +2143,71 @@ class BuildContextFromBlocksTests(unittest.TestCase):
             )
 
 
+class BuildContextNoVariableInteractionTests(unittest.TestCase):
+    """No-variable button interactions (e.g. ?[A | B | C]) carry a real learner
+    choice, but markdown-flow has no variable to recover it from and would
+    collapse the turn into {user: "ok"} + {assistant: "ok"}, dropping the
+    selection. build_context_from_blocks must reuse the choice captured in
+    generated_content, and skip the turn entirely when it is empty."""
+
+    DOC = (
+        "Content one.\n"
+        "---\n"
+        "?[网络招聘网站 | 猎头公司 | 人才测评 | 培训业务]\n"
+        "---\n"
+        "Second content."
+    )
+
+    def _blocks(self, selection):
+        return [
+            types.SimpleNamespace(
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                position=0,
+                generated_content="reply zero",
+            ),
+            types.SimpleNamespace(
+                type=BLOCK_TYPE_MDINTERACTION_VALUE,
+                position=1,
+                generated_content=selection,
+            ),
+        ]
+
+    def test_selection_reused_instead_of_collapsing_to_ok(self):
+        app = Flask(__name__)
+        with app.app_context():
+            messages = MdflowContextV2.build_context_from_blocks(
+                self._blocks("猎头公司"), self.DOC, {}
+            )
+
+        self.assertEqual(
+            messages,
+            [
+                {"role": "user", "content": "Content one."},
+                {"role": "assistant", "content": "reply zero"},
+                {"role": "user", "content": "猎头公司"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+        # No raw ?[...] leaks and the user turn is the real choice, not "ok".
+        self.assertTrue(all("?[" not in m["content"] for m in messages))
+
+    def test_empty_selection_skips_the_interaction_turn(self):
+        app = Flask(__name__)
+        with app.app_context():
+            messages = MdflowContextV2.build_context_from_blocks(
+                self._blocks("   "), self.DOC, {}
+            )
+
+        # Only the content block survives; the empty interaction contributes
+        # nothing rather than a fabricated {user: "ok"} pair.
+        self.assertEqual(
+            messages,
+            [
+                {"role": "user", "content": "Content one."},
+                {"role": "assistant", "content": "reply zero"},
+            ],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

During normal `/c/` learning, an interaction turn where the learner picked a
button option showed up in the rebuilt LLM context as `user: "ok"` /
`assistant: "ok"` — the actual choice (e.g. `猎头公司`) was dropped. In debug
mode the same interaction was correct.

## Root cause

`MdflowContextV2.build_context_from_blocks` rebuilds history from persisted
`LearnGeneratedBlock` rows. For **every** interaction block it handed the raw
`?[...]` syntax to markdown-flow as an assistant message and let
`_transform_context_messages` expand it:

- **Variable** interaction `?[%{{var}} A | B]` → markdown-flow looks the value
  up in `variables` → `{user: <value>}` + `{assistant: "ok"}`. ✅
- **No-variable** interaction `?[A | B | C]` → markdown-flow has no variable to
  recover the choice from → collapses to `{user: "ok"}` + `{assistant: "ok"}`. ❌

The learner's choice was never actually lost — it is captured correctly in
`generated_block.generated_content` (and flows into `check_text`, confirmed via
Langfuse) — it was only dropped when reconstructing history for the LLM.

## Fix

Detect the variable with `InteractionParser`:

- Variable interactions keep the existing markdown-flow delegation (unchanged).
- No-variable interactions reuse the real choice from `generated_content`, and
  **skip the turn entirely when it is empty** instead of fabricating an `"ok"`
  (mandatory single-selects always have a value; an empty one signals a real
  problem rather than something to mask).

## Tests

Added `BuildContextNoVariableInteractionTests`:
- no-variable choice is reused as the user message (not `"ok"`);
- empty selection skips the interaction turn.

All `test_context_v2.py` tests pass (`59 passed, 4 skipped`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how learner interaction history is reconstructed so selected answers are preserved more accurately.
  * Prevented empty interaction turns from showing up as placeholder “ok” messages in the conversation.
  * Kept the conversation cleaner by skipping interaction entries when no selection was made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->