### PR TITLE
test: sync China course creator URL expectation

### DIFF
--- a/src/cook-web/src/__tests__/url-utils.test.ts
+++ b/src/cook-web/src/__tests__/url-utils.test.ts
@@ -159,7 +159,7 @@ describe('domain aware urls', () => {
     });
 
     expect(getCourseCreatorUrl()).toBe(
-      'https://app.ai-shifu.cn/c/ed0e57ded79d4b7b88d1be348c151509?lessonid=77ff6ea94e4245d19172a29c0a279848',
+      'https://zhentouai.feishu.cn/wiki/AUE5wpipJi5bL4k6GticmxddnPb?from=from_copylink',
     );
   });
 


### PR DESCRIPTION
## Summary

- Update the `ai-shifu.cn` `getCourseCreatorUrl` Jest expectation to the Feishu Wiki URL already shipped in PR #1884.
- Leave the product implementation unchanged.

## Context

PR #1884 intentionally replaced the China course creator entry with the Feishu Wiki onboarding guide but did not update `src/cook-web/src/__tests__/url-utils.test.ts`. This PR is only the missing test synchronization and is unrelated to the course slug functionality.

## Verification

- `npm run test -- --runTestsByPath src/__tests__/url-utils.test.ts --runInBand` (16 passed)
- `npm exec prettier -- --check src/__tests__/url-utils.test.ts`
- `npm run lint -- --file src/__tests__/url-utils.test.ts`
- `npm run type-check`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated course creator links for the `app.ai-shifu.cn` environment to direct users to the correct Feishu wiki destination.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->