### PR TITLE
fix: render anonymous mixed inputs correctly

### DIFF
--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -23,6 +23,30 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
     );
   });
 
+  it('preserves custom values for anonymous mixed options', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender(
+        '?[Small//S | Medium//M | ...custom size]',
+      ),
+    ).toBe(
+      '<custom-variable placeholder="custom size" data-button-texts="[&quot;Small&quot;,&quot;Medium&quot;]" data-button-values="[&quot;S&quot;,&quot;M&quot;]"></custom-variable>',
+    );
+  });
+
+  it('uses a leading single separator without splitting double pipes in an option', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender('?[A | B||C | ...Other]'),
+    ).toBe(
+      '<custom-variable placeholder="Other" data-button-texts="[&quot;A&quot;,&quot;B||C&quot;]" data-button-values="[&quot;A&quot;,&quot;B||C&quot;]"></custom-variable>',
+    );
+  });
+
+  it('uses a leading double separator without splitting single pipes in an option', () => {
+    expect(adaptMarkdownFlowInteractionForRender('?[A||B | C||...Other]')).toBe(
+      '<custom-variable placeholder="Other" data-button-texts="[&quot;A&quot;,&quot;B | C&quot;]" data-button-values="[&quot;A&quot;,&quot;B | C&quot;]" data-is-multi-select="true"></custom-variable>',
+    );
+  });
+
   it('escapes the prompt when adapting it into an HTML attribute', () => {
     expect(
       adaptMarkdownFlowInteractionForRender(

--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -41,9 +41,11 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
     );
   });
 
-  it('uses a leading double separator without splitting single pipes in an option', () => {
-    expect(adaptMarkdownFlowInteractionForRender('?[A||B | C||...Other]')).toBe(
-      '<custom-variable placeholder="Other" data-button-texts="[&quot;A&quot;,&quot;B | C&quot;]" data-button-values="[&quot;A&quot;,&quot;B | C&quot;]" data-is-multi-select="true"></custom-variable>',
+  it('uses a leading double separator even when a single pipe precedes the prompt', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender('?[A||B | C | ...Other]'),
+    ).toBe(
+      '<custom-variable placeholder="Other" data-button-texts="[&quot;A&quot;,&quot;B | C |&quot;]" data-button-values="[&quot;A&quot;,&quot;B | C |&quot;]" data-is-multi-select="true"></custom-variable>',
     );
   });
 

--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -7,6 +7,22 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
     );
   });
 
+  it('keeps anonymous multi-select options separate from the text input', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender(
+        '?[搜索工具 || 效率助手 || 数字员工 || 组织重构力量 || ...其他角色（请简要补充）]',
+      ),
+    ).toBe(
+      '<custom-variable placeholder="其他角色（请简要补充）" data-button-texts="[&quot;搜索工具&quot;,&quot;效率助手&quot;,&quot;数字员工&quot;,&quot;组织重构力量&quot;]" data-button-values="[&quot;搜索工具&quot;,&quot;效率助手&quot;,&quot;数字员工&quot;,&quot;组织重构力量&quot;]" data-is-multi-select="true"></custom-variable>',
+    );
+  });
+
+  it('keeps anonymous single-select options separate from the text input', () => {
+    expect(adaptMarkdownFlowInteractionForRender('?[选项 | ...输入]')).toBe(
+      '<custom-variable placeholder="输入" data-button-texts="[&quot;选项&quot;]" data-button-values="[&quot;选项&quot;]"></custom-variable>',
+    );
+  });
+
   it('escapes the prompt when adapting it into an HTML attribute', () => {
     expect(
       adaptMarkdownFlowInteractionForRender(
@@ -20,6 +36,9 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
   it.each([
     '?[继续]',
     '?[%{{name}}...你叫什么名字]',
+    '?[%{{role}} 搜索工具 || ...其他角色]',
+    '?[搜索工具 || 效率助手]',
+    '?[处理中...请稍候]',
     '?[...]',
     '示例：?[...你叫什么名字]',
     '?[...你叫什么名字]\n?[继续]',

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -1,5 +1,7 @@
 const ANONYMOUS_TEXT_INPUT_PATTERN =
   /^(\s*)\?\[(?!\s*%\{\{)\s*(?:(.*?)\s*(\|\||\|)\s*)?\.\.\.([^\]]*?)\](\s*)$/;
+const SINGLE_OPTION_SEPARATOR_PATTERN = /(?<!\|)\|(?!\|)/;
+const BUTTON_VALUE_PATTERN = /^(.+?)\/\/(.+)$/;
 
 const escapeHtmlAttribute = (value: string) =>
   value
@@ -21,9 +23,19 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
     return content;
   }
 
-  const options = match[2]
-    ? match[2]
-        .split(match[3])
+  const optionContent = match[2]?.trim();
+  const separatorProbe = optionContent ? `${optionContent}${match[3]}` : '';
+  const firstSeparatorIndex = separatorProbe.indexOf('|');
+  const firstMultiSeparatorIndex = separatorProbe.indexOf('||');
+  const isMultiSelect =
+    firstMultiSeparatorIndex !== -1 &&
+    firstMultiSeparatorIndex <= firstSeparatorIndex;
+  const optionSeparator = isMultiSelect
+    ? '||'
+    : SINGLE_OPTION_SEPARATOR_PATTERN;
+  const options = optionContent
+    ? optionContent
+        .split(optionSeparator)
         .map(option => option.trim())
         .filter(Boolean)
     : [];
@@ -33,10 +45,23 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
     )}"></custom-variable>${match[5]}`;
   }
 
-  const optionValues = escapeStringArrayAttribute(options);
-  const multiSelectAttribute =
-    match[3] === '||' ? ' data-is-multi-select="true"' : '';
+  const parsedOptions = options.map(option => {
+    const valueMatch = BUTTON_VALUE_PATTERN.exec(option);
+    return {
+      text: valueMatch?.[1]?.trim() || option,
+      value: valueMatch?.[2]?.trim() || option,
+    };
+  });
+  const optionTexts = escapeStringArrayAttribute(
+    parsedOptions.map(option => option.text),
+  );
+  const optionValues = escapeStringArrayAttribute(
+    parsedOptions.map(option => option.value),
+  );
+  const multiSelectAttribute = isMultiSelect
+    ? ' data-is-multi-select="true"'
+    : '';
   return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
     prompt,
-  )}" data-button-texts="${optionValues}" data-button-values="${optionValues}"${multiSelectAttribute}></custom-variable>${match[5]}`;
+  )}" data-button-texts="${optionTexts}" data-button-values="${optionValues}"${multiSelectAttribute}></custom-variable>${match[5]}`;
 };

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -29,7 +29,7 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
   const firstMultiSeparatorIndex = separatorProbe.indexOf('||');
   const isMultiSelect =
     firstMultiSeparatorIndex !== -1 &&
-    firstMultiSeparatorIndex <= firstSeparatorIndex;
+    firstMultiSeparatorIndex === firstSeparatorIndex;
   const optionSeparator = isMultiSelect
     ? '||'
     : SINGLE_OPTION_SEPARATOR_PATTERN;

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -1,4 +1,5 @@
-const ANONYMOUS_TEXT_INPUT_PATTERN = /^(\s*)\?\[\s*\.\.\.([^\]]*?)\](\s*)$/;
+const ANONYMOUS_TEXT_INPUT_PATTERN =
+  /^(\s*)\?\[(?!\s*%\{\{)\s*(?:(.*?)\s*(\|\||\|)\s*)?\.\.\.([^\]]*?)\](\s*)$/;
 
 const escapeHtmlAttribute = (value: string) =>
   value
@@ -10,14 +11,32 @@ const escapeHtmlAttribute = (value: string) =>
     .replace(/\r/g, '&#13;')
     .replace(/\n/g, '&#10;');
 
+const escapeStringArrayAttribute = (values: string[]) =>
+  escapeHtmlAttribute(JSON.stringify(values));
+
 export const adaptMarkdownFlowInteractionForRender = (content: string) => {
   const match = ANONYMOUS_TEXT_INPUT_PATTERN.exec(content);
-  const prompt = match?.[2];
-  if (!match || !prompt?.trim()) {
+  const prompt = match?.[4]?.trim();
+  if (!match || !prompt) {
     return content;
   }
 
+  const options = match[2]
+    ? match[2]
+        .split(match[3])
+        .map(option => option.trim())
+        .filter(Boolean)
+    : [];
+  if (!options.length) {
+    return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
+      prompt,
+    )}"></custom-variable>${match[5]}`;
+  }
+
+  const optionValues = escapeStringArrayAttribute(options);
+  const multiSelectAttribute =
+    match[3] === '||' ? ' data-is-multi-select="true"' : '';
   return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
-    prompt.trim(),
-  )}"></custom-variable>${match[3]}`;
+    prompt,
+  )}" data-button-texts="${optionValues}" data-button-values="${optionValues}"${multiSelectAttribute}></custom-variable>${match[5]}`;
 };

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -1,5 +1,5 @@
 const ANONYMOUS_TEXT_INPUT_PATTERN =
-  /^(\s*)\?\[(?!\s*%\{\{)\s*(?:(.*?)\s*(\|\||\|)\s*)?\.\.\.([^\]]*?)\](\s*)$/;
+  /^(\s*)\?\[(?!\s*%\{\{)\s*(?:(.*?)(\|\||\|)\s*)?\.\.\.([^\]]*?)\](\s*)$/;
 const SINGLE_OPTION_SEPARATOR_PATTERN = /(?<!\|)\|(?!\|)/;
 const BUTTON_VALUE_PATTERN = /^(.+?)\/\/(.+)$/;
 
@@ -23,10 +23,9 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
     return content;
   }
 
-  const optionContent = match[2]?.trim();
-  const separatorProbe = optionContent ? `${optionContent}${match[3]}` : '';
-  const firstSeparatorIndex = separatorProbe.indexOf('|');
-  const firstMultiSeparatorIndex = separatorProbe.indexOf('||');
+  const optionContent = match[2] ? `${match[2]}${match[3]}`.trim() : '';
+  const firstSeparatorIndex = optionContent.indexOf('|');
+  const firstMultiSeparatorIndex = optionContent.indexOf('||');
   const isMultiSelect =
     firstMultiSeparatorIndex !== -1 &&
     firstMultiSeparatorIndex === firstSeparatorIndex;


### PR DESCRIPTION
## Summary

- Generalize the existing anonymous text-input compatibility adapter so a trailing ... input is separated from preceding single- or multi-select options.
- Preserve anonymous options as buttons and render the trailing prompt as a text input.
- Cover ?[选项 | ...输入], the reported multi-select case, and important non-matches.

## Root cause

The pinned MarkdownFlow parser currently treats a mixed anonymous interaction as buttons, while the host compatibility adapter only recognized the pure ?[...input] form.

## Validation

- 48 focused Jest tests passed across the adapter and both rendering paths.
- npm run type-check
- Targeted ESLint with zero warnings
- python3 scripts/check_dev_tools.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for anonymous single-select and multi-select prompts that include selectable options.
  * Options are now rendered as interactive buttons with the correct associated values, while the trailing text/placeholder is preserved.
* **Bug Fixes**
  * Improved parsing so option separators are handled correctly (including cases where `|`/`||` appear within options).
  * Non-target or unsupported prompt formats are returned unchanged.
* **Tests**
  * Expanded coverage for anonymous prompt and option conversion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->