### PR TITLE
refactor: unify learner error toast fallbacks

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -79,7 +79,7 @@ import {
   useLessonRunContentStore,
 } from '@/c-store/useLessonRunContentStore';
 import { parseLessonHistoryDate } from '@/lib/lesson-history-time';
-import { resolveLearnerErrorMessage } from '@/lib/learnerError';
+import { resolveLearnerErrorToast } from '@/lib/learnerError';
 import { debugWarn } from '@/c-utils/debugConsole';
 
 interface LessonFeedbackPopupState {
@@ -1808,14 +1808,14 @@ function useChatLogicHook({
                   : typeof rawContent?.code === 'number'
                     ? rawContent.code
                     : undefined;
-              const resolvedErrorMessage = resolveLearnerErrorMessage({
+              const resolvedErrorToast = resolveLearnerErrorToast({
                 message: errorContent,
                 fallbackMessage: t('module.chat.requestFailed'),
               });
 
               toast({
-                title: resolvedErrorMessage,
-                variant: 'destructive',
+                title: resolvedErrorToast.message,
+                variant: resolvedErrorToast.variant,
               });
               if (
                 effectivePreviewMode &&
@@ -2369,9 +2369,13 @@ function useChatLogicHook({
             businessError?.code === CREDIT_INSUFFICIENT_ERROR_CODE &&
             businessError?.message?.trim()
           ) {
+            const resolvedErrorToast = resolveLearnerErrorToast({
+              message: businessError.message.trim(),
+              fallbackMessage: t('module.chat.requestFailed'),
+            });
             toast({
-              title: businessError.message.trim(),
-              variant: 'destructive',
+              title: resolvedErrorToast.message,
+              variant: resolvedErrorToast.variant,
             });
             cleanupRunStreamState();
             setHasRunFailed(true);

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -65,7 +65,10 @@ import DebugConsoleOverlay from '@/components/debug/DebugConsoleOverlay';
 import ProfileOnboardingModal from '@/components/profile-onboarding/ProfileOnboardingModal';
 import { debugWarn } from '@/c-utils/debugConsole';
 import { ErrorWithCode } from '@/lib/request';
-import { resolveLearnerErrorMessage } from '@/lib/learnerError';
+import {
+  resolveLearnerErrorMessage,
+  resolveLearnerErrorToast,
+} from '@/lib/learnerError';
 import { toast } from '@/hooks/useToast';
 
 const PayModalM = dynamic(() => import('./Components/Pay/PayModalM'), {
@@ -425,12 +428,13 @@ export default function ChatPage() {
 
   const notifyProfileOnboardingLoadFailure = useCallback(
     (error: unknown) => {
+      const resolvedToast = resolveLearnerErrorToast({
+        error: error as Partial<ErrorWithCode>,
+        fallbackMessage: t('module.profileOnboarding.loadFailed'),
+      });
       toast({
-        title: resolveLearnerErrorMessage({
-          error: error as Partial<ErrorWithCode>,
-          fallbackMessage: t('module.profileOnboarding.loadFailed'),
-        }),
-        variant: 'destructive',
+        title: resolvedToast.message,
+        variant: resolvedToast.variant,
       });
     },
     [t],

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -172,4 +172,37 @@ describe('usePreviewChat helpers and business error rendering', () => {
       buildPreviewBusinessErrorItem('余额不足'),
     ]);
   });
+
+  test('keeps the preview business code on the rendered error row', () => {
+    expect(
+      buildPreviewBusinessErrorItem('积分不足，请稍后重试', 7101),
+    ).toMatchObject({
+      element_bid: 'preview-business-error',
+      generated_block_bid: 'preview-business-error',
+      content: '积分不足，请稍后重试',
+      type: ChatContentItemType.ERROR,
+      business_code: 7101,
+    });
+  });
+
+  test('drops the loading placeholder without appending an empty error row', () => {
+    const items: ChatContentItem[] = [
+      {
+        element_bid: 'content-1',
+        generated_block_bid: 'content-1',
+        content: 'Existing content',
+        type: ChatContentItemType.CONTENT,
+      },
+      {
+        element_bid: 'loading',
+        generated_block_bid: 'loading',
+        content: '',
+        type: ChatContentItemType.CONTENT,
+      },
+    ];
+
+    expect(replacePreviewLoadingWithBusinessError(items, '   ')).toEqual([
+      items[0],
+    ]);
+  });
 });

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -33,7 +33,10 @@ import { normalizeLegacyBlockCompatList } from '@/c-utils/chatUiCompat';
 import { getDynamicApiBaseUrl } from '@/config/environment';
 import { useShifu, useUserStore } from '@/store';
 import { toast } from '@/hooks/useToast';
-import { resolveLearnerErrorMessage } from '@/lib/learnerError';
+import {
+  resolveLearnerErrorMessage,
+  resolveLearnerErrorToast,
+} from '@/lib/learnerError';
 import { attachSseBusinessResponseFallback } from '@/lib/request';
 import type { ErrorWithCode } from '@/lib/request';
 import { buildTraceHeaders } from '@/lib/request-trace';
@@ -708,10 +711,12 @@ export function usePreviewChat() {
 
   const handlePreviewBusinessError = useCallback(
     (errorOrMessage?: string | ErrorWithCode | null, fallbackCode?: number) => {
-      const resolvedMessage =
-        typeof errorOrMessage === 'string'
-          ? errorOrMessage.trim() || t('module.preview.llmError')
-          : errorOrMessage?.message?.trim() || t('module.preview.llmError');
+      const resolvedToast = resolveLearnerErrorToast({
+        error: typeof errorOrMessage === 'string' ? undefined : errorOrMessage,
+        message:
+          typeof errorOrMessage === 'string' ? errorOrMessage : undefined,
+        fallbackMessage: t('module.preview.llmError'),
+      });
       const resolvedCode =
         typeof errorOrMessage === 'string'
           ? fallbackCode
@@ -719,11 +724,11 @@ export function usePreviewChat() {
       setTrackedContentList(prev =>
         replacePreviewLoadingWithBusinessError(
           prev,
-          resolvedMessage,
+          resolvedToast.message,
           resolvedCode,
         ),
       );
-      setError(resolvedMessage);
+      setError(resolvedToast.message);
       stopPreview();
     },
     [setTrackedContentList, stopPreview, t],

--- a/src/cook-web/src/lib/learnerError.test.ts
+++ b/src/cook-web/src/lib/learnerError.test.ts
@@ -1,5 +1,6 @@
 import {
   resolveLearnerErrorMessage,
+  resolveLearnerErrorToast,
   resolveLearnerPaymentToast,
 } from './learnerError';
 import { getRequestFallbackMessage } from './request';
@@ -77,6 +78,30 @@ describe('resolveLearnerErrorMessage', () => {
 });
 
 describe('resolveLearnerPaymentToast', () => {
+  it('builds a destructive toast from the shared learner error fallback', () => {
+    expect(
+      resolveLearnerErrorToast({
+        error: { status: 502 },
+        fallbackMessage: 'i18n:module.chat.requestFailed',
+      }),
+    ).toEqual({
+      message: 'request-fallback',
+      variant: 'destructive',
+    });
+  });
+
+  it('preserves explicit learner-facing toast messages', () => {
+    expect(
+      resolveLearnerErrorToast({
+        message: '请稍后重试',
+        fallbackMessage: 'i18n:module.preview.requestFailed',
+      }),
+    ).toEqual({
+      message: '请稍后重试',
+      variant: 'destructive',
+    });
+  });
+
   it('maps payment cancellation to a non-destructive canceled message', () => {
     expect(
       resolveLearnerPaymentToast({

--- a/src/cook-web/src/lib/learnerError.ts
+++ b/src/cook-web/src/lib/learnerError.ts
@@ -78,6 +78,23 @@ export const resolveLearnerErrorMessage = ({
   return fallbackMessage;
 };
 
+export const resolveLearnerErrorToast = ({
+  error,
+  message,
+  fallbackMessage,
+}: {
+  error?: LearnerErrorLike | string | null;
+  message?: string | null;
+  fallbackMessage: string;
+}): { message: string; variant: LearnerToastVariant } => ({
+  message: resolveLearnerErrorMessage({
+    error: typeof error === 'string' ? undefined : error,
+    message: typeof error === 'string' ? error : message,
+    fallbackMessage,
+  }),
+  variant: 'destructive',
+});
+
 export const resolveLearnerPaymentToast = ({
   error,
   message,


### PR DESCRIPTION
Summary
- add a shared learner destructive-toast resolver on top of the existing learner error helper
- reuse the shared toast fallback logic across learner onboarding, preview, and chat error paths
- extend preview helper tests so business error rendering keeps the expected fallback shape

Verification
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/lib/learnerError.ts --file src/lib/learnerError.test.ts --file 'src/app/c/[[...id]]/page.tsx' --file 'src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx' --file 'src/components/lesson-preview/usePreviewChat.tsx' --file 'src/components/lesson-preview/usePreviewChat.test.ts'
- cd src/cook-web && npm test -- --runTestsByPath 'src/components/lesson-preview/usePreviewChat.test.ts' 'src/lib/learnerError.test.ts' 'src/app/c/[[...id]]/page.test.tsx'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notifications across chat, lesson previews, and profile onboarding.
  * Standardized error messages and toast styling for clearer learner-facing feedback.
  * Prevented empty error rows from appearing when the backend returns a blank message.
  * Preserved backend business error codes in preview error details.

* **Tests**
  * Added coverage for standardized error toasts, business error codes, and blank error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->