### PR TITLE
fix: move lesson update notice to headers

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
@@ -15,8 +15,8 @@
   .headerRow {
     display: flex;
     width: 100%;
-    flex: 0 0 44px;
-    min-height: 44px;
+    flex: 0 0 var(--mobile-chat-header-base-height, 44px);
+    min-height: var(--mobile-chat-header-base-height, 44px);
     align-items: center;
     padding: 6px 20px;
     box-sizing: border-box;
@@ -49,7 +49,7 @@
 
   .noticeRow {
     display: flex;
-    flex: 0 0 32px;
+    flex: 0 0 var(--mobile-chat-header-notice-height, 32px);
     min-width: 0;
     align-items: center;
     justify-content: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
@@ -15,6 +15,7 @@
   .headerRow {
     display: flex;
     width: 100%;
+    flex: 0 0 44px;
     min-height: 44px;
     align-items: center;
     padding: 6px 20px;
@@ -44,6 +45,21 @@
       outline: 2px solid var(--primary, #0f63ee);
       outline-offset: 2px;
     }
+  }
+
+  .noticeRow {
+    display: flex;
+    flex: 0 0 32px;
+    min-width: 0;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 0 20px 8px;
+    box-sizing: border-box;
+  }
+
+  .lessonUpdateNotice {
+    width: 100%;
   }
 }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
@@ -12,12 +12,17 @@ import { shifu } from '@/c-service/Shifu';
 import CourseHeaderSummary from './CourseHeaderSummary';
 import LearningModeSwitch from './LearningModeSwitch';
 import PreviewHeaderBanner from './PreviewHeaderBanner';
+import LessonUpdateNotice from './LessonUpdateNotice';
 
 export const ChatMobileHeader = ({
   className,
   onSettingClick,
   navOpen,
   iconPopoverPayload,
+  lessonUpdateNoticeVisible = false,
+  chapterId,
+  lessonId,
+  lessonTitle,
 }) => {
   const { t } = useTranslation();
   const { onOpen: onIconPopoverOpen, onClose: onIconPopoverClose } =
@@ -74,6 +79,17 @@ export const ChatMobileHeader = ({
           </button>
         </div>
       </div>
+      {lessonUpdateNoticeVisible ? (
+        <div className={styles.noticeRow}>
+          <LessonUpdateNotice
+            chapterId={chapterId}
+            lessonId={lessonId}
+            lessonTitle={lessonTitle}
+            compact
+            className={styles.lessonUpdateNotice}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -28,7 +28,9 @@
     line-height: 20px;
 
     .headerMain {
-      display: flex;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+      column-gap: 12px;
       width: 100%;
       min-height: 64px;
       align-items: center;
@@ -37,8 +39,9 @@
     }
 
     .headerContent {
+      grid-column: 1;
       min-width: 0;
-      max-width: calc(100% - 160px);
+      max-width: 100%;
     }
 
     .courseSummary {
@@ -52,11 +55,20 @@
       line-height: var(--text-sm-line-height, 18px);
     }
 
+    .lessonUpdateNoticeTarget {
+      grid-column: 2;
+      display: flex;
+      min-width: 0;
+      max-width: min(420px, 42vw);
+      justify-content: center;
+    }
+
     .headerActions {
+      grid-column: 3;
+      justify-self: end;
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      margin-left: auto;
       flex-shrink: 0;
     }
   }

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -2,7 +2,7 @@
 
 import styles from './ChatUi.module.scss';
 
-import { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { useShallow } from 'zustand/react/shallow';
@@ -17,6 +17,7 @@ import type { ListenMobileViewModeChangeHandler } from './listenModeTypes';
 import CourseHeaderSummary from '../CourseHeaderSummary';
 import LearningModeSwitch from '../LearningModeSwitch';
 import PreviewHeaderBanner from '../PreviewHeaderBanner';
+import LessonUpdateNotice from '../LessonUpdateNotice';
 
 const ChatComponents = dynamic(() => import('./NewChatComp'), {
   ssr: false,
@@ -41,6 +42,7 @@ interface ChatUiProps {
   isNavOpen?: boolean;
   onListenMobileViewModeChange?: ListenMobileViewModeChangeHandler;
   showGenerateBtn?: boolean;
+  onLessonUpdateNoticeVisibilityChange?: (visible: boolean) => void;
 }
 
 /**
@@ -64,6 +66,7 @@ export const ChatUi = ({
   isNavOpen = false,
   onListenMobileViewModeChange,
   showGenerateBtn = false,
+  onLessonUpdateNoticeVisibilityChange,
 }: ChatUiProps) => {
   const { t } = useTranslation();
   const { frameLayout } = useUiLayoutStore(state => state);
@@ -91,12 +94,34 @@ export const ChatUi = ({
   const showHeader = frameLayout !== FRAME_LAYOUT_MOBILE;
   const footerSeparator = String.fromCharCode(124);
   const [isListenPlayerVisible, setIsListenPlayerVisible] = useState(false);
+  const [showLessonUpdateNoticeInHeader, setShowLessonUpdateNoticeInHeader] =
+    useState(false);
+
+  const handleLessonUpdateNoticeVisibilityChange = useCallback(
+    (visible: boolean) => {
+      setShowLessonUpdateNoticeInHeader(visible);
+      onLessonUpdateNoticeVisibilityChange?.(visible);
+    },
+    [onLessonUpdateNoticeVisibilityChange],
+  );
 
   useEffect(() => {
     if (!isSlideMode) {
       setIsListenPlayerVisible(false);
     }
   }, [isSlideMode]);
+
+  useEffect(() => {
+    setShowLessonUpdateNoticeInHeader(false);
+    onLessonUpdateNoticeVisibilityChange?.(false);
+  }, [lessonId, onLessonUpdateNoticeVisibilityChange]);
+
+  useEffect(
+    () => () => {
+      onLessonUpdateNoticeVisibilityChange?.(false);
+    },
+    [onLessonUpdateNoticeVisibilityChange],
+  );
 
   return (
     <div
@@ -137,6 +162,15 @@ export const ChatUi = ({
                   titleClassName={styles.courseSummaryTitle}
                 />
               </div>
+              {showLessonUpdateNoticeInHeader ? (
+                <div className={styles.lessonUpdateNoticeTarget}>
+                  <LessonUpdateNotice
+                    chapterId={chapterId}
+                    lessonId={lessonId}
+                    lessonTitle={lessonTitle}
+                  />
+                </div>
+              ) : null}
               {showModeToggle ? (
                 <div className={styles.headerActions}>
                   <LearningModeSwitch size='desktop' />
@@ -169,6 +203,9 @@ export const ChatUi = ({
           onListenMobileViewModeChange={onListenMobileViewModeChange}
           onListenPlayerVisibilityChange={setIsListenPlayerVisible}
           showGenerateBtn={showGenerateBtn}
+          onLessonUpdateNoticeVisibilityChange={
+            handleLessonUpdateNoticeVisibilityChange
+          }
         />
       }
       {showUserSettings && (

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppContext } from '../AppContext';
 import { NewChatComponents } from './NewChatComp';
+import LessonUpdateNotice from '../LessonUpdateNotice';
 
 const mockUseChatLogicHook = jest.fn();
 
@@ -235,7 +236,9 @@ jest.mock('@/components/audio/AudioPlayer', () => ({
   },
 }));
 
-const renderLessonUpdateNotice = () => {
+const renderNewChatComponents = (
+  onLessonUpdateNoticeVisibilityChange = jest.fn(),
+) => {
   mockUseChatLogicHook.mockReturnValue({
     currentStreamingElementBid: '',
     currentTypewriterElementBid: '',
@@ -283,10 +286,22 @@ const renderLessonUpdateNotice = () => {
         onGoChapter={jest.fn()}
         onPurchased={jest.fn()}
         updateSelectedLesson={jest.fn()}
+        onLessonUpdateNoticeVisibilityChange={
+          onLessonUpdateNoticeVisibilityChange
+        }
       />
     </AppContext.Provider>,
   );
 };
+
+const renderTitlebarLessonUpdateNotice = () =>
+  render(
+    <LessonUpdateNotice
+      chapterId='chapter-1'
+      lessonId='lesson-1'
+      lessonTitle='第一课'
+    />,
+  );
 
 describe('NewChatComponents lesson update notice', () => {
   let requestAnimationFrameSpy: jest.SpyInstance;
@@ -302,8 +317,8 @@ describe('NewChatComponents lesson update notice', () => {
     requestAnimationFrameSpy.mockRestore();
   });
 
-  it('renders retake as an inline action and opens the existing confirm dialog', async () => {
-    renderLessonUpdateNotice();
+  it('renders the titlebar retake action and opens the existing confirm dialog', async () => {
+    renderTitlebarLessonUpdateNotice();
 
     const retakeAction = screen.getByRole('button', {
       name: '重修本节课程',
@@ -323,5 +338,24 @@ describe('NewChatComponents lesson update notice', () => {
     expect(
       screen.getByText('重修会清空本节学习数据。确定重修？'),
     ).toBeInTheDocument();
+  });
+
+  it('reports the notice visibility without rendering it in chat content', async () => {
+    const onLessonUpdateNoticeVisibilityChange = jest.fn();
+    renderNewChatComponents(onLessonUpdateNoticeVisibilityChange);
+
+    await waitFor(() => {
+      expect(onLessonUpdateNoticeVisibilityChange).toHaveBeenLastCalledWith(
+        true,
+      );
+    });
+    expect(
+      screen.queryByRole('button', {
+        name: '重修本节课程',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('本节课程已更新，建议重修'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -11,21 +11,18 @@ import {
   useEffect,
   useMemo,
 } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@/lib/utils';
 import { runWithConcurrency } from '@/lib/runWithConcurrency';
 import { getDocumentFullscreenElement } from '@/c-utils/browserFullscreen';
-import { stopActiveLessonStream } from '@/app/c/[[...id]]/events';
 import { AppContext } from '../AppContext';
 import { useChatComponentsScroll } from './ChatComponents/useChatComponentsScroll';
 import { useTracking } from '@/c-common/hooks/useTracking';
-import { shifu } from '@/c-service/Shifu';
 import { useEnvStore } from '@/c-store/envStore';
 import { useUserStore } from '@/store';
 import { useCourseStore } from '@/c-store/useCourseStore';
 import { fail, toast } from '@/hooks/useToast';
-import { useSingleFlight } from '@/hooks/useSingleFlight';
 import useExclusiveAudio from '@/hooks/useExclusiveAudio';
 import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
 import InteractionBlock from './InteractionBlock';
@@ -107,6 +104,7 @@ interface NewChatComponentsProps {
   onListenPlayerVisibilityChange?: (visible: boolean) => void;
   onListenMobileViewModeChange?: ListenMobileViewModeChangeHandler;
   showGenerateBtn?: boolean;
+  onLessonUpdateNoticeVisibilityChange?: (visible: boolean) => void;
 }
 
 const isContentItemWithElementBid = (item: ChatContentItem) =>
@@ -132,6 +130,7 @@ export const NewChatComponents = ({
   onListenPlayerVisibilityChange,
   onListenMobileViewModeChange,
   showGenerateBtn = false,
+  onLessonUpdateNoticeVisibilityChange,
 }: NewChatComponentsProps) => {
   const { trackEvent, trackTrailProgress } = useTracking();
   const { t } = useTranslation();
@@ -280,23 +279,15 @@ export const NewChatComponents = ({
     });
   }, [resolveScrollPresentation]);
 
-  const {
-    openPayModal,
-    payModalResult,
-    resetChapter,
-    resetedLessonId,
-    resettingLessonId,
-    updateLessonId,
-  } = useCourseStore(
-    useShallow(state => ({
-      openPayModal: state.openPayModal,
-      payModalResult: state.payModalResult,
-      resetChapter: state.resetChapter,
-      resetedLessonId: state.resetedLessonId,
-      resettingLessonId: state.resettingLessonId,
-      updateLessonId: state.updateLessonId,
-    })),
-  );
+  const { openPayModal, payModalResult, resetedLessonId, resettingLessonId } =
+    useCourseStore(
+      useShallow(state => ({
+        openPayModal: state.openPayModal,
+        payModalResult: state.payModalResult,
+        resetedLessonId: state.resetedLessonId,
+        resettingLessonId: state.resettingLessonId,
+      })),
+    );
   const shouldShowResetLoading =
     mobileStyle &&
     (resettingLessonId === lessonId || resetedLessonId === lessonId);
@@ -321,48 +312,6 @@ export const NewChatComponents = ({
   const previousListenModeActiveRef = useRef(isListenModeActive);
   // Normalize lesson scope for downstream APIs and stores that require a string key.
   const resolvedLessonId = lessonId || '';
-  const isRetakingCurrentLesson =
-    Boolean(resolvedLessonId) && resettingLessonId === resolvedLessonId;
-  const [showRetakeConfirm, setShowRetakeConfirm] = useState(false);
-  const handleRetakeCurrentLesson = useSingleFlight(async () => {
-    if (!resolvedLessonId) {
-      return false;
-    }
-
-    try {
-      stopActiveLessonStream(resolvedLessonId);
-      await resetChapter(resolvedLessonId);
-      updateLessonId(resolvedLessonId);
-      shifu.resetTools.resetChapter({
-        chapter_id: chapterId,
-        lesson_id: resolvedLessonId,
-        chapter_name: lessonTitle,
-      });
-      return true;
-    } catch (error) {
-      fail(
-        (error as Error).message || t('module.backend.common.operationFailed'),
-      );
-      return false;
-    }
-  });
-  const handleRetakeButtonClick = useCallback(() => {
-    if (!resolvedLessonId || isRetakingCurrentLesson) {
-      return;
-    }
-
-    setShowRetakeConfirm(true);
-  }, [isRetakingCurrentLesson, resolvedLessonId]);
-  const handleRetakeConfirmOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && isRetakingCurrentLesson) {
-        return;
-      }
-
-      setShowRetakeConfirm(open);
-    },
-    [isRetakingCurrentLesson],
-  );
   const promptContextKey = `${resolvedLessonId}:${
     isClassroomMode ? 'classroom' : isListenModeActive ? 'listen' : 'read'
   }`;
@@ -498,6 +447,17 @@ export const NewChatComponents = ({
     showOutputInProgressToast,
     onPayModalOpen,
   });
+
+  useEffect(() => {
+    onLessonUpdateNoticeVisibilityChange?.(showLessonUpdateNotice);
+  }, [onLessonUpdateNoticeVisibilityChange, showLessonUpdateNotice]);
+
+  useEffect(
+    () => () => {
+      onLessonUpdateNoticeVisibilityChange?.(false);
+    },
+    [onLessonUpdateNoticeVisibilityChange],
+  );
 
   const requestListenAudioBackfillForBlock = useCallback(
     (blockBid: string, lessonIdAtRequest: string) => {
@@ -1277,82 +1237,6 @@ export const NewChatComponents = ({
         </div>
       </div>
     ) : null;
-  const lessonUpdateNotice = showLessonUpdateNotice ? (
-    <div className='mx-auto mb-3 mt-2 flex max-w-[1000px] justify-center px-4 md:px-5'>
-      <div
-        aria-live='polite'
-        className='inline-flex max-w-full items-center rounded-lg border border-amber-200/60 bg-amber-50/80 px-3 py-1.5 text-sm leading-6 text-amber-900'
-      >
-        <span className='min-w-0'>
-          <Trans
-            i18nKey='module.chat.lessonUpdateRecommendRetake'
-            components={{
-              action: (
-                <button
-                  type='button'
-                  aria-label={t(
-                    'module.chat.lessonUpdateRetakeAccessibleLabel',
-                  )}
-                  onClick={handleRetakeButtonClick}
-                  disabled={isRetakingCurrentLesson}
-                  className='inline-flex h-auto min-h-0 items-baseline rounded px-0.5 py-0 font-semibold text-amber-950 underline decoration-amber-700/35 underline-offset-[3px] transition-colors hover:bg-amber-100/80 hover:text-amber-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50 disabled:cursor-not-allowed disabled:opacity-60'
-                />
-              ),
-            }}
-          />
-        </span>
-        <Dialog
-          open={showRetakeConfirm}
-          onOpenChange={handleRetakeConfirmOpenChange}
-        >
-          <DialogContent
-            showClose={!isRetakingCurrentLesson}
-            onEscapeKeyDown={event => {
-              if (isRetakingCurrentLesson) {
-                event.preventDefault();
-              }
-            }}
-            onPointerDownOutside={event => {
-              if (isRetakingCurrentLesson) {
-                event.preventDefault();
-              }
-            }}
-          >
-            <DialogHeader>
-              <DialogTitle>{t('module.lesson.reset.confirmTitle')}</DialogTitle>
-              <DialogDescription>
-                {t('module.lesson.reset.confirmContent')}
-              </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-              <Button
-                type='button'
-                variant='outline'
-                onClick={() => setShowRetakeConfirm(false)}
-                disabled={isRetakingCurrentLesson}
-              >
-                {t('common.core.cancel')}
-              </Button>
-              <Button
-                type='button'
-                onClick={() => {
-                  void handleRetakeCurrentLesson().then(didReset => {
-                    if (didReset) {
-                      setShowRetakeConfirm(false);
-                    }
-                  });
-                }}
-                disabled={isRetakingCurrentLesson}
-              >
-                {t('common.core.ok')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
-    </div>
-  ) : null;
-
   return (
     <div
       className={containerClassName}
@@ -1361,7 +1245,6 @@ export const NewChatComponents = ({
       {isSlideMode ? (
         isClassroomMode || isListenModeAvailable ? (
           <>
-            {lessonUpdateNotice}
             <ListenModeSlideRenderer
               items={slideModeItems}
               mobileStyle={mobileStyle}
@@ -1413,7 +1296,6 @@ export const NewChatComponents = ({
               <></>
             ) : (
               <>
-                {lessonUpdateNotice}
                 {visibleReadModeItems.map((item, idx) => {
                   const isLongPressed =
                     longPressedBlockBid === item.element_bid;

--- a/src/cook-web/src/app/c/[[...id]]/Components/LessonUpdateNotice.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/LessonUpdateNotice.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
+import { cn } from '@/lib/utils';
+import { stopActiveLessonStream } from '@/app/c/[[...id]]/events';
+import { shifu } from '@/c-service/Shifu';
+import { useCourseStore } from '@/c-store/useCourseStore';
+import { fail } from '@/hooks/useToast';
+import { useSingleFlight } from '@/hooks/useSingleFlight';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/Button';
+
+interface LessonUpdateNoticeProps {
+  chapterId: string;
+  lessonId?: string;
+  lessonTitle?: string;
+  className?: string;
+  compact?: boolean;
+}
+
+export const LessonUpdateNotice = ({
+  chapterId,
+  lessonId,
+  lessonTitle = '',
+  className,
+  compact = false,
+}: LessonUpdateNoticeProps) => {
+  const { t } = useTranslation();
+  const { resetChapter, resettingLessonId, updateLessonId } = useCourseStore(
+    useShallow(state => ({
+      resetChapter: state.resetChapter,
+      resettingLessonId: state.resettingLessonId,
+      updateLessonId: state.updateLessonId,
+    })),
+  );
+  const resolvedLessonId = lessonId || '';
+  const isRetakingCurrentLesson =
+    Boolean(resolvedLessonId) && resettingLessonId === resolvedLessonId;
+  const [showRetakeConfirm, setShowRetakeConfirm] = useState(false);
+
+  const handleRetakeCurrentLesson = useSingleFlight(async () => {
+    if (!resolvedLessonId) {
+      return false;
+    }
+
+    try {
+      stopActiveLessonStream(resolvedLessonId);
+      await resetChapter(resolvedLessonId);
+      updateLessonId(resolvedLessonId);
+      shifu.resetTools.resetChapter({
+        chapter_id: chapterId,
+        lesson_id: resolvedLessonId,
+        chapter_name: lessonTitle,
+      });
+      return true;
+    } catch (error) {
+      fail(
+        (error as Error).message || t('module.backend.common.operationFailed'),
+      );
+      return false;
+    }
+  });
+
+  const handleRetakeButtonClick = useCallback(() => {
+    if (!resolvedLessonId || isRetakingCurrentLesson) {
+      return;
+    }
+
+    setShowRetakeConfirm(true);
+  }, [isRetakingCurrentLesson, resolvedLessonId]);
+
+  const handleRetakeConfirmOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && isRetakingCurrentLesson) {
+        return;
+      }
+
+      setShowRetakeConfirm(open);
+    },
+    [isRetakingCurrentLesson],
+  );
+
+  return (
+    <div
+      aria-live='polite'
+      className={cn(
+        'inline-flex max-w-full items-center text-amber-900',
+        compact
+          ? 'justify-center px-0 py-0 text-xs leading-5'
+          : 'rounded-lg border border-amber-200/60 bg-amber-50/80 px-3 py-1.5 text-sm leading-6',
+        className,
+      )}
+    >
+      <span className='inline-block min-w-0 max-w-full truncate align-bottom'>
+        <Trans
+          i18nKey='module.chat.lessonUpdateRecommendRetake'
+          components={{
+            action: (
+              <button
+                type='button'
+                aria-label={t('module.chat.lessonUpdateRetakeAccessibleLabel')}
+                onClick={handleRetakeButtonClick}
+                disabled={isRetakingCurrentLesson}
+                className={cn(
+                  'inline-flex h-auto min-h-0 items-baseline rounded px-0.5 py-0 font-semibold text-amber-950 underline decoration-amber-700/35 underline-offset-[3px] transition-colors hover:bg-amber-100/80 hover:text-amber-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 disabled:cursor-not-allowed disabled:opacity-60',
+                  compact
+                    ? 'focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--base-background,#fff)]'
+                    : 'focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50',
+                )}
+              />
+            ),
+          }}
+        />
+      </span>
+      <Dialog
+        open={showRetakeConfirm}
+        onOpenChange={handleRetakeConfirmOpenChange}
+      >
+        <DialogContent
+          showClose={!isRetakingCurrentLesson}
+          onEscapeKeyDown={event => {
+            if (isRetakingCurrentLesson) {
+              event.preventDefault();
+            }
+          }}
+          onPointerDownOutside={event => {
+            if (isRetakingCurrentLesson) {
+              event.preventDefault();
+            }
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>{t('module.lesson.reset.confirmTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('module.lesson.reset.confirmContent')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => setShowRetakeConfirm(false)}
+              disabled={isRetakingCurrentLesson}
+            >
+              {t('common.core.cancel')}
+            </Button>
+            <Button
+              type='button'
+              onClick={() => {
+                void handleRetakeCurrentLesson().then(didReset => {
+                  if (didReset) {
+                    setShowRetakeConfirm(false);
+                  }
+                });
+              }}
+              disabled={isRetakingCurrentLesson}
+            >
+              {t('common.core.ok')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default LessonUpdateNotice;

--- a/src/cook-web/src/app/c/[[...id]]/page.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/page.module.scss
@@ -35,4 +35,12 @@
   &.previewMode {
     --mobile-chat-header-height: 84px;
   }
+
+  &.lessonUpdateNoticeVisible {
+    --mobile-chat-header-height: 76px;
+  }
+
+  &.previewMode.lessonUpdateNoticeVisible {
+    --mobile-chat-header-height: 116px;
+  }
 }

--- a/src/cook-web/src/app/c/[[...id]]/page.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/page.module.scss
@@ -1,5 +1,8 @@
 .newChatPage {
-  --mobile-chat-header-height: 44px;
+  --mobile-chat-header-base-height: 44px;
+  --mobile-chat-header-notice-height: 32px;
+  --mobile-chat-preview-banner-height: 40px;
+  --mobile-chat-header-height: var(--mobile-chat-header-base-height);
   width: 100%;
   min-height: calc(var(--app-viewport-block-unit, 1dvh) * 100);
   display: flex;
@@ -33,14 +36,24 @@
   }
 
   &.previewMode {
-    --mobile-chat-header-height: 84px;
+    --mobile-chat-header-height: calc(
+      var(--mobile-chat-header-base-height) +
+        var(--mobile-chat-preview-banner-height)
+    );
   }
 
   &.lessonUpdateNoticeVisible {
-    --mobile-chat-header-height: 76px;
+    --mobile-chat-header-height: calc(
+      var(--mobile-chat-header-base-height) +
+        var(--mobile-chat-header-notice-height)
+    );
   }
 
   &.previewMode.lessonUpdateNoticeVisible {
-    --mobile-chat-header-height: 116px;
+    --mobile-chat-header-height: calc(
+      var(--mobile-chat-header-base-height) +
+        var(--mobile-chat-preview-banner-height) +
+        var(--mobile-chat-header-notice-height)
+    );
   }
 }

--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -12,8 +12,41 @@ const mockReloadTree = jest.fn();
 const mockUpdateLessonId = jest.fn();
 const mockUpdateChapterId = jest.fn();
 const mockTrackEvent = jest.fn();
+
+interface MockChatMobileHeaderProps {
+  lessonId?: string;
+  lessonTitle?: string;
+}
+
+interface MockChatUiProps {
+  lessonId?: string;
+}
+
+const mockChatMobileHeader = jest.fn(
+  ({ lessonId, lessonTitle }: MockChatMobileHeaderProps) => (
+    <div
+      data-testid='mobile-header'
+      data-lesson-id={lessonId}
+      data-lesson-title={lessonTitle}
+    />
+  ),
+);
+const mockChatUi = jest.fn(({ lessonId }: MockChatUiProps) => (
+  <div
+    data-testid='chat-ui'
+    data-lesson-id={lessonId}
+  />
+));
 const completeOnboardingLabel = 'complete onboarding';
 const skipOnboardingLabel = 'skip onboarding';
+let mockSelectedLessonId = 'lesson-1';
+let mockLessonTreeLessons = [
+  {
+    id: 'lesson-1',
+    name: 'Lesson title',
+    status: 'not_started',
+  },
+];
 
 const mockUserStoreState = {
   userInfo: {
@@ -172,17 +205,11 @@ jest.mock('./hooks/useLessonTree', () => ({
       catalogs: [
         {
           id: 'chapter-1',
-          lessons: [
-            {
-              id: 'lesson-1',
-              name: 'Lesson title',
-              status: 'not_started',
-            },
-          ],
+          lessons: mockLessonTreeLessons,
         },
       ],
     },
-    selectedLessonId: 'lesson-1',
+    selectedLessonId: mockSelectedLessonId,
     loadTree: mockLoadTree,
     reloadTree: mockReloadTree,
     updateSelectedLesson: jest.fn(),
@@ -209,12 +236,12 @@ jest.mock('./Components/NavDrawer/NavDrawer', () => ({
 
 jest.mock('./Components/ChatMobileHeader', () => ({
   __esModule: true,
-  default: () => null,
+  default: (props: MockChatMobileHeaderProps) => mockChatMobileHeader(props),
 }));
 
 jest.mock('./Components/ChatUi/ChatUi', () => ({
   __esModule: true,
-  default: () => <div data-testid='chat-ui' />,
+  default: (props: MockChatUiProps) => mockChatUi(props),
 }));
 
 jest.mock('@/c-components/TrackingVisit', () => ({
@@ -264,12 +291,30 @@ jest.mock('@/components/profile-onboarding/ProfileOnboardingModal', () => ({
 describe('ChatPage profile onboarding gate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCourseStoreState.lessonId = 'lesson-1';
+    mockCourseStoreState.chapterId = 'chapter-1';
+    mockSystemStoreState.previewMode = false;
+    mockSystemStoreState.learningMode = 'read';
+    mockUiLayoutStoreState.frameLayout = 'desktop';
+    mockSelectedLessonId = 'lesson-1';
+    mockLessonTreeLessons = [
+      {
+        id: 'lesson-1',
+        name: 'Lesson title',
+        status: 'not_started',
+      },
+    ];
     window.matchMedia = jest.fn().mockReturnValue({
       matches: false,
       addEventListener: jest.fn(),
       removeEventListener: jest.fn(),
       addListener: jest.fn(),
       removeListener: jest.fn(),
+    });
+    mockGetProfileOnboarding.mockResolvedValue({
+      should_show: false,
+      markdownflow: '',
+      current_values: {},
     });
     mockCompleteProfileOnboarding.mockResolvedValue({
       completed: true,
@@ -329,5 +374,30 @@ describe('ChatPage profile onboarding gate', () => {
     await waitFor(() => {
       expect(screen.getByTestId('chat-ui')).toBeInTheDocument();
     });
+  });
+
+  test('passes the resolved selected lesson id to chat headers when the store id is stale', async () => {
+    mockUiLayoutStoreState.frameLayout = 'mobile';
+    mockCourseStoreState.lessonId = 'lesson-old';
+    mockSelectedLessonId = 'lesson-new';
+    mockLessonTreeLessons = [
+      {
+        id: 'lesson-new',
+        name: 'New lesson title',
+        status: 'not_started',
+      },
+    ];
+
+    render(<ChatPage />);
+
+    const mobileHeader = await screen.findByTestId('mobile-header');
+    expect(mobileHeader).toHaveAttribute('data-lesson-id', 'lesson-new');
+    expect(mobileHeader).toHaveAttribute(
+      'data-lesson-title',
+      'New lesson title',
+    );
+
+    const chatUi = await screen.findByTestId('chat-ui');
+    expect(chatUi).toHaveAttribute('data-lesson-id', 'lesson-new');
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -889,7 +889,7 @@ export default function ChatPage() {
             onSettingClick={onNavToggle}
             lessonUpdateNoticeVisible={lessonUpdateNoticeVisible}
             chapterId={chapterId}
-            lessonId={lessonId}
+            lessonId={resolvedLessonId}
             lessonTitle={currentLessonTitle}
           />
         ) : null}
@@ -929,7 +929,7 @@ export default function ChatPage() {
 
         {initialized && profileOnboardingRuntimeReady ? (
           <ChatUi
-            lessonId={lessonId}
+            lessonId={resolvedLessonId}
             chapterId={chapterId}
             lessonTitle={currentLessonTitle}
             lessonStatus={currentLessonStatus}

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -144,6 +144,8 @@ export default function ChatPage() {
     })),
   );
   const isSlideMode = learningMode === 'listen' || learningMode === 'classroom';
+  const [lessonUpdateNoticeVisible, setLessonUpdateNoticeVisible] =
+    useState(false);
 
   useEffect(() => {
     if (!initialized) {
@@ -870,6 +872,7 @@ export default function ChatPage() {
       className={clsx(
         styles.newChatPage,
         previewMode ? styles.previewMode : '',
+        lessonUpdateNoticeVisible ? styles.lessonUpdateNoticeVisible : '',
         isSlideMode ? styles.listenMode : '',
         mobileStyle ? 'flex-col' : 'h-screen flex-row',
         'flex',
@@ -884,6 +887,10 @@ export default function ChatPage() {
             className={styles.chatMobileHeader}
             iconPopoverPayload={tree?.bannerInfo}
             onSettingClick={onNavToggle}
+            lessonUpdateNoticeVisible={lessonUpdateNoticeVisible}
+            chapterId={chapterId}
+            lessonId={lessonId}
+            lessonTitle={currentLessonTitle}
           />
         ) : null}
 
@@ -939,6 +946,7 @@ export default function ChatPage() {
             isNavOpen={navOpen}
             onListenMobileViewModeChange={setListenMobileViewMode}
             showGenerateBtn={false}
+            onLessonUpdateNoticeVisibilityChange={setLessonUpdateNoticeVisible}
           />
         ) : null}
 

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -23,7 +23,7 @@
   "lessonFeedbackPrompt": "Please rate this course section (1-5)",
   "lessonFeedbackScoreRequired": "Please choose a score from 1 to 5.",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
-  "lessonUpdateRecommendRetake": "This lesson has been updated. We recommend a <action>reset</action>",
+  "lessonUpdateRecommendRetake": "Lesson updated: <action>reset</action>",
   "lessonUpdateRetakeAccessibleLabel": "Reset this lesson",
   "lessonUpdateRetakeAction": "Reset",
   "listenAudioBackfillFailed": "Audio generation failed. Please retry or keep reading.",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -23,7 +23,7 @@
   "lessonFeedbackPrompt": "Veuillez noter cette section du cours (1 à 5)",
   "lessonFeedbackScoreRequired": "Veuillez choisir une note de 1 à 5.",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
-  "lessonUpdateRecommendRetake": "Cette leçon a été mise à jour. Nous vous recommandons de la <action>reprendre</action>",
+  "lessonUpdateRecommendRetake": "Leçon mise à jour : <action>reprendre</action>",
   "lessonUpdateRetakeAccessibleLabel": "Reprendre cette leçon",
   "lessonUpdateRetakeAction": "Reprendre",
   "listenAudioBackfillFailed": "La génération audio a échoué. Veuillez réessayer ou continuer la lecture.",


### PR DESCRIPTION
## Summary
- Move the lesson update reset reminder out of chat body content and into course headers for all learner modes.
- Reuse the shared header notice on desktop and mobile, including the existing reset confirmation flow and shorter English/French copy.
- Keep mobile layout stable by deriving header spacing from shared height variables when preview and update notices are visible.
- Pass the resolved selected lesson id to the header and chat runtime so reset targets match the visible lesson during store/tree sync.

## Verification
- `npm run test -- --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx`
- `npm run test -- --runTestsByPath src/app/c/[[...id]]/page.test.tsx`
- `npm run type-check`
- `npm run lint`
- `python3 scripts/check_dev_tools.py`
- `git diff --check`
- pre-commit hooks during `git commit`