### PR TITLE
fix: repair expired bucket ledger drift

### DIFF
--- a/docs/generated/uow-commit-baseline.json
+++ b/docs/generated/uow-commit-baseline.json
@@ -41,6 +41,7 @@
   "service/shifu/admin_operations/courses_transfer_copy.py": 2,
   "service/shifu/admin_operations/voice_clones.py": 1,
   "service/shifu/funcs.py": 6,
+  "service/shifu/repair.py": 1,
   "service/shifu/route.py": 2,
   "service/shifu/shifu_draft_funcs.py": 4,
   "service/shifu/shifu_import_export_funcs.py": 1,

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -92,6 +92,7 @@ from .subscriptions import (
 from .trials import backfill_missing_creator_trial_credits
 from .wallets import (
     rebuild_credit_wallet_snapshots,
+    repair_expire_ledger_bucket_drift,
     repair_credit_bucket_runtime_statuses,
 )
 
@@ -727,6 +728,52 @@ def register_billing_commands(console) -> None:
             current_app,
             creator_bid=creator_bid,
             wallet_bid=wallet_bid,
+            dry_run=not apply_changes,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="repair-expire-ledger-bucket-drift")
+    @click.option("--creator-bid", default="", help="Repair one creator.")
+    @click.option(
+        "--wallet-bucket-bid",
+        default="",
+        help="Repair one wallet bucket directly.",
+    )
+    @click.option(
+        "--all",
+        "process_all",
+        is_flag=True,
+        help="Scan every billing wallet bucket.",
+    )
+    @click.option(
+        "--apply",
+        "apply_changes",
+        is_flag=True,
+        help="Persist bucket and wallet snapshot repairs. Defaults to dry-run.",
+    )
+    @with_appcontext
+    def repair_expire_ledger_bucket_drift_command(
+        creator_bid: str,
+        wallet_bucket_bid: str,
+        process_all: bool,
+        apply_changes: bool,
+    ) -> None:
+        """Repair buckets skipped because an expire ledger already exists."""
+
+        if (
+            not str(creator_bid or "").strip()
+            and not str(wallet_bucket_bid or "").strip()
+            and not process_all
+        ):
+            raise click.ClickException(
+                "Pass --creator-bid, --wallet-bucket-bid, or --all for "
+                "expire-ledger bucket drift repair."
+            )
+
+        payload = repair_expire_ledger_bucket_drift(
+            current_app,
+            creator_bid=creator_bid,
+            wallet_bucket_bid=wallet_bucket_bid,
             dry_run=not apply_changes,
         )
         _echo_payload(payload)

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -740,6 +740,12 @@ def register_billing_commands(console) -> None:
         help="Repair one wallet bucket directly.",
     )
     @click.option(
+        "--limit",
+        type=click.IntRange(min=1),
+        default=None,
+        help="Maximum bucket rows to scan when used with --all.",
+    )
+    @click.option(
         "--all",
         "process_all",
         is_flag=True,
@@ -755,6 +761,7 @@ def register_billing_commands(console) -> None:
     def repair_expire_ledger_bucket_drift_command(
         creator_bid: str,
         wallet_bucket_bid: str,
+        limit: int | None,
         process_all: bool,
         apply_changes: bool,
     ) -> None:
@@ -774,6 +781,7 @@ def register_billing_commands(console) -> None:
             current_app,
             creator_bid=creator_bid,
             wallet_bucket_bid=wallet_bucket_bid,
+            limit=limit if process_all else None,
             dry_run=not apply_changes,
         )
         _echo_payload(payload)

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -11,6 +11,7 @@ from flask import Flask
 from sqlalchemy.exc import IntegrityError
 
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
 from flaskr.util.uuid import generate_id
 from flaskr.util.datetime import now_utc
@@ -147,6 +148,63 @@ class WalletExpirationResult:
             "creator_bid": self.creator_bid,
             "bucket_count": self.bucket_count,
             "expired_credits": self.expired_credits,
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_task_payload()[key]
+
+
+@dataclass(slots=True, frozen=True)
+class ExpireLedgerBucketDriftRecord:
+    wallet_bucket_bid: str
+    wallet_bid: str
+    creator_bid: str
+    previous_available_credits: int | float
+    available_credits: int | float
+    previous_expired_credits: int | float
+    expired_credits: int | float
+    previous_status: int
+    status: int
+    expire_ledger_count: int
+    expire_ledger_amount: int | float
+    changed: bool
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "wallet_bid": self.wallet_bid,
+            "creator_bid": self.creator_bid,
+            "previous_available_credits": self.previous_available_credits,
+            "available_credits": self.available_credits,
+            "previous_expired_credits": self.previous_expired_credits,
+            "expired_credits": self.expired_credits,
+            "previous_status": self.previous_status,
+            "status": self.status,
+            "expire_ledger_count": self.expire_ledger_count,
+            "expire_ledger_amount": self.expire_ledger_amount,
+            "changed": self.changed,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ExpireLedgerBucketDriftRepairResult:
+    status: str
+    creator_bid: str | None
+    wallet_bucket_bid: str | None
+    bucket_count: int
+    repaired_bucket_count: int
+    dry_run: bool
+    buckets: list[ExpireLedgerBucketDriftRecord] = field(default_factory=list)
+
+    def to_task_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "creator_bid": self.creator_bid,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "bucket_count": self.bucket_count,
+            "repaired_bucket_count": self.repaired_bucket_count,
+            "dry_run": self.dry_run,
+            "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
 
     def __getitem__(self, key: str) -> Any:
@@ -1085,6 +1143,168 @@ def expire_credit_wallet_buckets(
         )
         db.session.commit()
         return result
+
+
+def repair_expire_ledger_bucket_drift(
+    app: Flask,
+    *,
+    creator_bid: str = "",
+    wallet_bucket_bid: str = "",
+    repair_before: datetime | None = None,
+    dry_run: bool = True,
+) -> ExpireLedgerBucketDriftRepairResult:
+    """Close buckets whose expire ledger exists but bucket state stayed live.
+
+    This intentionally does not write another expire ledger. The target shape is
+    an active, already-ended bucket with remaining available credits and an
+    existing ``expire:<wallet_bucket_bid>`` ledger row. Writing a second ledger
+    would duplicate audit entries, so the repair only synchronizes the bucket
+    projection and wallet snapshot.
+    """
+
+    normalized_creator_bid = str(creator_bid or "").strip()
+    normalized_wallet_bucket_bid = str(wallet_bucket_bid or "").strip()
+    repaired_at = repair_before or now_utc()
+
+    with app.app_context():
+        query = CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+            CreditWalletBucket.effective_to.isnot(None),
+            CreditWalletBucket.effective_to <= repaired_at,
+            CreditWalletBucket.available_credits > _ZERO,
+        )
+        if normalized_creator_bid:
+            query = query.filter(
+                CreditWalletBucket.creator_bid == normalized_creator_bid
+            )
+        if normalized_wallet_bucket_bid:
+            query = query.filter(
+                CreditWalletBucket.wallet_bucket_bid == normalized_wallet_bucket_bid
+            )
+
+        candidate_buckets = query.order_by(
+            CreditWalletBucket.effective_to.asc(),
+            CreditWalletBucket.created_at.asc(),
+            CreditWalletBucket.id.asc(),
+        ).all()
+        records: list[ExpireLedgerBucketDriftRecord] = []
+        changed_wallets: dict[str, CreditWallet] = {}
+
+        for bucket in candidate_buckets:
+            expire_ledgers = (
+                CreditLedgerEntry.query.filter(
+                    CreditLedgerEntry.deleted == 0,
+                    CreditLedgerEntry.creator_bid == bucket.creator_bid,
+                    CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+                    CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+                    CreditLedgerEntry.idempotency_key
+                    == f"expire:{bucket.wallet_bucket_bid}",
+                )
+                .order_by(CreditLedgerEntry.id.asc())
+                .all()
+            )
+            if not expire_ledgers:
+                continue
+
+            previous_available = _quantize_credit_amount(bucket.available_credits)
+            previous_expired = _quantize_credit_amount(bucket.expired_credits)
+            previous_status = int(bucket.status or 0)
+            expire_ledger_amount = _quantize_credit_amount(
+                sum(
+                    (_to_decimal(ledger.amount) for ledger in expire_ledgers),
+                    start=_ZERO,
+                )
+            )
+            ledger_expired_amount = _quantize_credit_amount(
+                sum(
+                    (abs(_to_decimal(ledger.amount)) for ledger in expire_ledgers),
+                    start=_ZERO,
+                )
+            )
+            next_available = _ZERO
+            next_expired = max(
+                previous_expired,
+                ledger_expired_amount
+                if ledger_expired_amount > _ZERO
+                else _quantize_credit_amount(previous_expired + previous_available),
+            )
+            next_status = (
+                CREDIT_BUCKET_STATUS_EXHAUSTED
+                if _to_decimal(bucket.reserved_credits) > _ZERO
+                else CREDIT_BUCKET_STATUS_EXPIRED
+            )
+            changed = (
+                previous_available != next_available
+                or previous_expired != next_expired
+                or previous_status != next_status
+            )
+            records.append(
+                ExpireLedgerBucketDriftRecord(
+                    wallet_bucket_bid=bucket.wallet_bucket_bid,
+                    wallet_bid=bucket.wallet_bid,
+                    creator_bid=bucket.creator_bid,
+                    previous_available_credits=_credit_decimal_to_number(
+                        previous_available
+                    ),
+                    available_credits=_credit_decimal_to_number(next_available),
+                    previous_expired_credits=_credit_decimal_to_number(
+                        previous_expired
+                    ),
+                    expired_credits=_credit_decimal_to_number(next_expired),
+                    previous_status=previous_status,
+                    status=next_status,
+                    expire_ledger_count=len(expire_ledgers),
+                    expire_ledger_amount=_credit_decimal_to_number(
+                        expire_ledger_amount
+                    ),
+                    changed=changed,
+                )
+            )
+
+            if dry_run or not changed:
+                continue
+
+            bucket.available_credits = next_available
+            bucket.expired_credits = next_expired
+            bucket.status = next_status
+            bucket.updated_at = repaired_at
+            db.session.add(bucket)
+
+            wallet = changed_wallets.get(bucket.wallet_bid)
+            if wallet is None:
+                wallet = _load_credit_wallet_by_wallet_bid(bucket.wallet_bid)
+                if wallet is not None:
+                    changed_wallets[bucket.wallet_bid] = wallet
+
+        if not dry_run:
+            with unit_of_work():
+                db.session.flush()
+                for wallet in changed_wallets.values():
+                    refresh_credit_wallet_snapshot(wallet, snapshot_at=repaired_at)
+                    persist_credit_wallet_snapshot(
+                        wallet,
+                        available_credits=wallet.available_credits,
+                        reserved_credits=wallet.reserved_credits,
+                        updated_at=repaired_at,
+                    )
+
+        repaired_bucket_count = sum(1 for record in records if record.changed)
+        return ExpireLedgerBucketDriftRepairResult(
+            status=(
+                "dry_run"
+                if dry_run
+                else "repaired"
+                if repaired_bucket_count
+                else "noop"
+            ),
+            creator_bid=normalized_creator_bid or None,
+            wallet_bucket_bid=normalized_wallet_bucket_bid or None,
+            bucket_count=len(records),
+            repaired_bucket_count=repaired_bucket_count,
+            dry_run=dry_run,
+            buckets=records,
+        )
 
 
 def _expire_credit_wallet_buckets_in_session(

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -167,6 +167,8 @@ class ExpireLedgerBucketDriftRecord:
     status: int
     expire_ledger_count: int
     expire_ledger_amount: int | float
+    repair_action: str
+    repair_reason: str
     changed: bool
 
     def to_payload(self) -> dict[str, Any]:
@@ -182,6 +184,8 @@ class ExpireLedgerBucketDriftRecord:
             "status": self.status,
             "expire_ledger_count": self.expire_ledger_count,
             "expire_ledger_amount": self.expire_ledger_amount,
+            "repair_action": self.repair_action,
+            "repair_reason": self.repair_reason,
             "changed": self.changed,
         }
 
@@ -193,6 +197,7 @@ class ExpireLedgerBucketDriftRepairResult:
     wallet_bucket_bid: str | None
     bucket_count: int
     repaired_bucket_count: int
+    manual_review_count: int
     dry_run: bool
     buckets: list[ExpireLedgerBucketDriftRecord] = field(default_factory=list)
 
@@ -203,6 +208,7 @@ class ExpireLedgerBucketDriftRepairResult:
             "wallet_bucket_bid": self.wallet_bucket_bid,
             "bucket_count": self.bucket_count,
             "repaired_bucket_count": self.repaired_bucket_count,
+            "manual_review_count": self.manual_review_count,
             "dry_run": self.dry_run,
             "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
@@ -1151,6 +1157,7 @@ def repair_expire_ledger_bucket_drift(
     creator_bid: str = "",
     wallet_bucket_bid: str = "",
     repair_before: datetime | None = None,
+    limit: int | None = None,
     dry_run: bool = True,
 ) -> ExpireLedgerBucketDriftRepairResult:
     """Close buckets whose expire ledger exists but bucket state stayed live.
@@ -1164,6 +1171,7 @@ def repair_expire_ledger_bucket_drift(
 
     normalized_creator_bid = str(creator_bid or "").strip()
     normalized_wallet_bucket_bid = str(wallet_bucket_bid or "").strip()
+    normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
     repaired_at = repair_before or now_utc()
 
     with app.app_context():
@@ -1187,22 +1195,41 @@ def repair_expire_ledger_bucket_drift(
             CreditWalletBucket.effective_to.asc(),
             CreditWalletBucket.created_at.asc(),
             CreditWalletBucket.id.asc(),
-        ).all()
+        )
+        if normalized_limit is not None:
+            candidate_buckets = candidate_buckets.limit(normalized_limit)
+        candidate_buckets = candidate_buckets.all()
         records: list[ExpireLedgerBucketDriftRecord] = []
         changed_wallets: dict[str, CreditWallet] = {}
+        expire_ledgers_by_bucket: dict[str, list[CreditLedgerEntry]] = {}
+
+        if candidate_buckets:
+            bucket_bids = [bucket.wallet_bucket_bid for bucket in candidate_buckets]
+            ledger_rows = CreditLedgerEntry.query.filter(
+                CreditLedgerEntry.deleted == 0,
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+                CreditLedgerEntry.wallet_bucket_bid.in_(bucket_bids),
+                CreditLedgerEntry.idempotency_key.in_(
+                    [f"expire:{bucket_bid}" for bucket_bid in bucket_bids]
+                ),
+            ).all()
+            for ledger in ledger_rows:
+                if ledger.idempotency_key != f"expire:{ledger.wallet_bucket_bid}":
+                    continue
+                expire_ledgers_by_bucket.setdefault(
+                    ledger.wallet_bucket_bid, []
+                ).append(ledger)
 
         for bucket in candidate_buckets:
-            expire_ledgers = (
-                CreditLedgerEntry.query.filter(
-                    CreditLedgerEntry.deleted == 0,
-                    CreditLedgerEntry.creator_bid == bucket.creator_bid,
-                    CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
-                    CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-                    CreditLedgerEntry.idempotency_key
-                    == f"expire:{bucket.wallet_bucket_bid}",
-                )
-                .order_by(CreditLedgerEntry.id.asc())
-                .all()
+            expire_ledgers = sorted(
+                (
+                    ledger
+                    for ledger in expire_ledgers_by_bucket.get(
+                        bucket.wallet_bucket_bid, []
+                    )
+                    if ledger.creator_bid == bucket.creator_bid
+                ),
+                key=lambda ledger: int(ledger.id or 0),
             )
             if not expire_ledgers:
                 continue
@@ -1234,7 +1261,19 @@ def repair_expire_ledger_bucket_drift(
                 if _to_decimal(bucket.reserved_credits) > _ZERO
                 else CREDIT_BUCKET_STATUS_EXPIRED
             )
-            changed = (
+            has_amount_evidence = ledger_expired_amount == previous_available
+            has_expiry_evidence = all(
+                ledger.expires_at == bucket.effective_to for ledger in expire_ledgers
+            )
+            can_repair = has_amount_evidence and has_expiry_evidence
+            repair_action = "repair" if can_repair else "manual_review"
+            if not has_amount_evidence:
+                repair_reason = "expire_ledger_amount_mismatch"
+            elif not has_expiry_evidence:
+                repair_reason = "expire_ledger_expiry_mismatch"
+            else:
+                repair_reason = "expire_ledger_matches_bucket_balance_and_expiry"
+            changed = can_repair and (
                 previous_available != next_available
                 or previous_expired != next_expired
                 or previous_status != next_status
@@ -1258,6 +1297,8 @@ def repair_expire_ledger_bucket_drift(
                     expire_ledger_amount=_credit_decimal_to_number(
                         expire_ledger_amount
                     ),
+                    repair_action=repair_action,
+                    repair_reason=repair_reason,
                     changed=changed,
                 )
             )
@@ -1290,18 +1331,24 @@ def repair_expire_ledger_bucket_drift(
                     )
 
         repaired_bucket_count = sum(1 for record in records if record.changed)
+        manual_review_count = sum(
+            1 for record in records if record.repair_action == "manual_review"
+        )
         return ExpireLedgerBucketDriftRepairResult(
             status=(
                 "dry_run"
                 if dry_run
                 else "repaired"
                 if repaired_bucket_count
+                else "manual_review"
+                if manual_review_count
                 else "noop"
             ),
             creator_bid=normalized_creator_bid or None,
             wallet_bucket_bid=normalized_wallet_bucket_bid or None,
             bucket_count=len(records),
             repaired_bucket_count=repaired_bucket_count,
+            manual_review_count=manual_review_count,
             dry_run=dry_run,
             buckets=records,
         )

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -426,6 +426,79 @@ def test_billing_repair_bucket_status_cli_prints_helper_payload(
     assert payload["kwargs"]["wallet_bucket_bid"] == "bucket-cli-1"
 
 
+def test_billing_repair_expire_ledger_bucket_drift_cli_requires_scope(
+    billing_cli_runner,
+) -> None:
+    result = billing_cli_runner.invoke(
+        args=["console", "billing", "repair-expire-ledger-bucket-drift"]
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Pass --creator-bid, --wallet-bucket-bid, or --all for "
+        "expire-ledger bucket drift repair."
+    ) in result.output
+
+
+def test_billing_repair_expire_ledger_bucket_drift_cli_prints_helper_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.repair_expire_ledger_bucket_drift",
+        lambda app, **kwargs: {
+            "status": "dry_run",
+            "bucket_count": 1,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "repair-expire-ledger-bucket-drift",
+            "--wallet-bucket-bid",
+            "bucket-cli-1",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "dry_run"
+    assert payload["kwargs"]["wallet_bucket_bid"] == "bucket-cli-1"
+    assert payload["kwargs"]["dry_run"] is True
+
+
+def test_billing_repair_expire_ledger_bucket_drift_cli_apply_persists_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.repair_expire_ledger_bucket_drift",
+        lambda app, **kwargs: {
+            "status": "repaired",
+            "bucket_count": 1,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "repair-expire-ledger-bucket-drift",
+            "--all",
+            "--apply",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "repaired"
+    assert payload["kwargs"]["dry_run"] is False
+
+
 def test_billing_repair_subscription_cycle_cli_requires_explicit_scope(
     billing_cli_runner,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -467,6 +467,7 @@ def test_billing_repair_expire_ledger_bucket_drift_cli_prints_helper_payload(
     assert result.exit_code == 0
     assert payload["status"] == "dry_run"
     assert payload["kwargs"]["wallet_bucket_bid"] == "bucket-cli-1"
+    assert payload["kwargs"]["limit"] is None
     assert payload["kwargs"]["dry_run"] is True
 
 
@@ -489,6 +490,8 @@ def test_billing_repair_expire_ledger_bucket_drift_cli_apply_persists_payload(
             "billing",
             "repair-expire-ledger-bucket-drift",
             "--all",
+            "--limit",
+            "10",
             "--apply",
         ]
     )
@@ -496,6 +499,7 @@ def test_billing_repair_expire_ledger_bucket_drift_cli_apply_persists_payload(
     payload = json.loads(result.output)
     assert result.exit_code == 0
     assert payload["status"] == "repaired"
+    assert payload["kwargs"]["limit"] == 10
     assert payload["kwargs"]["dry_run"] is False
 
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -16,6 +16,7 @@ from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_BUCKET_STATUS_EXHAUSTED,
     CREDIT_BUCKET_STATUS_EXPIRED,
     CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
@@ -592,6 +593,161 @@ def test_repair_expire_ledger_bucket_drift_keeps_existing_expired_amount(
     assert payload["buckets"][0]["expired_credits"] == 2.5
     assert bucket.available_credits == Decimal("0")
     assert bucket.expired_credits == Decimal("2.5000000000")
+
+
+def test_repair_expire_ledger_bucket_drift_skips_reused_bucket_for_manual_review(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-reused",
+            creator_bid="creator-expire-ledger-drift-reused",
+            available_credits=Decimal("5.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("15.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-reused",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-reused-second-cycle",
+            priority=30,
+            original_credits=Decimal("15.0000000000"),
+            available_credits=Decimal("5.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("7.5000000000"),
+            expired_credits=Decimal("2.5000000000"),
+            effective_from=datetime(2026, 5, 1, 0, 0, 0),
+            effective_to=datetime(2026, 5, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-reused-old",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-reused-first-cycle",
+            idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=datetime(2026, 4, 7, 0, 0, 0),
+            consumable_from=datetime(2026, 4, 1, 0, 0, 0),
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            repair_before=datetime(2026, 5, 8, 0, 0, 0),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-reused"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-ledger-drift-reused"
+        ).one()
+
+    assert payload["status"] == "manual_review"
+    assert payload["bucket_count"] == 1
+    assert payload["repaired_bucket_count"] == 0
+    assert payload["manual_review_count"] == 1
+    assert payload["buckets"][0]["repair_action"] == "manual_review"
+    assert payload["buckets"][0]["repair_reason"] == "expire_ledger_amount_mismatch"
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("5.0000000000")
+    assert bucket.expired_credits == Decimal("2.5000000000")
+    assert wallet.available_credits == Decimal("5.0000000000")
+    assert wallet.version == 0
+
+
+def test_repair_expire_ledger_bucket_drift_sets_exhausted_for_reserved_bucket(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-reserved",
+            creator_bid="creator-expire-ledger-drift-reserved",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("1.0000000000"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-reserved",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-reserved",
+            priority=30,
+            original_credits=Decimal("10.0000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("1.0000000000"),
+            consumed_credits=Decimal("6.5000000000"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-reserved",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bucket.source_bid,
+            idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            repair_before=datetime(2026, 4, 8, 0, 0, 0),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-reserved"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-ledger-drift-reserved"
+        ).one()
+
+    assert payload["status"] == "repaired"
+    assert payload["repaired_bucket_count"] == 1
+    assert payload["manual_review_count"] == 0
+    assert payload["buckets"][0]["repair_action"] == "repair"
+    assert bucket.status == CREDIT_BUCKET_STATUS_EXHAUSTED
+    assert bucket.available_credits == Decimal("0")
+    assert bucket.reserved_credits == Decimal("1.0000000000")
+    assert bucket.expired_credits == Decimal("2.5000000000")
+    assert wallet.available_credits == Decimal("0E-10")
+    assert wallet.reserved_credits == Decimal("1.0000000000")
 
 
 def test_grant_refund_return_credits_creates_subscription_bucket_and_refund_ledger(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -42,6 +42,7 @@ from flaskr.service.billing.wallets import (
     grant_manual_credit_wallet_balance,
     grant_refund_return_credits,
     repair_credit_bucket_runtime_statuses,
+    repair_expire_ledger_bucket_drift,
     rebuild_credit_wallet_snapshots,
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
@@ -367,6 +368,230 @@ def test_repair_credit_bucket_runtime_statuses_reactivates_live_expired_bucket(
     assert payload["repaired_bucket_bids"] == ["bucket-repair-runtime-1"]
     assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
     assert wallet.available_credits == Decimal("5.0000000000")
+
+
+def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-dry-run",
+            creator_bid="creator-expire-ledger-drift-dry-run",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-dry-run",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-dry-run",
+            priority=30,
+            original_credits=Decimal("10.0000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("7.5000000000"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-dry-run",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bucket.source_bid,
+            idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            repair_before=datetime(2026, 4, 8, 0, 0, 0),
+            dry_run=True,
+        )
+
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-dry-run"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-ledger-drift-dry-run"
+        ).one()
+
+    assert payload["status"] == "dry_run"
+    assert payload["bucket_count"] == 1
+    assert payload["repaired_bucket_count"] == 1
+    assert payload["buckets"][0]["previous_available_credits"] == 2.5
+    assert payload["buckets"][0]["available_credits"] == 0
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("2.5000000000")
+    assert wallet.available_credits == Decimal("2.5000000000")
+
+
+def test_repair_expire_ledger_bucket_drift_applies_bucket_and_wallet_snapshot(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-apply",
+            creator_bid="creator-expire-ledger-drift-apply",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-apply",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-apply",
+            priority=30,
+            original_credits=Decimal("10.0000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("7.5000000000"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-apply",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bucket.source_bid,
+            idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            repair_before=datetime(2026, 4, 8, 0, 0, 0),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-apply"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-ledger-drift-apply"
+        ).one()
+        ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        ).all()
+
+    assert payload["status"] == "repaired"
+    assert payload["bucket_count"] == 1
+    assert payload["repaired_bucket_count"] == 1
+    assert bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+    assert bucket.available_credits == Decimal("0")
+    assert bucket.expired_credits == Decimal("2.5000000000")
+    assert wallet.available_credits == Decimal("0E-10")
+    assert wallet.version == 1
+    assert len(ledgers) == 1
+
+
+def test_repair_expire_ledger_bucket_drift_keeps_existing_expired_amount(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-counted",
+            creator_bid="creator-expire-ledger-drift-counted",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-counted",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-counted",
+            priority=30,
+            original_credits=Decimal("10.0000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("7.5000000000"),
+            expired_credits=Decimal("2.5000000000"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-counted",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bucket.source_bid,
+            idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            repair_before=datetime(2026, 4, 8, 0, 0, 0),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-counted"
+        ).one()
+
+    assert payload["status"] == "repaired"
+    assert payload["bucket_count"] == 1
+    assert payload["buckets"][0]["previous_expired_credits"] == 2.5
+    assert payload["buckets"][0]["expired_credits"] == 2.5
+    assert bucket.available_credits == Decimal("0")
+    assert bucket.expired_credits == Decimal("2.5000000000")
 
 
 def test_grant_refund_return_credits_creates_subscription_bucket_and_refund_ledger(


### PR DESCRIPTION
## What changed

- Added a dry-run-first billing repair command for expired wallet buckets that already have an `expire:<wallet_bucket_bid>` ledger but still show active bucket balances.
- The repair synchronizes the bucket projection and wallet snapshot without writing duplicate expire ledger entries.
- Constrained automatic repair to records whose existing expire ledger amount and expiry match the current bucket balance and effective window; mismatches are reported as `manual_review` and are not mutated.
- Added `--limit` support for bounded `--all` scans and bulk-loaded expire ledgers to avoid per-bucket ledger queries.
- Added focused wallet lifecycle and CLI coverage for dry-run, apply, scope validation, wallet snapshot refresh, existing expired amount behavior, reusable bucket manual-review protection, and reserved-balance exhausted behavior.
- Updated the generated UOW commit-site baseline for an existing `src/api/flaskr/service/shifu/repair.py` direct commit site surfaced by the local hook; this PR does not modify that repair code.

## Why

Production has historical bucket rows where the expire ledger exists, but the bucket projection stayed live (`status=active`, expired window, positive `available_credits`). The normal expiration job skips these rows because the ledger idempotency key already exists, so a separate repair path is needed to close the bucket state without duplicating audit ledger rows. Because bucket reuse can make an old expire ledger unsafe to apply automatically, this command now fails closed to manual review unless amount and expiry evidence match.

## Validation

- `python scripts/check_dev_tools.py`
- `cd src/api && pytest tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_cli.py -q`
- `git diff --check`
- `cd src/api && python -m py_compile flaskr/service/billing/wallets.py flaskr/service/billing/cli.py tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_cli.py`
- Broader billing suite was also sampled with `cd src/api && pytest tests/service/billing/ -q`; unrelated local failures remain in Celery-dependent tests because the local environment lacks `celery` / task decoration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline billing maintenance command to detect and repair “expire ledger bucket drift” for eligible wallet buckets.
  * Supports targeting by creator, wallet bucket, or scanning all eligible buckets.
  * Defaults to dry-run (no writes) and can persist changes with an apply option, returning repair status and per-bucket details (including manual-review cases).

* **Bug Fixes**
  * Reconciles wallet and bucket available/expired credits to match existing expire ledger entries.
  * Ensures idempotent behavior and correctly handles reserved buckets by transitioning them to the exhausted state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
