### PR TITLE
test(shifu): align backend tests with current i18n strings

### DIFF
--- a/src/api/tests/service/shifu/test_ask_provider_registry.py
+++ b/src/api/tests/service/shifu/test_ask_provider_registry.py
@@ -204,16 +204,19 @@ def test_ask_provider_metadata_exposes_minimal_schema_properties():
 def test_ask_provider_metadata_localizes_text_for_zh_cn(app):
     _ = app
     set_language("zh-CN")
+    try:
+        metadata = module.get_ask_provider_metadata()
+        providers = {item["provider"]: item for item in metadata.get("providers", [])}
+        coze = providers["coze"]
 
-    metadata = module.get_ask_provider_metadata()
-    providers = {item["provider"]: item for item in metadata.get("providers", [])}
-    coze = providers["coze"]
-
-    assert coze["title"] == "Coze"
-    assert coze["description"] == "用 Coze Bot 回答学员追问。"
-    assert coze["json_schema"]["properties"]["api_key"]["title"] == "API 密钥"
-    assert (
-        coze["json_schema"]["properties"]["bot_id"]["description"] == "Coze Bot 标识。"
-    )
-
-    set_language("en-US")
+        assert coze["title"] == "Coze"
+        assert coze["description"] == "用 Coze Bot 回答学员追问。"
+        assert coze["json_schema"]["properties"]["api_key"]["title"] == "API 密钥"
+        assert (
+            coze["json_schema"]["properties"]["bot_id"]["description"]
+            == "Coze Bot 标识。"
+        )
+    finally:
+        # Always restore the default locale so a failed assertion above
+        # cannot leak zh-CN into subsequent tests.
+        set_language("en-US")

--- a/src/api/tests/service/shifu/test_ask_provider_registry.py
+++ b/src/api/tests/service/shifu/test_ask_provider_registry.py
@@ -210,7 +210,7 @@ def test_ask_provider_metadata_localizes_text_for_zh_cn(app):
     coze = providers["coze"]
 
     assert coze["title"] == "Coze"
-    assert coze["description"] == "使用 Coze Bot 对话接口处理追问。"
+    assert coze["description"] == "用 Coze Bot 回答学员追问。"
     assert coze["json_schema"]["properties"]["api_key"]["title"] == "API 密钥"
     assert (
         coze["json_schema"]["properties"]["bot_id"]["description"] == "Coze Bot 标识。"

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -575,7 +575,7 @@ def test_copy_course_rejects_builtin_demo_course(app):
                 operator_user_bid=SOURCE_OPERATOR_BID,
             )
 
-        assert "copied" in exc_info.value.message.lower()
+        assert exc_info.value.message == _("server.shifu.copyCourseDemoNotAllowed")
         assert DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).count() == 1
 
 


### PR DESCRIPTION
## Problem

`Backend Tests / Run backend tests` was failing on `main` (2 failures),
unrelated to any product code — both tests asserted stale/locale-fragile
strings:

```
FAILED tests/service/shifu/test_ask_provider_registry.py::test_ask_provider_metadata_localizes_text_for_zh_cn
  AssertionError: assert '用 Coze Bot 回答学员追问。' == '使用 Coze Bot 对话接口处理追问。'
FAILED tests/service/shifu/test_course_copy.py::test_copy_course_rejects_builtin_demo_course
  AssertionError: assert 'copied' in '内置引导课程不支持复制'
```

## Root cause & fix

1. **`test_ask_provider_metadata_localizes_text_for_zh_cn`** — the zh-CN
   i18n resource `askProviderDescriptions.coze` was reworded from
   `使用 Coze Bot 对话接口处理追问。` to `用 Coze Bot 回答学员追问。`, but the test
   still expected the old text. Updated the expectation to the current
   string. (The other three assertions — title, `api_key` title, `bot_id`
   description — still match the current i18n and are unchanged.)

2. **`test_copy_course_rejects_builtin_demo_course`** — asserted the English
   substring `"copied"` in the raised `AppException.message`. The message is
   localized at raise time, so it resolves to zh-CN
   (`内置引导课程不支持复制`) depending on the active language, making the
   assertion fragile. Switched to comparing against
   `_("server.shifu.copyCourseDemoNotAllowed")`, which resolves the same key
   in the same active language — the language-robust pattern already used
   elsewhere in this file (e.g. the `checkRiskControlReject` test).

No product/runtime behavior changes; test-only.

## Verification

```
tests/service/shifu/test_ask_provider_registry.py + test_course_copy.py
21 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Chinese wording for a provider description to better match the in-app message shown to learners.
  * Improved the consistency of the error shown when trying to copy a demo course, using the localized message wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->