### PR TITLE
chore: make commit titles clear to product users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,8 @@ rules, but must not duplicate or redefine them.
   `type: summary`; do not use `type(scope): summary`. Write the summary in
   plain language that product users can understand. When a change affects
   users, describe the user-visible outcome or benefit instead of only naming
-  the internal implementation detail.
+  the internal implementation detail (e.g., 'fix: prevent audio overlapping'
+  instead of 'fix: update useExclusiveAudio state').
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
 - Classification: use `chore` for repository-maintenance-only instruction or
   generated guidance updates like this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,10 @@ rules, but must not duplicate or redefine them.
   check. It does not enforce the `Changed:` / `Benefit:` body or the
   classification rules below.
 - Subject: use English Conventional Commits without scope parentheses, such as
-  `type: summary`; do not use `type(scope): summary`.
+  `type: summary`; do not use `type(scope): summary`. Write the summary in
+  plain language that product users can understand. When a change affects
+  users, describe the user-visible outcome or benefit instead of only naming
+  the internal implementation detail.
 - Body: include exactly two sections, `Changed:` and `Benefit:`.
 - Classification: use `chore` for repository-maintenance-only instruction or
   generated guidance updates like this file.


### PR DESCRIPTION
## Summary

- Require commit summaries to use plain language that product users can understand.
- For user-impacting changes, describe the visible outcome or benefit instead of only internal implementation details.

## Why

Commit history should communicate the purpose of a change to product users and reviewers, not only to the implementation author.

## Validation

- `python3 scripts/check_dev_tools.py`
- `python3 scripts/check_repo_harness.py`
- Local lefthook `pre-commit` and `commit-msg` hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance for writing commit messages.
  * Clarified Conventional Commit subjects to describe user-visible outcomes/benefits when changes impact users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->