### PR TITLE
feat: enlarge classroom interaction controls

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -470,7 +470,7 @@
       border-radius: 12px;
     }
 
-    .single-select-container button {
+    .single-select-container > span:first-child > button {
       min-height: 48px;
       padding: 9px 18px;
       font-size: 21px;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -448,6 +448,7 @@
   .slide-player__interaction-body {
     --mdf-slide-font-size: 24px;
     --mdf-slide-line-height: 36px;
+
     box-sizing: border-box;
     flex: 1 1 auto;
     min-width: 0;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -394,6 +394,162 @@
   --slide-player-notes-arrow-offset: 168px;
 }
 
+.listen-reveal-wrapper--classroom:not(.mobile) {
+  .slide-interaction-overlay {
+    box-sizing: border-box;
+    display: flex;
+    width: min(1080px, calc(100% - 48px));
+    max-height: calc(100% - 48px);
+  }
+
+  .slide-interaction-overlay--with-player {
+    // Classroom mode hides the player, so the overlay does not reserve its height.
+    bottom: 24px;
+  }
+
+  .slide-player__interaction-card {
+    box-sizing: border-box;
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    max-height: 100%;
+    overflow: hidden;
+    border: 2px solid var(--border, #e5e7eb);
+    border-radius: 32px;
+  }
+
+  .slide-player__interaction-drag-handle {
+    top: 15px;
+    height: 48px;
+
+    svg {
+      width: 24px;
+      height: 24px;
+    }
+  }
+
+  .slide-player__interaction-drag-handle-icon {
+    width: 60px;
+    height: 48px;
+  }
+
+  .slide-player__interaction-header {
+    flex: 0 0 auto;
+    padding: 36px 84px 0 36px;
+  }
+
+  .slide-player__interaction-title {
+    font-size: 22px;
+    line-height: 30px;
+  }
+
+  .slide-player__interaction-body {
+    --mdf-slide-font-size: 24px;
+    --mdf-slide-line-height: 36px;
+    box-sizing: border-box;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    max-height: 640px;
+    padding: 0 36px 18px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    .content-render {
+      --content-render-font-size: 24px;
+      --content-render-line-height: 36px;
+    }
+
+    .custom-variable-container {
+      margin-top: 24px;
+      padding: 12px 18px;
+      border-radius: 12px;
+    }
+
+    .single-select-container button {
+      min-height: 48px;
+      padding: 9px 18px;
+      font-size: 21px;
+      line-height: 28px;
+    }
+
+    .multi-select-container {
+      gap: 18px;
+      padding: 6px 0;
+
+      label {
+        font-size: 21px;
+        line-height: 28px;
+
+        > span:first-child > span:last-child {
+          box-sizing: border-box;
+          display: inline-flex;
+          width: 24px;
+          height: 24px;
+          align-items: center;
+          justify-content: center;
+          flex: 0 0 24px;
+
+          svg {
+            width: 18px;
+            height: 18px;
+          }
+        }
+
+        > span:last-child {
+          margin-left: 12px;
+        }
+      }
+
+      > span.block {
+        width: 100%;
+        max-width: 750px;
+      }
+    }
+
+    .multi-select-confirm-button {
+      min-height: 48px;
+      padding: 10px 24px;
+      font-size: 21px;
+      line-height: 28px;
+    }
+
+    .input-container,
+    .multi-select-input-row {
+      width: 100%;
+      max-width: 750px;
+    }
+
+    .input-container,
+    .multi-select-input-row [data-slot='input-group'] {
+      min-height: 48px;
+    }
+
+    .input-container textarea,
+    .multi-select-input-row textarea {
+      min-height: 48px;
+      padding: 6px 18px;
+      font-size: 24px;
+      line-height: 36px;
+    }
+
+    .input-container [data-size='icon-sm'] {
+      width: 48px;
+      min-width: 48px;
+      height: 48px;
+      min-height: 48px;
+
+      img {
+        width: 32px;
+        height: 32px;
+      }
+    }
+  }
+}
+
 .listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)
   .listen-slide-shell
   > .slide-ask-overlay,


### PR DESCRIPTION
## Summary

- enlarge the desktop classroom interaction overlay to a projection-friendly 1080px maximum width
- increase typography, option controls, inputs, confirmation actions, and the drag handle
- keep long interactions inside the slide viewport with a 24px inset and a scrollable body
- preserve the existing drag transform and leave listen mode and mobile layouts unchanged

## Why

The default 760px interaction overlay and 16px content are difficult to read when classroom mode is projected. Classroom mode also hides the player visually, so reserving player space unnecessarily reduced the available overlay height.

## Impact

Classroom interactions are clearer and easier to operate from across a room. This is implemented entirely in AI-Shifu without changing or republishing `markdown-flow-ui`.

## Validation

- focused `ListenModeSlideRenderer.test.tsx`: 26/26 passing
- `npm run type-check`
- `npm run lint` (passes with existing repository warnings)
- `lefthook run pre-commit --all-files --no-stage-fixed`
- Chromium geometry checks at 1280×720 and 1920×1080 using the installed `markdown-flow-ui@0.2.5` markup and CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the classroom listen/reveal interface for larger screens.
  * Added a structured interaction panel with clearer spacing, typography, borders, and scrolling behavior.
  * Enhanced sizing and layout for prompts, single- and multi-select controls, text inputs, and text areas.
  * Adjusted overlay/player spacing and positioning to better fit when the audio player is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->