### PR TITLE
feat: upgrade markdown-flow-ui to 0.2.4

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.3",
+        "markdown-flow-ui": "0.2.4",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13549,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.3.tgz",
-      "integrity": "sha512-Mp0j3V3Bg+UaAqBmKU6HG2i62PgXYOl28v2zoGW6oP1XMc+byyKMi2Dy2DlgRIqHr2eXdLQRpxyTb7Ct1dJ+XQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.4.tgz",
+      "integrity": "sha512-b4luy8ev7gAF6zcZqnngRWXtCVCp+EtPKNU2bNXmXa5tAfqSpRvoLtbO8iJkt4kmyi80191lKPdOJI6GHLhccw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.3",
+    "markdown-flow-ui": "0.2.4",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Changed:
- bumped `markdown-flow-ui` from `0.2.3` to `0.2.4` in `src/cook-web/package.json`
- refreshed `src/cook-web/package-lock.json` to install the published 0.2.4 package
- package `0.2.4` includes the draggable interaction overlay reopen changes from markdown-flow-ui PR #202 and the follow-up pointer drag tests

Benefit:
- ai-shifu can verify and ship the draggable interaction overlay behavior against the published package version
- downstream installs now use the tested package instead of a local tarball or branch-only code
