### PR TITLE
fix: clarify billing rate source labels

### DIFF
--- a/src/i18n/en-US/modules/operations-config.json
+++ b/src/i18n/en-US/modules/operations-config.json
@@ -44,8 +44,8 @@
   "saveFailed": "Failed to save config. Please check the form.",
   "saveSuccess": "Config saved",
   "source": {
-    "default": "Default credit consumption multiplier",
-    "exact": "Custom credit consumption multiplier",
+    "default": "System default multiplier",
+    "exact": "Dedicated multiplier",
     "unconfigured": "Not configured"
   },
   "tabs": {

--- a/src/i18n/fr-FR/modules/operations-config.json
+++ b/src/i18n/fr-FR/modules/operations-config.json
@@ -44,8 +44,8 @@
   "saveFailed": "Échec de l’enregistrement. Veuillez vérifier le formulaire.",
   "saveSuccess": "Configuration enregistrée",
   "source": {
-    "default": "Multiplicateur de consommation par défaut",
-    "exact": "Multiplicateur de consommation personnalisé",
+    "default": "Multiplicateur par défaut du système",
+    "exact": "Multiplicateur dédié",
     "unconfigured": "Non configuré"
   },
   "tabs": {

--- a/src/i18n/zh-CN/modules/operations-config.json
+++ b/src/i18n/zh-CN/modules/operations-config.json
@@ -44,8 +44,8 @@
   "saveFailed": "配置保存失败，请检查填写内容。",
   "saveSuccess": "配置已保存",
   "source": {
-    "default": "使用默认消耗倍率",
-    "exact": "已单独调整",
+    "default": "系统默认倍率",
+    "exact": "专属倍率",
     "unconfigured": "未配置"
   },
   "tabs": {


### PR DESCRIPTION
## Summary
- update the billing rate source labels in operations config
- change the Chinese copy to `专属倍率` / `系统默认倍率`
- align the English and French labels to the same meaning

## Verification
- reviewed the three i18n files for zh-CN / en-US / fr-FR
- branch context self-review still reports `pre-commit run -a` unavailable in the local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated credit multiplier labels in English, French, and Chinese for clearer, more consistent wording.
  * Clarified the distinction between system-default and dedicated multipliers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->