### PR TITLE
fix: keep lesson PDF download visible

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ChatUi } from './ChatUi';
 import {
   FRAME_LAYOUT_MOBILE,
@@ -132,6 +132,29 @@ describe('ChatUi lesson PDF action', () => {
     mockChatComponentProps = {};
   });
 
+  it('keeps the action visible and disabled before the lesson content is ready', () => {
+    renderChatUi();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'module.chat.lessonPdfDownload',
+      }),
+    ).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      screen.queryByTestId('learning-mode-switch'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the disabled action visible before a lesson is selected', () => {
+    renderChatUi('');
+
+    expect(
+      screen.getByRole('button', {
+        name: 'module.chat.lessonPdfDownload',
+      }),
+    ).toHaveAttribute('aria-disabled', 'true');
+  });
+
   it('shows the action in the desktop titlebar without requiring a mode switch', () => {
     renderChatUi();
 
@@ -143,7 +166,7 @@ describe('ChatUi lesson PDF action', () => {
       screen.getByRole('button', {
         name: 'module.chat.lessonPdfDownload',
       }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute('aria-disabled', 'false');
     expect(
       screen.queryByTestId('learning-mode-switch'),
     ).not.toBeInTheDocument();
@@ -164,7 +187,7 @@ describe('ChatUi lesson PDF action', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('hides a stale action immediately when the lesson changes', () => {
+  it('disables a stale action immediately when the lesson changes', () => {
     const { rerender } = renderChatUi();
 
     act(() => {
@@ -178,11 +201,22 @@ describe('ChatUi lesson PDF action', () => {
 
     rerender(createChatUi('lesson-2'));
 
-    expect(
-      screen.queryByRole('button', {
-        name: 'module.chat.lessonPdfDownload',
-      }),
-    ).not.toBeInTheDocument();
+    const button = screen.getByRole('button', {
+      name: 'module.chat.lessonPdfDownload',
+    });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(button);
+    expect(pdfAction.onDownload).not.toHaveBeenCalled();
+
+    act(() => {
+      mockChatComponentProps.onLessonPdfActionChange({
+        ...pdfAction,
+        lessonId: 'lesson-2',
+      });
+    });
+    expect(button).toHaveAttribute('aria-disabled', 'false');
+    fireEvent.click(button);
+    expect(pdfAction.onDownload).toHaveBeenCalledTimes(1);
   });
 
   it('uses the compact mode switch in narrow desktop layouts', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -184,26 +184,25 @@ export const ChatUi = ({
                   />
                 </div>
               ) : null}
-              {currentLessonPdfDownloadAction || showModeToggle ? (
-                <div className={styles.headerActions}>
-                  {currentLessonPdfDownloadAction ? (
-                    <LessonPdfDownloadButton
-                      isFollowUpStreaming={
-                        currentLessonPdfDownloadAction.isFollowUpStreaming
-                      }
-                      isPreparing={currentLessonPdfDownloadAction.isPreparing}
-                      onDownload={currentLessonPdfDownloadAction.onDownload}
-                    />
-                  ) : null}
-                  {showModeToggle ? (
-                    <LearningModeSwitch
-                      size={
-                        frameLayout === FRAME_LAYOUT_PC ? 'desktop' : 'mobile'
-                      }
-                    />
-                  ) : null}
-                </div>
-              ) : null}
+              <div className={styles.headerActions}>
+                <LessonPdfDownloadButton
+                  isContentReady={Boolean(currentLessonPdfDownloadAction)}
+                  isFollowUpStreaming={
+                    currentLessonPdfDownloadAction?.isFollowUpStreaming ?? false
+                  }
+                  isPreparing={
+                    currentLessonPdfDownloadAction?.isPreparing ?? false
+                  }
+                  onDownload={currentLessonPdfDownloadAction?.onDownload}
+                />
+                {showModeToggle ? (
+                  <LearningModeSwitch
+                    size={
+                      frameLayout === FRAME_LAYOUT_PC ? 'desktop' : 'mobile'
+                    }
+                  />
+                ) : null}
+              </div>
             </div>
           </div>
         ) : null

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.test.tsx
@@ -9,11 +9,39 @@ jest.mock('react-i18next', () => ({
 }));
 
 describe('LessonPdfDownloadButton', () => {
+  it('keeps the action visible while lesson content is still generating', async () => {
+    const onDownload = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <LessonPdfDownloadButton
+        isContentReady={false}
+        isFollowUpStreaming={false}
+        isPreparing={false}
+        onDownload={onDownload}
+      />,
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'module.chat.lessonPdfDownload',
+    });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(button);
+    expect(onDownload).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await user.hover(button);
+    });
+    expect(
+      await screen.findAllByText('module.chat.lessonPdfContentInProgress'),
+    ).not.toHaveLength(0);
+  });
+
   it('keeps the unavailable action focusable and explains why it is disabled', async () => {
     const onDownload = jest.fn();
     const user = userEvent.setup();
     render(
       <LessonPdfDownloadButton
+        isContentReady={true}
         isFollowUpStreaming={true}
         isPreparing={false}
         onDownload={onDownload}
@@ -43,6 +71,7 @@ describe('LessonPdfDownloadButton', () => {
     const user = userEvent.setup();
     render(
       <LessonPdfDownloadButton
+        isContentReady={true}
         isFollowUpStreaming={false}
         isPreparing={false}
         onDownload={onDownload}
@@ -67,6 +96,7 @@ describe('LessonPdfDownloadButton', () => {
   it('announces the preparing state and prevents duplicate downloads', () => {
     render(
       <LessonPdfDownloadButton
+        isContentReady={true}
         isFollowUpStreaming={false}
         isPreparing={true}
         onDownload={jest.fn()}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.tsx
@@ -8,28 +8,37 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-export interface LessonPdfDownloadButtonProps {
+interface LessonPdfDownloadState {
   isFollowUpStreaming: boolean;
   isPreparing: boolean;
+}
+
+export interface LessonPdfDownloadButtonProps extends LessonPdfDownloadState {
+  isContentReady: boolean;
+  onDownload?: () => void;
+}
+
+export interface LessonPdfDownloadAction extends LessonPdfDownloadState {
+  lessonId: string;
   onDownload: () => void;
 }
 
-export interface LessonPdfDownloadAction extends LessonPdfDownloadButtonProps {
-  lessonId: string;
-}
-
 export default function LessonPdfDownloadButton({
+  isContentReady,
   isFollowUpStreaming,
   isPreparing,
   onDownload,
 }: LessonPdfDownloadButtonProps) {
   const { t } = useTranslation();
-  const isDisabled = isFollowUpStreaming || isPreparing;
-  const hint = isFollowUpStreaming
-    ? t('module.chat.lessonPdfFollowUpInProgress')
-    : isPreparing
-      ? t('module.chat.lessonPdfPreparing')
-      : t('module.chat.lessonPdfPrintHint');
+  const isContentAvailable = isContentReady && Boolean(onDownload);
+  const isDisabled = !isContentAvailable || isFollowUpStreaming || isPreparing;
+  const hint = isPreparing
+    ? t('module.chat.lessonPdfPreparing')
+    : !isContentAvailable
+      ? t('module.chat.lessonPdfContentInProgress')
+      : isFollowUpStreaming
+        ? t('module.chat.lessonPdfFollowUpInProgress')
+        : t('module.chat.lessonPdfPrintHint');
   const accessibleLabel = isPreparing
     ? t('module.chat.lessonPdfPreparing')
     : t('module.chat.lessonPdfDownload');

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -755,6 +755,7 @@ export type I18nKey =
   | 'module.chat.lessonFeedbackScoreRequired'
   | 'module.chat.lessonFeedbackSubmit'
   | 'module.chat.lessonFeedbackSubmitted'
+  | 'module.chat.lessonPdfContentInProgress'
   | 'module.chat.lessonPdfCourseQrLabel'
   | 'module.chat.lessonPdfDownload'
   | 'module.chat.lessonPdfFollowUpInProgress'

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -24,6 +24,7 @@
   "lessonFeedbackScoreRequired": "Please choose a score from 1 to 5.",
   "lessonFeedbackSubmit": "Submit",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
+  "lessonPdfContentInProgress": "Available when the lesson content finishes generating",
   "lessonPdfCourseQrLabel": "Scan to open the course",
   "lessonPdfDownload": "Download lesson PDF",
   "lessonPdfFollowUpInProgress": "Available when the follow-up answer finishes",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -24,6 +24,7 @@
   "lessonFeedbackScoreRequired": "Veuillez choisir une note de 1 à 5.",
   "lessonFeedbackSubmit": "Envoyer",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
+  "lessonPdfContentInProgress": "Disponible une fois le contenu de la leçon généré",
   "lessonPdfCourseQrLabel": "Scannez pour accéder au cours",
   "lessonPdfDownload": "Télécharger le PDF de la leçon",
   "lessonPdfFollowUpInProgress": "Disponible une fois la réponse de suivi terminée",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -24,6 +24,7 @@
   "lessonFeedbackScoreRequired": "请选择1-5分后再提交",
   "lessonFeedbackSubmit": "提交",
   "lessonFeedbackSubmitted": "感谢你的反馈",
+  "lessonPdfContentInProgress": "本节内容生成完成后可下载",
   "lessonPdfCourseQrLabel": "扫码访问课程",
   "lessonPdfDownload": "下载本节 PDF",
   "lessonPdfFollowUpInProgress": "追问回答生成后可下载",


### PR DESCRIPTION
## Summary

- Keep the desktop lesson PDF download action visible before lesson content is ready.
- Disable the action until a safe download handler exists, while preserving the existing follow-up-streaming and PDF-preparing states.
- Add localized unavailable-state guidance in Chinese, English, and French.
- Keep stale lesson actions disabled during lesson switches and restore the action only for the current lesson.

## Root cause

The desktop header only rendered the PDF button after the current lesson exposed a ready download action. While lesson content was loading, streaming, or still finishing its read-mode presentation, that action was `null`, so the button disappeared instead of remaining visible in a disabled state.

## User impact

Learners can now discover the PDF action consistently and understand why it is temporarily unavailable, without being able to trigger incomplete or stale downloads.

## Validation

- `npm test -- --runInBand --runTestsByPath 'src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx' 'src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.test.tsx'` (10 tests passed)
- `npm run type-check`
- `npm run lint`
- `npm run format:check:changed`
- `python3 scripts/check_dev_tools.py`
- Repository pre-commit and commit-message hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lesson PDF downloads remain visible while content is generating but are disabled until the lesson is ready.
  * Download actions are re-enabled automatically once the current lesson’s PDF is available.
  * Added progress guidance explaining when the PDF can be downloaded.

* **Bug Fixes**
  * Prevented downloads from triggering for outdated lesson content during lesson changes.
  * Added localized progress messaging in English, French, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->