### PR TITLE
chore: bump markdown-flow-ui to 0.2.3

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cook-web",
-  "version": "2.2.4",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cook-web",
-      "version": "2.2.4",
+      "version": "2.2.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.2",
+        "markdown-flow-ui": "0.2.3",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -170,7 +170,6 @@
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -893,7 +892,6 @@
     "node_modules/@codemirror/language": {
       "version": "6.11.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -970,7 +968,6 @@
     "node_modules/@codemirror/state": {
       "version": "6.5.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -988,7 +985,6 @@
     "node_modules/@codemirror/view": {
       "version": "6.38.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1064,7 +1060,6 @@
     "node_modules/@dnd-kit/core": {
       "version": "6.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1293,6 +1288,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
       "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/fast-memoize": "2.2.7",
         "@formatjs/intl-localematcher": "0.6.2",
@@ -1305,6 +1301,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
       "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -1314,6 +1311,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
       "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/icu-skeleton-parser": "1.8.16",
@@ -1325,6 +1323,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
       "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "tslib": "^2.8.0"
@@ -1335,6 +1334,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
       "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2708,7 +2708,6 @@
     "node_modules/@lezer/highlight": {
       "version": "1.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -2904,7 +2903,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -3561,7 +3559,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -5407,7 +5404,6 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.4.0.tgz",
       "integrity": "sha512-3LYVbK3Yg6NTGq3xB8jHSZF8VhoVjb3qJSAorzh2yuva/g4FMRmdQq68euk4hqaq2nRJHkr6x+Id473roUky1w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -5745,6 +5741,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5763,6 +5760,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6282,12 +6280,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6296,7 +6294,6 @@
       "version": "19.1.2",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -6372,7 +6369,6 @@
       "version": "8.29.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.29.1",
         "@typescript-eslint/types": "8.29.1",
@@ -6872,7 +6868,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7405,7 +7400,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -8094,7 +8088,6 @@
     "node_modules/cytoscape": {
       "version": "3.33.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8488,7 +8481,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9396,7 +9388,6 @@
       "version": "9.33.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9573,7 +9564,6 @@
       "version": "2.31.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -10820,7 +10810,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },
@@ -10893,7 +10882,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11487,6 +11475,7 @@
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -12845,7 +12834,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -12920,6 +12908,7 @@
     "node_modules/lib0": {
       "version": "0.2.103",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -13560,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.2.tgz",
-      "integrity": "sha512-FjD2+AZRBAIBZY53AjyHU9qTiFgm1Yu0gUex8mJxSbkwv+18A1w/+iM7xZKtgU/v82XXCy8BNQviJo4+O8QM1w==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.3.tgz",
+      "integrity": "sha512-Mp0j3V3Bg+UaAqBmKU6HG2i62PgXYOl28v2zoGW6oP1XMc+byyKMi2Dy2DlgRIqHr2eXdLQRpxyTb7Ct1dJ+XQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",
@@ -13862,7 +13851,8 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/markdown-flow-ui/node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -15186,7 +15176,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
       "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.19",
         "@swc/helpers": "0.5.15",
@@ -16134,7 +16123,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16186,7 +16174,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -16247,7 +16234,6 @@
     "node_modules/react-hook-form": {
       "version": "7.55.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -16971,7 +16957,6 @@
       "version": "1.89.2",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -17739,8 +17724,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17841,7 +17825,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17934,8 +17917,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -18045,7 +18027,6 @@
       "version": "5.8.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.2",
+    "markdown-flow-ui": "0.2.3",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- Bump Cook Web from `markdown-flow-ui@0.2.2` to `markdown-flow-ui@0.2.3`.
- Use the official release package, not a dev/pre-release package.

## Included markdown-flow-ui changes after 0.2.2

- ai-shifu/markdown-flow-ui#187 fix: open sandbox-rendered links in a new tab
- ai-shifu/markdown-flow-ui#190 fix: sync interaction overlay visibility with player controls
- ai-shifu/markdown-flow-ui#191 feat: extend silent image slide auto-advance delay
- ai-shifu/markdown-flow-ui#192 fix: allow reselecting history interactions
- ai-shifu/markdown-flow-ui#195 chore: make commit titles clear to product users

## Verification

- `npm view markdown-flow-ui@0.2.3 version gitHead`
- `cd src/cook-web && nvm exec 22.16.0 npm run type-check`
- `cd src/cook-web && nvm exec 22.16.0 npm run lint -- --file src/components/model-list/ModelList.tsx`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`

## Rollout

Deploy this PR to dev01 first and verify the MarkdownFlow UI behavior before merging to `main`.
