### PR TITLE
fix: stop selecting default courses automatically

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -501,10 +501,6 @@ CURRENCY_SYMBOL="¥"
 # Type: bool
 DEBUG_ERUDA_ENABLED="False"
 
-# Default course id for Cook Web
-# (Optional - default: )
-DEFAULT_COURSE_ID=""
-
 # Default login method tab. Values: "phone" | "email" | "google"
 # (Optional - default: phone)
 DEFAULT_LOGIN_METHOD="phone"
@@ -513,7 +509,7 @@ DEFAULT_LOGIN_METHOD="phone"
 # (Optional - default: )
 FAVICON_URL=""
 
-# Cook Web logo/home redirect URL (default: /admin)
+# Cook Web logo and entry redirect URL. Set /c/<shifu_bid> to use a course as the landing page (default: /admin)
 # (Optional - default: /admin)
 HOME_URL="/admin"
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -204,7 +204,10 @@ ENV_VARS: Dict[str, EnvVar] = {
     "HOME_URL": EnvVar(
         name="HOME_URL",
         default="/admin",
-        description="Cook Web logo/home redirect URL (default: /admin)",
+        description=(
+            "Cook Web logo and entry redirect URL. Set /c/<shifu_bid> to use "
+            "a course as the landing page (default: /admin)"
+        ),
         group="frontend",
     ),
     "CONTACT_US_URL": EnvVar(
@@ -329,12 +332,6 @@ ENV_VARS: Dict[str, EnvVar] = {
         type=int,
         description="Upper bound for the DSL `limit` field accepted by creator-analytics",
         group="analytics",
-    ),
-    "DEFAULT_COURSE_ID": EnvVar(
-        name="DEFAULT_COURSE_ID",
-        default="",
-        description="Default course id for Cook Web",
-        group="frontend",
     ),
     "DEFAULT_LOGIN_METHOD": EnvVar(
         name="DEFAULT_LOGIN_METHOD",

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -154,7 +154,6 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         official_site_url = get_config("OFFICIAL_SITE_URL", "")
 
         config = RuntimeConfigDTO(
-            courseId=get_config("DEFAULT_COURSE_ID", ""),
             defaultLlmModel=get_config("DEFAULT_LLM_MODEL", ""),
             wechatAppId=get_config("WECHAT_APP_ID", ""),
             enableWechatCode=bool(get_config("WECHAT_APP_ID", "")),

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -740,7 +740,6 @@ class RuntimeBillingContextDTO(BillingBaseDTO):
 
 
 class RuntimeConfigDTO(BillingBaseDTO):
-    courseId: str
     defaultLlmModel: str
     wechatAppId: str
     enableWechatCode: bool

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -28,7 +28,6 @@ from flaskr.service.shifu.shifu_struct_manager import (
     get_outline_item_dto,
     ShifuInfoDto,
     ShifuOutlineItemDto,
-    get_default_shifu_dto,
     get_shifu_struct,
 )
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
@@ -250,6 +249,7 @@ def run_script_inner(
 
     def _run() -> Generator[RunMarkdownFlowDTO | RunElementSSEMessageDTO, None, None]:
         run_script_context: RunScriptContextV2 | None = None
+        resolved_shifu_bid = shifu_bid
         try:
             user_info = load_user_aggregate(user_bid)
             if not user_info:
@@ -259,19 +259,18 @@ def run_script_inner(
             struct_info: HistoryItem = None
             if not outline_bid:
                 app.logger.info("lesson_id is None")
-                if not shifu_bid:
-                    shifu_info = get_default_shifu_dto(app, preview_mode)
-                else:
-                    shifu_info = get_shifu_dto(app, shifu_bid, preview_mode)
+                if not resolved_shifu_bid:
+                    raise_error("server.shifu.courseNotFound")
+                shifu_info = get_shifu_dto(app, resolved_shifu_bid, preview_mode)
                 if not shifu_info:
                     raise_error("server.outline.hasNotLesson")
-                shifu_bid = shifu_info.bid
+                resolved_shifu_bid = shifu_info.bid
             else:
                 outline_item_info = get_outline_item_dto(app, outline_bid, preview_mode)
                 if not outline_item_info:
                     raise_error("server.shifu.lessonNotFoundInCourse")
-                shifu_bid = outline_item_info.shifu_bid
-                shifu_info = get_shifu_dto(app, shifu_bid, preview_mode)
+                resolved_shifu_bid = outline_item_info.shifu_bid
+                shifu_info = get_shifu_dto(app, resolved_shifu_bid, preview_mode)
                 if not shifu_info:
                     raise_error("server.shifu.courseNotFound")
 
@@ -288,7 +287,7 @@ def run_script_inner(
                 success_buy_record = (
                     Order.query.filter(
                         Order.user_bid == user_bid,
-                        Order.shifu_bid == shifu_bid,
+                        Order.shifu_bid == resolved_shifu_bid,
                         Order.status == ORDER_STATUS_SUCCESS,
                         Order.deleted == 0,
                     )

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -262,17 +262,11 @@ def run_script_inner(
                 if not resolved_shifu_bid:
                     raise_error("server.shifu.courseNotFound")
                 shifu_info = get_shifu_dto(app, resolved_shifu_bid, preview_mode)
-                if not shifu_info:
-                    raise_error("server.outline.hasNotLesson")
                 resolved_shifu_bid = shifu_info.bid
             else:
                 outline_item_info = get_outline_item_dto(app, outline_bid, preview_mode)
-                if not outline_item_info:
-                    raise_error("server.shifu.lessonNotFoundInCourse")
                 resolved_shifu_bid = outline_item_info.shifu_bid
                 shifu_info = get_shifu_dto(app, resolved_shifu_bid, preview_mode)
-                if not shifu_info:
-                    raise_error("server.shifu.courseNotFound")
 
             struct_info = get_shifu_struct(app, shifu_info.bid, preview_mode)
             if not struct_info:

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -213,41 +213,6 @@ def get_shifu_dto(app: Flask, shifu_bid: str, is_preview: bool = False) -> Shifu
     )
 
 
-def get_default_shifu_dto(app: Flask, is_preview: bool = False) -> ShifuInfoDto:
-    """
-    Get default shifu dto
-    Args:
-        app: Flask application instance
-        is_preview: Is preview
-    Returns:
-        ShifuInfoDto: Shifu dto
-    """
-    if is_preview:
-        shifu_model = DraftShifu
-    else:
-        shifu_model = PublishedShifu
-    shifu: Union[DraftShifu, PublishedShifu] = (
-        shifu_model.query.filter(
-            shifu_model.deleted == 0,
-        )
-        .order_by(
-            shifu_model.id.asc(),
-        )
-        .first()
-    )
-    if not shifu:
-        raise_error("server.shifu.shifuNotFound")
-    return ShifuInfoDto(
-        bid=shifu.shifu_bid,
-        title=shifu.title,
-        description=shifu.description,
-        avatar=get_shifu_res_url(shifu.avatar_res_bid),
-        price=shifu.price,
-        outline_items=[],
-        use_learner_language=bool(getattr(shifu, "use_learner_language", 0)),
-    )
-
-
 def get_outline_item_dto(
     app: Flask, outline_item_bid: str, is_preview: bool = False
 ) -> ShifuOutlineItemDto:

--- a/src/api/tests/service/billing/test_billing_dtos.py
+++ b/src/api/tests/service/billing/test_billing_dtos.py
@@ -186,7 +186,6 @@ def test_billing_dto_json_serializes_metric_breakdowns_and_bucket_lists() -> Non
 
 def test_runtime_config_dto_json_uses_public_aliases() -> None:
     dto = RuntimeConfigDTO(
-        courseId="course-1",
         defaultLlmModel="gpt-5.4",
         wechatAppId="wechat-app-1",
         enableWechatCode=True,
@@ -266,6 +265,7 @@ def test_runtime_config_dto_json_uses_public_aliases() -> None:
     }
     assert payload["billingEnabled"] is True
     assert payload["billingCreditPrecision"] == 2
+    assert "courseId" not in payload
     assert payload["branding"]["home_url"] == "https://creator.example.com"
     assert payload["contactUsUrl"] == "https://ai-shifu.cn/contact.html"
     assert payload["officialSiteUrl"] == "https://official.example.com"

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -38,7 +38,6 @@ def runtime_config_client(monkeypatch):
 
     dao.db.init_app(app)
     config_values = {
-        "DEFAULT_COURSE_ID": "global-course-1",
         "DEFAULT_LLM_MODEL": "gpt-5.4",
         "WECHAT_APP_ID": "wechat-app-1",
         "BILL_ENABLED": True,
@@ -173,6 +172,7 @@ def test_runtime_config_returns_billing_extensions_for_custom_domain(
     )
     payload = response.get_json(force=True)["data"]
 
+    assert "courseId" not in payload
     assert payload["logoWideUrl"] == "https://cdn.example.com/creator-wide.png"
     assert payload["logoSquareUrl"] == "https://cdn.example.com/creator-square.png"
     assert payload["faviconUrl"] == "https://cdn.example.com/creator-favicon.ico"

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -612,6 +612,49 @@ def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():
     assert error_calls[1][0]["description"] == "boom"
 
 
+def test_run_script_inner_rejects_missing_course_without_default(monkeypatch):
+    app = Flask(__name__)
+    rollback_calls = []
+    remove_calls = []
+
+    monkeypatch.setattr(
+        runscript_v2,
+        "db",
+        SimpleNamespace(
+            session=SimpleNamespace(
+                rollback=lambda: rollback_calls.append("rollback"),
+                remove=lambda: remove_calls.append("remove"),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "load_user_aggregate",
+        lambda _user_bid: SimpleNamespace(user_id="user-1"),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_shifu_dto",
+        lambda *_args, **_kwargs: pytest.fail(
+            "missing course ids must not select a course"
+        ),
+    )
+
+    with pytest.raises(AppException) as exc_info:
+        list(
+            runscript_v2.run_script_inner(
+                app=app,
+                user_bid="user-1",
+                shifu_bid="",
+                outline_bid="",
+            )
+        )
+
+    assert exc_info.value.code == 4001
+    assert rollback_calls == ["rollback"]
+    assert remove_calls == ["remove"]
+
+
 def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
     app = Flask(__name__)
     session_spy = SimpleNamespace(

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -109,4 +109,34 @@ describe('course route entry redirect', () => {
       expect(replace).toHaveBeenCalledWith('/c/runtime-course');
     });
   });
+
+  it('redirects a direct /c entry to a configured root HOME_URL', async () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c',
+        pathname: '/c',
+        replace,
+      },
+    });
+    mockPathname = '/c';
+    act(() => {
+      useEnvStore.setState({
+        homeUrl: '/',
+        runtimeConfigLoaded: true,
+      });
+    });
+
+    render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/');
+    });
+    expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+  });
 });

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -203,4 +203,37 @@ describe('course route entry redirect', () => {
     });
     expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
   });
+
+  it.each(['/c', 'javascript:alert(1)'])(
+    'uses the not-found fallback when HOME_URL cannot redirect: %s',
+    async homeUrl => {
+      const replace = jest.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          href: 'https://app.example.com/c',
+          pathname: '/c',
+          replace,
+        },
+      });
+      mockPathname = '/c';
+      act(() => {
+        useEnvStore.setState({
+          homeUrl,
+          runtimeConfigLoaded: true,
+        });
+      });
+
+      render(
+        <ChatLayout>
+          <div>{childLabel}</div>
+        </ChatLayout>,
+      );
+
+      await waitFor(() => {
+        expect(replace).toHaveBeenCalledWith('/404');
+      });
+      expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+    },
+  );
 });

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -6,10 +6,12 @@ import ChatLayout from './layout';
 
 let mockPathname = '/c/course-1';
 let mockSearchParams = new URLSearchParams();
+const mockRouterReplace = jest.fn();
 const childLabel = 'content';
 
 jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useRouter: () => ({ replace: mockRouterReplace }),
   useSearchParams: () => mockSearchParams,
 }));
 
@@ -19,6 +21,7 @@ describe('course route entry redirect', () => {
   beforeEach(() => {
     mockPathname = '/c/course-1';
     mockSearchParams = new URLSearchParams();
+    mockRouterReplace.mockClear();
   });
 
   afterEach(() => {
@@ -231,8 +234,9 @@ describe('course route entry redirect', () => {
       );
 
       await waitFor(() => {
-        expect(replace).toHaveBeenCalledWith('/404');
+        expect(mockRouterReplace).toHaveBeenCalledWith('/404');
       });
+      expect(replace).not.toHaveBeenCalled();
       expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
     },
   );

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import { useEnvStore } from '@/c-store/envStore';
+import ChatLayout from './layout';
+
+let mockPathname = '/c/course-1';
+const childLabel = 'content';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+const originalLocation = window.location;
+
+describe('course route entry redirect', () => {
+  beforeEach(() => {
+    mockPathname = '/c/course-1';
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    act(() => {
+      useEnvStore.setState({
+        courseId: '',
+        homeUrl: '',
+        runtimeConfigLoaded: false,
+      });
+    });
+  });
+
+  it('rechecks HOME_URL after client navigation to bare /c despite a stale course id', async () => {
+    const replace = jest.fn();
+    const location = {
+      href: 'https://app.example.com/c/course-1',
+      pathname: '/c/course-1',
+      replace,
+    };
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: location,
+    });
+    act(() => {
+      useEnvStore.setState({
+        courseId: 'stale-course',
+        homeUrl: '/c/default-course',
+        runtimeConfigLoaded: true,
+      });
+    });
+
+    const { rerender } = render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await act(async () => {});
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText(childLabel)).toBeInTheDocument();
+
+    mockPathname = '/c';
+    location.href = 'https://app.example.com/c';
+    location.pathname = '/c';
+    rerender(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/c/default-course');
+    });
+    expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+  });
+
+  it('waits for the runtime HOME_URL before redirecting a direct /c entry', async () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c',
+        pathname: '/c',
+        replace,
+      },
+    });
+    mockPathname = '/c';
+
+    render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await act(async () => {});
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+
+    act(() => {
+      useEnvStore.setState({
+        homeUrl: '/c/runtime-course',
+        runtimeConfigLoaded: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/c/runtime-course');
+    });
+  });
+});

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -146,33 +146,59 @@ describe('course route entry redirect', () => {
     expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
   });
 
-  it('preserves an explicit courseId query entry instead of applying HOME_URL', async () => {
+  it('canonicalizes an explicit courseId query before mounting learner children', async () => {
     const replace = jest.fn();
+    const location = {
+      href: 'https://app.example.com/c?courseId=explicit%2Fcourse%20one&lessonid=lesson-1&preview=true&mode=listen&channel=share#chapter-2',
+      hash: '#chapter-2',
+      pathname: '/c',
+      replace,
+    };
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: {
-        href: 'https://app.example.com/c?courseId=explicit-course',
-        pathname: '/c',
-        replace,
-      },
+      value: location,
     });
     mockPathname = '/c';
-    mockSearchParams = new URLSearchParams('courseId=explicit-course');
+    mockSearchParams = new URLSearchParams(
+      'courseId=explicit%2Fcourse%20one&lessonid=lesson-1&preview=true&mode=listen&channel=share',
+    );
     act(() => {
       useEnvStore.setState({
         homeUrl: '/c/default-course',
-        runtimeConfigLoaded: true,
+        runtimeConfigLoaded: false,
       });
     });
 
-    render(
+    const { rerender } = render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith(
+        '/c/explicit%2Fcourse%20one?lessonid=lesson-1&preview=true&mode=listen&channel=share#chapter-2',
+      );
+    });
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+
+    mockRouterReplace.mockClear();
+    mockPathname = '/c/explicit%2Fcourse%20one';
+    mockSearchParams = new URLSearchParams(
+      'lessonid=lesson-1&preview=true&mode=listen&channel=share',
+    );
+    location.href =
+      'https://app.example.com/c/explicit%2Fcourse%20one?lessonid=lesson-1&preview=true&mode=listen&channel=share#chapter-2';
+    location.pathname = '/c/explicit%2Fcourse%20one';
+    rerender(
       <ChatLayout>
         <div>{childLabel}</div>
       </ChatLayout>,
     );
 
     await act(async () => {});
-    expect(replace).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
     expect(screen.getByText(childLabel)).toBeInTheDocument();
   });
 

--- a/src/cook-web/src/app/c/layout.test.tsx
+++ b/src/cook-web/src/app/c/layout.test.tsx
@@ -5,10 +5,12 @@ import { useEnvStore } from '@/c-store/envStore';
 import ChatLayout from './layout';
 
 let mockPathname = '/c/course-1';
+let mockSearchParams = new URLSearchParams();
 const childLabel = 'content';
 
 jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
 }));
 
 const originalLocation = window.location;
@@ -16,6 +18,7 @@ const originalLocation = window.location;
 describe('course route entry redirect', () => {
   beforeEach(() => {
     mockPathname = '/c/course-1';
+    mockSearchParams = new URLSearchParams();
   });
 
   afterEach(() => {
@@ -136,6 +139,67 @@ describe('course route entry redirect', () => {
 
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith('/');
+    });
+    expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
+  });
+
+  it('preserves an explicit courseId query entry instead of applying HOME_URL', async () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c?courseId=explicit-course',
+        pathname: '/c',
+        replace,
+      },
+    });
+    mockPathname = '/c';
+    mockSearchParams = new URLSearchParams('courseId=explicit-course');
+    act(() => {
+      useEnvStore.setState({
+        homeUrl: '/c/default-course',
+        runtimeConfigLoaded: true,
+      });
+    });
+
+    render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await act(async () => {});
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText(childLabel)).toBeInTheDocument();
+  });
+
+  it('treats a blank courseId query as a bare course entry', async () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c?courseId=%20',
+        pathname: '/c',
+        replace,
+      },
+    });
+    mockPathname = '/c';
+    mockSearchParams = new URLSearchParams('courseId=%20');
+    act(() => {
+      useEnvStore.setState({
+        homeUrl: '/c/default-course',
+        runtimeConfigLoaded: true,
+      });
+    });
+
+    render(
+      <ChatLayout>
+        <div>{childLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/c/default-course');
     });
     expect(screen.queryByText(childLabel)).not.toBeInTheDocument();
   });

--- a/src/cook-web/src/app/c/layout.tsx
+++ b/src/cook-web/src/app/c/layout.tsx
@@ -3,6 +3,13 @@
 // Probably don't need this.
 // import 'core-js/full';
 
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { useEnvStore } from '@/c-store/envStore';
+import { environment } from '@/config/environment';
+import { redirectToHomeUrlIfRootPath } from '@/lib/utils';
+
 import './layout.css';
 import '@/c-utils/pollyfill';
 
@@ -11,5 +18,21 @@ export default function ChatLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  const homeUrl = useEnvStore(state => state.homeUrl);
+  const runtimeConfigLoaded = useEnvStore(state => state.runtimeConfigLoaded);
+  const isCourseEntryPath = pathname?.replace(/\/+$/, '') === '/c';
+
+  useEffect(() => {
+    if (!runtimeConfigLoaded || !isCourseEntryPath) {
+      return;
+    }
+    redirectToHomeUrlIfRootPath(homeUrl || environment.homeUrl);
+  }, [homeUrl, isCourseEntryPath, runtimeConfigLoaded]);
+
+  if (isCourseEntryPath) {
+    return null;
+  }
+
   return <>{children}</>;
 }

--- a/src/cook-web/src/app/c/layout.tsx
+++ b/src/cook-web/src/app/c/layout.tsx
@@ -30,7 +30,12 @@ export default function ChatLayout({
     if (!runtimeConfigLoaded || !isBareCourseEntryPath) {
       return;
     }
-    redirectToHomeUrlIfRootPath(homeUrl || environment.homeUrl);
+    const redirected = redirectToHomeUrlIfRootPath(
+      homeUrl || environment.homeUrl,
+    );
+    if (!redirected) {
+      window.location.replace('/404');
+    }
   }, [homeUrl, isBareCourseEntryPath, runtimeConfigLoaded]);
 
   if (isBareCourseEntryPath) {

--- a/src/cook-web/src/app/c/layout.tsx
+++ b/src/cook-web/src/app/c/layout.tsx
@@ -4,7 +4,7 @@
 // import 'core-js/full';
 
 import { useEffect } from 'react';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import { useEnvStore } from '@/c-store/envStore';
 import { environment } from '@/config/environment';
@@ -19,18 +19,21 @@ export default function ChatLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const homeUrl = useEnvStore(state => state.homeUrl);
   const runtimeConfigLoaded = useEnvStore(state => state.runtimeConfigLoaded);
-  const isCourseEntryPath = pathname?.replace(/\/+$/, '') === '/c';
+  const explicitCourseId = searchParams?.get('courseId')?.trim() ?? '';
+  const isBareCourseEntryPath =
+    pathname?.replace(/\/+$/, '') === '/c' && !explicitCourseId;
 
   useEffect(() => {
-    if (!runtimeConfigLoaded || !isCourseEntryPath) {
+    if (!runtimeConfigLoaded || !isBareCourseEntryPath) {
       return;
     }
     redirectToHomeUrlIfRootPath(homeUrl || environment.homeUrl);
-  }, [homeUrl, isCourseEntryPath, runtimeConfigLoaded]);
+  }, [homeUrl, isBareCourseEntryPath, runtimeConfigLoaded]);
 
-  if (isCourseEntryPath) {
+  if (isBareCourseEntryPath) {
     return null;
   }
 

--- a/src/cook-web/src/app/c/layout.tsx
+++ b/src/cook-web/src/app/c/layout.tsx
@@ -23,9 +23,31 @@ export default function ChatLayout({
   const searchParams = useSearchParams();
   const homeUrl = useEnvStore(state => state.homeUrl);
   const runtimeConfigLoaded = useEnvStore(state => state.runtimeConfigLoaded);
+  const normalizedPath = pathname?.replace(/\/+$/, '');
+  const serializedSearchParams = searchParams?.toString() ?? '';
   const explicitCourseId = searchParams?.get('courseId')?.trim() ?? '';
-  const isBareCourseEntryPath =
-    pathname?.replace(/\/+$/, '') === '/c' && !explicitCourseId;
+  const isCourseEntryPath = normalizedPath === '/c';
+  const isCourseQueryEntryPath = isCourseEntryPath && !!explicitCourseId;
+  const isBareCourseEntryPath = isCourseEntryPath && !explicitCourseId;
+
+  useEffect(() => {
+    if (!isCourseQueryEntryPath) {
+      return;
+    }
+    const remainingSearchParams = new URLSearchParams(serializedSearchParams);
+    remainingSearchParams.delete('courseId');
+    const remainingQuery = remainingSearchParams.toString();
+    const hash = window.location.hash;
+    router.replace(
+      `/c/${encodeURIComponent(explicitCourseId)}` +
+        `${remainingQuery ? `?${remainingQuery}` : ''}${hash}`,
+    );
+  }, [
+    explicitCourseId,
+    isCourseQueryEntryPath,
+    router,
+    serializedSearchParams,
+  ]);
 
   useEffect(() => {
     if (!runtimeConfigLoaded || !isBareCourseEntryPath) {
@@ -39,7 +61,7 @@ export default function ChatLayout({
     }
   }, [homeUrl, isBareCourseEntryPath, router, runtimeConfigLoaded]);
 
-  if (isBareCourseEntryPath) {
+  if (isCourseEntryPath) {
     return null;
   }
 

--- a/src/cook-web/src/app/c/layout.tsx
+++ b/src/cook-web/src/app/c/layout.tsx
@@ -4,7 +4,7 @@
 // import 'core-js/full';
 
 import { useEffect } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { useEnvStore } from '@/c-store/envStore';
 import { environment } from '@/config/environment';
@@ -18,6 +18,7 @@ export default function ChatLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const homeUrl = useEnvStore(state => state.homeUrl);
@@ -34,9 +35,9 @@ export default function ChatLayout({
       homeUrl || environment.homeUrl,
     );
     if (!redirected) {
-      window.location.replace('/404');
+      router.replace('/404');
     }
-  }, [homeUrl, isBareCourseEntryPath, runtimeConfigLoaded]);
+  }, [homeUrl, isBareCourseEntryPath, router, runtimeConfigLoaded]);
 
   if (isBareCourseEntryPath) {
     return null;

--- a/src/cook-web/src/c-store/envStore.ts
+++ b/src/cook-web/src/c-store/envStore.ts
@@ -3,7 +3,7 @@ import { EnvStoreState } from '@/c-types/store';
 import { environment } from '@/config/environment';
 
 export const useEnvStore = create<EnvStoreState>(set => ({
-  courseId: environment.courseId,
+  courseId: '',
   updateCourseId: async (courseId: string) => set({ courseId }),
   defaultLlmModel: environment.defaultLlmModel,
   updateDefaultLlmModel: async (defaultLlmModel: string) =>

--- a/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
+++ b/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
@@ -12,11 +12,13 @@
 | -------------------------- | ---------- | ----------------------- |
 | `NEXT_PUBLIC_API_BASE_URL` | API基础URL | `http://localhost:8080` |
 
-### 2. 课程配置 (Course Configuration)
+### 2. 入口跳转配置 (Entry Redirect Configuration)
 
-| 变量名                          | 用途       | 默认值   |
-| ------------------------------- | ---------- | -------- |
-| `NEXT_PUBLIC_DEFAULT_COURSE_ID` | 默认课程ID | 空字符串 |
+| 变量名     | 用途                                       | 默认值   |
+| ---------- | ------------------------------------------ | -------- |
+| `HOME_URL` | `/`、`/c` 入口跳转地址及 Logo 点击目标 URL | `/admin` |
+
+如需将某门课程作为默认入口，配置 `HOME_URL=/c/<shifu_bid>`。`HOME_URL` 支持站内相对地址和绝对地址；老师品牌配置中的 `home_url` 会覆盖全局值。显式访问 `/c/<shifu_bid>` 时不会被该配置覆盖。
 
 ### 3. 微信集成 (WeChat Integration)
 
@@ -94,8 +96,8 @@ import { environment } from '@/config/environment';
 // Get API base URL
 const apiUrl = environment.apiBaseUrl;
 
-// Get course ID
-const courseId = environment.courseId;
+// Get the configured entry URL
+const homeUrl = environment.homeUrl;
 
 // Get WeChat configuration
 const wechatAppId = environment.wechatAppId;
@@ -133,12 +135,10 @@ export async function GET() {
 
 ## API配置响应
 
-`/api/config` 返回干净的JSON数据：
+Cook Web 内置的 `/api/config` 只返回 `apiBaseUrl`。后端 `/api/runtime-config` 返回浏览器运行时配置，例如：
 
 ```json
 {
-  "apiBaseUrl": "http://127.0.0.1:5800",
-  "courseId": "ca3265b045e84774b8d845a4c3c5b0a3",
   "wechatAppId": "wx973eb6079c64d030",
   "enableWechatCode": true,
   "billingEnabled": true,
@@ -151,6 +151,7 @@ export async function GET() {
   "enableEruda": "false",
   "loginMethodsEnabled": ["phone"],
   "defaultLoginMethod": "phone",
+  "homeUrl": "/admin",
   "stripePublishableKey": "pk_test_xxx",
   "stripeEnabled": false
 }
@@ -160,9 +161,10 @@ export async function GET() {
 
 ### `/c/[[...id]]` 路由
 
-- **配置获取方式**：通过 `/api/config` API
+- **配置获取方式**：通过后端 `/api/runtime-config` API
 - **用途**：课程学习页面，需要完整的配置信息
-- **包含配置**：课程ID、微信配置、UI配置、统计配置等
+- **课程标识来源**：显式 URL 路径 `/c/<shifu_bid>`；运行时配置不再提供默认课程 ID
+- **入口行为**：访问 `/c` 时跳转到 `HOME_URL`，配置 `HOME_URL=/c/<shifu_bid>` 即可指定默认课程入口
 
 ### `/main` 路由
 
@@ -185,7 +187,7 @@ Docker 部署不受影响：
 ```bash
 # 使用新的环境变量名
 docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
-           -e NEXT_PUBLIC_DEFAULT_COURSE_ID=your-course-id \
+           -e HOME_URL=/c/your-course-id \
            -e NEXT_PUBLIC_WECHAT_APP_ID=your-wechat-app-id \
            your-image:tag
 ```
@@ -242,7 +244,7 @@ docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
 ✅ **修复了配置数据字段映射**：
 
 - 更新了 `/c/[[...id]]/layout.tsx` 中的字段映射
-- 使用新的字段名（如 `courseId` 而不是 `NEXT_PUBLIC_COURSE_ID`）
+- 统一使用后端 `/api/runtime-config` 返回的运行时字段
 - 确保所有组件都能正确获取配置
 
 #### 7. 路由配置优化
@@ -269,7 +271,6 @@ docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
 | `SITE_HOST`                           | `NEXT_PUBLIC_API_BASE_URL`               | API基础URL         |
 | `NEXT_PUBLIC_BASEURL`                 | `NEXT_PUBLIC_API_BASE_URL`               | API基础URL         |
 | `NEXT_PUBLIC_SITE_URL`                | `NEXT_PUBLIC_API_BASE_URL`               | API基础URL         |
-| `NEXT_PUBLIC_COURSE_ID`               | `NEXT_PUBLIC_DEFAULT_COURSE_ID`          | 默认课程ID         |
 | `NEXT_PUBLIC_APP_ID`                  | `NEXT_PUBLIC_WECHAT_APP_ID`              | 微信App ID         |
 | `NEXT_PUBLIC_ENABLE_WXCODE`           | `NEXT_PUBLIC_WECHAT_CODE_ENABLED`        | 是否启用微信码     |
 | `NEXT_PUBLIC_ALWAYS_SHOW_LESSON_TREE` | `NEXT_PUBLIC_UI_ALWAYS_SHOW_LESSON_TREE` | 是否始终显示课程树 |
@@ -309,8 +310,8 @@ docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
 # ===== Core API Configuration =====
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:5800
 
-# ===== Content & Course Configuration =====
-NEXT_PUBLIC_DEFAULT_COURSE_ID=ca3265b045e84774b8d845a4c3c5b0a3
+# ===== Entry Redirect Configuration =====
+HOME_URL=/c/ca3265b045e84774b8d845a4c3c5b0a3
 
 # ===== WeChat Integration =====
 NEXT_PUBLIC_WECHAT_APP_ID=wx973eb6079c64d030
@@ -341,8 +342,8 @@ NEXT_PUBLIC_STRIPE_ENABLED=false
 # ===== Core API Configuration =====
 NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com
 
-# ===== Content & Course Configuration =====
-NEXT_PUBLIC_DEFAULT_COURSE_ID=your-default-course-id
+# ===== Entry Redirect Configuration =====
+HOME_URL=/c/your-course-id
 
 # ===== WeChat Integration =====
 NEXT_PUBLIC_WECHAT_APP_ID=your-wechat-app-id

--- a/src/cook-web/src/config/environment.ts
+++ b/src/cook-web/src/config/environment.ts
@@ -11,8 +11,7 @@ interface EnvironmentConfig {
   // Core API Configuration
   apiBaseUrl: string;
 
-  // Content & Course Configuration
-  courseId: string;
+  // Content Configuration
   defaultLlmModel: string;
   currencySymbol: string;
 
@@ -151,13 +150,6 @@ export async function getDynamicApiBaseUrl(): Promise<string> {
     // Client fetches it dynamically
     return getClientApiBaseUrl();
   }
-}
-
-/**
- * Gets course ID
- */
-function getCourseId(): string {
-  return '';
 }
 
 /**
@@ -380,8 +372,7 @@ export const environment: EnvironmentConfig = {
   // Core API Configuration
   apiBaseUrl: getApiBaseUrl(),
 
-  // Content & Course Configuration
-  courseId: getCourseId(),
+  // Content Configuration
   defaultLlmModel: getDefaultLlmModel(),
 
   // WeChat Integration

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -98,7 +98,6 @@ const loadRuntimeConfig = async () => {
     updateLoginMethodsEnabled,
     updateDefaultLoginMethod,
     updateLegalUrls,
-    updateCourseId,
   } = useEnvStore.getState() as EnvStoreState;
 
   const resolvedBase = await resolveRuntimeBase();
@@ -163,20 +162,6 @@ const loadRuntimeConfig = async () => {
     runtimeConfig?.loginMethodsEnabled,
     (useEnvStore.getState() as EnvStoreState).loginMethodsEnabled,
   );
-
-  /**
-   * Course id resolution priority
-   *
-   * 1. If URL path is /c/<shifu_bid>, keep using the path parameter.
-   *    Runtime default course id from backend MUST NOT override it.
-   * 2. Otherwise, fall back to backend-provided default course id.
-   */
-  const hasPathCourseId = !!pathShifuBid;
-
-  if (!hasPathCourseId) {
-    // Only apply backend default when there is no explicit course id in the URL path
-    await updateCourseId(runtimeConfig?.courseId || '');
-  }
 
   await updateAppId(runtimeConfig?.wechatAppId || '');
   await updateAlwaysShowLessonTree(

--- a/src/cook-web/src/lib/initializeEnvData.ts
+++ b/src/cook-web/src/lib/initializeEnvData.ts
@@ -2,7 +2,6 @@
 
 import { useEnvStore } from '@/c-store';
 import { EnvStoreState } from '@/c-types/store';
-import { redirectToHomeUrlIfRootPath } from '@/lib/utils';
 import { getBoolEnv } from '@/c-utils/envUtils';
 import {
   environment,
@@ -148,11 +147,6 @@ const loadRuntimeConfig = async () => {
 
   const payload = await fetchRuntimeConfig();
   const runtimeConfig = payload?.data ?? payload;
-  if (
-    redirectToHomeUrlIfRootPath(runtimeConfig?.homeUrl || environment.homeUrl)
-  ) {
-    return;
-  }
 
   const paymentChannels = normalizeStringArray(
     runtimeConfig?.paymentChannels,

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -25,6 +25,36 @@ describe('redirectToHomeUrlIfRootPath', () => {
     expect(replace).toHaveBeenCalledWith('/admin');
   });
 
+  it('redirects the course entry path to a course configured as HOME_URL', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c',
+        pathname: '/c',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/c/course-1')).toBe(true);
+    expect(replace).toHaveBeenCalledWith('/c/course-1');
+  });
+
+  it('does not override an explicit course path', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c/course-2',
+        pathname: '/c/course-2',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/c/course-1')).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it('does not redirect a non-entry path', () => {
     const replace = jest.fn();
     Object.defineProperty(window, 'location', {

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -70,6 +70,24 @@ describe('redirectToHomeUrlIfRootPath', () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
+  it.each(['javascript:alert(1)', 'data:text/html,unsafe'])(
+    'does not redirect to an unsafe protocol: %s',
+    homeUrl => {
+      const replace = jest.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          href: 'https://app.example.com/',
+          pathname: '/',
+          replace,
+        },
+      });
+
+      expect(redirectToHomeUrlIfRootPath(homeUrl)).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    },
+  );
+
   it('does not override an explicit course path', () => {
     const replace = jest.fn();
     Object.defineProperty(window, 'location', {

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -40,6 +40,43 @@ describe('redirectToHomeUrlIfRootPath', () => {
     expect(replace).toHaveBeenCalledWith('/c/course-1');
   });
 
+  it.each([
+    ['https://app.example.com/', '/'],
+    ['https://app.example.com/c', '/c'],
+  ])(
+    'redirects %s to a course configured through a legacy HOME_URL query',
+    (href, pathname) => {
+      const replace = jest.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          href,
+          pathname,
+          replace,
+        },
+      });
+
+      const homeUrl = '/c?courseId=course-1&lessonid=lesson-1';
+      expect(redirectToHomeUrlIfRootPath(homeUrl)).toBe(true);
+      expect(replace).toHaveBeenCalledWith(homeUrl);
+    },
+  );
+
+  it('does not redirect a legacy course query target to itself', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c?courseId=course-1',
+        pathname: '/c',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/c?courseId=course-1')).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it('redirects the course entry path to a configured root HOME_URL', () => {
     const replace = jest.fn();
     Object.defineProperty(window, 'location', {

--- a/src/cook-web/src/lib/utils.test.ts
+++ b/src/cook-web/src/lib/utils.test.ts
@@ -40,6 +40,36 @@ describe('redirectToHomeUrlIfRootPath', () => {
     expect(replace).toHaveBeenCalledWith('/c/course-1');
   });
 
+  it('redirects the course entry path to a configured root HOME_URL', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/c',
+        pathname: '/c',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/')).toBe(true);
+    expect(replace).toHaveBeenCalledWith('/');
+  });
+
+  it('does not redirect the root path to itself', () => {
+    const replace = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        href: 'https://app.example.com/',
+        pathname: '/',
+        replace,
+      },
+    });
+
+    expect(redirectToHomeUrlIfRootPath('/')).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it('does not override an explicit course path', () => {
     const replace = jest.fn();
     Object.defineProperty(window, 'location', {

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -26,7 +26,7 @@ export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
 
     if (
       currentUrl.origin === targetUrl.origin &&
-      (targetPath === '/' || targetPath === '/c' || currentPath === targetPath)
+      (targetPath === '/c' || currentPath === targetPath)
     ) {
       return false;
     }

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -27,10 +27,16 @@ export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
 
     const currentPath = currentUrl.pathname.replace(/\/+$/, '') || '/';
     const targetPath = targetUrl.pathname.replace(/\/+$/, '') || '/';
+    const targetCourseId = targetUrl.searchParams.get('courseId')?.trim() ?? '';
+    const isTargetBareCourse = targetPath === '/c' && !targetCourseId;
+    const isSameTarget =
+      currentPath === targetPath &&
+      currentUrl.search === targetUrl.search &&
+      currentUrl.hash === targetUrl.hash;
 
     if (
       currentUrl.origin === targetUrl.origin &&
-      (targetPath === '/c' || currentPath === targetPath)
+      (isTargetBareCourse || isSameTarget)
     ) {
       return false;
     }

--- a/src/cook-web/src/lib/utils.ts
+++ b/src/cook-web/src/lib/utils.ts
@@ -21,6 +21,10 @@ export const redirectToHomeUrlIfRootPath = (homeUrl?: string): boolean => {
     const currentUrl = new URL(window.location.href);
     const targetUrl = new URL(homeUrl, window.location.href);
 
+    if (targetUrl.protocol !== 'http:' && targetUrl.protocol !== 'https:') {
+      return false;
+    }
+
     const currentPath = currentUrl.pathname.replace(/\/+$/, '') || '/';
     const targetPath = targetUrl.pathname.replace(/\/+$/, '') || '/';
 


### PR DESCRIPTION
## What changed

- Removed `DEFAULT_COURSE_ID` from backend configuration, Docker examples, the runtime-config DTO, and the Cook Web bootstrap path.
- Removed the implicit fallback that selected the first database course when no course identifier was provided; missing course identifiers now return the existing course-not-found business error.
- Kept active `courseId` state route-driven, documented `HOME_URL=/c/<shifu_bid>` as the explicit course landing mechanism, and moved bare `/c` redirects to the course route boundary so runtime configuration also applies after client-side navigation, including `HOME_URL=/`, while preserving explicit `/c/<shifu_bid>`, canonicalizing legacy `/c?courseId=<shifu_bid>` entries to path-based routes before learner content mounts, and preserving legacy query-based `HOME_URL` targets.
- Restricted `HOME_URL` entry redirects to HTTP(S) targets so unsafe browser navigation schemes are rejected; rejected or self-targeting bare course entries use the existing not-found fallback without mounting stale course state.

## Why

Course entry had two competing default-selection paths: a configured runtime course ID and an implicit first-course database lookup. This made entry behavior harder to reason about and could silently choose an unintended course. `HOME_URL` already provides one explicit landing-page contract.

## Impact

Deployments that previously set `DEFAULT_COURSE_ID` should set `HOME_URL=/c/<shifu_bid>` instead. Explicit `/c/<shifu_bid>` links remain authoritative and are not overridden.

## Validation

- `15 passed`: billing DTO and runtime-config tests
- `25 passed`: learning runtime tests
- `18 passed`: HOME_URL root, course-entry, client-navigation, explicit-query canonicalization, query-target, unsafe-protocol, and not-found fallback tests
- `npm run type-check`
- `npm run lint`
- Architecture boundary and repository harness checks

Pre-commit hooks and all PR checks passed, including the runtime harness and GitGuardian security checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated course entry behavior to redirect via `HOME_URL`, with `/c/<shifu_bid>` acting as the course landing page.
  * Runtime configuration no longer includes a default course identifier.
* **Bug Fixes**
  * Rejects course execution when no course/shifu is explicitly selected and no default is available.
  * Preserves explicitly requested course paths/parameters during home redirection.
* **Documentation**
  * Updated environment variable docs/examples and migration guidance for `HOME_URL`-based entry and runtime-config behavior.
* **Tests**
  * Added/expanded coverage for `/c` redirect conditions and missing-course rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->