### PR TITLE
chore: bump LiteLLM to 1.84.8

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -66,7 +66,7 @@ mistune==3.2.1
 mpmath==1.3.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
-litellm==1.84.0
+litellm==1.84.8
 openpyxl==3.1.5
 opentelemetry-api==1.36.0
 opentelemetry-exporter-otlp-proto-http==1.36.0


### PR DESCRIPTION
## Summary

- Pin the backend `litellm` dependency from `1.84.0` to exactly `1.84.8`.

## Impact

- Backend installations use the requested LiteLLM patch release while keeping dependency resolution reproducible.
- The LiteLLM APIs used by the shared wrapper remain available.

## Validation

- `python3 scripts/check_dev_tools.py`
- `git diff --check`
- LLM/OpenAI tests against LiteLLM 1.84.8: `20 passed`
- Lefthook pre-commit and commit-message checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying AI integration dependency to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->