### PR TITLE
fix: let learners select multiple anonymous choices

### DIFF
--- a/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
+++ b/src/cook-web/src/__tests__/markdown-flow-interaction.test.tsx
@@ -17,6 +17,16 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
     );
   });
 
+  it('adapts a variable-free multi-select into selectable options', () => {
+    expect(
+      adaptMarkdownFlowInteractionForRender(
+        '?[ 搜索工具 || 效率助手 || 数字员工 || 组织重构力量 ]',
+      ),
+    ).toBe(
+      '<custom-variable data-button-texts="[&quot;搜索工具&quot;,&quot;效率助手&quot;,&quot;数字员工&quot;,&quot;组织重构力量&quot;]" data-button-values="[&quot;搜索工具&quot;,&quot;效率助手&quot;,&quot;数字员工&quot;,&quot;组织重构力量&quot;]" data-is-multi-select="true"></custom-variable>',
+    );
+  });
+
   it('keeps anonymous single-select options separate from the text input', () => {
     expect(adaptMarkdownFlowInteractionForRender('?[选项 | ...输入]')).toBe(
       '<custom-variable placeholder="输入" data-button-texts="[&quot;选项&quot;]" data-button-values="[&quot;选项&quot;]"></custom-variable>',
@@ -63,7 +73,8 @@ describe('adaptMarkdownFlowInteractionForRender', () => {
     '?[继续]',
     '?[%{{name}}...你叫什么名字]',
     '?[%{{role}} 搜索工具 || ...其他角色]',
-    '?[搜索工具 || 效率助手]',
+    '?[搜索工具 | 效率助手]',
+    '?[搜索工具 | 效率助手||数字员工]',
     '?[处理中...请稍候]',
     '?[...]',
     '示例：?[...你叫什么名字]',

--- a/src/cook-web/src/c-utils/markdown-flow-interaction.ts
+++ b/src/cook-web/src/c-utils/markdown-flow-interaction.ts
@@ -1,5 +1,7 @@
 const ANONYMOUS_TEXT_INPUT_PATTERN =
   /^(\s*)\?\[(?!\s*%\{\{)\s*(?:(.*?)(\|\||\|)\s*)?\.\.\.([^\]]*?)\](\s*)$/;
+const ANONYMOUS_INTERACTION_PATTERN =
+  /^(\s*)\?\[(?!\s*%\{\{)\s*([^\]]*?)\s*\](\s*)$/;
 const SINGLE_OPTION_SEPARATOR_PATTERN = /(?<!\|)\|(?!\|)/;
 const BUTTON_VALUE_PATTERN = /^(.+?)\/\/(.+)$/;
 
@@ -16,14 +18,7 @@ const escapeHtmlAttribute = (value: string) =>
 const escapeStringArrayAttribute = (values: string[]) =>
   escapeHtmlAttribute(JSON.stringify(values));
 
-export const adaptMarkdownFlowInteractionForRender = (content: string) => {
-  const match = ANONYMOUS_TEXT_INPUT_PATTERN.exec(content);
-  const prompt = match?.[4]?.trim();
-  if (!match || !prompt) {
-    return content;
-  }
-
-  const optionContent = match[2] ? `${match[2]}${match[3]}`.trim() : '';
+const parseAnonymousOptions = (optionContent: string) => {
   const firstSeparatorIndex = optionContent.indexOf('|');
   const firstMultiSeparatorIndex = optionContent.indexOf('||');
   const isMultiSelect =
@@ -38,12 +33,6 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
         .map(option => option.trim())
         .filter(Boolean)
     : [];
-  if (!options.length) {
-    return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
-      prompt,
-    )}"></custom-variable>${match[5]}`;
-  }
-
   const parsedOptions = options.map(option => {
     const valueMatch = BUTTON_VALUE_PATTERN.exec(option);
     return {
@@ -51,16 +40,84 @@ export const adaptMarkdownFlowInteractionForRender = (content: string) => {
       value: valueMatch?.[2]?.trim() || option,
     };
   });
-  const optionTexts = escapeStringArrayAttribute(
-    parsedOptions.map(option => option.text),
-  );
-  const optionValues = escapeStringArrayAttribute(
-    parsedOptions.map(option => option.value),
-  );
-  const multiSelectAttribute = isMultiSelect
-    ? ' data-is-multi-select="true"'
-    : '';
-  return `${match[1]}<custom-variable placeholder="${escapeHtmlAttribute(
-    prompt,
-  )}" data-button-texts="${optionTexts}" data-button-values="${optionValues}"${multiSelectAttribute}></custom-variable>${match[5]}`;
+
+  return { isMultiSelect, parsedOptions };
+};
+
+const renderAnonymousInteraction = ({
+  leadingWhitespace,
+  trailingWhitespace,
+  prompt,
+  isMultiSelect,
+  parsedOptions,
+}: {
+  leadingWhitespace: string;
+  trailingWhitespace: string;
+  prompt?: string;
+  isMultiSelect: boolean;
+  parsedOptions: Array<{ text: string; value: string }>;
+}) => {
+  const attributes: string[] = [];
+
+  if (prompt) {
+    attributes.push(`placeholder="${escapeHtmlAttribute(prompt)}"`);
+  }
+  if (parsedOptions.length) {
+    attributes.push(
+      `data-button-texts="${escapeStringArrayAttribute(
+        parsedOptions.map(option => option.text),
+      )}"`,
+      `data-button-values="${escapeStringArrayAttribute(
+        parsedOptions.map(option => option.value),
+      )}"`,
+    );
+  }
+  if (isMultiSelect) {
+    attributes.push('data-is-multi-select="true"');
+  }
+
+  return `${leadingWhitespace}<custom-variable${
+    attributes.length ? ` ${attributes.join(' ')}` : ''
+  }></custom-variable>${trailingWhitespace}`;
+};
+
+export const adaptMarkdownFlowInteractionForRender = (content: string) => {
+  const textInputMatch = ANONYMOUS_TEXT_INPUT_PATTERN.exec(content);
+  if (textInputMatch) {
+    const prompt = textInputMatch[4]?.trim();
+    if (!prompt) {
+      return content;
+    }
+
+    const optionContent = textInputMatch[2]
+      ? `${textInputMatch[2]}${textInputMatch[3]}`.trim()
+      : '';
+    const { isMultiSelect, parsedOptions } =
+      parseAnonymousOptions(optionContent);
+    return renderAnonymousInteraction({
+      leadingWhitespace: textInputMatch[1],
+      trailingWhitespace: textInputMatch[5],
+      prompt,
+      isMultiSelect,
+      parsedOptions,
+    });
+  }
+
+  const interactionMatch = ANONYMOUS_INTERACTION_PATTERN.exec(content);
+  if (!interactionMatch) {
+    return content;
+  }
+
+  const optionContent = interactionMatch[2].trim();
+  const { isMultiSelect, parsedOptions } = parseAnonymousOptions(optionContent);
+  if (!isMultiSelect || !parsedOptions.length) {
+    return content;
+  }
+
+  return renderAnonymousInteraction({
+    leadingWhitespace: interactionMatch[1],
+    trailingWhitespace: interactionMatch[3],
+    isMultiSelect,
+    parsedOptions,
+  });
 };


### PR DESCRIPTION
## Summary

- Adapt variable-free MarkdownFlow interactions whose first separator is `||` into the multi-select rendering contract.
- Preserve existing single-select, variable-bound, custom-value, and mixed text-input behavior.
- Add regression coverage for the reported four-option interaction.

## Root cause

`remark-flow` parses variable-free interactions as non-assignment buttons and drops the detected multi-select flag. The renderer therefore showed each option as an immediate-submit button even when the author used `||`.

## User impact

Learners can select multiple anonymous options and confirm them together. The existing `selectedValues` to `user_input` path continues to preserve their choices without creating a course variable.

## Validation

- `npm test -- --runInBand src/__tests__/markdown-flow-interaction.test.tsx src/__tests__/content-block-pay-interaction.test.tsx src/__tests__/interaction-user-input.test.ts` — 32 tests passed
- `npm test -- --runInBand --runTestsByPath 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx'` — 26 tests passed
- `npm run type-check`
- `npm run lint` — passed with existing repository warnings
- Focused lefthook pre-commit and commit-message hooks — passed
- `lefthook run pre-commit --all-files` — all checks except the unrelated existing UoW baseline ratchet passed; `flaskr/service/shifu/repair.py` already has fewer commit sites than the committed baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for anonymous multi-select interactions without a prompt.
  * Improved parsing of multi-select options using spaced `|` and `||` delimiters.
  * Preserved the original content for unsupported or invalid interaction formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->