### PR TITLE
feat: upgrade markdown-flow-ui to 0.2.5

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.4",
+        "markdown-flow-ui": "0.2.5",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13549,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.4.tgz",
-      "integrity": "sha512-b4luy8ev7gAF6zcZqnngRWXtCVCp+EtPKNU2bNXmXa5tAfqSpRvoLtbO8iJkt4kmyi80191lKPdOJI6GHLhccw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.5.tgz",
+      "integrity": "sha512-1hNUddxxMO+YRu50kZ3R0By0mUCj/Z3DzO/peeqBi+cv808Xevhs7n4spgFTQX/tHuZ+gyDGoSjJojnf+RM+AA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.4",
+    "markdown-flow-ui": "0.2.5",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## What
- bump `src/cook-web` from `markdown-flow-ui@0.2.4` to `markdown-flow-ui@0.2.5`
- refresh `src/cook-web/package-lock.json` to the published npm package

## Why
- bring in the latest interaction overlay drag-area fix from `markdown-flow-ui`

## Verification
- `npm install markdown-flow-ui@0.2.5 --save-exact`
- `python scripts/check_dev_tools.py` *(fails locally because required pre-commit tools like `ruff` and `pre-commit-hooks` are not installed in this environment)*
- `branch_context_manager.py pre-pr-review` *(reports `pre-commit run -a` failure for the same missing local tooling, while `cd src/cook-web && npm run lint` passes)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown Flow UI component library to version 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->