### PR TITLE
refactor: split learner chat hook helpers

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.helpers.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.helpers.ts
@@ -1,0 +1,363 @@
+import {
+  type AudioCompleteData,
+  type AudioSegmentData,
+  ELEMENT_TYPE,
+  type ListenSlideData,
+  type StudyRecordItem,
+} from '@/c-api/studyV2';
+import {
+  getAudioSegmentDataListFromTracks,
+  mergeAudioSegmentDataList,
+  normalizeAudioSubtitleCues,
+  sortAudioTracksByPosition,
+  type AudioTrack,
+} from '@/c-utils/audio-utils';
+import { type ChatContentItem, ChatContentItemType } from '@/c-types/chatUi';
+import {
+  normalizeLegacyBlockCompatList,
+  stripCustomButtonAfterContent,
+} from './chatUiUtils';
+
+const DEFAULT_LISTEN_AUDIO_POSITION = 0;
+
+export const normalizeOptionalNumber = (value: unknown) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const normalized = Number(value);
+  return Number.isFinite(normalized) ? normalized : undefined;
+};
+
+export const resolveStudyRecordAudioComplete = (
+  record: StudyRecordItem,
+): Partial<AudioCompleteData> | null => {
+  const audioPayload = record.payload?.audio as
+    | Record<string, unknown>
+    | undefined;
+  const audioUrl =
+    (typeof record.audio_url === 'string' && record.audio_url.trim()) ||
+    (typeof audioPayload?.audio_url === 'string' &&
+      audioPayload.audio_url.trim()) ||
+    '';
+
+  if (!audioUrl) {
+    return null;
+  }
+
+  const audioBid =
+    typeof audioPayload?.audio_bid === 'string'
+      ? audioPayload.audio_bid
+      : undefined;
+  const durationMs = normalizeOptionalNumber(audioPayload?.duration_ms);
+  const position = normalizeOptionalNumber(audioPayload?.position);
+  const slideId =
+    typeof audioPayload?.slide_id === 'string'
+      ? audioPayload.slide_id
+      : undefined;
+  const avContract =
+    audioPayload?.av_contract &&
+    typeof audioPayload.av_contract === 'object' &&
+    !Array.isArray(audioPayload.av_contract)
+      ? (audioPayload.av_contract as Record<string, unknown>)
+      : undefined;
+  const subtitleCues = normalizeAudioSubtitleCues(audioPayload?.subtitle_cues);
+
+  return {
+    audio_url: audioUrl,
+    ...(audioBid ? { audio_bid: audioBid } : {}),
+    ...(durationMs === undefined ? {} : { duration_ms: durationMs }),
+    ...(position === undefined ? {} : { position }),
+    ...(slideId ? { slide_id: slideId } : {}),
+    ...(avContract ? { av_contract: avContract } : {}),
+    ...(subtitleCues ? { subtitle_cues: subtitleCues } : {}),
+  };
+};
+
+export const hydrateAudioTracksWithCompleteUrl = (
+  tracks: AudioTrack[] = [],
+  audioComplete?: Partial<AudioCompleteData> | null,
+): AudioTrack[] => {
+  if (!audioComplete?.audio_url) {
+    return tracks;
+  }
+
+  const position =
+    normalizeOptionalNumber(audioComplete.position) ??
+    DEFAULT_LISTEN_AUDIO_POSITION;
+  const targetIndex = tracks.findIndex(track => track.position === position);
+  const targetTrack =
+    targetIndex >= 0
+      ? { ...tracks[targetIndex] }
+      : {
+          position,
+          audioSegments: [],
+          isAudioStreaming: false,
+        };
+
+  const nextTrack: AudioTrack = {
+    ...targetTrack,
+    audioUrl: audioComplete.audio_url,
+    durationMs: audioComplete.duration_ms ?? targetTrack.durationMs,
+    isAudioStreaming: false,
+    slideId: audioComplete.slide_id ?? targetTrack.slideId,
+    avContract: audioComplete.av_contract ?? targetTrack.avContract,
+    subtitleCues: audioComplete.subtitle_cues ?? targetTrack.subtitleCues,
+  };
+  const nextTracks =
+    targetIndex >= 0
+      ? tracks.map((track, index) =>
+          index === targetIndex ? nextTrack : track,
+        )
+      : [...tracks, nextTrack];
+
+  return sortAudioTracksByPosition(nextTracks);
+};
+
+const normalizeCanonicalChatContentItem = (
+  item: ChatContentItem,
+): ChatContentItem => {
+  const nextContent =
+    typeof item.content === 'string'
+      ? (stripCustomButtonAfterContent(item.content) ?? '')
+      : item.content;
+  const nextAskList = Array.isArray(item.ask_list)
+    ? item.ask_list.map(normalizeCanonicalChatContentItem)
+    : item.ask_list;
+  const hasContentChanged = nextContent !== item.content;
+  const hasAskListChanged = nextAskList !== item.ask_list;
+
+  if (!hasContentChanged && !hasAskListChanged) {
+    return item;
+  }
+
+  return {
+    ...item,
+    ...(hasContentChanged ? { content: nextContent } : {}),
+    ...(hasAskListChanged ? { ask_list: nextAskList } : {}),
+  };
+};
+
+export const normalizeCanonicalChatContentList = (
+  items: ChatContentItem[],
+): ChatContentItem[] =>
+  normalizeLegacyBlockCompatList(items).map(normalizeCanonicalChatContentItem);
+
+const resolvePayloadVisualContent = (
+  payload?: StudyRecordItem['payload'] | null,
+) => {
+  const previousVisuals = payload?.previous_visuals;
+  if (!Array.isArray(previousVisuals)) {
+    return '';
+  }
+
+  return previousVisuals
+    .map(item => {
+      if (!item || typeof item !== 'object') {
+        return '';
+      }
+      const content = (item as { content?: unknown }).content;
+      return typeof content === 'string' ? content.trim() : '';
+    })
+    .filter(Boolean)
+    .join('\n\n');
+};
+
+export const resolveRenderableRecordContent = (record: StudyRecordItem) => {
+  const content = record.content ?? '';
+  if (content.trim()) {
+    return content;
+  }
+  return resolvePayloadVisualContent(record.payload) || content;
+};
+
+export const normalizeHistoryAudioTracks = (
+  audios: AudioSegmentData[] = [],
+  audioComplete?: Partial<AudioCompleteData> | null,
+): AudioTrack[] => {
+  if (!audios.length) {
+    return hydrateAudioTracksWithCompleteUrl([], audioComplete);
+  }
+
+  const trackByPosition = new Map<number, AudioTrack>();
+
+  [...audios]
+    .sort(
+      (a, b) =>
+        Number(a.position ?? 0) - Number(b.position ?? 0) ||
+        Number(a.segment_index ?? 0) - Number(b.segment_index ?? 0),
+    )
+    .forEach(audio => {
+      const position = Number(audio.position ?? 0);
+      const track = trackByPosition.get(position) ?? {
+        position,
+        audioSegments: [],
+        isAudioStreaming: false,
+      };
+
+      track.audioSegments = [
+        ...(track.audioSegments ?? []),
+        {
+          segmentIndex: Number(audio.segment_index ?? 0),
+          audioData: audio.audio_data,
+          durationMs: Number(audio.duration_ms ?? 0),
+          isFinal: Boolean(audio.is_final),
+          position,
+          elementId: audio.element_id,
+          slideId: audio.slide_id,
+          avContract: audio.av_contract ?? null,
+          subtitleCues: audio.subtitle_cues,
+        },
+      ];
+      track.isAudioStreaming = Boolean(
+        track.audioSegments?.some(segment => !segment.isFinal),
+      );
+
+      trackByPosition.set(position, track);
+    });
+
+  return hydrateAudioTracksWithCompleteUrl(
+    [...trackByPosition.values()],
+    audioComplete,
+  );
+};
+
+export const resolveRecordUserInput = (
+  record?: Pick<StudyRecordItem, 'user_input' | 'payload'> | null,
+) => {
+  if (!record) {
+    return undefined;
+  }
+
+  const payloadUserInput =
+    typeof record.payload?.user_input === 'string'
+      ? record.payload.user_input
+      : undefined;
+
+  return record.user_input ?? payloadUserInput;
+};
+
+export const resolveRecordElementType = (
+  record?: Pick<StudyRecordItem, 'element_type'> | null,
+) => {
+  const rawElementType = (record as { element_type?: unknown } | null)
+    ?.element_type;
+  return typeof rawElementType === 'string' ? rawElementType : '';
+};
+
+export const isAskOrAnswerElementType = (elementType?: string | null) => {
+  return elementType === 'ask' || elementType === 'answer';
+};
+
+export const buildElementContentItem = (
+  record: StudyRecordItem,
+  options: {
+    getPendingListenSlides: (identityBids: string[]) => ListenSlideData[];
+    isAudioBackfillReadyForBlock: (
+      generatedBlockBid?: string | null,
+      elementBid?: string | null,
+    ) => boolean;
+    mergeListenSlides: (
+      ...slideLists: Array<ListenSlideData[] | undefined>
+    ) => ListenSlideData[];
+    previousItem?: ChatContentItem;
+    resolveElementItemBid: (
+      record?: Pick<
+        StudyRecordItem,
+        'element_bid' | 'generated_block_bid' | 'target_element_bid'
+      > | null,
+    ) => string;
+    resolveListenSlideIdentityBids: (
+      ...sources: Array<
+        Partial<StudyRecordItem & ListenSlideData> | string | null | undefined
+      >
+    ) => string[];
+    isHistory?: boolean;
+    shouldRenderAsHistoryInReadMode?: boolean;
+    shouldUseTypewriter?: boolean;
+    listenSlides?: ListenSlideData[];
+  },
+): ChatContentItem => {
+  const itemBid = options.resolveElementItemBid(record);
+  const previousAudioSegments = Array.isArray(
+    options.previousItem?.audio_segments,
+  )
+    ? options.previousItem?.audio_segments
+    : [];
+  const previousTrackAudioSegments = getAudioSegmentDataListFromTracks(
+    options.previousItem?.audioTracks ?? [],
+  );
+  const incomingAudioSegments = Array.isArray(record.audio_segments)
+    ? record.audio_segments
+    : [];
+  const mergedAudioSegments = mergeAudioSegmentDataList(itemBid, [
+    ...previousAudioSegments,
+    ...previousTrackAudioSegments,
+    ...incomingAudioSegments,
+  ]);
+  const historyTracks = normalizeHistoryAudioTracks(
+    mergedAudioSegments,
+    resolveStudyRecordAudioComplete(record),
+  );
+  const singleTrack = historyTracks.length === 1 ? historyTracks[0] : null;
+  const isInteractionElement = record.element_type === ELEMENT_TYPE.INTERACTION;
+  const generatedBlockBid = record.generated_block_bid || itemBid;
+  const identityBids = options.resolveListenSlideIdentityBids(
+    record,
+    itemBid,
+    generatedBlockBid,
+  );
+  const pendingListenSlides = options.getPendingListenSlides(identityBids);
+  const content = resolveRenderableRecordContent(record);
+
+  return {
+    ...options.previousItem,
+    ...record,
+    element_bid: itemBid,
+    generated_block_bid: generatedBlockBid,
+    content,
+    customRenderBar: () => null,
+    user_input:
+      resolveRecordUserInput(record) ?? options.previousItem?.user_input ?? '',
+    readonly: options.previousItem?.readonly ?? false,
+    isHistory: options.isHistory,
+    shouldRenderAsHistoryInReadMode:
+      options.shouldRenderAsHistoryInReadMode ??
+      (options.previousItem?.isHistory
+        ? false
+        : (options.previousItem?.shouldRenderAsHistoryInReadMode ?? false)),
+    is_final:
+      options.previousItem?.is_final === true ? true : Boolean(record.is_final),
+    shouldUseTypewriter:
+      options.shouldUseTypewriter ??
+      options.previousItem?.shouldUseTypewriter ??
+      false,
+    isAudioBackfillReady:
+      options.isHistory ||
+      options.previousItem?.isHistory ||
+      options.previousItem?.isAudioBackfillReady ||
+      options.isAudioBackfillReadyForBlock(generatedBlockBid, itemBid),
+    type: isInteractionElement
+      ? ChatContentItemType.INTERACTION
+      : ChatContentItemType.CONTENT,
+    audioUrl:
+      singleTrack?.audioUrl ??
+      record.audio_url ??
+      options.previousItem?.audioUrl,
+    audioDurationMs:
+      singleTrack?.durationMs ?? options.previousItem?.audioDurationMs,
+    audioTracks:
+      historyTracks.length > 0
+        ? historyTracks
+        : options.previousItem?.audioTracks,
+    audio_segments:
+      mergedAudioSegments.length > 0
+        ? mergedAudioSegments
+        : options.previousItem?.audio_segments,
+    listenSlides: options.mergeListenSlides(
+      options.previousItem?.listenSlides,
+      options.listenSlides,
+      pendingListenSlides,
+    ),
+  };
+};

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -20,7 +20,6 @@ import {
   StudyRecordItem,
   LikeStatus,
   AudioCompleteData,
-  type AudioSegmentData,
   type ListenSlideData,
   type ElementType,
   getRunMessage,
@@ -38,17 +37,12 @@ import {
   ELEMENT_TYPE,
 } from '@/c-api/studyV2';
 import {
-  getAudioSegmentDataListFromTracks,
   getAudioTrackByPosition,
-  mergeAudioSegmentDataList,
   normalizeAudioCompletePayload,
   normalizeAudioSegmentPayload,
-  normalizeAudioSubtitleCues,
-  sortAudioTracksByPosition,
   toAudioSegmentData,
   upsertAudioComplete,
   upsertAudioSegment,
-  type AudioTrack,
 } from '@/c-utils/audio-utils';
 import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
@@ -68,10 +62,7 @@ import LoadingBar from './LoadingBar';
 import { useTranslation } from 'react-i18next';
 import { show as showToast, toast } from '@/hooks/useToast';
 import { AppContext } from '../AppContext';
-import {
-  normalizeLegacyBlockCompatList,
-  stripCustomButtonAfterContent,
-} from './chatUiUtils';
+import { stripCustomButtonAfterContent } from './chatUiUtils';
 import {
   buildLessonRunContentCacheKey,
   EMPTY_LESSON_RUN_CONTENT_ENTRY,
@@ -81,254 +72,31 @@ import {
 import { parseLessonHistoryDate } from '@/lib/lesson-history-time';
 import { resolveLearnerErrorToast } from '@/lib/learnerError';
 import { debugWarn } from '@/c-utils/debugConsole';
-
-interface LessonFeedbackPopupState {
-  open: boolean;
-  outlineBid: string;
-  modeKey: 'listen' | 'read' | '';
-  elementBid: string;
-  defaultScoreText: string;
-  defaultCommentText: string;
-  readonly: boolean;
-}
+import {
+  buildElementContentItem as buildChatElementContentItem,
+  isAskOrAnswerElementType,
+  normalizeCanonicalChatContentList,
+  normalizeOptionalNumber,
+  resolveRecordElementType,
+} from './useChatLogicHook.helpers';
+import type {
+  LessonFeedbackPopupState,
+  RequestAudioForBlockOptions,
+  SSEParams,
+  TtsStreamCancel,
+  UseChatSessionParams,
+  UseChatSessionResult,
+} from './useChatLogicHook.types';
 
 const LESSON_FEEDBACK_DISMISS_CACHE_LIMIT = 200;
 const RUN_STREAM_IDLE_TIMEOUT_MS = 15000;
 const MOBILE_RUN_STREAM_IDLE_TIMEOUT_MS = 60000;
 const TTS_BACKFILL_IDLE_TIMEOUT_MS = 120000;
 const STREAM_TIMEOUT_ITEM_BID_PREFIX = 'stream-timeout-error';
-const DEFAULT_LISTEN_AUDIO_POSITION = 0;
 const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
 
 export { ChatContentItemType };
 export type { ChatContentItem };
-
-interface SSEParams {
-  input: string | Record<string, any>;
-  input_type: SSE_INPUT_TYPE;
-  reload_generated_block_bid?: string;
-  reload_element_bid?: string;
-}
-
-interface RequestAudioForBlockOptions {
-  listen?: boolean;
-  shouldApplyResult?: () => boolean;
-  onStreamSettled?: () => void;
-}
-
-type TtsStreamCancel = (options?: { updateState?: boolean }) => void;
-
-const normalizeOptionalNumber = (value: unknown) => {
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-
-  const normalized = Number(value);
-  return Number.isFinite(normalized) ? normalized : undefined;
-};
-
-const resolveStudyRecordAudioComplete = (
-  record: StudyRecordItem,
-): Partial<AudioCompleteData> | null => {
-  const audioPayload = record.payload?.audio as
-    | Record<string, unknown>
-    | undefined;
-  const audioUrl =
-    (typeof record.audio_url === 'string' && record.audio_url.trim()) ||
-    (typeof audioPayload?.audio_url === 'string' &&
-      audioPayload.audio_url.trim()) ||
-    '';
-
-  if (!audioUrl) {
-    return null;
-  }
-
-  const audioBid =
-    typeof audioPayload?.audio_bid === 'string'
-      ? audioPayload.audio_bid
-      : undefined;
-  const durationMs = normalizeOptionalNumber(audioPayload?.duration_ms);
-  const position = normalizeOptionalNumber(audioPayload?.position);
-  const slideId =
-    typeof audioPayload?.slide_id === 'string'
-      ? audioPayload.slide_id
-      : undefined;
-  const avContract =
-    audioPayload?.av_contract &&
-    typeof audioPayload.av_contract === 'object' &&
-    !Array.isArray(audioPayload.av_contract)
-      ? (audioPayload.av_contract as Record<string, unknown>)
-      : undefined;
-  const subtitleCues = normalizeAudioSubtitleCues(audioPayload?.subtitle_cues);
-
-  return {
-    audio_url: audioUrl,
-    ...(audioBid ? { audio_bid: audioBid } : {}),
-    ...(durationMs === undefined ? {} : { duration_ms: durationMs }),
-    ...(position === undefined ? {} : { position }),
-    ...(slideId ? { slide_id: slideId } : {}),
-    ...(avContract ? { av_contract: avContract } : {}),
-    ...(subtitleCues ? { subtitle_cues: subtitleCues } : {}),
-  };
-};
-
-const hydrateAudioTracksWithCompleteUrl = (
-  tracks: AudioTrack[] = [],
-  audioComplete?: Partial<AudioCompleteData> | null,
-): AudioTrack[] => {
-  if (!audioComplete?.audio_url) {
-    return tracks;
-  }
-
-  const position =
-    normalizeOptionalNumber(audioComplete.position) ??
-    DEFAULT_LISTEN_AUDIO_POSITION;
-  const targetIndex = tracks.findIndex(track => track.position === position);
-  const targetTrack =
-    targetIndex >= 0
-      ? { ...tracks[targetIndex] }
-      : {
-          position,
-          audioSegments: [],
-          isAudioStreaming: false,
-        };
-
-  const nextTrack: AudioTrack = {
-    ...targetTrack,
-    audioUrl: audioComplete.audio_url,
-    durationMs: audioComplete.duration_ms ?? targetTrack.durationMs,
-    isAudioStreaming: false,
-    slideId: audioComplete.slide_id ?? targetTrack.slideId,
-    avContract: audioComplete.av_contract ?? targetTrack.avContract,
-    subtitleCues: audioComplete.subtitle_cues ?? targetTrack.subtitleCues,
-  };
-  const nextTracks =
-    targetIndex >= 0
-      ? tracks.map((track, index) =>
-          index === targetIndex ? nextTrack : track,
-        )
-      : [...tracks, nextTrack];
-
-  return sortAudioTracksByPosition(nextTracks);
-};
-
-const normalizeCanonicalChatContentItem = (
-  item: ChatContentItem,
-): ChatContentItem => {
-  const nextContent =
-    typeof item.content === 'string'
-      ? (stripCustomButtonAfterContent(item.content) ?? '')
-      : item.content;
-  const nextAskList = Array.isArray(item.ask_list)
-    ? item.ask_list.map(normalizeCanonicalChatContentItem)
-    : item.ask_list;
-  const hasContentChanged = nextContent !== item.content;
-  const hasAskListChanged = nextAskList !== item.ask_list;
-
-  if (!hasContentChanged && !hasAskListChanged) {
-    return item;
-  }
-
-  return {
-    ...item,
-    ...(hasContentChanged ? { content: nextContent } : {}),
-    ...(hasAskListChanged ? { ask_list: nextAskList } : {}),
-  };
-};
-
-const normalizeCanonicalChatContentList = (
-  items: ChatContentItem[],
-): ChatContentItem[] =>
-  normalizeLegacyBlockCompatList(items).map(normalizeCanonicalChatContentItem);
-
-const resolvePayloadVisualContent = (
-  payload?: StudyRecordItem['payload'] | null,
-) => {
-  const previousVisuals = payload?.previous_visuals;
-  if (!Array.isArray(previousVisuals)) {
-    return '';
-  }
-
-  return previousVisuals
-    .map(item => {
-      if (!item || typeof item !== 'object') {
-        return '';
-      }
-      const content = (item as { content?: unknown }).content;
-      return typeof content === 'string' ? content.trim() : '';
-    })
-    .filter(Boolean)
-    .join('\n\n');
-};
-
-const resolveRenderableRecordContent = (record: StudyRecordItem) => {
-  const content = record.content ?? '';
-  if (content.trim()) {
-    return content;
-  }
-  return resolvePayloadVisualContent(record.payload) || content;
-};
-
-export interface UseChatSessionParams {
-  shifuBid: string;
-  outlineBid: string;
-  lessonId: string;
-  chapterId?: string;
-  previewMode?: boolean;
-  lessonHasContentUpdate?: boolean;
-  isListenMode?: boolean;
-  listenRequestEnabled?: boolean;
-  shouldPromptLessonFeedback?: boolean;
-  trackEvent: (name: string, payload?: Record<string, any>) => void;
-  trackTrailProgress: (courseId: string, elementBid: string) => void;
-  lessonUpdate?: (params: Record<string, any>) => void;
-  chapterUpdate?: (params: Record<string, any>) => void;
-  updateSelectedLesson: (lessonId: string, forceExpand?: boolean) => void;
-  getNextLessonId: (lessonId?: string | null) => string | null;
-  scrollToLesson: (lessonId: string) => void;
-  // scrollToBottom: (behavior?: ScrollBehavior) => void;
-  showOutputInProgressToast: () => void;
-  onPayModalOpen: () => void;
-  onGoChapter: (lessonId: string) => void;
-}
-
-export interface UseChatSessionResult {
-  items: ChatContentItem[];
-  isLoading: boolean;
-  isOutputInProgress: boolean;
-  hasRunFailed: boolean;
-  currentStreamingElementBid: string;
-  currentTypewriterElementBid: string;
-  onSend: (content: OnSendContentParams, blockBid: string) => void;
-  onRefresh: (elementBid: string) => void;
-  toggleAskExpanded: (parentElementBid: string) => void;
-  syncAskListByParentElement: (
-    parentElementBid: string,
-    askList: ChatContentItem[],
-    options?: {
-      expand?: boolean;
-    },
-  ) => void;
-  requestAudioForBlock: (
-    elementBid: string,
-    options?: RequestAudioForBlockOptions,
-  ) => Promise<AudioCompleteData | null>;
-  reGenerateConfirm: {
-    open: boolean;
-    onConfirm: () => void;
-    onCancel: () => void;
-  };
-  lessonFeedbackPopup: {
-    open: boolean;
-    elementBid: string;
-    defaultScoreText: string;
-    defaultCommentText: string;
-    readonly: boolean;
-    onClose: () => void;
-    onSubmit: (score: number, comment: string) => void;
-  };
-  showLessonUpdateNotice: boolean;
-}
 
 /**
  * useChatLogicHook orchestrates the streaming chat lifecycle for lesson content.
@@ -709,40 +477,6 @@ function useChatLogicHook({
     [finalizeLikeStatusByParent, isListenModeLatest],
   );
 
-  const resolveRecordUserInput = useCallback(
-    (record?: Pick<StudyRecordItem, 'user_input' | 'payload'> | null) => {
-      if (!record) {
-        return undefined;
-      }
-
-      const payloadUserInput =
-        typeof record.payload?.user_input === 'string'
-          ? record.payload.user_input
-          : undefined;
-
-      return record.user_input ?? payloadUserInput;
-    },
-    [],
-  );
-
-  const resolveRecordElementType = useCallback(
-    (record?: Pick<StudyRecordItem, 'element_type'> | null) => {
-      const rawElementType = (record as { element_type?: unknown } | null)
-        ?.element_type;
-      return typeof rawElementType === 'string' ? rawElementType : '';
-    },
-    [],
-  );
-
-  const isAskOrAnswerElementType = useCallback(
-    (elementType?: string | null) => {
-      return (
-        elementType === BLOCK_TYPE.ASK || elementType === BLOCK_TYPE.ANSWER
-      );
-    },
-    [],
-  );
-
   const resolveAskAnchorElementBid = useCallback(
     (record: StudyRecordItem, items: ChatContentItem[] = []) => {
       const payload = (record.payload ?? {}) as Record<string, unknown>;
@@ -877,60 +611,6 @@ function useChatLogicHook({
       return nextItems;
     },
     [mobileStyle],
-  );
-
-  const normalizeHistoryAudioTracks = useCallback(
-    (
-      audios: AudioSegmentData[] = [],
-      audioComplete?: Partial<AudioCompleteData> | null,
-    ): AudioTrack[] => {
-      if (!audios.length) {
-        return hydrateAudioTracksWithCompleteUrl([], audioComplete);
-      }
-
-      const trackByPosition = new Map<number, AudioTrack>();
-
-      [...audios]
-        .sort(
-          (a, b) =>
-            Number(a.position ?? 0) - Number(b.position ?? 0) ||
-            Number(a.segment_index ?? 0) - Number(b.segment_index ?? 0),
-        )
-        .forEach(audio => {
-          const position = Number(audio.position ?? 0);
-          const track = trackByPosition.get(position) ?? {
-            position,
-            audioSegments: [],
-            isAudioStreaming: false,
-          };
-
-          track.audioSegments = [
-            ...(track.audioSegments ?? []),
-            {
-              segmentIndex: Number(audio.segment_index ?? 0),
-              audioData: audio.audio_data,
-              durationMs: Number(audio.duration_ms ?? 0),
-              isFinal: Boolean(audio.is_final),
-              position,
-              elementId: audio.element_id,
-              slideId: audio.slide_id,
-              avContract: audio.av_contract ?? null,
-              subtitleCues: audio.subtitle_cues,
-            },
-          ];
-          track.isAudioStreaming = Boolean(
-            track.audioSegments?.some(segment => !segment.isFinal),
-          );
-
-          trackByPosition.set(position, track);
-        });
-
-      return hydrateAudioTracksWithCompleteUrl(
-        [...trackByPosition.values()],
-        audioComplete,
-      );
-    },
-    [],
   );
 
   const sortSlidesByTimeline = useCallback((slides: ListenSlideData[] = []) => {
@@ -1118,7 +798,7 @@ function useChatLogicHook({
     [],
   );
 
-  const buildElementContentItem = useCallback(
+  const buildContentItem = useCallback(
     (
       record: StudyRecordItem,
       options?: {
@@ -1128,104 +808,21 @@ function useChatLogicHook({
         listenSlides?: ListenSlideData[];
         previousItem?: ChatContentItem;
       },
-    ): ChatContentItem => {
-      const itemBid = resolveElementItemBid(record);
-      const previousAudioSegments = Array.isArray(
-        options?.previousItem?.audio_segments,
-      )
-        ? options?.previousItem?.audio_segments
-        : [];
-      const previousTrackAudioSegments = getAudioSegmentDataListFromTracks(
-        options?.previousItem?.audioTracks ?? [],
-      );
-      const incomingAudioSegments = Array.isArray(record.audio_segments)
-        ? record.audio_segments
-        : [];
-      const mergedAudioSegments = mergeAudioSegmentDataList(itemBid, [
-        ...previousAudioSegments,
-        ...previousTrackAudioSegments,
-        ...incomingAudioSegments,
-      ]);
-      const historyTracks = normalizeHistoryAudioTracks(
-        mergedAudioSegments,
-        resolveStudyRecordAudioComplete(record),
-      );
-      const singleTrack = historyTracks.length === 1 ? historyTracks[0] : null;
-      const isInteractionElement =
-        record.element_type === ELEMENT_TYPE.INTERACTION;
-      const generatedBlockBid = record.generated_block_bid || itemBid;
-      const identityBids = resolveListenSlideIdentityBids(
-        record,
-        itemBid,
-        generatedBlockBid,
-      );
-      const pendingListenSlides = getPendingListenSlides(identityBids);
-      const content = resolveRenderableRecordContent(record);
-
-      return {
-        ...options?.previousItem,
-        ...record,
-        element_bid: itemBid,
-        generated_block_bid: generatedBlockBid,
-        content,
-        customRenderBar: () => null,
-        user_input:
-          resolveRecordUserInput(record) ??
-          options?.previousItem?.user_input ??
-          '',
-        readonly: options?.previousItem?.readonly ?? false,
-        isHistory: options?.isHistory,
-        shouldRenderAsHistoryInReadMode:
-          options?.shouldRenderAsHistoryInReadMode ??
-          (options?.previousItem?.isHistory
-            ? false
-            : (options?.previousItem?.shouldRenderAsHistoryInReadMode ??
-              false)),
-        is_final:
-          options?.previousItem?.is_final === true
-            ? true
-            : Boolean(record.is_final),
-        shouldUseTypewriter:
-          options?.shouldUseTypewriter ??
-          options?.previousItem?.shouldUseTypewriter ??
-          false,
-        isAudioBackfillReady:
-          options?.isHistory ||
-          options?.previousItem?.isHistory ||
-          options?.previousItem?.isAudioBackfillReady ||
-          isAudioBackfillReadyForBlock(generatedBlockBid, itemBid),
-        type: isInteractionElement
-          ? ChatContentItemType.INTERACTION
-          : ChatContentItemType.CONTENT,
-        audioUrl:
-          singleTrack?.audioUrl ??
-          record.audio_url ??
-          options?.previousItem?.audioUrl,
-        audioDurationMs:
-          singleTrack?.durationMs ?? options?.previousItem?.audioDurationMs,
-        audioTracks:
-          historyTracks.length > 0
-            ? historyTracks
-            : options?.previousItem?.audioTracks,
-        audio_segments:
-          mergedAudioSegments.length > 0
-            ? mergedAudioSegments
-            : options?.previousItem?.audio_segments,
-        listenSlides: mergeListenSlides(
-          options?.previousItem?.listenSlides,
-          options?.listenSlides,
-          pendingListenSlides,
-        ),
-      };
-    },
+    ): ChatContentItem =>
+      buildChatElementContentItem(record, {
+        ...options,
+        getPendingListenSlides,
+        isAudioBackfillReadyForBlock,
+        mergeListenSlides,
+        resolveElementItemBid,
+        resolveListenSlideIdentityBids,
+      }),
     [
       getPendingListenSlides,
       isAudioBackfillReadyForBlock,
       mergeListenSlides,
-      normalizeHistoryAudioTracks,
       resolveElementItemBid,
       resolveListenSlideIdentityBids,
-      resolveRecordUserInput,
     ],
   );
 
@@ -1926,7 +1523,7 @@ function useChatLogicHook({
               const previousItem = contentListRef.current.find(item =>
                 itemMatchesElementCacheIdentity(item, elementCacheIdentitySet),
               );
-              const nextItem = buildElementContentItem(elementRecord, {
+              const nextItem = buildContentItem(elementRecord, {
                 previousItem,
                 shouldUseTypewriter:
                   previousItem?.shouldUseTypewriter ?? elementType === 'text',
@@ -2412,7 +2009,7 @@ function useChatLogicHook({
       });
     },
     [
-      buildElementContentItem,
+      buildContentItem,
       chapterId,
       chapterUpdate,
       effectivePreviewMode,
@@ -2425,7 +2022,6 @@ function useChatLogicHook({
       shifuBid,
       lessonId,
       mobileStyle,
-      resolveRecordElementType,
       t,
       trackEvent,
       trackTrailProgress,
@@ -2437,7 +2033,6 @@ function useChatLogicHook({
       ensureContentItem,
       finalizeElementOutputInList,
       getPendingListenSlides,
-      isAskOrAnswerElementType,
       isAudioBackfillReadyForBlock,
       isLessonFeedbackContent,
       itemMatchesElementCacheIdentity,
@@ -2549,7 +2144,7 @@ function useChatLogicHook({
           return;
         }
 
-        const nextItem = buildElementContentItem(item, {
+        const nextItem = buildContentItem(item, {
           isHistory: true,
           shouldUseTypewriter: false,
         });
@@ -2588,12 +2183,10 @@ function useChatLogicHook({
       return result;
     },
     [
-      buildElementContentItem,
-      isAskOrAnswerElementType,
+      buildContentItem,
       removeLikeStatusByParent,
       resolveAskAnchorElementBid,
       resolveElementItemBid,
-      resolveRecordElementType,
       shouldAttachLikeStatusByElement,
       upsertAskMessageByParent,
       upsertLikeStatusByParent,

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
@@ -1,0 +1,88 @@
+import { type AudioCompleteData, type SSE_INPUT_TYPE } from '@/c-api/studyV2';
+import { type ChatContentItem } from '@/c-types/chatUi';
+import { type OnSendContentParams } from 'markdown-flow-ui/renderer';
+
+export interface LessonFeedbackPopupState {
+  open: boolean;
+  outlineBid: string;
+  modeKey: 'listen' | 'read' | '';
+  elementBid: string;
+  defaultScoreText: string;
+  defaultCommentText: string;
+  readonly: boolean;
+}
+
+export interface SSEParams {
+  input: string | Record<string, any>;
+  input_type: SSE_INPUT_TYPE;
+  reload_generated_block_bid?: string;
+  reload_element_bid?: string;
+}
+
+export interface RequestAudioForBlockOptions {
+  listen?: boolean;
+  shouldApplyResult?: () => boolean;
+  onStreamSettled?: () => void;
+}
+
+export type TtsStreamCancel = (options?: { updateState?: boolean }) => void;
+
+export interface UseChatSessionParams {
+  shifuBid: string;
+  outlineBid: string;
+  lessonId: string;
+  chapterId?: string;
+  previewMode?: boolean;
+  lessonHasContentUpdate?: boolean;
+  isListenMode?: boolean;
+  listenRequestEnabled?: boolean;
+  shouldPromptLessonFeedback?: boolean;
+  trackEvent: (name: string, payload?: Record<string, any>) => void;
+  trackTrailProgress: (courseId: string, elementBid: string) => void;
+  lessonUpdate?: (params: Record<string, any>) => void;
+  chapterUpdate?: (params: Record<string, any>) => void;
+  updateSelectedLesson: (lessonId: string, forceExpand?: boolean) => void;
+  getNextLessonId: (lessonId?: string | null) => string | null;
+  scrollToLesson: (lessonId: string) => void;
+  showOutputInProgressToast: () => void;
+  onPayModalOpen: () => void;
+  onGoChapter: (lessonId: string) => void;
+}
+
+export interface UseChatSessionResult {
+  items: ChatContentItem[];
+  isLoading: boolean;
+  isOutputInProgress: boolean;
+  hasRunFailed: boolean;
+  currentStreamingElementBid: string;
+  currentTypewriterElementBid: string;
+  onSend: (content: OnSendContentParams, blockBid: string) => void;
+  onRefresh: (elementBid: string) => void;
+  toggleAskExpanded: (parentElementBid: string) => void;
+  syncAskListByParentElement: (
+    parentElementBid: string,
+    askList: ChatContentItem[],
+    options?: {
+      expand?: boolean;
+    },
+  ) => void;
+  requestAudioForBlock: (
+    elementBid: string,
+    options?: RequestAudioForBlockOptions,
+  ) => Promise<AudioCompleteData | null>;
+  reGenerateConfirm: {
+    open: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+  };
+  lessonFeedbackPopup: {
+    open: boolean;
+    elementBid: string;
+    defaultScoreText: string;
+    defaultCommentText: string;
+    readonly: boolean;
+    onClose: () => void;
+    onSubmit: (score: number, comment: string) => void;
+  };
+  showLessonUpdateNotice: boolean;
+}


### PR DESCRIPTION
Summary
- extract pure helper logic from `useChatLogicHook` into dedicated helper and type modules
- keep learner streaming behavior unchanged while reducing the main hook size
- make follow-up learner refactors safer by isolating normalization and local contracts

Verification
- python scripts/check_dev_tools.py
- cd src/cook-web && npm run type-check
- cd src/cook-web && npm run lint -- --file src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx --file src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.helpers.ts --file src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
- cd src/cook-web && npm test -- --runInBand --runTestsByPath src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat content handling for streamed and saved conversations.
  * Enhanced audio playback data, including track ordering, duration, position, subtitles, and recovery of incomplete audio.
  * Preserved user inputs, visual content, slide references, and interactive chat elements more consistently.
  * Added stronger support for displaying conversation history and typewriter content.

* **Refactor**
  * Improved internal organization of chat session and audio-processing logic without changing the user-facing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->