### PR TITLE
refactor: reduce learner console and storage noise

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/learningModeStorage.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/learningModeStorage.ts
@@ -1,4 +1,8 @@
 import type { LearningMode } from './learningModeOptions';
+import {
+  readLocalStorageItem,
+  writeLocalStorageItem,
+} from '@/c-utils/runtimeStorage';
 
 const LEARNING_MODE_STORAGE_PREFIX = 'course_learning_mode';
 
@@ -20,13 +24,11 @@ export const readLearningModeFromStorage = (
     return null;
   }
 
-  try {
-    const value = window.localStorage.getItem(key);
-    return isStoredLearningMode(value) ? value : null;
-  } catch (error) {
-    console.warn('Failed to read learning mode from storage', error);
-    return null;
-  }
+  const value = readLocalStorageItem(
+    key,
+    '[learning-mode-storage] failed to read localStorage',
+  );
+  return isStoredLearningMode(value) ? value : null;
 };
 
 export const writeLearningModeToStorage = (
@@ -42,9 +44,9 @@ export const writeLearningModeToStorage = (
     return;
   }
 
-  try {
-    window.localStorage.setItem(key, mode);
-  } catch (error) {
-    console.warn('Failed to write learning mode to storage', error);
-  }
+  writeLocalStorageItem(
+    key,
+    mode,
+    '[learning-mode-storage] failed to write localStorage',
+  );
 };

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -7,7 +7,7 @@ import { parseUrlParams } from '@/c-utils/urlUtils';
 // import { ConfigProvider } from 'antd';
 import { useSystemStore } from '@/c-store/useSystemStore';
 import { useTranslation } from 'react-i18next';
-import { debugError, debugInfo } from '@/c-utils/debugConsole';
+import { debugError, debugInfo, debugWarn } from '@/c-utils/debugConsole';
 
 import { useShallow } from 'zustand/react/shallow';
 import { useParams } from 'next/navigation';
@@ -211,7 +211,7 @@ export default function ChatLayout({
     const currCode = params.code;
 
     if (!appId) {
-      console.warn('WeChat appId missing, skip OAuth redirect');
+      debugWarn('[lesson-layout] WeChat appId missing, skip OAuth redirect');
       setCheckWxcode(true);
       return;
     }
@@ -553,7 +553,7 @@ export default function ChatLayout({
               typeof navigator !== 'undefined' ? Boolean(inWechat()) : false,
             has_token: Boolean(useUserStore.getState().getToken()),
           });
-          console.warn('Skip 404 redirect for non-notfound course info error', {
+          debugWarn('[course-info] skip 404 redirect for non-notfound error', {
             courseId,
             error,
           });

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -63,6 +63,7 @@ import MiniProgramPayGuide from './Components/Pay/MiniProgramPayGuide';
 import { trackCourseVisitIfNeeded } from './courseVisitTracking';
 import DebugConsoleOverlay from '@/components/debug/DebugConsoleOverlay';
 import ProfileOnboardingModal from '@/components/profile-onboarding/ProfileOnboardingModal';
+import { debugWarn } from '@/c-utils/debugConsole';
 import { ErrorWithCode } from '@/lib/request';
 import { resolveLearnerErrorMessage } from '@/lib/learnerError';
 import { toast } from '@/hooks/useToast';
@@ -167,8 +168,7 @@ export default function ChatPage() {
     }
 
     void updateWxcode({ wxcode: wechatCode }).catch(err => {
-      // eslint-disable-next-line no-console
-      console.warn('Failed to update WeChat OpenID:', err);
+      debugWarn('[lesson-page] failed to update WeChat OpenID', err);
     });
   }, [initialized, isLoggedIn, wechatCode]);
 
@@ -474,8 +474,7 @@ export default function ChatPage() {
         setProfileOnboardingRuntimeReady(true);
       })
       .catch(error => {
-        // eslint-disable-next-line no-console
-        console.warn('Failed to load profile onboarding:', error);
+        debugWarn('[profile-onboarding] failed to load status', error);
         notifyProfileOnboardingLoadFailure(error);
         setProfileOnboardingRuntimeReady(true);
       });
@@ -497,8 +496,7 @@ export default function ChatPage() {
           variables,
         });
         await refreshUserInfo().catch(error => {
-          // eslint-disable-next-line no-console
-          console.warn('Failed to refresh user info after onboarding:', error);
+          debugWarn('[profile-onboarding] failed to refresh user info', error);
           notifyProfileOnboardingRefreshDelay();
         });
         closeProfileOnboarding();

--- a/src/cook-web/src/c-utils/runtimeStorage.ts
+++ b/src/cook-web/src/c-utils/runtimeStorage.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { debugWarn } from './debugConsole';
+
+export const readLocalStorageItem = (
+  key: string,
+  debugLabel: string,
+): string | null => {
+  if (typeof window === 'undefined' || !key) {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    debugWarn(debugLabel, error);
+    return null;
+  }
+};
+
+export const writeLocalStorageItem = (
+  key: string,
+  value: string,
+  debugLabel: string,
+) => {
+  if (typeof window === 'undefined' || !key) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    debugWarn(debugLabel, error);
+  }
+};

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -18,6 +18,7 @@ import {
   mergeStreamingMarkdownText,
   maskIncompleteMermaidBlock,
 } from '@/c-utils/markdownUtils';
+import { debugError, debugWarn } from '@/c-utils/debugConsole';
 import {
   getAudioTrackByPosition,
   normalizeAudioCompletePayload,
@@ -142,7 +143,7 @@ const parseObjectPayload = <T extends Record<string, unknown>>(
       return parsed as T;
     }
   } catch (error) {
-    console.warn('Failed to parse preview payload object:', error);
+    debugWarn('[preview-chat] failed to parse preview payload object', error);
   }
   return null;
 };
@@ -572,7 +573,7 @@ export function usePreviewChat() {
           content,
         ) as InteractionParseResult;
       } catch (error) {
-        console.warn('Failed to parse interaction block', error);
+        debugWarn('[preview-chat] failed to parse interaction block', error);
         return null;
       }
     },
@@ -1267,7 +1268,7 @@ export function usePreviewChat() {
           }
         }
       } catch (err) {
-        console.warn('preview SSE handling error:', err);
+        debugWarn('[preview-chat] SSE handling error', err);
       }
     },
     [
@@ -1432,7 +1433,7 @@ export function usePreviewChat() {
           if (sseRef.current !== source) {
             return;
           }
-          console.error('[preview sse error]', err);
+          debugError('[preview-chat] preview SSE error', err);
           const latestActionableItem = finalizePreviewItems();
           const hasReceivedNonTerminalDone =
             doneTerminalStateRef.current === false;
@@ -1459,7 +1460,7 @@ export function usePreviewChat() {
         });
         source.stream();
       } catch (err) {
-        console.error('preview stream error', err);
+        debugError('[preview-chat] preview stream error', err);
         handlePreviewBusinessError(
           resolveLearnerErrorMessage({
             error: err as ErrorWithCode,
@@ -1478,6 +1479,7 @@ export function usePreviewChat() {
       setTrackedContentList,
       stopPreview,
       stopPreviewAndContinueIfNeeded,
+      t,
     ],
   );
 
@@ -1994,12 +1996,12 @@ export function usePreviewChat() {
               resolve(audioComplete ?? null);
             }
           } catch (err) {
-            console.warn('preview audio stream parse error:', err);
+            debugWarn('[preview-chat] preview audio stream parse error', err);
           }
         });
 
         source.addEventListener('error', err => {
-          console.error('[preview audio sse error]', err);
+          debugError('[preview-chat] preview audio SSE error', err);
           setTrackedContentList(prevState =>
             ensureAudioItem(
               prevState.map(item => {

--- a/src/cook-web/src/components/lesson-preview/variableStorage.ts
+++ b/src/cook-web/src/components/lesson-preview/variableStorage.ts
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+  readLocalStorageItem,
+  writeLocalStorageItem,
+} from '@/c-utils/runtimeStorage';
+import { debugWarn } from '@/c-utils/debugConsole';
+
 const STORAGE_PREFIX = 'lesson_preview_variables';
 const GLOBAL_STORAGE_KEY = STORAGE_PREFIX;
 
@@ -34,11 +40,16 @@ const readStorage = (key: string): PreviewVariablesMap => {
   if (typeof window === 'undefined' || !key) {
     return {};
   }
+
+  const raw = readLocalStorageItem(
+    key,
+    '[preview-variable-storage] failed to read localStorage',
+  );
+  if (!raw) {
+    return {};
+  }
+
   try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) {
-      return {};
-    }
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
       return {};
@@ -49,7 +60,10 @@ const readStorage = (key: string): PreviewVariablesMap => {
       return acc;
     }, {});
   } catch (error) {
-    console.warn('Failed to parse preview variables from storage', error);
+    debugWarn('[preview-variable-storage] failed to parse localStorage JSON', {
+      key,
+      error,
+    });
     return {};
   }
 };
@@ -58,11 +72,11 @@ const writeStorage = (key: string, data: PreviewVariablesMap) => {
   if (typeof window === 'undefined' || !key) {
     return;
   }
-  try {
-    window.localStorage.setItem(key, JSON.stringify(data));
-  } catch (error) {
-    console.warn('Failed to save preview variables to storage', error);
-  }
+  writeLocalStorageItem(
+    key,
+    JSON.stringify(data),
+    '[preview-variable-storage] failed to write localStorage',
+  );
 };
 
 export const getStoredPreviewVariables = (


### PR DESCRIPTION
Summary
- route learner page, layout, and preview diagnostics through the shared debug console helper
- add a small runtime localStorage helper and reuse it for learning mode and preview variable storage
- keep learner-facing behavior unchanged while reducing noisy console warnings/errors

Verification
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/c-utils/runtimeStorage.ts --file 'src/app/c/[[...id]]/Components/learningModeStorage.ts' --file 'src/components/lesson-preview/variableStorage.ts' --file 'src/app/c/[[...id]]/page.tsx' --file 'src/app/c/[[...id]]/layout.tsx' --file 'src/components/lesson-preview/usePreviewChat.tsx'
- cd src/cook-web && npm test -- --runTestsByPath 'src/app/c/[[...id]]/page.test.tsx'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving and loading learning settings and lesson preview data.
  * Added safer handling for browser storage access failures and unavailable browser environments.
  * Preserved existing behavior when stored data is missing or invalid.

* **Diagnostics**
  * Standardized warning and error reporting across course loading, onboarding, preview chat, and text-to-speech features.
  * Improved context in diagnostic messages while reducing direct console logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->