### PR TITLE
refactor: share admin paginated list state

### DIFF
--- a/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
+++ b/src/cook-web/src/app/admin/billing/components/BillingRecentActivitySection.tsx
@@ -22,6 +22,7 @@ import {
   registerBillingTranslationUsage,
   resolveBillingLedgerReasonLabel,
 } from '@/lib/billing';
+import { useAdminPaginatedListState } from '@/app/admin/hooks/useAdminPaginatedListState';
 
 const RECENT_ITEMS_LIMIT = 20;
 
@@ -80,8 +81,8 @@ export function BillingRecentActivitySection({
   registerBillingTranslationUsage(t);
   const sectionRef = React.useRef<HTMLElement | null>(null);
   const headingRef = React.useRef<HTMLHeadingElement | null>(null);
-  const [pageIndex, setPageIndex] = React.useState(1);
-  const [pageCount, setPageCount] = React.useState(1);
+  const { pageIndex, pageCount, setPageCount, goToPage } =
+    useAdminPaginatedListState();
   const lastPageIndexRef = React.useRef(pageIndex);
 
   const {
@@ -107,7 +108,7 @@ export function BillingRecentActivitySection({
     if (ledgerData) {
       setPageCount(ledgerPageCount);
     }
-  }, [ledgerData, ledgerPageCount]);
+  }, [ledgerData, ledgerPageCount, setPageCount]);
   React.useEffect(() => {
     if (lastPageIndexRef.current === pageIndex) {
       return;
@@ -123,10 +124,6 @@ export function BillingRecentActivitySection({
     });
     headingRef.current?.focus({ preventScroll: true });
   }, [pageIndex]);
-  const handlePageChange = React.useCallback((nextPage: number) => {
-    setPageIndex(nextPage);
-  }, []);
-
   return (
     <section
       ref={sectionRef}
@@ -164,7 +161,7 @@ export function BillingRecentActivitySection({
               ? {
                   pageIndex: currentPage,
                   pageCount,
-                  onPageChange: handlePageChange,
+                  onPageChange: goToPage,
                   prevLabel: t('module.order.paginationPrev'),
                   nextLabel: t('module.order.paginationNext'),
                   prevAriaLabel: t(

--- a/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.test.tsx
+++ b/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAdminPaginatedListState } from './useAdminPaginatedListState';
+
+describe('useAdminPaginatedListState', () => {
+  test('tracks page changes within bounds', () => {
+    const onPageChange = jest.fn();
+    const { result } = renderHook(() =>
+      useAdminPaginatedListState({
+        initialPageCount: 3,
+        onPageChange,
+      }),
+    );
+
+    expect(result.current.pageIndex).toBe(1);
+    expect(result.current.pageCount).toBe(3);
+
+    act(() => {
+      result.current.goToPage(2);
+    });
+
+    expect(result.current.pageIndex).toBe(2);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+
+    act(() => {
+      result.current.goToPage(99);
+    });
+
+    expect(result.current.pageIndex).toBe(3);
+    expect(onPageChange).toHaveBeenLastCalledWith(3);
+  });
+
+  test('ignores same-page navigation and invalid page values', () => {
+    const onPageChange = jest.fn();
+    const { result } = renderHook(() =>
+      useAdminPaginatedListState({
+        initialPageCount: 3,
+        onPageChange,
+      }),
+    );
+
+    act(() => {
+      result.current.goToPage(1);
+      result.current.goToPage(Number.NaN);
+    });
+
+    expect(result.current.pageIndex).toBe(1);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  test('clamps the current page when page count shrinks', () => {
+    const { result } = renderHook(() =>
+      useAdminPaginatedListState({
+        initialPageCount: 5,
+      }),
+    );
+
+    act(() => {
+      result.current.goToPage(5);
+    });
+    expect(result.current.pageIndex).toBe(5);
+
+    act(() => {
+      result.current.setPageCount(2);
+    });
+
+    expect(result.current.pageCount).toBe(2);
+    expect(result.current.pageIndex).toBe(2);
+  });
+
+  test('resets to the first page', () => {
+    const { result } = renderHook(() =>
+      useAdminPaginatedListState({
+        initialPageCount: 3,
+      }),
+    );
+
+    act(() => {
+      result.current.goToPage(2);
+    });
+    expect(result.current.pageIndex).toBe(2);
+
+    act(() => {
+      result.current.resetPage();
+    });
+
+    expect(result.current.pageIndex).toBe(1);
+  });
+});

--- a/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.ts
@@ -37,17 +37,15 @@ export function useAdminPaginatedListState({
 
   const goToPage = React.useCallback(
     (nextPage: number) => {
-      setPageIndexState(currentPageIndex => {
-        const normalizedNextPage = normalizePageValue(nextPage, currentPageIndex);
-        const clampedNextPage = Math.min(normalizedNextPage, pageCount);
-        if (clampedNextPage === currentPageIndex) {
-          return currentPageIndex;
-        }
-        onPageChange?.(clampedNextPage);
-        return clampedNextPage;
-      });
+      const normalizedNextPage = normalizePageValue(nextPage, pageIndex);
+      const clampedNextPage = Math.min(normalizedNextPage, pageCount);
+      if (clampedNextPage === pageIndex) {
+        return;
+      }
+      setPageIndexState(clampedNextPage);
+      onPageChange?.(clampedNextPage);
     },
-    [onPageChange, pageCount],
+    [onPageChange, pageCount, pageIndex],
   );
 
   const resetPage = React.useCallback(() => {

--- a/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.ts
+++ b/src/cook-web/src/app/admin/hooks/useAdminPaginatedListState.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import * as React from 'react';
+
+type UseAdminPaginatedListStateOptions = {
+  initialPageIndex?: number;
+  initialPageCount?: number;
+  onPageChange?: (nextPage: number) => void;
+};
+
+const normalizePageValue = (value: number | undefined, fallback: number) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+};
+
+export function useAdminPaginatedListState({
+  initialPageIndex = 1,
+  initialPageCount = 1,
+  onPageChange,
+}: UseAdminPaginatedListStateOptions = {}) {
+  const [pageIndex, setPageIndexState] = React.useState(() =>
+    normalizePageValue(initialPageIndex, 1),
+  );
+  const [pageCount, setPageCountState] = React.useState(() =>
+    normalizePageValue(initialPageCount, 1),
+  );
+
+  const setPageCount = React.useCallback((nextPageCount: number) => {
+    const normalizedPageCount = normalizePageValue(nextPageCount, 1);
+    setPageCountState(normalizedPageCount);
+    setPageIndexState(currentPageIndex =>
+      Math.min(currentPageIndex, normalizedPageCount),
+    );
+  }, []);
+
+  const goToPage = React.useCallback(
+    (nextPage: number) => {
+      setPageIndexState(currentPageIndex => {
+        const normalizedNextPage = normalizePageValue(nextPage, currentPageIndex);
+        const clampedNextPage = Math.min(normalizedNextPage, pageCount);
+        if (clampedNextPage === currentPageIndex) {
+          return currentPageIndex;
+        }
+        onPageChange?.(clampedNextPage);
+        return clampedNextPage;
+      });
+    },
+    [onPageChange, pageCount],
+  );
+
+  const resetPage = React.useCallback(() => {
+    goToPage(1);
+  }, [goToPage]);
+
+  return {
+    pageIndex,
+    pageCount,
+    setPageCount,
+    goToPage,
+    resetPage,
+  };
+}


### PR DESCRIPTION
Summary
- Add a shared `useAdminPaginatedListState` hook for admin paginated lists.
- Move BillingRecentActivitySection pagination state onto the shared hook while preserving its existing SWR request, scroll, and focus behavior.
- Add focused hook tests for bounds, invalid values, page-count shrinking, and reset behavior.

Testing
- cd src/cook-web && npm test -- useAdminPaginatedListState.test.tsx BillingRecentActivitySection.test.tsx --runInBand
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized pagination state manager for the admin billing recent activity view.
* **Bug Fixes**
  * Improved page navigation to ignore invalid/duplicate selections and prevent landing on out-of-range pages.
  * Ensured page index stays in sync when the available page count changes and properly resets to the first page.
* **Tests**
  * Added coverage for pagination state behaviors, including clamping and reset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->