### PR TITLE
chore: bump markdown-flow-ui to 0.1.129

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.1.128",
+        "markdown-flow-ui": "0.1.129",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13560,9 +13560,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.1.128",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.128.tgz",
-      "integrity": "sha512-I41Bi114IHnzrtoMuw8PSWGet/jG7ecPpARN+DWMx9rz4pQ82VE35bfIA9YDDRf08nIEvHDGpxjbRVvsI8v4EQ==",
+      "version": "0.1.129",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.1.129.tgz",
+      "integrity": "sha512-b8pdmjzcGgikFijHZenx0zF2U419OxZOO3cAzwpnz9SAWMAoFUDC8Cqdm8mG8WuO/FcjK+o17RGvdBaoN/WvCQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.1.128",
+    "markdown-flow-ui": "0.1.129",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- Bump `markdown-flow-ui` from `0.1.128` to `0.1.129` in `src/cook-web/package.json`.
- Refresh the matching `package-lock.json` entry with the 0.1.129 tarball and integrity.

## Verification
- `python3 scripts/check_dev_tools.py`
- `git diff --check`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint` (passes with existing warnings)
- `cd src/cook-web && env npm_config_cache=/private/tmp/ai-shifu-npm-cache npx --yes npm@10.9.2 ci --dry-run --ignore-scripts --registry=https://registry.npmjs.org/` (passes with existing peer/engine warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an app dependency to a newer version for the web experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->