### PR TITLE
ci(runtime-harness): cache Docker layers and Playwright browsers

### DIFF
--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -72,9 +72,38 @@ jobs:
           CELERY_RESULT_BACKEND=redis://ai-shifu-redis:6379/1
           EOF
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the two from-source images with a persistent GitHub Actions layer
+      # cache and load them into the local Docker daemon under the exact tags the
+      # compose file references, so "up" below reuses them instead of rebuilding
+      # from scratch on every run. Contexts/dockerfiles mirror docker-compose.dev.yml.
+      - name: Build API image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/api/Dockerfile
+          tags: ai-shifu-api-dev:latest
+          load: true
+          cache-from: type=gha,scope=runtime-harness-api
+          cache-to: type=gha,mode=max,scope=runtime-harness-api
+
+      - name: Build cook-web image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: src/cook-web
+          file: src/cook-web/Dockerfile_DEV
+          tags: ai-shifu-cook-web-dev:latest
+          load: true
+          cache-from: type=gha,scope=runtime-harness-cook-web
+          cache-to: type=gha,mode=max,scope=runtime-harness-cook-web
+
       - name: Start dev stack
         working-directory: docker
-        run: docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker-compose.dev.yml up -d --build
+        # Images are prebuilt above; --build is intentionally omitted so compose
+        # reuses the cached images instead of rebuilding.
+        run: docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker-compose.dev.yml up -d
 
       - name: Wait for API and observability health
         run: |
@@ -92,6 +121,14 @@ jobs:
           docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml ps
           docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml logs ai-shifu-api-dev
           exit 1
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('src/cook-web/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install frontend dependencies
         working-directory: src/cook-web


### PR DESCRIPTION
## Motivation

The `runtime-harness` check runs ~6.5 min per PR. Measured breakdown of a
representative successful run (total 6m33s):

| Step | Duration | Why |
|---|---|---|
| Start dev stack (`up --build`) | **3m05s** | Rebuilds the API + cook-web images from source every run, **no layer cache**, then pulls ~11 third-party images |
| Wait for API + observability health | 1m18s | Fresh MySQL + full `flask db upgrade` + demo import + Loki/Tempo/Prometheus/Grafana readiness |
| Install frontend deps | 56s | `npm ci` + `playwright install` (re-downloads Chromium each run) |
| Run smoke harness | 56s | 3 Playwright browser tests |

The two biggest, semantics-neutral wins are caching the image build layers and
the Playwright browser bundle.

## Changes (CI-only; harness behavior unchanged)

1. **Docker layer cache.** Prebuild `ai-shifu-api-dev:latest` and
   `ai-shifu-cook-web-dev:latest` with `docker/build-push-action@v6` using a
   persistent GitHub Actions cache (`type=gha`, per-image `scope`), `load: true`
   into the local daemon, then drop `--build` from `docker compose up` so the
   stack reuses the prebuilt images. Build contexts/dockerfiles mirror
   `docker-compose.dev.yml` exactly (API context = repo root + `src/api/Dockerfile`;
   cook-web context = `src/cook-web` + `Dockerfile_DEV`), following the same
   buildx/`type=gha` convention already used in `build-latest.yml`.
2. **Playwright browser cache.** Cache `~/.cache/ms-playwright` keyed on
   `src/cook-web/package-lock.json`, so `playwright install` skips the Chromium
   download on cache hits.

## Expected effect

On cache hits, the image build drops from ~3 min toward well under a minute
(pip/npm layers reused; only changed layers rebuild), and the Chromium download
is skipped. The **first** run on this branch still pays full cost to populate the
caches — so the run on this very PR is expected to be slow; re-running it (or the
next push) should be noticeably faster.

No change to what the harness verifies (same stack, same migrations, same 3
smoke tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the runtime harness workflow to reuse cached Docker images and browser assets, which should speed up automated test runs and reduce setup time.
  * Kept the existing health checks, end-to-end execution, log capture, teardown, and artifact upload flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->