### PR TITLE
fix: skip non-speakable TTS provider requests

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -79,6 +79,7 @@ _EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "volcengine"}
 _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
 _TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}
+_NON_SPEAKABLE_TTS_SKIP_PROVIDERS = {"minimax", "tencent", "volcengine"}
 
 _VISUAL_SLIDE_KINDS = frozenset(
     {
@@ -113,8 +114,8 @@ def _tts_error_text_preview(
     return f"{normalized[:max_chars]}...(truncated, total_len={len(normalized)})"
 
 
-def _is_tencent_provider(tts_provider: str) -> bool:
-    return (tts_provider or "").strip().lower() == "tencent"
+def _normalize_tts_provider(tts_provider: str) -> str:
+    return (tts_provider or "").strip().lower()
 
 
 def _has_speakable_text(text: str) -> bool:
@@ -123,8 +124,28 @@ def _has_speakable_text(text: str) -> bool:
     )
 
 
-def _should_skip_tencent_tts_text(text: str, tts_provider: str) -> bool:
-    return _is_tencent_provider(tts_provider) and not _has_speakable_text(text)
+def _should_skip_non_speakable_tts_text(text: str, tts_provider: str) -> bool:
+    return _normalize_tts_provider(
+        tts_provider
+    ) in _NON_SPEAKABLE_TTS_SKIP_PROVIDERS and not _has_speakable_text(text)
+
+
+def _log_skipped_non_speakable_tts_text(
+    *,
+    segment_index: int | str,
+    text: str,
+    tts_provider: str,
+    tts_model: str,
+) -> None:
+    logger.info(
+        "TTS segment %s skipped before provider synthesis: "
+        "non_speakable_text provider=%s model=%s text_len=%s text_preview=%r",
+        segment_index,
+        tts_provider or "(auto)",
+        tts_model or "(unset)",
+        len(text or ""),
+        _tts_error_text_preview(text or ""),
+    )
 
 
 def _should_use_volcengine_timestamp_stream(tts_provider: str) -> bool:
@@ -502,16 +523,12 @@ class StreamingTTSProcessor:
     ) -> TTSSegment:
         """Synthesize a segment in a background thread."""
         with self.app.app_context():
-            if _should_skip_tencent_tts_text(segment.text or "", tts_provider):
-                logger.info(
-                    "TTS segment %s skipped before Tencent synthesis: "
-                    "non_speakable_text provider=%s model=%s text_len=%s "
-                    "text_preview=%r",
-                    segment.index,
-                    tts_provider or "(auto)",
-                    tts_model or "(unset)",
-                    len(segment.text or ""),
-                    _tts_error_text_preview(segment.text or ""),
+            if _should_skip_non_speakable_tts_text(segment.text or "", tts_provider):
+                _log_skipped_non_speakable_tts_text(
+                    segment_index=segment.index,
+                    text=segment.text or "",
+                    tts_provider=tts_provider,
+                    tts_model=tts_model,
                 )
                 segment.is_ready = True
                 with self._lock:
@@ -1433,6 +1450,15 @@ class StreamingTTSProcessor:
         from flaskr.service.tts.tts_usage_recorder import record_tts_segment_usage
 
         for request_index, request_text in enumerate(request_texts):
+            if _should_skip_non_speakable_tts_text(request_text, self.tts_provider):
+                _log_skipped_non_speakable_tts_text(
+                    segment_index=request_index,
+                    text=request_text,
+                    tts_provider=self.tts_provider,
+                    tts_model=self.tts_model,
+                )
+                continue
+
             request_started_at = time.monotonic()
             audio_chunks: list[bytes] = []
             source_emitted_ms = 0
@@ -1764,6 +1790,14 @@ class StreamingTTSProcessor:
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         request_text = (cleaned_text or "").strip()
         if not self._enabled or not request_text:
+            return
+        if _should_skip_non_speakable_tts_text(request_text, self.tts_provider):
+            _log_skipped_non_speakable_tts_text(
+                segment_index=0,
+                text=request_text,
+                tts_provider=self.tts_provider,
+                tts_model=self.tts_model,
+            )
             return
 
         request_started_at = time.monotonic()

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -336,13 +336,15 @@ class TestStreamingSynthesisRetries:
     @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")
     @patch("flaskr.service.tts.streaming_tts.synthesize_text")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
-    def test_tencent_non_speakable_segment_skips_provider_call(
+    @pytest.mark.parametrize("tts_provider", ["tencent", "volcengine", "minimax"])
+    def test_non_speakable_segment_skips_configured_provider_call(
         self,
         mock_is_configured,
         mock_synthesize_text,
         mock_record_usage,
         mock_logger,
         mock_app,
+        tts_provider,
     ):
         mock_is_configured.return_value = True
         app_context = MagicMock()
@@ -350,7 +352,7 @@ class TestStreamingSynthesisRetries:
         app_context.__exit__.return_value = False
         mock_app.app_context.return_value = app_context
 
-        processor = create_test_processor(mock_app, tts_provider="tencent")
+        processor = create_test_processor(mock_app, tts_provider=tts_provider)
         segment = TTSSegment(index=10, text="---")
 
         result = processor._synthesize_in_thread(
@@ -369,7 +371,68 @@ class TestStreamingSynthesisRetries:
         assert result.is_ready is True
         assert processor._completed_segments[10] is result
         info_args = mock_logger.info.call_args.args
-        assert "skipped before Tencent synthesis" in info_args[0]
+        assert "skipped before provider synthesis" in info_args[0]
+        assert tts_provider in info_args
+        assert "---" in info_args
+
+    @patch("flaskr.service.tts.streaming_tts.logger")
+    @patch("flaskr.service.tts.streaming_tts.MinimaxTTSProvider")
+    @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
+    def test_minimax_http_stream_skips_non_speakable_request(
+        self,
+        mock_is_configured,
+        mock_minimax_provider,
+        mock_logger,
+        mock_app,
+    ):
+        mock_is_configured.return_value = True
+        processor = create_test_processor(mock_app, tts_provider="minimax")
+
+        events = list(
+            processor._finalize_minimax_http_stream(
+                raw_text="---",
+                cleaned_text="---",
+                cleaned_text_length=3,
+                commit=True,
+            )
+        )
+
+        assert events == []
+        mock_minimax_provider.return_value.stream_synthesize.assert_not_called()
+        mock_logger.error.assert_not_called()
+        info_args = mock_logger.info.call_args.args
+        assert "skipped before provider synthesis" in info_args[0]
+        assert "minimax" in info_args
+        assert "---" in info_args
+
+    @patch("flaskr.service.tts.streaming_tts.logger")
+    @patch("flaskr.service.tts.streaming_tts.synthesize_text")
+    @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
+    def test_volcengine_timestamp_stream_skips_non_speakable_request(
+        self,
+        mock_is_configured,
+        mock_synthesize_text,
+        mock_logger,
+        mock_app,
+    ):
+        mock_is_configured.return_value = True
+        processor = create_test_processor(mock_app, tts_provider="volcengine")
+
+        events = list(
+            processor._finalize_volcengine_timestamp_stream(
+                raw_text="---",
+                cleaned_text="---",
+                cleaned_text_length=3,
+                commit=True,
+            )
+        )
+
+        assert events == []
+        mock_synthesize_text.assert_not_called()
+        mock_logger.error.assert_not_called()
+        info_args = mock_logger.info.call_args.args
+        assert "skipped before provider synthesis" in info_args[0]
+        assert "volcengine" in info_args
         assert "---" in info_args
 
     @patch("flaskr.service.tts.streaming_tts.time.sleep")


### PR DESCRIPTION
## Summary
- generalize non-speakable TTS skipping to Tencent, Volcengine, and MiniMax via one provider whitelist
- reuse a shared skip predicate and logging helper instead of provider-specific branches
- apply the skip before generic segment synthesis, MiniMax HTTP streaming requests, and Volcengine timestamp-stream requests
- keep ERROR alerts unchanged for speakable text that still fails provider synthesis

## Tests
- python3 -m py_compile src/api/flaskr/service/tts/streaming_tts.py src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
- uvx ruff==0.15.13 check --fix src/api/flaskr/service/tts/streaming_tts.py src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
- uvx ruff==0.15.13 format src/api/flaskr/service/tts/streaming_tts.py src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming text-to-speech handling for non-speakable content across Tencent, MiniMax, and Volcengine.
  * Non-speakable segments are now skipped consistently during synthesis, including HTTP and timestamp-based streaming.
  * Prevented unnecessary speech requests and related output for content that cannot be spoken.
* **Tests**
  * Expanded automated coverage across supported streaming providers and synthesis paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->