### PR TITLE
fix: fill printable width in every lesson PDF layout

### DIFF
--- a/src/cook-web/e2e/lesson-pdf-print.spec.ts
+++ b/src/cook-web/e2e/lesson-pdf-print.spec.ts
@@ -1,0 +1,102 @@
+import { expect, Page, test } from '@playwright/test';
+
+type PrintLayoutMetrics = {
+  pageWidth: number;
+  sections: Array<{
+    maxWidth: string;
+    width: number;
+  }>;
+  snapshotMaxWidth: string;
+};
+
+const readPrintLayoutMetrics = (page: Page) =>
+  page.evaluate<PrintLayoutMetrics>(() => {
+    const printPage = document.querySelector<HTMLElement>(
+      '[data-lesson-print-scroll="true"] > [data-lesson-print-page="true"]',
+    );
+    const sections = Array.from(
+      printPage?.querySelectorAll<HTMLElement>(
+        ':scope > [data-print-section="true"]',
+      ) ?? [],
+    );
+    const snapshot = printPage?.querySelector<HTMLElement>(
+      '[data-lesson-print-iframe-snapshot="true"]',
+    );
+
+    if (!printPage || !snapshot) {
+      throw new Error('Lesson PDF print fixture is incomplete');
+    }
+
+    return {
+      pageWidth: printPage.getBoundingClientRect().width,
+      sections: sections.map(section => ({
+        maxWidth: getComputedStyle(section).maxWidth,
+        width: section.getBoundingClientRect().width,
+      })),
+      snapshotMaxWidth: getComputedStyle(snapshot).maxWidth,
+    };
+  });
+
+test('lesson PDF sections use the printable width only in landscape', async ({
+  page,
+}) => {
+  await page.goto('/login');
+  await page.evaluate(() => {
+    const fixture = document.createElement('main');
+    fixture.dataset.lessonPrintPage = 'true';
+    fixture.innerHTML = `
+      <section data-lesson-print-scroll="true">
+        <div data-lesson-print-page="true">
+          <header data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
+            Course header
+          </header>
+          <article data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
+            Lesson content
+            <div data-lesson-print-iframe-snapshot="true">Embedded lesson</div>
+          </article>
+          <footer data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
+            Course QR footer
+          </footer>
+        </div>
+      </section>
+    `;
+    document.body.append(fixture);
+  });
+  await page.emulateMedia({ media: 'print' });
+  await page.evaluate(() =>
+    document.documentElement.classList.add('lesson-pdf-print'),
+  );
+
+  await page.setViewportSize({ width: 1200, height: 1600 });
+  await expect
+    .poll(() =>
+      page.evaluate(() => matchMedia('(orientation: portrait)').matches),
+    )
+    .toBe(true);
+  const portrait = await readPrintLayoutMetrics(page);
+
+  expect(portrait.pageWidth).toBeGreaterThan(1000);
+  expect(portrait.sections).toHaveLength(3);
+  expect(portrait.snapshotMaxWidth).toBe('100%');
+  for (const section of portrait.sections) {
+    expect(section.maxWidth).toBe('1000px');
+    expect(section.width).toBeCloseTo(1000, 0);
+    expect(section.width).toBeLessThan(portrait.pageWidth);
+  }
+
+  await page.setViewportSize({ width: 1600, height: 1200 });
+  await expect
+    .poll(() =>
+      page.evaluate(() => matchMedia('(orientation: landscape)').matches),
+    )
+    .toBe(true);
+  const landscape = await readPrintLayoutMetrics(page);
+
+  expect(landscape.pageWidth).toBeGreaterThan(1000);
+  expect(landscape.sections).toHaveLength(3);
+  expect(landscape.snapshotMaxWidth).toBe('100%');
+  for (const section of landscape.sections) {
+    expect(section.maxWidth).toBe('none');
+    expect(section.width).toBeCloseTo(landscape.pageWidth, 0);
+  }
+});

--- a/src/cook-web/e2e/lesson-pdf-print.spec.ts
+++ b/src/cook-web/e2e/lesson-pdf-print.spec.ts
@@ -23,7 +23,7 @@ type PrintLayoutMetrics = {
 const readPrintLayoutMetrics = (page: Page) =>
   page.evaluate<PrintLayoutMetrics>(() => {
     const printPage = document.querySelector<HTMLElement>(
-      '[data-lesson-print-scroll="true"] > [data-lesson-print-page="true"]',
+      '[data-lesson-print-scroll="true"] > [data-lesson-print-content-page="true"]',
     );
     const sections = Array.from(
       printPage?.querySelectorAll<HTMLElement>(
@@ -107,7 +107,7 @@ test('lesson PDF uses the printable width in every orientation', async ({
     fixture.dataset.lessonPrintPage = 'true';
     fixture.innerHTML = `
       <section data-lesson-print-scroll="true">
-        <div data-lesson-print-page="true">
+        <div data-lesson-print-content-page="true">
           <header data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
             Course header
           </header>

--- a/src/cook-web/e2e/lesson-pdf-print.spec.ts
+++ b/src/cook-web/e2e/lesson-pdf-print.spec.ts
@@ -7,6 +7,17 @@ type PrintLayoutMetrics = {
     width: number;
   }>;
   snapshotMaxWidth: string;
+  snapshotWidth: number;
+  snapshotHeight: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  stageWidth: number;
+  stageHeight: number;
+  stageZoom: number;
+  probeWidth: number;
+  probeHeight: number;
+  probeRightGap: number;
+  probeBottomGap: number;
 };
 
 const readPrintLayoutMetrics = (page: Page) =>
@@ -22,10 +33,20 @@ const readPrintLayoutMetrics = (page: Page) =>
     const snapshot = printPage?.querySelector<HTMLElement>(
       '[data-lesson-print-iframe-snapshot="true"]',
     );
+    const stage = snapshot?.shadowRoot?.querySelector<HTMLElement>(
+      '[data-lesson-print-iframe-stage="true"]',
+    );
+    const probe = stage?.querySelector<HTMLElement>(
+      '[data-print-scale-probe="true"]',
+    );
 
-    if (!printPage || !snapshot) {
+    if (!printPage || !snapshot || !stage || !probe) {
       throw new Error('Lesson PDF print fixture is incomplete');
     }
+
+    const snapshotRect = snapshot.getBoundingClientRect();
+    const stageRect = stage.getBoundingClientRect();
+    const probeRect = probe.getBoundingClientRect();
 
     return {
       pageWidth: printPage.getBoundingClientRect().width,
@@ -34,10 +55,50 @@ const readPrintLayoutMetrics = (page: Page) =>
         width: section.getBoundingClientRect().width,
       })),
       snapshotMaxWidth: getComputedStyle(snapshot).maxWidth,
+      snapshotWidth: snapshotRect.width,
+      snapshotHeight: snapshotRect.height,
+      sourceWidth: Number.parseFloat(
+        snapshot.style.getPropertyValue('--lesson-print-iframe-source-width'),
+      ),
+      sourceHeight: Number.parseFloat(
+        snapshot.style.getPropertyValue('--lesson-print-iframe-source-height'),
+      ),
+      stageWidth: stageRect.width,
+      stageHeight: stageRect.height,
+      stageZoom: Number.parseFloat(getComputedStyle(stage).zoom),
+      probeWidth: probeRect.width,
+      probeHeight: probeRect.height,
+      probeRightGap: stageRect.right - probeRect.right,
+      probeBottomGap: stageRect.bottom - probeRect.bottom,
     };
   });
 
-test('lesson PDF sections use the printable width only in landscape', async ({
+const expectPrintableWidthLayout = (metrics: PrintLayoutMetrics) => {
+  expect(metrics.sections).toHaveLength(3);
+  expect(metrics.snapshotMaxWidth).toBe('100%');
+  for (const section of metrics.sections) {
+    expect(section.maxWidth).toBe('none');
+    expect(section.width).toBeCloseTo(metrics.pageWidth, 0);
+  }
+
+  const expectedSnapshotWidth = metrics.sections[1].width - 40;
+  const expectedScale = expectedSnapshotWidth / metrics.sourceWidth;
+
+  expect(metrics.snapshotWidth).toBeCloseTo(expectedSnapshotWidth, 0);
+  expect(metrics.stageWidth).toBeCloseTo(metrics.snapshotWidth, 0);
+  expect(metrics.stageHeight).toBeCloseTo(
+    metrics.sourceHeight * expectedScale,
+    0,
+  );
+  expect(metrics.snapshotHeight).toBeCloseTo(metrics.stageHeight, 0);
+  expect(metrics.stageZoom).toBeCloseTo(expectedScale, 3);
+  expect(metrics.probeWidth).toBeCloseTo(120 * expectedScale, 0);
+  expect(metrics.probeHeight).toBeCloseTo(60 * expectedScale, 0);
+  expect(metrics.probeRightGap).toBeCloseTo(0, 0);
+  expect(metrics.probeBottomGap).toBeCloseTo(0, 0);
+};
+
+test('lesson PDF uses the printable width in every orientation', async ({
   page,
 }) => {
   await page.goto('/login');
@@ -52,7 +113,10 @@ test('lesson PDF sections use the printable width only in landscape', async ({
           </header>
           <article data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
             Lesson content
-            <div data-lesson-print-iframe-snapshot="true">Embedded lesson</div>
+            <div
+              data-lesson-print-iframe-snapshot="true"
+              style="--lesson-print-iframe-source-width: 960px; --lesson-print-iframe-source-height: 540px;"
+            ></div>
           </article>
           <footer data-print-section="true" style="box-sizing: border-box; margin: 0 auto; max-width: 1000px; padding: 0 20px;">
             Course QR footer
@@ -61,11 +125,61 @@ test('lesson PDF sections use the printable width only in landscape', async ({
       </section>
     `;
     document.body.append(fixture);
+
+    const snapshot = fixture.querySelector<HTMLElement>(
+      '[data-lesson-print-iframe-snapshot="true"]',
+    );
+    if (!snapshot) {
+      throw new Error('Lesson PDF snapshot fixture is missing');
+    }
+
+    const shadowRoot = snapshot.attachShadow({ mode: 'open' });
+    const snapshotStyles = document.createElement('style');
+    snapshotStyles.textContent = `
+      :host {
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        container-type: inline-size;
+      }
+      [data-lesson-print-iframe-stage='true'] {
+        position: relative;
+        width: var(--lesson-print-iframe-source-width);
+        height: var(--lesson-print-iframe-source-height);
+        overflow: hidden;
+        zoom: calc(100cqw / var(--lesson-print-iframe-source-width));
+      }
+      [data-print-scale-probe='true'] {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        width: 120px;
+        height: 60px;
+      }
+    `;
+    const stage = document.createElement('div');
+    stage.setAttribute('data-lesson-print-iframe-stage', 'true');
+    const probe = document.createElement('div');
+    probe.setAttribute('data-print-scale-probe', 'true');
+    stage.appendChild(probe);
+    shadowRoot.append(snapshotStyles, stage);
   });
   await page.emulateMedia({ media: 'print' });
   await page.evaluate(() =>
     document.documentElement.classList.add('lesson-pdf-print'),
   );
+
+  await page.setViewportSize({ width: 800, height: 1200 });
+  await expect
+    .poll(() =>
+      page.evaluate(() => matchMedia('(orientation: portrait)').matches),
+    )
+    .toBe(true);
+  const narrowPortrait = await readPrintLayoutMetrics(page);
+
+  expect(narrowPortrait.pageWidth).toBeLessThan(1000);
+  expect(narrowPortrait.stageZoom).toBeLessThan(1);
+  expectPrintableWidthLayout(narrowPortrait);
 
   await page.setViewportSize({ width: 1200, height: 1600 });
   await expect
@@ -76,13 +190,8 @@ test('lesson PDF sections use the printable width only in landscape', async ({
   const portrait = await readPrintLayoutMetrics(page);
 
   expect(portrait.pageWidth).toBeGreaterThan(1000);
-  expect(portrait.sections).toHaveLength(3);
-  expect(portrait.snapshotMaxWidth).toBe('100%');
-  for (const section of portrait.sections) {
-    expect(section.maxWidth).toBe('1000px');
-    expect(section.width).toBeCloseTo(1000, 0);
-    expect(section.width).toBeLessThan(portrait.pageWidth);
-  }
+  expect(portrait.stageZoom).toBeGreaterThan(1);
+  expectPrintableWidthLayout(portrait);
 
   await page.setViewportSize({ width: 1600, height: 1200 });
   await expect
@@ -93,10 +202,6 @@ test('lesson PDF sections use the printable width only in landscape', async ({
   const landscape = await readPrintLayoutMetrics(page);
 
   expect(landscape.pageWidth).toBeGreaterThan(1000);
-  expect(landscape.sections).toHaveLength(3);
-  expect(landscape.snapshotMaxWidth).toBe('100%');
-  for (const section of landscape.sections) {
-    expect(section.maxWidth).toBe('none');
-    expect(section.width).toBeCloseTo(landscape.pageWidth, 0);
-  }
+  expect(landscape.stageZoom).toBeGreaterThan(portrait.stageZoom);
+  expectPrintableWidthLayout(landscape);
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -510,7 +510,7 @@ describe('NewChatComponents', () => {
       },
     ]);
     const printPage = container.querySelector<HTMLElement>(
-      '[data-lesson-print-scroll="true"] > [data-lesson-print-page="true"]',
+      '[data-lesson-print-scroll="true"] > [data-lesson-print-content-page="true"]',
     );
     const printHeader = container
       .querySelector('[data-lesson-print-course-name="true"]')

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -220,8 +220,10 @@ jest.mock(
 jest.mock(
   './ContentBlock',
   () =>
-    function MockContentBlock() {
-      return <div />;
+    function MockContentBlock({ item }: { item: { element_bid?: string } }) {
+      return (
+        <div data-testid={`content-block-${item.element_bid || 'item'}`} />
+      );
     },
 );
 jest.mock(
@@ -282,13 +284,14 @@ jest.mock('@/components/audio/AudioPlayer', () => ({
 const renderNewChatComponents = (
   onLessonUpdateNoticeVisibilityChange = jest.fn(),
   onLessonPdfActionChange = jest.fn(),
+  items: Array<Record<string, unknown>> = [],
 ) => {
   mockUseChatLogicHook.mockReturnValue({
     currentStreamingElementBid: '',
     currentTypewriterElementBid: '',
     isLoading: false,
     isOutputInProgress: false,
-    items: [],
+    items,
     lessonFeedbackPopup: {
       defaultCommentText: '',
       defaultScoreText: '',
@@ -482,6 +485,59 @@ describe('NewChatComponents', () => {
       '扫码进入课程，获得一对一讲解与答疑',
     );
     expect(footer.nextElementSibling).toHaveAttribute('id', 'chat-box-bottom');
+  });
+
+  it('groups printable lesson sections under the print page width scope', async () => {
+    mockLearningMode = 'read';
+
+    const { container } = renderNewChatComponents(jest.fn(), jest.fn(), [
+      {
+        content: '课时正文',
+        element_bid: 'content-1',
+        type: 'content',
+      },
+      {
+        ask_list: [],
+        element_bid: 'ask-1',
+        isAskExpanded: true,
+        parent_element_bid: 'content-1',
+        type: 'ask',
+      },
+      {
+        content: '?[选择答案](answer)',
+        element_bid: 'interaction-1',
+        type: 'interaction',
+      },
+    ]);
+    const printPage = container.querySelector<HTMLElement>(
+      '[data-lesson-print-scroll="true"] > [data-lesson-print-page="true"]',
+    );
+    const printHeader = container
+      .querySelector('[data-lesson-print-course-name="true"]')
+      ?.closest('header');
+    const lessonContent = screen.getByTestId('content-block-content-1');
+    const followUp = container.querySelector<HTMLElement>(
+      '[data-lesson-print-follow-up="true"]',
+    );
+    const interaction = container.querySelector<HTMLElement>(
+      '[data-lesson-print-interaction="true"]',
+    );
+    const footer = await waitFor(() => {
+      const element = container.querySelector<HTMLElement>(
+        '[data-lesson-print-course-qr="true"]',
+      );
+      expect(element).toBeInTheDocument();
+      return element as HTMLElement;
+    });
+
+    expect(printPage).toContainElement(printHeader as HTMLElement);
+    expect(printHeader?.parentElement).toBe(printPage);
+    expect(printPage).toContainElement(lessonContent);
+    expect(lessonContent.parentElement?.parentElement).toBe(printPage);
+    expect(followUp?.parentElement).toBe(printPage);
+    expect(interaction?.parentElement).toBe(printPage);
+    expect(printPage).toContainElement(footer);
+    expect(footer.parentElement).toBe(printPage);
   });
 
   it('includes the course avatar, site brand, and official link in the print header', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -1376,7 +1376,7 @@ export const NewChatComponents = ({
           aria-hidden={isSlideMode ? 'true' : undefined}
           style={{ width: '100%', height: '100%', overflowY: 'auto' }}
         >
-          <div>
+          <div data-lesson-print-page='true'>
             <header
               data-lesson-print-only='true'
               className='lesson-pdf-print-header mx-auto max-w-[1000px] border-b border-border px-5 pb-5'

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -1376,7 +1376,7 @@ export const NewChatComponents = ({
           aria-hidden={isSlideMode ? 'true' : undefined}
           style={{ width: '100%', height: '100%', overflowY: 'auto' }}
         >
-          <div data-lesson-print-page='true'>
+          <div data-lesson-print-content-page='true'>
             <header
               data-lesson-print-only='true'
               className='lesson-pdf-print-header mx-auto max-w-[1000px] border-b border-border px-5 pb-5'

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useLessonPdfPrint.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useLessonPdfPrint.test.tsx
@@ -1231,7 +1231,7 @@ describe('useLessonPdfPrint', () => {
       }),
     );
     expect((snapshotLayoutDuringPrint as { styles: string }).styles).toContain(
-      'calc(100cqw / var(--lesson-print-iframe-source-width))',
+      'zoom: calc(100cqw / var(--lesson-print-iframe-source-width))',
     );
     expect(onError).not.toHaveBeenCalled();
     expect(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useLessonPdfPrint.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useLessonPdfPrint.ts
@@ -556,10 +556,7 @@ const PRINT_SNAPSHOT_STYLES = `
     width: var(${IFRAME_PRINT_SOURCE_WIDTH_PROPERTY});
     height: var(${IFRAME_PRINT_SOURCE_HEIGHT_PROPERTY});
     overflow: hidden;
-    zoom: min(
-      1,
-      calc(100cqw / var(${IFRAME_PRINT_SOURCE_WIDTH_PROPERTY}))
-    );
+    zoom: calc(100cqw / var(${IFRAME_PRINT_SOURCE_WIDTH_PROPERTY}));
   }
 `;
 
@@ -896,12 +893,11 @@ const copyComputedStyleTree = (
     ...Array.from(targetRoot.querySelectorAll('*')),
   ];
   if (sourceElements.length !== targetElements.length) {
-    return false;
+    return;
   }
   sourceElements.forEach((sourceElement, index) => {
     copyComputedStyle(sourceElement, targetElements[index], sourceWindow);
   });
-  return true;
 };
 
 const hideSnapshotOnlyControls = (snapshotRoot: HTMLElement) => {
@@ -989,11 +985,7 @@ const createIframePrintSnapshots = (
         iframeWindow,
       );
       copyComputedStyle(iframeDocument.body, snapshotBody, iframeWindow);
-      const didFreezeRootLayout = copyComputedStyleTree(
-        iframeRoot,
-        snapshotRoot,
-        iframeWindow,
-      );
+      copyComputedStyleTree(iframeRoot, snapshotRoot, iframeWindow);
       neutralizeSnapshotMarkup(snapshotHtml);
       trackSnapshotIframeLoads(snapshotRoot);
       hideSnapshotOnlyControls(snapshotRoot);
@@ -1002,7 +994,6 @@ const createIframePrintSnapshots = (
       const sourceWidth = iframe.clientWidth || iframeRect.width;
       const sourceHeight = iframe.clientHeight || iframeRect.height;
       if (
-        didFreezeRootLayout &&
         Number.isFinite(sourceWidth) &&
         Number.isFinite(sourceHeight) &&
         sourceWidth > 0 &&

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -328,6 +328,13 @@ body.listen-mode-vh-fallback #root {
     overflow: visible !important;
   }
 
+  html.lesson-pdf-print
+    [data-lesson-print-scroll='true']
+    > [data-lesson-print-page='true']
+    > :not([data-lesson-print-exclude='true']) {
+    max-width: none !important;
+  }
+
   html.lesson-pdf-print [data-lesson-print-only='true'] {
     display: block !important;
   }
@@ -506,14 +513,5 @@ body.listen-mode-vh-fallback #root {
 
   html.lesson-pdf-print [data-lesson-print-scroll] :is(iframe, table) {
     max-width: 100% !important;
-  }
-}
-
-@media print and (orientation: landscape) {
-  html.lesson-pdf-print
-    [data-lesson-print-scroll='true']
-    > [data-lesson-print-page='true']
-    > :not([data-lesson-print-exclude='true']) {
-    max-width: none !important;
   }
 }

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -330,7 +330,7 @@ body.listen-mode-vh-fallback #root {
 
   html.lesson-pdf-print
     [data-lesson-print-scroll='true']
-    > [data-lesson-print-page='true']
+    > [data-lesson-print-content-page='true']
     > :not([data-lesson-print-exclude='true']) {
     max-width: none !important;
   }

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -508,3 +508,12 @@ body.listen-mode-vh-fallback #root {
     max-width: 100% !important;
   }
 }
+
+@media print and (orientation: landscape) {
+  html.lesson-pdf-print
+    [data-lesson-print-scroll='true']
+    > [data-lesson-print-page='true']
+    > :not([data-lesson-print-exclude='true']) {
+    max-width: none !important;
+  }
+}


### PR DESCRIPTION
## Root cause

Lesson PDF output retained two reading-mode width limits:

- Direct printable sections kept a `1000px` maximum width on larger paper.
- Sandboxed HTML snapshots used `zoom: min(1, ...)`, so they could shrink but never expand to a wider print host.

Together these limits left excessive application-level whitespace in landscape output and on larger portrait paper.

## Changes

- Removed the direct-section maximum width whenever the dedicated lesson PDF print mode is active, independent of paper orientation.
- Kept each HTML snapshot frozen at its source viewport, then scaled its stage proportionally to the complete print host width in either direction.
- Kept the outer lesson-page accessibility marker separate from the inner printable-content width marker.
- Kept the behavior scoped to lesson PDF preparation; normal reading layouts and ordinary browser printing are unchanged.
- Expanded the print-media browser regression to cover narrow portrait, wide portrait, and landscape geometry, including Shadow DOM stage and edge-probe measurements.

## Impact

Lesson headers, content, embedded HTML slides, and QR footers now use the available printable width on larger portrait and landscape pages. Existing printer safety margins and the `20px` lesson content padding remain in place. The change does not add `@page`, force an orientation, or modify the native `window.print()` flow.

## Checks

- Focused Jest suites: 3 suites, 25 tests passed.
- Playwright print-media regression: 1 test passed with system Chrome.
- TypeScript type-check passed.
- Targeted ESLint passed with no warnings or errors; full frontend lint completed with existing repository warnings only.
- Prettier, `git diff --check`, and the repository-wide lefthook gate passed.
- Generated and inspected A4 portrait at 100%, A3 portrait at 70%, A4 landscape at 70%, and A3 landscape at 100% with `pdfinfo` and `pdftoppm`.
- Long text, tables, responsive images, SVG/Mermaid-style diagrams, embedded HTML snapshots, and the QR footer remained inside the printable area without clipping or horizontal overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced lesson PDF print layout to use the full printable width consistently across portrait and landscape while preserving correct section behavior.

* **Bug Fixes**
  * Ensured lesson print content (content, follow-ups, interactions, print header, and QR footer) remains scoped to the same printable-width page area.
  * Updated print snapshot scaling to use the intended zoom calculation for more accurate sizing across orientations.

* **Tests**
  * Strengthened unit/E2E assertions to verify printable-width layout and scaling metrics in multiple orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
