### PR TITLE
refactor: align admin select checkmark placement

### DIFF
--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationConfigTab.tsx
@@ -585,7 +585,6 @@ export function CreditNotificationConfigTab({
                         key={timezone}
                         value={timezone}
                         className='pl-2 pr-8'
-                        indicatorClassName='left-auto right-2'
                       >
                         {timezone}
                       </SelectItem>

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
@@ -21,7 +21,6 @@ import {
 } from './creditNotificationUtils';
 
 const SELECT_ITEM_CLASS = 'pl-3 pr-8';
-const SELECT_ITEM_INDICATOR_CLASS = 'left-auto right-2';
 
 export function CreditNotificationRecordsFilter({
   draftFilters,
@@ -74,7 +73,6 @@ export function CreditNotificationRecordsFilter({
           <SelectItem
             value={ALL_OPTION_VALUE}
             className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
           >
             {t('module.operationsCreditNotifications.filters.all')}
           </SelectItem>
@@ -83,7 +81,6 @@ export function CreditNotificationRecordsFilter({
               key={type}
               value={type}
               className={SELECT_ITEM_CLASS}
-              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
             >
               {resolveTypeLabel(type)}
             </SelectItem>
@@ -114,7 +111,6 @@ export function CreditNotificationRecordsFilter({
           <SelectItem
             value={ALL_OPTION_VALUE}
             className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
           >
             {t('module.operationsCreditNotifications.filters.all')}
           </SelectItem>
@@ -123,7 +119,6 @@ export function CreditNotificationRecordsFilter({
               key={status}
               value={status}
               className={SELECT_ITEM_CLASS}
-              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
             >
               {resolveDeliveryStatusLabel(status)}
             </SelectItem>
@@ -153,7 +148,6 @@ export function CreditNotificationRecordsFilter({
           <SelectItem
             value={ALL_OPTION_VALUE}
             className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
           >
             {t('module.operationsCreditNotifications.filters.all')}
           </SelectItem>
@@ -162,7 +156,6 @@ export function CreditNotificationRecordsFilter({
               key={reason}
               value={reason}
               className={SELECT_ITEM_CLASS}
-              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
             >
               {resolveSkipReasonLabel(reason)}
             </SelectItem>
@@ -192,7 +185,6 @@ export function CreditNotificationRecordsFilter({
           <SelectItem
             value={ALL_OPTION_VALUE}
             className={SELECT_ITEM_CLASS}
-            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
           >
             {t('module.operationsCreditNotifications.filters.all')}
           </SelectItem>
@@ -201,7 +193,6 @@ export function CreditNotificationRecordsFilter({
               key={sourceType}
               value={sourceType}
               className={SELECT_ITEM_CLASS}
-              indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
             >
               {resolveSourceTypeLabel(sourceType)}
             </SelectItem>

--- a/src/cook-web/src/app/admin/operations/operationCoursePageShared.tsx
+++ b/src/cook-web/src/app/admin/operations/operationCoursePageShared.tsx
@@ -54,7 +54,7 @@ export const DEFAULT_COLUMN_WIDTHS = {
 export type ColumnKey = keyof typeof DEFAULT_COLUMN_WIDTHS;
 export const COLUMN_KEYS = Object.keys(DEFAULT_COLUMN_WIDTHS) as ColumnKey[];
 export const SINGLE_SELECT_ITEM_CLASS =
-  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
+  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
 export const TRANSFER_PHONE_PATTERN = /^\d{11}$/;
 export const EMPTY_STATE_LABEL = '--';
 export const EMPTY_COURSE_OVERVIEW: AdminOperationCourseOverview = {

--- a/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
@@ -254,7 +254,7 @@ export const PROMOTION_USAGE_DIALOG_COLUMN_COUNT = {
   withCourse: 5,
 } as const;
 export const SINGLE_SELECT_ITEM_CLASS =
-  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
+  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
 export const TABLE_HEAD_CLASS = ADMIN_TABLE_HEADER_CELL_CENTER_CLASS;
 export const TABLE_ACTION_HEAD_CLASS =
   getAdminStickyRightHeaderClass('text-center');

--- a/src/cook-web/src/app/admin/operations/referrals/ReferralRelationsPanel.tsx
+++ b/src/cook-web/src/app/admin/operations/referrals/ReferralRelationsPanel.tsx
@@ -43,7 +43,7 @@ import {
 export const REFERRAL_PAGE_SIZE = 20;
 const ALL_OPTION_VALUE = '__all__';
 const SINGLE_SELECT_ITEM_CLASS =
-  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
+  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
 const TABLE_HEAD_CLASS = 'whitespace-nowrap';
 const TABLE_CELL_CLASS = 'whitespace-nowrap';
 

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodeDialog.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodeDialog.tsx
@@ -45,7 +45,6 @@ import { useCreatorPublishedCourseOptions } from './useCreatorPublishedCourseOpt
 
 const SELECT_ITEM_CLASS =
   'pl-3 pr-8 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
-const SELECT_ITEM_INDICATOR_CLASS = 'left-auto right-2';
 
 const CreatorRedemptionCodeDialog = ({
   open,
@@ -222,14 +221,12 @@ const CreatorRedemptionCodeDialog = ({
                 <SelectItem
                   value='801'
                   className={SELECT_ITEM_CLASS}
-                  indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
                 >
                   {tPromotion('usageType.generic')}
                 </SelectItem>
                 <SelectItem
                   value='802'
                   className={SELECT_ITEM_CLASS}
-                  indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
                 >
                   {tPromotion('usageType.singleUse')}
                 </SelectItem>
@@ -251,14 +248,12 @@ const CreatorRedemptionCodeDialog = ({
                 <SelectItem
                   value='701'
                   className={SELECT_ITEM_CLASS}
-                  indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
                 >
                   {tPromotion('discountType.fixed')}
                 </SelectItem>
                 <SelectItem
                   value='702'
                   className={SELECT_ITEM_CLASS}
-                  indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
                 >
                   {tPromotion('discountType.percent')}
                 </SelectItem>
@@ -351,7 +346,6 @@ const CreatorRedemptionCodeDialog = ({
                             key={course.bid}
                             value={course.bid}
                             className={SELECT_ITEM_CLASS}
-                            indicatorClassName={SELECT_ITEM_INDICATOR_CLASS}
                           >
                             {course.name || course.bid}
                           </SelectItem>

--- a/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/CreatorRedemptionCodesFilterPanel.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/app/admin/components/adminFilterFieldBuilders';
 import { COUPON_OPS_STATE_OPTIONS } from '@/app/admin/operations/promotions/promotionPageShared';
 import {
-  SINGLE_SELECT_INDICATOR_CLASS,
   SINGLE_SELECT_ITEM_CLASS,
   fromSelectValue,
   toSelectValue,
@@ -104,7 +103,6 @@ export default function CreatorRedemptionCodesFilterPanel({
       })),
       labelClassName: getOrderFilterLabelClassName(labelWidth),
       selectItemClassName: SINGLE_SELECT_ITEM_CLASS,
-      indicatorClassName: SINGLE_SELECT_INDICATOR_CLASS,
     });
 
   const buildTextItem = (

--- a/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
+++ b/src/cook-web/src/app/admin/orders/OrdersFilterPanel.tsx
@@ -29,7 +29,7 @@ import type { OrderFilters } from './ordersPageShared';
 
 const ALL_OPTION_VALUE = '__all__';
 const SINGLE_SELECT_ITEM_CLASS =
-  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground [&>span:first-child]:hidden';
+  'pl-3 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
 
 type SelectOption = {
   value: string;

--- a/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
+++ b/src/cook-web/src/app/admin/orders/creatorRedemptionCodeShared.ts
@@ -3,7 +3,6 @@ export const USAGE_PROGRESS_SEPARATOR = '/';
 export const ALL_OPTION_VALUE = '__all__';
 export const SINGLE_SELECT_ITEM_CLASS =
   'pl-3 pr-8 data-[state=checked]:bg-muted data-[state=checked]:text-foreground';
-export const SINGLE_SELECT_INDICATOR_CLASS = 'left-auto right-2';
 export const FILTER_LABEL_CLASS =
   'shrink-0 whitespace-nowrap text-[length:var(--text-sm-font-size,14px)] not-italic font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]';
 

--- a/src/cook-web/src/components/model-list/ModelList.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 import { ModelOption } from '@/types/shifu';
 
-const MODEL_SELECT_ITEM_INDICATOR_CLASS_NAME = 'left-auto right-3';
+const MODEL_SELECT_ITEM_INDICATOR_CLASS_NAME = 'right-3';
 
 function ModelOptionLabel({
   label,

--- a/src/cook-web/src/components/ui/DropdownMenu.tsx
+++ b/src/cook-web/src/components/ui/DropdownMenu.tsx
@@ -104,13 +104,13 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
     {...props}
   >
-    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+    <span className='absolute right-2 flex h-3.5 w-3.5 items-center justify-center'>
       <DropdownMenuPrimitive.ItemIndicator>
         <Check className='h-4 w-4' />
       </DropdownMenuPrimitive.ItemIndicator>
@@ -128,12 +128,12 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+    <span className='absolute right-2 flex h-3.5 w-3.5 items-center justify-center'>
       <DropdownMenuPrimitive.ItemIndicator>
         <Circle className='h-2 w-2 fill-current' />
       </DropdownMenuPrimitive.ItemIndicator>

--- a/src/cook-web/src/components/ui/Select.tsx
+++ b/src/cook-web/src/components/ui/Select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
-import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import { Check, ChevronDown } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -118,14 +118,14 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
     <span
       className={cn(
-        'absolute left-2 flex h-3.5 w-3.5 items-center justify-center',
+        'absolute right-2 flex h-3.5 w-3.5 items-center justify-center',
         indicatorClassName,
       )}
     >


### PR DESCRIPTION
Summary
- Move shared SelectItem selected indicators to the right side by default.
- Align DropdownMenu checkbox/radio selected indicators with the same right-side placement.
- Remove now-redundant admin page overrides that manually repositioned or hid selected indicators.

Testing
- cd src/cook-web && npm test -- Select.test.tsx ModelList.test.tsx --runInBand
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint
- git diff --check
