### PR TITLE
feat: add model rate configuration

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -301,7 +301,7 @@ WECHAT_APP_SECRET=""
 # Type: bool
 CREATOR_CUSTOMIZATION_ENABLED="False"
 
-# Fernet key used only for course-owner integration secrets.
+# Required when CREATOR_CUSTOMIZATION_ENABLED is true; Fernet key used for course-owner integration secrets and callback tokens.
 # (Optional - default: )
 # Secret value
 CREATOR_INTEGRATION_ENCRYPTION_KEY=""
@@ -323,13 +323,13 @@ BILLING_BUCKET_EXPIRE_CRON="* * * * *"
 # (Optional - default: 0 * * * *)
 BILLING_CREDIT_EXPIRING_CRON="0 * * * *"
 
-# Cron expression for finalizing the previous day's billing usage metrics.
-# (Optional - default: 15 1 * * *)
-BILLING_DAILY_USAGE_METRICS_CRON="15 1 * * *"
-
 # Cron expression for finalizing the previous day's billing ledger summary.
 # (Optional - default: 30 1 * * *)
 BILLING_DAILY_LEDGER_SUMMARY_CRON="30 1 * * *"
+
+# Cron expression for finalizing the previous day's billing usage metrics.
+# (Optional - default: 15 1 * * *)
+BILLING_DAILY_USAGE_METRICS_CRON="15 1 * * *"
 
 # Cron expression for scanning billing low-balance alerts.
 # (Optional - default: 0 * * * *)
@@ -728,6 +728,10 @@ LLM_ALLOWED_MODELS=""
 # Type: list
 LLM_ALLOWED_MODEL_DISPLAY_NAMES=""
 
+# Fixed global 1x credit anchor for LLM output tokens, expressed as credits consumed per 1000 output tokens. This value is used for operator rate multiplier display, save conversion, and model-picker multiplier labels. It must not be derived from DEFAULT_LLM_MODEL.
+# (Optional - default: )
+LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS="0.066667"
+
 # Optional JSON object mapping full routed LLM model ids to positive maximum output token limits. Values extend LiteLLM model metadata and are sent as max_tokens for matching requests.
 # (Optional - default: )
 # (Has validation)
@@ -1116,7 +1120,7 @@ TTS_ALLOWED_MODELS=""
 # (Optional - default: )
 TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON=""
 
-# TTS characters synthesized per LLM output token in a task, used to put TTS (billed per character) and LLM (billed per token) on one shared 1x anchor. Default 0.216 = omega(13.5%) x 1.6 chars/token. The picker multiplier is TTS char cost x this factor / the default LLM output-token cost, so TTS tiers stay on the same scale as LLM model multipliers and track the default LLM price automatically.
+# TTS characters synthesized per LLM output token in a task, used to put TTS (billed per character) and LLM (billed per token) on one shared 1x anchor. Default 0.216 = omega(13.5%) x 1.6 chars/token. The picker multiplier is TTS char cost x this factor / the fixed LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS anchor, so TTS tiers stay on the same scale as LLM model multipliers without depending on the current DEFAULT_LLM_MODEL price.
 # (Optional - default: 0.216)
 # Type: float
 TTS_CHARS_PER_LLM_TOKEN="0.216"

--- a/docs/generated/uow-commit-baseline.json
+++ b/docs/generated/uow-commit-baseline.json
@@ -41,7 +41,6 @@
   "service/shifu/admin_operations/courses_transfer_copy.py": 2,
   "service/shifu/admin_operations/voice_clones.py": 1,
   "service/shifu/funcs.py": 6,
-  "service/shifu/repair.py": 1,
   "service/shifu/route.py": 2,
   "service/shifu/shifu_draft_funcs.py": 4,
   "service/shifu/shifu_import_export_funcs.py": 1,

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -38,7 +38,7 @@ from flaskr.service.billing.consts import (
 from flaskr.service.billing.models import CreditUsageRate
 from flaskr.service.billing.rate_references import (
     format_credit_multiplier,
-    load_default_llm_reference_cost,
+    load_llm_credit_1x_unit_cost,
 )
 from flaskr.service.metering import UsageContext, record_llm_usage
 from flaskr.service.metering.consts import (
@@ -1184,13 +1184,13 @@ def _attach_credit_multipliers(
     app: Flask, options: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     default_model = str(get_config("DEFAULT_LLM_MODEL", "") or "").strip()
-    if not options or not default_model:
+    if not options:
         return [{**option, "credit_multiplier": None} for option in options]
 
     try:
         rows = _load_llm_output_rate_rows(app)
         now = now_utc()
-        default_rate = load_default_llm_reference_cost(default_model)
+        default_rate = load_llm_credit_1x_unit_cost()
         if default_rate is None or default_rate <= 0:
             return [{**option, "credit_multiplier": None} for option in options]
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -36,6 +36,10 @@ from flaskr.service.billing.consts import (
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.billing.rate_references import (
+    format_credit_multiplier,
+    load_default_llm_reference_cost,
+)
 from flaskr.service.metering import UsageContext, record_llm_usage
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
@@ -1186,17 +1190,7 @@ def _attach_credit_multipliers(
     try:
         rows = _load_llm_output_rate_rows(app)
         now = now_utc()
-        default_provider, default_model_candidates = _resolve_billing_rate_identity(
-            default_model
-        )
-        default_rate = _rate_per_token(
-            _select_credit_usage_rate(
-                rows,
-                provider=default_provider,
-                model_candidates=default_model_candidates,
-                now=now,
-            )
-        )
+        default_rate = load_default_llm_reference_cost(default_model)
         if default_rate is None or default_rate <= 0:
             return [{**option, "credit_multiplier": None} for option in options]
 
@@ -1213,13 +1207,21 @@ def _attach_credit_multipliers(
                 )
             )
             multiplier = None
+            multiplier_label = None
             if model_rate is not None and model_rate > 0:
+                multiplier_value = model_rate / default_rate
                 multiplier = int(
-                    (model_rate / default_rate).to_integral_value(
-                        rounding=ROUND_CEILING
-                    )
+                    multiplier_value.to_integral_value(rounding=ROUND_CEILING)
                 )
-            enriched.append({**option, "credit_multiplier": multiplier})
+                multiplier_label = format_credit_multiplier(multiplier_value)
+            enriched.append(
+                {
+                    **option,
+                    "credit_multiplier": multiplier,
+                    "credit_multiplier_label": multiplier_label,
+                    "is_default": model == default_model,
+                }
+            )
         return enriched
     except Exception as exc:
         _log_warning(f"load LLM credit multipliers error: {exc}")

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -26,6 +26,7 @@ from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_OUTPUT_TOKENS,
     BILLING_METRIC_TTS_OUTPUT_CHARS,
 )
+from flaskr.service.billing.rate_references import load_default_llm_reference_cost
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
     BILL_USAGE_TYPE_LLM,
@@ -349,7 +350,9 @@ def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | No
         # chars-synthesized-per-token, then take the ratio. The label is
         # therefore "TTS task consumption / LLM task consumption" on the very
         # same scale as the LLM model multipliers.
-        baseline_cost = _load_default_llm_unit_cost()
+        baseline_cost = load_default_llm_reference_cost()
+        if baseline_cost is None or baseline_cost <= 0:
+            baseline_cost = _load_default_llm_unit_cost()
         if baseline_cost is None or baseline_cost <= 0:
             return None
         chars_per_token = _load_tts_chars_per_llm_token()

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -22,16 +22,9 @@ from flaskr.common.config import get_config
 from flaskr.util.datetime import now_utc
 from flaskr.common.log import AppLoggerProxy
 from flaskr.i18n import get_current_language
-from flaskr.service.billing.consts import (
-    BILLING_METRIC_LLM_OUTPUT_TOKENS,
-    BILLING_METRIC_TTS_OUTPUT_CHARS,
-)
-from flaskr.service.billing.rate_references import load_default_llm_reference_cost
-from flaskr.service.metering.consts import (
-    BILL_USAGE_SCENE_PROD,
-    BILL_USAGE_TYPE_LLM,
-    BILL_USAGE_TYPE_TTS,
-)
+from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
+from flaskr.service.billing.rate_references import load_llm_credit_1x_unit_cost
+from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_TTS
 
 # Re-export base classes for backward compatibility
 from flaskr.api.tts.base import (
@@ -344,15 +337,10 @@ def _resolve_localized_tts_label(
 
 def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | None:
     try:
-        # One shared 1x anchor for LLM and TTS: the default LLM output-token
-        # price (DeepSeek-V4-Flash). TTS is priced per character, so translate
-        # its per-character cost into the same per-LLM-token dimension using
-        # chars-synthesized-per-token, then take the ratio. The label is
-        # therefore "TTS task consumption / LLM task consumption" on the very
-        # same scale as the LLM model multipliers.
-        baseline_cost = load_default_llm_reference_cost()
-        if baseline_cost is None or baseline_cost <= 0:
-            baseline_cost = _load_default_llm_unit_cost()
+        # One shared fixed 1x anchor for LLM and TTS. TTS is priced per
+        # character, so translate its per-character cost into the same
+        # per-LLM-token dimension using chars-synthesized-per-token.
+        baseline_cost = load_llm_credit_1x_unit_cost()
         if baseline_cost is None or baseline_cost <= 0:
             return None
         chars_per_token = _load_tts_chars_per_llm_token()
@@ -374,35 +362,11 @@ def _resolve_credit_multiplier_label(provider_name: str, model: str) -> str | No
         return None
 
 
-def _resolve_default_llm_rate_identity() -> tuple[str, list[str]]:
-    default_model = str(get_config("DEFAULT_LLM_MODEL", "") or "").strip()
-    if not default_model:
-        return "", [""]
-    try:
-        from flaskr.api.llm import _resolve_billing_rate_identity
-
-        return _resolve_billing_rate_identity(default_model)
-    except Exception:
-        return "", [default_model]
-
-
-def _load_default_llm_unit_cost() -> Decimal | None:
-    provider, model_candidates = _resolve_default_llm_rate_identity()
-    return _load_usage_rate_unit_cost(
-        usage_type=BILL_USAGE_TYPE_LLM,
-        provider=provider,
-        model_candidates=model_candidates or [""],
-        billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
-    )
-
-
 def _load_tts_chars_per_llm_token() -> Decimal | None:
-    # TTS is billed per character but the 1x anchor is an LLM output token, so we
-    # need "how many TTS characters one LLM token turns into" to compare them on
-    # one scale. This is omega x 1.6 (TTS-token share of a task x token->char
-    # ratio); see TTS_CHARS_PER_LLM_TOKEN. Keeping it a factor over the shared
-    # LLM baseline (rather than a standalone TTS baseline) means the TTS 1x
-    # tracks the default LLM price automatically.
+    # TTS is billed per character but the fixed 1x anchor is an LLM output token,
+    # so we need "how many TTS characters one LLM token turns into" to compare
+    # them on one scale. This is omega x 1.6 (TTS-token share of a task x
+    # token->char ratio); see TTS_CHARS_PER_LLM_TOKEN.
     try:
         raw = get_config("TTS_CHARS_PER_LLM_TOKEN", "")
         if raw is None or str(raw).strip() == "":

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -638,6 +638,19 @@ DeepSeek: deepseek-chat
 Gemini: gemini-1.5-flash, gemini-1.5-flash-8b, gemini-1.5-pro""",
         group="llm",
     ),
+    "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": EnvVar(
+        name="LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS",
+        default="",
+        example="0.066667",
+        description=(
+            "Fixed global 1x credit anchor for LLM output tokens, expressed as "
+            "credits consumed per 1000 output tokens. This value is used for "
+            "operator rate multiplier display, save conversion, and model-picker "
+            "multiplier labels. It must not be derived from DEFAULT_LLM_MODEL."
+        ),
+        group="llm",
+        required=False,
+    ),
     "LLM_ALLOWED_MODELS": EnvVar(
         name="LLM_ALLOWED_MODELS",
         default=[],
@@ -1554,9 +1567,10 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
             "TTS characters synthesized per LLM output token in a task, used to "
             "put TTS (billed per character) and LLM (billed per token) on one "
             "shared 1x anchor. Default 0.216 = omega(13.5%) x 1.6 chars/token. "
-            "The picker multiplier is TTS char cost x this factor / the default "
-            "LLM output-token cost, so TTS tiers stay on the same scale as LLM "
-            "model multipliers and track the default LLM price automatically."
+            "The picker multiplier is TTS char cost x this factor / the fixed "
+            "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS anchor, so TTS tiers stay on "
+            "the same scale as LLM model multipliers without depending on the "
+            "current DEFAULT_LLM_MODEL price."
         ),
         group="tts",
     ),

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -28,6 +28,7 @@ from .consts import (
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from .models import CreditUsageRate
+from .rate_references import resolve_llm_rate_identity
 from flaskr.util.datetime import now_utc
 
 from .primitives import (
@@ -264,6 +265,18 @@ def load_usage_rate(
 ) -> CreditUsageRate | None:
     provider = str(usage.provider or "").strip()
     model = str(usage.model or "").strip()
+    model_candidates = [model] if model else [""]
+    if int(usage.usage_type or 0) == BILL_USAGE_TYPE_LLM and model:
+        resolved_provider, resolved_models = resolve_llm_rate_identity(model)
+        if not provider and resolved_provider:
+            provider = resolved_provider
+        model_candidates = []
+        for candidate in [*resolved_models, model]:
+            normalized = str(candidate or "").strip()
+            if normalized and normalized not in model_candidates:
+                model_candidates.append(normalized)
+        if not model_candidates:
+            model_candidates = [model]
     usage_scene = int(usage.usage_scene or 0)
     rows = (
         CreditUsageRate.query.filter(
@@ -282,14 +295,19 @@ def load_usage_rate(
         if row.effective_from <= settlement_at
         and (row.effective_to is None or row.effective_to > settlement_at)
         and row.provider in {provider, "*"}
-        and row.model in {model, "*"}
+        and row.model in set(model_candidates).union({"*"})
     ]
     if not candidates:
         return None
+    model_priority = {
+        candidate: len(model_candidates) - index
+        for index, candidate in enumerate(model_candidates)
+    }
     candidates.sort(
         key=lambda row: (
             row.provider == provider,
-            row.model == model,
+            row.model in set(model_candidates),
+            model_priority.get(row.model, 0),
             row.effective_from or datetime.min,
             int(row.id or 0),
         ),

--- a/src/api/flaskr/service/billing/rate_references.py
+++ b/src/api/flaskr/service/billing/rate_references.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
+from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.config.funcs import get_config
+from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
+from flaskr.service.metering.models import BillUsageRecord
+from flaskr.util.datetime import now_utc
+
+
+def rate_unit_cost(rate: CreditUsageRate | None) -> Decimal | None:
+    if rate is None:
+        return None
+    try:
+        unit_size = max(int(rate.unit_size or 1), 1)
+        return Decimal(str(rate.credits_per_unit or 0)) / Decimal(str(unit_size))
+    except (InvalidOperation, TypeError, ValueError, ZeroDivisionError):
+        return None
+
+
+def format_credit_multiplier(value: Decimal | None) -> str | None:
+    if value is None or value <= 0:
+        return None
+    rounded = value.quantize(Decimal("0.01"))
+    text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
+    return f"{text or '0'}x"
+
+
+def resolve_llm_rate_identity(model: str) -> tuple[str, list[str]]:
+    normalized = str(model or "").strip()
+    if not normalized:
+        return "", []
+    try:
+        from flaskr.api.llm import _resolve_billing_rate_identity
+
+        return _resolve_billing_rate_identity(normalized)
+    except Exception:
+        if "/" in normalized:
+            provider, actual_model = normalized.split("/", 1)
+            return provider.strip(), [actual_model.strip(), normalized]
+        return "", [normalized]
+
+
+def _load_current_default_llm_output_cost(
+    default_model: str | None = None,
+) -> Decimal | None:
+    from flaskr.service.billing.charges import load_usage_rate
+
+    default_model = str(
+        default_model
+        if default_model is not None
+        else get_config("DEFAULT_LLM_MODEL", "") or ""
+    ).strip()
+    provider = ""
+    model_candidates = [default_model] if default_model else [""]
+    if default_model:
+        provider, model_candidates = resolve_llm_rate_identity(default_model)
+    for model in model_candidates or [""]:
+        rate = load_usage_rate(
+            usage=BillUsageRecord(
+                usage_type=BILL_USAGE_TYPE_LLM,
+                provider=provider,
+                model=model,
+                usage_scene=BILL_USAGE_SCENE_PROD,
+            ),
+            billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            settlement_at=now_utc(),
+        )
+        cost = rate_unit_cost(rate)
+        if cost and cost > 0:
+            return cost
+    return None
+
+
+def load_default_llm_reference_cost(default_model: str | None = None) -> Decimal | None:
+    """Return the stable 1x anchor for model multiplier display.
+
+    The configurable page can edit the default LLM itself. If display code uses
+    the current default-model price as the denominator, the edited default model
+    always renders as 1x. Use the earliest default-model output-token price as
+    the stable reference instead.
+    """
+
+    default_model = str(
+        default_model
+        if default_model is not None
+        else get_config("DEFAULT_LLM_MODEL", "") or ""
+    ).strip()
+    if not default_model:
+        return _load_current_default_llm_output_cost(default_model)
+    provider, model_candidates = resolve_llm_rate_identity(default_model)
+    normalized_models = [
+        str(model or "").strip()
+        for model in model_candidates
+        if str(model or "").strip()
+    ]
+    if not normalized_models:
+        return _load_current_default_llm_output_cost(default_model)
+    model_priority = {
+        model: len(normalized_models) - index
+        for index, model in enumerate(normalized_models)
+    }
+    rows = (
+        CreditUsageRate.query.filter(
+            CreditUsageRate.deleted == 0,
+            CreditUsageRate.usage_type == BILL_USAGE_TYPE_LLM,
+            CreditUsageRate.provider == provider,
+            CreditUsageRate.model.in_(normalized_models),
+            CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
+            CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        )
+        .order_by(CreditUsageRate.effective_from.asc(), CreditUsageRate.id.asc())
+        .all()
+    )
+    if not rows:
+        return _load_current_default_llm_output_cost(default_model)
+    rows.sort(
+        key=lambda row: (
+            row.effective_from,
+            -model_priority.get(str(row.model or ""), 0),
+            int(row.id or 0),
+        )
+    )
+    return rate_unit_cost(rows[0]) or _load_current_default_llm_output_cost(
+        default_model
+    )

--- a/src/api/flaskr/service/billing/rate_references.py
+++ b/src/api/flaskr/service/billing/rate_references.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
 
-from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
 from flaskr.service.billing.models import CreditUsageRate
-from flaskr.service.config.funcs import get_config
-from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
-from flaskr.service.metering.models import BillUsageRecord
-from flaskr.util.datetime import now_utc
+from flaskr.service.common.credit_rate_references import (
+    load_llm_credit_1x_unit_cost,
+)
 
 
 def rate_unit_cost(rate: CreditUsageRate | None) -> Decimal | None:
@@ -28,6 +26,18 @@ def format_credit_multiplier(value: Decimal | None) -> str | None:
     return f"{text or '0'}x"
 
 
+def load_default_llm_reference_cost(default_model: str | None = None) -> Decimal | None:
+    """Backward-compatible alias for the fixed LLM 1x anchor.
+
+    DEFAULT_LLM_MODEL no longer participates in multiplier calculation; it only
+    decides which LLM is selected by default. Keep the old function name so
+    existing callers share the fixed anchor without a broad rename.
+    """
+
+    _ = default_model
+    return load_llm_credit_1x_unit_cost()
+
+
 def resolve_llm_rate_identity(model: str) -> tuple[str, list[str]]:
     normalized = str(model or "").strip()
     if not normalized:
@@ -41,88 +51,3 @@ def resolve_llm_rate_identity(model: str) -> tuple[str, list[str]]:
             provider, actual_model = normalized.split("/", 1)
             return provider.strip(), [actual_model.strip(), normalized]
         return "", [normalized]
-
-
-def _load_current_default_llm_output_cost(
-    default_model: str | None = None,
-) -> Decimal | None:
-    from flaskr.service.billing.charges import load_usage_rate
-
-    default_model = str(
-        default_model
-        if default_model is not None
-        else get_config("DEFAULT_LLM_MODEL", "") or ""
-    ).strip()
-    provider = ""
-    model_candidates = [default_model] if default_model else [""]
-    if default_model:
-        provider, model_candidates = resolve_llm_rate_identity(default_model)
-    for model in model_candidates or [""]:
-        rate = load_usage_rate(
-            usage=BillUsageRecord(
-                usage_type=BILL_USAGE_TYPE_LLM,
-                provider=provider,
-                model=model,
-                usage_scene=BILL_USAGE_SCENE_PROD,
-            ),
-            billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
-            settlement_at=now_utc(),
-        )
-        cost = rate_unit_cost(rate)
-        if cost and cost > 0:
-            return cost
-    return None
-
-
-def load_default_llm_reference_cost(default_model: str | None = None) -> Decimal | None:
-    """Return the stable 1x anchor for model multiplier display.
-
-    The configurable page can edit the default LLM itself. If display code uses
-    the current default-model price as the denominator, the edited default model
-    always renders as 1x. Use the earliest default-model output-token price as
-    the stable reference instead.
-    """
-
-    default_model = str(
-        default_model
-        if default_model is not None
-        else get_config("DEFAULT_LLM_MODEL", "") or ""
-    ).strip()
-    if not default_model:
-        return _load_current_default_llm_output_cost(default_model)
-    provider, model_candidates = resolve_llm_rate_identity(default_model)
-    normalized_models = [
-        str(model or "").strip()
-        for model in model_candidates
-        if str(model or "").strip()
-    ]
-    if not normalized_models:
-        return _load_current_default_llm_output_cost(default_model)
-    model_priority = {
-        model: len(normalized_models) - index
-        for index, model in enumerate(normalized_models)
-    }
-    rows = (
-        CreditUsageRate.query.filter(
-            CreditUsageRate.deleted == 0,
-            CreditUsageRate.usage_type == BILL_USAGE_TYPE_LLM,
-            CreditUsageRate.provider == provider,
-            CreditUsageRate.model.in_(normalized_models),
-            CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
-            CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        )
-        .order_by(CreditUsageRate.effective_from.asc(), CreditUsageRate.id.asc())
-        .all()
-    )
-    if not rows:
-        return _load_current_default_llm_output_cost(default_model)
-    rows.sort(
-        key=lambda row: (
-            row.effective_from,
-            -model_priority.get(str(row.model or ""), 0),
-            int(row.id or 0),
-        )
-    )
-    return rate_unit_cost(rows[0]) or _load_current_default_llm_output_cost(
-        default_model
-    )

--- a/src/api/flaskr/service/common/credit_rate_references.py
+++ b/src/api/flaskr/service/common/credit_rate_references.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from decimal import Decimal, InvalidOperation
+
+from flaskr.service.config.funcs import get_config
+
+logger = logging.getLogger(__name__)
+
+LLM_CREDIT_1X_PER_1000_CONFIG = "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS"
+_LLM_CREDIT_1X_UNIT_DIVISOR = Decimal("1000")
+
+
+def load_llm_credit_1x_per_1000_output_tokens() -> Decimal | None:
+    """Return the fixed global LLM 1x anchor in credits per 1000 output tokens."""
+
+    raw_value = get_config(LLM_CREDIT_1X_PER_1000_CONFIG, "")
+    if raw_value is None or str(raw_value).strip() == "":
+        logger.error(
+            "%s is not configured; credit multipliers are disabled",
+            LLM_CREDIT_1X_PER_1000_CONFIG,
+        )
+        return None
+    try:
+        value = Decimal(str(raw_value).strip())
+    except (InvalidOperation, TypeError, ValueError):
+        logger.error(
+            "%s must be a positive decimal; got %r",
+            LLM_CREDIT_1X_PER_1000_CONFIG,
+            raw_value,
+        )
+        return None
+    if value <= 0:
+        logger.error(
+            "%s must be greater than 0; got %s",
+            LLM_CREDIT_1X_PER_1000_CONFIG,
+            value,
+        )
+        return None
+    return value
+
+
+def load_llm_credit_1x_unit_cost() -> Decimal | None:
+    """Return the fixed global LLM 1x anchor in credits per output token."""
+
+    per_1000 = load_llm_credit_1x_per_1000_output_tokens()
+    if per_1000 is None:
+        return None
+    return per_1000 / _LLM_CREDIT_1X_UNIT_DIVISOR

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -21,6 +21,10 @@ from flaskr.service.billing.consts import (
     CREDIT_USAGE_RATE_STATUS_LABELS,
 )
 from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.common.credit_rate_references import (
+    load_llm_credit_1x_per_1000_output_tokens,
+    load_llm_credit_1x_unit_cost,
+)
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.config.funcs import get_config
 from flaskr.service.metering.consts import (
@@ -114,52 +118,10 @@ def _resolve_llm_rate_identity(model: str) -> tuple[str, list[str]]:
     return _resolve_billing_rate_identity(normalized)
 
 
-def _load_default_llm_reference_cost(
-    default_model: str | None = None,
-) -> Decimal | None:
-    """Return the stable 1x anchor used by the operator config page."""
+def _load_llm_credit_1x_reference_cost() -> Decimal | None:
+    """Return the fixed 1x anchor used by the operator config page."""
 
-    default_model = str(
-        default_model
-        if default_model is not None
-        else get_config("DEFAULT_LLM_MODEL", "") or ""
-    ).strip()
-    if not default_model:
-        return None
-    provider, model_candidates = _resolve_llm_rate_identity(default_model)
-    normalized_models = [
-        str(model or "").strip()
-        for model in model_candidates
-        if str(model or "").strip()
-    ]
-    if not normalized_models:
-        return None
-    model_priority = {
-        model: len(normalized_models) - index
-        for index, model in enumerate(normalized_models)
-    }
-    rows = (
-        CreditUsageRate.query.filter(
-            CreditUsageRate.deleted == 0,
-            CreditUsageRate.usage_type == BILL_USAGE_TYPE_LLM,
-            CreditUsageRate.provider == provider,
-            CreditUsageRate.model.in_(normalized_models),
-            CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
-            CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        )
-        .order_by(CreditUsageRate.effective_from.asc(), CreditUsageRate.id.asc())
-        .all()
-    )
-    if not rows:
-        return None
-    rows.sort(
-        key=lambda row: (
-            row.effective_from,
-            -model_priority.get(str(row.model or ""), 0),
-            int(row.id or 0),
-        )
-    )
-    return _unit_cost(rows[0])
+    return load_llm_credit_1x_unit_cost()
 
 
 def _load_default_llm_metric_ratio(metric: int) -> Decimal:
@@ -389,11 +351,16 @@ def _build_tts_rows(baseline_cost: Decimal | None) -> list[dict[str, Any]]:
 
 def get_operator_rate_config(app: Flask) -> dict[str, Any]:
     with app_context_scope(app):
-        baseline_cost = _load_default_llm_reference_cost()
+        baseline_cost = _load_llm_credit_1x_reference_cost()
+        baseline_per_1000 = load_llm_credit_1x_per_1000_output_tokens()
         return {
             "baseline": {
                 "default_llm_model": str(get_config("DEFAULT_LLM_MODEL", "") or ""),
                 "unit_cost": _decimal_to_number(baseline_cost or Decimal("0")),
+                "per_1000_output_tokens": _decimal_to_number(
+                    baseline_per_1000 or Decimal("0")
+                ),
+                "is_configured": bool(baseline_cost and baseline_cost > 0),
                 "tts_chars_per_llm_token": _decimal_to_number(
                     _load_tts_chars_per_llm_token() or Decimal("0")
                 ),
@@ -465,6 +432,10 @@ def update_operator_rate_config(
         unit_size = int(payload.get("unit_size") or 1)
         if unit_size <= 0:
             raise_param_error("unit_size")
+
+        baseline_cost = _load_llm_credit_1x_reference_cost()
+        if baseline_cost is None or baseline_cost <= 0:
+            raise_param_error("llm_credit_1x_per_1000_output_tokens")
 
         credits_per_unit = _decimal(
             payload.get("credits_per_unit"), field_name="credits_per_unit"
@@ -586,7 +557,6 @@ def update_operator_rate_config(
                     status=status_code,
                 )
             )
-        baseline_cost = _load_default_llm_reference_cost()
         return _serialize_rate_row(
             usage_type=usage_type,
             provider=provider,

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -46,6 +46,11 @@ _USAGE_TYPE_LABELS = {
 _USAGE_TYPE_CODES = {value: key for key, value in _USAGE_TYPE_LABELS.items()}
 _SCENE_LABELS = {BILL_USAGE_SCENE_PROD: "production"}
 _METRIC_CODES = {value: key for key, value in BILLING_METRIC_LABELS.items()}
+_LLM_MISSING_RATE_FALLBACK_RATIOS = {
+    BILLING_METRIC_LLM_INPUT_TOKENS: Decimal("0.25"),
+    BILLING_METRIC_LLM_CACHE_TOKENS: Decimal("0.125"),
+    BILLING_METRIC_LLM_OUTPUT_TOKENS: Decimal("1"),
+}
 
 
 def _rate_effective_now():
@@ -155,6 +160,45 @@ def _load_default_llm_reference_cost(
         )
     )
     return _unit_cost(rows[0])
+
+
+def _load_default_llm_metric_ratio(metric: int) -> Decimal:
+    if metric == BILLING_METRIC_LLM_OUTPUT_TOKENS:
+        return Decimal("1")
+
+    default_model = str(get_config("DEFAULT_LLM_MODEL", "") or "").strip()
+    if default_model:
+        provider, model_candidates = _resolve_llm_rate_identity(default_model)
+        metric_cost = _unit_cost(
+            _rate_for_identity(
+                usage_type=BILL_USAGE_TYPE_LLM,
+                provider=provider,
+                model_candidates=model_candidates,
+                billing_metric=metric,
+            )
+        )
+        output_cost = _unit_cost(
+            _rate_for_identity(
+                usage_type=BILL_USAGE_TYPE_LLM,
+                provider=provider,
+                model_candidates=model_candidates,
+                billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            )
+        )
+        if metric_cost and output_cost and output_cost > 0:
+            return metric_cost / output_cost
+
+    return _LLM_MISSING_RATE_FALLBACK_RATIOS.get(metric, Decimal("1"))
+
+
+def _llm_credits_for_missing_metric(
+    *,
+    metric: int,
+    output_unit_cost: Decimal,
+    unit_size: int,
+) -> Decimal:
+    ratio = _load_default_llm_metric_ratio(metric)
+    return output_unit_cost * ratio * Decimal(str(unit_size))
 
 
 def _rate_for_identity(
@@ -493,13 +537,23 @@ def update_operator_rate_config(
         for metric in metrics_to_update:
             next_unit_size = unit_size
             next_credits_per_unit = credits_per_unit
-            if usage_type == BILL_USAGE_TYPE_LLM and llm_scale is not None:
+            if usage_type == BILL_USAGE_TYPE_LLM:
                 current_metric_rate = current_rates_by_metric.get(metric)
                 current_metric_cost = _unit_cost(current_metric_rate)
-                if current_metric_rate is not None and current_metric_cost is not None:
+                if (
+                    llm_scale is not None
+                    and current_metric_rate is not None
+                    and current_metric_cost is not None
+                ):
                     next_unit_size = max(int(current_metric_rate.unit_size or 1), 1)
                     next_credits_per_unit = (
                         current_metric_cost * llm_scale * Decimal(str(next_unit_size))
+                    )
+                else:
+                    next_credits_per_unit = _llm_credits_for_missing_metric(
+                        metric=metric,
+                        output_unit_cost=target_unit_cost,
+                        unit_size=next_unit_size,
                     )
             same_second_row = CreditUsageRate.query.filter(
                 CreditUsageRate.deleted == 0,

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -532,7 +532,6 @@ def update_operator_rate_config(
         )
         for row in existing_rows:
             row.effective_to = now
-            row.status = CREDIT_USAGE_RATE_STATUS_INACTIVE
 
         for metric in metrics_to_update:
             next_unit_size = unit_size

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from flask import Flask
+
+from flaskr.api.llm import get_current_models
+from flaskr.api.tts import get_all_provider_configs
+from flaskr.dao import db
+from flaskr.dao.uow import app_context_scope, unit_of_work
+from flaskr.service.billing.consts import (
+    BILLING_METRIC_LABELS,
+    BILLING_METRIC_LLM_CACHE_TOKENS,
+    BILLING_METRIC_LLM_INPUT_TOKENS,
+    BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    BILLING_METRIC_TTS_OUTPUT_CHARS,
+    CREDIT_ROUNDING_MODE_CEIL,
+    CREDIT_USAGE_RATE_STATUS_ACTIVE,
+    CREDIT_USAGE_RATE_STATUS_INACTIVE,
+    CREDIT_USAGE_RATE_STATUS_LABELS,
+)
+from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.common.models import raise_param_error
+from flaskr.service.config.funcs import get_config
+from flaskr.service.metering.consts import (
+    BILL_USAGE_SCENE_PROD,
+    BILL_USAGE_TYPE_LLM,
+    BILL_USAGE_TYPE_TTS,
+)
+from flaskr.util import generate_id
+from flaskr.util.datetime import now_utc, to_utc_iso
+
+_RATE_METRICS = {
+    BILL_USAGE_TYPE_LLM: (
+        BILLING_METRIC_LLM_INPUT_TOKENS,
+        BILLING_METRIC_LLM_CACHE_TOKENS,
+        BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    ),
+    BILL_USAGE_TYPE_TTS: (BILLING_METRIC_TTS_OUTPUT_CHARS,),
+}
+_USAGE_TYPE_LABELS = {
+    BILL_USAGE_TYPE_LLM: "llm",
+    BILL_USAGE_TYPE_TTS: "tts",
+}
+_USAGE_TYPE_CODES = {value: key for key, value in _USAGE_TYPE_LABELS.items()}
+_SCENE_LABELS = {BILL_USAGE_SCENE_PROD: "production"}
+_METRIC_CODES = {value: key for key, value in BILLING_METRIC_LABELS.items()}
+
+
+def _rate_effective_now():
+    # MySQL DATETIME columns in this schema do not keep fractional seconds.
+    # Truncate before writing so a just-saved rate is immediately readable and
+    # repeated saves in one second hit the same deterministic version.
+    return now_utc().replace(microsecond=0)
+
+
+def _decimal(value: Any, *, field_name: str) -> Decimal:
+    try:
+        result = Decimal(str(value).strip())
+    except (InvalidOperation, AttributeError, TypeError, ValueError):
+        raise_param_error(field_name)
+    if result < 0:
+        raise_param_error(field_name)
+    return result
+
+
+def _decimal_to_number(value: Decimal | int | float | str) -> int | float:
+    decimal_value = Decimal(str(value or 0))
+    normalized = decimal_value.normalize()
+    if normalized == normalized.to_integral_value():
+        return int(normalized)
+    return float(normalized)
+
+
+def _unit_cost(rate: CreditUsageRate | None) -> Decimal | None:
+    if rate is None:
+        return None
+    try:
+        unit_size = max(int(rate.unit_size or 1), 1)
+        return Decimal(str(rate.credits_per_unit or 0)) / Decimal(str(unit_size))
+    except (InvalidOperation, TypeError, ValueError, ZeroDivisionError):
+        return None
+
+
+def _format_multiplier(value: Decimal | None) -> float | None:
+    if value is None:
+        return None
+    if value < 0:
+        return None
+    rounded = value.quantize(Decimal("0.01"))
+    return float(rounded)
+
+
+def _load_tts_chars_per_llm_token() -> Decimal | None:
+    try:
+        value = Decimal(str(get_config("TTS_CHARS_PER_LLM_TOKEN", "") or ""))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _resolve_llm_rate_identity(model: str) -> tuple[str, list[str]]:
+    normalized = str(model or "").strip()
+    if not normalized:
+        return "", []
+    from flaskr.api.llm import _resolve_billing_rate_identity
+
+    return _resolve_billing_rate_identity(normalized)
+
+
+def _load_default_llm_reference_cost(
+    default_model: str | None = None,
+) -> Decimal | None:
+    """Return the stable 1x anchor used by the operator config page."""
+
+    default_model = str(
+        default_model
+        if default_model is not None
+        else get_config("DEFAULT_LLM_MODEL", "") or ""
+    ).strip()
+    if not default_model:
+        return None
+    provider, model_candidates = _resolve_llm_rate_identity(default_model)
+    normalized_models = [
+        str(model or "").strip()
+        for model in model_candidates
+        if str(model or "").strip()
+    ]
+    if not normalized_models:
+        return None
+    model_priority = {
+        model: len(normalized_models) - index
+        for index, model in enumerate(normalized_models)
+    }
+    rows = (
+        CreditUsageRate.query.filter(
+            CreditUsageRate.deleted == 0,
+            CreditUsageRate.usage_type == BILL_USAGE_TYPE_LLM,
+            CreditUsageRate.provider == provider,
+            CreditUsageRate.model.in_(normalized_models),
+            CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
+            CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        )
+        .order_by(CreditUsageRate.effective_from.asc(), CreditUsageRate.id.asc())
+        .all()
+    )
+    if not rows:
+        return None
+    rows.sort(
+        key=lambda row: (
+            row.effective_from,
+            -model_priority.get(str(row.model or ""), 0),
+            int(row.id or 0),
+        )
+    )
+    return _unit_cost(rows[0])
+
+
+def _rate_for_identity(
+    *,
+    usage_type: int,
+    provider: str,
+    model_candidates: list[str],
+    billing_metric: int,
+) -> CreditUsageRate | None:
+    normalized_provider = str(provider or "").strip()
+    normalized_models = [
+        str(model or "").strip()
+        for model in model_candidates
+        if str(model or "").strip()
+    ]
+    if not normalized_models:
+        normalized_models = [""]
+    model_priority = {
+        model: len(normalized_models) - index
+        for index, model in enumerate(normalized_models)
+    }
+    settlement_at = now_utc()
+    rows = (
+        CreditUsageRate.query.filter(
+            CreditUsageRate.deleted == 0,
+            CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+            CreditUsageRate.usage_type == usage_type,
+            CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
+            CreditUsageRate.billing_metric == billing_metric,
+        )
+        .order_by(CreditUsageRate.effective_from.desc(), CreditUsageRate.id.desc())
+        .all()
+    )
+    candidates = [
+        row
+        for row in rows
+        if row.effective_from <= settlement_at
+        and (row.effective_to is None or row.effective_to > settlement_at)
+        and str(row.provider or "") in {normalized_provider, "*"}
+        and str(row.model or "") in set(normalized_models).union({"*"})
+    ]
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda row: (
+            str(row.provider or "") == normalized_provider,
+            str(row.model or "") in set(normalized_models),
+            model_priority.get(str(row.model or ""), 0),
+            row.effective_from,
+            int(row.id or 0),
+        ),
+        reverse=True,
+    )
+    return candidates[0]
+
+
+def _serialize_rate_row(
+    *,
+    usage_type: int,
+    provider: str,
+    model: str,
+    model_candidates: list[str] | None = None,
+    rate_model: str | None = None,
+    display_name: str,
+    billing_metric: int,
+    baseline_cost: Decimal | None,
+    tts_chars_per_llm_token: Decimal | None,
+) -> dict[str, Any]:
+    rate_model_candidates = model_candidates or [model]
+    resolved_rate_model = rate_model or (
+        rate_model_candidates[0] if rate_model_candidates else model
+    )
+    rate = _rate_for_identity(
+        usage_type=usage_type,
+        provider=provider,
+        model_candidates=rate_model_candidates,
+        billing_metric=billing_metric,
+    )
+    unit_cost = _unit_cost(rate)
+    multiplier: Decimal | None = None
+    if unit_cost is not None and baseline_cost and baseline_cost > 0:
+        if usage_type == BILL_USAGE_TYPE_TTS:
+            if tts_chars_per_llm_token and tts_chars_per_llm_token > 0:
+                multiplier = (unit_cost * tts_chars_per_llm_token) / baseline_cost
+        else:
+            multiplier = unit_cost / baseline_cost
+
+    exact = bool(
+        rate
+        and str(rate.provider or "") == str(provider or "")
+        and str(rate.model or "") in {str(item or "") for item in rate_model_candidates}
+    )
+    return {
+        "rate_bid": str(rate.rate_bid or "") if rate else "",
+        "usage_type": _USAGE_TYPE_LABELS.get(usage_type, str(usage_type)),
+        "usage_type_code": int(usage_type),
+        "provider": provider,
+        "model": model,
+        "rate_model": resolved_rate_model,
+        "display_name": display_name or model or provider or "*",
+        "usage_scene": _SCENE_LABELS[BILL_USAGE_SCENE_PROD],
+        "usage_scene_code": BILL_USAGE_SCENE_PROD,
+        "billing_metric": BILLING_METRIC_LABELS.get(
+            billing_metric, str(billing_metric)
+        ),
+        "billing_metric_code": int(billing_metric),
+        "unit_size": int(rate.unit_size or 1) if rate else 1,
+        "credits_per_unit": _decimal_to_number(rate.credits_per_unit) if rate else 0,
+        "unit_cost": _decimal_to_number(unit_cost or Decimal("0")),
+        "multiplier": _format_multiplier(multiplier),
+        "rounding_mode": (
+            int(rate.rounding_mode or CREDIT_ROUNDING_MODE_CEIL)
+            if rate
+            else CREDIT_ROUNDING_MODE_CEIL
+        ),
+        "status": (
+            CREDIT_USAGE_RATE_STATUS_LABELS.get(int(rate.status or 0), "unconfigured")
+            if rate
+            else "unconfigured"
+        ),
+        "status_code": int(rate.status or 0) if rate else 0,
+        "effective_from": to_utc_iso(rate.effective_from) if rate else None,
+        "effective_to": to_utc_iso(rate.effective_to) if rate else None,
+        "updated_at": to_utc_iso(rate.updated_at) if rate else None,
+        "source": "exact" if exact else ("default" if rate else "unconfigured"),
+    }
+
+
+def _build_llm_rows(app: Flask, baseline_cost: Decimal | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for option in get_current_models(app):
+        model = str(option.get("model") or "").strip()
+        if not model:
+            continue
+        provider, model_candidates = _resolve_llm_rate_identity(model)
+        rate_model = model_candidates[0] if model_candidates else model
+        display_name = str(option.get("display_name") or model).strip()
+        key = (provider, rate_model)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            _serialize_rate_row(
+                usage_type=BILL_USAGE_TYPE_LLM,
+                provider=provider,
+                model=model,
+                model_candidates=model_candidates,
+                rate_model=rate_model,
+                display_name=display_name,
+                billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+                baseline_cost=baseline_cost,
+                tts_chars_per_llm_token=None,
+            )
+        )
+    return rows
+
+
+def _build_tts_rows(baseline_cost: Decimal | None) -> list[dict[str, Any]]:
+    config = get_all_provider_configs()
+    tts_chars_per_llm_token = _load_tts_chars_per_llm_token()
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for option in config.get("model_options") or []:
+        provider = str(option.get("provider") or "").strip()
+        model = str(option.get("model") or "").strip()
+        if not provider:
+            continue
+        key = (provider, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            _serialize_rate_row(
+                usage_type=BILL_USAGE_TYPE_TTS,
+                provider=provider,
+                model=model,
+                model_candidates=[model],
+                rate_model=model,
+                display_name=str(option.get("label") or model or provider).strip(),
+                billing_metric=BILLING_METRIC_TTS_OUTPUT_CHARS,
+                baseline_cost=baseline_cost,
+                tts_chars_per_llm_token=tts_chars_per_llm_token,
+            )
+        )
+    return rows
+
+
+def get_operator_rate_config(app: Flask) -> dict[str, Any]:
+    with app_context_scope(app):
+        baseline_cost = _load_default_llm_reference_cost()
+        return {
+            "baseline": {
+                "default_llm_model": str(get_config("DEFAULT_LLM_MODEL", "") or ""),
+                "unit_cost": _decimal_to_number(baseline_cost or Decimal("0")),
+                "tts_chars_per_llm_token": _decimal_to_number(
+                    _load_tts_chars_per_llm_token() or Decimal("0")
+                ),
+            },
+            "llm_rates": _build_llm_rows(app, baseline_cost),
+            "tts_rates": _build_tts_rows(baseline_cost),
+        }
+
+
+def _normalize_usage_type(value: Any) -> int:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _USAGE_TYPE_CODES:
+            return _USAGE_TYPE_CODES[normalized]
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError):
+        raise_param_error("usage_type")
+    if numeric not in _RATE_METRICS:
+        raise_param_error("usage_type")
+    return numeric
+
+
+def _normalize_metric(value: Any, *, usage_type: int) -> int:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized in _METRIC_CODES:
+            metric = _METRIC_CODES[normalized]
+        else:
+            raise_param_error("billing_metric")
+    else:
+        try:
+            metric = int(value)
+        except (TypeError, ValueError):
+            raise_param_error("billing_metric")
+    if metric not in _RATE_METRICS[usage_type]:
+        raise_param_error("billing_metric")
+    return metric
+
+
+def update_operator_rate_config(
+    app: Flask,
+    *,
+    payload: dict[str, Any],
+    operator_user_bid: str,
+) -> dict[str, Any]:
+    with app_context_scope(app), unit_of_work():
+        usage_type = _normalize_usage_type(payload.get("usage_type"))
+        billing_metric = _normalize_metric(
+            payload.get("billing_metric"), usage_type=usage_type
+        )
+        provider = str(payload.get("provider") or "").strip()
+        requested_model = str(payload.get("model") or "").strip()
+        model = requested_model
+        rate_model = str(payload.get("rate_model") or "").strip()
+        model_candidates = [model]
+        if usage_type == BILL_USAGE_TYPE_LLM:
+            resolved_provider, resolved_model_candidates = _resolve_llm_rate_identity(
+                requested_model
+            )
+            if not provider:
+                provider = resolved_provider
+            model_candidates = resolved_model_candidates or [model]
+            model = rate_model or model_candidates[0]
+            if model and model not in model_candidates:
+                model_candidates = [model, *model_candidates]
+        if not provider and usage_type == BILL_USAGE_TYPE_TTS:
+            raise_param_error("provider")
+        unit_size = int(payload.get("unit_size") or 1)
+        if unit_size <= 0:
+            raise_param_error("unit_size")
+
+        credits_per_unit = _decimal(
+            payload.get("credits_per_unit"), field_name="credits_per_unit"
+        )
+        if credits_per_unit <= 0:
+            raise_param_error("credits_per_unit")
+        status = payload.get("status")
+        if isinstance(status, str):
+            status_code = (
+                CREDIT_USAGE_RATE_STATUS_ACTIVE
+                if status.strip().lower() == "active"
+                else CREDIT_USAGE_RATE_STATUS_INACTIVE
+            )
+        else:
+            status_code = int(status or CREDIT_USAGE_RATE_STATUS_ACTIVE)
+        if status_code not in {
+            CREDIT_USAGE_RATE_STATUS_ACTIVE,
+            CREDIT_USAGE_RATE_STATUS_INACTIVE,
+        }:
+            raise_param_error("status")
+
+        now = _rate_effective_now()
+        metrics_to_update = (
+            _RATE_METRICS[BILL_USAGE_TYPE_LLM]
+            if usage_type == BILL_USAGE_TYPE_LLM
+            else (billing_metric,)
+        )
+        target_unit_cost = credits_per_unit / Decimal(str(unit_size))
+        current_rates_by_metric: dict[int, CreditUsageRate | None] = {}
+        if usage_type == BILL_USAGE_TYPE_LLM:
+            current_rates_by_metric = {
+                metric: _rate_for_identity(
+                    usage_type=usage_type,
+                    provider=provider,
+                    model_candidates=model_candidates,
+                    billing_metric=metric,
+                )
+                for metric in metrics_to_update
+            }
+        llm_scale: Decimal | None = None
+        if usage_type == BILL_USAGE_TYPE_LLM:
+            current_output_cost = _unit_cost(
+                current_rates_by_metric.get(BILLING_METRIC_LLM_OUTPUT_TOKENS)
+            )
+            if current_output_cost and current_output_cost > 0:
+                llm_scale = target_unit_cost / current_output_cost
+
+        existing_rows = (
+            CreditUsageRate.query.filter(
+                CreditUsageRate.deleted == 0,
+                CreditUsageRate.usage_type == usage_type,
+                CreditUsageRate.provider == provider,
+                CreditUsageRate.model.in_(model_candidates),
+                CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
+                CreditUsageRate.billing_metric.in_(metrics_to_update),
+                CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+            )
+            .filter(CreditUsageRate.effective_from <= now)
+            .filter(
+                (CreditUsageRate.effective_to.is_(None))
+                | (CreditUsageRate.effective_to > now)
+            )
+            .order_by(CreditUsageRate.effective_from.desc(), CreditUsageRate.id.desc())
+            .all()
+        )
+        for row in existing_rows:
+            row.effective_to = now
+            row.status = CREDIT_USAGE_RATE_STATUS_INACTIVE
+
+        for metric in metrics_to_update:
+            next_unit_size = unit_size
+            next_credits_per_unit = credits_per_unit
+            if usage_type == BILL_USAGE_TYPE_LLM and llm_scale is not None:
+                current_metric_rate = current_rates_by_metric.get(metric)
+                current_metric_cost = _unit_cost(current_metric_rate)
+                if current_metric_rate is not None and current_metric_cost is not None:
+                    next_unit_size = max(int(current_metric_rate.unit_size or 1), 1)
+                    next_credits_per_unit = (
+                        current_metric_cost * llm_scale * Decimal(str(next_unit_size))
+                    )
+            same_second_row = CreditUsageRate.query.filter(
+                CreditUsageRate.deleted == 0,
+                CreditUsageRate.usage_type == usage_type,
+                CreditUsageRate.provider == provider,
+                CreditUsageRate.model == model,
+                CreditUsageRate.usage_scene == BILL_USAGE_SCENE_PROD,
+                CreditUsageRate.billing_metric == metric,
+                CreditUsageRate.effective_from == now,
+            ).first()
+            if same_second_row is not None:
+                same_second_row.unit_size = next_unit_size
+                same_second_row.credits_per_unit = next_credits_per_unit
+                same_second_row.rounding_mode = CREDIT_ROUNDING_MODE_CEIL
+                same_second_row.effective_to = None
+                same_second_row.status = status_code
+                continue
+            db.session.add(
+                CreditUsageRate(
+                    rate_bid=generate_id(app),
+                    usage_type=usage_type,
+                    provider=provider,
+                    model=model,
+                    usage_scene=BILL_USAGE_SCENE_PROD,
+                    billing_metric=metric,
+                    unit_size=next_unit_size,
+                    credits_per_unit=next_credits_per_unit,
+                    rounding_mode=CREDIT_ROUNDING_MODE_CEIL,
+                    effective_from=now,
+                    effective_to=None,
+                    status=status_code,
+                )
+            )
+        baseline_cost = _load_default_llm_reference_cost()
+        return _serialize_rate_row(
+            usage_type=usage_type,
+            provider=provider,
+            model=model,
+            model_candidates=model_candidates,
+            rate_model=model,
+            display_name=str(payload.get("display_name") or model or provider),
+            billing_metric=(
+                BILLING_METRIC_LLM_OUTPUT_TOKENS
+                if usage_type == BILL_USAGE_TYPE_LLM
+                else billing_metric
+            ),
+            baseline_cost=baseline_cost,
+            tts_chars_per_llm_token=_load_tts_chars_per_llm_token(),
+        )

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -73,6 +73,10 @@ from flaskr.service.shifu.admin_operations.credit_notifications import (
     sync_operator_credit_notification_template,
     update_operator_credit_notification_config,
 )
+from flaskr.service.shifu.admin_operations.config_rates import (
+    get_operator_rate_config,
+    update_operator_rate_config,
+)
 from flaskr.service.shifu.admin_operations.profile_onboarding import (
     get_operator_profile_onboarding_config,
     update_operator_profile_onboarding_config,
@@ -995,6 +999,33 @@ def register_admin_operations_routes(
             raise_param_error("profile_onboarding_config")
         return make_common_response(
             update_operator_profile_onboarding_config(
+                app,
+                payload=payload,
+                operator_user_bid=str(getattr(request.user, "user_id", "") or ""),
+            )
+        )
+
+    @app.route(
+        path_prefix + "/admin/operations/config/rates",
+        methods=["GET"],
+    )
+    def admin_operation_rate_config():
+        """Get operator-managed model and TTS credit rate config."""
+        _require_operator()
+        return make_common_response(get_operator_rate_config(app))
+
+    @app.route(
+        path_prefix + "/admin/operations/config/rates",
+        methods=["POST"],
+    )
+    def admin_operation_update_rate_config():
+        """Update one operator-managed model or TTS credit rate config."""
+        _require_operator()
+        payload = request.get_json(silent=True) or {}
+        if not isinstance(payload, dict):
+            raise_param_error("rate_config")
+        return make_common_response(
+            update_operator_rate_config(
                 app,
                 payload=payload,
                 operator_user_bid=str(getattr(request.user, "user_id", "") or ""),

--- a/src/api/tests/service/billing/test_rate_references.py
+++ b/src/api/tests/service/billing/test_rate_references.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from flaskr.dao import db
+from flaskr.service.billing.consts import (
+    BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    CREDIT_ROUNDING_MODE_CEIL,
+    CREDIT_USAGE_RATE_STATUS_ACTIVE,
+)
+from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.billing import rate_references
+from flaskr.service.common import credit_rate_references
+from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
+
+
+def _rate(
+    rate_bid: str, credits_per_unit: str, effective_from: datetime
+) -> CreditUsageRate:
+    return CreditUsageRate(
+        rate_bid=rate_bid,
+        usage_type=BILL_USAGE_TYPE_LLM,
+        provider="qwen",
+        model="deepseek-v4-flash",
+        usage_scene=BILL_USAGE_SCENE_PROD,
+        billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        unit_size=1,
+        credits_per_unit=Decimal(credits_per_unit),
+        rounding_mode=CREDIT_ROUNDING_MODE_CEIL,
+        effective_from=effective_from,
+        effective_to=None,
+        status=CREDIT_USAGE_RATE_STATUS_ACTIVE,
+    )
+
+
+def test_llm_credit_1x_unit_cost_uses_fixed_config(monkeypatch, app):
+    values = {
+        "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
+        "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+    }
+    monkeypatch.setattr(
+        credit_rate_references,
+        "get_config",
+        lambda key, default=None: values.get(key, default),
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        db.session.add_all(
+            [
+                _rate("old-default-rate", "0.000066667", datetime(2026, 1, 1, 0, 0, 0)),
+                _rate("new-default-rate", "0.000466669", datetime(2026, 2, 1, 0, 0, 0)),
+            ]
+        )
+        db.session.commit()
+
+        assert rate_references.load_llm_credit_1x_unit_cost() == Decimal("0.000066667")
+
+        values["DEFAULT_LLM_MODEL"] = "ark/doubao-seed-2-0-lite-260428"
+        assert rate_references.load_llm_credit_1x_unit_cost() == Decimal("0.000066667")
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()
+        assert rate_references.load_llm_credit_1x_unit_cost() == Decimal("0.000066667")
+
+
+def test_llm_credit_1x_unit_cost_rejects_missing_or_invalid_config(monkeypatch):
+    for raw_value in [None, "", "bad", "0", "-1"]:
+        monkeypatch.setattr(
+            credit_rate_references,
+            "get_config",
+            lambda key, default=None, raw_value=raw_value: (
+                raw_value if key == "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS" else default
+            ),
+        )
+
+        assert rate_references.load_llm_credit_1x_unit_cost() is None

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1540,6 +1540,78 @@ def test_build_usage_metric_charges_matches_llm_rate_model_alias(
         assert charge.consumed_credits == Decimal("6.00")
 
 
+def test_build_usage_metric_charges_uses_superseded_rate_for_old_settlement_time(
+    billing_settlement_app: Flask,
+    monkeypatch,
+) -> None:
+    from flaskr.service.billing import charges as charge_module
+
+    monkeypatch.setattr(
+        charge_module,
+        "resolve_llm_rate_identity",
+        lambda _model: ("deepseek", ["deepseek-v4-flash"]),
+    )
+
+    with billing_settlement_app.app_context():
+        old_rate = _create_rate(
+            rate_bid="rate-old-deepseek-flash",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            credits_per_unit="2.0000000000",
+            unit_size=1000,
+        )
+        old_rate.effective_from = datetime(2026, 4, 1, 0, 0, 0)
+        old_rate.effective_to = datetime(2026, 4, 8, 12, 0, 0)
+        # Superseded rows stay active so delayed settlement can still resolve
+        # by the usage's original settlement window.
+        old_rate.status = CREDIT_USAGE_RATE_STATUS_ACTIVE
+
+        new_rate = _create_rate(
+            rate_bid="rate-new-deepseek-flash",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            credits_per_unit="8.0000000000",
+            unit_size=1000,
+        )
+        new_rate.effective_from = datetime(2026, 4, 8, 12, 0, 0)
+
+        wildcard_rate = _create_rate(
+            rate_bid="rate-wildcard-fallback",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="*",
+            model="*",
+            billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            credits_per_unit="5.0000000000",
+            unit_size=1000,
+        )
+
+        usage = _create_usage(
+            usage_bid="usage-before-rate-change",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="deepseek",
+            model="deepseek-v4-flash",
+            input_value=0,
+            input_cache=0,
+            output=1000,
+            total=1000,
+        )
+        dao.db.session.add_all([old_rate, new_rate, wildcard_rate, usage])
+        dao.db.session.commit()
+
+        [charge] = build_usage_metric_charges(
+            usage,
+            settlement_at=datetime(2026, 4, 8, 11, 59, 59),
+        )
+
+        assert charge.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        assert charge.credits_per_unit == Decimal("2.0000000000")
+        assert charge.consumed_credits == Decimal("2.00")
+
+
 def test_resolve_credit_multiplier_label_uses_utc_default_settlement(monkeypatch):
     from flaskr.service.billing import charges
 

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1482,6 +1482,64 @@ def test_build_usage_metric_charges_uses_public_charge_module(
         assert charges[0]["raw_amount"] == 1200
 
 
+def test_build_usage_metric_charges_matches_llm_rate_model_alias(
+    billing_settlement_app: Flask,
+    monkeypatch,
+) -> None:
+    from flaskr.service.billing import charges as charge_module
+
+    monkeypatch.setattr(
+        charge_module,
+        "resolve_llm_rate_identity",
+        lambda _model: ("qwen", ["deepseek-v4-flash", "qwen/deepseek-v4-flash"]),
+    )
+
+    with billing_settlement_app.app_context():
+        dao.db.session.add_all(
+            [
+                _create_rate(
+                    rate_bid="rate-alias-specific",
+                    usage_type=BILL_USAGE_TYPE_LLM,
+                    provider="qwen",
+                    model="deepseek-v4-flash",
+                    billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+                    credits_per_unit="6.0000000000",
+                    unit_size=1000,
+                ),
+                _create_rate(
+                    rate_bid="rate-alias-wildcard",
+                    usage_type=BILL_USAGE_TYPE_LLM,
+                    provider="*",
+                    model="*",
+                    billing_metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+                    credits_per_unit="3.0000000000",
+                    unit_size=1000,
+                ),
+            ]
+        )
+        usage = _create_usage(
+            usage_bid="usage-alias-specific",
+            usage_type=BILL_USAGE_TYPE_LLM,
+            provider="qwen",
+            model="qwen/deepseek-v4-flash",
+            input_value=0,
+            input_cache=0,
+            output=1000,
+            total=1000,
+        )
+        dao.db.session.add(usage)
+        dao.db.session.commit()
+
+        [charge] = build_usage_metric_charges(
+            usage,
+            settlement_at=datetime(2026, 4, 8, 12, 0, 0),
+        )
+
+        assert charge.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        assert charge.credits_per_unit == Decimal("6.0000000000")
+        assert charge.consumed_credits == Decimal("6.00")
+
+
 def test_resolve_credit_multiplier_label_uses_utc_default_settlement(monkeypatch):
     from flaskr.service.billing import charges
 

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1607,9 +1607,9 @@ def test_build_usage_metric_charges_uses_superseded_rate_for_old_settlement_time
             settlement_at=datetime(2026, 4, 8, 11, 59, 59),
         )
 
-        assert charge.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        assert charge.credits_per_unit == Decimal("2.0000000000")
-        assert charge.consumed_credits == Decimal("2.00")
+        assert charge["billing_metric"] == BILLING_METRIC_LLM_OUTPUT_TOKENS
+        assert charge["credits_per_unit"] == Decimal("2.0000000000")
+        assert charge["consumed_credits"] == Decimal("2.00")
 
 
 def test_resolve_credit_multiplier_label_uses_utc_default_settlement(monkeypatch):

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -125,6 +125,7 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
 
         config = config_rates.get_operator_rate_config(app)
         row = config["llm_rates"][0]
+        rate_change_at = fixed_now.replace(microsecond=0)
         active_rows = {
             rate.billing_metric: rate
             for rate in CreditUsageRate.query.filter(
@@ -132,8 +133,17 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
                 CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
                 CreditUsageRate.provider == "qwen",
                 CreditUsageRate.model == "deepseek-v4-flash",
+                CreditUsageRate.effective_from == rate_change_at,
+                CreditUsageRate.effective_to.is_(None),
             ).all()
         }
+        superseded_rows = CreditUsageRate.query.filter(
+            CreditUsageRate.deleted == 0,
+            CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+            CreditUsageRate.provider == "qwen",
+            CreditUsageRate.model == "deepseek-v4-flash",
+            CreditUsageRate.effective_from == datetime(2026, 1, 1, 0, 0, 0),
+        ).all()
 
         assert result["rate_model"] == "deepseek-v4-flash"
         assert result["multiplier"] == 4
@@ -148,8 +158,13 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
             BILLING_METRIC_LLM_OUTPUT_TOKENS
         ].credits_per_unit == Decimal("12")
         assert active_rows[BILLING_METRIC_LLM_OUTPUT_TOKENS].effective_from == (
-            fixed_now.replace(microsecond=0)
+            rate_change_at
         )
+        assert len(superseded_rows) == 3
+        assert {row.status for row in superseded_rows} == {
+            CREDIT_USAGE_RATE_STATUS_ACTIVE
+        }
+        assert {row.effective_to for row in superseded_rows} == {rate_change_at}
 
         # A second save in the same DB second should update the deterministic
         # version instead of colliding on the rate lookup unique key.
@@ -176,6 +191,8 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
             CreditUsageRate.provider == "qwen",
             CreditUsageRate.model == "deepseek-v4-flash",
             CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
+            CreditUsageRate.effective_from == rate_change_at,
+            CreditUsageRate.effective_to.is_(None),
         ).all()
 
         assert second_result["multiplier"] == 7

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -13,6 +13,7 @@ from flaskr.service.billing.consts import (
 )
 from flaskr.service.billing.models import CreditUsageRate
 from flaskr.service.billing import rate_references
+from flaskr.service.common import credit_rate_references
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.shifu.admin_operations import config_rates
 
@@ -71,12 +72,13 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+            "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
         }.get(key, default)
 
     monkeypatch.setattr(config_rates, "get_config", config_getter)
     monkeypatch.setattr(
-        rate_references,
+        credit_rate_references,
         "get_config",
         config_getter,
     )
@@ -208,6 +210,7 @@ def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+            "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
         }.get(key, default)
 
@@ -216,7 +219,7 @@ def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
         return provider, [actual_model, model]
 
     monkeypatch.setattr(config_rates, "get_config", config_getter)
-    monkeypatch.setattr(rate_references, "get_config", config_getter)
+    monkeypatch.setattr(credit_rate_references, "get_config", config_getter)
     monkeypatch.setattr(config_rates, "_resolve_llm_rate_identity", resolve_identity)
     monkeypatch.setattr(rate_references, "resolve_llm_rate_identity", resolve_identity)
     monkeypatch.setattr(
@@ -269,6 +272,98 @@ def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
         assert active_rows[
             BILLING_METRIC_LLM_OUTPUT_TOKENS
         ].credits_per_unit == Decimal("12")
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()
+
+
+def test_operator_rate_config_exposes_fixed_credit_1x_baseline(monkeypatch, app):
+    def config_getter(key, default=None):
+        return {
+            "DEFAULT_LLM_MODEL": "ark/doubao-seed-2-0-lite-260428",
+            "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
+            "TTS_CHARS_PER_LLM_TOKEN": "0.216",
+        }.get(key, default)
+
+    monkeypatch.setattr(config_rates, "get_config", config_getter)
+    monkeypatch.setattr(credit_rate_references, "get_config", config_getter)
+    monkeypatch.setattr(
+        config_rates,
+        "get_current_models",
+        lambda _app: [
+            {
+                "model": "qwen/deepseek-v4-flash",
+                "display_name": "DeepSeek-V4-Flash",
+            }
+        ],
+    )
+    monkeypatch.setattr(config_rates, "get_all_provider_configs", lambda: {})
+    monkeypatch.setattr(
+        config_rates,
+        "_resolve_llm_rate_identity",
+        lambda _model: ("qwen", ["deepseek-v4-flash", "qwen/deepseek-v4-flash"]),
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        _seed_default_llm_rates()
+
+        config = config_rates.get_operator_rate_config(app)
+
+        assert config["baseline"]["default_llm_model"] == (
+            "ark/doubao-seed-2-0-lite-260428"
+        )
+        assert config["baseline"]["per_1000_output_tokens"] == 0.066667
+        assert config["baseline"]["unit_cost"] == 0.000066667
+        assert config["baseline"]["is_configured"] is True
+        assert config["llm_rates"][0]["multiplier"] == 44999.78
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()
+
+
+def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app):
+    def config_getter(key, default=None):
+        return {
+            "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+            "TTS_CHARS_PER_LLM_TOKEN": "1",
+        }.get(key, default)
+
+    monkeypatch.setattr(config_rates, "get_config", config_getter)
+    monkeypatch.setattr(credit_rate_references, "get_config", config_getter)
+    monkeypatch.setattr(
+        config_rates,
+        "_resolve_llm_rate_identity",
+        lambda _model: ("qwen", ["deepseek-v4-flash", "qwen/deepseek-v4-flash"]),
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        _seed_default_llm_rates()
+
+        try:
+            config_rates.update_operator_rate_config(
+                app,
+                payload={
+                    "usage_type": "llm",
+                    "provider": "qwen",
+                    "model": "qwen/deepseek-v4-flash",
+                    "rate_model": "deepseek-v4-flash",
+                    "display_name": "DeepSeek-V4-Flash",
+                    "billing_metric": "llm_output_tokens",
+                    "unit_size": 1,
+                    "credits_per_unit": 12,
+                    "status": "active",
+                },
+                operator_user_bid="operator-test",
+            )
+        except Exception as exc:
+            assert "llm_credit_1x_per_1000_output_tokens" in str(exc)
+        else:
+            raise AssertionError("missing 1x anchor should reject save")
+
+        assert CreditUsageRate.query.count() == 3
+        assert {rate.effective_to for rate in CreditUsageRate.query.all()} == {None}
 
         db.session.query(CreditUsageRate).delete()
         db.session.commit()

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -185,3 +185,73 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
 
         db.session.query(CreditUsageRate).delete()
         db.session.commit()
+
+
+def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
+    def config_getter(key, default=None):
+        return {
+            "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+            "TTS_CHARS_PER_LLM_TOKEN": "1",
+        }.get(key, default)
+
+    def resolve_identity(model: str):
+        provider, actual_model = model.split("/", 1)
+        return provider, [actual_model, model]
+
+    monkeypatch.setattr(config_rates, "get_config", config_getter)
+    monkeypatch.setattr(rate_references, "get_config", config_getter)
+    monkeypatch.setattr(config_rates, "_resolve_llm_rate_identity", resolve_identity)
+    monkeypatch.setattr(rate_references, "resolve_llm_rate_identity", resolve_identity)
+    monkeypatch.setattr(
+        config_rates,
+        "get_current_models",
+        lambda _app: [
+            {
+                "model": "qwen/new-rate-model",
+                "display_name": "New Rate Model",
+            }
+        ],
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        _seed_default_llm_rates()
+
+        config_rates.update_operator_rate_config(
+            app,
+            payload={
+                "usage_type": "llm",
+                "provider": "qwen",
+                "model": "qwen/new-rate-model",
+                "rate_model": "new-rate-model",
+                "display_name": "New Rate Model",
+                "billing_metric": "llm_output_tokens",
+                "unit_size": 1,
+                "credits_per_unit": 12,
+                "status": "active",
+            },
+            operator_user_bid="operator-test",
+        )
+
+        active_rows = {
+            rate.billing_metric: rate
+            for rate in CreditUsageRate.query.filter(
+                CreditUsageRate.deleted == 0,
+                CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+                CreditUsageRate.provider == "qwen",
+                CreditUsageRate.model == "new-rate-model",
+            ).all()
+        }
+
+        assert active_rows[BILLING_METRIC_LLM_INPUT_TOKENS].credits_per_unit == Decimal(
+            "4"
+        )
+        assert active_rows[BILLING_METRIC_LLM_CACHE_TOKENS].credits_per_unit == Decimal(
+            "2"
+        )
+        assert active_rows[
+            BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ].credits_per_unit == Decimal("12")
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from flaskr.dao import db
+from flaskr.service.billing.consts import (
+    BILLING_METRIC_LLM_CACHE_TOKENS,
+    BILLING_METRIC_LLM_INPUT_TOKENS,
+    BILLING_METRIC_LLM_OUTPUT_TOKENS,
+    CREDIT_ROUNDING_MODE_CEIL,
+    CREDIT_USAGE_RATE_STATUS_ACTIVE,
+)
+from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.billing import rate_references
+from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
+from flaskr.service.shifu.admin_operations import config_rates
+
+
+def _credit_rate(
+    *,
+    rate_bid: str,
+    model: str,
+    metric: int,
+    credits_per_unit: str,
+    unit_size: int = 1,
+) -> CreditUsageRate:
+    return CreditUsageRate(
+        rate_bid=rate_bid,
+        usage_type=BILL_USAGE_TYPE_LLM,
+        provider="qwen",
+        model=model,
+        usage_scene=BILL_USAGE_SCENE_PROD,
+        billing_metric=metric,
+        unit_size=unit_size,
+        credits_per_unit=Decimal(credits_per_unit),
+        rounding_mode=CREDIT_ROUNDING_MODE_CEIL,
+        effective_from=datetime(2026, 1, 1, 0, 0, 0),
+        effective_to=None,
+        status=CREDIT_USAGE_RATE_STATUS_ACTIVE,
+    )
+
+
+def _seed_default_llm_rates() -> None:
+    db.session.add_all(
+        [
+            _credit_rate(
+                rate_bid="rate-input",
+                model="deepseek-v4-flash",
+                metric=BILLING_METRIC_LLM_INPUT_TOKENS,
+                credits_per_unit="1",
+            ),
+            _credit_rate(
+                rate_bid="rate-cache",
+                model="deepseek-v4-flash",
+                metric=BILLING_METRIC_LLM_CACHE_TOKENS,
+                credits_per_unit="0.5",
+            ),
+            _credit_rate(
+                rate_bid="rate-output",
+                model="deepseek-v4-flash",
+                metric=BILLING_METRIC_LLM_OUTPUT_TOKENS,
+                credits_per_unit="3",
+            ),
+        ]
+    )
+    db.session.commit()
+
+
+def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, app):
+    def config_getter(key, default=None):
+        return {
+            "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+            "TTS_CHARS_PER_LLM_TOKEN": "1",
+        }.get(key, default)
+
+    monkeypatch.setattr(config_rates, "get_config", config_getter)
+    monkeypatch.setattr(
+        rate_references,
+        "get_config",
+        config_getter,
+    )
+    monkeypatch.setattr(
+        config_rates,
+        "get_current_models",
+        lambda _app: [
+            {
+                "model": "qwen/deepseek-v4-flash",
+                "display_name": "DeepSeek-V4-Flash",
+            }
+        ],
+    )
+    fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)
+    monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
+    monkeypatch.setattr(
+        config_rates,
+        "_resolve_llm_rate_identity",
+        lambda _model: ("qwen", ["deepseek-v4-flash", "qwen/deepseek-v4-flash"]),
+    )
+    monkeypatch.setattr(
+        rate_references,
+        "resolve_llm_rate_identity",
+        lambda _model: ("qwen", ["deepseek-v4-flash", "qwen/deepseek-v4-flash"]),
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        _seed_default_llm_rates()
+
+        result = config_rates.update_operator_rate_config(
+            app,
+            payload={
+                "usage_type": "llm",
+                "provider": "qwen",
+                "model": "qwen/deepseek-v4-flash",
+                "rate_model": "deepseek-v4-flash",
+                "display_name": "DeepSeek-V4-Flash",
+                "billing_metric": "llm_output_tokens",
+                "unit_size": 1,
+                "credits_per_unit": 12,
+                "status": "active",
+            },
+            operator_user_bid="operator-test",
+        )
+
+        config = config_rates.get_operator_rate_config(app)
+        row = config["llm_rates"][0]
+        active_rows = {
+            rate.billing_metric: rate
+            for rate in CreditUsageRate.query.filter(
+                CreditUsageRate.deleted == 0,
+                CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+                CreditUsageRate.provider == "qwen",
+                CreditUsageRate.model == "deepseek-v4-flash",
+            ).all()
+        }
+
+        assert result["rate_model"] == "deepseek-v4-flash"
+        assert result["multiplier"] == 4
+        assert row["multiplier"] == 4
+        assert active_rows[BILLING_METRIC_LLM_INPUT_TOKENS].credits_per_unit == Decimal(
+            "4"
+        )
+        assert active_rows[BILLING_METRIC_LLM_CACHE_TOKENS].credits_per_unit == Decimal(
+            "2.0"
+        )
+        assert active_rows[
+            BILLING_METRIC_LLM_OUTPUT_TOKENS
+        ].credits_per_unit == Decimal("12")
+        assert active_rows[BILLING_METRIC_LLM_OUTPUT_TOKENS].effective_from == (
+            fixed_now.replace(microsecond=0)
+        )
+
+        # A second save in the same DB second should update the deterministic
+        # version instead of colliding on the rate lookup unique key.
+        second_result = config_rates.update_operator_rate_config(
+            app,
+            payload={
+                "usage_type": "llm",
+                "provider": "qwen",
+                "model": "qwen/deepseek-v4-flash",
+                "rate_model": "deepseek-v4-flash",
+                "display_name": "DeepSeek-V4-Flash",
+                "billing_metric": "llm_output_tokens",
+                "unit_size": 1,
+                "credits_per_unit": 21,
+                "status": "active",
+            },
+            operator_user_bid="operator-test",
+        )
+        config = config_rates.get_operator_rate_config(app)
+        db.session.expire_all()
+        active_output_rows = CreditUsageRate.query.filter(
+            CreditUsageRate.deleted == 0,
+            CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
+            CreditUsageRate.provider == "qwen",
+            CreditUsageRate.model == "deepseek-v4-flash",
+            CreditUsageRate.billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS,
+        ).all()
+
+        assert second_result["multiplier"] == 7
+        assert config["llm_rates"][0]["multiplier"] == 7
+        assert len(active_output_rows) == 1
+        assert active_output_rows[0].credits_per_unit == Decimal("21")
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 
 from flask import Flask
 
@@ -150,6 +151,9 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
     )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.5"))
     monkeypatch.setattr(
+        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+    )
+    monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
@@ -159,12 +163,6 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
     # baseline and the TTS rate are looked up (one shared anchor, not a standalone
     # TTS baseline).
     assert tts_api._resolve_credit_multiplier_label("tencent", "") == "4x"
-    assert (
-        BILL_USAGE_TYPE_LLM,
-        "qwen",
-        "deepseek-v4-flash",
-        BILLING_METRIC_LLM_OUTPUT_TOKENS,
-    ) in captured
     assert (
         BILL_USAGE_TYPE_TTS,
         "tencent",
@@ -203,6 +201,9 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
         lambda: ("qwen", ["deepseek-v4-flash"]),
     )
     monkeypatch.setattr(
+        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+    )
+    monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
@@ -239,6 +240,9 @@ def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
     )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.216"))
     monkeypatch.setattr(
+        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+    )
+    monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
@@ -266,6 +270,9 @@ def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch):
         lambda: ("qwen", ["deepseek-v4-flash"]),
     )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config(""))
+    monkeypatch.setattr(
+        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+    )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -115,26 +115,13 @@ def _chars_per_token_config(value: str):
 
 def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import (
-        BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        BILLING_METRIC_TTS_OUTPUT_CHARS,
-    )
-    from flaskr.service.metering.consts import (
-        BILL_USAGE_TYPE_LLM,
-        BILL_USAGE_TYPE_TTS,
-    )
+    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
     captured = []
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
         captured.append((usage.usage_type, usage.provider, usage.model, billing_metric))
-        if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and usage.provider == "qwen"
-            and usage.model == "deepseek-v4-flash"
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")  # 0.0001/token
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and usage.provider == "tencent"
@@ -144,24 +131,17 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
             return _FakeRate("8", 10000, "tencent", "")  # 0.0008/char
         return None
 
-    monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.5"))
     monkeypatch.setattr(
-        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+        tts_api, "load_llm_credit_1x_unit_cost", lambda: Decimal("0.0001")
     )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
         fake_load_usage_rate,
     )
 
-    # TTS 0.0008/char x 0.5 chars/token = 0.0004 credits per LLM token; the shared
-    # 1x anchor is the LLM rate 0.0001/token -> 0.0004 / 0.0001 = 4x. Both the LLM
-    # baseline and the TTS rate are looked up (one shared anchor, not a standalone
-    # TTS baseline).
+    # TTS 0.0008/char x 0.5 chars/token = 0.0004 credits per LLM token; the fixed
+    # 1x anchor is 0.0001 credits/token -> 0.0004 / 0.0001 = 4x.
     assert tts_api._resolve_credit_multiplier_label("tencent", "") == "4x"
     assert (
         BILL_USAGE_TYPE_TTS,
@@ -173,21 +153,10 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
 
 def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import (
-        BILLING_METRIC_LLM_OUTPUT_TOKENS,
-        BILLING_METRIC_TTS_OUTPUT_CHARS,
-    )
-    from flaskr.service.metering.consts import (
-        BILL_USAGE_TYPE_LLM,
-        BILL_USAGE_TYPE_TTS,
-    )
+    from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
+    from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")  # 0.0001/token
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
             and billing_metric == BILLING_METRIC_TTS_OUTPUT_CHARS
@@ -196,12 +165,7 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
         return None
 
     monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
-    monkeypatch.setattr(
-        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+        tts_api, "load_llm_credit_1x_unit_cost", lambda: Decimal("0.0001")
     )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
@@ -222,25 +186,13 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
 
 def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
-    from flaskr.service.metering.consts import BILL_USAGE_TYPE_LLM
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
         return None  # no curated TTS rate
 
-    monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.216"))
     monkeypatch.setattr(
-        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+        tts_api, "load_llm_credit_1x_unit_cost", lambda: Decimal("0.0001")
     )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",
@@ -253,25 +205,13 @@ def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
 
 def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch):
     import flaskr.api.tts as tts_api
-    from flaskr.service.billing.consts import BILLING_METRIC_LLM_OUTPUT_TOKENS
-    from flaskr.service.metering.consts import BILL_USAGE_TYPE_LLM
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
-        if (
-            usage.usage_type == BILL_USAGE_TYPE_LLM
-            and billing_metric == BILLING_METRIC_LLM_OUTPUT_TOKENS
-        ):
-            return _FakeRate("1", 10000, "qwen", "deepseek-v4-flash")
         return _FakeRate("8", 10000, "tencent", "")
 
-    monkeypatch.setattr(
-        tts_api,
-        "_resolve_default_llm_rate_identity",
-        lambda: ("qwen", ["deepseek-v4-flash"]),
-    )
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config(""))
     monkeypatch.setattr(
-        tts_api, "load_default_llm_reference_cost", lambda: Decimal("0.0001")
+        tts_api, "load_llm_credit_1x_unit_cost", lambda: Decimal("0.0001")
     )
     monkeypatch.setattr(
         "flaskr.service.billing.charges.load_usage_rate",

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -287,11 +287,52 @@ def test_get_current_models_adds_output_token_credit_multiplier(monkeypatch, app
 
     by_model = {item["model"]: item for item in models}
     assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier"] == 1
+    assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier_label"] == "1x"
+    assert by_model["qwen/deepseek-v4-flash"]["is_default"] is True
     assert by_model["ark/doubao-seed-2-0-lite-260428"]["credit_multiplier"] == 3
+    assert (
+        by_model["ark/doubao-seed-2-0-lite-260428"]["credit_multiplier_label"] == "2.7x"
+    )
     assert by_model["qwen/no-rate-model"]["credit_multiplier"] is None
+    assert by_model["qwen/no-rate-model"]["credit_multiplier_label"] is None
     assert by_model["ark/doubao-seed-2-0-lite-260428"]["display_name"] == (
         "Doubao-Seed-2.0-lite"
     )
+
+
+def test_get_current_models_uses_stable_default_multiplier_anchor(monkeypatch, app):
+    _configure_model_list(monkeypatch)
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        db.session.add_all(
+            [
+                _create_credit_rate(
+                    rate_bid="default-original-output",
+                    provider="qwen",
+                    model="qwen/deepseek-v4-flash",
+                    credits_per_unit="0.000066667",
+                    effective_from=datetime(2026, 1, 1, 0, 0, 0),
+                ),
+                _create_credit_rate(
+                    rate_bid="default-edited-output",
+                    provider="qwen",
+                    model="qwen/deepseek-v4-flash",
+                    credits_per_unit="0.000466669",
+                    effective_from=datetime(2026, 2, 1, 0, 0, 0),
+                ),
+            ]
+        )
+        db.session.commit()
+
+        models = llm.get_current_models(app)
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()
+
+    by_model = {item["model"]: item for item in models}
+    assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier"] == pytest.approx(7)
+    assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier_label"] == "7x"
+    assert by_model["qwen/deepseek-v4-flash"]["is_default"] is True
 
 
 def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(monkeypatch, app):

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -100,6 +100,7 @@ from flaskr.service.billing.consts import (
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from flaskr.service.billing.models import CreditUsageRate
+from flaskr.service.common import credit_rate_references
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
@@ -214,6 +215,7 @@ def _configure_model_list(monkeypatch):
     )
     config = {
         "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+        "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
         "LLM_ALLOWED_MODELS": ",".join(available_models),
         "LLM_ALLOWED_MODEL_DISPLAY_NAMES": (
             "DeepSeek-V4-Flash,Doubao-Seed-2.0-lite,No Rate"
@@ -221,6 +223,11 @@ def _configure_model_list(monkeypatch):
     }
     monkeypatch.setattr(
         llm, "get_config", lambda key, default=None: config.get(key, default)
+    )
+    monkeypatch.setattr(
+        credit_rate_references,
+        "get_config",
+        lambda key, default=None: config.get(key, default),
     )
 
 
@@ -274,7 +281,7 @@ def test_get_current_models_adds_output_token_credit_multiplier(monkeypatch, app
                     rate_bid="doubao-output",
                     provider="ark",
                     model="ark/doubao-seed-2-0-lite-260428",
-                    credits_per_unit="0.00018",
+                    credits_per_unit="0.0001800009",
                 ),
             ]
         )
@@ -300,7 +307,7 @@ def test_get_current_models_adds_output_token_credit_multiplier(monkeypatch, app
     )
 
 
-def test_get_current_models_uses_stable_default_multiplier_anchor(monkeypatch, app):
+def test_get_current_models_uses_fixed_credit_1x_anchor(monkeypatch, app):
     _configure_model_list(monkeypatch)
     with app.app_context():
         db.session.query(CreditUsageRate).delete()
@@ -320,6 +327,13 @@ def test_get_current_models_uses_stable_default_multiplier_anchor(monkeypatch, a
                     credits_per_unit="0.000466669",
                     effective_from=datetime(2026, 2, 1, 0, 0, 0),
                 ),
+                _create_credit_rate(
+                    rate_bid="doubao-output",
+                    provider="ark",
+                    model="ark/doubao-seed-2-0-lite-260428",
+                    credits_per_unit="0.0001800009",
+                    effective_from=datetime(2026, 1, 1, 0, 0, 0),
+                ),
             ]
         )
         db.session.commit()
@@ -333,6 +347,51 @@ def test_get_current_models_uses_stable_default_multiplier_anchor(monkeypatch, a
     assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier"] == pytest.approx(7)
     assert by_model["qwen/deepseek-v4-flash"]["credit_multiplier_label"] == "7x"
     assert by_model["qwen/deepseek-v4-flash"]["is_default"] is True
+    assert (
+        by_model["ark/doubao-seed-2-0-lite-260428"]["credit_multiplier_label"] == "2.7x"
+    )
+
+
+def test_get_current_models_hides_multiplier_when_credit_1x_anchor_missing(
+    monkeypatch, app
+):
+    _configure_model_list(monkeypatch)
+    missing_anchor_config = {
+        "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
+        "LLM_ALLOWED_MODELS": (
+            "qwen/deepseek-v4-flash,ark/doubao-seed-2-0-lite-260428"
+        ),
+    }
+    monkeypatch.setattr(
+        llm,
+        "get_config",
+        lambda key, default=None: missing_anchor_config.get(key, default),
+    )
+    monkeypatch.setattr(
+        credit_rate_references,
+        "get_config",
+        lambda key, default=None: missing_anchor_config.get(key, default),
+    )
+
+    with app.app_context():
+        db.session.query(CreditUsageRate).delete()
+        db.session.add(
+            _create_credit_rate(
+                rate_bid="default-output",
+                provider="qwen",
+                model="qwen/deepseek-v4-flash",
+                credits_per_unit="0.000066667",
+            )
+        )
+        db.session.commit()
+
+        models = llm.get_current_models(app)
+
+        db.session.query(CreditUsageRate).delete()
+        db.session.commit()
+
+    assert all(item["credit_multiplier"] is None for item in models)
+    assert all(item.get("credit_multiplier_label") is None for item in models)
 
 
 def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(monkeypatch, app):

--- a/src/cook-web/src/api/api.test.ts
+++ b/src/cook-web/src/api/api.test.ts
@@ -31,6 +31,12 @@ describe('profile onboarding api definitions', () => {
     expect(api.updateAdminOperationProfileOnboardingConfig).toBe(
       'POST /shifu/admin/operations/profile-onboarding',
     );
+    expect(api.getAdminOperationConfigRates).toBe(
+      'GET /shifu/admin/operations/config/rates',
+    );
+    expect(api.updateAdminOperationConfigRate).toBe(
+      'POST /shifu/admin/operations/config/rates',
+    );
   });
 });
 

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -216,6 +216,8 @@ const api = {
     'GET /shifu/admin/operations/profile-onboarding',
   updateAdminOperationProfileOnboardingConfig:
     'POST /shifu/admin/operations/profile-onboarding',
+  getAdminOperationConfigRates: 'GET /shifu/admin/operations/config/rates',
+  updateAdminOperationConfigRate: 'POST /shifu/admin/operations/config/rates',
   getAdminOperationReferrals: 'GET /shifu/admin/operations/referrals',
   getAdminOperationReferralsOverview:
     'GET /shifu/admin/operations/referrals/overview',

--- a/src/cook-web/src/app/admin/admin-menu.test.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.test.tsx
@@ -75,6 +75,11 @@ describe('buildAdminMenuItems', () => {
           href: '/admin/operations/profile-onboarding',
         },
         {
+          id: 'operations-config',
+          label: 'common.core.configManagement',
+          href: '/admin/operations/config',
+        },
+        {
           id: 'operations-brand-payments',
           label: 'common.core.brandPaymentsManagement',
           href: '/admin/operations/billing',

--- a/src/cook-web/src/app/admin/admin-menu.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.tsx
@@ -99,6 +99,11 @@ export const buildAdminMenuItems = ({
           href: '/admin/operations/profile-onboarding',
         },
         {
+          id: 'operations-config',
+          label: t('common.core.configManagement'),
+          href: '/admin/operations/config',
+        },
+        {
           id: 'operations-brand-payments',
           label: t('common.core.brandPaymentsManagement'),
           href: '/admin/operations/billing',

--- a/src/cook-web/src/app/admin/operations/config/page.tsx
+++ b/src/cook-web/src/app/admin/operations/config/page.tsx
@@ -81,7 +81,7 @@ type RateConfigResponse = {
 type EditState = {
   row: RateRow;
   unitSize: string;
-  creditsPerUnit: string;
+  creditsPerUnit: string | null;
   multiplier: string;
 };
 
@@ -89,6 +89,9 @@ const getRateRowKey = (row: RateRow) =>
   `${row.usage_type}-${row.provider}-${row.rate_model || row.model}-${row.billing_metric}`;
 
 const formatNumber = (value: unknown, fallback = '-') => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) {
     return fallback;
@@ -437,7 +440,7 @@ export default function AdminOperationsConfigPage() {
   }, []);
 
   const updateCreditsFromMultiplier = React.useCallback(
-    (multiplierText: string, current: EditState) => {
+    (multiplierText: string, current: EditState): string | null => {
       const multiplier = Number(multiplierText);
       const unitSize = Number(current.unitSize || 1);
       const baseline = Number(config.baseline?.unit_cost || 0);
@@ -446,13 +449,13 @@ export default function AdminOperationsConfigPage() {
         !Number.isFinite(unitSize) ||
         baseline <= 0
       ) {
-        return current.creditsPerUnit;
+        return null;
       }
       let value = baseline * multiplier * unitSize;
       if (current.row.usage_type === 'tts') {
         const factor = Number(config.baseline?.tts_chars_per_llm_token || 0);
         if (factor <= 0) {
-          return current.creditsPerUnit;
+          return null;
         }
         value = (baseline * multiplier * unitSize) / factor;
       }
@@ -473,7 +476,7 @@ export default function AdminOperationsConfigPage() {
       editState.multiplier,
       editState,
     );
-    if (Number(nextCreditsPerUnit) <= 0) {
+    if (nextCreditsPerUnit == null || Number(nextCreditsPerUnit) <= 0) {
       toast({ title: t('invalidMultiplier'), variant: 'destructive' });
       return;
     }
@@ -541,11 +544,11 @@ export default function AdminOperationsConfigPage() {
         ? {
             ...current,
             multiplier: '',
-            creditsPerUnit: updateCreditsFromMultiplier('', current),
+            creditsPerUnit: null,
           }
         : current,
     );
-  }, [updateCreditsFromMultiplier]);
+  }, []);
 
   if (!isReady) {
     return <Loading />;

--- a/src/cook-web/src/app/admin/operations/config/page.tsx
+++ b/src/cook-web/src/app/admin/operations/config/page.tsx
@@ -72,6 +72,8 @@ type RateConfigResponse = {
   baseline?: {
     default_llm_model?: string;
     unit_cost?: number;
+    per_1000_output_tokens?: number;
+    is_configured?: boolean;
     tts_chars_per_llm_token?: number;
   };
   llm_rates?: RateRow[];
@@ -128,8 +130,12 @@ function ConfigReferenceTooltip({
   const { t } = useTranslation(['module.operationsConfig']);
   const items = [
     {
-      label: t('rules.baselineModel'),
-      value: baseline?.default_llm_model || '-',
+      label: t('rules.baselinePer1000'),
+      value: baseline?.is_configured
+        ? t('rules.baselinePer1000Value', {
+            value: formatNumber(baseline?.per_1000_output_tokens),
+          })
+        : t('rules.baselineMissing'),
     },
     {
       label: t('rules.baselineUnitCost'),
@@ -141,7 +147,7 @@ function ConfigReferenceTooltip({
     },
     {
       label: t('rules.effectScope'),
-      value: t('rules.futureOnly'),
+      value: `${t('rules.fixedBaseline')}；${t('rules.futureOnly')}`,
     },
   ];
 
@@ -472,6 +478,10 @@ export default function AdminOperationsConfigPage() {
       toast({ title: t('invalidMultiplier'), variant: 'destructive' });
       return;
     }
+    if (!config.baseline?.is_configured) {
+      toast({ title: t('baselineMissing'), variant: 'destructive' });
+      return;
+    }
     const nextCreditsPerUnit = updateCreditsFromMultiplier(
       editState.multiplier,
       editState,
@@ -506,7 +516,14 @@ export default function AdminOperationsConfigPage() {
     } finally {
       setSaving(false);
     }
-  }, [editState, loadConfig, t, toast, updateCreditsFromMultiplier]);
+  }, [
+    config.baseline?.is_configured,
+    editState,
+    loadConfig,
+    t,
+    toast,
+    updateCreditsFromMultiplier,
+  ]);
 
   const requestSaveEdit = React.useCallback(() => {
     if (!editState) {
@@ -516,8 +533,12 @@ export default function AdminOperationsConfigPage() {
       toast({ title: t('invalidMultiplier'), variant: 'destructive' });
       return;
     }
+    if (!config.baseline?.is_configured) {
+      toast({ title: t('baselineMissing'), variant: 'destructive' });
+      return;
+    }
     setConfirmOpen(true);
-  }, [editState, t, toast]);
+  }, [config.baseline?.is_configured, editState, t, toast]);
 
   const updateEditMultiplier = React.useCallback(
     (rawValue: string) => {

--- a/src/cook-web/src/app/admin/operations/config/page.tsx
+++ b/src/cook-web/src/app/admin/operations/config/page.tsx
@@ -1,0 +1,673 @@
+'use client';
+
+import React from 'react';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import api from '@/api';
+import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
+import AdminTableShell from '@/components/admin/AdminTableShell';
+import AdminTitle from '@/app/admin/components/AdminTitle';
+import {
+  getAdminStickyRightCellClass,
+  getAdminStickyRightHeaderClass,
+} from '@/components/admin/adminTableStyles';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/AlertDialog';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+import Loading from '@/components/loading';
+import {
+  ADMIN_BILLING_TABS_LIST_CLASSNAME,
+  ADMIN_BILLING_TABS_TRIGGER_CLASSNAME,
+} from '@/components/billing/AdminBillingShared';
+import { useToast } from '@/hooks/useToast';
+import { ErrorWithCode } from '@/lib/request';
+import { useTranslation } from 'react-i18next';
+import useOperatorGuard from '../useOperatorGuard';
+
+const RATE_TABS = ['llm', 'tts'] as const;
+const RATE_TABLE_PAGE_SIZE = 10;
+type RateTab = (typeof RATE_TABS)[number];
+
+type RateRow = {
+  rate_bid?: string;
+  usage_type: 'llm' | 'tts' | string;
+  usage_type_code: number;
+  provider: string;
+  model: string;
+  rate_model?: string;
+  display_name: string;
+  usage_scene: string;
+  usage_scene_code: number;
+  billing_metric: string;
+  billing_metric_code: number;
+  unit_size: number;
+  credits_per_unit: number;
+  unit_cost: number;
+  multiplier: number | null;
+  rounding_mode: number;
+  status_code: number;
+  updated_at?: string | null;
+  source: string;
+};
+
+type RateConfigResponse = {
+  baseline?: {
+    default_llm_model?: string;
+    unit_cost?: number;
+    tts_chars_per_llm_token?: number;
+  };
+  llm_rates?: RateRow[];
+  tts_rates?: RateRow[];
+};
+
+type EditState = {
+  row: RateRow;
+  unitSize: string;
+  creditsPerUnit: string;
+  multiplier: string;
+};
+
+const getRateRowKey = (row: RateRow) =>
+  `${row.usage_type}-${row.provider}-${row.rate_model || row.model}-${row.billing_metric}`;
+
+const formatNumber = (value: unknown, fallback = '-') => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+  return numeric.toLocaleString(undefined, { maximumFractionDigits: 6 });
+};
+
+const normalizeMultiplierInput = (value: string) => {
+  const normalized = value.replace(/[。．｡]/g, '.');
+  const cleaned = normalized.replace(/[^\d.]/g, '');
+  const [integerPart = '', ...decimalParts] = cleaned.split('.');
+  const decimalPart = decimalParts.join('').slice(0, 2);
+  if (cleaned.includes('.')) {
+    return `${integerPart || '0'}.${decimalPart}`;
+  }
+  return integerPart;
+};
+
+const isValidMultiplier = (value: string) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0;
+};
+
+const formatMultiplier = (value: unknown) => {
+  const formatted = formatNumber(value);
+  return formatted === '-' ? formatted : `${formatted}x`;
+};
+
+function ConfigReferenceTooltip({
+  baseline,
+}: {
+  baseline?: RateConfigResponse['baseline'];
+}) {
+  const { t } = useTranslation(['module.operationsConfig']);
+  const items = [
+    {
+      label: t('rules.baselineModel'),
+      value: baseline?.default_llm_model || '-',
+    },
+    {
+      label: t('rules.baselineUnitCost'),
+      value: formatNumber(baseline?.unit_cost),
+    },
+    {
+      label: t('rules.ttsFactor'),
+      value: formatNumber(baseline?.tts_chars_per_llm_token),
+    },
+    {
+      label: t('rules.effectScope'),
+      value: t('rules.futureOnly'),
+    },
+  ];
+
+  return (
+    <span className='group relative ml-1 inline-flex'>
+      <button
+        type='button'
+        aria-label={t('rules.tooltipAriaLabel')}
+        className='inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30'
+      >
+        <QuestionMarkCircleIcon className='h-4 w-4' />
+      </button>
+      <span className='pointer-events-none absolute left-full top-1/2 z-50 ml-3 hidden w-[min(390px,calc(100vw-48px))] -translate-y-1/2 rounded-lg bg-[#171717] p-3 text-left text-xs font-normal leading-5 text-white shadow-lg group-hover:block group-focus-within:block'>
+        <span className='absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45 bg-[#171717]' />
+        <span className='block max-h-[220px] overflow-auto'>
+          <span className='block font-medium leading-5'>
+            {t('rules.intro')}
+          </span>
+          <span className='mt-2 grid gap-x-3 gap-y-1.5'>
+            {items.map(item => (
+              <span
+                key={item.label}
+                className='grid grid-cols-[128px_1fr] gap-2'
+              >
+                <span className='text-white/60'>{item.label}</span>
+                <span className='min-w-0 break-words text-white'>
+                  {item.value}
+                </span>
+              </span>
+            ))}
+          </span>
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function RateTable({
+  rows,
+  loading,
+  onEdit,
+  onCancelEdit,
+  onMultiplierChange,
+  onMultiplierBlur,
+  onSaveEdit,
+  editState,
+  saving,
+  modelHeader,
+  showProvider,
+  multiplierHeader,
+}: {
+  rows: RateRow[];
+  loading: boolean;
+  onEdit: (row: RateRow) => void;
+  onCancelEdit: () => void;
+  onMultiplierChange: (value: string) => void;
+  onMultiplierBlur: () => void;
+  onSaveEdit: () => void;
+  editState: EditState | null;
+  saving: boolean;
+  modelHeader: string;
+  showProvider: boolean;
+  multiplierHeader: string;
+}) {
+  const { t } = useTranslation(['module.operationsConfig', 'common.core']);
+  const [pageIndex, setPageIndex] = React.useState(1);
+  const pageCount = Math.max(Math.ceil(rows.length / RATE_TABLE_PAGE_SIZE), 1);
+  const safePageIndex = Math.min(pageIndex, pageCount);
+  const visibleRows = React.useMemo(() => {
+    const start = (safePageIndex - 1) * RATE_TABLE_PAGE_SIZE;
+    return rows.slice(start, start + RATE_TABLE_PAGE_SIZE);
+  }, [rows, safePageIndex]);
+  const dataColSpan = showProvider ? 6 : 5;
+  const emptyColSpan = dataColSpan + 1;
+
+  React.useEffect(() => {
+    setPageIndex(1);
+  }, [rows]);
+
+  return (
+    <AdminTableShell
+      loading={loading}
+      isEmpty={!rows.length}
+      emptyContent={t('empty')}
+      emptyColSpan={emptyColSpan}
+      stickyActionEmpty={{
+        contentColSpan: dataColSpan,
+        actionClassName: getAdminStickyRightCellClass(
+          'w-[132px] min-w-[132px] whitespace-nowrap text-left',
+        ),
+      }}
+      pagination={{
+        pageIndex: safePageIndex,
+        pageCount,
+        onPageChange: setPageIndex,
+        prevLabel: t('pagination.prev'),
+        nextLabel: t('pagination.next'),
+        prevAriaLabel: t('pagination.prev'),
+        nextAriaLabel: t('pagination.next'),
+        hideWhenSinglePage: true,
+        jumpInputThreshold: Number.MAX_SAFE_INTEGER,
+      }}
+      footerClassName='justify-end'
+      table={emptyRow => (
+        <Table className={showProvider ? 'min-w-[860px]' : 'min-w-[760px]'}>
+          <TableHeader>
+            <TableRow>
+              {showProvider ? (
+                <TableHead className='min-w-[120px]'>
+                  {t('fields.provider')}
+                </TableHead>
+              ) : null}
+              <TableHead className='min-w-[180px]'>{modelHeader}</TableHead>
+              <TableHead className='min-w-[160px]'>
+                {t('fields.displayName')}
+              </TableHead>
+              <TableHead className='min-w-[148px]'>
+                {multiplierHeader}
+              </TableHead>
+              <TableHead className='min-w-[104px]'>
+                {t('fields.source')}
+              </TableHead>
+              <TableHead className='min-w-[150px]'>
+                {t('fields.updatedAt')}
+              </TableHead>
+              <TableHead
+                className={getAdminStickyRightHeaderClass(
+                  'w-[132px] min-w-[132px] whitespace-nowrap text-left',
+                )}
+              >
+                {t('fields.actions')}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {emptyRow}
+            {visibleRows.map(row => {
+              const isEditing =
+                editState?.row &&
+                getRateRowKey(editState.row) === getRateRowKey(row);
+
+              return (
+                <TableRow key={getRateRowKey(row)}>
+                  {showProvider ? (
+                    <TableCell className='font-medium'>
+                      {row.provider || '-'}
+                    </TableCell>
+                  ) : null}
+                  <TableCell>
+                    <span className='block max-w-[220px] truncate font-mono text-xs'>
+                      {row.model || '-'}
+                    </span>
+                    {!showProvider && row.provider ? (
+                      <span className='mt-1 block max-w-[220px] truncate text-xs text-muted-foreground'>
+                        {row.provider}
+                      </span>
+                    ) : null}
+                  </TableCell>
+                  <TableCell>
+                    <span className='block max-w-[220px] truncate'>
+                      {row.display_name || '-'}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    {isEditing ? (
+                      <div className='flex items-center gap-2'>
+                        <Input
+                          type='text'
+                          inputMode='decimal'
+                          value={editState.multiplier}
+                          className='h-8 w-[84px] px-2 text-sm font-medium'
+                          disabled={saving}
+                          onChange={event =>
+                            onMultiplierChange(event.target.value)
+                          }
+                          onBlur={onMultiplierBlur}
+                        />
+                        <span className='select-none text-sm font-medium text-foreground'>
+                          {t('fields.multiplierSuffix')}
+                        </span>
+                      </div>
+                    ) : row.multiplier == null ? (
+                      '-'
+                    ) : (
+                      `${formatNumber(row.multiplier)}x`
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {row.source === 'exact'
+                      ? t('source.exact')
+                      : row.source === 'default'
+                        ? t('source.default')
+                        : row.source === 'unconfigured'
+                          ? t('source.unconfigured')
+                          : row.source || '-'}
+                  </TableCell>
+                  <TableCell>
+                    {row.updated_at
+                      ? formatAdminUtcDateTime(row.updated_at)
+                      : '-'}
+                  </TableCell>
+                  <TableCell
+                    className={getAdminStickyRightCellClass(
+                      'w-[132px] min-w-[132px] whitespace-nowrap text-left',
+                    )}
+                  >
+                    {isEditing ? (
+                      <div className='flex items-center justify-start gap-3'>
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='sm'
+                          className='h-auto justify-center rounded-none p-0 text-primary hover:bg-transparent hover:text-primary/80'
+                          disabled={saving}
+                          onClick={onSaveEdit}
+                        >
+                          {t('actions.save')}
+                        </Button>
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='sm'
+                          className='h-auto justify-center rounded-none p-0 text-muted-foreground hover:bg-transparent hover:text-foreground'
+                          disabled={saving}
+                          onClick={onCancelEdit}
+                        >
+                          {t('common.core:cancel')}
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        className='h-auto justify-center rounded-none p-0 text-primary hover:bg-transparent hover:text-primary/80'
+                        disabled={saving}
+                        onClick={() => onEdit(row)}
+                      >
+                        {t('actions.edit')}
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    />
+  );
+}
+
+export default function AdminOperationsConfigPage() {
+  const { t } = useTranslation(['module.operationsConfig', 'common.core']);
+  const { toast } = useToast();
+  const { isReady } = useOperatorGuard();
+  const [activeTab, setActiveTab] = React.useState<RateTab>('llm');
+  const [config, setConfig] = React.useState<RateConfigResponse>({});
+  const [loading, setLoading] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+  const [editState, setEditState] = React.useState<EditState | null>(null);
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+
+  const loadConfig = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = (await api.getAdminOperationConfigRates(
+        {},
+      )) as RateConfigResponse;
+      setConfig(response || {});
+    } catch (caughtError) {
+      const typedError = caughtError as Partial<ErrorWithCode>;
+      toast({
+        title: typedError.message || t('loadFailed'),
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [t, toast]);
+
+  React.useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+    void loadConfig();
+  }, [isReady, loadConfig]);
+
+  const openEditor = React.useCallback((row: RateRow) => {
+    setEditState({
+      row,
+      unitSize: String(row.unit_size || 1),
+      creditsPerUnit: String(row.credits_per_unit ?? 0),
+      multiplier: row.multiplier == null ? '' : String(row.multiplier),
+    });
+  }, []);
+
+  const updateCreditsFromMultiplier = React.useCallback(
+    (multiplierText: string, current: EditState) => {
+      const multiplier = Number(multiplierText);
+      const unitSize = Number(current.unitSize || 1);
+      const baseline = Number(config.baseline?.unit_cost || 0);
+      if (
+        !Number.isFinite(multiplier) ||
+        !Number.isFinite(unitSize) ||
+        baseline <= 0
+      ) {
+        return current.creditsPerUnit;
+      }
+      let value = baseline * multiplier * unitSize;
+      if (current.row.usage_type === 'tts') {
+        const factor = Number(config.baseline?.tts_chars_per_llm_token || 0);
+        if (factor <= 0) {
+          return current.creditsPerUnit;
+        }
+        value = (baseline * multiplier * unitSize) / factor;
+      }
+      return String(Number(value.toFixed(10)));
+    },
+    [config.baseline?.tts_chars_per_llm_token, config.baseline?.unit_cost],
+  );
+
+  const saveEdit = React.useCallback(async () => {
+    if (!editState) {
+      return;
+    }
+    if (!isValidMultiplier(editState.multiplier)) {
+      toast({ title: t('invalidMultiplier'), variant: 'destructive' });
+      return;
+    }
+    const nextCreditsPerUnit = updateCreditsFromMultiplier(
+      editState.multiplier,
+      editState,
+    );
+    if (Number(nextCreditsPerUnit) <= 0) {
+      toast({ title: t('invalidMultiplier'), variant: 'destructive' });
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.updateAdminOperationConfigRate({
+        usage_type: editState.row.usage_type,
+        provider: editState.row.provider,
+        model: editState.row.model,
+        rate_model: editState.row.rate_model || editState.row.model,
+        display_name: editState.row.display_name,
+        billing_metric: editState.row.billing_metric,
+        unit_size: Number(editState.unitSize || 1),
+        credits_per_unit: Number(nextCreditsPerUnit),
+        status: 'active',
+      });
+      toast({ title: t('saveSuccess') });
+      setEditState(null);
+      setConfirmOpen(false);
+      await loadConfig();
+    } catch (caughtError) {
+      const typedError = caughtError as Partial<ErrorWithCode>;
+      toast({
+        title: typedError.message || t('saveFailed'),
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [editState, loadConfig, t, toast, updateCreditsFromMultiplier]);
+
+  const requestSaveEdit = React.useCallback(() => {
+    if (!editState) {
+      return;
+    }
+    if (!isValidMultiplier(editState.multiplier)) {
+      toast({ title: t('invalidMultiplier'), variant: 'destructive' });
+      return;
+    }
+    setConfirmOpen(true);
+  }, [editState, t, toast]);
+
+  const updateEditMultiplier = React.useCallback(
+    (rawValue: string) => {
+      const nextMultiplier = normalizeMultiplierInput(rawValue);
+      setEditState(current =>
+        current
+          ? {
+              ...current,
+              multiplier: nextMultiplier,
+              creditsPerUnit: updateCreditsFromMultiplier(
+                nextMultiplier,
+                current,
+              ),
+            }
+          : current,
+      );
+    },
+    [updateCreditsFromMultiplier],
+  );
+
+  const clearInvalidEditMultiplier = React.useCallback(() => {
+    setEditState(current =>
+      current && !isValidMultiplier(current.multiplier)
+        ? {
+            ...current,
+            multiplier: '',
+            creditsPerUnit: updateCreditsFromMultiplier('', current),
+          }
+        : current,
+    );
+  }, [updateCreditsFromMultiplier]);
+
+  if (!isReady) {
+    return <Loading />;
+  }
+
+  const llmRows = config.llm_rates || [];
+  const ttsRows = config.tts_rates || [];
+  const confirmModelName =
+    editState?.row.display_name || editState?.row.model || '-';
+  const confirmFromMultiplier = formatMultiplier(editState?.row.multiplier);
+  const confirmToMultiplier = formatMultiplier(editState?.multiplier);
+
+  return (
+    <>
+      <AdminBreadcrumb items={[{ label: t('title') }]} />
+
+      <Tabs
+        className='flex min-h-0 flex-1 flex-col'
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as RateTab)}
+      >
+        <AdminTitle
+          title={t('title')}
+          description={
+            <span className='inline-flex items-center'>
+              <span>{t('description')}</span>
+              <ConfigReferenceTooltip baseline={config.baseline} />
+            </span>
+          }
+          tabs={
+            <TabsList className={ADMIN_BILLING_TABS_LIST_CLASSNAME}>
+              {RATE_TABS.map(tab => (
+                <TabsTrigger
+                  key={tab}
+                  value={tab}
+                  className={ADMIN_BILLING_TABS_TRIGGER_CLASSNAME}
+                >
+                  {tab === 'llm' ? t('tabs.llm') : t('tabs.tts')}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          }
+        />
+
+        <div className='flex min-h-0 flex-1 flex-col gap-4'>
+          <TabsContent
+            value='llm'
+            className='mt-0'
+          >
+            <RateTable
+              rows={llmRows}
+              loading={loading}
+              onEdit={openEditor}
+              onCancelEdit={() => setEditState(null)}
+              onMultiplierChange={updateEditMultiplier}
+              onMultiplierBlur={clearInvalidEditMultiplier}
+              onSaveEdit={requestSaveEdit}
+              editState={editState}
+              saving={saving}
+              modelHeader={t('fields.model')}
+              showProvider={false}
+              multiplierHeader={t('fields.multiplier')}
+            />
+          </TabsContent>
+
+          <TabsContent
+            value='tts'
+            className='mt-0'
+          >
+            <RateTable
+              rows={ttsRows}
+              loading={loading}
+              onEdit={openEditor}
+              onCancelEdit={() => setEditState(null)}
+              onMultiplierChange={updateEditMultiplier}
+              onMultiplierBlur={clearInvalidEditMultiplier}
+              onSaveEdit={requestSaveEdit}
+              editState={editState}
+              saving={saving}
+              modelHeader={t('fields.modelTier')}
+              showProvider
+              multiplierHeader={t('fields.ttsMultiplier')}
+            />
+          </TabsContent>
+        </div>
+      </Tabs>
+
+      <AlertDialog
+        open={confirmOpen}
+        onOpenChange={open => {
+          if (!saving) {
+            setConfirmOpen(open);
+          }
+        }}
+      >
+        <AlertDialogContent className='max-w-[420px]'>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('confirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription className='leading-6 text-foreground'>
+              {t('confirm.description', {
+                model: confirmModelName,
+                from: confirmFromMultiplier,
+                to: confirmToMultiplier,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>
+              {t('common.core:cancel')}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={saving}
+              onClick={event => {
+                event.preventDefault();
+                void saveEdit();
+              }}
+            >
+              {t('actions.save')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/cook-web/src/components/model-list/ModelList.test.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.test.tsx
@@ -170,8 +170,9 @@ describe('ModelList', () => {
   });
 
   test('refreshes model options on open with a short ttl', () => {
+    const initialNow = Date.now() + 1_000_000;
     const nowSpy = jest.spyOn(Date, 'now');
-    nowSpy.mockReturnValue(1_000_000);
+    nowSpy.mockReturnValue(initialNow);
 
     try {
       render(
@@ -185,7 +186,7 @@ describe('ModelList', () => {
       fireEvent.click(screen.getByTestId('model-select'));
       expect(mockLoadModels).toHaveBeenCalledTimes(1);
 
-      nowSpy.mockReturnValue(1_031_000);
+      nowSpy.mockReturnValue(initialNow + 31_000);
       fireEvent.click(screen.getByTestId('model-select'));
       expect(mockLoadModels).toHaveBeenCalledTimes(2);
     } finally {

--- a/src/cook-web/src/components/model-list/ModelList.test.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.test.tsx
@@ -3,12 +3,16 @@ import { render, screen, within } from '@testing-library/react';
 
 import ModelList from './ModelList';
 
+const mockLoadModels = jest.fn();
+
 const mockShifuState = {
   models: [
     {
       value: 'qwen/deepseek-v4-flash',
       label: 'DeepSeek-V4-Flash',
-      creditMultiplier: 1,
+      creditMultiplier: 6,
+      creditMultiplierLabel: '6x',
+      isDefault: true,
     },
     {
       value: 'ark/doubao-seed-2-0-lite-260428',
@@ -21,6 +25,9 @@ const mockShifuState = {
       creditMultiplier: null,
     },
   ],
+  actions: {
+    loadModels: mockLoadModels,
+  },
 };
 
 jest.mock('@/store', () => ({
@@ -87,7 +94,7 @@ describe('ModelList', () => {
     expect(screen.getByText('DeepSeek-V4-Flash')).toBeInTheDocument();
     expect(screen.getByText('Doubao-Seed-2.0-lite')).toBeInTheDocument();
     expect(screen.getByText('No Rate')).toBeInTheDocument();
-    expect(screen.getAllByText('1x')).toHaveLength(3);
+    expect(screen.getAllByText('6x')).toHaveLength(3);
     expect(screen.getByText('3x')).toBeInTheDocument();
 
     const trigger = screen.getByRole('button');
@@ -98,7 +105,7 @@ describe('ModelList', () => {
     expect(
       within(trigger).getByText('common.core.default'),
     ).toBeInTheDocument();
-    expect(within(trigger).getByText('1x')).toBeInTheDocument();
+    expect(within(trigger).getByText('6x')).toBeInTheDocument();
 
     const noRateOption = screen.getByText('No Rate').closest('[role="option"]');
     expect(noRateOption).toBeTruthy();
@@ -117,7 +124,7 @@ describe('ModelList', () => {
       expect.stringContaining('right-3'),
     );
     expect(
-      within(defaultOption as HTMLElement).getByText('1x'),
+      within(defaultOption as HTMLElement).getByText('6x'),
     ).toBeInTheDocument();
   });
 

--- a/src/cook-web/src/components/model-list/ModelList.test.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import ModelList from './ModelList';
 
@@ -43,7 +43,19 @@ jest.mock('react-i18next', () => ({
 
 jest.mock('../ui/Select', () => ({
   __esModule: true,
-  Select: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  Select: ({
+    children,
+    onOpenChange,
+  }: React.PropsWithChildren<{
+    onOpenChange?: (open: boolean) => void;
+  }>) => (
+    <div
+      data-testid='model-select'
+      onClick={() => onOpenChange?.(true)}
+    >
+      {children}
+    </div>
+  ),
   SelectTrigger: ({
     children,
     className,
@@ -72,6 +84,7 @@ jest.mock('../ui/Select', () => ({
   }>) => (
     <div
       role='option'
+      aria-selected='false'
       data-value={value}
       data-indicator-class={indicatorClassName}
       data-class={className}
@@ -82,6 +95,10 @@ jest.mock('../ui/Select', () => ({
 }));
 
 describe('ModelList', () => {
+  beforeEach(() => {
+    mockLoadModels.mockClear();
+  });
+
   test('renders multiplier badges only for models that have a multiplier', () => {
     render(
       <ModelList
@@ -150,5 +167,29 @@ describe('ModelList', () => {
     expect(
       screen.getByRole('listbox').querySelector('[data-value="__empty__"]'),
     ).toBeNull();
+  });
+
+  test('refreshes model options on open with a short ttl', () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000_000);
+
+    try {
+      render(
+        <ModelList
+          value=''
+          onChange={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('model-select'));
+      fireEvent.click(screen.getByTestId('model-select'));
+      expect(mockLoadModels).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(1_031_000);
+      fireEvent.click(screen.getByTestId('model-select'));
+      expect(mockLoadModels).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/src/cook-web/src/components/model-list/ModelList.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.tsx
@@ -1,4 +1,5 @@
 import { useShifu } from '@/store';
+import * as React from 'react';
 import {
   Select,
   SelectContent,
@@ -54,8 +55,18 @@ export default function ModelList({
   options?: ModelOption[];
   showDefaultOption?: boolean;
 }) {
-  const { models } = useShifu();
+  const { models, actions } = useShifu();
   const { t } = useTranslation();
+
+  const refreshModelOptions = React.useCallback(
+    (open: boolean) => {
+      if (!open || options || disabled) {
+        return;
+      }
+      void actions.loadModels();
+    },
+    [actions, disabled, options],
+  );
 
   const modelOptions: ModelOption[] = options || models || [];
 
@@ -64,11 +75,13 @@ export default function ModelList({
   const DEFAULT_MODEL_OPTION_VALUE = '__empty__';
   const displayValue =
     showDefaultOption && value === '' ? DEFAULT_MODEL_OPTION_VALUE : value;
+  const defaultModelOption =
+    modelOptions.find(item => item.isDefault) || modelOptions[0];
   const defaultOption: ModelOption = {
     value: DEFAULT_MODEL_OPTION_VALUE,
     label: t('common.core.default'),
-    creditMultiplier: 1,
-    creditMultiplierLabel: '',
+    creditMultiplier: defaultModelOption?.creditMultiplier ?? null,
+    creditMultiplierLabel: defaultModelOption?.creditMultiplierLabel || '',
   };
   const selectedOption =
     showDefaultOption && displayValue === DEFAULT_MODEL_OPTION_VALUE
@@ -85,6 +98,7 @@ export default function ModelList({
   return (
     <Select
       onValueChange={handleChange}
+      onOpenChange={refreshModelOptions}
       value={displayValue}
       disabled={disabled}
     >

--- a/src/cook-web/src/components/model-list/ModelList.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.tsx
@@ -12,6 +12,8 @@ import { useTranslation } from 'react-i18next';
 import { ModelOption } from '@/types/shifu';
 
 const MODEL_SELECT_ITEM_INDICATOR_CLASS_NAME = 'right-3';
+const MODEL_OPTIONS_REFRESH_TTL_MS = 30_000;
+let lastModelOptionsRefreshAt = 0;
 
 function ModelOptionLabel({
   label,
@@ -63,6 +65,14 @@ export default function ModelList({
       if (!open || options || disabled) {
         return;
       }
+      const now = Date.now();
+      if (
+        lastModelOptionsRefreshAt &&
+        now - lastModelOptionsRefreshAt < MODEL_OPTIONS_REFRESH_TTL_MS
+      ) {
+        return;
+      }
+      lastModelOptionsRefreshAt = now;
       void actions.loadModels();
     },
     [actions, disabled, options],

--- a/src/cook-web/src/store/modelOptions.test.ts
+++ b/src/cook-web/src/store/modelOptions.test.ts
@@ -8,6 +8,7 @@ describe('normalizeModelOptions', () => {
           model: 'qwen/deepseek-v4-flash',
           display_name: 'DeepSeek-V4-Flash',
           credit_multiplier: 1,
+          is_default: true,
         },
         {
           model: 'ark/doubao-seed-2-0-lite-260428',
@@ -27,18 +28,21 @@ describe('normalizeModelOptions', () => {
         label: 'DeepSeek-V4-Flash',
         creditMultiplier: 1,
         creditMultiplierLabel: '',
+        isDefault: true,
       },
       {
         value: 'ark/doubao-seed-2-0-lite-260428',
         label: 'Doubao-Seed-2.0-lite',
         creditMultiplier: 3,
         creditMultiplierLabel: '3x',
+        isDefault: false,
       },
       {
         value: 'qwen/no-rate-model',
         label: 'No Rate',
         creditMultiplier: null,
         creditMultiplierLabel: '',
+        isDefault: false,
       },
     ]);
   });

--- a/src/cook-web/src/store/modelOptions.ts
+++ b/src/cook-web/src/store/modelOptions.ts
@@ -33,7 +33,13 @@ export const normalizeModelOptions = (list: any): ModelOption[] => {
         item.credit_multiplier_label || item.creditMultiplierLabel || '',
       ).trim();
       seen.add(value);
-      options.push({ value, label, creditMultiplier, creditMultiplierLabel });
+      options.push({
+        value,
+        label,
+        creditMultiplier,
+        creditMultiplierLabel,
+        isDefault: Boolean(item.is_default ?? item.isDefault),
+      });
     }
   });
 

--- a/src/cook-web/src/types/shifu.ts
+++ b/src/cook-web/src/types/shifu.ts
@@ -15,6 +15,7 @@ export interface ModelOption {
   label: string;
   creditMultiplier?: number | null;
   creditMultiplierLabel?: string;
+  isDefault?: boolean;
 }
 
 export interface Shifu {

--- a/src/i18n/en-US/common/core.json
+++ b/src/i18n/en-US/common/core.json
@@ -12,6 +12,7 @@
   "collapse": "Collapse",
   "companyAddress": "Room 163, 19th Floor, Donghuan Building, Wangjing, Chaoyang District, Beijing",
   "companyName": "Beijing Chanchanshanmu Technology Co., Ltd.",
+  "configManagement": "Config Management",
   "confirm": "Confirm",
   "courseManagement": "Course Management",
   "createBlankShifu": "Create Course",

--- a/src/i18n/en-US/modules/operations-config.json
+++ b/src/i18n/en-US/modules/operations-config.json
@@ -5,8 +5,8 @@
     "save": "Save"
   },
   "confirm": {
-    "description": "Change {model} multiplier from {from} to {to}?",
-    "title": "Confirm multiplier change"
+    "description": "Change {model} credit consumption multiplier from {from} to {to}?",
+    "title": "Confirm credit consumption multiplier change"
   },
   "description": "Manage credit consumption rules for LLM and speech synthesis. Changes only affect future usage settlement.",
   "empty": "No configurable models.",
@@ -15,14 +15,14 @@
     "displayName": "Display Name",
     "model": "Model",
     "modelTier": "Model / Tier",
-    "multiplier": "Multiplier",
+    "multiplier": "Credit Consumption Multiplier",
     "multiplierSuffix": "x",
     "provider": "Voice Provider",
     "source": "Configuration",
-    "ttsMultiplier": "Conversion Multiplier",
+    "ttsMultiplier": "Credit Consumption Multiplier",
     "updatedAt": "Updated At"
   },
-  "invalidMultiplier": "Enter a multiplier greater than 0 with up to 2 decimal places.",
+  "invalidMultiplier": "Enter a credit consumption multiplier greater than 0 with up to 2 decimal places.",
   "loadFailed": "Failed to load config. Please try again later.",
   "pagination": {
     "next": "Next",
@@ -33,20 +33,20 @@
     "baselineUnitCost": "Current reference unit credits",
     "effectScope": "Effective Scope",
     "futureOnly": "Only future usage is affected. Historical bills are not recalculated.",
-    "intro": "Reference values used to calculate multipliers, for operations review only.",
+    "intro": "Reference values used to calculate credit consumption multipliers, for operations review only.",
     "tooltipAriaLabel": "View configuration reference",
     "ttsFactor": "TTS character conversion factor"
   },
   "saveFailed": "Failed to save config. Please check the form.",
   "saveSuccess": "Config saved",
   "source": {
-    "default": "Default multiplier",
-    "exact": "Custom multiplier",
+    "default": "Default credit consumption multiplier",
+    "exact": "Custom credit consumption multiplier",
     "unconfigured": "Not configured"
   },
   "tabs": {
-    "llm": "LLM Multipliers",
-    "tts": "TTS Multipliers"
+    "llm": "LLM Credit Consumption",
+    "tts": "TTS Credit Consumption"
   },
   "title": "Config Management"
 }

--- a/src/i18n/en-US/modules/operations-config.json
+++ b/src/i18n/en-US/modules/operations-config.json
@@ -4,6 +4,7 @@
     "edit": "Edit",
     "save": "Save"
   },
+  "baselineMissing": "The 1x baseline is not configured, so credit consumption multipliers cannot be saved.",
   "confirm": {
     "description": "Change {model} credit consumption multiplier from {from} to {to}?",
     "title": "Confirm credit consumption multiplier change"
@@ -29,11 +30,14 @@
     "prev": "Previous"
   },
   "rules": {
-    "baselineModel": "LLM 1x reference model",
-    "baselineUnitCost": "Current reference unit credits",
+    "baselineMissing": "The 1x baseline is not configured, so credit consumption multipliers cannot be saved.",
+    "baselinePer1000": "1x Baseline",
+    "baselinePer1000Value": "{value} credits per 1000 LLM output tokens",
+    "baselineUnitCost": "Per-token baseline",
     "effectScope": "Effective Scope",
+    "fixedBaseline": "This is a fixed global baseline and does not change with the default model or model multiplier updates.",
     "futureOnly": "Only future usage is affected. Historical bills are not recalculated.",
-    "intro": "Reference values used to calculate credit consumption multipliers, for operations review only.",
+    "intro": "Fixed reference values used to calculate credit consumption multipliers, for operations review only.",
     "tooltipAriaLabel": "View configuration reference",
     "ttsFactor": "TTS character conversion factor"
   },

--- a/src/i18n/en-US/modules/operations-config.json
+++ b/src/i18n/en-US/modules/operations-config.json
@@ -1,0 +1,52 @@
+{
+  "__namespace__": "module.operationsConfig",
+  "actions": {
+    "edit": "Edit",
+    "save": "Save"
+  },
+  "confirm": {
+    "description": "Change {model} multiplier from {from} to {to}?",
+    "title": "Confirm multiplier change"
+  },
+  "description": "Manage credit consumption rules for LLM and speech synthesis. Changes only affect future usage settlement.",
+  "empty": "No configurable models.",
+  "fields": {
+    "actions": "Actions",
+    "displayName": "Display Name",
+    "model": "Model",
+    "modelTier": "Model / Tier",
+    "multiplier": "Multiplier",
+    "multiplierSuffix": "x",
+    "provider": "Voice Provider",
+    "source": "Configuration",
+    "ttsMultiplier": "Conversion Multiplier",
+    "updatedAt": "Updated At"
+  },
+  "invalidMultiplier": "Enter a multiplier greater than 0 with up to 2 decimal places.",
+  "loadFailed": "Failed to load config. Please try again later.",
+  "pagination": {
+    "next": "Next",
+    "prev": "Previous"
+  },
+  "rules": {
+    "baselineModel": "LLM 1x reference model",
+    "baselineUnitCost": "Current reference unit credits",
+    "effectScope": "Effective Scope",
+    "futureOnly": "Only future usage is affected. Historical bills are not recalculated.",
+    "intro": "Reference values used to calculate multipliers, for operations review only.",
+    "tooltipAriaLabel": "View configuration reference",
+    "ttsFactor": "TTS character conversion factor"
+  },
+  "saveFailed": "Failed to save config. Please check the form.",
+  "saveSuccess": "Config saved",
+  "source": {
+    "default": "Default multiplier",
+    "exact": "Custom multiplier",
+    "unconfigured": "Not configured"
+  },
+  "tabs": {
+    "llm": "LLM Multipliers",
+    "tts": "TTS Multipliers"
+  },
+  "title": "Config Management"
+}

--- a/src/i18n/fr-FR/common/core.json
+++ b/src/i18n/fr-FR/common/core.json
@@ -12,6 +12,7 @@
   "collapse": "Réduire",
   "companyAddress": "Bureau 163, 19e étage, bâtiment Donghuan, Wangjing, district de Chaoyang, Pékin",
   "companyName": "Beijing Chanchanshanmu Technology Co., Ltd.",
+  "configManagement": "Gestion de la configuration",
   "confirm": "Confirmer",
   "courseManagement": "Gestion des cours",
   "createBlankShifu": "Créer un cours",

--- a/src/i18n/fr-FR/modules/operations-config.json
+++ b/src/i18n/fr-FR/modules/operations-config.json
@@ -4,6 +4,7 @@
     "edit": "Modifier",
     "save": "Enregistrer"
   },
+  "baselineMissing": "La référence 1x n’est pas configurée ; les multiplicateurs de consommation ne peuvent pas être enregistrés.",
   "confirm": {
     "description": "Confirmer le passage du multiplicateur de consommation de crédits de {model} de {from} à {to}.",
     "title": "Confirmer le multiplicateur de consommation"
@@ -29,11 +30,14 @@
     "prev": "Précédent"
   },
   "rules": {
-    "baselineModel": "Modèle de référence LLM 1x",
-    "baselineUnitCost": "Crédits unitaires de référence actuels",
+    "baselineMissing": "La référence 1x n’est pas configurée ; les multiplicateurs de consommation ne peuvent pas être enregistrés.",
+    "baselinePer1000": "Référence 1x",
+    "baselinePer1000Value": "{value} crédits pour 1000 tokens de sortie LLM",
+    "baselineUnitCost": "Référence par token",
     "effectScope": "Périmètre d’effet",
+    "fixedBaseline": "Cette référence globale est fixe et ne change pas avec le modèle par défaut ni les mises à jour de multiplicateur.",
     "futureOnly": "Seuls les usages futurs sont affectés. Les factures historiques ne sont pas recalculées.",
-    "intro": "Valeurs de référence utilisées pour calculer les multiplicateurs de consommation, uniquement pour vérification opérationnelle.",
+    "intro": "Valeurs de référence fixes utilisées pour calculer les multiplicateurs de consommation, uniquement pour vérification opérationnelle.",
     "tooltipAriaLabel": "Voir la référence de configuration",
     "ttsFactor": "Facteur de conversion des caractères TTS"
   },

--- a/src/i18n/fr-FR/modules/operations-config.json
+++ b/src/i18n/fr-FR/modules/operations-config.json
@@ -1,0 +1,52 @@
+{
+  "__namespace__": "module.operationsConfig",
+  "actions": {
+    "edit": "Modifier",
+    "save": "Enregistrer"
+  },
+  "confirm": {
+    "description": "Confirmer le passage du multiplicateur de {model} de {from} à {to}.",
+    "title": "Confirmer le multiplicateur"
+  },
+  "description": "Gérer les règles de consommation de crédits pour le LLM et la synthèse vocale. Les changements n’affectent que les usages futurs.",
+  "empty": "Aucun modèle configurable.",
+  "fields": {
+    "actions": "Actions",
+    "displayName": "Nom affiché",
+    "model": "Modèle",
+    "modelTier": "Modèle / Niveau",
+    "multiplier": "Multiplicateur",
+    "multiplierSuffix": "x",
+    "provider": "Fournisseur vocal",
+    "source": "Configuration",
+    "ttsMultiplier": "Multiplicateur de conversion",
+    "updatedAt": "Mis à jour le"
+  },
+  "invalidMultiplier": "Saisissez un multiplicateur supérieur à 0 avec 2 décimales au maximum.",
+  "loadFailed": "Échec du chargement de la configuration. Veuillez réessayer plus tard.",
+  "pagination": {
+    "next": "Suivant",
+    "prev": "Précédent"
+  },
+  "rules": {
+    "baselineModel": "Modèle de référence LLM 1x",
+    "baselineUnitCost": "Crédits unitaires de référence actuels",
+    "effectScope": "Périmètre d’effet",
+    "futureOnly": "Seuls les usages futurs sont affectés. Les factures historiques ne sont pas recalculées.",
+    "intro": "Valeurs de référence utilisées pour calculer les multiplicateurs, uniquement pour vérification opérationnelle.",
+    "tooltipAriaLabel": "Voir la référence de configuration",
+    "ttsFactor": "Facteur de conversion des caractères TTS"
+  },
+  "saveFailed": "Échec de l’enregistrement. Veuillez vérifier le formulaire.",
+  "saveSuccess": "Configuration enregistrée",
+  "source": {
+    "default": "Multiplicateur par défaut",
+    "exact": "Multiplicateur personnalisé",
+    "unconfigured": "Non configuré"
+  },
+  "tabs": {
+    "llm": "Multiplicateurs LLM",
+    "tts": "Multiplicateurs TTS"
+  },
+  "title": "Gestion de la configuration"
+}

--- a/src/i18n/fr-FR/modules/operations-config.json
+++ b/src/i18n/fr-FR/modules/operations-config.json
@@ -5,8 +5,8 @@
     "save": "Enregistrer"
   },
   "confirm": {
-    "description": "Confirmer le passage du multiplicateur de {model} de {from} à {to}.",
-    "title": "Confirmer le multiplicateur"
+    "description": "Confirmer le passage du multiplicateur de consommation de crédits de {model} de {from} à {to}.",
+    "title": "Confirmer le multiplicateur de consommation"
   },
   "description": "Gérer les règles de consommation de crédits pour le LLM et la synthèse vocale. Les changements n’affectent que les usages futurs.",
   "empty": "Aucun modèle configurable.",
@@ -15,14 +15,14 @@
     "displayName": "Nom affiché",
     "model": "Modèle",
     "modelTier": "Modèle / Niveau",
-    "multiplier": "Multiplicateur",
+    "multiplier": "Multiplicateur de consommation",
     "multiplierSuffix": "x",
     "provider": "Fournisseur vocal",
     "source": "Configuration",
-    "ttsMultiplier": "Multiplicateur de conversion",
+    "ttsMultiplier": "Multiplicateur de consommation",
     "updatedAt": "Mis à jour le"
   },
-  "invalidMultiplier": "Saisissez un multiplicateur supérieur à 0 avec 2 décimales au maximum.",
+  "invalidMultiplier": "Saisissez un multiplicateur de consommation supérieur à 0 avec 2 décimales au maximum.",
   "loadFailed": "Échec du chargement de la configuration. Veuillez réessayer plus tard.",
   "pagination": {
     "next": "Suivant",
@@ -33,20 +33,20 @@
     "baselineUnitCost": "Crédits unitaires de référence actuels",
     "effectScope": "Périmètre d’effet",
     "futureOnly": "Seuls les usages futurs sont affectés. Les factures historiques ne sont pas recalculées.",
-    "intro": "Valeurs de référence utilisées pour calculer les multiplicateurs, uniquement pour vérification opérationnelle.",
+    "intro": "Valeurs de référence utilisées pour calculer les multiplicateurs de consommation, uniquement pour vérification opérationnelle.",
     "tooltipAriaLabel": "Voir la référence de configuration",
     "ttsFactor": "Facteur de conversion des caractères TTS"
   },
   "saveFailed": "Échec de l’enregistrement. Veuillez vérifier le formulaire.",
   "saveSuccess": "Configuration enregistrée",
   "source": {
-    "default": "Multiplicateur par défaut",
-    "exact": "Multiplicateur personnalisé",
+    "default": "Multiplicateur de consommation par défaut",
+    "exact": "Multiplicateur de consommation personnalisé",
     "unconfigured": "Non configuré"
   },
   "tabs": {
-    "llm": "Multiplicateurs LLM",
-    "tts": "Multiplicateurs TTS"
+    "llm": "Consommation LLM",
+    "tts": "Consommation TTS"
   },
   "title": "Gestion de la configuration"
 }

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -36,6 +36,7 @@
     "module.groupon",
     "module.lesson",
     "module.onboarding",
+    "module.operationsConfig",
     "module.operationsCourse",
     "module.operationsCreditNotifications",
     "module.operationsOrder",

--- a/src/i18n/zh-CN/common/core.json
+++ b/src/i18n/zh-CN/common/core.json
@@ -12,6 +12,7 @@
   "collapse": "收起",
   "companyAddress": "北京朝阳区望京东煌大厦19层163室",
   "companyName": "北京潺潺山木科技有限公司",
+  "configManagement": "配置管理",
   "confirm": "确认",
   "courseManagement": "课程管理",
   "createBlankShifu": "新建课程",

--- a/src/i18n/zh-CN/modules/operations-config.json
+++ b/src/i18n/zh-CN/modules/operations-config.json
@@ -4,6 +4,7 @@
     "edit": "编辑",
     "save": "保存"
   },
+  "baselineMissing": "1x 基准未配置，暂不能保存消耗倍率。",
   "confirm": {
     "description": "确认将 {model} 的消耗倍率从 {from} 调整到 {to}。",
     "title": "确认保存消耗倍率"
@@ -29,11 +30,14 @@
     "prev": "上一页"
   },
   "rules": {
-    "baselineModel": "LLM 1x 参考模型",
-    "baselineUnitCost": "当前参考单位积分",
+    "baselineMissing": "1x 基准未配置，暂不能保存消耗倍率。",
+    "baselinePer1000": "1x 基准",
+    "baselinePer1000Value": "每 1000 个 LLM 输出 Token 消耗 {value} 积分",
+    "baselineUnitCost": "单 Token 基准",
     "effectScope": "生效范围",
+    "fixedBaseline": "该基准为全局固定值，不随默认模型和模型倍率调整而变化",
     "futureOnly": "仅影响后续新产生的用量，历史账单不回算",
-    "intro": "当前系统用于计算消耗倍率的参考值，仅供运营配置时核对。",
+    "intro": "当前系统用于计算消耗倍率的固定参考值，仅供运营配置时核对。",
     "tooltipAriaLabel": "查看配置参考",
     "ttsFactor": "TTS 字符折算系数"
   },

--- a/src/i18n/zh-CN/modules/operations-config.json
+++ b/src/i18n/zh-CN/modules/operations-config.json
@@ -1,0 +1,52 @@
+{
+  "__namespace__": "module.operationsConfig",
+  "actions": {
+    "edit": "编辑",
+    "save": "保存"
+  },
+  "confirm": {
+    "description": "确认将 {model} 的倍率从 {from} 调整到 {to}。",
+    "title": "确认保存倍率"
+  },
+  "description": "维护 LLM 与语音合成的积分消耗规则，调整后仅影响后续新产生的用量结算。",
+  "empty": "暂无可配置模型。",
+  "fields": {
+    "actions": "操作",
+    "displayName": "展示名称",
+    "model": "模型",
+    "modelTier": "模型 / 档位",
+    "multiplier": "倍率",
+    "multiplierSuffix": "x",
+    "provider": "语音厂商",
+    "source": "配置方式",
+    "ttsMultiplier": "折算倍率",
+    "updatedAt": "更新时间"
+  },
+  "invalidMultiplier": "请输入大于 0 的倍率，最多保留 2 位小数。",
+  "loadFailed": "配置加载失败，请稍后重试。",
+  "pagination": {
+    "next": "下一页",
+    "prev": "上一页"
+  },
+  "rules": {
+    "baselineModel": "LLM 1x 参考模型",
+    "baselineUnitCost": "当前参考单位积分",
+    "effectScope": "生效范围",
+    "futureOnly": "仅影响后续新产生的用量，历史账单不回算",
+    "intro": "当前系统用于计算倍率的参考值，仅供运营配置时核对。",
+    "tooltipAriaLabel": "查看配置参考",
+    "ttsFactor": "TTS 字符折算系数"
+  },
+  "saveFailed": "配置保存失败，请检查填写内容。",
+  "saveSuccess": "配置已保存",
+  "source": {
+    "default": "使用默认倍率",
+    "exact": "已单独调整",
+    "unconfigured": "未配置"
+  },
+  "tabs": {
+    "llm": "LLM 倍率",
+    "tts": "TTS 倍率"
+  },
+  "title": "配置管理"
+}

--- a/src/i18n/zh-CN/modules/operations-config.json
+++ b/src/i18n/zh-CN/modules/operations-config.json
@@ -5,8 +5,8 @@
     "save": "保存"
   },
   "confirm": {
-    "description": "确认将 {model} 的倍率从 {from} 调整到 {to}。",
-    "title": "确认保存倍率"
+    "description": "确认将 {model} 的消耗倍率从 {from} 调整到 {to}。",
+    "title": "确认保存消耗倍率"
   },
   "description": "维护 LLM 与语音合成的积分消耗规则，调整后仅影响后续新产生的用量结算。",
   "empty": "暂无可配置模型。",
@@ -15,14 +15,14 @@
     "displayName": "展示名称",
     "model": "模型",
     "modelTier": "模型 / 档位",
-    "multiplier": "倍率",
+    "multiplier": "消耗倍率",
     "multiplierSuffix": "x",
     "provider": "语音厂商",
     "source": "配置方式",
-    "ttsMultiplier": "折算倍率",
+    "ttsMultiplier": "消耗倍率",
     "updatedAt": "更新时间"
   },
-  "invalidMultiplier": "请输入大于 0 的倍率，最多保留 2 位小数。",
+  "invalidMultiplier": "请输入大于 0 的消耗倍率，最多保留 2 位小数。",
   "loadFailed": "配置加载失败，请稍后重试。",
   "pagination": {
     "next": "下一页",
@@ -33,20 +33,20 @@
     "baselineUnitCost": "当前参考单位积分",
     "effectScope": "生效范围",
     "futureOnly": "仅影响后续新产生的用量，历史账单不回算",
-    "intro": "当前系统用于计算倍率的参考值，仅供运营配置时核对。",
+    "intro": "当前系统用于计算消耗倍率的参考值，仅供运营配置时核对。",
     "tooltipAriaLabel": "查看配置参考",
     "ttsFactor": "TTS 字符折算系数"
   },
   "saveFailed": "配置保存失败，请检查填写内容。",
   "saveSuccess": "配置已保存",
   "source": {
-    "default": "使用默认倍率",
+    "default": "使用默认消耗倍率",
     "exact": "已单独调整",
     "unconfigured": "未配置"
   },
   "tabs": {
-    "llm": "LLM 倍率",
-    "tts": "TTS 倍率"
+    "llm": "LLM 消耗倍率",
+    "tts": "TTS 消耗倍率"
   },
   "title": "配置管理"
 }


### PR DESCRIPTION
## Summary

- Add an operator-facing `配置管理` page for LLM and TTS consumption multipliers.
- Add backend admin endpoints for reading/updating active billing rates.
- Align model-list multiplier display with the same stable reference cost used by the new config page.
- Fix LLM billing rate lookup so provider/model aliases such as `qwen/deepseek-v4-flash` resolve to the configured active rate row.

## Behavior

- Operators can edit a model multiplier inline and confirm the change before saving.
- LLM edits scale input/cache/output token rates proportionally from the output-token multiplier, preserving the existing billing structure.
- TTS edits update the output-character rate using the shared LLM reference and configured chars-per-token factor.
- Changes only affect new usage settlement after the new active rate version is saved.

## Verification

- `PATH="$HOME/.local/bin:$PATH" ruff check src/api/flaskr/service/shifu/admin_operations/config_rates.py src/api/flaskr/service/shifu/admin_operations/route.py src/api/flaskr/service/billing/rate_references.py src/api/flaskr/service/billing/charges.py src/api/flaskr/api/llm/__init__.py src/api/flaskr/api/tts/__init__.py src/api/tests/service/billing/test_usage_settlement.py src/api/tests/service/shifu/test_admin_config_rates.py src/api/tests/service/tts/test_tts_config_options.py src/api/tests/test_llm.py`
- `docker exec ai-shifu-local-ai-shifu-api-dev-1 bash -lc 'cd /app && python -m pytest tests/service/billing/test_usage_settlement.py::test_build_usage_metric_charges_matches_llm_rate_model_alias tests/test_llm.py::test_get_current_models_uses_stable_default_multiplier_anchor tests/service/shifu/test_admin_config_rates.py tests/service/tts/test_tts_config_options.py::test_tts_credit_multiplier_uses_shared_llm_anchor tests/service/tts/test_tts_config_options.py::test_tts_credit_multiplier_scales_with_chars_per_token tests/service/tts/test_tts_config_options.py::test_tts_credit_multiplier_none_when_tts_rate_missing tests/service/tts/test_tts_config_options.py::test_tts_credit_multiplier_none_when_conversion_unset -q'`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint -- --file src/app/admin/operations/config/page.tsx --file src/components/model-list/ModelList.tsx --file src/store/modelOptions.ts --file src/api/api.ts --file src/app/admin/admin-menu.tsx`
- `cd src/cook-web && npm test -- --runTestsByPath src/components/model-list/ModelList.test.tsx src/store/modelOptions.test.ts src/api/api.test.ts src/app/admin/admin-menu.test.tsx --runInBand`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- `python scripts/check_architecture_boundaries.py`
- `python scripts/check_uow_commit_sites.py`
- `python scripts/check_translation_usage.py`
- `git diff --check HEAD^ HEAD`

## Manual runtime coverage

Real learning-end billing was exercised locally against course `2d65bdd1a96d4f699dc427592d857905` and lesson `004851e77c13456f81fc307932e37602`.

Validated successful usage settlement for:

- LLM: `ark/doubao-seed-2-0-pro-260215`
- LLM: `ark/doubao-seed-2-0-lite-260428`
- LLM: `gemini-3.5-flash`
- TTS: `minimax/speech-2.8-turbo`

Provider-credential/account blockers in local environment:

- Qwen models returned Ali Model Studio account access/payment errors.
- Tencent TTS returned provider-side unknown error.
- Volcengine TTS returned 401 Unauthorized.

These should be covered by test-environment regression where provider credentials are valid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an operator Configuration Management page to view/edit LLM and TTS credit multipliers.
  * Introduced GET/POST admin endpoints for operation rate configuration and connected them to the UI.
* **Bug Fixes**
  * Improved LLM billing rate resolution using model/provider identity expansion with correct wildcard and time-window selection.
  * Stabilized the shared “1x” multiplier anchor for both LLM and TTS, including consistent labeling and default indicators.
* **Tests**
  * Added/expanded coverage for alias-based LLM rate matching, “superseded” time selection, and updated UI multiplier behavior.
* **Documentation**
  * Added i18n strings/locales for the new operations configuration module and menu entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->