### PR TITLE
fix: clarify personalized PDF course access

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -22,7 +22,7 @@ jest.mock('react-i18next', () => {
     'module.chat.lessonUpdateRecommendRetake':
       '本节课程已更新，建议<action>重修</action>',
     'module.chat.lessonFeedbackSubmit': '提交',
-    'module.chat.lessonPdfCourseQrLabel': '扫码访问课程',
+    'module.chat.lessonPdfCourseQrLabel': '扫码进入课程，获得一对一讲解与答疑',
     'module.chat.lessonUpdateRetakeAccessibleLabel': '重修本节课程',
     'module.chat.lessonUpdateRetakeAction': '重修',
     'module.lesson.reset.confirmContent': '重修会清空本节学习数据。确定重修？',
@@ -467,12 +467,17 @@ describe('NewChatComponents', () => {
     const qrCode = footer.querySelector('svg');
 
     expect(footer).toHaveAttribute('data-lesson-print-only', 'true');
-    expect(footer).toHaveTextContent('扫码访问课程');
+    expect(footer).toHaveTextContent('扫码进入课程，获得一对一讲解与答疑');
     expect(link).toHaveAttribute('href', courseUrl);
-    expect(link).toHaveAttribute('aria-label', '扫码访问课程');
+    expect(link).toHaveAttribute(
+      'aria-label',
+      '扫码进入课程，获得一对一讲解与答疑',
+    );
     expect(qrCode).toHaveAttribute('width', '144');
     expect(qrCode).toHaveAttribute('height', '144');
-    expect(qrCode?.querySelector('title')).toHaveTextContent('扫码访问课程');
+    expect(qrCode?.querySelector('title')).toHaveTextContent(
+      '扫码进入课程，获得一对一讲解与答疑',
+    );
     expect(footer.nextElementSibling).toHaveAttribute('id', 'chat-box-bottom');
   });
 

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -25,7 +25,7 @@
   "lessonFeedbackSubmit": "Submit",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
   "lessonPdfContentInProgress": "Available when the lesson content finishes generating",
-  "lessonPdfCourseQrLabel": "Scan to enter the course for one-to-one teaching and Q&A",
+  "lessonPdfCourseQrLabel": "Scan to enter the course for one-on-one teaching and Q&A",
   "lessonPdfDownload": "Download lesson PDF",
   "lessonPdfFollowUpInProgress": "Available when the follow-up answer finishes",
   "lessonPdfPrepareFailed": "Couldn't prepare the PDF. Please try again.",

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -25,7 +25,7 @@
   "lessonFeedbackSubmit": "Submit",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
   "lessonPdfContentInProgress": "Available when the lesson content finishes generating",
-  "lessonPdfCourseQrLabel": "Scan to open the course",
+  "lessonPdfCourseQrLabel": "Scan to enter the course for one-to-one teaching and Q&A",
   "lessonPdfDownload": "Download lesson PDF",
   "lessonPdfFollowUpInProgress": "Available when the follow-up answer finishes",
   "lessonPdfPrepareFailed": "Couldn't prepare the PDF. Please try again.",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -25,7 +25,7 @@
   "lessonFeedbackSubmit": "Envoyer",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
   "lessonPdfContentInProgress": "Disponible une fois le contenu de la leçon généré",
-  "lessonPdfCourseQrLabel": "Scannez pour accéder au cours",
+  "lessonPdfCourseQrLabel": "Scannez pour un enseignement individuel et des réponses à vos questions",
   "lessonPdfDownload": "Télécharger le PDF de la leçon",
   "lessonPdfFollowUpInProgress": "Disponible une fois la réponse de suivi terminée",
   "lessonPdfPrepareFailed": "Impossible de préparer le PDF. Veuillez réessayer.",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -25,7 +25,7 @@
   "lessonFeedbackSubmit": "Envoyer",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
   "lessonPdfContentInProgress": "Disponible une fois le contenu de la leçon généré",
-  "lessonPdfCourseQrLabel": "Scannez pour un enseignement individuel et des réponses à vos questions",
+  "lessonPdfCourseQrLabel": "Scannez pour accéder au cours et bénéficier d'un enseignement individuel et de réponses à vos questions",
   "lessonPdfDownload": "Télécharger le PDF de la leçon",
   "lessonPdfFollowUpInProgress": "Disponible une fois la réponse de suivi terminée",
   "lessonPdfPrepareFailed": "Impossible de préparer le PDF. Veuillez réessayer.",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -25,7 +25,7 @@
   "lessonFeedbackSubmit": "提交",
   "lessonFeedbackSubmitted": "感谢你的反馈",
   "lessonPdfContentInProgress": "本节内容生成完成后可下载",
-  "lessonPdfCourseQrLabel": "扫码访问课程",
+  "lessonPdfCourseQrLabel": "扫码进入课程，获得一对一讲解与答疑",
   "lessonPdfDownload": "下载本节 PDF",
   "lessonPdfFollowUpInProgress": "追问回答生成后可下载",
   "lessonPdfPrepareFailed": "PDF 准备失败，请重试。",


### PR DESCRIPTION
## Summary

- Update the PDF course QR call to action to highlight one-to-one teaching and Q&A.
- Align English and French translations with the learner-facing benefit.
- Update QR footer regression coverage.

## Why

The previous label only described course access and did not communicate the personalized learning experience available after scanning.

## Validation

- ./node_modules/.bin/jest --runInBand --runTestsByPath "/Users/sunner/.codex/worktrees/977e/ai-shifu/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx"
- lefthook pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the course QR-code message to invite learners to scan for course access, one-to-one instruction, and Q&A support.
  * Applied the revised wording across English, French, and Simplified Chinese translations.
* **Tests**
  * Updated coverage to verify the revised text appears in the printed lesson footer, link label, and QR-code title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->