### PR TITLE
fix: rebuild draft struct after default outline init

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -308,6 +308,7 @@ def create_shifu_draft(
             chapter_name=chapter_name,
             lesson_name=lesson_name,
             now_time=now_time,
+            shifu_db_id=shifu_draft.id,
         )
 
         draft_persist_elapsed_ms = round((perf_counter() - stage_started_at) * 1000, 2)

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -325,15 +325,30 @@ def __save_new_item_history(
 
     q = queue.Queue()
     q.put(history)
+    parent_found = False
     while not q.empty():
         item = q.get()
         if item.bid == parent_bid:
             item.children.append(
                 HistoryItem(bid=item_bid, id=id, type=type, children=[])
             )
+            parent_found = True
             break
         for child in item.children:
             q.put(child)
+
+    if not parent_found:
+        app.logger.error(
+            "Failed to append %s history node because parent is missing | shifu_bid=%s item_bid=%s item_id=%s parent_bid=%s",
+            type,
+            shifu_bid,
+            item_bid,
+            id,
+            parent_bid,
+        )
+        raise RuntimeError(
+            f"Parent history node not found for {type} {item_bid} under {parent_bid}"
+        )
 
     __save_shifu_history(app, user_id, shifu_bid, history)
 

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -477,10 +477,10 @@ def create_default_outlines_for_new_shifu(
     outline_items = __get_existing_outline_items(shifu_id)
     history_tree = _build_outline_history_tree(outline_items)
     save_outline_tree_history(
-        app,
-        user_id,
-        shifu_id,
-        history_tree,
+        app=app,
+        user_id=user_id,
+        shifu_bid=shifu_id,
+        outline_tree=history_tree,
         shifu_id=shifu_db_id,
     )
     return chapter, lesson
@@ -494,12 +494,12 @@ def _build_outline_history_tree(
         parent_bid = str(outline.parent_bid or "").strip()
         outline_children_map.setdefault(parent_bid, []).append(outline)
 
+    output_lang = get_markdownflow_output_language()
+
     def _count_blocks(content: str) -> int:
         if not content:
             return 0
-        mdflow = MarkdownFlow(content).set_output_language(
-            get_markdownflow_output_language()
-        )
+        mdflow = MarkdownFlow(content).set_output_language(output_lang)
         return len(mdflow.get_all_blocks())
 
     def _build(parent_bid: str) -> list[HistoryItem]:

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -279,6 +279,7 @@ def __insert_outline_locked(
     is_hidden: bool,
     now_time,
     outline_bid: str,
+    persist_history: bool = True,
 ) -> SimpleOutlineDto:
     """Insert one outline row, allocating its position from current siblings.
 
@@ -356,9 +357,10 @@ def __insert_outline_locked(
     # save to database (flush only; the caller owns the commit)
     db.session.add(new_outline)
     db.session.flush()
-    save_new_outline_history(
-        app, user_id, shifu_id, outline_bid, new_outline.id, parent_id, max_index
-    )
+    if persist_history:
+        save_new_outline_history(
+            app, user_id, shifu_id, outline_bid, new_outline.id, parent_id, max_index
+        )
 
     return SimpleOutlineDto(
         bid=outline_bid,
@@ -431,6 +433,7 @@ def create_default_outlines_for_new_shifu(
     chapter_name: str,
     lesson_name: str,
     now_time,
+    shifu_db_id: int | None = None,
 ) -> tuple[SimpleOutlineDto, SimpleOutlineDto]:
     """Create the default chapter/lesson pair for a brand-new shifu draft.
 
@@ -456,6 +459,7 @@ def create_default_outlines_for_new_shifu(
         False,
         now_time,
         chapter_bid,
+        persist_history=False,
     )
     lesson = __insert_outline_locked(
         app,
@@ -468,8 +472,51 @@ def create_default_outlines_for_new_shifu(
         False,
         now_time,
         lesson_bid,
+        persist_history=False,
+    )
+    outline_items = __get_existing_outline_items(shifu_id)
+    history_tree = _build_outline_history_tree(outline_items)
+    save_outline_tree_history(
+        app,
+        user_id,
+        shifu_id,
+        history_tree,
+        shifu_id=shifu_db_id,
     )
     return chapter, lesson
+
+
+def _build_outline_history_tree(
+    outlines: list[DraftOutlineItem],
+) -> list[HistoryItem]:
+    outline_children_map: dict[str, list[DraftOutlineItem]] = {}
+    for outline in outlines:
+        parent_bid = str(outline.parent_bid or "").strip()
+        outline_children_map.setdefault(parent_bid, []).append(outline)
+
+    def _count_blocks(content: str) -> int:
+        if not content:
+            return 0
+        mdflow = MarkdownFlow(content).set_output_language(
+            get_markdownflow_output_language()
+        )
+        return len(mdflow.get_all_blocks())
+
+    def _build(parent_bid: str) -> list[HistoryItem]:
+        children = outline_children_map.get(parent_bid, [])
+        children.sort(key=lambda item: (item.position or "", item.id))
+        return [
+            HistoryItem(
+                bid=str(child.outline_item_bid or "").strip(),
+                id=int(child.id),
+                type="outline",
+                children=_build(str(child.outline_item_bid or "").strip()),
+                child_count=_count_blocks(child.content or ""),
+            )
+            for child in children
+        ]
+
+    return _build("")
 
 
 def create_outlines_batch(

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -11,10 +11,11 @@ def _get_models():
     from flaskr.service.shifu.models import (
         DraftOutlineItem,
         DraftShifu,
+        LogDraftStruct,
         ShifuUserArchive,
     )
 
-    return DraftOutlineItem, DraftShifu, ShifuUserArchive
+    return DraftOutlineItem, DraftShifu, LogDraftStruct, ShifuUserArchive
 
 
 def _get_archive_funcs():
@@ -32,7 +33,7 @@ def _get_draft_module():
 def _seed_shifu(app, shifu_bid: str, owner_bid: str):
     """Create draft shifu row and clear archive state for testing."""
     with app.app_context():
-        _, DraftShifu, ShifuUserArchive = _get_models()
+        _, DraftShifu, _, ShifuUserArchive = _get_models()
         DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
         ShifuUserArchive.query.filter_by(
             shifu_bid=shifu_bid, user_bid=owner_bid
@@ -69,7 +70,7 @@ def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
     archive_shifu(app, owner_bid, shifu_bid)
 
     with app.app_context():
-        _, DraftShifu, ShifuUserArchive = _get_models()
+        _, DraftShifu, _, ShifuUserArchive = _get_models()
         draft = (
             DraftShifu.query.filter_by(shifu_bid=shifu_bid)
             .order_by(DraftShifu.id.desc())
@@ -90,7 +91,7 @@ def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
     unarchive_shifu(app, owner_bid, shifu_bid)
 
     with app.app_context():
-        _, DraftShifu, ShifuUserArchive = _get_models()
+        _, DraftShifu, _, ShifuUserArchive = _get_models()
         draft = (
             DraftShifu.query.filter_by(shifu_bid=shifu_bid)
             .order_by(DraftShifu.id.desc())
@@ -112,7 +113,7 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
     created_at = datetime(2026, 4, 21, 0, 0, 0)
     owner_bid = "owner-create-utc"
     draft_module = _get_draft_module()
-    _, DraftShifu, _ = _get_models()
+    _, DraftShifu, _, _ = _get_models()
 
     monkeypatch.setattr(draft_module, "now_utc", lambda: created_at)
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-create-utc")
@@ -152,7 +153,8 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
 def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypatch):
     owner_bid = "owner-default-outline"
     draft_module = _get_draft_module()
-    DraftOutlineItem, _, _ = _get_models()
+    DraftOutlineItem, _, LogDraftStruct, _ = _get_models()
+    from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
     generated_ids = iter(
         ["shifu-default-outline", "chapter-default-outline", "lesson-default-outline"]
@@ -189,12 +191,116 @@ def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypa
             .order_by(DraftOutlineItem.position.asc())
             .all()
         )
+        latest_struct = (
+            LogDraftStruct.query.filter_by(shifu_bid=result.bid, deleted=0)
+            .order_by(LogDraftStruct.id.desc())
+            .first()
+        )
 
     assert [item.outline_item_bid for item in outline_items] == [
         "chapter-default-outline",
         "lesson-default-outline",
     ]
     assert [item.position for item in outline_items] == ["01", "0101"]
+    assert latest_struct is not None
+    history = HistoryItem.from_json(latest_struct.struct)
+    assert [child.bid for child in history.children] == ["chapter-default-outline"]
+    assert [child.bid for child in history.children[0].children] == [
+        "lesson-default-outline"
+    ]
+
+
+def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
+    app, monkeypatch
+):
+    owner_bid = "owner-empty-struct-rebuild"
+    now_time = datetime(2026, 7, 13, 12, 0, 0)
+    draft_module = _get_draft_module()
+    DraftOutlineItem, DraftShifu, LogDraftStruct, _ = _get_models()
+    from flaskr.service.shifu.shifu_history_manager import HistoryItem
+    from flaskr.service.shifu.shifu_outline_funcs import (
+        create_default_outlines_for_new_shifu,
+    )
+
+    generated_ids = iter(["chapter-empty-struct", "lesson-empty-struct"])
+    monkeypatch.setattr(draft_module, "generate_id", lambda _app: "unused-shifu-id")
+
+    from flaskr.service.shifu import shifu_outline_funcs
+
+    monkeypatch.setattr(
+        shifu_outline_funcs, "generate_id", lambda _app: next(generated_ids)
+    )
+
+    with app.app_context():
+        shifu = DraftShifu(
+            shifu_bid="shifu-empty-struct",
+            title="Draft",
+            description="desc",
+            avatar_res_bid="res",
+            keywords="",
+            llm="gpt-test",
+            llm_temperature=Decimal("0.3"),
+            price=Decimal("0"),
+            deleted=0,
+            created_user_bid=owner_bid,
+            created_at=now_time,
+            updated_user_bid=owner_bid,
+            updated_at=now_time,
+        )
+        dao.db.session.add(shifu)
+        dao.db.session.flush()
+
+        empty_history = LogDraftStruct(
+            struct_bid="empty-struct-bid",
+            shifu_bid=shifu.shifu_bid,
+            struct=HistoryItem(
+                bid=shifu.shifu_bid,
+                id=shifu.id,
+                type="shifu",
+                children=[],
+            ).to_json(),
+            created_user_bid=owner_bid,
+            created_at=now_time,
+            updated_user_bid=owner_bid,
+            updated_at=now_time,
+        )
+        dao.db.session.add(empty_history)
+        dao.db.session.flush()
+
+        create_default_outlines_for_new_shifu(
+            app=app,
+            user_id=owner_bid,
+            shifu_id=shifu.shifu_bid,
+            chapter_name="Default Chapter",
+            lesson_name="Default Lesson",
+            now_time=now_time,
+            shifu_db_id=shifu.id,
+        )
+        dao.db.session.commit()
+
+        outline_items = (
+            DraftOutlineItem.query.filter_by(shifu_bid=shifu.shifu_bid, deleted=0)
+            .order_by(DraftOutlineItem.position.asc())
+            .all()
+        )
+        latest_struct = (
+            LogDraftStruct.query.filter_by(shifu_bid=shifu.shifu_bid, deleted=0)
+            .order_by(LogDraftStruct.id.desc())
+            .first()
+        )
+
+    assert [item.outline_item_bid for item in outline_items] == [
+        "chapter-empty-struct",
+        "lesson-empty-struct",
+    ]
+    assert [item.position for item in outline_items] == ["01", "0101"]
+    assert latest_struct is not None
+    rebuilt_history = HistoryItem.from_json(latest_struct.struct)
+    assert rebuilt_history.id == shifu.id
+    assert [child.bid for child in rebuilt_history.children] == ["chapter-empty-struct"]
+    assert [child.bid for child in rebuilt_history.children[0].children] == [
+        "lesson-empty-struct"
+    ]
 
 
 def test_create_shifu_draft_skips_risk_check_for_default_outline_content(

--- a/src/api/tests/service/shifu/test_shifu_history_manager.py
+++ b/src/api/tests/service/shifu/test_shifu_history_manager.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from flaskr.dao import db
+from flaskr.service.shifu.models import DraftShifu, LogDraftStruct
+from flaskr.service.shifu.shifu_history_manager import (
+    HistoryItem,
+    save_new_outline_history,
+    save_shifu_history,
+)
+
+
+def _seed_shifu(shifu_bid: str, user_bid: str) -> DraftShifu:
+    shifu = DraftShifu(
+        shifu_bid=shifu_bid,
+        title="History Course",
+        created_user_bid=user_bid,
+        updated_user_bid=user_bid,
+        deleted=0,
+    )
+    db.session.add(shifu)
+    db.session.flush()
+    return shifu
+
+
+def test_save_new_outline_history_raises_when_parent_missing(app):
+    shifu_bid = "history-parent-missing"
+    user_bid = "creator-history"
+
+    with app.app_context():
+        shifu = _seed_shifu(shifu_bid, user_bid)
+        save_shifu_history(app, user_bid, shifu_bid, shifu.id)
+
+        before_count = LogDraftStruct.query.filter_by(
+            shifu_bid=shifu_bid, deleted=0
+        ).count()
+
+        with pytest.raises(RuntimeError, match="Parent history node not found"):
+            save_new_outline_history(
+                app,
+                user_bid,
+                shifu_bid,
+                outline_bid="outline-1",
+                id=123,
+                parent_bid="missing-parent",
+            )
+
+        after_logs = (
+            LogDraftStruct.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+            .order_by(LogDraftStruct.id.asc())
+            .all()
+        )
+
+    assert len(after_logs) == before_count
+    latest_history = HistoryItem.from_json(after_logs[-1].struct)
+    assert latest_history.children == []


### PR DESCRIPTION
## What
- rebuild the initial draft struct from the persisted default outline rows instead of incrementally patching history during new-course initialization
- fail fast when `save_new_outline_history(...)` cannot find the parent history node, rather than silently saving a broken latest struct
- add regression coverage for the normal default chapter/lesson path, the empty-latest-struct recovery path, and missing-parent history writes

## Why
A production draft preview lost Chapter 1 because the latest `shifu_log_draft_structs` snapshot drifted away from the active `shifu_draft_outline_items`. The first-layer fix is to close the new-course initialization path that could preserve an empty or partial latest struct.

## Verification
- `cd src/api && pytest tests/service/shifu/ -q`
- `cd src/api && pytest tests/service/shifu/test_archive.py tests/service/shifu/test_shifu_history_manager.py tests/service/shifu/test_create_outlines_batch.py tests/service/shifu/test_shifu_outline_tree.py -q`
- `cd src/api && ruff check flaskr/service/shifu/shifu_draft_funcs.py flaskr/service/shifu/shifu_outline_funcs.py flaskr/service/shifu/shifu_history_manager.py tests/service/shifu/test_archive.py tests/service/shifu/test_shifu_history_manager.py`
- `lefthook run pre-commit --file src/api/flaskr/service/shifu/shifu_draft_funcs.py --file src/api/flaskr/service/shifu/shifu_outline_funcs.py --file src/api/flaskr/service/shifu/shifu_history_manager.py --file src/api/tests/service/shifu/test_archive.py --file src/api/tests/service/shifu/test_shifu_history_manager.py`
- manual checks: create course, create chapter, reorder chapters, delete chapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New draft outlines now initialize with a complete, accurately ordered chapter and lesson history.
  * Draft structure records are rebuilt when existing history is empty or incomplete.

* **Bug Fixes**
  * Improved reliability when adding outline history by clearly reporting missing parent entries instead of failing silently.
  * Prevented duplicate or unnecessary history entries during initial draft setup.

* **Tests**
  * Expanded coverage for draft archiving, outline initialization, history rebuilding, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->