### PR TITLE
feat: support routed LLM output limits

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -705,6 +705,11 @@ LLM_ALLOWED_MODELS=""
 # Type: list
 LLM_ALLOWED_MODEL_DISPLAY_NAMES=""
 
+# Optional JSON object mapping full routed LLM model ids to positive maximum output token limits. Values extend LiteLLM model metadata and are sent as max_tokens for matching requests.
+# (Optional - default: )
+# (Has validation)
+LLM_MODEL_MAX_OUTPUT_TOKENS=""
+
 # OpenAI API key for GPT models
 # (Optional - default: )
 # Secret value

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -24,7 +24,10 @@ from flaskr.api.langfuse import (
     get_request_id,
     resolve_langfuse_trace_id,
 )
-from flaskr.common.config import get_explicit_env_override
+from flaskr.common.config import (
+    get_explicit_env_override,
+    parse_llm_model_max_output_tokens,
+)
 from flaskr.service.config import get_config
 from flaskr.util.datetime import now_utc
 from flaskr.service.common.models import raise_error_with_args
@@ -39,7 +42,6 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_TYPE_LLM,
     normalize_usage_scene,
 )
-from litellm import get_max_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +111,7 @@ class ProviderState:
 
 MODEL_ALIAS_MAP: Dict[str, Tuple[str, str]] = {}
 PROVIDER_STATES: Dict[str, ProviderState] = {}
+MODEL_MAX_OUTPUT_TOKENS: Dict[str, int] = {}
 _USAGE_OUTPUT_TEXT_MAX_LENGTH = 12000
 
 
@@ -229,6 +232,37 @@ def _resolve_allowed_model_config() -> tuple[list[str], list[str]]:
     return allowed, display_names
 
 
+def _load_and_register_model_max_output_tokens() -> Dict[str, int]:
+    raw_limits = get_config("LLM_MODEL_MAX_OUTPUT_TOKENS", "")
+    try:
+        limits = parse_llm_model_max_output_tokens(raw_limits)
+    except ValueError as exc:
+        _log_warning(f"Ignoring invalid LLM_MODEL_MAX_OUTPUT_TOKENS: {exc}")
+        return {}
+    if not limits:
+        return {}
+
+    register_model = getattr(litellm, "register_model", None)
+    if not callable(register_model):
+        _log_warning(
+            "LiteLLM register_model is unavailable; using configured model "
+            "output limits without extending LiteLLM metadata"
+        )
+        return limits
+    try:
+        register_model(
+            {
+                model: {"max_output_tokens": max_output_tokens}
+                for model, max_output_tokens in limits.items()
+            }
+        )
+    except Exception as exc:
+        _log_warning(
+            f"Registering LLM_MODEL_MAX_OUTPUT_TOKENS with LiteLLM failed: {exc}"
+        )
+    return limits
+
+
 def _register_provider_models(
     config: ProviderConfig, raw_models: List[Union[str, Tuple[str, str]]]
 ) -> List[str]:
@@ -335,14 +369,33 @@ def _is_litellm_repeated_stream_chunk_error(exc: Exception) -> bool:
 
 
 def _stream_litellm_completion(
-    app: Flask, model: str, messages: list, params: dict, kwargs: dict
+    app: Flask,
+    requested_model: str,
+    model: str,
+    messages: list,
+    params: dict,
+    kwargs: dict,
 ):
     try:
-        try:
-            max_tokens = get_max_tokens(model)
-            kwargs["max_tokens"] = max_tokens
-        except Exception as exc:
-            _log_warning(f"get max tokens for {model} failed: {exc}")
+        # Routed ids are the application-level identity. LiteLLM completion uses
+        # the stripped provider model id, which can collide across routes (for
+        # example, a Qwen-hosted DeepSeek model and the direct DeepSeek provider).
+        max_tokens = MODEL_MAX_OUTPUT_TOKENS.get(requested_model)
+        if max_tokens is None:
+            try:
+                max_tokens = litellm.get_max_tokens(model)
+            except Exception as exc:
+                _log_warning(f"get max tokens for {model} failed: {exc}")
+        if max_tokens is not None:
+            requested_max_tokens = kwargs.get("max_tokens")
+            if (
+                isinstance(requested_max_tokens, int)
+                and not isinstance(requested_max_tokens, bool)
+                and requested_max_tokens > 0
+            ):
+                kwargs["max_tokens"] = min(requested_max_tokens, max_tokens)
+            else:
+                kwargs["max_tokens"] = max_tokens
         app.logger.info(
             f"stream_litellm_completion: {model} {messages} {params} {kwargs}"
         )
@@ -602,6 +655,8 @@ for config in LITELLM_PROVIDER_CONFIGS:
     PROVIDER_STATES[config.key] = _init_litellm_provider(config)
     PROVIDER_CONFIG_HINTS[config.key] = config.config_hint or config.api_key_env
 
+MODEL_MAX_OUTPUT_TOKENS.update(_load_and_register_model_max_output_tokens())
+
 
 any_litellm_enabled = any(state.enabled for state in PROVIDER_STATES.values())
 if not any_litellm_enabled:
@@ -718,6 +773,7 @@ def invoke_llm(
             )
         response = _stream_litellm_completion(
             app,
+            model,
             invoke_model,
             messages,
             params,
@@ -887,6 +943,7 @@ def chat_llm(
         kwargs["stream_options"] = {"include_usage": True}
         response = _stream_litellm_completion(
             app,
+            model,
             invoke_model,
             messages,
             params,

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -104,6 +104,46 @@ def _is_valid_rpm_limits_json(value: Any) -> bool:
     return True
 
 
+def parse_llm_model_max_output_tokens(value: Any) -> Dict[str, int]:
+    """Parse a routed model id -> maximum output token JSON map."""
+
+    if value in (None, ""):
+        return {}
+    if isinstance(value, dict):
+        candidate = value
+    else:
+        try:
+            candidate = json.loads(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("must be a JSON object") from exc
+    if not isinstance(candidate, dict):
+        raise ValueError("must be a JSON object")
+
+    parsed: Dict[str, int] = {}
+    for model, max_output_tokens in candidate.items():
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError("model ids must be non-empty strings")
+        normalized_model = model.strip()
+        if normalized_model in parsed:
+            raise ValueError("model ids must be unique after trimming whitespace")
+        if (
+            isinstance(max_output_tokens, bool)
+            or not isinstance(max_output_tokens, int)
+            or max_output_tokens <= 0
+        ):
+            raise ValueError("maximum output token values must be positive integers")
+        parsed[normalized_model] = max_output_tokens
+    return parsed
+
+
+def _is_valid_llm_model_max_output_tokens_json(value: Any) -> bool:
+    try:
+        parse_llm_model_max_output_tokens(value)
+    except ValueError:
+        return False
+    return True
+
+
 # Environment variable registry
 ENV_VARS: Dict[str, EnvVar] = {
     # Application Configuration
@@ -599,6 +639,19 @@ Gemini: gemini-1.5-flash, gemini-1.5-flash-8b, gemini-1.5-pro""",
         ),
         group="llm",
         required=False,
+    ),
+    "LLM_MODEL_MAX_OUTPUT_TOKENS": EnvVar(
+        name="LLM_MODEL_MAX_OUTPUT_TOKENS",
+        default="",
+        type=str,
+        description=(
+            "Optional JSON object mapping full routed LLM model ids to positive "
+            "maximum output token limits. Values extend LiteLLM model metadata "
+            "and are sent as max_tokens for matching requests."
+        ),
+        group="llm",
+        required=False,
+        validator=_is_valid_llm_model_max_output_tokens_json,
     ),
     "DEFAULT_LLM_TEMPERATURE": EnvVar(
         name="DEFAULT_LLM_TEMPERATURE",

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -3,7 +3,11 @@ Unit tests for EnvVar dataclass.
 """
 
 import pytest
-from flaskr.common.config import EnvVar
+from flaskr.common.config import (
+    ENV_VARS,
+    EnvVar,
+    parse_llm_model_max_output_tokens,
+)
 from tests.common.fixtures.mock_validators import (
     mock_port_validator,
     mock_email_validator,
@@ -231,6 +235,37 @@ class TestEnvVarValidation:
         assert env_var.validate_value(2.0) is True
         assert env_var.validate_value(-0.1) is False
         assert env_var.validate_value(2.1) is False
+
+
+class TestLLMModelMaxOutputTokensConfig:
+    def test_parse_valid_routed_model_limits(self):
+        assert parse_llm_model_max_output_tokens(
+            '{"qwen/deepseek-v4-flash":393216,"gemini-3.5-flash":65536}'
+        ) == {
+            "qwen/deepseek-v4-flash": 393216,
+            "gemini-3.5-flash": 65536,
+        }
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-json",
+            "[]",
+            '{"": 1}',
+            '{"qwen/model": 0}',
+            '{"qwen/model": -1}',
+            '{"qwen/model": true}',
+            '{"qwen/model": 1.5}',
+            '{"qwen/model": "8192"}',
+            '{"qwen/model": 8192, " qwen/model ": 4096}',
+        ],
+    )
+    def test_reject_invalid_routed_model_limits(self, value):
+        env_var = ENV_VARS["LLM_MODEL_MAX_OUTPUT_TOKENS"]
+
+        assert env_var.validate_value(value) is False
+        with pytest.raises(ValueError):
+            parse_llm_model_max_output_tokens(value)
 
 
 class TestEnvVarMultilineDescription:

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -13,6 +13,12 @@ def _install_litellm_stub() -> None:
         return
 
     litellm_stub = types.ModuleType("litellm")
+    litellm_stub.model_cost = {}
+
+    def register_model(model_map):
+        litellm_stub.model_cost.update(model_map)
+
+    litellm_stub.register_model = register_model
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.completion = lambda *args, **kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
@@ -386,6 +392,11 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
     monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {})
     monkeypatch.setattr(
         llm,
+        "MODEL_MAX_OUTPUT_TOKENS",
+        {"qwen/deepseek-v4-flash": 393216},
+    )
+    monkeypatch.setattr(
+        llm,
         "PROVIDER_CONFIG_HINTS",
         {"qwen": "QWEN_API_KEY,QWEN_API_URL"},
     )
@@ -406,6 +417,144 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
     assert captured["model"] == "deepseek-v4-flash"
     assert captured["kwargs"]["temperature"] == 0.7
     assert captured["kwargs"]["extra_body"] == {"enable_thinking": False}
+    assert captured["kwargs"]["max_tokens"] == 393216
+
+
+def test_load_and_register_model_max_output_tokens(monkeypatch):
+    configured = {
+        "qwen/deepseek-v4-flash": 393216,
+        "ark/doubao-seed-2-0-lite-260428": 131072,
+    }
+    captured = {}
+
+    monkeypatch.setattr(
+        llm,
+        "get_config",
+        lambda key, default=None: (
+            configured if key == "LLM_MODEL_MAX_OUTPUT_TOKENS" else default
+        ),
+    )
+    monkeypatch.setattr(
+        llm.litellm,
+        "register_model",
+        lambda model_map: captured.update(model_map),
+    )
+
+    limits = llm._load_and_register_model_max_output_tokens()
+
+    assert limits == configured
+    assert captured == {
+        "qwen/deepseek-v4-flash": {"max_output_tokens": 393216},
+        "ark/doubao-seed-2-0-lite-260428": {"max_output_tokens": 131072},
+    }
+
+
+def test_load_model_max_output_tokens_ignores_invalid_config(monkeypatch):
+    monkeypatch.setattr(
+        llm,
+        "get_config",
+        lambda key, default=None: (
+            '{"qwen/model": 0}' if key == "LLM_MODEL_MAX_OUTPUT_TOKENS" else default
+        ),
+    )
+    monkeypatch.setattr(
+        llm.litellm,
+        "register_model",
+        lambda _model_map: pytest.fail("invalid limits must not be registered"),
+    )
+
+    assert llm._load_and_register_model_max_output_tokens() == {}
+
+
+def test_stream_litellm_completion_falls_back_to_litellm_limit(monkeypatch, app):
+    captured = {}
+    monkeypatch.setattr(llm, "MODEL_MAX_OUTPUT_TOKENS", {})
+    monkeypatch.setattr(llm.litellm, "get_max_tokens", lambda model: 8192)
+    monkeypatch.setattr(
+        llm.litellm,
+        "completion",
+        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+    )
+
+    list(
+        llm._stream_litellm_completion(
+            app,
+            "openai/gpt-test",
+            "gpt-test",
+            [],
+            {},
+            {},
+        )
+    )
+
+    assert captured["max_tokens"] == 8192
+
+
+@pytest.mark.parametrize(
+    ("requested_max_tokens", "expected_max_tokens"),
+    [(None, 131072), (4096, 4096), (200000, 131072)],
+)
+def test_stream_litellm_completion_applies_configured_limit_as_ceiling(
+    monkeypatch,
+    app,
+    requested_max_tokens,
+    expected_max_tokens,
+):
+    captured = {}
+    monkeypatch.setattr(
+        llm,
+        "MODEL_MAX_OUTPUT_TOKENS",
+        {"ark/doubao-seed-2-0-lite-260428": 131072},
+    )
+    monkeypatch.setattr(
+        llm.litellm,
+        "completion",
+        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+    )
+    kwargs = {}
+    if requested_max_tokens is not None:
+        kwargs["max_tokens"] = requested_max_tokens
+
+    list(
+        llm._stream_litellm_completion(
+            app,
+            "ark/doubao-seed-2-0-lite-260428",
+            "doubao-seed-2-0-lite-260428",
+            [],
+            {},
+            kwargs,
+        )
+    )
+
+    assert captured["max_tokens"] == expected_max_tokens
+
+
+def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app):
+    captured = {}
+
+    def raise_unknown(_model):
+        raise ValueError("unknown model")
+
+    monkeypatch.setattr(llm, "MODEL_MAX_OUTPUT_TOKENS", {})
+    monkeypatch.setattr(llm.litellm, "get_max_tokens", raise_unknown)
+    monkeypatch.setattr(
+        llm.litellm,
+        "completion",
+        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+    )
+
+    list(
+        llm._stream_litellm_completion(
+            app,
+            "qwen/unknown-model",
+            "unknown-model",
+            [],
+            {},
+            {},
+        )
+    )
+
+    assert "max_tokens" not in captured
 
 
 def test_qwen_provider_config_keeps_prefix_fallback():


### PR DESCRIPTION
## Summary

- add validated `LLM_MODEL_MAX_OUTPUT_TOKENS` configuration keyed by full routed model IDs
- register configured `max_output_tokens` metadata with LiteLLM while keeping provider routes isolated
- apply each configured value as the request ceiling, preserving smaller explicit `max_tokens` values
- document the environment variable and add routing, fallback, validation, and ceiling tests

## Why

LiteLLM does not know the custom model routes supplied by our deployment configuration. The existing request path therefore either omitted `max_tokens` or resolved metadata from a stripped model ID that could collide with another provider. The new route-aware configuration lets each deployment own its model limits without hardcoding production model IDs in AI Shifu.

## Impact

- deployments without the new variable keep the existing LiteLLM fallback behavior
- configured routes use their declared output ceiling when callers omit `max_tokens`
- smaller caller-provided limits remain unchanged, while oversized values are capped
- the companion China production values remain in `deploy-config` and are intentionally not part of this PR

## Validation

- `125 passed`: LLM, OpenAI streaming, and configuration test suites
- Black formatting check passed
- Ruff check passed
- architecture boundary, translations, generated locales, merge-conflict, symlink, whitespace, and hardcoded-CJK checks passed
- Commitizen validation passed

`scripts/check_uow_commit_sites.py` remains red on the unchanged `flaskr/service/shifu/repair.py` direct commit already present on `main`; this PR does not modify that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional per-model maximum output token limits through `LLM_MODEL_MAX_OUTPUT_TOKENS`.
  - Configured limits are applied automatically to LLM requests and cap requested output sizes.
  - Requests fall back to provider-defined limits when no custom limit is configured.
  - Invalid configuration values are safely ignored with validation warnings.

- **Tests**
  - Added coverage for valid, invalid, fallback, capped, and unknown-model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->