### PR TITLE
fix: add temporary host-side patch for variable-free inputs

### DIFF
--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2247,6 +2247,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
                 {"role": "assistant", "content": "ok"},
             ],
         )
+        self.assertTrue(all("?[" not in message["content"] for message in messages))
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2166,10 +2166,10 @@ class BuildContextFromBlocksTests(unittest.TestCase):
 
 
 class BuildContextNoVariableInteractionTests(unittest.TestCase):
-    """No-variable button interactions (e.g. ?[A | B | C]) carry a real learner
-    choice, but markdown-flow has no variable to recover it from and would
-    collapse the turn into {user: "ok"} + {assistant: "ok"}, dropping the
-    selection. build_context_from_blocks must reuse the choice captured in
+    """No-variable interactions carry a real learner answer, but markdown-flow
+    has no variable to recover it from and would collapse the turn into
+    {user: "ok"} + {assistant: "ok"}, dropping the answer.
+    build_context_from_blocks must reuse the value captured in
     generated_content, and skip the turn entirely when it is empty."""
 
     DOC = (
@@ -2227,6 +2227,24 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             [
                 {"role": "user", "content": "Content one."},
                 {"role": "assistant", "content": "reply zero"},
+            ],
+        )
+
+    def test_variable_free_text_input_reuses_the_learner_answer(self):
+        document = "Content one.\n---\n?[...What is your name?]\n---\nSecond content."
+        app = Flask(__name__)
+        with app.app_context():
+            messages = MdflowContextV2.build_context_from_blocks(
+                self._blocks("Alice"), document, {}
+            )
+
+        self.assertEqual(
+            messages,
+            [
+                {"role": "user", "content": "Content one."},
+                {"role": "assistant", "content": "reply zero"},
+                {"role": "user", "content": "Alice"},
+                {"role": "assistant", "content": "ok"},
             ],
         )
 

--- a/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/content-block-pay-interaction.test.tsx
@@ -99,6 +99,45 @@ describe('ContentBlock pay interaction overrides', () => {
     );
   });
 
+  it('adapts a variable-free ellipsis interaction into a text input', () => {
+    const onSend = jest.fn();
+    render(
+      <ContentBlock
+        item={
+          {
+            type: 'interaction',
+            content: '?[...你叫什么名字]',
+            element_bid: 'anonymous-input',
+            readonly: false,
+            user_input: '小明',
+          } as any
+        }
+        mobileStyle={false}
+        blockBid='anonymous-input'
+        onSend={onSend}
+      />,
+    );
+
+    const contentRenderProps = mockContentRender.mock.calls[0]?.[0];
+    expect(contentRenderProps).toEqual(
+      expect.objectContaining({
+        content:
+          '<custom-variable placeholder="你叫什么名字"></custom-variable>',
+        userInput: '小明',
+      }),
+    );
+
+    const onContentRenderSend = contentRenderProps?.onSend as
+      | ((content: Record<string, unknown>) => void)
+      | undefined;
+    onContentRenderSend?.({ variableName: '', inputText: '小红' });
+
+    expect(onSend).toHaveBeenCalledWith(
+      { variableName: '', inputText: '小红' },
+      'anonymous-input',
+    );
+  });
+
   it('enables typewriter only for text elements marked as typewriter candidates', () => {
     render(
       <ContentBlock

--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -1,0 +1,27 @@
+import { adaptMarkdownFlowInteractionForRender } from '@/c-utils/markdown-flow-interaction';
+
+describe('adaptMarkdownFlowInteractionForRender', () => {
+  it('adapts a variable-free ellipsis interaction into input markup', () => {
+    expect(adaptMarkdownFlowInteractionForRender('?[...你叫什么名字]')).toBe(
+      '<custom-variable placeholder="你叫什么名字"></custom-variable>',
+    );
+  });
+
+  it('escapes the prompt when adapting it into an HTML attribute', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender('?[...输入 "昵称" & <个人标签>]'),
+    ).toBe(
+      '<custom-variable placeholder="输入 &quot;昵称&quot; &amp; &lt;个人标签&gt;"></custom-variable>',
+    );
+  });
+
+  it.each([
+    '?[继续]',
+    '?[%{{name}}...你叫什么名字]',
+    '?[...]',
+    '示例：?[...你叫什么名字]',
+    '?[...你叫什么名字]\n?[继续]',
+  ])('keeps non-target interaction content unchanged: %s', content => {
+    expect(adaptMarkdownFlowInteractionForRender(content)).toBe(content);
+  });
+});

--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -9,9 +9,11 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
 
   it('escapes the prompt when adapting it into an HTML attribute', () => {
     expect(
-      adaptMarkdownFlowInteractionForRender('?[...输入 "昵称" & <个人标签>]'),
+      adaptMarkdownFlowInteractionForRender(
+        '?[...输入 "昵称"、\'代号\' & <个人标签>]',
+      ),
     ).toBe(
-      '<custom-variable placeholder="输入 &quot;昵称&quot; &amp; &lt;个人标签&gt;"></custom-variable>',
+      '<custom-variable placeholder="输入 &quot;昵称&quot;、&#39;代号&#39; &amp; &lt;个人标签&gt;"></custom-variable>',
     );
   });
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -301,6 +301,64 @@ describe('ListenModeSlideRenderer', () => {
     );
   });
 
+  it('adapts a variable-free ellipsis interaction into a slide text input', () => {
+    const onSend = jest.fn();
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Hello',
+            element_bid: 'content-1',
+            is_speakable: true,
+          },
+          {
+            type: 'interaction',
+            content: '?[...你叫什么名字]',
+            element_bid: 'anonymous-input',
+            user_input: '小明',
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        onSend={onSend}
+      />,
+    );
+
+    const slideProps = getMockSlide().mock.calls[0]?.[0] as
+      | {
+          elementList?: Array<Record<string, unknown>>;
+          onSend?: (
+            content: Record<string, unknown>,
+            element?: Record<string, unknown>,
+          ) => void;
+        }
+      | undefined;
+    const interactionElement = slideProps?.elementList?.find(
+      element => element.blockBid === 'anonymous-input',
+    );
+
+    expect(interactionElement).toEqual(
+      expect.objectContaining({
+        content:
+          '<custom-variable placeholder="你叫什么名字"></custom-variable>',
+        user_input: '小明',
+      }),
+    );
+
+    act(() => {
+      slideProps?.onSend?.(
+        { variableName: '', inputText: '小红' },
+        interactionElement,
+      );
+    });
+
+    expect(onSend).toHaveBeenCalledWith(
+      { variableName: '', inputText: '小红' },
+      'anonymous-input',
+    );
+  });
+
   it('keeps the next lesson system interaction clickable when lesson feedback follows', () => {
     render(
       <ListenModeSlideRenderer

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/Popover';
 import { lessonFeedbackInteractionDefaultValueOptions } from '@/c-utils/lesson-feedback-interaction-defaults';
 import { resolveInteractionSubmission } from '@/c-utils/interaction-user-input';
+import { adaptMarkdownFlowInteractionForRender } from '@/c-utils/markdown-flow-interaction';
 import { isLessonFeedbackInteractionContent } from '@/c-utils/lesson-feedback-interaction';
 import {
   isSystemInteractionContent,
@@ -605,6 +606,7 @@ const buildSlideElementList = ({
     const askList = askListByAnchorElementBid.get(item.element_bid);
 
     sequenceNumber += 1;
+    const localizedContent = localizeSystemContent(item.content || '');
     elementList.push({
       sequence_number: resolveRenderSequence({
         item,
@@ -612,7 +614,7 @@ const buildSlideElementList = ({
         fallbackSequence: sequenceNumber,
       }),
       type: 'interaction',
-      content: localizeSystemContent(item.content || ''),
+      content: adaptMarkdownFlowInteractionForRender(localizedContent),
       is_marker: item.is_marker ?? true,
       is_renderable: item.is_renderable ?? true,
       is_new: item.is_new ?? true,

--- a/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
+++ b/src/cook-web/src/c-components/ChatUi/ContentBlock.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/c-utils/system-interaction';
 import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 import { resolveMarkdownFlowLocale } from '@/lib/markdown-flow-locale';
+import { adaptMarkdownFlowInteractionForRender } from '@/c-utils/markdown-flow-interaction';
 
 interface ContentBlockProps {
   item: ChatContentItem;
@@ -112,6 +113,10 @@ const ContentBlock = memo(
       shouldEnableTypewriter || shouldRenderExternalCustomButton
         ? (stripCustomButtonAfterContent(localizedContent) ?? '')
         : localizedContent;
+    const markdownFlowContent =
+      item.type === ChatContentItemType.INTERACTION
+        ? adaptMarkdownFlowInteractionForRender(renderedContent)
+        : renderedContent;
     const externalCustomButtonInnerHtml = shouldRenderExternalCustomButton
       ? extractCustomButtonAfterContentInnerHtml(localizedContent)
       : '';
@@ -137,7 +142,7 @@ const ContentBlock = memo(
           locale={markdownFlowLocale}
           enableTypewriter={shouldEnableTypewriter}
           typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
-          content={renderedContent}
+          content={markdownFlowContent}
           onClickCustomButtonAfterContent={handleClick}
           customRenderBar={item.customRenderBar}
           userInput={resolvedUserInput}

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -4,6 +4,7 @@ const escapeHtmlAttribute = (value: string) =>
   value
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/\r/g, '&#13;')

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -1,0 +1,22 @@
+const ANONYMOUS_TEXT_INPUT_PATTERN = /^(\s*)\?\[\s*\.\.\.([^\]]*?)\](\s*)$/;
+
+const escapeHtmlAttribute = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\r/g, '&#13;')
+    .replace(/\n/g, '&#10;');
+
+export const adaptMarkdownFlowInteractionForRender = (content: string) => {
+  const match = ANONYMOUS_TEXT_INPUT_PATTERN.exec(content);
+  const prompt = match?.[2];
+  if (!match || !prompt?.trim()) {
+    return content;
+  }
+
+  return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
+    prompt.trim(),
+  )}"></custom-variable>${match[3]}`;
+};


### PR DESCRIPTION
## Summary

- Add a **temporary ai-shifu-side rendering patch** so `?[...prompt]` renders as a text input instead of a button.
- Apply the patch to read mode, creator preview, listen mode, and classroom mode.
- Preserve the existing variable-free submission contract and learner-answer context.

## Why this is temporary

The underlying issue is in the currently consumed MarkdownFlow parsing stack, where variable-free ellipsis interactions are classified as non-assignment buttons. Per the requested scope, this PR does **not** modify or upgrade `markdown-flow`, `markdown-flow-ui`, or any other repository.

This adapter should be removed after the upstream parser version used by ai-shifu natively renders variable-free ellipsis syntax as a text input.

## Implementation

- Convert only complete, non-empty `?[...prompt]` interaction blocks into render-only `custom-variable` input markup.
- Leave ordinary buttons, existing variable inputs, empty interactions, mixed interactions, and inline examples unchanged.
- Escape prompt text before placing it in the render-only HTML attribute.
- Keep submissions variable-free (`variableName: ""`) so no synthetic course variable is persisted.

## User impact

Teachers can use `?[...你叫什么名字]` for free-text questions immediately without adding a variable or waiting for a dependency release.

## Validation

- 36 focused frontend tests passed.
- 3 focused backend context tests passed.
- `npm run type-check` passed.
- `npm run lint` passed.
- Ruff and Prettier checks passed.
- Architecture boundary validation passed.
- Real-browser verification confirmed a textbox is rendered and Enter submits `{ "variableName": "", "inputText": "小明" }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rendering for variable-free ellipsis interactions, turning them into text-entry fields in chat and listen mode.
  * Prompts are displayed with correctly escaped special characters.
* **Bug Fixes**
  * Improved context generation to reuse the learner’s submitted answer and avoid fallback/fabricated responses when input is empty.
* **Tests**
  * Added coverage for the new rendering and context-building behaviors, including non-matching content cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->