### PR TITLE
fix: refresh billing credit bucket details

### DIFF
--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -181,6 +181,46 @@ describe('BillingCreditDetailsPanel', () => {
     });
   });
 
+  test('revalidates wallet buckets when the subscription period changes', async () => {
+    const refreshWalletBuckets = jest.fn();
+    const overview = mockUseBillingOverview().data;
+    mockUseBillingOverview.mockImplementation(() => ({
+      data: overview,
+      error: undefined,
+      isLoading: false,
+    }));
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: { items: [] },
+      error: undefined,
+      isLoading: false,
+      mutate: refreshWalletBuckets,
+    });
+
+    const { rerender } = render(<BillingCreditDetailsPanel />);
+
+    await waitFor(() => {
+      expect(refreshWalletBuckets).toHaveBeenCalledTimes(1);
+    });
+
+    mockUseBillingOverview.mockImplementation(() => ({
+      data: {
+        ...overview,
+        subscription: {
+          ...overview.subscription,
+          current_period_end_at: '2026-11-12T23:59:00',
+        },
+      },
+      error: undefined,
+      isLoading: false,
+    }));
+
+    rerender(<BillingCreditDetailsPanel />);
+
+    await waitFor(() => {
+      expect(refreshWalletBuckets).toHaveBeenCalledTimes(2);
+    });
+  });
+
   test('falls back to the earliest manual grant expiry when no active subscription remains', () => {
     mockUseBillingOverview.mockReturnValue({
       data: {

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   useBillingOverview,
@@ -163,6 +163,22 @@ describe('BillingCreditDetailsPanel', () => {
     );
 
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test('revalidates wallet buckets after the overview snapshot loads', async () => {
+    const refreshWalletBuckets = jest.fn();
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: { items: [] },
+      error: undefined,
+      isLoading: false,
+      mutate: refreshWalletBuckets,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    await waitFor(() => {
+      expect(refreshWalletBuckets).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('falls back to the earliest manual grant expiry when no active subscription remains', () => {

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -233,8 +233,10 @@ export function BillingCreditDetailsPanel({
     void refreshWalletBuckets?.();
   }, [
     overview?.creator_bid,
-    overview?.wallet.available_credits,
-    overview?.wallet.reserved_credits,
+    overview?.wallet?.available_credits,
+    overview?.wallet?.reserved_credits,
+    overview?.subscription?.status,
+    overview?.subscription?.current_period_end_at,
     overviewLoading,
     refreshWalletBuckets,
   ]);

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -214,6 +214,7 @@ export function BillingCreditDetailsPanel({
     data: bucketList,
     error: bucketsError,
     isLoading: bucketsLoading,
+    mutate: refreshWalletBuckets,
   } = useBillingWalletBuckets();
   const hasActiveSubscription = Boolean(
     overview?.subscription &&
@@ -223,6 +224,20 @@ export function BillingCreditDetailsPanel({
     hasActiveSubscription && overview?.subscription?.current_period_end_at
       ? String(overview.subscription.current_period_end_at)
       : null;
+
+  React.useEffect(() => {
+    if (overviewLoading || !overview?.creator_bid) {
+      return;
+    }
+
+    void refreshWalletBuckets?.();
+  }, [
+    overview?.creator_bid,
+    overview?.wallet.available_credits,
+    overview?.wallet.reserved_credits,
+    overviewLoading,
+    refreshWalletBuckets,
+  ]);
 
   const summaryRows = useMemo(
     () =>


### PR DESCRIPTION
## What changed

- Refresh the billing wallet bucket details after the billing overview snapshot loads.
- Revalidate wallet buckets again when overview wallet totals, subscription status, or subscription period end changes.
- Use defensive wallet optional chaining in the refresh dependencies.
- Add focused regression tests for overview-driven and subscription-period-driven bucket revalidation.

## Why

The credit details page reads total balance from `/api/billing/overview` but bucket rows from `/api/billing/wallet-buckets`. After backend wallet repairs or balance updates, the overview could refresh while bucket details remained in the stale SWR cache, showing a correct total but a stale subscription/topup breakdown. Subscription period changes can produce the same stale bucket detail issue even when the total balance does not change.

## Validation

- `python scripts/check_dev_tools.py`
- `cd src/cook-web && npm test -- BillingCreditDetailsPanel.test.tsx --runInBand`
- `cd src/cook-web && npm run type-check`
- pre-commit hooks during commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing credit details now refresh wallet credit information after the billing overview loads.
  * Available and reserved credit values stay synchronized when billing data changes.

* **Tests**
  * Added coverage to verify wallet information is revalidated when the billing overview becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
