### PR TITLE
fix: reject unavailable minimax custom voice in tts preview

### DIFF
--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -612,6 +612,14 @@ class MinimaxTTSProvider(BaseTTSProvider):
         if status_code != 0:
             status_msg = base_resp.get("status_msg", "Unknown error")
             logger.error(f"Minimax TTS API error: {status_code} - {status_msg}")
+            # 2054 means the requested voice id does not exist on MiniMax (a stale
+            # or foreign clone id that passed local shape validation). Surface it
+            # as an actionable message instead of a generic API error.
+            if status_code == 2054:
+                raise ValueError(
+                    "Minimax TTS voice is not available "
+                    f"(voice id does not exist on provider): {status_msg}"
+                )
             raise ValueError(f"Minimax TTS API error: {status_code} - {status_msg}")
 
         return result

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -20,7 +20,10 @@ from flaskr.service.metering import UsageContext, record_tts_usage
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 from flaskr.service.tts import preprocess_for_tts, resolve_tts_billable_chars
 from flaskr.service.tts.pipeline import split_text_for_tts
-from flaskr.service.tts.validation import validate_tts_settings_strict
+from flaskr.service.tts.validation import (
+    assert_minimax_preview_voice_available,
+    validate_tts_settings_strict,
+)
 from flaskr.util.uuid import generate_id
 
 
@@ -69,6 +72,17 @@ def build_tts_preview_response(
 
     if not is_tts_configured(validated.provider):
         raise_param_error(f"TTS provider is not configured: {validated.provider}")
+
+    # A MiniMax custom (clone) voice id passes local format validation but only
+    # fails at the provider with "2054 - voice id not exist". Verify the id maps
+    # to a ready clone owned by this creator before streaming, so an unavailable
+    # voice returns a clean parameter error instead of a broken preview stream.
+    if validated.provider == "minimax":
+        assert_minimax_preview_voice_available(
+            app,
+            voice_id=validated.voice_id,
+            owner_user_bid=str(request_user_id or "").strip(),
+        )
 
     if len(text) > 200:
         text = text[:200]

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -198,24 +198,30 @@ def assert_minimax_preview_voice_available(
     if normalized_voice_id in built_in_voice_ids:
         return
 
-    with app.app_context():
-        query = TTSMiniMaxClonedVoice.query.filter(
-            TTSMiniMaxClonedVoice.voice_id == normalized_voice_id,
-            TTSMiniMaxClonedVoice.status == TTS_MINIMAX_CLONE_STATUS_READY,
-            TTSMiniMaxClonedVoice.deleted == 0,
-        )
-        normalized_owner = (owner_user_bid or "").strip()
-        if normalized_owner:
-            query = query.filter(
-                TTSMiniMaxClonedVoice.owner_user_bid == normalized_owner
+    # Custom clone voices are private per creator. Always scope the lookup by the
+    # requesting owner so an empty/whitespace owner cannot bypass the filter and
+    # preview another creator's clone. An empty owner therefore matches nothing
+    # and is rejected below, exactly like an unknown voice.
+    normalized_owner = (owner_user_bid or "").strip()
+    ready_clone = None
+    if normalized_owner:
+        with app.app_context():
+            ready_clone = (
+                TTSMiniMaxClonedVoice.query.filter(
+                    TTSMiniMaxClonedVoice.voice_id == normalized_voice_id,
+                    TTSMiniMaxClonedVoice.status == TTS_MINIMAX_CLONE_STATUS_READY,
+                    TTSMiniMaxClonedVoice.deleted == 0,
+                    TTSMiniMaxClonedVoice.owner_user_bid == normalized_owner,
+                )
+                .order_by(TTSMiniMaxClonedVoice.id.desc())
+                .first()
             )
-        ready_clone = query.order_by(TTSMiniMaxClonedVoice.id.desc()).first()
 
     if ready_clone is None:
         app.logger.warning(
             "Rejecting MiniMax preview voice_id %s for owner %s: "
             "no ready cloned voice found",
             normalized_voice_id,
-            (owner_user_bid or "").strip() or "-",
+            normalized_owner or "-",
         )
         _raise_param_error(f"TTS voice is not available: {normalized_voice_id}")

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from flask import Flask
+
 from flaskr.api.tts import get_tts_provider
 from flaskr.service.common.models import raise_error_with_args
 from flaskr.service.tts.minimax_voice_clone import is_valid_minimax_custom_voice_id
+from flaskr.service.tts.models import (
+    TTSMiniMaxClonedVoice,
+    TTS_MINIMAX_CLONE_STATUS_READY,
+)
 
 
 SUPPORTED_TTS_PROVIDERS = {
@@ -164,3 +170,52 @@ def validate_tts_settings_strict(
         pitch=pitch_value,
         emotion=emotion_value,
     )
+
+
+def assert_minimax_preview_voice_available(
+    app: Flask, *, voice_id: str, owner_user_bid: str
+) -> None:
+    """Reject a MiniMax preview voice id that would fail at the provider.
+
+    Built-in MiniMax voices are always allowed. A custom (clone) voice id shares
+    the same character shape as built-in ids, so it passes local format
+    validation even when it was never created, has failed, or belongs to another
+    account. Such an id only surfaces as ``2054 - voice id not exist`` after the
+    external call, aborting the preview stream. Fail fast instead: accept a
+    custom id only when a ready, non-deleted clone row exists and belongs to the
+    requesting creator.
+    """
+    normalized_voice_id = (voice_id or "").strip()
+    if not normalized_voice_id:
+        _raise_param_error("TTS voice_id is required when TTS is enabled")
+
+    provider_config = get_tts_provider("minimax").get_provider_config()
+    built_in_voice_ids = {
+        (voice.get("value") or "").strip()
+        for voice in (provider_config.voices or [])
+        if (voice.get("value") or "").strip()
+    }
+    if normalized_voice_id in built_in_voice_ids:
+        return
+
+    with app.app_context():
+        query = TTSMiniMaxClonedVoice.query.filter(
+            TTSMiniMaxClonedVoice.voice_id == normalized_voice_id,
+            TTSMiniMaxClonedVoice.status == TTS_MINIMAX_CLONE_STATUS_READY,
+            TTSMiniMaxClonedVoice.deleted == 0,
+        )
+        normalized_owner = (owner_user_bid or "").strip()
+        if normalized_owner:
+            query = query.filter(
+                TTSMiniMaxClonedVoice.owner_user_bid == normalized_owner
+            )
+        ready_clone = query.order_by(TTSMiniMaxClonedVoice.id.desc()).first()
+
+    if ready_clone is None:
+        app.logger.warning(
+            "Rejecting MiniMax preview voice_id %s for owner %s: "
+            "no ready cloned voice found",
+            normalized_voice_id,
+            (owner_user_bid or "").strip() or "-",
+        )
+        _raise_param_error(f"TTS voice is not available: {normalized_voice_id}")

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+import pytest
 from flask import Flask
 
+from flaskr.service.common.models import AppException, ERROR_CODE
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 from flaskr.service.shifu.tts_preview import build_tts_preview_response
 
@@ -210,3 +212,59 @@ def test_build_tts_preview_response_normalizes_removed_fields(monkeypatch) -> No
 
     assert captured["pitch"] == 0
     assert captured["emotion"] == ""
+
+
+def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> None:
+    app = Flask(__name__)
+    guard_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.validate_tts_settings_strict",
+        lambda **_kwargs: SimpleNamespace(
+            provider="minimax",
+            model="speech-2.8-turbo",
+            voice_id="AiShifu_missing_voice",
+            speed=1.0,
+            pitch=0,
+            emotion="",
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.is_tts_configured",
+        lambda _provider: True,
+        raising=False,
+    )
+
+    def _fake_guard(_app, *, voice_id, owner_user_bid):
+        guard_calls.append({"voice_id": voice_id, "owner_user_bid": owner_user_bid})
+        raise AppException("voice unavailable", ERROR_CODE["server.common.paramsError"])
+
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.assert_minimax_preview_voice_available",
+        _fake_guard,
+        raising=False,
+    )
+
+    with app.test_request_context("/api/shifu/tts/preview", method="POST"):
+        with pytest.raises(AppException) as exc_info:
+            build_tts_preview_response(
+                {
+                    "provider": "minimax",
+                    "model": "speech-2.8-turbo",
+                    "voice_id": "AiShifu_missing_voice",
+                    "speed": 1.0,
+                    "text": "hello",
+                },
+                request_user_id="creator-debug-tts-1",
+                request_user_is_creator=True,
+            )
+
+    # The guard runs before any streaming/synthesis and blocks the request.
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+    assert guard_calls == [
+        {
+            "voice_id": "AiShifu_missing_voice",
+            "owner_user_bid": "creator-debug-tts-1",
+        }
+    ]

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -9,7 +9,11 @@ from flaskr.service.common.models import AppException, ERROR_CODE
 from flaskr.service.tts.validation import (
     assert_minimax_preview_voice_available,
 )
-from flaskr.service.tts.models import TTSMiniMaxClonedVoice
+from flaskr.service.tts.models import (
+    TTSMiniMaxClonedVoice,
+    TTS_MINIMAX_CLONE_STATUS_FAILED,
+    TTS_MINIMAX_CLONE_STATUS_READY,
+)
 
 
 _BUILT_IN_VOICE_ID = "female-shaonv"
@@ -62,7 +66,12 @@ def test_built_in_voice_is_always_allowed(app):
 
 def test_ready_clone_owned_by_requester_is_allowed(app):
     _prepare_tables(app)
-    _seed_clone(app, voice_id="AiShifu_ready_1", owner="creator-1", status="ready")
+    _seed_clone(
+        app,
+        voice_id="AiShifu_ready_1",
+        owner="creator-1",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+    )
     with app.app_context():
         assert_minimax_preview_voice_available(
             app, voice_id="AiShifu_ready_1", owner_user_bid="creator-1"
@@ -71,7 +80,12 @@ def test_ready_clone_owned_by_requester_is_allowed(app):
 
 def test_ready_clone_owned_by_another_user_is_rejected(app):
     _prepare_tables(app)
-    _seed_clone(app, voice_id="AiShifu_ready_2", owner="other-creator", status="ready")
+    _seed_clone(
+        app,
+        voice_id="AiShifu_ready_2",
+        owner="other-creator",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+    )
     with app.app_context():
         with pytest.raises(AppException) as exc_info:
             assert_minimax_preview_voice_available(
@@ -80,13 +94,83 @@ def test_ready_clone_owned_by_another_user_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
+def test_isolation_when_same_voice_id_has_different_owners(app):
+    """Two clones share the same voice_id but differ by owner: the requester
+    only matches their own row, never the foreign one."""
+    _prepare_tables(app)
+    _seed_clone(
+        app,
+        voice_id="AiShifu_shared_id",
+        owner="creator-1",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+    )
+    _seed_clone(
+        app,
+        voice_id="AiShifu_shared_id",
+        owner="creator-2",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+    )
+    with app.app_context():
+        # creator-1 owns a ready clone with this id -> allowed.
+        assert_minimax_preview_voice_available(
+            app, voice_id="AiShifu_shared_id", owner_user_bid="creator-1"
+        )
+        # creator-3 owns none -> rejected even though the id exists for others.
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_shared_id", owner_user_bid="creator-3"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_custom_voice_with_empty_owner_is_rejected(app):
+    """An empty owner must not bypass owner scoping and match any ready clone."""
+    _prepare_tables(app)
+    _seed_clone(
+        app,
+        voice_id="AiShifu_ready_owned",
+        owner="creator-1",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+    )
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_ready_owned", owner_user_bid=""
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
 def test_failed_clone_is_rejected(app):
     _prepare_tables(app)
-    _seed_clone(app, voice_id="AiShifu_failed_1", owner="creator-1", status="failed")
+    _seed_clone(
+        app,
+        voice_id="AiShifu_failed_1",
+        owner="creator-1",
+        status=TTS_MINIMAX_CLONE_STATUS_FAILED,
+    )
     with app.app_context():
         with pytest.raises(AppException) as exc_info:
             assert_minimax_preview_voice_available(
                 app, voice_id="AiShifu_failed_1", owner_user_bid="creator-1"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_deleted_clone_is_rejected(app):
+    """A ready, owned clone that has been soft-deleted is rejected like an
+    unknown voice."""
+    _prepare_tables(app)
+    _seed_clone(
+        app,
+        voice_id="AiShifu_deleted_1",
+        owner="creator-1",
+        status=TTS_MINIMAX_CLONE_STATUS_READY,
+        deleted=1,
+    )
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_deleted_1", owner_user_bid="creator-1"
             )
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from flaskr.dao import db
+from flaskr.service.common.models import AppException, ERROR_CODE
+from flaskr.service.tts.validation import (
+    assert_minimax_preview_voice_available,
+)
+from flaskr.service.tts.models import TTSMiniMaxClonedVoice
+
+
+_BUILT_IN_VOICE_ID = "female-shaonv"
+
+
+@pytest.fixture(autouse=True)
+def _fake_minimax_provider(monkeypatch):
+    """Isolate the guard from real provider config/credentials."""
+    provider = SimpleNamespace(
+        get_provider_config=lambda: SimpleNamespace(
+            voices=[{"value": _BUILT_IN_VOICE_ID, "label": "少女音色"}]
+        )
+    )
+    monkeypatch.setattr(
+        "flaskr.service.tts.validation.get_tts_provider",
+        lambda _name: provider,
+        raising=False,
+    )
+
+
+def _prepare_tables(app) -> None:
+    with app.app_context():
+        TTSMiniMaxClonedVoice.__table__.create(db.engine, checkfirst=True)
+
+
+def _seed_clone(app, *, voice_id: str, owner: str, status: str, deleted: int = 0):
+    with app.app_context():
+        db.session.add(
+            TTSMiniMaxClonedVoice(
+                voice_bid=f"vb-{voice_id}-{owner}",
+                owner_user_bid=owner,
+                shifu_bid="",
+                display_name=voice_id,
+                voice_id=voice_id,
+                status=status,
+                deleted=deleted,
+            )
+        )
+        db.session.commit()
+
+
+def test_built_in_voice_is_always_allowed(app):
+    _prepare_tables(app)
+    with app.app_context():
+        # No clone rows, unknown owner: a built-in voice must still pass.
+        assert_minimax_preview_voice_available(
+            app, voice_id=_BUILT_IN_VOICE_ID, owner_user_bid=""
+        )
+
+
+def test_ready_clone_owned_by_requester_is_allowed(app):
+    _prepare_tables(app)
+    _seed_clone(app, voice_id="AiShifu_ready_1", owner="creator-1", status="ready")
+    with app.app_context():
+        assert_minimax_preview_voice_available(
+            app, voice_id="AiShifu_ready_1", owner_user_bid="creator-1"
+        )
+
+
+def test_ready_clone_owned_by_another_user_is_rejected(app):
+    _prepare_tables(app)
+    _seed_clone(app, voice_id="AiShifu_ready_2", owner="other-creator", status="ready")
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_ready_2", owner_user_bid="creator-1"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_failed_clone_is_rejected(app):
+    _prepare_tables(app)
+    _seed_clone(app, voice_id="AiShifu_failed_1", owner="creator-1", status="failed")
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_failed_1", owner_user_bid="creator-1"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_unknown_custom_voice_is_rejected(app):
+    _prepare_tables(app)
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="AiShifu_does_not_exist", owner_user_bid="creator-1"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
+
+
+def test_empty_voice_id_is_rejected(app):
+    _prepare_tables(app)
+    with app.app_context():
+        with pytest.raises(AppException) as exc_info:
+            assert_minimax_preview_voice_available(
+                app, voice_id="   ", owner_user_bid="creator-1"
+            )
+    assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]


### PR DESCRIPTION
## Problem

Production alert (2026-07-09) from `/api/shifu/tts/preview`:

```
Minimax TTS API error: 2054 - voice id not exist
TTS preview stream failed  (ValueError raised, stream aborts with a generic 500)
```

Root cause: for MiniMax, a custom (clone) voice id is accepted by
`validate_tts_settings_strict` on a **format-only** regex check
(`is_valid_minimax_custom_voice_id`). Any string with the right shape — a stale,
failed, deleted, or foreign-account clone id — passes local validation and is
sent to MiniMax, which rejects it with `2054 - voice id not exist`. The learner
runtime path (`_resolve_runtime_tts_voice_id`) already verifies the clone is a
`ready` row and falls back, but **preview had no such check**.

## Changed

- Added `assert_minimax_preview_voice_available` to the TTS validation module:
  built-in voices are always allowed; a custom id is accepted only when a
  `ready`, non-deleted clone row **owned by the requesting creator** exists,
  otherwise a clean `paramsError` is returned before any streaming starts.
- Wired it into `build_tts_preview_response` (MiniMax provider only).
- Mapped MiniMax status code `2054` in the provider to an explicit
  "voice is not available" error instead of a generic API error, for the
  residual drift case (row `ready` locally but deleted on MiniMax).

## Tests

- New `tests/service/tts/test_minimax_preview_voice_guard.py`: built-in allowed;
  ready+owned allowed; ready-but-foreign-owner rejected; failed rejected;
  unknown rejected; empty rejected.
- Extended `tests/service/shifu/test_tts_preview_helper.py`: the guard runs and
  blocks the preview before synthesis for an unavailable custom voice.
- Full `tests/service/tts` + `tests/service/shifu` green (403 passed);
  `lefthook run pre-commit` gates pass.

## Notes

- Scoped to the preview path (the alert surface). Learner runtime already had
  its own resilient resolver; this change does not touch it.
- Owner scoping is by `owner_user_bid == request_user_id`; preview carries no
  `shifu_bid`, so cross-creator shared clones are intentionally rejected in
  preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MiniMax voice preview validation so unavailable custom voices now fail fast with a clear parameter error instead of a broken preview.
  * Added more specific error messaging when the provider reports an unavailable voice ID.
* **Tests**
  * Added coverage for built-in voices, owned clone voices, invalid ownership, failed clones, unknown voices, and empty voice IDs.
  * Verified preview requests are blocked before streaming when the voice is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->