### PR TITLE
fix: align wallet drift probe with consumable credits

### DIFF
--- a/src/api/scripts/observability_consistency_probes.py
+++ b/src/api/scripts/observability_consistency_probes.py
@@ -23,7 +23,15 @@ if str(API_ROOT) not in sys.path:
 os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
 
 CREDIT_BUCKET_STATUS_ACTIVE = 7441
+BILLING_SUBSCRIPTION_STATUS_ACTIVE = 7202
+BILLING_SUBSCRIPTION_STATUS_PAST_DUE = 7203
+BILLING_SUBSCRIPTION_STATUS_PAUSED = 7204
+BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED = 7205
+BILLING_SUBSCRIPTION_STATUS_DRAFT = 7201
+CREDIT_BUCKET_CATEGORY_FREE = 7431
 CREDIT_LEDGER_ENTRY_TYPE_CONSUME = 7402
+CREDIT_SOURCE_TYPE_GIFT = 7413
+CREDIT_SOURCE_TYPE_MANUAL = 7416
 CREDIT_SOURCE_TYPE_USAGE = 7414
 
 ProbeFn = Callable[[Any, Any, argparse.Namespace, datetime, datetime], dict[str, Any]]
@@ -199,30 +207,47 @@ def probe_wallet_snapshot(
     since: datetime,
 ) -> dict[str, Any]:
     description = (
-        "Wallet available/reserved totals that differ from active bucket totals."
+        "Wallet available/reserved totals that differ from current consumable "
+        "bucket totals."
     )
-    if not table_has_columns(
-        inspector,
-        "credit_wallets",
-        {
-            "wallet_bid",
-            "creator_bid",
-            "available_credits",
-            "reserved_credits",
-            "deleted",
-        },
-    ) or not table_has_columns(
-        inspector,
-        "credit_wallet_buckets",
-        {
-            "wallet_bid",
-            "available_credits",
-            "reserved_credits",
-            "effective_from",
-            "effective_to",
-            "status",
-            "deleted",
-        },
+    if (
+        not table_has_columns(
+            inspector,
+            "credit_wallets",
+            {
+                "wallet_bid",
+                "creator_bid",
+                "available_credits",
+                "reserved_credits",
+                "deleted",
+            },
+        )
+        or not table_has_columns(
+            inspector,
+            "credit_wallet_buckets",
+            {
+                "wallet_bid",
+                "available_credits",
+                "reserved_credits",
+                "bucket_category",
+                "source_type",
+                "effective_from",
+                "effective_to",
+                "status",
+                "deleted",
+            },
+        )
+        or not table_has_columns(
+            inspector,
+            "bill_subscriptions",
+            {
+                "creator_bid",
+                "status",
+                "current_period_start_at",
+                "current_period_end_at",
+                "deleted",
+            },
+        )
     ):
         return skipped_probe(
             "wallet-snapshot", description, "required tables are missing"
@@ -243,20 +268,42 @@ def probe_wallet_snapshot(
                AND b.status = :active_status
                AND b.effective_from <= :now
                AND (b.effective_to IS NULL OR b.effective_to > :now)
+               AND (
+                 b.bucket_category = :free_category
+                 OR b.source_type IN (:gift_source, :manual_source)
+                 OR active_subscription.creator_bid IS NOT NULL
+               )
               THEN b.available_credits
               ELSE 0
-            END), 0) AS active_bucket_available_credits,
+            END), 0) AS current_consumable_bucket_available_credits,
             COALESCE(SUM(CASE
               WHEN b.deleted = 0
                AND b.status = :active_status
-               AND b.effective_from <= :now
-               AND (b.effective_to IS NULL OR b.effective_to > :now)
               THEN b.reserved_credits
               ELSE 0
             END), 0) AS active_bucket_reserved_credits
           FROM credit_wallets w
           LEFT JOIN credit_wallet_buckets b
             ON b.wallet_bid = w.wallet_bid
+          LEFT JOIN (
+            SELECT DISTINCT creator_bid
+            FROM bill_subscriptions
+            WHERE deleted = 0
+              AND status IN (
+                :subscription_status_active,
+                :subscription_status_past_due,
+                :subscription_status_paused,
+                :subscription_status_cancel_scheduled,
+                :subscription_status_draft
+              )
+              AND (
+                current_period_start_at IS NULL
+                OR current_period_start_at <= :now
+              )
+              AND current_period_end_at IS NOT NULL
+              AND current_period_end_at > :now
+          ) active_subscription
+            ON active_subscription.creator_bid = w.creator_bid
           WHERE w.deleted = 0
           GROUP BY
             w.wallet_bid,
@@ -264,15 +311,25 @@ def probe_wallet_snapshot(
             w.available_credits,
             w.reserved_credits
         ) snapshot
-        WHERE ABS(wallet_available_credits - active_bucket_available_credits) > :epsilon
+        WHERE ABS(wallet_available_credits - current_consumable_bucket_available_credits) > :epsilon
            OR ABS(wallet_reserved_credits - active_bucket_reserved_credits) > :epsilon
         ORDER BY wallet_bid
         LIMIT :limit
         """,
         {
             "active_status": CREDIT_BUCKET_STATUS_ACTIVE,
+            "free_category": CREDIT_BUCKET_CATEGORY_FREE,
+            "gift_source": CREDIT_SOURCE_TYPE_GIFT,
+            "manual_source": CREDIT_SOURCE_TYPE_MANUAL,
+            "subscription_status_active": BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            "subscription_status_past_due": BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
+            "subscription_status_paused": BILLING_SUBSCRIPTION_STATUS_PAUSED,
+            "subscription_status_cancel_scheduled": (
+                BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED
+            ),
+            "subscription_status_draft": BILLING_SUBSCRIPTION_STATUS_DRAFT,
             "now": now,
-            "epsilon": Decimal("0.000001"),
+            "epsilon": 0.000001,
             "limit": args.limit,
         },
     )

--- a/src/api/scripts/observability_consistency_probes.py
+++ b/src/api/scripts/observability_consistency_probes.py
@@ -13,7 +13,7 @@ import sys
 import time
 from typing import Any, Callable
 
-from sqlalchemy import inspect, text
+from sqlalchemy import Numeric, bindparam, inspect, text
 
 
 API_ROOT = Path(__file__).resolve().parents[1]
@@ -134,7 +134,15 @@ def rows_probe(
 
 
 def execute_rows(db: Any, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
-    rows = db.session.execute(text(sql), params).mappings().all()
+    statement = text(sql)
+    decimal_params = [
+        bindparam(key, type_=Numeric(20, 10))
+        for key, value in params.items()
+        if isinstance(value, Decimal)
+    ]
+    if decimal_params:
+        statement = statement.bindparams(*decimal_params)
+    rows = db.session.execute(statement, params).mappings().all()
     return [row_to_dict(row) for row in rows]
 
 
@@ -329,7 +337,7 @@ def probe_wallet_snapshot(
             ),
             "subscription_status_draft": BILLING_SUBSCRIPTION_STATUS_DRAFT,
             "now": now,
-            "epsilon": 0.000001,
+            "epsilon": Decimal("0.000001"),
             "limit": args.limit,
         },
     )

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+
+from scripts.observability_consistency_probes import probe_wallet_snapshot
+
+
+class _Db:
+    def __init__(self, session):
+        self.session = session
+
+
+def _build_db():
+    engine = create_engine("sqlite:///:memory:")
+    session = sessionmaker(bind=engine)()
+    session.execute(
+        text(
+            """
+            CREATE TABLE credit_wallets (
+              id INTEGER PRIMARY KEY,
+              wallet_bid TEXT NOT NULL,
+              creator_bid TEXT NOT NULL,
+              available_credits NUMERIC NOT NULL,
+              reserved_credits NUMERIC NOT NULL,
+              deleted INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TABLE credit_wallet_buckets (
+              id INTEGER PRIMARY KEY,
+              wallet_bid TEXT NOT NULL,
+              creator_bid TEXT NOT NULL,
+              available_credits NUMERIC NOT NULL,
+              reserved_credits NUMERIC NOT NULL,
+              bucket_category INTEGER NOT NULL,
+              source_type INTEGER NOT NULL,
+              effective_from DATETIME NOT NULL,
+              effective_to DATETIME,
+              status INTEGER NOT NULL,
+              deleted INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+    )
+    session.execute(
+        text(
+            """
+            CREATE TABLE bill_subscriptions (
+              id INTEGER PRIMARY KEY,
+              creator_bid TEXT NOT NULL,
+              status INTEGER NOT NULL,
+              current_period_start_at DATETIME,
+              current_period_end_at DATETIME,
+              deleted INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+    )
+    session.commit()
+    return SimpleNamespace(engine=engine, session=session, db=_Db(session))
+
+
+def _args():
+    return argparse.Namespace(limit=20)
+
+
+def _insert_wallet(
+    session, *, wallet_bid: str, creator_bid: str, available: str, reserved: str = "0"
+):
+    session.execute(
+        text(
+            """
+            INSERT INTO credit_wallets (
+              wallet_bid, creator_bid, available_credits, reserved_credits, deleted
+            ) VALUES (:wallet_bid, :creator_bid, :available, :reserved, 0)
+            """
+        ),
+        {
+            "wallet_bid": wallet_bid,
+            "creator_bid": creator_bid,
+            "available": available,
+            "reserved": reserved,
+        },
+    )
+
+
+def _insert_bucket(
+    session,
+    *,
+    wallet_bid: str,
+    creator_bid: str,
+    available: str,
+    reserved: str = "0",
+    category: int = 7432,
+    source_type: int = 7411,
+    effective_from: datetime,
+    effective_to: datetime | None = None,
+):
+    session.execute(
+        text(
+            """
+            INSERT INTO credit_wallet_buckets (
+              wallet_bid,
+              creator_bid,
+              available_credits,
+              reserved_credits,
+              bucket_category,
+              source_type,
+              effective_from,
+              effective_to,
+              status,
+              deleted
+            ) VALUES (
+              :wallet_bid,
+              :creator_bid,
+              :available,
+              :reserved,
+              :category,
+              :source_type,
+              :effective_from,
+              :effective_to,
+              7441,
+              0
+            )
+            """
+        ),
+        {
+            "wallet_bid": wallet_bid,
+            "creator_bid": creator_bid,
+            "available": available,
+            "reserved": reserved,
+            "category": category,
+            "source_type": source_type,
+            "effective_from": effective_from,
+            "effective_to": effective_to,
+        },
+    )
+
+
+def _insert_active_subscription(session, *, creator_bid: str, now: datetime):
+    session.execute(
+        text(
+            """
+            INSERT INTO bill_subscriptions (
+              creator_bid,
+              status,
+              current_period_start_at,
+              current_period_end_at,
+              deleted
+            ) VALUES (:creator_bid, 7202, :start_at, :end_at, 0)
+            """
+        ),
+        {
+            "creator_bid": creator_bid,
+            "start_at": now - timedelta(days=1),
+            "end_at": now + timedelta(days=29),
+        },
+    )
+
+
+def _probe(env, *, now: datetime):
+    return probe_wallet_snapshot(
+        env.db,
+        inspect(env.engine),
+        _args(),
+        now,
+        now - timedelta(hours=24),
+    )
+
+
+def test_wallet_snapshot_probe_uses_current_consumable_bucket_total():
+    now = datetime(2026, 7, 19, 12, 0, 0)
+    env = _build_db()
+    _insert_wallet(
+        env.session,
+        wallet_bid="wallet-topup",
+        creator_bid="creator-topup",
+        available="100",
+    )
+    _insert_bucket(
+        env.session,
+        wallet_bid="wallet-topup",
+        creator_bid="creator-topup",
+        available="100",
+        category=7433,
+        source_type=7412,
+        effective_from=now - timedelta(days=1),
+    )
+    env.session.commit()
+
+    result = _probe(env, now=now)
+
+    assert result["status"] == "warning"
+    assert result["findings_count"] == 1
+    assert result["sample"][0]["wallet_bid"] == "wallet-topup"
+    assert result["sample"][0]["current_consumable_bucket_available_credits"] == 0
+
+
+def test_wallet_snapshot_probe_allows_manual_grants_without_subscription():
+    now = datetime(2026, 7, 19, 12, 0, 0)
+    env = _build_db()
+    _insert_wallet(
+        env.session,
+        wallet_bid="wallet-manual",
+        creator_bid="creator-manual",
+        available="25",
+    )
+    _insert_bucket(
+        env.session,
+        wallet_bid="wallet-manual",
+        creator_bid="creator-manual",
+        available="25",
+        category=7432,
+        source_type=7416,
+        effective_from=now - timedelta(days=1),
+    )
+    env.session.commit()
+
+    result = _probe(env, now=now)
+
+    assert result["status"] == "ok"
+    assert result["findings_count"] == 0
+
+
+def test_wallet_snapshot_probe_counts_reserved_future_buckets_separately():
+    now = datetime(2026, 7, 19, 12, 0, 0)
+    env = _build_db()
+    _insert_wallet(
+        env.session,
+        wallet_bid="wallet-future",
+        creator_bid="creator-future",
+        available="0",
+        reserved="10",
+    )
+    _insert_bucket(
+        env.session,
+        wallet_bid="wallet-future",
+        creator_bid="creator-future",
+        available="0",
+        reserved="10",
+        category=7432,
+        source_type=7411,
+        effective_from=now + timedelta(days=1),
+    )
+    env.session.commit()
+
+    result = _probe(env, now=now)
+
+    assert result["status"] == "ok"
+    assert result["findings_count"] == 0
+
+
+def test_wallet_snapshot_probe_allows_subscription_and_topup_with_active_subscription():
+    now = datetime(2026, 7, 19, 12, 0, 0)
+    env = _build_db()
+    _insert_wallet(
+        env.session,
+        wallet_bid="wallet-active",
+        creator_bid="creator-active",
+        available="120",
+    )
+    _insert_active_subscription(env.session, creator_bid="creator-active", now=now)
+    _insert_bucket(
+        env.session,
+        wallet_bid="wallet-active",
+        creator_bid="creator-active",
+        available="80",
+        category=7432,
+        source_type=7411,
+        effective_from=now - timedelta(days=1),
+    )
+    _insert_bucket(
+        env.session,
+        wallet_bid="wallet-active",
+        creator_bid="creator-active",
+        available="40",
+        category=7433,
+        source_type=7412,
+        effective_from=now - timedelta(days=1),
+    )
+    env.session.commit()
+
+    result = _probe(env, now=now)
+
+    assert result["status"] == "ok"
+    assert result["findings_count"] == 0


### PR DESCRIPTION
## What changed

- Updated the read-only `wallet-snapshot` observability probe to compare wallet balances against the current consumable bucket total instead of a raw active bucket total.
- Included subscription-gating rules in the probe so top-up/subscription buckets require an active subscription, while manual/gift/free credits remain consumable without one.
- Kept reserved balance comparison against active bucket reserved totals so future reserved credits are still visible in drift checks.
- Added focused SQLite tests for top-up without subscription, manual grants, future reserved buckets, and active subscription + top-up cases.

## Why

The current production investigation showed that `credit_wallets.available_credits` can diverge from the amount that runtime and operator surfaces treat as currently consumable. The old probe could miss or misclassify this drift because it did not model the subscription gate used by the billing balance rules.

This PR is intentionally diagnostic only: it does not change runtime admission, settlement, billing API contracts, or frontend balance display.

## Validation

- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- `PATH="$HOME/.local/bin:$PATH" lefthook run pre-commit --file src/api/scripts/observability_consistency_probes.py --file src/api/tests/scripts/test_observability_consistency_probes.py`
- `cd src/api && python -m ruff check scripts/observability_consistency_probes.py tests/scripts/test_observability_consistency_probes.py tests/service/shifu/test_admin_users.py`
- `cd src/api && pytest tests/scripts/test_observability_consistency_probes.py tests/service/shifu/test_admin_users.py::test_list_operator_users_includes_creator_credit_summaries tests/service/shifu/test_admin_users.py::test_get_operator_user_credits_excludes_topup_from_available_without_subscription tests/service/shifu/test_admin_users.py::test_get_operator_user_credits_returns_summary_and_paginated_ledger -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the wallet consistency probe to more accurately compute **current consumable** credits using bucket category/source distinctions and active subscription context.
  * Ensured probes properly treat **reserved future credits** as non-findings.
  * Correctly handles **manual grants** without subscriptions and **subscription-backed topups** when an active subscription exists.
* **Tests**
  * Added in-memory test coverage for the wallet-snapshot probe scenarios around consumable totals, manual grants, future reservations, and active subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->