### PR TITLE
fix: clarify lesson PDF availability

### DIFF
--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "Please choose a score from 1 to 5.",
   "lessonFeedbackSubmit": "Submit",
   "lessonFeedbackSubmitted": "Thanks for your feedback!",
-  "lessonPdfContentInProgress": "Available when the lesson content finishes generating",
+  "lessonPdfContentInProgress": "Available after completing the entire lesson",
   "lessonPdfCourseQrLabel": "Scan to enter the course for one-on-one teaching and Q&A",
   "lessonPdfDownload": "Download lesson PDF",
   "lessonPdfFollowUpInProgress": "Available when the follow-up answer finishes",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "Veuillez choisir une note de 1 à 5.",
   "lessonFeedbackSubmit": "Envoyer",
   "lessonFeedbackSubmitted": "Merci pour votre retour !",
-  "lessonPdfContentInProgress": "Disponible une fois le contenu de la leçon généré",
+  "lessonPdfContentInProgress": "Disponible après avoir terminé la leçon en entier",
   "lessonPdfCourseQrLabel": "Scannez pour accéder au cours et bénéficier d'un enseignement individuel et de réponses à vos questions",
   "lessonPdfDownload": "Télécharger le PDF de la leçon",
   "lessonPdfFollowUpInProgress": "Disponible une fois la réponse de suivi terminée",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -24,7 +24,7 @@
   "lessonFeedbackScoreRequired": "请选择1-5分后再提交",
   "lessonFeedbackSubmit": "提交",
   "lessonFeedbackSubmitted": "感谢你的反馈",
-  "lessonPdfContentInProgress": "本节内容生成完成后可下载",
+  "lessonPdfContentInProgress": "完整学完本节课后可下载",
   "lessonPdfCourseQrLabel": "扫码进入课程，获得一对一讲解与答疑",
   "lessonPdfDownload": "下载本节 PDF",
   "lessonPdfFollowUpInProgress": "追问回答生成后可下载",


### PR DESCRIPTION
## Summary

- Update the unavailable lesson PDF hint to state that learners must complete the entire lesson before downloading.
- Keep the Chinese, English, and French translations aligned.

## Why

The existing hint said the PDF would become available after lesson content generation finished. That wording did not match the intended requirement that learners complete the full lesson before downloading.

## Impact

Learners receive accurate and consistent download guidance in every supported language. This is a copy-only change with no API or runtime behavior changes.

## Validation

- `python3 scripts/check_translations.py`
- `python3 scripts/check_translation_usage.py --fail-on-unused`
- Repository pre-commit and commit-message hooks