### PR TITLE
chore: bump markdown-flow-ui to 0.2.2

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.1",
+        "markdown-flow-ui": "0.2.2",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13560,9 +13560,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.1.tgz",
-      "integrity": "sha512-MgUPdcnE8mSoYqi/Ga5NYBTOx7oPLcLgSzICH+GYNrHfOcFfab+3WgwzSNifrwfuJFUZrB5OB5cp0TCPxxGMZg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.2.tgz",
+      "integrity": "sha512-FjD2+AZRBAIBZY53AjyHU9qTiFgm1Yu0gUex8mJxSbkwv+18A1w/+iM7xZKtgU/v82XXCy8BNQviJo4+O8QM1w==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.1",
+    "markdown-flow-ui": "0.2.2",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- bump `markdown-flow-ui` from `0.2.1` to `0.2.2`
- update the exact dependency pin and npm lockfile metadata

## Impact

Cook Web now consumes the latest stable MarkdownFlow UI release while preserving reproducible exact-version installs.

## Verification

- `npm run type-check`
- `npm run lint` (passes with existing warnings)
- `python3 scripts/check_dev_tools.py`
- `git diff --check`
- pre-commit and commit-message hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering component to version 0.2.2, incorporating the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->