### PR TITLE
chore: bump markdown-flow-ui to 0.2.6

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.5",
+        "markdown-flow-ui": "0.2.6",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13549,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.5.tgz",
-      "integrity": "sha512-1hNUddxxMO+YRu50kZ3R0By0mUCj/Z3DzO/peeqBi+cv808Xevhs7n4spgFTQX/tHuZ+gyDGoSjJojnf+RM+AA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.6.tgz",
+      "integrity": "sha512-k0pFgQ+41Bf9XyTu1AHEwjC0iWUvjV0ng4mc78RHwhr/z1Nook/TRFlY80dL0ptbTrZF3QG/fhtceVvwB78Zhw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.5",
+    "markdown-flow-ui": "0.2.6",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## What changed

- Updated the exact `markdown-flow-ui` dependency pin from `0.2.5` to `0.2.6`.
- Refreshed the npm lockfile resolution and integrity metadata.

## Why

This keeps AI Shifu on the latest stable MarkdownFlow UI release while preserving the repository's exact-version pinning policy.

## Validation

- `npm run type-check`
- `npm run lint`
- `npx --yes npm@10.9.2 ci --dry-run --ignore-scripts --registry=https://registry.npmjs.org/`
- `git diff --check`
- Repository pre-commit and commit-message hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering component to the latest available patch version, bringing minor improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->