### PR TITLE
fix: use link icon for publish copy action

### DIFF
--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -16,6 +16,7 @@ import {
   Copy,
   Headphones,
   History,
+  Link2,
   Presentation,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -495,7 +496,7 @@ const Header = ({
                         void copyLearningModeUrl(mode);
                       }}
                     >
-                      <Copy className='h-3.5 w-3.5' />
+                      <Link2 className='h-3.5 w-3.5' />
                     </button>
                   );
                   const rowContent = (


### PR DESCRIPTION
## Summary

- Replaced the publish dropdown copy action icon with a link icon.
- Kept the copy URL behavior, disabled state, tooltip, and tracking unchanged.

## Validation

- `python3 scripts/check_dev_tools.py`
- `cd src/cook-web && npm run type-check`
- `git diff --check`
- pre-commit hooks during commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon used for the publish dropdown’s copy action to a link-style symbol for a clearer visual cue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->