### PR TITLE
fix(api): downgrade shifu summary shutdown race logs

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -233,12 +233,14 @@ def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None)
         get_shifu_summary(app, shifu_id)
     except Exception as e:
         message = str(e)
-        if "cannot schedule new futures after shutdown" in message:
+        if "cannot schedule new futures after" in message:
             # Summary generation runs in a fire-and-forget daemon thread. When
             # the worker/process is recycled mid-LLM-call (e.g. a deploy),
             # litellm's fallback tries to schedule on an executor that is already
-            # shutting down. This is an expected shutdown race, not a real
-            # failure, so log at warning level to avoid paging ops on deploys.
+            # shutting down. Python may report this as either "after shutdown"
+            # or "after interpreter shutdown" depending on where teardown is
+            # observed. This is an expected shutdown race, not a real failure,
+            # so log at warning level to avoid paging ops on deploys.
             app.logger.warning(
                 "Skipped shifu summary for %s due to worker shutdown race: %s",
                 shifu_id,

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -2,6 +2,7 @@ import sys
 import types
 from datetime import datetime
 
+import pytest
 from flask import Flask
 
 from flaskr.dao import db
@@ -163,7 +164,16 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch):
     assert trace.updated["output"] == "summary result"
 
 
-def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
+@pytest.mark.parametrize(
+    "shutdown_message",
+    [
+        "cannot schedule new futures after shutdown",
+        "cannot schedule new futures after interpreter shutdown",
+    ],
+)
+def test_run_summary_downgrades_shutdown_race_to_warning(
+    monkeypatch, shutdown_message
+):
     from unittest.mock import MagicMock
     from flaskr.service.shifu import shifu_publish_funcs as module
 
@@ -172,7 +182,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
     def _raise_shutdown(*_a, **_k):
         raise RuntimeError(
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
-            "cannot schedule new futures after shutdown"
+            f"{shutdown_message}"
         )
 
     monkeypatch.setattr(module, "get_shifu_summary", _raise_shutdown)


### PR DESCRIPTION
## Summary
- Handles the ops-group error at 2026-07-13 17:45:20 where shifu summary generation logged `cannot schedule new futures after interpreter shutdown` as an ERROR.
- Broadens the existing shutdown-race detection from only `after shutdown` to `cannot schedule new futures after...`, covering Python's `after interpreter shutdown` wording.
- Keeps true summary-generation failures logged as errors.

## Ops source
运维保障群报错：`_run_summary_with_error_handling` failed for shifu `aec19909544249af9b50feefdc0826fc` with `litellm.MidStreamFallbackError ... cannot schedule new futures after interpreter shutdown`.

## Verification
- `python3 -m py_compile flaskr/service/shifu/shifu_publish_funcs.py tests/service/shifu/test_shifu_publish_funcs.py`
- Targeted pytest could not run in this local environment because `pytest` is not installed for the available Python interpreter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected shutdown conditions during summary generation.
  * Prevented routine shutdown races from being reported as errors, reducing unnecessary error alerts.

* **Tests**
  * Added coverage for multiple shutdown-related error messages to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->