### PR TITLE
fix: skip non-speakable Tencent TTS segments

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -119,8 +119,7 @@ def _is_tencent_provider(tts_provider: str) -> bool:
 
 def _has_speakable_text(text: str) -> bool:
     return any(
-        unicodedata.category(char).startswith(("L", "N"))
-        for char in str(text or "")
+        unicodedata.category(char).startswith(("L", "N")) for char in str(text or "")
     )
 
 

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -10,6 +10,7 @@ This module provides real-time TTS synthesis during content streaming.
 import base64
 import logging
 import traceback
+import unicodedata
 import uuid
 import threading
 import time
@@ -110,6 +111,21 @@ def _tts_error_text_preview(
     if len(normalized) <= max_chars:
         return normalized
     return f"{normalized[:max_chars]}...(truncated, total_len={len(normalized)})"
+
+
+def _is_tencent_provider(tts_provider: str) -> bool:
+    return (tts_provider or "").strip().lower() == "tencent"
+
+
+def _has_speakable_text(text: str) -> bool:
+    return any(
+        unicodedata.category(char).startswith(("L", "N"))
+        for char in str(text or "")
+    )
+
+
+def _should_skip_tencent_tts_text(text: str, tts_provider: str) -> bool:
+    return _is_tencent_provider(tts_provider) and not _has_speakable_text(text)
 
 
 def _should_use_volcengine_timestamp_stream(tts_provider: str) -> bool:
@@ -487,6 +503,22 @@ class StreamingTTSProcessor:
     ) -> TTSSegment:
         """Synthesize a segment in a background thread."""
         with self.app.app_context():
+            if _should_skip_tencent_tts_text(segment.text or "", tts_provider):
+                logger.info(
+                    "TTS segment %s skipped before Tencent synthesis: "
+                    "non_speakable_text provider=%s model=%s text_len=%s "
+                    "text_preview=%r",
+                    segment.index,
+                    tts_provider or "(auto)",
+                    tts_model or "(unset)",
+                    len(segment.text or ""),
+                    _tts_error_text_preview(segment.text or ""),
+                )
+                segment.is_ready = True
+                with self._lock:
+                    self._completed_segments[segment.index] = segment
+                return segment
+
             try:
                 segment_start = time.monotonic()
                 result = self._synthesize_text_with_retry(

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -311,7 +311,7 @@ class TestStreamingSynthesisRetries:
         mock_app.app_context.return_value = app_context
 
         processor = create_test_processor(mock_app, tts_provider="tencent")
-        segment = TTSSegment(index=5, text="！？")
+        segment = TTSSegment(index=5, text="这句有文字但腾讯没返回。")
 
         result = processor._synthesize_in_thread(
             segment,
@@ -328,9 +328,49 @@ class TestStreamingSynthesisRetries:
         warning_args = mock_logger.warning.call_args.args
         error_args = mock_logger.error.call_args.args
         assert "text_preview=%r" in warning_args[0]
-        assert "！？" in warning_args
+        assert "这句有文字但腾讯没返回。" in warning_args
         assert "text_preview=%r" in error_args[0]
-        assert "！？" in error_args
+        assert "这句有文字但腾讯没返回。" in error_args
+
+    @patch("flaskr.service.tts.streaming_tts.logger")
+    @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")
+    @patch("flaskr.service.tts.streaming_tts.synthesize_text")
+    @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
+    def test_tencent_non_speakable_segment_skips_provider_call(
+        self,
+        mock_is_configured,
+        mock_synthesize_text,
+        mock_record_usage,
+        mock_logger,
+        mock_app,
+    ):
+        mock_is_configured.return_value = True
+        app_context = MagicMock()
+        app_context.__enter__.return_value = None
+        app_context.__exit__.return_value = False
+        mock_app.app_context.return_value = app_context
+
+        processor = create_test_processor(mock_app, tts_provider="tencent")
+        segment = TTSSegment(index=10, text="---")
+
+        result = processor._synthesize_in_thread(
+            segment,
+            processor.voice_settings,
+            processor.audio_settings,
+            processor.tts_provider,
+            processor.tts_model,
+        )
+
+        mock_synthesize_text.assert_not_called()
+        mock_record_usage.assert_not_called()
+        mock_logger.error.assert_not_called()
+        assert result.error is None
+        assert result.audio_data is None
+        assert result.is_ready is True
+        assert processor._completed_segments[10] is result
+        info_args = mock_logger.info.call_args.args
+        assert "skipped before Tencent synthesis" in info_args[0]
+        assert "---" in info_args
 
     @patch("flaskr.service.tts.streaming_tts.time.sleep")
     @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")


### PR DESCRIPTION
## Summary
- skip Tencent TTS synthesis for segments with no letters or numbers, such as `---`, before calling the provider
- keep the existing ERROR alert path for speakable text that still returns no audio
- log skipped Tencent punctuation/symbol-only segments at info level with text preview for investigation
- add regression coverage for Tencent provider-call skipping and preserve failure logging for speakable text

## Tests
- python3 -m py_compile src/api/flaskr/service/tts/streaming_tts.py src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tencent text-to-speech now skips segments that contain no speakable characters, avoiding wasted processing.
  * Marked such segments as complete without generating audio, retries, usage tracking, or error logging.
  * Added clearer handling for non-speakable marker segments so they return a ready result cleanly.
* **Tests**
  * Updated the Tencent empty-audio regression test expectations.
  * Added coverage for non-speakable segments to verify the skip behavior and log messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->