### PR TITLE
fix: retry transient url image download timeouts

### DIFF
--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -25,6 +25,27 @@ from flaskr.service.common.storage import upload_to_storage
 from .utils import get_shifu_creator_bid
 
 
+IMAGE_DOWNLOAD_TIMEOUTS = (10, 20, 30)
+
+
+def _download_image_from_url(url: str, headers: dict):
+    """Download an image URL with short retries for transient upstream slowness."""
+    last_error = None
+    for timeout in IMAGE_DOWNLOAD_TIMEOUTS:
+        try:
+            response = requests.get(url, headers=headers, timeout=timeout)
+            response.raise_for_status()
+            return response
+        except (requests.Timeout, requests.ConnectionError) as e:
+            last_error = e
+            continue
+        except requests.RequestException:
+            raise
+    if last_error is not None:
+        raise last_error
+    raise requests.RequestException("failed to download image")
+
+
 def mark_favorite_shifu(app, user_id: str, shifu_id: str):
     """
     Mark a shifu as favorite for a user.
@@ -194,8 +215,7 @@ def upload_url(app, user_id: str, url: str) -> str:
             }
 
             app.logger.info(f"Downloading image from URL: {clean_url}")
-            response = requests.get(clean_url, headers=headers, timeout=10)
-            response.raise_for_status()
+            response = _download_image_from_url(clean_url, headers=headers)
 
             content_type = response.headers.get("Content-Type", "")
             if not content_type.startswith("image/"):

--- a/src/api/tests/service/shifu/test_upload_url_download_retry.py
+++ b/src/api/tests/service/shifu/test_upload_url_download_retry.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from flaskr.service.shifu import funcs
+
+
+def test_download_image_from_url_retries_transient_timeouts(monkeypatch):
+    calls = []
+    expected_response = Mock()
+    expected_response.raise_for_status.return_value = None
+
+    def fake_get(url, headers, timeout):
+        calls.append((url, headers, timeout))
+        if len(calls) < 3:
+            raise requests.Timeout("upstream timed out")
+        return expected_response
+
+    monkeypatch.setattr(funcs.requests, "get", fake_get)
+
+    response = funcs._download_image_from_url("https://example.com/image.jpg", {"Accept": "image/*"})
+
+    assert response is expected_response
+    assert [call[2] for call in calls] == [10, 20, 30]
+
+
+def test_download_image_from_url_does_not_retry_http_errors(monkeypatch):
+    calls = []
+    expected_response = Mock()
+    expected_response.raise_for_status.side_effect = requests.HTTPError("404")
+
+    def fake_get(url, headers, timeout):
+        calls.append(timeout)
+        return expected_response
+
+    monkeypatch.setattr(funcs.requests, "get", fake_get)
+
+    with pytest.raises(requests.HTTPError):
+        funcs._download_image_from_url("https://example.com/missing.jpg", {})
+
+    assert calls == [10]


### PR DESCRIPTION
## 群内报错来源

运维保障群 2026-07-09 20:27~20:30 多条 `/api/shifu/url-upfile` 报错：下载 Wikimedia 图片时 `Read timed out. (read timeout=10)`，导致 URL 图片上传失败。

## 修复内容

- 为 URL 图片下载增加短重试：10s / 20s / 30s。
- 仅对 `Timeout` / `ConnectionError` 等瞬时网络问题重试；HTTP 4xx/5xx 仍保持快速失败，避免掩盖无效 URL。
- 增加单元测试覆盖重试成功和 HTTP 错误不重试。

## 验证

- `python3 -m py_compile src/api/flaskr/service/shifu/funcs.py src/api/tests/service/shifu/test_upload_url_download_retry.py` ✅
- `python3 -m pytest src/api/tests/service/shifu/test_upload_url_download_retry.py -q` 未能在本机执行：系统 Python 缺少 pytest。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image downloads from URLs by retrying temporary timeout and connection failures with progressively longer timeouts.
  * HTTP errors now fail immediately instead of triggering unnecessary retries.

* **Tests**
  * Added coverage for successful retries after temporary failures.
  * Added coverage confirming HTTP errors are not retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->