### PR TITLE
fix: default missing home URL to admin

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -513,9 +513,9 @@ DEFAULT_LOGIN_METHOD="phone"
 # (Optional - default: )
 FAVICON_URL=""
 
-# Cook Web logo/home redirect URL (default: /)
-# (Optional - default: /)
-HOME_URL="/"
+# Cook Web logo/home redirect URL (default: /admin)
+# (Optional - default: /admin)
+HOME_URL="/admin"
 
 # Canonical public web origin used to derive third-party callback and payment return URLs, e.g. https://your-domain.com. Required outside local/test environments.
 # (Optional - default: )

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -203,8 +203,8 @@ ENV_VARS: Dict[str, EnvVar] = {
     ),
     "HOME_URL": EnvVar(
         name="HOME_URL",
-        default="/",
-        description="Cook Web logo/home redirect URL (default: /)",
+        default="/admin",
+        description="Cook Web logo/home redirect URL (default: /admin)",
         group="frontend",
     ),
     "CONTACT_US_URL": EnvVar(

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -146,7 +146,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
         favicon_url = branding.favicon_url or get_config("FAVICON_URL", "")
-        home_url = branding.home_url or get_config("HOME_URL", "/admin")
+        home_url = branding.home_url or get_config("HOME_URL")
         contact_us_url = branding.contact_us_url or get_config("CONTACT_US_URL", "")
         official_site_url = get_config("OFFICIAL_SITE_URL", "")
 

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -1,5 +1,6 @@
 from flask import Flask, request
 
+from flaskr.common.config import ENV_VARS
 from flaskr.common.public_urls import build_google_oauth_callback_url
 from flaskr.common.shifu_context import get_shifu_creator_bid, with_shifu_context
 from flaskr.service.billing.dtos import (
@@ -146,7 +147,9 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
         favicon_url = branding.favicon_url or get_config("FAVICON_URL", "")
-        home_url = branding.home_url or get_config("HOME_URL")
+        home_url = branding.home_url or get_config(
+            "HOME_URL", ENV_VARS["HOME_URL"].default
+        )
         contact_us_url = branding.contact_us_url or get_config("CONTACT_US_URL", "")
         official_site_url = get_config("OFFICIAL_SITE_URL", "")
 

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -146,7 +146,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
         favicon_url = branding.favicon_url or get_config("FAVICON_URL", "")
-        home_url = branding.home_url or get_config("HOME_URL", "/")
+        home_url = branding.home_url or get_config("HOME_URL", "/admin")
         contact_us_url = branding.contact_us_url or get_config("CONTACT_US_URL", "")
         official_site_url = get_config("OFFICIAL_SITE_URL", "")
 

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -7,6 +7,7 @@ import pytest
 
 import flaskr.dao as dao
 import flaskr.common.public_urls as public_urls
+from flaskr.common.config import ENV_VARS
 from flaskr.route import config as config_route
 from flaskr.service.billing.consts import (
     BILLING_DOMAIN_BINDING_STATUS_VERIFIED,
@@ -271,7 +272,7 @@ def test_runtime_config_defaults_home_url_to_admin_when_unconfigured(
 
     def get_config_override(key, default=""):
         if key == "HOME_URL":
-            return default
+            return ENV_VARS["HOME_URL"].default
         return original_route_get_config(key, default)
 
     monkeypatch.setattr(config_route, "get_config", get_config_override)

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -263,6 +263,26 @@ def test_runtime_config_returns_empty_official_site_url_when_unconfigured(
     assert payload["officialSiteUrl"] == ""
 
 
+def test_runtime_config_defaults_home_url_to_admin_when_unconfigured(
+    runtime_config_client,
+    monkeypatch,
+) -> None:
+    original_route_get_config = config_route.get_config
+
+    def get_config_override(key, default=""):
+        if key == "HOME_URL":
+            return default
+        return original_route_get_config(key, default)
+
+    monkeypatch.setattr(config_route, "get_config", get_config_override)
+
+    response = runtime_config_client.get("/api/runtime-config")
+    payload = response.get_json(force=True)["data"]
+
+    assert response.status_code == 200
+    assert payload["homeUrl"] == "/admin"
+
+
 def test_runtime_config_keeps_global_branding_when_host_binding_is_not_effective(
     runtime_config_client,
 ) -> None:

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -264,15 +264,15 @@ def test_runtime_config_returns_empty_official_site_url_when_unconfigured(
     assert payload["officialSiteUrl"] == ""
 
 
-def test_runtime_config_defaults_home_url_to_admin_when_unconfigured(
+def test_runtime_config_uses_registered_home_url_default_on_config_lock_miss(
     runtime_config_client,
     monkeypatch,
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key, default=""):
+    def get_config_override(key, default=None):
         if key == "HOME_URL":
-            return ENV_VARS["HOME_URL"].default
+            return default
         return original_route_get_config(key, default)
 
     monkeypatch.setattr(config_route, "get_config", get_config_override)
@@ -281,7 +281,8 @@ def test_runtime_config_defaults_home_url_to_admin_when_unconfigured(
     payload = response.get_json(force=True)["data"]
 
     assert response.status_code == 200
-    assert payload["homeUrl"] == "/admin"
+    assert ENV_VARS["HOME_URL"].default == "/admin"
+    assert payload["homeUrl"] == ENV_VARS["HOME_URL"].default
 
 
 def test_runtime_config_keeps_global_branding_when_host_binding_is_not_effective(

--- a/src/cook-web/src/app/page.tsx
+++ b/src/cook-web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { redirectToHomeUrlIfRootPath } from '@/lib/utils';
 import { useEnvStore } from '@/c-store';
 import { EnvStoreState } from '@/c-types/store';
+import { environment } from '@/config/environment';
 
 export default function Home() {
   const homeUrl = useEnvStore((state: EnvStoreState) => state.homeUrl);
@@ -15,7 +16,7 @@ export default function Home() {
     if (!runtimeConfigLoaded) {
       return;
     }
-    redirectToHomeUrlIfRootPath(homeUrl || '/admin');
+    redirectToHomeUrlIfRootPath(homeUrl || environment.homeUrl);
   }, [homeUrl, runtimeConfigLoaded]);
 
   return (

--- a/src/cook-web/src/app/page.tsx
+++ b/src/cook-web/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
     if (!runtimeConfigLoaded) {
       return;
     }
-    redirectToHomeUrlIfRootPath(homeUrl || '/');
+    redirectToHomeUrlIfRootPath(homeUrl || '/admin');
   }, [homeUrl, runtimeConfigLoaded]);
 
   return (

--- a/src/cook-web/src/config/environment.ts
+++ b/src/cook-web/src/config/environment.ts
@@ -308,7 +308,7 @@ function getDefaultLoginMethod(): string {
  * Gets home URL
  */
 function getHomeUrl(): string {
-  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '/';
+  return getRuntimeEnv('HOME_URL') || process.env.HOME_URL || '/admin';
 }
 
 /**

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -189,7 +189,7 @@ const loadRuntimeConfig = async () => {
     runtimeConfig?.enableWechatCode?.toString() || 'true',
   );
   await updateDefaultLlmModel(runtimeConfig?.defaultLlmModel || '');
-  await updateHomeUrl(runtimeConfig?.homeUrl || '/');
+  await updateHomeUrl(runtimeConfig?.homeUrl || '/admin');
   await updateContactUsUrl(runtimeConfig?.contactUsUrl || '');
   await updateOfficialSiteUrl(
     resolveOfficialSiteUrl(runtimeConfig?.officialSiteUrl),
@@ -297,7 +297,7 @@ export const applyCreatorBranding = async (
       updateLogoSquareUrl,
       updateFaviconUrl,
     } = useEnvStore.getState() as EnvStoreState;
-    await updateHomeUrl(runtimeConfig.homeUrl || '/');
+    await updateHomeUrl(runtimeConfig.homeUrl || '/admin');
     await updateLogoWideUrl(runtimeConfig.logoWideUrl || '');
     await updateLogoSquareUrl(runtimeConfig.logoSquareUrl || '');
     await updateFaviconUrl(runtimeConfig.faviconUrl || '');

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -148,9 +148,7 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  const defaultHomeUrl =
-    window.location.pathname === '/' ? '/admin' : undefined;
-  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || defaultHomeUrl)) {
+  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || '/admin')) {
     return;
   }
 

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -148,7 +148,7 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl)) {
+  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || '/admin')) {
     return;
   }
 

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -5,6 +5,7 @@ import { EnvStoreState } from '@/c-types/store';
 import { redirectToHomeUrlIfRootPath } from '@/lib/utils';
 import { getBoolEnv } from '@/c-utils/envUtils';
 import {
+  environment,
   getDynamicApiBaseUrl,
   resolveOfficialSiteUrl,
 } from '@/config/environment';
@@ -148,7 +149,9 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || '/admin')) {
+  if (
+    redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || environment.homeUrl)
+  ) {
     return;
   }
 
@@ -189,7 +192,7 @@ const loadRuntimeConfig = async () => {
     runtimeConfig?.enableWechatCode?.toString() || 'true',
   );
   await updateDefaultLlmModel(runtimeConfig?.defaultLlmModel || '');
-  await updateHomeUrl(runtimeConfig?.homeUrl || '/admin');
+  await updateHomeUrl(runtimeConfig?.homeUrl || environment.homeUrl);
   await updateContactUsUrl(runtimeConfig?.contactUsUrl || '');
   await updateOfficialSiteUrl(
     resolveOfficialSiteUrl(runtimeConfig?.officialSiteUrl),
@@ -297,7 +300,7 @@ export const applyCreatorBranding = async (
       updateLogoSquareUrl,
       updateFaviconUrl,
     } = useEnvStore.getState() as EnvStoreState;
-    await updateHomeUrl(runtimeConfig.homeUrl || '/admin');
+    await updateHomeUrl(runtimeConfig.homeUrl || environment.homeUrl);
     await updateLogoWideUrl(runtimeConfig.logoWideUrl || '');
     await updateLogoSquareUrl(runtimeConfig.logoSquareUrl || '');
     await updateFaviconUrl(runtimeConfig.faviconUrl || '');

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -148,7 +148,9 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || '/admin')) {
+  const defaultHomeUrl =
+    window.location.pathname === '/' ? '/admin' : undefined;
+  if (redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || defaultHomeUrl)) {
     return;
   }
 

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -3,7 +3,7 @@ import { redirectToHomeUrlIfRootPath } from './utils';
 const originalLocation = window.location;
 
 describe('redirectToHomeUrlIfRootPath', () => {
-  afterAll(() => {
+  afterEach(() => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: originalLocation,

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -1,0 +1,27 @@
+import { redirectToHomeUrlIfRootPath } from './utils';
+
+const originalLocation = window.location;
+
+describe('redirectToHomeUrlIfRootPath', () => {
+  afterAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('redirects the root path to the admin fallback', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/',
+        pathname: '/',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/admin')).toBe(true);
+    expect(replace).toHaveBeenCalledWith('/admin');
+  });
+});

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -24,4 +24,19 @@ describe('redirectToHomeUrlIfRootPath', () => {
     expect(redirectToHomeUrlIfRootPath('/admin')).toBe(true);
     expect(replace).toHaveBeenCalledWith('/admin');
   });
+
+  it('does not redirect a non-entry path', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/admin',
+        pathname: '/admin',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/admin')).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Default the backend and frontend `HOME_URL` fallback to `/admin`.
- Keep creator branding and explicitly configured home URLs authoritative.
- Add backend and frontend regression coverage for the default redirect.

## Why

When neither creator branding nor the global `HOME_URL` configured a destination, visiting Cook Web at `/` resolved back to `/` and left the user on an empty root page. The fallback now enters the admin experience while preserving explicit values such as `/`.

## Validation

- `python3 scripts/check_dev_tools.py`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/billing/test_runtime_config_billing.py -q` — 12 passed
- `npm run test -- src/lib/utils.test.ts` — 1 passed
- `npm run type-check`
- Repository pre-commit and commit-message hooks
- Playwright browser check: missing `homeUrl` navigates `/` to `/admin`; explicit `homeUrl: "/"` remains on `/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default home destination from the root path (`/`) to the Admin area (`/admin`).
  * Root-path visits now redirect to `/admin` when no custom home URL is configured.
  * Runtime configuration and creator branding consistently use `/admin` as the fallback home destination.

* **Bug Fixes**
  * Improved home-page redirect behavior when configuration values are unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->