### PR TITLE
fix: clear stale learn retry streaming guard

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -2997,6 +2997,43 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(result.current.isOutputInProgress).toBe(true);
   });
 
+  it('keeps the current stream guard when run status cannot be confirmed', async () => {
+    const params = buildBaseParams();
+    const { result } = renderHook(() => useChatLogicHook(params), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+    const staleRun = activeRun;
+    const initialRunCount = mockGetRunMessage.mock.calls.length;
+
+    await act(async () => {
+      await staleRun?.onMessage({
+        generated_block_bid: 'content-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-1',
+          generated_block_bid: 'content-1',
+          element_type: 'content',
+          content: 'partial content',
+          like_status: 'none',
+        },
+      });
+    });
+
+    mockCheckIsRunning.mockRejectedValueOnce(new Error('network down'));
+
+    await act(async () => {
+      await result.current.onRefresh('content-1');
+    });
+
+    expect(mockGetRunMessage).toHaveBeenCalledTimes(initialRunCount);
+    expect(staleRun?.source.close).not.toHaveBeenCalled();
+    expect(activeRun).toBe(staleRun);
+    expect(params.showOutputInProgressToast).toHaveBeenCalledTimes(1);
+    expect(result.current.isOutputInProgress).toBe(true);
+  });
+
   it('does not treat the latest interaction as regenerate when helper rows are trailing', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -2953,6 +2953,50 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(result.current.hasRunFailed).toBe(false);
   });
 
+  it('clears a stale local streaming guard before retrying the original run', async () => {
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+    const staleRun = activeRun;
+    const initialRunCount = mockGetRunMessage.mock.calls.length;
+
+    await act(async () => {
+      await staleRun?.onMessage({
+        generated_block_bid: 'content-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'content-1',
+          generated_block_bid: 'content-1',
+          element_type: 'content',
+          content: 'partial content',
+          like_status: 'none',
+        },
+      });
+    });
+
+    mockCheckIsRunning.mockResolvedValueOnce({
+      is_running: false,
+      running_time: 0,
+    });
+
+    await act(async () => {
+      await result.current.onRefresh('content-1');
+    });
+
+    await waitFor(() =>
+      expect(mockGetRunMessage).toHaveBeenCalledTimes(initialRunCount + 1),
+    );
+    expect(staleRun?.source.close).toHaveBeenCalled();
+    expect(activeRun).not.toBe(staleRun);
+    expect(toast).not.toHaveBeenCalledWith({
+      title: 'module.chat.outputInProgress',
+    });
+    expect(result.current.hasRunFailed).toBe(false);
+    expect(result.current.isOutputInProgress).toBe(true);
+  });
+
   it('does not treat the latest interaction as regenerate when helper rows are trailing', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2943,11 +2943,15 @@ function useChatLogicHook({
       const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
         error => {
           if (options?.swallowRequestError) {
-            return null;
+            return undefined;
           }
           throw error;
         },
       );
+
+      if (runningRes === undefined) {
+        return true;
+      }
 
       if (runningRes?.is_running) {
         return true;
@@ -2967,7 +2971,7 @@ function useChatLogicHook({
    */
   const onRefresh = useCallback(
     async (elementBid: string) => {
-      if (await hasActiveRunInProgress()) {
+      if (await hasActiveRunInProgress({ swallowRequestError: true })) {
         showOutputInProgressToast();
         return;
       }

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2935,17 +2935,39 @@ function useChatLogicHook({
   );
 
   /**
+   * If the frontend still thinks a run is streaming but the backend no longer
+   * reports an active run, clear the stale local guard so retry / resend can proceed.
+   */
+  const hasActiveRunInProgress = useCallback(
+    async (options?: { swallowRequestError?: boolean }) => {
+      const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
+        error => {
+          if (options?.swallowRequestError) {
+            return null;
+          }
+          throw error;
+        },
+      );
+
+      if (runningRes?.is_running) {
+        return true;
+      }
+
+      if (isStreamingRef.current) {
+        stopActiveRunStream();
+      }
+
+      return false;
+    },
+    [outlineBid, shifuBid, stopActiveRunStream],
+  );
+
+  /**
    * onRefresh replays a block from the server using the original inputs.
    */
   const onRefresh = useCallback(
     async (elementBid: string) => {
-      if (isStreamingRef.current) {
-        showOutputInProgressToast();
-        return;
-      }
-
-      const runningRes = await checkIsRunning(shifuBid, outlineBid);
-      if (runningRes.is_running) {
+      if (await hasActiveRunInProgress()) {
         showOutputInProgressToast();
         return;
       }
@@ -2974,11 +2996,9 @@ function useChatLogicHook({
       });
     },
     [
+      hasActiveRunInProgress,
       isTypeFinishedRef,
-      outlineBid,
       resolveSourceGeneratedBlockBid,
-      shifuBid,
-      isStreamingRef,
       setTrackedContentList,
       showOutputInProgressToast,
     ],
@@ -3005,11 +3025,6 @@ function useChatLogicHook({
         isReGenerate =
           Boolean(lastActionableElementBid) &&
           blockBid !== lastActionableElementBid;
-      }
-
-      if (!isReGenerate && isStreamingRef.current) {
-        showOutputInProgressToast();
-        return;
       }
 
       const { variableName, buttonText, inputText } = content;
@@ -3158,12 +3173,10 @@ function useChatLogicHook({
         return;
       }
 
-      const runningRes = await checkIsRunning(shifuBid, outlineBid).catch(
-        () => {
-          return null;
-        },
-      );
-      if (!isReGenerate && runningRes?.is_running) {
+      if (
+        !isReGenerate &&
+        (await hasActiveRunInProgress({ swallowRequestError: true }))
+      ) {
         showOutputInProgressToast();
         return;
       }
@@ -3209,6 +3222,7 @@ function useChatLogicHook({
       getLessonFeedbackDefaults,
       getNextLessonId,
       isTypeFinishedRef,
+      hasActiveRunInProgress,
       isLessonFeedbackContent,
       isListenMode,
       lessonId,


### PR DESCRIPTION
## What
- add a backend-verified stale-stream cleanup before lesson retry / resend guards
- clear the local streaming state when the frontend still thinks a run is active but `checkIsRunning` reports idle
- add a focused hook regression test that covers retrying the original run after a dropped stream

## Why
When a learn-side SSE stream breaks, the frontend can keep a stale local `isStreamingRef` guard even after the backend run has already stopped. That blocks retrying the original stream and shows the `outputInProgress` toast instead.

## Verification
- `python scripts/check_dev_tools.py`
- `cd src/cook-web && npm test -- useChatLogicHook.test.tsx --runInBand`
- `cd src/cook-web && npm run lint -- --file 'src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx' --file 'src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry behavior when a conversation’s local streaming state becomes outdated.
  * Retries now correctly stop stale streams and start a new run instead of being blocked incorrectly.
  * Improved handling of run-status checks during retries, allowing output generation to resume without showing an incorrect “output in progress” message.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->