### PR TITLE
fix: default missing home URL to admin

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -513,9 +513,9 @@ DEFAULT_LOGIN_METHOD="phone"
 # (Optional - default: )
 FAVICON_URL=""
 
-# Cook Web logo/home redirect URL (default: /)
-# (Optional - default: /)
-HOME_URL="/"
+# Cook Web logo/home redirect URL (default: /admin)
+# (Optional - default: /admin)
+HOME_URL="/admin"
 
 # Canonical public web origin used to derive third-party callback and payment return URLs, e.g. https://your-domain.com. Required outside local/test environments.
 # (Optional - default: )

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -203,8 +203,8 @@ ENV_VARS: Dict[str, EnvVar] = {
     ),
     "HOME_URL": EnvVar(
         name="HOME_URL",
-        default="/",
-        description="Cook Web logo/home redirect URL (default: /)",
+        default="/admin",
+        description="Cook Web logo/home redirect URL (default: /admin)",
         group="frontend",
     ),
     "CONTACT_US_URL": EnvVar(

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -146,7 +146,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
         favicon_url = branding.favicon_url or get_config("FAVICON_URL", "")
-        home_url = branding.home_url or get_config("HOME_URL", "/")
+        home_url = branding.home_url or get_config("HOME_URL", "/admin")
         contact_us_url = branding.contact_us_url or get_config("CONTACT_US_URL", "")
         official_site_url = get_config("OFFICIAL_SITE_URL", "")
 

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -263,6 +263,26 @@ def test_runtime_config_returns_empty_official_site_url_when_unconfigured(
     assert payload["officialSiteUrl"] == ""
 
 
+def test_runtime_config_defaults_home_url_to_admin_when_unconfigured(
+    runtime_config_client,
+    monkeypatch,
+) -> None:
+    original_route_get_config = config_route.get_config
+
+    def get_config_override(key, default=""):
+        if key == "HOME_URL":
+            return default
+        return original_route_get_config(key, default)
+
+    monkeypatch.setattr(config_route, "get_config", get_config_override)
+
+    response = runtime_config_client.get("/api/runtime-config")
+    payload = response.get_json(force=True)["data"]
+
+    assert response.status_code == 200
+    assert payload["homeUrl"] == "/admin"
+
+
 def test_runtime_config_keeps_global_branding_when_host_binding_is_not_effective(
     runtime_config_client,
 ) -> None:

--- a/src/cook-web/src/app/page.tsx
+++ b/src/cook-web/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
     if (!runtimeConfigLoaded) {
       return;
     }
-    redirectToHomeUrlIfRootPath(homeUrl || '/');
+    redirectToHomeUrlIfRootPath(homeUrl || '/admin');
   }, [homeUrl, runtimeConfigLoaded]);
 
   return (

--- a/src/cook-web/src/config/environment.ts
+++ b/src/cook-web/src/config/environment.ts
@@ -308,7 +308,7 @@ function getDefaultLoginMethod(): string {
  * Gets home URL
  */
 function getHomeUrl(): string {
-  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '/';
+  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '/admin';
 }
 
 /**

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -189,7 +189,7 @@ const loadRuntimeConfig = async () => {
     runtimeConfig?.enableWechatCode?.toString() || 'true',
   );
   await updateDefaultLlmModel(runtimeConfig?.defaultLlmModel || '');
-  await updateHomeUrl(runtimeConfig?.homeUrl || '/');
+  await updateHomeUrl(runtimeConfig?.homeUrl || '/admin');
   await updateContactUsUrl(runtimeConfig?.contactUsUrl || '');
   await updateOfficialSiteUrl(
     resolveOfficialSiteUrl(runtimeConfig?.officialSiteUrl),
@@ -297,7 +297,7 @@ export const applyCreatorBranding = async (
       updateLogoSquareUrl,
       updateFaviconUrl,
     } = useEnvStore.getState() as EnvStoreState;
-    await updateHomeUrl(runtimeConfig.homeUrl || '/');
+    await updateHomeUrl(runtimeConfig.homeUrl || '/admin');
     await updateLogoWideUrl(runtimeConfig.logoWideUrl || '');
     await updateLogoSquareUrl(runtimeConfig.logoSquareUrl || '');
     await updateFaviconUrl(runtimeConfig.faviconUrl || '');

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -1,0 +1,27 @@
+import { redirectToHomeUrlIfRootPath } from './utils';
+
+const originalLocation = window.location;
+
+describe('redirectToHomeUrlIfRootPath', () => {
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('redirects the root path to the admin fallback', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/',
+        pathname: '/',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/admin')).toBe(true);
+    expect(replace).toHaveBeenCalledWith('/admin');
+  });
+});


### PR DESCRIPTION
## Summary

- Default the backend and frontend `HOME_URL` fallback to `/admin`.
- Keep creator branding and explicitly configured home URLs authoritative.
- Add backend and frontend regression coverage for the default redirect.

## Why

When neither creator branding nor the global `HOME_URL` configured a destination, visiting Cook Web at `/` resolved back to `/` and left the user on an empty root page. The fallback now enters the admin experience while preserving explicit values such as `/`.

## Validation

- `python3 scripts/check_dev_tools.py`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/billing/test_runtime_config_billing.py -q` — 12 passed
- `npm run test -- src/lib/utils.test.ts` — 1 passed
- `npm run type-check`
- Repository pre-commit and commit-message hooks
- Playwright browser check: missing `homeUrl` navigates `/` to `/admin`; explicit `homeUrl: "/"` remains on `/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default home destination from `/` to `/admin` across the application.
  * Root-path visits now redirect to the administration area when no custom home URL is configured.

* **Bug Fixes**
  * Ensured runtime configuration and creator branding consistently use `/admin` as the fallback home URL.

* **Tests**
  * Added coverage verifying default runtime configuration and root-path redirection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->