### PR TITLE
refactor: share admin overview filter actions

### DIFF
--- a/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.test.tsx
@@ -113,4 +113,38 @@ describe('AdminMetricCardGroup', () => {
       screen.getByText('Failed notifications').closest('.rounded-lg'),
     ).toHaveClass('has-[.metric-control:hover]:border-primary/30');
   });
+
+  test('renders shared stale warning and active filter chip', () => {
+    const onClear = jest.fn();
+
+    render(
+      <AdminMetricCardGroup
+        title='Order overview'
+        staleMessage='Showing the last successful overview'
+        activeFilter={{
+          label: 'Active filter',
+          value: 'Paid orders',
+          clearAriaLabel: 'Paid orders Clear',
+          onClear,
+        }}
+        items={[
+          {
+            key: 'paid',
+            label: 'Paid orders',
+            value: 5,
+            tooltip: 'Paid order records',
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText('Showing the last successful overview'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Active filter')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Paid orders Clear' }));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { X } from 'lucide-react';
+import { AlertCircle, X } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
@@ -139,8 +139,9 @@ export function AdminMetricCardGroup({
   const grid = (
     <>
       {staleMessage ? (
-        <div className='mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
-          {staleMessage}
+        <div className='mb-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
+          <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' />
+          <span>{staleMessage}</span>
         </div>
       ) : null}
       <TooltipProvider delayDuration={tooltipDelayDuration}>

--- a/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
+++ b/src/cook-web/src/app/admin/components/AdminMetricCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import { X } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
@@ -18,6 +19,13 @@ export type AdminMetricCardItem = {
   onClick?: () => void;
 };
 
+export type AdminMetricCardActiveFilter = {
+  label: ReactNode;
+  value: ReactNode;
+  clearAriaLabel: string;
+  onClear: () => void;
+};
+
 type AdminMetricCardProps = Omit<AdminMetricCardItem, 'key'> & {
   hoverMode?: AdminMetricCardHoverMode;
   className?: string;
@@ -32,6 +40,8 @@ type AdminMetricCardGroupProps = {
   cardHoverMode?: AdminMetricCardHoverMode;
   tooltipDelayDuration?: number;
   valueClassName?: string;
+  staleMessage?: ReactNode;
+  activeFilter?: AdminMetricCardActiveFilter | null;
 };
 
 const CARD_CLASS = 'rounded-lg border border-border/70 bg-muted/20 p-4';
@@ -123,23 +133,48 @@ export function AdminMetricCardGroup({
   cardHoverMode = 'card',
   tooltipDelayDuration = 150,
   valueClassName,
+  staleMessage,
+  activeFilter,
 }: AdminMetricCardGroupProps) {
   const grid = (
-    <TooltipProvider delayDuration={tooltipDelayDuration}>
-      <div className={cn('grid gap-3', gridClassName)}>
-        {items.map(item => (
-          <AdminMetricCard
-            key={item.key}
-            label={item.label}
-            value={item.value}
-            tooltip={item.tooltip}
-            onClick={item.onClick}
-            hoverMode={cardHoverMode}
-            valueClassName={valueClassName}
-          />
-        ))}
-      </div>
-    </TooltipProvider>
+    <>
+      {staleMessage ? (
+        <div className='mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
+          {staleMessage}
+        </div>
+      ) : null}
+      <TooltipProvider delayDuration={tooltipDelayDuration}>
+        <div className={cn('grid gap-3', gridClassName)}>
+          {items.map(item => (
+            <AdminMetricCard
+              key={item.key}
+              label={item.label}
+              value={item.value}
+              tooltip={item.tooltip}
+              onClick={item.onClick}
+              hoverMode={cardHoverMode}
+              valueClassName={valueClassName}
+            />
+          ))}
+        </div>
+      </TooltipProvider>
+      {activeFilter ? (
+        <div className='mt-4 flex flex-wrap items-center gap-2'>
+          <span className='text-sm text-muted-foreground'>
+            {activeFilter.label}
+          </span>
+          <button
+            type='button'
+            aria-label={activeFilter.clearAriaLabel}
+            className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
+            onClick={activeFilter.onClear}
+          >
+            <span>{activeFilter.value}</span>
+            <X className='h-3.5 w-3.5' />
+          </button>
+        </div>
+      ) : null}
+    </>
   );
 
   if (!title) {

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationOverviewCards.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationOverviewCards.tsx
@@ -1,11 +1,5 @@
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { AdminMetricCardGroup } from '@/app/admin/components/AdminMetricCard';
 import type { AdminOperationCreditNotificationOverview } from '../operation-credit-notification-types';
 import type { NotificationOverviewCardKey } from './creditNotificationUtils';
 
@@ -55,45 +49,12 @@ export function CreditNotificationOverviewCards({
   ];
 
   return (
-    <TooltipProvider delayDuration={150}>
-      <div className='grid gap-3 md:grid-cols-3 xl:grid-cols-5'>
-        {overviewItems.map(item => (
-          <div
-            key={item.key}
-            className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
-          >
-            <div className='flex items-start justify-between gap-2'>
-              <button
-                type='button'
-                aria-label={item.label}
-                className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                onClick={() => applyOverviewFilter(item.key)}
-              >
-                <div className='text-sm text-muted-foreground'>
-                  {item.label}
-                </div>
-                <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                  {item.value}
-                </div>
-              </button>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type='button'
-                    aria-label={item.tooltip}
-                    className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                  >
-                    <QuestionMarkCircleIcon className='h-4 w-4' />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent className='max-w-56 text-left leading-5'>
-                  {item.tooltip}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-        ))}
-      </div>
-    </TooltipProvider>
+    <AdminMetricCardGroup
+      items={overviewItems.map(item => ({
+        ...item,
+        onClick: () => applyOverviewFilter(item.key),
+      }))}
+      gridClassName='md:grid-cols-3 xl:grid-cols-5'
+    />
   );
 }

--- a/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/OrderOverviewSection.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { X } from 'lucide-react';
 import { AdminMetricCardGroup } from '@/app/admin/components/AdminMetricCard';
 import { cn } from '@/lib/utils';
 
@@ -35,41 +34,24 @@ export default function OrderOverviewSection({
   gridClassName,
 }: OrderOverviewSectionProps) {
   return (
-    <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm'>
-      <div className='mb-3'>
-        <h2 className='text-base font-semibold text-foreground'>{title}</h2>
-      </div>
-
-      {staleMessage ? (
-        <div className='mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
-          {staleMessage}
-        </div>
-      ) : null}
-
-      <AdminMetricCardGroup
-        items={cards}
-        gridClassName={cn(
-          'grid-cols-2 md:grid-cols-3 xl:grid-cols-4 min-[1680px]:grid-cols-6',
-          gridClassName,
-        )}
-      />
-
-      {activeCardLabel && onClearActive ? (
-        <div className='mt-4 flex flex-wrap items-center gap-2'>
-          <span className='text-sm text-muted-foreground'>
-            {activeFilterLabel}
-          </span>
-          <button
-            type='button'
-            aria-label={`${activeCardLabel} ${clearLabel}`}
-            className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
-            onClick={onClearActive}
-          >
-            <span>{activeCardLabel}</span>
-            <X className='h-3.5 w-3.5' />
-          </button>
-        </div>
-      ) : null}
-    </div>
+    <AdminMetricCardGroup
+      title={title}
+      items={cards}
+      gridClassName={cn(
+        'grid-cols-2 md:grid-cols-3 xl:grid-cols-4 min-[1680px]:grid-cols-6',
+        gridClassName,
+      )}
+      staleMessage={staleMessage}
+      activeFilter={
+        activeCardLabel && onClearActive
+          ? {
+              label: activeFilterLabel,
+              value: activeCardLabel,
+              clearAriaLabel: `${activeCardLabel} ${clearLabel}`,
+              onClear: onClearActive,
+            }
+          : null
+      }
+    />
   );
 }

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -2,8 +2,6 @@
 
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { AlertCircle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useSWRConfig } from 'swr';
 import api from '@/api';
@@ -15,6 +13,7 @@ import AdminTitle from '@/app/admin/components/AdminTitle';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import AdminTooltipText from '@/app/admin/components/AdminTooltipText';
 import AdminRowActions from '@/app/admin/components/AdminRowActions';
+import { AdminMetricCardGroup } from '@/app/admin/components/AdminMetricCard';
 import {
   formatAdminCount,
   formatAdminCredits,
@@ -55,12 +54,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { useEnvStore } from '@/c-store';
 import type { EnvStoreState } from '@/c-types/store';
 import { BILLING_OVERVIEW_SWR_KEY } from '@/hooks/useBillingData';
@@ -1081,76 +1075,35 @@ export default function AdminOperationUsersPage() {
           <AdminBreadcrumb items={[{ label: tOperationsUsers('title') }]} />
           <AdminTitle title={tOperationsUsers('title')} />
 
-          <div className='mb-5 rounded-xl border border-border bg-white p-4 shadow-sm'>
-            <div className='mb-3'>
-              <h2 className='text-base font-semibold text-foreground'>
-                {tOperationsUsers('overview.title')}
-              </h2>
-            </div>
-            {userOverviewError ? (
-              <div className='mb-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800'>
-                <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' />
-                <span>{tOperationsUsers('overview.staleData')}</span>
-              </div>
-            ) : null}
-            <div className='grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-5'>
-              {overviewCards.map(card => (
-                <div
-                  key={card.key}
-                  className='rounded-lg border border-border/70 bg-muted/20 p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.04]'
-                >
-                  <div className='flex items-start justify-between gap-2'>
-                    <button
-                      type='button'
-                      aria-label={card.label}
-                      className='group min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                      onClick={() => applyQuickFilter(card.quickFilterKey)}
-                    >
-                      <div className='text-sm text-muted-foreground'>
-                        {card.label}
-                      </div>
-                      <div className='mt-3 text-2xl font-semibold text-foreground transition-colors group-hover:text-primary'>
-                        {formatAdminCount(card.value, i18n.language)}
-                      </div>
-                    </button>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type='button'
-                          aria-label={card.tooltip}
-                          className='inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2'
-                        >
-                          <QuestionMarkCircleIcon className='h-4 w-4' />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent className='max-w-56 text-left leading-5'>
-                        {card.tooltip}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+          <AdminMetricCardGroup
+            title={tOperationsUsers('overview.title')}
+            items={overviewCards.map(card => ({
+              key: card.key,
+              label: card.label,
+              value: formatAdminCount(card.value, i18n.language),
+              tooltip: card.tooltip,
+              onClick: () => applyQuickFilter(card.quickFilterKey),
+            }))}
+            gridClassName='grid-cols-2 md:grid-cols-4 xl:grid-cols-5'
+            staleMessage={
+              userOverviewError ? tOperationsUsers('overview.staleData') : null
+            }
+            activeFilter={
+              activeQuickFilterCard
+                ? {
+                    label: tOperationsUsers('overview.activeFilter'),
+                    value: activeQuickFilterCard.label,
+                    clearAriaLabel: `${activeQuickFilterCard.label} ${t(
+                      'common.core.close',
+                    )}`,
+                    onClear: () => applyQuickFilter(''),
+                  }
+                : null
+            }
+          />
 
           <div className='rounded-xl border border-border bg-white p-4 mb-5 shadow-sm transition-all'>
             <div className='space-y-4'>
-              {activeQuickFilterCard ? (
-                <div className='flex flex-wrap items-center gap-2'>
-                  <span className='text-sm text-muted-foreground'>
-                    {tOperationsUsers('overview.activeFilter')}
-                  </span>
-                  <button
-                    type='button'
-                    aria-label={`${activeQuickFilterCard.label} ${t('common.core.close')}`}
-                    className='inline-flex items-center gap-1 rounded-full border border-border bg-muted/30 px-3 py-1 text-sm text-foreground transition-colors hover:bg-muted'
-                    onClick={() => applyQuickFilter('')}
-                  >
-                    <span>{activeQuickFilterCard.label}</span>
-                    <X className='h-3.5 w-3.5' />
-                  </button>
-                </div>
-              ) : null}
               <AdminFilter
                 items={[
                   ...expandedFirstRowFilterItems,


### PR DESCRIPTION
Summary
- Extend AdminMetricCardGroup with shared stale-warning and active-filter chip rendering.
- Reuse the shared overview behavior in admin users, learn orders, credit orders, and credit notification overview cards.
- Keep page-specific quick-filter and request logic local; this PR only consolidates the UI/action shell.

Testing
- cd src/cook-web && npm test -- AdminMetricCard.test.tsx LearnOrdersTab.test.tsx CreditOrdersTab.test.tsx operations/users/page.test.tsx operations/credit-notifications/page.test.tsx --runInBand
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint
- cd src/cook-web && npm run format:check:changed
- git diff --check

Notes
- Local user-page tests still print existing React act warnings, but the suite passes.
- Local npm install was run after pulling main to refresh node_modules for the current markdown-flow-ui types; package-lock changes were not kept.
