### PR TITLE
fix: open lesson history in the same window

### DIFF
--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -420,8 +420,6 @@ const Header = ({
                     <TooltipTrigger asChild>
                       <Link
                         href={lessonHistoryUrl || '#'}
-                        target='_blank'
-                        rel='noopener noreferrer'
                         onClick={onLessonHistoryClick}
                         className='inline-flex items-center text-sm font-normal leading-5 text-[rgba(0,0,0,0.45)] transition-colors hover:text-foreground'
                         aria-label={historyTooltip}

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -81,8 +81,6 @@ jest.mock('../header', () => ({
     lessonHistoryUrl ? (
       <a
         href={lessonHistoryUrl}
-        target='_blank'
-        rel='noopener noreferrer'
         title='module.shifu.history.title'
         data-testid='lesson-history-link'
         data-history-updated-at={
@@ -620,7 +618,7 @@ describe('ShifuEdit draft conflict checks', () => {
     }
   });
 
-  test('renders the history entry as a native link for the current lesson', async () => {
+  test('renders the history entry as a same-window link for the current lesson', async () => {
     setLessonNode();
 
     render(<ScriptEditor id='shifu-1' />);
@@ -632,8 +630,8 @@ describe('ShifuEdit draft conflict checks', () => {
     expect(historyLink.getAttribute('href')).toBe(
       '/shifu/shifu-1/history?lessonid=lesson-1',
     );
-    expect(historyLink.getAttribute('target')).toBe('_blank');
-    expect(historyLink.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(historyLink).not.toHaveAttribute('target');
+    expect(historyLink).not.toHaveAttribute('rel');
   });
 
   test('does not use global save time as lesson history timestamp fallback', async () => {
@@ -655,6 +653,7 @@ describe('ShifuEdit draft conflict checks', () => {
     render(<ScriptEditor id='shifu-1' />);
 
     const historyLink = screen.getByTitle('module.shifu.history.title');
+    historyLink.addEventListener('click', event => event.preventDefault());
     historyLink.click();
 
     expect(mockTrackEvent).toHaveBeenCalledWith('creator_lesson_history_click');


### PR DESCRIPTION
## Summary

- open the lesson history page in the current browser tab
- update the editor regression test to assert same-window navigation
- preserve the existing lesson history click tracking

## Root cause

The lesson history link explicitly used `target="_blank"`, which always opened the history page in a new tab.

## Impact

Teachers can move from the editor to a lesson's history without creating an extra browser tab.

## Verification

- `npm test -- --runInBand src/components/shifu-edit/ShifuEdit.test.tsx` (16 tests passed)
- `npm run type-check`
- `npm run lint` (passed with existing repository warnings)
- repository pre-commit and commit-message hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lesson history links now open in the current browser window instead of opening a new tab.
  * Updated lesson history link behavior to prevent unintended navigation during click handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->