### PR TITLE
chore: bump markdown-flow-ui to 0.2.1

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.0",
+        "markdown-flow-ui": "0.2.1",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13560,9 +13560,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.0.tgz",
-      "integrity": "sha512-zuuQ4dz5WH/XhYNm67M2FAqQy2neirrb+9+8tGeZpJGJYn63yuTos/N7492domtgjp1Mv5vx8PZR4s31fTVyLA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.1.tgz",
+      "integrity": "sha512-MgUPdcnE8mSoYqi/Ga5NYBTOx7oPLcLgSzICH+GYNrHfOcFfab+3WgwzSNifrwfuJFUZrB5OB5cp0TCPxxGMZg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.0",
+    "markdown-flow-ui": "0.2.1",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- Pin `markdown-flow-ui` to the stable `0.2.1` release.
- Refresh only the corresponding root dependency and package entry in `src/cook-web/package-lock.json`.

## Impact

AI-Shifu picks up the released CJK font fallback fixes for iframe, Tailwind, and Mermaid content while preserving exact, reproducible dependency resolution.

## Validation

- Confirmed npm `latest` is `0.2.1`.
- Verified declared, locked, and installed versions are all `0.2.1`.
- `npx --yes npm@10.9.2 ci --dry-run --ignore-scripts`
- `npm run type-check`
- `npm run lint`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering interface dependency to version 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->