### PR TITLE
fix: retire duplicate outline root generations

### DIFF
--- a/src/api/flaskr/service/shifu/cli.py
+++ b/src/api/flaskr/service/shifu/cli.py
@@ -22,6 +22,15 @@ def register_shifu_commands(console, app) -> None:
         help="Restrict repair to one or more shifu business identifiers.",
     )
     @click.option(
+        "--keep-root-bid",
+        "keep_root_bids",
+        multiple=True,
+        help=(
+            "For one shifu, keep these root outlines and retire duplicate root "
+            "generations sharing their positions."
+        ),
+    )
+    @click.option(
         "--user-bid",
         default=None,
         help="Operator user bid recorded on appended repair rows.",
@@ -33,6 +42,7 @@ def register_shifu_commands(console, app) -> None:
     )
     def repair_outline_structure_command(
         shifu_bids: tuple[str, ...],
+        keep_root_bids: tuple[str, ...],
         user_bid: str | None,
         dry_run: bool,
     ) -> None:
@@ -46,6 +56,7 @@ def register_shifu_commands(console, app) -> None:
             app,
             user_bid=user_bid,
             shifu_bids=list(shifu_bids) or None,
+            keep_root_bids=list(keep_root_bids) or None,
             dry_run=dry_run,
         ).to_payload()
         click.echo(json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True))

--- a/src/api/flaskr/service/shifu/cli.py
+++ b/src/api/flaskr/service/shifu/cli.py
@@ -51,6 +51,10 @@ def register_shifu_commands(console, app) -> None:
             raise click.ClickException(
                 "Pass --user-bid for non-dry-run outline repair."
             )
+        if keep_root_bids and len(shifu_bids) != 1:
+            raise click.ClickException(
+                "Pass exactly one --shifu-bid when using --keep-root-bid."
+            )
 
         payload = repair_shifu_outline_structure(
             app,

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -303,7 +303,9 @@ def _collect_retired_duplicate_root_bids(
 
     keep_roots = [by_bid[bid] for bid in keep_root_bids]
     non_root_keep_bids = [
-        bid for bid, item in zip(keep_root_bids, keep_roots) if item.parent_bid
+        bid
+        for bid, item in zip(keep_root_bids, keep_roots)
+        if str(item.parent_bid or "").strip()
     ]
     if non_root_keep_bids:
         return [], f"Keep outline is not a root: {', '.join(non_root_keep_bids)}"
@@ -489,7 +491,9 @@ def repair_shifu_outline_structure(
                 record.retired_outline_bids = locked_retired_outline_bids
 
                 current_time = now_utc()
-                change_by_bid = {item.outline_item_bid: item for item in changes}
+                change_by_bid = {
+                    str(item.outline_item_bid or "").strip(): item for item in changes
+                }
                 retired_bid_set = set(locked_retired_outline_bids)
                 for item in _load_latest_active_outline_items(shifu_bid):
                     outline_bid = str(item.outline_item_bid or "").strip()

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 
 from flask import Flask
 
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.util.datetime import now_utc
 
 from .models import DraftOutlineItem, DraftShifu
@@ -42,6 +44,7 @@ class OutlineStructureRepairRecord:
     shifu_title: str
     issue_types: list[str]
     changed_outlines: list[OutlineStructureChange] = field(default_factory=list)
+    retired_outline_bids: list[str] = field(default_factory=list)
 
     def to_payload(self) -> dict:
         return {
@@ -50,6 +53,8 @@ class OutlineStructureRepairRecord:
             "issue_types": self.issue_types,
             "changed_outline_count": len(self.changed_outlines),
             "changed_outlines": [item.to_payload() for item in self.changed_outlines],
+            "retired_outline_count": len(self.retired_outline_bids),
+            "retired_outline_bids": self.retired_outline_bids,
         }
 
 
@@ -72,6 +77,7 @@ class OutlineStructureRepairResult:
     scanned_shifu_count: int
     repaired_shifu_count: int
     changed_outline_count: int
+    retired_outline_count: int
     rebuilt_struct_count: int
     repaired_records: list[OutlineStructureRepairRecord] = field(default_factory=list)
     skipped_records: list[OutlineStructureSkippedRecord] = field(default_factory=list)
@@ -83,6 +89,7 @@ class OutlineStructureRepairResult:
             "scanned_shifu_count": self.scanned_shifu_count,
             "repaired_shifu_count": self.repaired_shifu_count,
             "changed_outline_count": self.changed_outline_count,
+            "retired_outline_count": self.retired_outline_count,
             "rebuilt_struct_count": self.rebuilt_struct_count,
             "repaired_records": [item.to_payload() for item in self.repaired_records],
             "skipped_records": [item.to_payload() for item in self.skipped_records],
@@ -269,15 +276,84 @@ def _plan_outline_structure_repair(
     return changes, None
 
 
+def _normalize_bid_list(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    if not values:
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        bid = str(value or "").strip()
+        if bid and bid not in seen:
+            normalized.append(bid)
+            seen.add(bid)
+    return normalized
+
+
+def _collect_retired_duplicate_root_bids(
+    items: list[DraftOutlineItem],
+    keep_root_bids: list[str],
+) -> tuple[list[str], str | None]:
+    if not keep_root_bids:
+        return [], None
+
+    by_bid = {str(item.outline_item_bid or "").strip(): item for item in items}
+    missing_keep_bids = [bid for bid in keep_root_bids if bid not in by_bid]
+    if missing_keep_bids:
+        return [], f"Keep root outline not found: {', '.join(missing_keep_bids)}"
+
+    keep_roots = [by_bid[bid] for bid in keep_root_bids]
+    non_root_keep_bids = [
+        bid for bid, item in zip(keep_root_bids, keep_roots) if item.parent_bid
+    ]
+    if non_root_keep_bids:
+        return [], f"Keep outline is not a root: {', '.join(non_root_keep_bids)}"
+
+    children_by_parent: dict[str, list[DraftOutlineItem]] = defaultdict(list)
+    for item in items:
+        children_by_parent[str(item.parent_bid or "").strip()].append(item)
+
+    keep_positions = {str(item.position or "").strip() for item in keep_roots}
+    keep_bid_set = set(keep_root_bids)
+    duplicate_root_bids = [
+        str(item.outline_item_bid or "").strip()
+        for item in children_by_parent.get("", [])
+        if str(item.position or "").strip() in keep_positions
+        and str(item.outline_item_bid or "").strip() not in keep_bid_set
+    ]
+
+    retired: list[str] = []
+    seen: set[str] = set()
+
+    def _walk_retired_subtree(outline_bid: str) -> None:
+        if outline_bid in seen:
+            return
+        seen.add(outline_bid)
+        retired.append(outline_bid)
+        for child in children_by_parent.get(outline_bid, []):
+            child_bid = str(child.outline_item_bid or "").strip()
+            if child_bid:
+                _walk_retired_subtree(child_bid)
+
+    for outline_bid in duplicate_root_bids:
+        _walk_retired_subtree(outline_bid)
+
+    return retired, None
+
+
 def repair_shifu_outline_structure(
     app: Flask,
     *,
     user_bid: str | None,
     shifu_bids: list[str] | None = None,
+    keep_root_bids: list[str] | None = None,
     dry_run: bool = False,
 ) -> OutlineStructureRepairResult:
     if not dry_run and not user_bid:
         raise ValueError("user_bid is required when dry_run is False")
+
+    normalized_keep_root_bids = _normalize_bid_list(keep_root_bids)
+    if normalized_keep_root_bids and (not shifu_bids or len(shifu_bids) != 1):
+        raise ValueError("keep_root_bids requires exactly one shifu_bid")
 
     with app.app_context():
         items = _load_latest_active_outline_items(shifu_bids)
@@ -300,97 +376,153 @@ def repair_shifu_outline_structure(
         skipped_records: list[OutlineStructureSkippedRecord] = []
         rebuilt_struct_count = 0
         changed_outline_count = 0
+        retired_outline_count = 0
 
-        for shifu_bid in target_shifu_bids:
-            shifu_items = items_by_shifu.get(shifu_bid, [])
-            if not shifu_items:
-                continue
-
-            issue_types = _detect_issue_types(shifu_items)
-            if not issue_types:
-                continue
-
-            changes, skip_reason = _plan_outline_structure_repair(shifu_items)
-            if skip_reason:
-                skipped_records.append(
-                    OutlineStructureSkippedRecord(
-                        shifu_bid=shifu_bid,
-                        reason=skip_reason,
-                    )
-                )
-                continue
-
-            if not changes:
-                continue
-
-            record = OutlineStructureRepairRecord(
-                shifu_bid=shifu_bid,
-                shifu_title=shifu_titles.get(shifu_bid, ""),
-                issue_types=issue_types,
-                changed_outlines=changes,
-            )
-            repaired_records.append(record)
-            changed_outline_count += len(changes)
-
-            if dry_run:
-                continue
-
-            __lock_shifu_for_outline_write(shifu_bid)
-            locked_items = _load_latest_active_outline_items(shifu_bid)
-            changes, skip_reason = _plan_outline_structure_repair(locked_items)
-            if skip_reason:
-                repaired_records.pop()
-                changed_outline_count -= len(record.changed_outlines)
-                skipped_records.append(
-                    OutlineStructureSkippedRecord(
-                        shifu_bid=shifu_bid,
-                        reason=skip_reason,
-                    )
-                )
-                continue
-            if not changes:
-                repaired_records.pop()
-                changed_outline_count -= len(record.changed_outlines)
-                continue
-            changed_outline_count += len(changes) - len(record.changed_outlines)
-            record.changed_outlines = changes
-
-            current_time = now_utc()
-            change_by_bid = {item.outline_item_bid: item for item in changes}
-            for item in locked_items:
-                change = change_by_bid.get(item.outline_item_bid)
-                if not change:
+        transaction_scope = nullcontext() if dry_run else unit_of_work()
+        with transaction_scope:
+            for shifu_bid in target_shifu_bids:
+                shifu_items = items_by_shifu.get(shifu_bid, [])
+                if not shifu_items:
                     continue
-                new_item = item.clone()
-                new_item.parent_bid = change.new_parent_bid
-                new_item.position = change.new_position
-                new_item.updated_user_bid = user_bid
-                new_item.updated_at = current_time
-                db.session.add(new_item)
 
-            db.session.flush()
+                issue_types = _detect_issue_types(shifu_items)
+                retired_outline_bids: list[str] = []
+                if normalized_keep_root_bids:
+                    retired_outline_bids, skip_reason = (
+                        _collect_retired_duplicate_root_bids(
+                            shifu_items,
+                            normalized_keep_root_bids,
+                        )
+                    )
+                    if skip_reason:
+                        skipped_records.append(
+                            OutlineStructureSkippedRecord(
+                                shifu_bid=shifu_bid,
+                                reason=skip_reason,
+                            )
+                        )
+                        continue
+                    if retired_outline_bids:
+                        issue_types = sorted(
+                            set(issue_types) | {"root_generation_collision"}
+                        )
+                        retired_bid_set = set(retired_outline_bids)
+                        shifu_items = [
+                            item
+                            for item in shifu_items
+                            if str(item.outline_item_bid or "").strip()
+                            not in retired_bid_set
+                        ]
+                if not issue_types:
+                    continue
 
-            latest_items = _load_latest_active_outline_items(shifu_bid)
-            history_tree = build_outline_history_tree_from_outlines(latest_items)
-            shifu_db_row = (
-                DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
-                .order_by(DraftShifu.id.desc())
-                .first()
-            )
-            save_outline_tree_history(
-                app=app,
-                user_id=user_bid,
-                shifu_bid=shifu_bid,
-                outline_tree=history_tree,
-                shifu_id=shifu_db_row.id if shifu_db_row else None,
-            )
-            rebuilt_struct_count += 1
+                changes, skip_reason = _plan_outline_structure_repair(shifu_items)
+                if skip_reason:
+                    skipped_records.append(
+                        OutlineStructureSkippedRecord(
+                            shifu_bid=shifu_bid,
+                            reason=skip_reason,
+                        )
+                    )
+                    continue
 
-        if not dry_run and (repaired_records or skipped_records):
-            db.session.commit()
+                if not changes:
+                    if not retired_outline_bids:
+                        continue
 
-        if not dry_run and not repaired_records and not skipped_records:
-            db.session.rollback()
+                record = OutlineStructureRepairRecord(
+                    shifu_bid=shifu_bid,
+                    shifu_title=shifu_titles.get(shifu_bid, ""),
+                    issue_types=issue_types,
+                    changed_outlines=changes,
+                    retired_outline_bids=retired_outline_bids,
+                )
+                repaired_records.append(record)
+                changed_outline_count += len(changes)
+                retired_outline_count += len(retired_outline_bids)
+
+                if dry_run:
+                    continue
+
+                __lock_shifu_for_outline_write(shifu_bid)
+                locked_items = _load_latest_active_outline_items(shifu_bid)
+                locked_retired_outline_bids: list[str] = []
+                skip_reason = None
+                if normalized_keep_root_bids:
+                    locked_retired_outline_bids, skip_reason = (
+                        _collect_retired_duplicate_root_bids(
+                            locked_items,
+                            normalized_keep_root_bids,
+                        )
+                    )
+                    if skip_reason is None:
+                        locked_retired_bid_set = set(locked_retired_outline_bids)
+                        locked_items = [
+                            item
+                            for item in locked_items
+                            if str(item.outline_item_bid or "").strip()
+                            not in locked_retired_bid_set
+                        ]
+                if skip_reason is None:
+                    changes, skip_reason = _plan_outline_structure_repair(locked_items)
+                if skip_reason:
+                    repaired_records.pop()
+                    changed_outline_count -= len(record.changed_outlines)
+                    retired_outline_count -= len(record.retired_outline_bids)
+                    skipped_records.append(
+                        OutlineStructureSkippedRecord(
+                            shifu_bid=shifu_bid,
+                            reason=skip_reason,
+                        )
+                    )
+                    continue
+                if not changes and not locked_retired_outline_bids:
+                    repaired_records.pop()
+                    changed_outline_count -= len(record.changed_outlines)
+                    retired_outline_count -= len(record.retired_outline_bids)
+                    continue
+                changed_outline_count += len(changes) - len(record.changed_outlines)
+                retired_outline_count += len(locked_retired_outline_bids) - len(
+                    record.retired_outline_bids
+                )
+                record.changed_outlines = changes
+                record.retired_outline_bids = locked_retired_outline_bids
+
+                current_time = now_utc()
+                change_by_bid = {item.outline_item_bid: item for item in changes}
+                retired_bid_set = set(locked_retired_outline_bids)
+                for item in _load_latest_active_outline_items(shifu_bid):
+                    outline_bid = str(item.outline_item_bid or "").strip()
+                    change = change_by_bid.get(outline_bid)
+                    if not change and outline_bid not in retired_bid_set:
+                        continue
+                    new_item = item.clone()
+                    if change:
+                        new_item.parent_bid = change.new_parent_bid
+                        new_item.position = change.new_position
+                    if outline_bid in retired_bid_set:
+                        new_item.deleted = 1
+                    new_item.updated_user_bid = user_bid
+                    new_item.updated_at = current_time
+                    db.session.add(new_item)
+
+                db.session.flush()
+
+                latest_items = _load_latest_active_outline_items(shifu_bid)
+                history_tree = build_outline_history_tree_from_outlines(latest_items)
+                shifu_db_row = (
+                    DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+                    .order_by(DraftShifu.id.desc())
+                    .first()
+                )
+                save_outline_tree_history(
+                    app=app,
+                    user_id=user_bid,
+                    shifu_bid=shifu_bid,
+                    outline_tree=history_tree,
+                    shifu_id=shifu_db_row.id if shifu_db_row else None,
+                )
+                rebuilt_struct_count += 1
 
         status = "noop"
         if repaired_records:
@@ -404,6 +536,7 @@ def repair_shifu_outline_structure(
             scanned_shifu_count=len(target_shifu_bids),
             repaired_shifu_count=len(repaired_records),
             changed_outline_count=changed_outline_count,
+            retired_outline_count=retired_outline_count,
             rebuilt_struct_count=rebuilt_struct_count,
             repaired_records=repaired_records,
             skipped_records=skipped_records,

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -319,7 +319,8 @@ def _collect_retired_duplicate_root_bids(
     duplicate_root_bids = [
         str(item.outline_item_bid or "").strip()
         for item in children_by_parent.get("", [])
-        if str(item.position or "").strip() in keep_positions
+        if str(item.outline_item_bid or "").strip()
+        and str(item.position or "").strip() in keep_positions
         and str(item.outline_item_bid or "").strip() not in keep_bid_set
     ]
 
@@ -327,6 +328,8 @@ def _collect_retired_duplicate_root_bids(
     seen: set[str] = set()
 
     def _walk_retired_subtree(outline_bid: str) -> None:
+        if not outline_bid:
+            return
         if outline_bid in seen:
             return
         seen.add(outline_bid)
@@ -448,6 +451,7 @@ def repair_shifu_outline_structure(
 
                 __lock_shifu_for_outline_write(shifu_bid)
                 locked_items = _load_latest_active_outline_items(shifu_bid)
+                locked_issue_types = _detect_issue_types(locked_items)
                 locked_retired_outline_bids: list[str] = []
                 skip_reason = None
                 if normalized_keep_root_bids:
@@ -465,6 +469,10 @@ def repair_shifu_outline_structure(
                             if str(item.outline_item_bid or "").strip()
                             not in locked_retired_bid_set
                         ]
+                    if locked_retired_outline_bids:
+                        locked_issue_types = sorted(
+                            set(locked_issue_types) | {"root_generation_collision"}
+                        )
                 if skip_reason is None:
                     changes, skip_reason = _plan_outline_structure_repair(locked_items)
                 if skip_reason:
@@ -489,6 +497,7 @@ def repair_shifu_outline_structure(
                 )
                 record.changed_outlines = changes
                 record.retired_outline_bids = locked_retired_outline_bids
+                record.issue_types = locked_issue_types
 
                 current_time = now_utc()
                 change_by_bid = {

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -310,11 +310,30 @@ def _collect_retired_duplicate_root_bids(
     if non_root_keep_bids:
         return [], f"Keep outline is not a root: {', '.join(non_root_keep_bids)}"
 
+    keep_positions_by_bid = {
+        bid: str(item.position or "").strip()
+        for bid, item in zip(keep_root_bids, keep_roots)
+    }
+    keep_bids_by_position: dict[str, list[str]] = defaultdict(list)
+    for bid, position in keep_positions_by_bid.items():
+        keep_bids_by_position[position].append(bid)
+    duplicated_keep_positions = {
+        position: bids
+        for position, bids in keep_bids_by_position.items()
+        if len(bids) > 1
+    }
+    if duplicated_keep_positions:
+        details = ", ".join(
+            f"{position}: {', '.join(bids)}"
+            for position, bids in sorted(duplicated_keep_positions.items())
+        )
+        return [], f"Keep root outlines must have unique positions: {details}"
+
     children_by_parent: dict[str, list[DraftOutlineItem]] = defaultdict(list)
     for item in items:
         children_by_parent[str(item.parent_bid or "").strip()].append(item)
 
-    keep_positions = {str(item.position or "").strip() for item in keep_roots}
+    keep_positions = set(keep_positions_by_bid.values())
     keep_bid_set = set(keep_root_bids)
     duplicate_root_bids = [
         str(item.outline_item_bid or "").strip()

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -346,3 +346,88 @@ def test_repair_shifu_outline_structure_retires_duplicate_root_generations(app):
         "keep-stage-2",
         "keep-stage-3",
     ]
+
+
+def test_repair_shifu_outline_structure_accepts_space_only_keep_root_parent(app):
+    with app.app_context():
+        _mk_shifu("shifu-space-root-parent")
+        _mk_outline(
+            "shifu-space-root-parent",
+            "old-root",
+            "01",
+            title="Old root",
+        )
+        _mk_outline(
+            "shifu-space-root-parent",
+            "keep-root",
+            "01",
+            parent_bid=" ",
+            title="Keep root",
+        )
+        db.session.commit()
+
+        result = repair_shifu_outline_structure(
+            app,
+            user_bid="repair-user-1",
+            shifu_bids=["shifu-space-root-parent"],
+            keep_root_bids=["keep-root"],
+            dry_run=False,
+        )
+
+        latest_keep = (
+            DraftOutlineItem.query.filter_by(
+                shifu_bid="shifu-space-root-parent",
+                outline_item_bid="keep-root",
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+
+    assert result.status == "repaired"
+    assert result.skipped_records == []
+    assert result.retired_outline_count == 1
+    assert result.changed_outline_count == 1
+    assert latest_keep is not None
+    assert latest_keep.deleted == 0
+    assert latest_keep.parent_bid == ""
+
+
+def test_repair_shifu_outline_structure_applies_changes_for_space_padded_bid(app):
+    with app.app_context():
+        _mk_shifu("shifu-space-padded-bid")
+        _mk_outline("shifu-space-padded-bid", "root-1", "01")
+        _mk_outline(
+            "shifu-space-padded-bid",
+            " child-a ",
+            "0101",
+            parent_bid="",
+        )
+        _mk_outline(
+            "shifu-space-padded-bid",
+            "child-b",
+            "0101",
+            parent_bid="root-1",
+        )
+        db.session.commit()
+
+        result = repair_shifu_outline_structure(
+            app,
+            user_bid="repair-user-1",
+            shifu_bids=["shifu-space-padded-bid"],
+            dry_run=False,
+        )
+
+        latest_child = (
+            DraftOutlineItem.query.filter_by(
+                shifu_bid="shifu-space-padded-bid",
+                outline_item_bid=" child-a ",
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+
+    assert result.status == "repaired"
+    assert result.changed_outline_count == 2
+    assert latest_child is not None
+    assert latest_child.parent_bid == "root-1"
+    assert latest_child.position == "0101"

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -509,3 +509,63 @@ def test_repair_shifu_outline_structure_does_not_retire_blank_outline_bid(app):
         "": 0,
         "keep-root": 0,
     }
+
+
+def test_repair_shifu_outline_structure_rejects_duplicate_keep_root_positions(app):
+    with app.app_context():
+        _mk_shifu("shifu-duplicate-keep-position")
+        _mk_outline(
+            "shifu-duplicate-keep-position",
+            "keep-root-a",
+            "01",
+            title="Keep root A",
+        )
+        _mk_outline(
+            "shifu-duplicate-keep-position",
+            "keep-root-b",
+            "01",
+            title="Keep root B",
+        )
+        _mk_outline(
+            "shifu-duplicate-keep-position",
+            "old-root",
+            "01",
+            title="Old root",
+        )
+        db.session.commit()
+
+        result = repair_shifu_outline_structure(
+            app,
+            user_bid="repair-user-1",
+            shifu_bids=["shifu-duplicate-keep-position"],
+            keep_root_bids=["keep-root-a", "keep-root-b"],
+            dry_run=False,
+        )
+
+        latest_ids = (
+            db.session.query(db.func.max(DraftOutlineItem.id).label("id"))
+            .filter(DraftOutlineItem.shifu_bid == "shifu-duplicate-keep-position")
+            .group_by(DraftOutlineItem.outline_item_bid)
+            .subquery()
+        )
+        latest_rows = (
+            DraftOutlineItem.query.filter(
+                DraftOutlineItem.id.in_(db.session.query(latest_ids.c.id)),
+                DraftOutlineItem.shifu_bid == "shifu-duplicate-keep-position",
+            )
+            .order_by(DraftOutlineItem.outline_item_bid.asc())
+            .all()
+        )
+
+    assert result.status == "skipped"
+    assert result.repaired_shifu_count == 0
+    assert result.retired_outline_count == 0
+    assert result.changed_outline_count == 0
+    assert result.skipped_records[0].reason == (
+        "Keep root outlines must have unique positions: 01: keep-root-a, keep-root-b"
+    )
+    assert {row.outline_item_bid: row.deleted for row in latest_rows} == {
+        "keep-root-a": 0,
+        "keep-root-b": 0,
+        "old-root": 0,
+    }

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -233,3 +233,116 @@ def test_repair_shifu_outline_structure_detects_parent_position_mismatch(app):
     assert result.repaired_records[0].changed_outlines[0].new_parent_bid == "root-b"
     assert result.repaired_records[0].changed_outlines[0].old_position == "0101"
     assert result.repaired_records[0].changed_outlines[0].new_position == "0201"
+
+
+def test_repair_shifu_outline_structure_retires_duplicate_root_generations(app):
+    with app.app_context():
+        shifu = _mk_shifu("shifu-root-generation", title="Python 新人训 AI 课")
+        shifu_db_id = shifu.id
+        for generation in range(1, 4):
+            _mk_outline(
+                "shifu-root-generation",
+                f"old-stage-1-{generation}",
+                "01",
+                title="阶段一",
+            )
+            _mk_outline(
+                "shifu-root-generation",
+                f"old-stage-2-{generation}",
+                "02",
+                title="阶段二：循环语句",
+            )
+            _mk_outline(
+                "shifu-root-generation",
+                f"old-stage-3-{generation}",
+                "03",
+                title="阶段三：列表・字符串・随机数",
+            )
+        _mk_outline(
+            "shifu-root-generation",
+            "keep-stage-1",
+            "01",
+            title="阶段一",
+        )
+        _mk_outline(
+            "shifu-root-generation",
+            "keep-stage-2",
+            "02",
+            title="阶段二：循环语句",
+        )
+        _mk_outline(
+            "shifu-root-generation",
+            "keep-stage-3",
+            "03",
+            title="阶段三：列表・字符串・随机数",
+        )
+        _mk_outline(
+            "shifu-root-generation",
+            "old-child",
+            "0101",
+            parent_bid="old-stage-1-1",
+        )
+        _mk_outline(
+            "shifu-root-generation",
+            "keep-child",
+            "0101",
+            parent_bid="keep-stage-1",
+        )
+        db.session.commit()
+
+        result = repair_shifu_outline_structure(
+            app,
+            user_bid="repair-user-1",
+            shifu_bids=["shifu-root-generation"],
+            keep_root_bids=["keep-stage-1", "keep-stage-2", "keep-stage-3"],
+            dry_run=False,
+        )
+
+        latest_ids = (
+            db.session.query(db.func.max(DraftOutlineItem.id).label("id"))
+            .filter(DraftOutlineItem.shifu_bid == "shifu-root-generation")
+            .group_by(DraftOutlineItem.outline_item_bid)
+            .subquery()
+        )
+        active_rows = (
+            DraftOutlineItem.query.filter(
+                DraftOutlineItem.id.in_(db.session.query(latest_ids.c.id)),
+                DraftOutlineItem.deleted == 0,
+            )
+            .order_by(DraftOutlineItem.position.asc(), DraftOutlineItem.id.asc())
+            .all()
+        )
+        active_by_bid = {row.outline_item_bid: row for row in active_rows}
+        latest_struct = (
+            LogDraftStruct.query.filter_by(shifu_bid="shifu-root-generation", deleted=0)
+            .order_by(LogDraftStruct.id.desc())
+            .first()
+        )
+
+    assert result.status == "repaired"
+    assert result.repaired_shifu_count == 1
+    assert result.changed_outline_count == 0
+    assert result.retired_outline_count == 10
+    assert result.repaired_records[0].issue_types == [
+        "position_collision",
+        "root_generation_collision",
+    ]
+    assert set(active_by_bid) == {
+        "keep-stage-1",
+        "keep-stage-2",
+        "keep-stage-3",
+        "keep-child",
+    }
+    assert active_by_bid["keep-stage-1"].position == "01"
+    assert active_by_bid["keep-stage-2"].position == "02"
+    assert active_by_bid["keep-stage-3"].position == "03"
+    assert active_by_bid["keep-child"].parent_bid == "keep-stage-1"
+
+    assert latest_struct is not None
+    history = HistoryItem.from_json(latest_struct.struct)
+    assert history.id == shifu_db_id
+    assert [child.bid for child in history.children] == [
+        "keep-stage-1",
+        "keep-stage-2",
+        "keep-stage-3",
+    ]

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -313,6 +313,17 @@ def test_repair_shifu_outline_structure_retires_duplicate_root_generations(app):
             .all()
         )
         active_by_bid = {row.outline_item_bid: row for row in active_rows}
+        retired_versions_by_bid = {
+            outline_bid: (
+                DraftOutlineItem.query.filter_by(
+                    shifu_bid="shifu-root-generation",
+                    outline_item_bid=outline_bid,
+                )
+                .order_by(DraftOutlineItem.id.asc())
+                .all()
+            )
+            for outline_bid in result.repaired_records[0].retired_outline_bids
+        }
         latest_struct = (
             LogDraftStruct.query.filter_by(shifu_bid="shifu-root-generation", deleted=0)
             .order_by(LogDraftStruct.id.desc())
@@ -327,6 +338,23 @@ def test_repair_shifu_outline_structure_retires_duplicate_root_generations(app):
         "position_collision",
         "root_generation_collision",
     ]
+    assert result.repaired_records[0].retired_outline_bids == [
+        "old-stage-1-1",
+        "old-child",
+        "old-stage-1-2",
+        "old-stage-1-3",
+        "old-stage-2-1",
+        "old-stage-2-2",
+        "old-stage-2-3",
+        "old-stage-3-1",
+        "old-stage-3-2",
+        "old-stage-3-3",
+    ]
+    for outline_bid, versions in retired_versions_by_bid.items():
+        assert len(versions) == 2
+        assert versions[0].deleted == 0
+        assert versions[-1].deleted == 1
+        assert versions[-1].updated_user_bid == "repair-user-1", outline_bid
     assert set(active_by_bid) == {
         "keep-stage-1",
         "keep-stage-2",
@@ -431,3 +459,53 @@ def test_repair_shifu_outline_structure_applies_changes_for_space_padded_bid(app
     assert latest_child is not None
     assert latest_child.parent_bid == "root-1"
     assert latest_child.position == "0101"
+
+
+def test_repair_shifu_outline_structure_does_not_retire_blank_outline_bid(app):
+    with app.app_context():
+        _mk_shifu("shifu-blank-outline-bid")
+        _mk_outline(
+            "shifu-blank-outline-bid",
+            "",
+            "01",
+            title="Blank bid root",
+        )
+        _mk_outline(
+            "shifu-blank-outline-bid",
+            "keep-root",
+            "01",
+            title="Keep root",
+        )
+        db.session.commit()
+
+        result = repair_shifu_outline_structure(
+            app,
+            user_bid="repair-user-1",
+            shifu_bids=["shifu-blank-outline-bid"],
+            keep_root_bids=["keep-root"],
+            dry_run=False,
+        )
+
+        latest_ids = (
+            db.session.query(db.func.max(DraftOutlineItem.id).label("id"))
+            .filter(DraftOutlineItem.shifu_bid == "shifu-blank-outline-bid")
+            .group_by(DraftOutlineItem.outline_item_bid)
+            .subquery()
+        )
+        latest_rows = (
+            DraftOutlineItem.query.filter(
+                DraftOutlineItem.id.in_(db.session.query(latest_ids.c.id)),
+                DraftOutlineItem.shifu_bid == "shifu-blank-outline-bid",
+            )
+            .order_by(DraftOutlineItem.outline_item_bid.asc())
+            .all()
+        )
+
+    assert result.status == "skipped"
+    assert result.repaired_shifu_count == 0
+    assert result.retired_outline_count == 0
+    assert result.skipped_records[0].shifu_bid == "shifu-blank-outline-bid"
+    assert {row.outline_item_bid: row.deleted for row in latest_rows} == {
+        "": 0,
+        "keep-root": 0,
+    }


### PR DESCRIPTION
## What changed

- Added explicit `--keep-root-bid` support to the offline shifu outline repair CLI.
- When a course has repeated root-generation outlines, the repair keeps the provided root BIDs and retires duplicate root subtrees with append-only deleted rows.
- Rebuilds draft outline struct history after the repair.
- Added fail-closed guards for invalid keep-root input, including duplicate kept positions, non-root keep BIDs, blank legacy BIDs, and stale locked snapshots.
- Added regression coverage for repeated root-generation data and edge-case dirty data.

## Why

A production course failed publish validation because multiple root outlines shared `position=01/02/03`. The existing generic repair can renumber broken outline trees, but this incident needs deterministic retirement of stale repeated root generations rather than preserving all duplicate chapters.

This PR is repair-only. It adds an auditable offline cleanup tool for historical dirty data. It is not the root-cause fix that prevents duplicate outlines from being created again. Recurrence prevention still depends on the normal outline creation locks and batch/atomic creation paths.

## Validation

- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- `PATH="$HOME/.local/bin:$PATH" ruff check src/api/flaskr/service/shifu/repair.py src/api/flaskr/service/shifu/cli.py src/api/tests/service/shifu/test_outline_repair.py src/api/tests/service/shifu/test_create_outlines_batch.py src/api/tests/service/shifu/test_shifu_publish_funcs.py`
- `cd src/api && PATH="$HOME/.local/bin:$PATH" python -m pytest -q tests/service/shifu/test_outline_repair.py tests/service/shifu/test_create_outlines_batch.py tests/service/shifu/test_shifu_publish_funcs.py`

## Operation notes

Do not mechanically execute the example command after merge. The reported production course has already been repaired by later user edits, so a fresh dry-run should return no retired outlines.

If a future course has confirmed repeated root generations, dry-run the specific course first:

```bash
cd src/api
FLASK_APP=app.py flask shifu repair-outline-structure \
  --shifu-bid <shifu_bid> \
  --keep-root-bid <root_bid_to_keep_for_position_01> \
  --keep-root-bid <root_bid_to_keep_for_position_02> \
  --keep-root-bid <root_bid_to_keep_for_position_03> \
  --dry-run
```

Only run the same command without `--dry-run` and with `--user-bid <operator_user_bid>` after confirming the dry-run `retired_outline_bids` exactly matches the stale root subtrees that should be retired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to preserve selected root outline generations during structure repairs.
  * Repairs can now retire duplicate root generations (offline), and results report retired-outline count/details.
* **Bug Fixes**
  * Improved repair behavior for root-generation collisions, including correct re-parenting/re-positioning while retaining chosen roots.
  * Added normalization for space-padded parent/bid inputs to ensure accurate parent/position updates.
* **Tests**
  * Added coverage for duplicate-root retirement, rebuilt outline history, and space-handling cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
