### PR TITLE
fix: preserve referral reward renewal orders

### DIFF
--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -48,6 +48,7 @@ from .queries import (
 from .subscriptions import (
     activate_subscription_for_paid_order as _activate_subscription_for_paid_order,
     ensure_subscription_renewal_order,
+    is_paid_referral_invitation_renewal as _is_paid_referral_invitation_renewal,
     load_billing_product_by_bid as _load_billing_product_by_bid,
     load_latest_subscription_renewal_order as _load_latest_subscription_renewal_order,
     load_subscription_by_bid as _load_subscription_by_bid,
@@ -586,6 +587,15 @@ def _execute_subscription_renewal(
     payload_json["bill_order_bid"] = order.bill_order_bid
     event.payload_json = payload_json
     db.session.add(event)
+
+    if _is_paid_referral_invitation_renewal(order):
+        _complete_renewal_event(event, now=now)
+        db.session.commit()
+        return _result_from_event(
+            "queued_for_reconcile",
+            event,
+            bill_order_bid=order.bill_order_bid,
+        )
 
     if order.payment_provider == "pingxx" and not order.provider_reference_id:
         _complete_renewal_event(event, now=now)

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -483,17 +483,9 @@ def ensure_subscription_renewal_order(
         cycle_start_at=cycle_start_at,
         cycle_end_at=cycle_end_at,
     )
-    if order is not None and _is_paid_referral_invitation_renewal(order):
-        metadata = (
-            dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
-        )
-        metadata["renewal_event_bid"] = _normalize_bid(renewal_event_bid) or None
-        order.metadata_json = _normalize_json_object(metadata).to_metadata_json()
-        db.session.add(order)
-        db.session.flush()
-        return order
-
-    if order is not None and _is_preorder_order(order):
+    if order is not None and (
+        _is_paid_referral_invitation_renewal(order) or _is_preorder_order(order)
+    ):
         metadata = (
             dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
         )
@@ -671,18 +663,10 @@ def _is_referral_invitation_renewal(order: BillingOrder) -> bool:
     )
 
 
-def _is_manual_referral_invitation_renewal(order: BillingOrder) -> bool:
-    return (
-        _normalize_bid(order.payment_provider) == "manual"
-        and _is_referral_invitation_renewal(order)
-    )
-
-
 def _is_paid_referral_invitation_renewal(order: BillingOrder) -> bool:
-    return (
-        int(order.status or 0) == BILLING_ORDER_STATUS_PAID
-        and _is_referral_invitation_renewal(order)
-    )
+    return int(
+        order.status or 0
+    ) == BILLING_ORDER_STATUS_PAID and _is_referral_invitation_renewal(order)
 
 
 def _should_defer_subscription_renewal_activation(

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -483,6 +483,16 @@ def ensure_subscription_renewal_order(
         cycle_start_at=cycle_start_at,
         cycle_end_at=cycle_end_at,
     )
+    if order is not None and _is_paid_referral_invitation_renewal(order):
+        metadata = (
+            dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
+        )
+        metadata["renewal_event_bid"] = _normalize_bid(renewal_event_bid) or None
+        order.metadata_json = _normalize_json_object(metadata).to_metadata_json()
+        db.session.add(order)
+        db.session.flush()
+        return order
+
     if order is not None and _is_preorder_order(order):
         metadata = (
             dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
@@ -650,17 +660,28 @@ def _should_defer_pingxx_renewal_activation(order: BillingOrder) -> bool:
     return order.paid_at < renewal_cycle_start_at
 
 
-def _is_manual_referral_invitation_renewal(order: BillingOrder) -> bool:
-    if (
-        order.order_type != BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL
-        or _normalize_bid(order.payment_provider) != "manual"
-    ):
+def _is_referral_invitation_renewal(order: BillingOrder) -> bool:
+    if order.order_type != BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
         return False
 
     metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
     checkout_type = str(metadata.get("checkout_type") or "").strip()
     return checkout_type == "referral_invitation_reward" or (
         metadata.get("referral_invitation_reward") is True
+    )
+
+
+def _is_manual_referral_invitation_renewal(order: BillingOrder) -> bool:
+    return (
+        _normalize_bid(order.payment_provider) == "manual"
+        and _is_referral_invitation_renewal(order)
+    )
+
+
+def _is_paid_referral_invitation_renewal(order: BillingOrder) -> bool:
+    return (
+        int(order.status or 0) == BILLING_ORDER_STATUS_PAID
+        and _is_referral_invitation_renewal(order)
     )
 
 
@@ -683,7 +704,7 @@ def _should_defer_subscription_renewal_activation(
     return (
         _should_defer_pingxx_renewal_activation(order)
         or _is_preorder_order(order)
-        or _is_manual_referral_invitation_renewal(order)
+        or _is_referral_invitation_renewal(order)
     )
 
 
@@ -701,7 +722,7 @@ def _has_paid_referral_invitation_renewal_at_boundary(
     )
     if order is None:
         return False
-    return _is_manual_referral_invitation_renewal(order)
+    return _is_referral_invitation_renewal(order)
 
 
 def _is_same_product_preorder_renewal(order: BillingOrder) -> bool:
@@ -2613,5 +2634,6 @@ load_billing_product_by_bid = _load_billing_product_by_bid
 load_or_create_credit_wallet = _load_or_create_credit_wallet
 sync_subscription_lifecycle_events = _sync_subscription_lifecycle_events
 merge_provider_metadata = _merge_provider_metadata
+is_paid_referral_invitation_renewal = _is_paid_referral_invitation_renewal
 void_reserved_subscription_grant_for_order = _void_reserved_subscription_grant_for_order
 void_reserved_preorder_grant = _void_reserved_subscription_grant_for_order

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -11,7 +11,9 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
+    BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+    BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -720,6 +722,117 @@ def test_referral_plan_reward_releases_reserved_manual_renewal_at_boundary(
         assert bucket.effective_from == boundary_at
         assert bucket.effective_to == next_cycle_end
         assert ledger.metadata_json["bucket_credit_state"] == "available"
+
+
+def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
+    referral_billing_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    boundary_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
+    current_cycle_start = boundary_at - timedelta(days=30)
+
+    def _fail_provider_sync(*_args, **_kwargs):
+        raise AssertionError("paid referral reward orders must not sync providers")
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.renewal.sync_billing_order",
+        _fail_provider_sync,
+    )
+
+    with referral_billing_app.app_context():
+        product = BillingProduct.query.filter_by(
+            product_bid="bill-product-plan-monthly-pro",
+        ).one()
+        next_cycle_end = calculate_self_managed_billing_cycle_end_after_boundary(
+            product,
+            cycle_boundary_at=boundary_at,
+        )
+        assert next_cycle_end is not None
+        subscription = BillingSubscription(
+            subscription_bid="sub-referral-pingxx-renewal",
+            creator_bid="creator-ref-billing-1",
+            product_bid="bill-product-plan-monthly-pro",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="pingxx",
+            provider_subscription_id="",
+            provider_customer_id="",
+            billing_anchor_at=current_cycle_start,
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=boundary_at,
+            grace_period_end_at=None,
+            cancel_at_period_end=0,
+            next_product_bid="",
+            last_renewed_at=current_cycle_start,
+            last_failed_at=None,
+            metadata_json={"checkout_started": True},
+        )
+        order = BillingOrder(
+            bill_order_bid="bill-referral-pingxx-paid-renewal",
+            creator_bid="creator-ref-billing-1",
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid="bill-product-plan-monthly-pro",
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="referral-reward:ref-reward-pingxx-renewal",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=boundary_at - timedelta(days=1),
+            metadata_json={
+                "checkout_type": "referral_invitation_reward",
+                "referral_invitation_reward": True,
+                "reward_bid": "ref-reward-pingxx-renewal",
+                "campaign_bid": "ref-campaign-billing",
+                "reward_rule_bid": "ref-rule-billing",
+                "renewal_cycle_start_at": boundary_at.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        event = BillingRenewalEvent(
+            renewal_event_bid="renewal-referral-pingxx",
+            subscription_bid=subscription.subscription_bid,
+            creator_bid=subscription.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+            scheduled_at=boundary_at - timedelta(days=7),
+            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            attempt_count=0,
+            last_error="",
+            payload_json={"source": "pytest"},
+            processed_at=None,
+        )
+        dao.db.session.add_all([subscription, order, event])
+        dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        referral_billing_app,
+        renewal_event_bid="renewal-referral-pingxx",
+    )
+
+    assert payload.status == "queued_for_reconcile"
+    assert payload.bill_order_bid == "bill-referral-pingxx-paid-renewal"
+
+    with referral_billing_app.app_context():
+        event = BillingRenewalEvent.query.filter_by(
+            renewal_event_bid="renewal-referral-pingxx",
+        ).one()
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="bill-referral-pingxx-paid-renewal",
+        ).one()
+
+        assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+        assert event.last_error == ""
+        assert event.payload_json["bill_order_bid"] == order.bill_order_bid
+        assert order.payment_provider == "manual"
+        assert order.channel == "manual"
+        assert (
+            order.provider_reference_id
+            == "referral-reward:ref-reward-pingxx-renewal"
+        )
+        assert order.product_bid == "bill-product-plan-monthly-pro"
+        assert order.metadata_json["renewal_event_bid"] == "renewal-referral-pingxx"
+        assert order.metadata_json["referral_invitation_reward"] is True
 
 
 def test_referral_plan_reward_releases_reserved_trial_reward_at_boundary(

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -827,8 +827,7 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
         assert order.payment_provider == "manual"
         assert order.channel == "manual"
         assert (
-            order.provider_reference_id
-            == "referral-reward:ref-reward-pingxx-renewal"
+            order.provider_reference_id == "referral-reward:ref-reward-pingxx-renewal"
         )
         assert order.product_bid == "bill-product-plan-monthly-pro"
         assert order.metadata_json["renewal_event_bid"] == "renewal-referral-pingxx"


### PR DESCRIPTION
Summary
- Preserve paid referral reward renewal orders when provider renewal events find them by cycle.
- Skip provider payment sync for paid referral reward renewal orders so they do not hit unsupported pingxx/manual channel combinations.
- Add regression coverage for a pingxx subscription renewal event that matches a paid referral reward renewal order.

Root Cause
- A pingxx renewal event could locate an existing paid referral reward renewal order by cycle and then treat it as a normal provider renewal order.
- That path overwrote the reward order with the active subscription provider/product fields, creating an invalid shape such as `payment_provider=pingxx`, `channel=manual`, and `provider_reference_id=referral-reward:...`.
- The later provider sync attempted to reconcile that invalid order and failed with `Unsupported Payment Channel`.

Validation
- `cd src/api && pytest tests/service/billing/test_referral_plan_rewards.py tests/service/billing/test_billing_renewal_execution.py::test_run_billing_renewal_event_queues_pingxx_order_without_provider_sync -q`
- `cd src/api && pytest tests/service/billing/test_billing_renewal_execution.py -q`
- `cd src/api && python3 -m ruff check flaskr/service/billing/subscriptions.py flaskr/service/billing/renewal.py tests/service/billing/test_referral_plan_rewards.py`
- `cd src/api && python3 -m compileall flaskr/service/billing/subscriptions.py flaskr/service/billing/renewal.py`
- `git diff --check`

Production Follow-up
- After deploy, review the known failed event `a77a52ae5e234d0b95c7e2f733224d74` and the already-mutated order `6f0aa2ee10614103af15143cc6e0b3f4` before any targeted data repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paid referral-invitation subscription renewals so they’re queued for reconciliation while keeping the existing renewal flow intact.
  * Renewal events are now marked as succeeded for this scenario, and the original order payment/channel/provider details and related metadata are preserved.
  * Expanded renewal deferral and boundary checks to cover all referral-invitation renewals consistently.
* **Tests**
  * Added coverage to ensure the renewal event payload and reconciliation target remain correct and the event status updates as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->