### PR TITLE
feat: add official site link to lesson PDFs

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -10,6 +10,7 @@ let mockCourseAvatar = '';
 let mockLearningMode = 'listen';
 let mockLogoHorizontal = '';
 let mockLogoWideUrl = '';
+let mockOfficialSiteUrl = 'https://official.example.com';
 let mockLessonPdfReady = false;
 let mockLessonPdfPreparing = false;
 const mockPrintLessonPdf = jest.fn();
@@ -136,6 +137,7 @@ jest.mock('@/c-store/envStore', () => ({
       selector({
         logoHorizontal: mockLogoHorizontal,
         logoWideUrl: mockLogoWideUrl,
+        officialSiteUrl: mockOfficialSiteUrl,
       }),
     {
       getState: () => ({
@@ -361,6 +363,7 @@ describe('NewChatComponents', () => {
     mockLearningMode = 'listen';
     mockLogoHorizontal = '';
     mockLogoWideUrl = '';
+    mockOfficialSiteUrl = 'https://official.example.com';
     mockLessonPdfReady = false;
     mockLessonPdfPreparing = false;
     requestAnimationFrameSpy = jest
@@ -481,24 +484,40 @@ describe('NewChatComponents', () => {
     expect(footer.nextElementSibling).toHaveAttribute('id', 'chat-box-bottom');
   });
 
-  it('includes the course avatar and configured site brand in the print header', () => {
+  it('includes the course avatar, site brand, and official link in the print header', () => {
     mockCourseAvatar = '/course-avatar.png';
     mockLearningMode = 'read';
     mockLogoHorizontal = '/runtime-horizontal-logo.png';
     mockLogoWideUrl = '/configured-wide-logo.png';
+    mockOfficialSiteUrl = 'https://learn.example.com';
 
     const { container } = renderNewChatComponents();
 
     const courseAvatar = container.querySelector(
       '[data-lesson-print-course-avatar="true"]',
     );
-    const siteLogo = container.querySelector(
+    const siteBrand = container.querySelector<HTMLElement>(
+      '[data-lesson-print-site-brand="true"]',
+    );
+    const siteLogo = container.querySelector<HTMLImageElement>(
       '[data-lesson-print-site-logo="true"]',
+    );
+    const siteUrl = container.querySelector<HTMLAnchorElement>(
+      '[data-lesson-print-site-url="true"]',
     );
     expect(courseAvatar).toHaveAttribute('src', '/course-avatar.png');
     expect(courseAvatar).toHaveAttribute('loading', 'eager');
+    expect(siteBrand).toHaveClass('ml-auto', 'items-end', 'text-right');
+    expect(siteBrand).toContainElement(siteLogo);
+    expect(siteBrand).toContainElement(siteUrl);
     expect(siteLogo).toHaveAttribute('src', '/configured-wide-logo.png');
     expect(siteLogo).toHaveAttribute('loading', 'eager');
+    expect(siteUrl).toBeInstanceOf(HTMLAnchorElement);
+    expect(siteUrl).toHaveAttribute('href', 'https://learn.example.com');
+    expect(siteUrl).toHaveAttribute('target', '_blank');
+    expect(siteUrl).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(siteUrl).toHaveTextContent('https://learn.example.com');
+    expect(siteLogo?.nextElementSibling).toBe(siteUrl);
     expect(
       container.querySelector('[data-lesson-print-course-name="true"]'),
     ).toHaveTextContent('测试课程');

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -1410,7 +1410,7 @@ export const NewChatComponents = ({
                 </div>
                 <div
                   data-lesson-print-site-brand='true'
-                  className='lesson-pdf-site-brand ml-auto flex shrink-0 flex-col items-end gap-1 text-right'
+                  className='lesson-pdf-site-brand ml-auto flex shrink-0 flex-col items-end text-right'
                 >
                   <Image
                     data-lesson-print-site-logo='true'

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -28,6 +28,7 @@ import { fail, toast } from '@/hooks/useToast';
 import useExclusiveAudio from '@/hooks/useExclusiveAudio';
 import AskIcon from '@/c-assets/newchat/light/icon_ask.svg';
 import { resolveWideLogoSource } from '@/c-components/logo/logoSource';
+import { resolveOfficialSiteUrl } from '@/config/environment';
 import InteractionBlock from './InteractionBlock';
 import useChatLogicHook, { ChatContentItemType } from './useChatLogicHook';
 import type { ChatContentItem } from './useChatLogicHook';
@@ -173,13 +174,19 @@ export const NewChatComponents = ({
   useEffect(() => {
     setLessonPdfCourseUrl(buildCoursePageUrl(window.location.href));
   }, [shifuBid]);
-  const { logoHorizontal, logoWideUrl } = useEnvStore(
+  const {
+    logoHorizontal,
+    logoWideUrl,
+    officialSiteUrl: officialSiteUrlValue,
+  } = useEnvStore(
     useShallow(state => ({
       logoHorizontal: state.logoHorizontal,
       logoWideUrl: state.logoWideUrl,
+      officialSiteUrl: state.officialSiteUrl,
     })),
   );
   const printBrandLogo = resolveWideLogoSource(logoWideUrl, logoHorizontal);
+  const officialSiteUrl = resolveOfficialSiteUrl(officialSiteUrlValue);
   const { refreshUserInfo } = useUserStore(
     useShallow(state => ({
       refreshUserInfo: state.refreshUserInfo,
@@ -1401,16 +1408,30 @@ export const NewChatComponents = ({
                     {lessonTitle}
                   </h2>
                 </div>
-                <Image
-                  data-lesson-print-site-logo='true'
-                  src={printBrandLogo}
-                  alt=''
-                  width={92}
-                  height={24}
-                  loading='eager'
-                  unoptimized
-                  className='h-6 w-auto shrink-0 object-contain'
-                />
+                <div
+                  data-lesson-print-site-brand='true'
+                  className='lesson-pdf-site-brand ml-auto flex shrink-0 flex-col items-end gap-1 text-right'
+                >
+                  <Image
+                    data-lesson-print-site-logo='true'
+                    src={printBrandLogo}
+                    alt=''
+                    width={92}
+                    height={24}
+                    loading='eager'
+                    unoptimized
+                    className='h-6 w-auto object-contain'
+                  />
+                  <a
+                    data-lesson-print-site-url='true'
+                    href={officialSiteUrl}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='lesson-pdf-site-link block text-right'
+                  >
+                    {officialSiteUrl}
+                  </a>
+                </div>
               </div>
             </header>
             {shouldShowResetLoading ? (

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -481,6 +481,28 @@ body.listen-mode-vh-fallback #root {
     object-fit: contain !important;
   }
 
+  html.lesson-pdf-print .lesson-pdf-site-brand {
+    display: flex !important;
+    flex-direction: column;
+    align-items: flex-end;
+    flex-shrink: 0;
+    gap: 4px;
+    margin-left: auto;
+    text-align: right;
+  }
+
+  html.lesson-pdf-print .lesson-pdf-site-link {
+    display: block !important;
+    max-width: 220px;
+    color: #525252 !important;
+    font-size: 10px;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    text-align: right;
+    text-decoration: underline !important;
+    text-underline-offset: 2px;
+  }
+
   html.lesson-pdf-print [data-lesson-print-scroll] :is(iframe, table) {
     max-width: 100% !important;
   }

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -486,7 +486,6 @@ body.listen-mode-vh-fallback #root {
     flex-direction: column;
     align-items: flex-end;
     flex-shrink: 0;
-    gap: 4px;
     margin-left: auto;
     text-align: right;
   }
@@ -494,6 +493,7 @@ body.listen-mode-vh-fallback #root {
   html.lesson-pdf-print .lesson-pdf-site-link {
     display: block !important;
     max-width: 220px;
+    margin-top: 4px;
     color: #525252 !important;
     font-size: 10px;
     line-height: 1.4;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -498,10 +498,16 @@ body.listen-mode-vh-fallback #root {
     font-size: 10px;
     line-height: 1.4;
     overflow-wrap: anywhere;
-    word-break: break-word;
+    word-break: break-all;
     text-align: right;
     text-decoration: underline !important;
     text-underline-offset: 2px;
+  }
+
+  @supports (overflow-wrap: anywhere) {
+    html.lesson-pdf-print .lesson-pdf-site-link {
+      word-break: normal;
+    }
   }
 
   html.lesson-pdf-print [data-lesson-print-scroll] :is(iframe, table) {

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -498,7 +498,7 @@ body.listen-mode-vh-fallback #root {
     font-size: 10px;
     line-height: 1.4;
     overflow-wrap: anywhere;
-    word-break: break-all;
+    word-break: break-word;
     text-align: right;
     text-decoration: underline !important;
     text-underline-offset: 2px;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -498,6 +498,7 @@ body.listen-mode-vh-fallback #root {
     font-size: 10px;
     line-height: 1.4;
     overflow-wrap: anywhere;
+    word-break: break-all;
     text-align: right;
     text-decoration: underline !important;
     text-underline-offset: 2px;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -494,7 +494,7 @@ body.listen-mode-vh-fallback #root {
     display: block !important;
     max-width: 220px;
     margin-top: 4px;
-    color: #525252 !important;
+    color: #374151 !important;
     font-size: 10px;
     line-height: 1.4;
     overflow-wrap: break-word;

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -497,17 +497,11 @@ body.listen-mode-vh-fallback #root {
     color: #525252 !important;
     font-size: 10px;
     line-height: 1.4;
+    overflow-wrap: break-word;
     overflow-wrap: anywhere;
-    word-break: break-all;
     text-align: right;
     text-decoration: underline !important;
     text-underline-offset: 2px;
-  }
-
-  @supports (overflow-wrap: anywhere) {
-    html.lesson-pdf-print .lesson-pdf-site-link {
-      word-break: normal;
-    }
   }
 
   html.lesson-pdf-print [data-lesson-print-scroll] :is(iframe, table) {


### PR DESCRIPTION
## Summary

- Display the configured official site URL below the site logo in exported lesson PDFs.
- Keep the logo and URL right-aligned in the print header, including safe wrapping for long URLs.
- Render the URL as a real external link so it remains clickable in browser-generated PDFs.
- Add focused regression coverage for the configured URL, anchor semantics, and header alignment.

## Why

Exported lesson PDFs showed the configured site logo but did not provide a direct way to reach the configured official website.

## Impact

Learners can open the configured website directly from the PDF while the existing course and lesson branding remains intact.

## Validation

- `python3 scripts/check_dev_tools.py`
- Focused Jest: `NewChatComp.lessonUpdateNotice.test.tsx` (8 tests passed)
- `npm run type-check`
- `npm run lint`
- Lefthook pre-commit checks, including architecture boundaries, translations, ESLint, and Prettier
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lesson PDF print headers now include an official site link alongside the existing site branding/logo.
  * The link uses the configured official site URL and is set up to open externally.

* **Style**
  * Print-only styling improves right-aligned layout, spacing, and typography for the site brand and link.
  * The link is visibly underlined and wraps cleanly for longer URLs.

* **Tests**
  * Updated coverage to verify the official-site link appears in the printed header with the expected attributes and placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->