### PR TITLE
fix: retry Tencent TTS empty audio

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -74,8 +74,9 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 _tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
 
 _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"
-_EMPTY_AUDIO_RETRY_PROVIDERS = {"", "volcengine"}
+_EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "volcengine"}
 _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
+_TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}
 
 _VISUAL_SLIDE_KINDS = frozenset(
@@ -99,6 +100,16 @@ def _is_retryable_empty_audio_error(error: Exception, provider_name: str) -> boo
         normalized_provider in _EMPTY_AUDIO_RETRY_PROVIDERS
         and _EMPTY_AUDIO_ERROR_MESSAGE in str(error)
     )
+
+
+def _tts_error_text_preview(
+    text: str,
+    max_chars: int = _TTS_ERROR_TEXT_PREVIEW_CHARS,
+) -> str:
+    normalized = str(text or "").replace("\r", "\\r").replace("\n", "\\n")
+    if len(normalized) <= max_chars:
+        return normalized
+    return f"{normalized[:max_chars]}...(truncated, total_len={len(normalized)})"
 
 
 def _should_use_volcengine_timestamp_stream(tts_provider: str) -> bool:
@@ -451,11 +462,13 @@ class StreamingTTSProcessor:
                     e, tts_provider
                 ):
                     logger.warning(
-                        "TTS segment %s returned no audio; retrying once: provider=%s model=%s text_len=%s",
+                        "TTS segment %s returned no audio; retrying once: "
+                        "provider=%s model=%s text_len=%s text_preview=%r",
                         segment_index if segment_index is not None else "request",
                         tts_provider or "(auto)",
                         tts_model or "(unset)",
                         len(text or ""),
+                        _tts_error_text_preview(text or ""),
                     )
                     time.sleep(_EMPTY_AUDIO_RETRY_DELAY_SECONDS)
                     continue
@@ -538,7 +551,16 @@ class StreamingTTSProcessor:
                 segment.error = str(e)
                 segment.is_ready = True
             except Exception as e:
-                logger.error(f"TTS segment {segment.index} failed: {e}")
+                logger.error(
+                    "TTS segment %s failed: %s provider=%s model=%s "
+                    "text_len=%s text_preview=%r",
+                    segment.index,
+                    e,
+                    tts_provider or "(auto)",
+                    tts_model or "(unset)",
+                    len(segment.text or ""),
+                    _tts_error_text_preview(segment.text or ""),
+                )
                 segment.error = str(e)
                 segment.is_ready = True
 

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -106,7 +106,7 @@ def _tts_error_text_preview(
     text: str,
     max_chars: int = _TTS_ERROR_TEXT_PREVIEW_CHARS,
 ) -> str:
-    normalized = str(text or "").replace("\r", "\\r").replace("\n", "\\n")
+    normalized = str(text or "")
     if len(normalized) <= max_chars:
         return normalized
     return f"{normalized[:max_chars]}...(truncated, total_len={len(normalized)})"

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -246,6 +246,96 @@ class TestStreamingSynthesisRetries:
     @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")
     @patch("flaskr.service.tts.streaming_tts.synthesize_text")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
+    def test_tencent_empty_audio_segment_retries_once(
+        self,
+        mock_is_configured,
+        mock_synthesize_text,
+        mock_record_usage,
+        mock_sleep,
+        mock_app,
+    ):
+        mock_is_configured.return_value = True
+        mock_synthesize_text.side_effect = [
+            ValueError("No audio data received from Tencent TTS"),
+            TTSResult(
+                audio_data=b"audio",
+                duration_ms=321,
+                sample_rate=16000,
+                format="mp3",
+                word_count=4,
+            ),
+        ]
+        app_context = MagicMock()
+        app_context.__enter__.return_value = None
+        app_context.__exit__.return_value = False
+        mock_app.app_context.return_value = app_context
+
+        processor = create_test_processor(mock_app, tts_provider="tencent")
+        segment = TTSSegment(index=3, text="腾讯重试这一句。")
+
+        result = processor._synthesize_in_thread(
+            segment,
+            processor.voice_settings,
+            processor.audio_settings,
+            processor.tts_provider,
+            processor.tts_model,
+        )
+
+        assert mock_synthesize_text.call_count == 2
+        mock_sleep.assert_called_once()
+        assert result.error is None
+        assert result.audio_data == b"audio"
+        assert result.duration_ms == 321
+        assert result.word_count == 4
+        mock_record_usage.assert_called_once()
+
+    @patch("flaskr.service.tts.streaming_tts.logger")
+    @patch("flaskr.service.tts.streaming_tts.time.sleep")
+    @patch("flaskr.service.tts.streaming_tts.synthesize_text")
+    @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
+    def test_tencent_empty_audio_failure_logs_text_after_retry(
+        self,
+        mock_is_configured,
+        mock_synthesize_text,
+        mock_sleep,
+        mock_logger,
+        mock_app,
+    ):
+        mock_is_configured.return_value = True
+        mock_synthesize_text.side_effect = ValueError(
+            "No audio data received from Tencent TTS"
+        )
+        app_context = MagicMock()
+        app_context.__enter__.return_value = None
+        app_context.__exit__.return_value = False
+        mock_app.app_context.return_value = app_context
+
+        processor = create_test_processor(mock_app, tts_provider="tencent")
+        segment = TTSSegment(index=5, text="！？")
+
+        result = processor._synthesize_in_thread(
+            segment,
+            processor.voice_settings,
+            processor.audio_settings,
+            processor.tts_provider,
+            processor.tts_model,
+        )
+
+        assert mock_synthesize_text.call_count == 2
+        mock_sleep.assert_called_once()
+        assert result.error == "No audio data received from Tencent TTS"
+        assert result.is_ready is True
+        warning_args = mock_logger.warning.call_args.args
+        error_args = mock_logger.error.call_args.args
+        assert "text_preview=%r" in warning_args[0]
+        assert "！？" in warning_args
+        assert "text_preview=%r" in error_args[0]
+        assert "！？" in error_args
+
+    @patch("flaskr.service.tts.streaming_tts.time.sleep")
+    @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")
+    @patch("flaskr.service.tts.streaming_tts.synthesize_text")
+    @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_volcengine_empty_audio_segment_retries_once(
         self,
         mock_is_configured,


### PR DESCRIPTION
## Summary
- retry Tencent TTS empty-audio responses using the existing transient empty-audio retry path
- include provider/model/text length and a sanitized text preview in retry/failure logs so Feishu alerts keep the failing text context
- add regression coverage for Tencent retry success and final failure logging

## Tests
- python3 -m py_compile src/api/flaskr/service/tts/streaming_tts.py src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py

## Note
This is the clean main-targeted PR for the same fix that was accidentally opened and merged against dev02 in #2134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty audio responses from the Tencent text-to-speech provider.
  * Added an automatic retry before reporting synthesis failure.
  * Enhanced error logs with provider, model, and a shortened text preview for easier troubleshooting.

* **Tests**
  * Added coverage for successful retries and repeated synthesis failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->