### PR TITLE
fix: restrict owner course card actions to published courses

### DIFF
--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -91,6 +91,7 @@ class ShifuDto(BaseModel):
             "name": self.name,
             "description": self.description,
             "avatar": self.avatar,
+            "state": self.state,
             "is_favorite": self.is_favorite,
             "archived": self.archived,
             "can_manage_archive": self.can_manage_archive,

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -777,13 +777,12 @@ def get_shifu_draft_list(
                 draft for draft in shifu_drafts if draft.shifu_bid in favorite_ids
             ]
 
-        archive_map = _get_user_archive_map(
-            app, user_id, [draft.shifu_bid for draft in shifu_drafts]
-        )
+        current_shifu_bids = [draft.shifu_bid for draft in shifu_drafts]
+        archive_map = _get_user_archive_map(app, user_id, current_shifu_bids)
         published_bid_rows = (
             db.session.query(PublishedShifu.shifu_bid)
             .filter(
-                PublishedShifu.shifu_bid.in_([draft.shifu_bid for draft in shifu_drafts]),
+                PublishedShifu.shifu_bid.in_(current_shifu_bids),
                 PublishedShifu.deleted == 0,
             )
             .distinct()

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -780,6 +780,18 @@ def get_shifu_draft_list(
         archive_map = _get_user_archive_map(
             app, user_id, [draft.shifu_bid for draft in shifu_drafts]
         )
+        published_bid_rows = (
+            db.session.query(PublishedShifu.shifu_bid)
+            .filter(
+                PublishedShifu.shifu_bid.in_([draft.shifu_bid for draft in shifu_drafts]),
+                PublishedShifu.deleted == 0,
+            )
+            .distinct()
+            .all()
+        )
+        published_bids = {
+            str(row[0]).strip() for row in published_bid_rows if row and row[0]
+        }
 
         def is_archived(draft: DraftShifu) -> bool:
             return bool(archive_map.get(draft.shifu_bid))
@@ -809,7 +821,11 @@ def get_shifu_draft_list(
                 shifu_draft.title,
                 shifu_draft.description,
                 res_url_map.get(shifu_draft.avatar_res_bid, ""),
-                STATUS_DRAFT,
+                (
+                    STATUS_PUBLISHED
+                    if shifu_draft.shifu_bid in published_bids
+                    else STATUS_DRAFT
+                ),
                 bool(is_favorite),
                 is_archived(shifu_draft),
                 can_manage_archive=True,

--- a/src/api/tests/service/shifu/test_dtos.py
+++ b/src/api/tests/service/shifu/test_dtos.py
@@ -1,0 +1,17 @@
+from flaskr.service.shifu.consts import STATUS_PUBLISHED
+from flaskr.service.shifu.dtos import ShifuDto
+
+
+def test_shifu_dto_json_includes_state():
+    dto = ShifuDto(
+        shifu_id="course-1",
+        shifu_name="Course 1",
+        shifu_description="description",
+        shifu_avatar="avatar",
+        shifu_state=STATUS_PUBLISHED,
+        is_favorite=False,
+        archived=False,
+        created_user_bid="owner-1",
+    )
+
+    assert dto.__json__()["state"] == STATUS_PUBLISHED

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -7,9 +7,11 @@ import flaskr.dao as dao
 from flaskr.service.shifu.models import (
     DraftOutlineItem,
     DraftShifu,
+    PublishedShifu,
     PublishedOutlineItem,
 )
 from flaskr.service.shifu.shifu_draft_funcs import get_shifu_draft_list
+from flaskr.service.shifu.consts import STATUS_DRAFT, STATUS_PUBLISHED
 
 
 def _seed_draft(
@@ -246,3 +248,62 @@ def test_get_shifu_draft_list_ignores_published_outline_activity(app):
         "draft-published-outline-reference",
         "draft-published-outline-course",
     ]
+
+
+def test_get_shifu_draft_list_marks_courses_with_published_versions(app):
+    owner_bid = "draft-list-published-state-owner"
+    with app.app_context():
+        PublishedShifu.query.filter(
+            PublishedShifu.shifu_bid == "draft-published-state-course"
+        ).delete(synchronize_session=False)
+        DraftShifu.query.filter(
+            DraftShifu.created_user_bid == owner_bid,
+            DraftShifu.shifu_bid.in_(
+                ["draft-published-state-course", "draft-only-state-course"]
+            ),
+        ).delete(synchronize_session=False)
+
+        _seed_draft(
+            shifu_bid="draft-published-state-course",
+            title="Published Draft",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 10, 10, 0, 0),
+            updated_at=datetime(2026, 5, 11, 10, 0, 0),
+        )
+        _seed_draft(
+            shifu_bid="draft-only-state-course",
+            title="Draft Only",
+            owner_bid=owner_bid,
+            created_at=datetime(2026, 5, 10, 10, 0, 0),
+            updated_at=datetime(2026, 5, 10, 10, 0, 0),
+        )
+        dao.db.session.add(
+            PublishedShifu(
+                shifu_bid="draft-published-state-course",
+                title="Published Draft",
+                description="desc",
+                avatar_res_bid="res",
+                keywords="test",
+                llm="gpt",
+                llm_temperature=Decimal("0"),
+                llm_system_prompt="",
+                price=Decimal("0"),
+                created_user_bid=owner_bid,
+                updated_user_bid=owner_bid,
+            )
+        )
+        dao.db.session.commit()
+
+        result = get_shifu_draft_list(
+            app,
+            owner_bid,
+            page_index=1,
+            page_size=10,
+            is_favorite=False,
+            archived=False,
+            creator_only=True,
+        )
+
+    state_by_bid = {item.bid: item.state for item in result.data[:2]}
+    assert state_by_bid["draft-published-state-course"] == STATUS_PUBLISHED
+    assert state_by_bid["draft-only-state-course"] == STATUS_DRAFT

--- a/src/cook-web/src/app/admin/page.test.tsx
+++ b/src/cook-web/src/app/admin/page.test.tsx
@@ -320,6 +320,7 @@ describe('AdminPage', () => {
           bid: 'course-1',
           name: 'Course 1',
           description: 'Course description',
+          state: 1,
           archived: false,
           avatar: '',
           is_favorite: false,
@@ -408,6 +409,7 @@ describe('AdminPage', () => {
           bid: 'course-shared-1',
           name: 'Shared Course',
           description: 'Shared course description',
+          state: 1,
           archived: false,
           avatar: '',
           is_favorite: false,
@@ -421,6 +423,47 @@ describe('AdminPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Shared Course')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.more',
+      }),
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'module.order.importActivation.action',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'module.order.redemptionCodes.action',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not show import activation or redemption code actions for unpublished owner courses', async () => {
+    mockGetShifuList.mockResolvedValue({
+      items: [
+        {
+          bid: 'course-draft-1',
+          name: 'Draft Course',
+          description: 'Draft course description',
+          state: 0,
+          archived: false,
+          avatar: '',
+          is_favorite: false,
+          created_user_bid: 'user-1',
+          can_manage_permissions: true,
+        },
+      ],
+    });
+
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Draft Course')).toBeInTheDocument();
     });
 
     fireEvent.click(

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -87,6 +87,7 @@ const COURSE_TABS_TRIGGER_CLASS =
 const CREATE_SUCCESS_TOAST_DURATION_MS = 2000;
 const CREATE_SUCCESS_REDIRECT_DELAY_MS = 600;
 const ACTION_DIALOG_RESET_DELAY_MS = 200;
+const SHIFU_STATE_PUBLISHED = 1;
 
 const ShifuCard = ({
   id,
@@ -813,36 +814,42 @@ const ScriptManagementPage = () => {
           />
           <div className='flex-1 overflow-auto'>
             <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-              {shifus.map(shifu => (
-                <ShifuCard
-                  id={shifu.bid + ''}
-                  key={shifu.bid}
-                  image={shifu.avatar}
-                  title={shifu.name || ''}
-                  description={shifu.description || ''}
-                  isFavorite={shifu.is_favorite || false}
-                  archived={Boolean(shifu.archived)}
-                  canManageArchive={canManageArchive(shifu)}
-                  canManagePermissions={canManagePermissions(shifu)}
-                  onArchiveRequest={() => handleArchiveRequest(shifu)}
-                  onPermissionRequest={() => handlePermissionRequest(shifu)}
-                  onImportActivationRequest={
-                    canManageOwnerCourseAction(shifu, currentUserId)
-                      ? () => handleImportActivationRequest(shifu)
-                      : undefined
-                  }
-                  onRedemptionCodeRequest={
-                    canManageOwnerCourseAction(shifu, currentUserId)
-                      ? () => handleRedemptionCodeRequest(shifu)
-                      : undefined
-                  }
-                  onboardingTargetId={
-                    shifu.bid === onboardingStatus?.guide_course.bid
-                      ? guideCourseTargetId
-                      : undefined
-                  }
-                />
-              ))}
+              {shifus.map(shifu => {
+                const canManagePublishedOwnerActions =
+                  canManageOwnerCourseAction(shifu, currentUserId) &&
+                  shifu.state === SHIFU_STATE_PUBLISHED;
+
+                return (
+                  <ShifuCard
+                    id={shifu.bid + ''}
+                    key={shifu.bid}
+                    image={shifu.avatar}
+                    title={shifu.name || ''}
+                    description={shifu.description || ''}
+                    isFavorite={shifu.is_favorite || false}
+                    archived={Boolean(shifu.archived)}
+                    canManageArchive={canManageArchive(shifu)}
+                    canManagePermissions={canManagePermissions(shifu)}
+                    onArchiveRequest={() => handleArchiveRequest(shifu)}
+                    onPermissionRequest={() => handlePermissionRequest(shifu)}
+                    onImportActivationRequest={
+                      canManagePublishedOwnerActions
+                        ? () => handleImportActivationRequest(shifu)
+                        : undefined
+                    }
+                    onRedemptionCodeRequest={
+                      canManagePublishedOwnerActions
+                        ? () => handleRedemptionCodeRequest(shifu)
+                        : undefined
+                    }
+                    onboardingTargetId={
+                      shifu.bid === onboardingStatus?.guide_course.bid
+                        ? guideCourseTargetId
+                        : undefined
+                    }
+                  />
+                );
+              })}
             </div>
             <div
               ref={containerRef}


### PR DESCRIPTION
## What changed
- gate course card `导入开通` and `创建兑换码` actions on owner + published status in the admin course list
- return `state` from the shifu list DTO and derive published state in the draft list when a published version exists
- add frontend and backend regression coverage for the published-state behavior

## Verification
- cd src/cook-web && npm test -- --runInBand src/app/admin/page.test.tsx
- cd src/api && pytest -q tests/service/shifu/test_shifu_draft_list.py tests/service/shifu/test_dtos.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shifu listings now indicate whether each item is published or still a draft.
  * Published-state information is now included when Shifu data is serialized for the application.

* **Bug Fixes**
  * Admin “import activation” and “redemption code” actions are now shown only for published Shifus (in addition to the existing permission check).

* **Tests**
  * Added unit tests to verify serialized published state and to ensure draft items do not render the restricted admin action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->