### PR TITLE
fix: reuse thinking copy for audio wait

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -171,9 +171,7 @@ describe('ListenModeSlideRenderer', () => {
       />,
     );
 
-    expect(
-      screen.queryByText('module.chat.slideAudioBufferingWaitingForAudio'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('module.chat.thinking')).not.toBeInTheDocument();
     expect(
       screen.getByRole('status', {
         name: 'module.chat.slideAudioBufferingLoadingAudio',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1983,9 +1983,7 @@ const ListenModeSlideRenderer = ({
             copiedButtonText: t('module.renderUi.core.copied'),
           }}
           bufferingText={{
-            waitingForAudio: t(
-              'module.chat.slideAudioBufferingWaitingForAudio',
-            ),
+            waitingForAudio: t('module.chat.thinking'),
             loadingAudio: t('module.chat.slideAudioBufferingLoadingAudio'),
             waitingForMoreAudio: t(
               'module.chat.slideAudioBufferingWaitingForMoreAudio',

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -782,7 +782,6 @@ export type I18nKey =
   | 'module.chat.regenerateConfirmTitle'
   | 'module.chat.slideAudioBuffering'
   | 'module.chat.slideAudioBufferingLoadingAudio'
-  | 'module.chat.slideAudioBufferingWaitingForAudio'
   | 'module.chat.slideAudioBufferingWaitingForMoreAudio'
   | 'module.chat.streamTimeoutRetry'
   | 'module.chat.thinking'

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -52,7 +52,6 @@
   "regenerateConfirmTitle": "Confirm regenerate this content?",
   "slideAudioBuffering": "Buffering...",
   "slideAudioBufferingLoadingAudio": "Loading audio...",
-  "slideAudioBufferingWaitingForAudio": "Waiting for audio...",
   "slideAudioBufferingWaitingForMoreAudio": "Waiting for more audio...",
   "streamTimeoutRetry": "The service timed out. Please refresh and try again.",
   "thinking": "Thinking...",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -52,7 +52,6 @@
   "regenerateConfirmTitle": "Confirmer la régénération de ce contenu ?",
   "slideAudioBuffering": "Mise en mémoire tampon…",
   "slideAudioBufferingLoadingAudio": "Chargement audio…",
-  "slideAudioBufferingWaitingForAudio": "En attente de l’audio…",
   "slideAudioBufferingWaitingForMoreAudio": "En attente de plus d’audio…",
   "streamTimeoutRetry": "Le service a expiré. Veuillez actualiser et réessayer.",
   "thinking": "Réflexion…",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -52,7 +52,6 @@
   "regenerateConfirmTitle": "确定重新生成此内容？",
   "slideAudioBuffering": "正在缓冲中...",
   "slideAudioBufferingLoadingAudio": "正在加载音频",
-  "slideAudioBufferingWaitingForAudio": "正在合成音频",
   "slideAudioBufferingWaitingForMoreAudio": "正在等待音频",
   "streamTimeoutRetry": "系统服务超时，请刷新重试",
   "thinking": "思考中...",


### PR DESCRIPTION
## Summary
- Reuse the existing chat thinking copy for listen-mode audio waiting text.
- Remove the now-unused slideAudioBufferingWaitingForAudio key from all locales and generated i18n types.

## Validation
- python3 scripts/check_dev_tools.py
- git diff --check
- python3 scripts/check_translations.py
- python3 scripts/check_translation_usage.py --fail-on-unused
- npm run test -- --runTestsByPath 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx'
- pre-commit hook suite during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the chat audio buffering message so the correct “thinking”/loading text appears while waiting for more audio.
  * Aligned the displayed status across supported languages, including English, French, and Chinese.

* **Documentation**
  * Refreshed translation labels to match the latest chat status wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->