### PR TITLE
fix: protect paid renewal drift repair

### DIFF
--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -48,6 +48,7 @@ from .queries import (
     calculate_self_managed_billing_cycle_end_after_boundary as _calculate_self_managed_billing_cycle_end_after_boundary,
 )
 from .subscriptions import (
+    IncompleteReservedGrantActivationError,
     activate_subscription_for_paid_order as _activate_subscription_for_paid_order,
     ensure_subscription_renewal_order,
     is_paid_referral_invitation_renewal as _is_paid_referral_invitation_renewal,
@@ -73,6 +74,24 @@ _TERMINAL_EVENT_STATUSES = (
 
 # Shared session-scope guard; see flaskr/dao/uow.py for the rationale.
 _app_context_scope = app_context_scope
+
+
+def _fail_paid_renewal_activation_event(
+    event: BillingRenewalEvent,
+    *,
+    now: datetime,
+    bill_order_bid: str,
+) -> RenewalEventResult:
+    _fail_renewal_event(
+        event,
+        now=now,
+        error="paid_renewal_activation_failed",
+    )
+    return _result_from_event(
+        "failed",
+        event,
+        bill_order_bid=bill_order_bid,
+    )
 
 
 @dataclass(slots=True, frozen=True)
@@ -361,21 +380,23 @@ def _execute_expire_subscription(
                 paid_renewal_order,
                 boundary_at=boundary_at,
             )
-            activated = _activate_subscription_for_paid_order(
-                app,
-                paid_renewal_order,
-                subscription=subscription,
-                force=True,
-            )
-            if not activated:
-                _fail_renewal_event(
+            try:
+                activated = _activate_subscription_for_paid_order(
+                    app,
+                    paid_renewal_order,
+                    subscription=subscription,
+                    force=True,
+                )
+            except IncompleteReservedGrantActivationError:
+                return _fail_paid_renewal_activation_event(
                     event,
                     now=now,
-                    error="paid_renewal_activation_failed",
+                    bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
-                return _result_from_event(
-                    "failed",
+            if not activated:
+                return _fail_paid_renewal_activation_event(
                     event,
+                    now=now,
                     bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
             notification_bid = _stage_preorder_credit_release_notification(
@@ -442,21 +463,23 @@ def _execute_downgrade_effective(
                 paid_renewal_order,
                 boundary_at=boundary_at,
             )
-            activated = _activate_subscription_for_paid_order(
-                app,
-                paid_renewal_order,
-                subscription=subscription,
-                force=True,
-            )
-            if not activated:
-                _fail_renewal_event(
+            try:
+                activated = _activate_subscription_for_paid_order(
+                    app,
+                    paid_renewal_order,
+                    subscription=subscription,
+                    force=True,
+                )
+            except IncompleteReservedGrantActivationError:
+                return _fail_paid_renewal_activation_event(
                     event,
                     now=now,
-                    error="paid_renewal_activation_failed",
+                    bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
-                return _result_from_event(
-                    "failed",
+            if not activated:
+                return _fail_paid_renewal_activation_event(
                     event,
+                    now=now,
                     bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
             notification_bid = _stage_preorder_credit_release_notification(

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -989,7 +989,7 @@ def _cycle_has_reserved_activation_evidence(cycle_orders: list[BillingOrder]) ->
         ):
             if (
                 grant_entry is not None
-                and _reserved_grant_state(grant_entry) == "reserved"
+                and _reserved_grant_state(grant_entry) != "available"
             ):
                 return True
     return False
@@ -1114,6 +1114,18 @@ def _reserved_grant_state(grant_entry: CreditLedgerEntry) -> str:
 
 
 def _expected_subscription_grant_amount(order: BillingOrder) -> Decimal:
+    grant_entry = _load_grant_ledger_entry_for_order(order)
+    if grant_entry is not None:
+        metadata = _normalize_json_object(grant_entry.metadata_json)
+        for key in ("grant_credit_amount", "credit_amount"):
+            if metadata.get(key) is not None:
+                amount = _quantize_credit_amount(_to_decimal(metadata.get(key)))
+                if amount > 0:
+                    return amount
+    return Decimal("0")
+
+
+def _expected_subscription_cycle_grant_amount(order: BillingOrder) -> Decimal:
     product = _load_billing_product_by_bid(order.product_bid)
     if product is None:
         raise IncompleteReservedGrantActivationError(
@@ -1136,7 +1148,7 @@ def _build_reserved_activation_target(
     expected_amount: Decimal,
     fallback_bucket_category: int | None = None,
 ) -> ReservedActivationTarget | None:
-    if expected_amount <= 0:
+    if kind != "subscription" and expected_amount <= 0:
         return None
     if grant_entry is None:
         raise IncompleteReservedGrantActivationError(
@@ -1152,7 +1164,7 @@ def _build_reserved_activation_target(
         )
 
     amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
-    if kind != "subscription" and amount != expected_amount:
+    if expected_amount > 0 and amount != expected_amount:
         raise IncompleteReservedGrantActivationError(
             f"{kind}_amount_mismatch:{order.bill_order_bid}"
         )
@@ -1192,7 +1204,7 @@ def _build_reserved_completion_target(
     expected_amount: Decimal,
     fallback_bucket_category: int | None = None,
 ) -> ReservedActivationTarget | None:
-    if expected_amount <= 0:
+    if kind != "subscription" and expected_amount <= 0:
         return None
     if grant_entry is None:
         raise IncompleteReservedGrantActivationError(
@@ -1204,7 +1216,7 @@ def _build_reserved_completion_target(
             f"incomplete_{kind}_activation:{order.bill_order_bid}"
         )
     amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
-    if kind != "subscription" and amount != expected_amount:
+    if expected_amount > 0 and amount != expected_amount:
         raise IncompleteReservedGrantActivationError(
             f"{kind}_amount_mismatch:{order.bill_order_bid}"
         )
@@ -1290,6 +1302,7 @@ def _preflight_reserved_renewal_grants_for_cycle(
                 required_reserved_by_bucket.get(target.wallet_bucket_bid, Decimal("0"))
                 + target.amount
             )
+    _assert_subscription_cycle_grant_amounts(cycle_orders, targets)
 
     for wallet_bucket_bid, required_reserved in required_reserved_by_bucket.items():
         bucket = (
@@ -1316,8 +1329,55 @@ def _preflight_reserved_renewal_grants_for_cycle(
 def _assert_reserved_activation_targets_completed(
     cycle_orders: list[BillingOrder],
 ) -> None:
+    targets: list[ReservedActivationTarget] = []
     for cycle_order in cycle_orders:
-        _load_reserved_completion_targets_for_cycle_order(cycle_order)
+        targets.extend(_load_reserved_completion_targets_for_cycle_order(cycle_order))
+    _assert_subscription_cycle_grant_amounts(cycle_orders, targets)
+
+
+def _assert_subscription_cycle_grant_amounts(
+    cycle_orders: list[BillingOrder],
+    targets: list[ReservedActivationTarget] | tuple[ReservedActivationTarget, ...],
+) -> None:
+    subscription_amount_by_product: dict[str, Decimal] = {}
+    expected_subscription_amount_by_product: dict[str, Decimal] = {}
+    orders_by_bid = {
+        _normalize_bid(order.bill_order_bid): order for order in cycle_orders
+    }
+    orders_with_subscription_targets: set[str] = set()
+    for target in targets:
+        if target.kind != "subscription":
+            continue
+        order_bid = _normalize_bid(target.order_bid)
+        order = orders_by_bid.get(order_bid)
+        if order is None:
+            continue
+        orders_with_subscription_targets.add(order_bid)
+        product_bid = _normalize_bid(order.product_bid)
+        subscription_amount_by_product[product_bid] = (
+            subscription_amount_by_product.get(product_bid, Decimal("0"))
+            + target.amount
+        )
+
+    for order in cycle_orders:
+        order_bid = _normalize_bid(order.bill_order_bid)
+        if order_bid not in orders_with_subscription_targets:
+            continue
+        if _is_referral_invitation_renewal(order):
+            continue
+        product_bid = _normalize_bid(order.product_bid)
+        expected_subscription_amount_by_product[product_bid] = (
+            expected_subscription_amount_by_product.get(product_bid, Decimal("0"))
+            + _expected_subscription_cycle_grant_amount(order)
+        )
+
+    for product_bid, expected_amount in expected_subscription_amount_by_product.items():
+        if _quantize_credit_amount(
+            subscription_amount_by_product.get(product_bid, Decimal("0"))
+        ) < _quantize_credit_amount(expected_amount):
+            raise IncompleteReservedGrantActivationError(
+                f"subscription_cycle_amount_mismatch:{product_bid}"
+            )
 
 
 def _sync_activated_reserved_renewal_ledger_balances(
@@ -2153,6 +2213,7 @@ def _grant_paid_order_credits(app: Flask, order: BillingOrder) -> bool:
                 "product_bid": order.product_bid,
                 "payment_provider": order.payment_provider,
                 "grant_reason": grant_context.grant_reason,
+                "grant_credit_amount": str(amount),
                 "bucket_credit_state": "reserved" if reserve_grant else "available",
                 "reserved_until": (
                     effective_from.isoformat() if reserve_grant else None

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -843,6 +843,11 @@ def _activate_subscription_for_paid_order(
                 reserved_credits=wallet.reserved_credits,
                 updated_at=now_utc(),
             )
+            _sync_activated_reserved_renewal_ledger_balances(
+                order=order,
+                effective_from=effective_from,
+                balance_after=wallet.available_credits,
+            )
         if _is_preorder_order(order):
             _mark_preorder_effective_applied(order)
             _clear_subscription_preorder_metadata(subscription)
@@ -1166,6 +1171,50 @@ def _assert_reserved_activation_targets_completed(
             raise IncompleteReservedGrantActivationError(
                 f"incomplete_{target.kind}_activation:{target.order_bid}"
             )
+
+
+def _sync_activated_reserved_renewal_ledger_balances(
+    *,
+    order: BillingOrder,
+    effective_from: datetime,
+    balance_after: Decimal,
+) -> None:
+    cycle_orders = list(
+        _load_paid_subscription_renewal_orders_for_cycle(
+            subscription_bid=order.subscription_bid,
+            effective_from=effective_from,
+        )
+    )
+    if not cycle_orders:
+        cycle_orders = [order]
+
+    idempotency_keys: list[str] = []
+    for cycle_order in cycle_orders:
+        idempotency_keys.append(f"grant:{cycle_order.bill_order_bid}")
+        idempotency_keys.append(f"grant:campaign_bonus:{cycle_order.bill_order_bid}")
+
+    if not idempotency_keys:
+        return
+
+    grant_entries = CreditLedgerEntry.query.filter(
+        CreditLedgerEntry.deleted == 0,
+        CreditLedgerEntry.creator_bid == order.creator_bid,
+        CreditLedgerEntry.idempotency_key.in_(idempotency_keys),
+        CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    ).all()
+    now = now_utc()
+    for grant_entry in grant_entries:
+        metadata = _normalize_json_object(grant_entry.metadata_json)
+        if (
+            str(metadata.get("bucket_credit_state") or "").strip().lower()
+            != "available"
+        ):
+            continue
+        if "activated_at" not in metadata:
+            continue
+        grant_entry.balance_after = _quantize_credit_amount(balance_after)
+        grant_entry.updated_at = now
+        db.session.add(grant_entry)
 
 
 def _repair_existing_paid_order_grant_bucket(

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -923,21 +923,22 @@ def _activate_reserved_renewal_grants_for_cycle(
     )
 
     targets = _preflight_reserved_renewal_grants_for_cycle(cycle_orders)
-    for cycle_order in cycle_orders:
-        _activate_reserved_subscription_grant_for_order(
-            app,
-            order=cycle_order,
-            effective_from=effective_from,
-            effective_to=effective_to,
-            attribution_order_bid=attribution_order_bid,
-        )
-        _activate_reserved_campaign_bonus_grant_for_order(
-            app,
-            order=cycle_order,
-            effective_from=effective_from,
-            effective_to=effective_to,
-        )
-    _assert_reserved_activation_targets_completed(targets)
+    with db.session.begin_nested():
+        for cycle_order in cycle_orders:
+            _activate_reserved_subscription_grant_for_order(
+                app,
+                order=cycle_order,
+                effective_from=effective_from,
+                effective_to=effective_to,
+                attribution_order_bid=attribution_order_bid,
+            )
+            _activate_reserved_campaign_bonus_grant_for_order(
+                app,
+                order=cycle_order,
+                effective_from=effective_from,
+                effective_to=effective_to,
+            )
+        _assert_reserved_activation_targets_completed(targets)
     return True
 
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -120,6 +120,20 @@ _PENDING_RENEWAL_EVENT_STATUSES = (
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
 )
 
+
+class IncompleteReservedGrantActivationError(RuntimeError):
+    """Raised when a renewal cycle cannot activate every reserved grant atomically."""
+
+
+@dataclass(slots=True, frozen=True)
+class ReservedActivationTarget:
+    kind: str
+    order_bid: str
+    ledger_bid: str
+    wallet_bucket_bid: str
+    amount: Decimal
+
+
 SELF_MANAGED_BILLING_PROVIDERS = {"pingxx", "alipay", "wechatpay", "manual"}
 
 
@@ -908,39 +922,23 @@ def _activate_reserved_renewal_grants_for_cycle(
         order.bill_order_bid,
     )
 
-    blocked = False
+    targets = _preflight_reserved_renewal_grants_for_cycle(cycle_orders)
     for cycle_order in cycle_orders:
-        subscription_activated = _activate_reserved_subscription_grant_for_order(
+        _activate_reserved_subscription_grant_for_order(
             app,
             order=cycle_order,
             effective_from=effective_from,
             effective_to=effective_to,
             attribution_order_bid=attribution_order_bid,
         )
-        bonus_activated = _activate_reserved_campaign_bonus_grant_for_order(
+        _activate_reserved_campaign_bonus_grant_for_order(
             app,
             order=cycle_order,
             effective_from=effective_from,
             effective_to=effective_to,
         )
-        if subscription_activated or bonus_activated:
-            continue
-        grant_entry = _load_grant_ledger_entry_for_order(cycle_order)
-        grant_metadata = _normalize_json_object(
-            grant_entry.metadata_json if grant_entry is not None else {}
-        )
-        bonus_entry = _load_campaign_bonus_ledger_entry_for_order(cycle_order)
-        bonus_metadata = _normalize_json_object(
-            bonus_entry.metadata_json if bonus_entry is not None else {}
-        )
-        if (
-            str(grant_metadata.get("bucket_credit_state") or "").strip().lower()
-            == "reserved"
-            or str(bonus_metadata.get("bucket_credit_state") or "").strip().lower()
-            == "reserved"
-        ):
-            blocked = True
-    return not blocked
+    _assert_reserved_activation_targets_completed(targets)
+    return True
 
 
 def _realign_active_topup_bucket_effective_to(
@@ -1030,6 +1028,143 @@ def _load_grant_ledger_entry_for_order(order: BillingOrder) -> CreditLedgerEntry
         .order_by(CreditLedgerEntry.id.desc())
         .first()
     )
+
+
+def _load_reserved_activation_bucket(
+    order: BillingOrder,
+    grant_entry: CreditLedgerEntry,
+    *,
+    fallback_bucket_category: int | None = None,
+) -> CreditWalletBucket | None:
+    bucket = None
+    if _normalize_bid(grant_entry.wallet_bucket_bid):
+        bucket = (
+            CreditWalletBucket.query.filter(
+                CreditWalletBucket.deleted == 0,
+                CreditWalletBucket.wallet_bucket_bid == grant_entry.wallet_bucket_bid,
+            )
+            .order_by(CreditWalletBucket.id.desc())
+            .first()
+        )
+    if bucket is None and fallback_bucket_category is not None:
+        bucket = load_primary_credit_bucket_by_category(
+            order.creator_bid,
+            bucket_category=fallback_bucket_category,
+        )
+    return bucket
+
+
+def _build_reserved_activation_target(
+    *,
+    order: BillingOrder,
+    grant_entry: CreditLedgerEntry | None,
+    kind: str,
+    fallback_bucket_category: int | None = None,
+) -> ReservedActivationTarget | None:
+    if grant_entry is None:
+        return None
+    metadata = _normalize_json_object(grant_entry.metadata_json)
+    if str(metadata.get("bucket_credit_state") or "").strip().lower() != "reserved":
+        return None
+    bucket = _load_reserved_activation_bucket(
+        order,
+        grant_entry,
+        fallback_bucket_category=fallback_bucket_category,
+    )
+    if bucket is None:
+        raise IncompleteReservedGrantActivationError(
+            f"missing_{kind}_bucket:{order.bill_order_bid}"
+        )
+    amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
+    if amount <= 0:
+        raise IncompleteReservedGrantActivationError(
+            f"invalid_{kind}_amount:{order.bill_order_bid}"
+        )
+    return ReservedActivationTarget(
+        kind=kind,
+        order_bid=order.bill_order_bid,
+        ledger_bid=grant_entry.ledger_bid,
+        wallet_bucket_bid=bucket.wallet_bucket_bid,
+        amount=amount,
+    )
+
+
+def _load_reserved_activation_targets_for_cycle_order(
+    order: BillingOrder,
+) -> tuple[ReservedActivationTarget, ...]:
+    targets: list[ReservedActivationTarget] = []
+    subscription_target = _build_reserved_activation_target(
+        order=order,
+        grant_entry=_load_grant_ledger_entry_for_order(order),
+        kind="subscription",
+        fallback_bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+    )
+    if subscription_target is not None:
+        targets.append(subscription_target)
+    campaign_target = _build_reserved_activation_target(
+        order=order,
+        grant_entry=_load_campaign_bonus_ledger_entry_for_order(order),
+        kind="campaign_bonus",
+    )
+    if campaign_target is not None:
+        targets.append(campaign_target)
+    return tuple(targets)
+
+
+def _preflight_reserved_renewal_grants_for_cycle(
+    cycle_orders: list[BillingOrder],
+) -> tuple[ReservedActivationTarget, ...]:
+    targets: list[ReservedActivationTarget] = []
+    required_reserved_by_bucket: dict[str, Decimal] = {}
+    for cycle_order in cycle_orders:
+        for target in _load_reserved_activation_targets_for_cycle_order(cycle_order):
+            targets.append(target)
+            required_reserved_by_bucket[target.wallet_bucket_bid] = (
+                required_reserved_by_bucket.get(target.wallet_bucket_bid, Decimal("0"))
+                + target.amount
+            )
+
+    for wallet_bucket_bid, required_reserved in required_reserved_by_bucket.items():
+        bucket = (
+            CreditWalletBucket.query.filter(
+                CreditWalletBucket.deleted == 0,
+                CreditWalletBucket.wallet_bucket_bid == wallet_bucket_bid,
+            )
+            .order_by(CreditWalletBucket.id.desc())
+            .first()
+        )
+        if bucket is None:
+            raise IncompleteReservedGrantActivationError(
+                f"missing_bucket:{wallet_bucket_bid}"
+            )
+        if _quantize_credit_amount(
+            _to_decimal(bucket.reserved_credits)
+        ) < _quantize_credit_amount(required_reserved):
+            raise IncompleteReservedGrantActivationError(
+                f"insufficient_reserved:{wallet_bucket_bid}"
+            )
+    return tuple(targets)
+
+
+def _assert_reserved_activation_targets_completed(
+    targets: tuple[ReservedActivationTarget, ...],
+) -> None:
+    for target in targets:
+        ledger_entry = (
+            CreditLedgerEntry.query.filter(
+                CreditLedgerEntry.deleted == 0,
+                CreditLedgerEntry.ledger_bid == target.ledger_bid,
+            )
+            .order_by(CreditLedgerEntry.id.desc())
+            .first()
+        )
+        metadata = _normalize_json_object(
+            ledger_entry.metadata_json if ledger_entry is not None else {}
+        )
+        if str(metadata.get("bucket_credit_state") or "").strip().lower() == "reserved":
+            raise IncompleteReservedGrantActivationError(
+                f"incomplete_{target.kind}_activation:{target.order_bid}"
+            )
 
 
 def _repair_existing_paid_order_grant_bucket(

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -790,6 +790,15 @@ def _activate_subscription_for_paid_order(
         BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
         BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     }:
+        if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL and not (
+            _activate_reserved_renewal_grants_for_cycle(
+                app,
+                order=order,
+                effective_from=effective_from,
+                effective_to=effective_to,
+            )
+        ):
+            return False
         if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
             subscription.product_bid = (
                 _normalize_bid(subscription.next_product_bid) or order.product_bid
@@ -812,11 +821,13 @@ def _activate_subscription_for_paid_order(
             effective_to=effective_to,
         )
         if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
-            _activate_reserved_renewal_grants_for_cycle(
-                app,
-                order=order,
-                effective_from=effective_from,
-                effective_to=effective_to,
+            wallet = _load_or_create_credit_wallet(app, order.creator_bid)
+            refresh_credit_wallet_snapshot(wallet, snapshot_at=effective_from)
+            persist_credit_wallet_snapshot(
+                wallet,
+                available_credits=wallet.available_credits,
+                reserved_credits=wallet.reserved_credits,
+                updated_at=now_utc(),
             )
         if _is_preorder_order(order):
             _mark_preorder_effective_applied(order)
@@ -897,28 +908,39 @@ def _activate_reserved_renewal_grants_for_cycle(
         order.bill_order_bid,
     )
 
-    activated = False
+    blocked = False
     for cycle_order in cycle_orders:
-        activated = (
-            _activate_reserved_subscription_grant_for_order(
-                app,
-                order=cycle_order,
-                effective_from=effective_from,
-                effective_to=effective_to,
-                attribution_order_bid=attribution_order_bid,
-            )
-            or activated
+        subscription_activated = _activate_reserved_subscription_grant_for_order(
+            app,
+            order=cycle_order,
+            effective_from=effective_from,
+            effective_to=effective_to,
+            attribution_order_bid=attribution_order_bid,
         )
-        activated = (
-            _activate_reserved_campaign_bonus_grant_for_order(
-                app,
-                order=cycle_order,
-                effective_from=effective_from,
-                effective_to=effective_to,
-            )
-            or activated
+        bonus_activated = _activate_reserved_campaign_bonus_grant_for_order(
+            app,
+            order=cycle_order,
+            effective_from=effective_from,
+            effective_to=effective_to,
         )
-    return activated
+        if subscription_activated or bonus_activated:
+            continue
+        grant_entry = _load_grant_ledger_entry_for_order(cycle_order)
+        grant_metadata = _normalize_json_object(
+            grant_entry.metadata_json if grant_entry is not None else {}
+        )
+        bonus_entry = _load_campaign_bonus_ledger_entry_for_order(cycle_order)
+        bonus_metadata = _normalize_json_object(
+            bonus_entry.metadata_json if bonus_entry is not None else {}
+        )
+        if (
+            str(grant_metadata.get("bucket_credit_state") or "").strip().lower()
+            == "reserved"
+            or str(bonus_metadata.get("bucket_credit_state") or "").strip().lower()
+            == "reserved"
+        ):
+            blocked = True
+    return not blocked
 
 
 def _realign_active_topup_bucket_effective_to(
@@ -1325,6 +1347,11 @@ def _activate_reserved_subscription_grant_for_order(
     if bucket is None:
         return False
 
+    grant_amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
+    reserved_credits = _quantize_credit_amount(_to_decimal(bucket.reserved_credits))
+    if grant_amount <= 0 or reserved_credits < grant_amount:
+        return False
+
     wallet = _load_or_create_credit_wallet(app, order.creator_bid)
     is_first_cycle_activation = (
         bucket.effective_from is None or bucket.effective_from < effective_from
@@ -1339,10 +1366,7 @@ def _activate_reserved_subscription_grant_for_order(
         )
 
     now = now_utc()
-    release_amount = min(
-        _to_decimal(grant_entry.amount),
-        _to_decimal(bucket.reserved_credits),
-    )
+    release_amount = grant_amount
     bucket.wallet_bid = wallet.wallet_bid
     bucket.bucket_category = CREDIT_BUCKET_CATEGORY_SUBSCRIPTION
     bucket.source_type = resolve_bucket_source_type_for_category(
@@ -1434,12 +1458,14 @@ def _activate_reserved_campaign_bonus_grant_for_order(
     if bucket is None:
         return False
 
+    grant_amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
+    reserved_credits = _quantize_credit_amount(_to_decimal(bucket.reserved_credits))
+    if grant_amount <= 0 or reserved_credits < grant_amount:
+        return False
+
     wallet = _load_or_create_credit_wallet(app, order.creator_bid)
     now = now_utc()
-    release_amount = min(
-        _to_decimal(grant_entry.amount),
-        _to_decimal(bucket.reserved_credits),
-    )
+    release_amount = grant_amount
     bucket.reserved_credits = _quantize_credit_amount(
         _to_decimal(bucket.reserved_credits) - release_amount
     )

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -799,20 +799,19 @@ def _activate_subscription_for_paid_order(
         db.session.add(subscription)
         return False
 
+    activated_reserved_targets: tuple[ReservedActivationTarget, ...] = ()
     if order.order_type in {
         BILLING_ORDER_TYPE_SUBSCRIPTION_START,
         BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
         BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     }:
-        if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL and not (
-            _activate_reserved_renewal_grants_for_cycle(
+        if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
+            activated_reserved_targets = _activate_reserved_renewal_grants_for_cycle(
                 app,
                 order=order,
                 effective_from=effective_from,
                 effective_to=effective_to,
             )
-        ):
-            return False
         if order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
             subscription.product_bid = (
                 _normalize_bid(subscription.next_product_bid) or order.product_bid
@@ -844,9 +843,8 @@ def _activate_subscription_for_paid_order(
                 updated_at=now_utc(),
             )
             _sync_activated_reserved_renewal_ledger_balances(
-                order=order,
-                effective_from=effective_from,
-                balance_after=wallet.available_credits,
+                targets=activated_reserved_targets,
+                final_balance_after=wallet.available_credits,
             )
         if _is_preorder_order(order):
             _mark_preorder_effective_applied(order)
@@ -900,23 +898,11 @@ def _activate_reserved_renewal_grants_for_cycle(
     order: BillingOrder,
     effective_from: datetime,
     effective_to: datetime | None,
-) -> bool:
-    cycle_orders = list(
-        _load_paid_subscription_renewal_orders_for_cycle(
-            subscription_bid=order.subscription_bid,
-            effective_from=effective_from,
-        )
+) -> tuple[ReservedActivationTarget, ...]:
+    cycle_orders = _load_sorted_paid_subscription_renewal_orders_for_cycle(
+        order=order,
+        effective_from=effective_from,
     )
-    if not cycle_orders:
-        cycle_orders = [order]
-    else:
-        cycle_orders.sort(
-            key=lambda row: (
-                0 if row.bill_order_bid == order.bill_order_bid else 1,
-                row.created_at or datetime.min,
-                row.id,
-            )
-        )
 
     attribution_order_bid = next(
         (
@@ -926,6 +912,9 @@ def _activate_reserved_renewal_grants_for_cycle(
         ),
         order.bill_order_bid,
     )
+
+    if not _cycle_has_reserved_activation_evidence(cycle_orders):
+        return ()
 
     targets = _preflight_reserved_renewal_grants_for_cycle(cycle_orders)
     with db.session.begin_nested():
@@ -943,8 +932,67 @@ def _activate_reserved_renewal_grants_for_cycle(
                 effective_from=effective_from,
                 effective_to=effective_to,
             )
-        _assert_reserved_activation_targets_completed(targets)
-    return True
+        _assert_reserved_activation_targets_completed(cycle_orders)
+    return targets
+
+
+def validate_reserved_renewal_cycle_activation(
+    order: BillingOrder,
+    *,
+    effective_from: datetime | None = None,
+) -> tuple[ReservedActivationTarget, ...]:
+    """Validate a renewal cycle can activate every reserved grant atomically."""
+
+    resolved_effective_from = effective_from or _resolve_credit_bucket_effective_from(
+        order=order,
+        default_effective_from=order.paid_at or now_utc(),
+    )
+    cycle_orders = _load_sorted_paid_subscription_renewal_orders_for_cycle(
+        order=order,
+        effective_from=resolved_effective_from,
+    )
+    return _preflight_reserved_renewal_grants_for_cycle(cycle_orders)
+
+
+def _load_sorted_paid_subscription_renewal_orders_for_cycle(
+    *,
+    order: BillingOrder,
+    effective_from: datetime,
+) -> list[BillingOrder]:
+    cycle_orders = list(
+        _load_paid_subscription_renewal_orders_for_cycle(
+            subscription_bid=order.subscription_bid,
+            effective_from=effective_from,
+        )
+    )
+    if not cycle_orders:
+        cycle_orders = [order]
+    else:
+        cycle_orders.sort(
+            key=lambda row: (
+                0
+                if int(row.paid_amount or 0) > 0 or int(row.payable_amount or 0) > 0
+                else 1,
+                row.paid_at or row.created_at or datetime.min,
+                row.created_at or datetime.min,
+                row.id,
+            )
+        )
+    return cycle_orders
+
+
+def _cycle_has_reserved_activation_evidence(cycle_orders: list[BillingOrder]) -> bool:
+    for cycle_order in cycle_orders:
+        for grant_entry in (
+            _load_grant_ledger_entry_for_order(cycle_order),
+            _load_campaign_bonus_ledger_entry_for_order(cycle_order),
+        ):
+            if (
+                grant_entry is not None
+                and _reserved_grant_state(grant_entry) == "reserved"
+            ):
+                return True
+    return False
 
 
 def _realign_active_topup_bucket_effective_to(
@@ -1060,18 +1108,59 @@ def _load_reserved_activation_bucket(
     return bucket
 
 
+def _reserved_grant_state(grant_entry: CreditLedgerEntry) -> str:
+    metadata = _normalize_json_object(grant_entry.metadata_json)
+    return str(metadata.get("bucket_credit_state") or "").strip().lower()
+
+
+def _expected_subscription_grant_amount(order: BillingOrder) -> Decimal:
+    product = _load_billing_product_by_bid(order.product_bid)
+    if product is None:
+        raise IncompleteReservedGrantActivationError(
+            f"missing_subscription_product:{order.bill_order_bid}"
+        )
+    return _quantize_credit_amount(_to_decimal(product.credit_amount))
+
+
+def _expected_campaign_bonus_grant_amount(order: BillingOrder) -> Decimal:
+    if not _normalize_bid(order.campaign_bid):
+        return Decimal("0")
+    return _quantize_credit_amount(_to_decimal(order.campaign_bonus_credit_amount))
+
+
 def _build_reserved_activation_target(
     *,
     order: BillingOrder,
     grant_entry: CreditLedgerEntry | None,
     kind: str,
+    expected_amount: Decimal,
     fallback_bucket_category: int | None = None,
 ) -> ReservedActivationTarget | None:
+    if expected_amount <= 0:
+        return None
     if grant_entry is None:
+        raise IncompleteReservedGrantActivationError(
+            f"missing_{kind}_ledger:{order.bill_order_bid}"
+        )
+
+    state = _reserved_grant_state(grant_entry)
+    if state == "available":
         return None
-    metadata = _normalize_json_object(grant_entry.metadata_json)
-    if str(metadata.get("bucket_credit_state") or "").strip().lower() != "reserved":
-        return None
+    if state != "reserved":
+        raise IncompleteReservedGrantActivationError(
+            f"invalid_{kind}_state:{order.bill_order_bid}:{state or 'missing'}"
+        )
+
+    amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
+    if kind != "subscription" and amount != expected_amount:
+        raise IncompleteReservedGrantActivationError(
+            f"{kind}_amount_mismatch:{order.bill_order_bid}"
+        )
+    if amount <= 0:
+        raise IncompleteReservedGrantActivationError(
+            f"invalid_{kind}_amount:{order.bill_order_bid}"
+        )
+
     bucket = _load_reserved_activation_bucket(
         order,
         grant_entry,
@@ -1081,10 +1170,56 @@ def _build_reserved_activation_target(
         raise IncompleteReservedGrantActivationError(
             f"missing_{kind}_bucket:{order.bill_order_bid}"
         )
-    amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
-    if amount <= 0:
+    if _quantize_credit_amount(_to_decimal(bucket.reserved_credits)) < amount:
         raise IncompleteReservedGrantActivationError(
-            f"invalid_{kind}_amount:{order.bill_order_bid}"
+            f"insufficient_{kind}_reserved:{order.bill_order_bid}"
+        )
+
+    return ReservedActivationTarget(
+        kind=kind,
+        order_bid=order.bill_order_bid,
+        ledger_bid=grant_entry.ledger_bid,
+        wallet_bucket_bid=bucket.wallet_bucket_bid,
+        amount=amount,
+    )
+
+
+def _build_reserved_completion_target(
+    *,
+    order: BillingOrder,
+    grant_entry: CreditLedgerEntry | None,
+    kind: str,
+    expected_amount: Decimal,
+    fallback_bucket_category: int | None = None,
+) -> ReservedActivationTarget | None:
+    if expected_amount <= 0:
+        return None
+    if grant_entry is None:
+        raise IncompleteReservedGrantActivationError(
+            f"missing_{kind}_ledger:{order.bill_order_bid}"
+        )
+    state = _reserved_grant_state(grant_entry)
+    if state != "available":
+        raise IncompleteReservedGrantActivationError(
+            f"incomplete_{kind}_activation:{order.bill_order_bid}"
+        )
+    amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
+    if kind != "subscription" and amount != expected_amount:
+        raise IncompleteReservedGrantActivationError(
+            f"{kind}_amount_mismatch:{order.bill_order_bid}"
+        )
+    bucket = _load_reserved_activation_bucket(
+        order,
+        grant_entry,
+        fallback_bucket_category=fallback_bucket_category,
+    )
+    if bucket is None:
+        raise IncompleteReservedGrantActivationError(
+            f"missing_{kind}_bucket:{order.bill_order_bid}"
+        )
+    if _quantize_credit_amount(_to_decimal(bucket.available_credits)) < amount:
+        raise IncompleteReservedGrantActivationError(
+            f"incomplete_{kind}_bucket:{order.bill_order_bid}"
         )
     return ReservedActivationTarget(
         kind=kind,
@@ -1103,6 +1238,7 @@ def _load_reserved_activation_targets_for_cycle_order(
         order=order,
         grant_entry=_load_grant_ledger_entry_for_order(order),
         kind="subscription",
+        expected_amount=_expected_subscription_grant_amount(order),
         fallback_bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     )
     if subscription_target is not None:
@@ -1111,6 +1247,31 @@ def _load_reserved_activation_targets_for_cycle_order(
         order=order,
         grant_entry=_load_campaign_bonus_ledger_entry_for_order(order),
         kind="campaign_bonus",
+        expected_amount=_expected_campaign_bonus_grant_amount(order),
+    )
+    if campaign_target is not None:
+        targets.append(campaign_target)
+    return tuple(targets)
+
+
+def _load_reserved_completion_targets_for_cycle_order(
+    order: BillingOrder,
+) -> tuple[ReservedActivationTarget, ...]:
+    targets: list[ReservedActivationTarget] = []
+    subscription_target = _build_reserved_completion_target(
+        order=order,
+        grant_entry=_load_grant_ledger_entry_for_order(order),
+        kind="subscription",
+        expected_amount=_expected_subscription_grant_amount(order),
+        fallback_bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+    )
+    if subscription_target is not None:
+        targets.append(subscription_target)
+    campaign_target = _build_reserved_completion_target(
+        order=order,
+        grant_entry=_load_campaign_bonus_ledger_entry_for_order(order),
+        kind="campaign_bonus",
+        expected_amount=_expected_campaign_bonus_grant_amount(order),
     )
     if campaign_target is not None:
         targets.append(campaign_target)
@@ -1153,10 +1314,25 @@ def _preflight_reserved_renewal_grants_for_cycle(
 
 
 def _assert_reserved_activation_targets_completed(
-    targets: tuple[ReservedActivationTarget, ...],
+    cycle_orders: list[BillingOrder],
 ) -> None:
+    for cycle_order in cycle_orders:
+        _load_reserved_completion_targets_for_cycle_order(cycle_order)
+
+
+def _sync_activated_reserved_renewal_ledger_balances(
+    *,
+    targets: tuple[ReservedActivationTarget, ...],
+    final_balance_after: Decimal,
+) -> None:
+    if not targets:
+        return
+
+    total_activated = sum((target.amount for target in targets), start=Decimal("0"))
+    running_balance = _quantize_credit_amount(final_balance_after - total_activated)
+    now = now_utc()
     for target in targets:
-        ledger_entry = (
+        grant_entry = (
             CreditLedgerEntry.query.filter(
                 CreditLedgerEntry.deleted == 0,
                 CreditLedgerEntry.ledger_bid == target.ledger_bid,
@@ -1164,55 +1340,12 @@ def _assert_reserved_activation_targets_completed(
             .order_by(CreditLedgerEntry.id.desc())
             .first()
         )
-        metadata = _normalize_json_object(
-            ledger_entry.metadata_json if ledger_entry is not None else {}
-        )
-        if str(metadata.get("bucket_credit_state") or "").strip().lower() == "reserved":
+        if grant_entry is None or _reserved_grant_state(grant_entry) != "available":
             raise IncompleteReservedGrantActivationError(
                 f"incomplete_{target.kind}_activation:{target.order_bid}"
             )
-
-
-def _sync_activated_reserved_renewal_ledger_balances(
-    *,
-    order: BillingOrder,
-    effective_from: datetime,
-    balance_after: Decimal,
-) -> None:
-    cycle_orders = list(
-        _load_paid_subscription_renewal_orders_for_cycle(
-            subscription_bid=order.subscription_bid,
-            effective_from=effective_from,
-        )
-    )
-    if not cycle_orders:
-        cycle_orders = [order]
-
-    idempotency_keys: list[str] = []
-    for cycle_order in cycle_orders:
-        idempotency_keys.append(f"grant:{cycle_order.bill_order_bid}")
-        idempotency_keys.append(f"grant:campaign_bonus:{cycle_order.bill_order_bid}")
-
-    if not idempotency_keys:
-        return
-
-    grant_entries = CreditLedgerEntry.query.filter(
-        CreditLedgerEntry.deleted == 0,
-        CreditLedgerEntry.creator_bid == order.creator_bid,
-        CreditLedgerEntry.idempotency_key.in_(idempotency_keys),
-        CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-    ).all()
-    now = now_utc()
-    for grant_entry in grant_entries:
-        metadata = _normalize_json_object(grant_entry.metadata_json)
-        if (
-            str(metadata.get("bucket_credit_state") or "").strip().lower()
-            != "available"
-        ):
-            continue
-        if "activated_at" not in metadata:
-            continue
-        grant_entry.balance_after = _quantize_credit_amount(balance_after)
+        running_balance = _quantize_credit_amount(running_balance + target.amount)
+        grant_entry.balance_after = running_balance
         grant_entry.updated_at = now
         db.session.add(grant_entry)
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -19,6 +19,9 @@ from flaskr.util.datetime import now_utc
 
 from .consts import (
     ACTIVE_SUBSCRIPTION_STATUSES,
+    BILLING_ORDER_STATUS_PAID,
+    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,
@@ -45,6 +48,8 @@ from .bucket_categories import (
 )
 from .dtos import BillingLedgerAdjustResultDTO, BillingWalletRefDTO
 from .models import (
+    BillingOrder,
+    BillingRenewalEvent,
     BillingSubscription,
     CreditLedgerEntry,
     CreditWallet,
@@ -253,6 +258,33 @@ class ManualCreditGrantResult:
 
 
 @dataclass(slots=True, frozen=True)
+class ReservedGrantRepairRecord:
+    creator_bid: str
+    bill_order_bid: str
+    subscription_bid: str | None
+    grant_ledger_bid: str
+    wallet_bucket_bid: str | None
+    consumable_from: datetime | None
+    paid_at: datetime | None
+    renewal_event_bids: list[str] = field(default_factory=list)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "creator_bid": self.creator_bid,
+            "bill_order_bid": self.bill_order_bid,
+            "subscription_bid": self.subscription_bid,
+            "grant_ledger_bid": self.grant_ledger_bid,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "consumable_from": self.consumable_from,
+            "paid_at": self.paid_at,
+            "renewal_event_bids": list(self.renewal_event_bids),
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_payload()[key]
+
+
+@dataclass(slots=True, frozen=True)
 class RenewalStateDriftRepairResult:
     status: str
     creator_bid: str | None
@@ -263,7 +295,14 @@ class RenewalStateDriftRepairResult:
     expired_bucket_count: int
     expired_credits: int | float
     dry_run: bool
+    overdue_reserved_grant_count: int = 0
+    activated_reserved_order_count: int = 0
+    protected_creator_count: int = 0
     creator_bids: list[str] = field(default_factory=list)
+    protected_creator_bids: list[str] = field(default_factory=list)
+    overdue_reserved_grants: list[ReservedGrantRepairRecord] = field(
+        default_factory=list
+    )
 
     def to_task_payload(self) -> dict[str, Any]:
         return {
@@ -276,11 +315,134 @@ class RenewalStateDriftRepairResult:
             "expired_bucket_count": self.expired_bucket_count,
             "expired_credits": self.expired_credits,
             "dry_run": self.dry_run,
+            "overdue_reserved_grant_count": self.overdue_reserved_grant_count,
+            "activated_reserved_order_count": self.activated_reserved_order_count,
+            "protected_creator_count": self.protected_creator_count,
             "creator_bids": list(self.creator_bids),
+            "protected_creator_bids": list(self.protected_creator_bids),
+            "overdue_reserved_grants": [
+                record.to_payload() for record in self.overdue_reserved_grants
+            ],
         }
 
     def __getitem__(self, key: str) -> Any:
         return self.to_task_payload()[key]
+
+
+def _normalize_bid(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_json_dict(payload: object) -> dict[str, Any]:
+    return payload if isinstance(payload, dict) else {}
+
+
+def _extract_order_bid_from_renewal_event(event: BillingRenewalEvent) -> str:
+    payload = _normalize_json_dict(event.payload_json)
+    return _normalize_bid(payload.get("bill_order_bid"))
+
+
+def _load_overdue_reserved_paid_order_records(
+    *,
+    repaired_at: datetime,
+    creator_bid: str = "",
+    creator_bids: set[str] | None = None,
+) -> list[ReservedGrantRepairRecord]:
+    query = CreditLedgerEntry.query.filter(
+        CreditLedgerEntry.deleted == 0,
+        CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+        CreditLedgerEntry.consumable_from.isnot(None),
+        CreditLedgerEntry.consumable_from <= repaired_at,
+    ).order_by(CreditLedgerEntry.consumable_from.asc(), CreditLedgerEntry.id.asc())
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    if normalized_creator_bid:
+        query = query.filter(CreditLedgerEntry.creator_bid == normalized_creator_bid)
+    elif creator_bids:
+        query = query.filter(CreditLedgerEntry.creator_bid.in_(sorted(creator_bids)))
+
+    candidate_ledgers: list[tuple[CreditLedgerEntry, str]] = []
+    candidate_order_bids: set[str] = set()
+    candidate_creator_bids: set[str] = set()
+    for ledger in query.all():
+        metadata = _normalize_json_dict(ledger.metadata_json)
+        if str(metadata.get("bucket_credit_state") or "").strip().lower() != "reserved":
+            continue
+        bill_order_bid = _normalize_bid(
+            metadata.get("bill_order_bid")
+        ) or _normalize_bid(ledger.source_bid)
+        if not bill_order_bid:
+            continue
+        candidate_ledgers.append((ledger, bill_order_bid))
+        candidate_order_bids.add(bill_order_bid)
+        candidate_creator_bids.add(_normalize_bid(ledger.creator_bid))
+
+    if not candidate_ledgers:
+        return []
+
+    orders = (
+        BillingOrder.query.filter(
+            BillingOrder.deleted == 0,
+            BillingOrder.bill_order_bid.in_(sorted(candidate_order_bids)),
+            BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+        )
+        .order_by(BillingOrder.id.asc())
+        .all()
+    )
+    orders_by_bid = {
+        _normalize_bid(order.bill_order_bid): order
+        for order in orders
+        if _normalize_bid(order.bill_order_bid)
+    }
+    if not orders_by_bid:
+        return []
+
+    renewal_events_by_order_bid: dict[str, list[str]] = {}
+    if candidate_creator_bids:
+        event_rows = (
+            BillingRenewalEvent.query.filter(
+                BillingRenewalEvent.deleted == 0,
+                BillingRenewalEvent.creator_bid.in_(sorted(candidate_creator_bids)),
+                BillingRenewalEvent.status.notin_(
+                    [
+                        BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+                        BILLING_RENEWAL_EVENT_STATUS_FAILED,
+                    ]
+                ),
+            )
+            .order_by(
+                BillingRenewalEvent.scheduled_at.asc(), BillingRenewalEvent.id.asc()
+            )
+            .all()
+        )
+        for event in event_rows:
+            bill_order_bid = _extract_order_bid_from_renewal_event(event)
+            if not bill_order_bid or bill_order_bid not in orders_by_bid:
+                continue
+            renewal_event_bid = _normalize_bid(event.renewal_event_bid)
+            if not renewal_event_bid:
+                continue
+            renewal_events_by_order_bid.setdefault(bill_order_bid, []).append(
+                renewal_event_bid
+            )
+
+    records: list[ReservedGrantRepairRecord] = []
+    for ledger, bill_order_bid in candidate_ledgers:
+        order = orders_by_bid.get(bill_order_bid)
+        if order is None:
+            continue
+        records.append(
+            ReservedGrantRepairRecord(
+                creator_bid=_normalize_bid(ledger.creator_bid),
+                bill_order_bid=bill_order_bid,
+                subscription_bid=_normalize_bid(order.subscription_bid) or None,
+                grant_ledger_bid=_normalize_bid(ledger.ledger_bid),
+                wallet_bucket_bid=_normalize_bid(ledger.wallet_bucket_bid) or None,
+                consumable_from=ledger.consumable_from,
+                paid_at=order.paid_at,
+                renewal_event_bids=renewal_events_by_order_bid.get(bill_order_bid, []),
+            )
+        )
+    return records
 
 
 def _build_legacy_expire_ledger_idempotency_key(wallet_bucket_bid: str) -> str:
@@ -699,6 +861,10 @@ def repair_renewal_state_drift(
             CreditWalletBucket.created_at.asc(),
             CreditWalletBucket.id.asc(),
         ).all()
+        overdue_reserved_grants = _load_overdue_reserved_paid_order_records(
+            repaired_at=repaired_at,
+            creator_bid=normalized_creator_bid,
+        )
 
         creator_bids: list[str] = []
         seen_creator_bids: set[str] = set()
@@ -709,6 +875,11 @@ def repair_renewal_state_drift(
                 creator_bids.append(candidate)
         for row in stale_buckets:
             candidate = str(row.creator_bid or "").strip()
+            if candidate and candidate not in seen_creator_bids:
+                seen_creator_bids.add(candidate)
+                creator_bids.append(candidate)
+        for record in overdue_reserved_grants:
+            candidate = _normalize_bid(record.creator_bid)
             if candidate and candidate not in seen_creator_bids:
                 seen_creator_bids.add(candidate)
                 creator_bids.append(candidate)
@@ -726,7 +897,12 @@ def repair_renewal_state_drift(
                 expired_bucket_count=0,
                 expired_credits=0,
                 dry_run=dry_run,
+                overdue_reserved_grant_count=0,
+                activated_reserved_order_count=0,
+                protected_creator_count=0,
                 creator_bids=[],
+                protected_creator_bids=[],
+                overdue_reserved_grants=[],
             )
 
         scoped_creator_bids = set(creator_bids)
@@ -740,13 +916,65 @@ def repair_renewal_state_drift(
             for row in stale_buckets
             if str(row.creator_bid or "").strip() in scoped_creator_bids
         )
+        scoped_overdue_reserved_grants = [
+            record
+            for record in overdue_reserved_grants
+            if _normalize_bid(record.creator_bid) in scoped_creator_bids
+        ]
+        overdue_reserved_order_bids_by_creator: dict[str, list[str]] = {}
+        for record in scoped_overdue_reserved_grants:
+            overdue_reserved_order_bids_by_creator.setdefault(
+                _normalize_bid(record.creator_bid), []
+            ).append(record.bill_order_bid)
 
         expired_bucket_count = 0
         expired_credits = 0.0
         updated_subscription_count = 0
+        activated_reserved_order_count = 0
+        protected_creator_bids: list[str] = []
 
         if not dry_run:
             for target_creator_bid in creator_bids:
+                candidate_order_bids = sorted(
+                    {
+                        order_bid
+                        for order_bid in overdue_reserved_order_bids_by_creator.get(
+                            target_creator_bid, []
+                        )
+                        if _normalize_bid(order_bid)
+                    }
+                )
+                if candidate_order_bids:
+                    from .subscriptions import grant_paid_order_credits
+
+                    candidate_orders = (
+                        BillingOrder.query.filter(
+                            BillingOrder.deleted == 0,
+                            BillingOrder.creator_bid == target_creator_bid,
+                            BillingOrder.bill_order_bid.in_(candidate_order_bids),
+                            BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+                        )
+                        .order_by(
+                            BillingOrder.paid_at.asc(),
+                            BillingOrder.created_at.asc(),
+                            BillingOrder.id.asc(),
+                        )
+                        .all()
+                    )
+                    if candidate_orders:
+                        with unit_of_work():
+                            for order in candidate_orders:
+                                grant_paid_order_credits(app, order)
+                                activated_reserved_order_count += 1
+
+                remaining_reserved_records = _load_overdue_reserved_paid_order_records(
+                    repaired_at=repaired_at,
+                    creator_bid=target_creator_bid,
+                )
+                if remaining_reserved_records:
+                    protected_creator_bids.append(target_creator_bid)
+                    continue
+
                 expiration_payload = expire_credit_wallet_buckets(
                     app,
                     creator_bid=target_creator_bid,
@@ -769,10 +997,18 @@ def repair_renewal_state_drift(
             if changed_subscriptions:
                 with unit_of_work():
                     for subscription in changed_subscriptions:
+                        if _normalize_bid(subscription.creator_bid) in set(
+                            protected_creator_bids
+                        ):
+                            continue
                         subscription.status = BILLING_SUBSCRIPTION_STATUS_EXPIRED
                         subscription.updated_at = repaired_at
                         db.session.add(subscription)
                         updated_subscription_count += 1
+        else:
+            protected_creator_bids = sorted(
+                overdue_reserved_order_bids_by_creator.keys()
+            )
 
         return RenewalStateDriftRepairResult(
             status="dry_run" if dry_run else "repaired",
@@ -784,7 +1020,12 @@ def repair_renewal_state_drift(
             expired_bucket_count=expired_bucket_count,
             expired_credits=expired_credits,
             dry_run=dry_run,
+            overdue_reserved_grant_count=len(scoped_overdue_reserved_grants),
+            activated_reserved_order_count=activated_reserved_order_count,
+            protected_creator_count=len(protected_creator_bids),
             creator_bids=creator_bids,
+            protected_creator_bids=protected_creator_bids,
+            overdue_reserved_grants=scoped_overdue_reserved_grants,
         )
 
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from flask import Flask
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
@@ -345,9 +346,83 @@ def _normalize_json_dict(payload: object) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+@dataclass(slots=True, frozen=True)
+class ReservedGrantActivationSnapshot:
+    grant_ledger_bid: str
+    wallet_bucket_bid: str
+    grant_amount: Decimal
+    reserved_credits: Decimal
+
+
 def _extract_order_bid_from_renewal_event(event: BillingRenewalEvent) -> str:
     payload = _normalize_json_dict(event.payload_json)
     return _normalize_bid(payload.get("bill_order_bid"))
+
+
+def _capture_reserved_grant_activation_snapshot(
+    order: BillingOrder,
+) -> ReservedGrantActivationSnapshot | None:
+    grant_entry = (
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.creator_bid == order.creator_bid,
+            CreditLedgerEntry.idempotency_key == f"grant:{order.bill_order_bid}",
+        )
+        .order_by(CreditLedgerEntry.id.desc())
+        .first()
+    )
+    if grant_entry is None or not _normalize_bid(grant_entry.wallet_bucket_bid):
+        return None
+    bucket = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.wallet_bucket_bid == grant_entry.wallet_bucket_bid,
+        )
+        .order_by(CreditWalletBucket.id.desc())
+        .first()
+    )
+    if bucket is None:
+        return None
+    return ReservedGrantActivationSnapshot(
+        grant_ledger_bid=grant_entry.ledger_bid,
+        wallet_bucket_bid=bucket.wallet_bucket_bid,
+        grant_amount=_to_decimal(grant_entry.amount),
+        reserved_credits=_to_decimal(bucket.reserved_credits),
+    )
+
+
+def _reserved_grant_activation_completed(
+    order: BillingOrder,
+    snapshot: ReservedGrantActivationSnapshot | None,
+) -> bool:
+    if snapshot is None:
+        return False
+    grant_entry = (
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.ledger_bid == snapshot.grant_ledger_bid,
+        )
+        .order_by(CreditLedgerEntry.id.desc())
+        .first()
+    )
+    bucket = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.wallet_bucket_bid == snapshot.wallet_bucket_bid,
+        )
+        .order_by(CreditWalletBucket.id.desc())
+        .first()
+    )
+    if grant_entry is None or bucket is None:
+        return False
+    metadata = _normalize_json_dict(grant_entry.metadata_json)
+    if str(metadata.get("bucket_credit_state") or "").strip().lower() == "reserved":
+        return False
+    moved_reserved_amount = _quantize_credit_amount(
+        snapshot.reserved_credits - _to_decimal(bucket.reserved_credits)
+    )
+    expected_amount = _quantize_credit_amount(snapshot.grant_amount)
+    return moved_reserved_amount == expected_amount
 
 
 def _load_overdue_reserved_paid_order_records(
@@ -453,6 +528,50 @@ def _load_overdue_reserved_paid_order_records(
             )
         )
     return records
+
+
+def _load_overdue_reserved_paid_order_creator_bids(
+    *,
+    repaired_at: datetime,
+    creator_bid: str = "",
+    limit: int | None = None,
+) -> list[str]:
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
+    bill_order_bid_expr = func.coalesce(
+        func.json_extract(CreditLedgerEntry.metadata_json, "$.bill_order_bid"),
+        CreditLedgerEntry.source_bid,
+    )
+    query = (
+        db.session.query(CreditLedgerEntry.creator_bid)
+        .join(
+            BillingOrder,
+            BillingOrder.bill_order_bid == bill_order_bid_expr,
+        )
+        .filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            CreditLedgerEntry.consumable_from.isnot(None),
+            CreditLedgerEntry.consumable_from <= repaired_at,
+            func.lower(
+                func.coalesce(
+                    func.json_extract(
+                        CreditLedgerEntry.metadata_json, "$.bucket_credit_state"
+                    ),
+                    "",
+                )
+            )
+            == "reserved",
+            BillingOrder.deleted == 0,
+            BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+        )
+    )
+    if normalized_creator_bid:
+        query = query.filter(CreditLedgerEntry.creator_bid == normalized_creator_bid)
+    query = query.distinct().order_by(CreditLedgerEntry.creator_bid.asc())
+    if normalized_limit is not None:
+        query = query.limit(normalized_limit)
+    return [_normalize_bid(row[0]) for row in query.all() if _normalize_bid(row[0])]
 
 
 def _build_legacy_expire_ledger_idempotency_key(wallet_bucket_bid: str) -> str:
@@ -883,13 +1002,19 @@ def repair_renewal_state_drift(
             if candidate and candidate not in seen_creator_bids:
                 seen_creator_bids.add(candidate)
                 creator_bids.append(candidate)
-        overdue_reserved_grants = _load_overdue_reserved_paid_order_records(
-            repaired_at=repaired_at,
-            creator_bid=normalized_creator_bid,
-            creator_bids=None if normalized_creator_bid else seen_creator_bids,
-        )
-        for record in overdue_reserved_grants:
-            candidate = _normalize_bid(record.creator_bid)
+        remaining_limit = None
+        if normalized_limit is not None:
+            remaining_limit = max(normalized_limit - len(creator_bids), 0)
+        overdue_reserved_creator_bids: list[str] = []
+        if remaining_limit is None or remaining_limit > 0:
+            overdue_reserved_creator_bids = (
+                _load_overdue_reserved_paid_order_creator_bids(
+                    repaired_at=repaired_at,
+                    creator_bid=normalized_creator_bid,
+                    limit=remaining_limit,
+                )
+            )
+        for candidate in overdue_reserved_creator_bids:
             if candidate and candidate not in seen_creator_bids:
                 seen_creator_bids.add(candidate)
                 creator_bids.append(candidate)
@@ -920,6 +1045,11 @@ def repair_renewal_state_drift(
             )
 
         scoped_creator_bids = set(creator_bids)
+        overdue_reserved_grants = _load_overdue_reserved_paid_order_records(
+            repaired_at=repaired_at,
+            creator_bid=normalized_creator_bid,
+            creator_bids=scoped_creator_bids,
+        )
         scoped_stale_subscription_count = sum(
             1
             for row in stale_subscriptions
@@ -981,9 +1111,18 @@ def repair_renewal_state_drift(
                     if candidate_orders:
                         with unit_of_work():
                             for order in candidate_orders:
+                                activation_snapshot = (
+                                    _capture_reserved_grant_activation_snapshot(order)
+                                )
                                 grant_paid_order_credits(app, order)
-                                activated_reserved_order_count += 1
-                        activated_creator_bids.append(target_creator_bid)
+                                if _reserved_grant_activation_completed(
+                                    order, activation_snapshot
+                                ):
+                                    activated_reserved_order_count += 1
+                                    if target_creator_bid not in activated_creator_bids:
+                                        activated_creator_bids.append(
+                                            target_creator_bid
+                                        )
 
                 remaining_reserved_records = _load_overdue_reserved_paid_order_records(
                     repaired_at=repaired_at,

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from flask import Flask
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
@@ -301,10 +301,12 @@ class RenewalStateDriftRepairResult:
     activated_reserved_order_count: int = 0
     activated_creator_count: int = 0
     protected_creator_count: int = 0
+    manual_review_creator_count: int = 0
     creator_bids: list[str] = field(default_factory=list)
     activatable_creator_bids: list[str] = field(default_factory=list)
     activated_creator_bids: list[str] = field(default_factory=list)
     protected_creator_bids: list[str] = field(default_factory=list)
+    manual_review_creator_bids: list[str] = field(default_factory=list)
     overdue_reserved_grants: list[ReservedGrantRepairRecord] = field(
         default_factory=list
     )
@@ -325,10 +327,12 @@ class RenewalStateDriftRepairResult:
             "activated_reserved_order_count": self.activated_reserved_order_count,
             "activated_creator_count": self.activated_creator_count,
             "protected_creator_count": self.protected_creator_count,
+            "manual_review_creator_count": self.manual_review_creator_count,
             "creator_bids": list(self.creator_bids),
             "activatable_creator_bids": list(self.activatable_creator_bids),
             "activated_creator_bids": list(self.activated_creator_bids),
             "protected_creator_bids": list(self.protected_creator_bids),
+            "manual_review_creator_bids": list(self.manual_review_creator_bids),
             "overdue_reserved_grants": [
                 record.to_payload() for record in self.overdue_reserved_grants
             ],
@@ -342,6 +346,11 @@ def _normalize_bid(value: object) -> str:
     return str(value or "").strip()
 
 
+def _normalize_optional_metadata_bid(value: object) -> str:
+    normalized = _normalize_bid(value)
+    return "" if normalized.lower() == "null" else normalized
+
+
 def _normalize_json_dict(payload: object) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
@@ -353,6 +362,15 @@ def _json_extract_text(column: Any, path: str) -> Any:
     if dialect_name == "mysql":
         return func.json_unquote(extracted)
     return extracted
+
+
+def _sql_null_if_empty_or_json_null(value: Any) -> Any:
+    text = func.trim(func.coalesce(value, ""))
+    return case(
+        (func.lower(text) == "null", None),
+        (text == "", None),
+        else_=text,
+    )
 
 
 def _extract_order_bid_from_renewal_event(event: BillingRenewalEvent) -> str:
@@ -400,9 +418,9 @@ def _load_overdue_reserved_paid_order_records(
         metadata = _normalize_json_dict(ledger.metadata_json)
         if str(metadata.get("bucket_credit_state") or "").strip().lower() != "reserved":
             continue
-        bill_order_bid = _normalize_bid(
+        bill_order_bid = _normalize_optional_metadata_bid(
             metadata.get("bill_order_bid")
-        ) or _normalize_bid(ledger.source_bid)
+        ) or _normalize_optional_metadata_bid(ledger.source_bid)
         if not bill_order_bid:
             continue
         candidate_ledgers.append((ledger, bill_order_bid))
@@ -487,8 +505,10 @@ def _load_overdue_reserved_paid_order_creator_bids(
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
     bill_order_bid_expr = func.coalesce(
-        _json_extract_text(CreditLedgerEntry.metadata_json, "$.bill_order_bid"),
-        CreditLedgerEntry.source_bid,
+        _sql_null_if_empty_or_json_null(
+            _json_extract_text(CreditLedgerEntry.metadata_json, "$.bill_order_bid")
+        ),
+        _sql_null_if_empty_or_json_null(CreditLedgerEntry.source_bid),
     )
     query = (
         db.session.query(CreditLedgerEntry.creator_bid)
@@ -985,10 +1005,12 @@ def repair_renewal_state_drift(
                 activated_reserved_order_count=0,
                 activated_creator_count=0,
                 protected_creator_count=0,
+                manual_review_creator_count=0,
                 creator_bids=[],
                 activatable_creator_bids=[],
                 activated_creator_bids=[],
                 protected_creator_bids=[],
+                manual_review_creator_bids=[],
                 overdue_reserved_grants=[],
             )
 
@@ -1018,48 +1040,68 @@ def repair_renewal_state_drift(
             overdue_reserved_order_bids_by_creator.setdefault(
                 _normalize_bid(record.creator_bid), []
             ).append(record.bill_order_bid)
-        activatable_creator_bids = sorted(overdue_reserved_order_bids_by_creator.keys())
 
         expired_bucket_count = 0
         expired_credits = 0.0
         updated_subscription_count = 0
         activated_reserved_order_count = 0
+        activatable_creator_bids: list[str] = []
         activated_creator_bids: list[str] = []
         protected_creator_bids: list[str] = []
+        manual_review_creator_bids: list[str] = []
+        candidate_orders_by_creator: dict[str, list[BillingOrder]] = {}
+
+        # Local import avoids a circular dependency with subscriptions.py.
+        from .subscriptions import (
+            IncompleteReservedGrantActivationError,
+            grant_paid_order_credits,
+            validate_reserved_renewal_cycle_activation,
+        )
+
+        for target_creator_bid in creator_bids:
+            candidate_order_bids = sorted(
+                {
+                    order_bid
+                    for order_bid in overdue_reserved_order_bids_by_creator.get(
+                        target_creator_bid, []
+                    )
+                    if _normalize_bid(order_bid)
+                }
+            )
+            if not candidate_order_bids:
+                continue
+            candidate_orders = (
+                BillingOrder.query.filter(
+                    BillingOrder.deleted == 0,
+                    BillingOrder.creator_bid == target_creator_bid,
+                    BillingOrder.bill_order_bid.in_(candidate_order_bids),
+                    BillingOrder.status == BILLING_ORDER_STATUS_PAID,
+                )
+                .order_by(
+                    BillingOrder.paid_at.asc(),
+                    BillingOrder.created_at.asc(),
+                    BillingOrder.id.asc(),
+                )
+                .all()
+            )
+            candidate_orders_by_creator[target_creator_bid] = candidate_orders
+            try:
+                for order in candidate_orders:
+                    validate_reserved_renewal_cycle_activation(order)
+            except IncompleteReservedGrantActivationError:
+                manual_review_creator_bids.append(target_creator_bid)
+                protected_creator_bids.append(target_creator_bid)
+                continue
+            if candidate_orders:
+                activatable_creator_bids.append(target_creator_bid)
 
         if not dry_run:
-            # Local import avoids a circular dependency with subscriptions.py.
-            from .subscriptions import (
-                IncompleteReservedGrantActivationError,
-                grant_paid_order_credits,
-            )
-
             for target_creator_bid in creator_bids:
-                candidate_order_bids = sorted(
-                    {
-                        order_bid
-                        for order_bid in overdue_reserved_order_bids_by_creator.get(
-                            target_creator_bid, []
-                        )
-                        if _normalize_bid(order_bid)
-                    }
+                candidate_orders = candidate_orders_by_creator.get(
+                    target_creator_bid, []
                 )
-                candidate_orders: list[BillingOrder] = []
-                if candidate_order_bids:
-                    candidate_orders = (
-                        BillingOrder.query.filter(
-                            BillingOrder.deleted == 0,
-                            BillingOrder.creator_bid == target_creator_bid,
-                            BillingOrder.bill_order_bid.in_(candidate_order_bids),
-                            BillingOrder.status == BILLING_ORDER_STATUS_PAID,
-                        )
-                        .order_by(
-                            BillingOrder.paid_at.asc(),
-                            BillingOrder.created_at.asc(),
-                            BillingOrder.id.asc(),
-                        )
-                        .all()
-                    )
+                if target_creator_bid in set(manual_review_creator_bids):
+                    continue
                 if candidate_orders:
                     reserved_order_bids_before = _collect_overdue_reserved_order_bids(
                         repaired_at=repaired_at,
@@ -1071,6 +1113,7 @@ def repair_renewal_state_drift(
                                 grant_paid_order_credits(app, order)
                     except IncompleteReservedGrantActivationError:
                         protected_creator_bids.append(target_creator_bid)
+                        manual_review_creator_bids.append(target_creator_bid)
                         continue
                     reserved_order_bids_after = _collect_overdue_reserved_order_bids(
                         repaired_at=repaired_at,
@@ -1135,14 +1178,16 @@ def repair_renewal_state_drift(
             expired_credits=expired_credits,
             dry_run=dry_run,
             overdue_reserved_grant_count=len(scoped_overdue_reserved_grants),
-            activatable_creator_count=len(activatable_creator_bids),
+            activatable_creator_count=len(sorted(set(activatable_creator_bids))),
             activated_reserved_order_count=activated_reserved_order_count,
-            activated_creator_count=len(activated_creator_bids),
-            protected_creator_count=len(protected_creator_bids),
+            activated_creator_count=len(sorted(set(activated_creator_bids))),
+            protected_creator_count=len(sorted(set(protected_creator_bids))),
+            manual_review_creator_count=len(sorted(set(manual_review_creator_bids))),
             creator_bids=creator_bids,
-            activatable_creator_bids=activatable_creator_bids,
-            activated_creator_bids=activated_creator_bids,
-            protected_creator_bids=protected_creator_bids,
+            activatable_creator_bids=sorted(set(activatable_creator_bids)),
+            activated_creator_bids=sorted(set(activated_creator_bids)),
+            protected_creator_bids=sorted(set(protected_creator_bids)),
+            manual_review_creator_bids=sorted(set(manual_review_creator_bids)),
             overdue_reserved_grants=scoped_overdue_reserved_grants,
         )
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -15,7 +15,7 @@ from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
 from flaskr.util.uuid import generate_id
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 
 from .consts import (
     ACTIVE_SUBSCRIPTION_STATUSES,
@@ -275,8 +275,8 @@ class ReservedGrantRepairRecord:
             "subscription_bid": self.subscription_bid,
             "grant_ledger_bid": self.grant_ledger_bid,
             "wallet_bucket_bid": self.wallet_bucket_bid,
-            "consumable_from": self.consumable_from,
-            "paid_at": self.paid_at,
+            "consumable_from": to_utc_iso(self.consumable_from),
+            "paid_at": to_utc_iso(self.paid_at),
             "renewal_event_bids": list(self.renewal_event_bids),
         }
 
@@ -296,9 +296,13 @@ class RenewalStateDriftRepairResult:
     expired_credits: int | float
     dry_run: bool
     overdue_reserved_grant_count: int = 0
+    activatable_creator_count: int = 0
     activated_reserved_order_count: int = 0
+    activated_creator_count: int = 0
     protected_creator_count: int = 0
     creator_bids: list[str] = field(default_factory=list)
+    activatable_creator_bids: list[str] = field(default_factory=list)
+    activated_creator_bids: list[str] = field(default_factory=list)
     protected_creator_bids: list[str] = field(default_factory=list)
     overdue_reserved_grants: list[ReservedGrantRepairRecord] = field(
         default_factory=list
@@ -316,9 +320,13 @@ class RenewalStateDriftRepairResult:
             "expired_credits": self.expired_credits,
             "dry_run": self.dry_run,
             "overdue_reserved_grant_count": self.overdue_reserved_grant_count,
+            "activatable_creator_count": self.activatable_creator_count,
             "activated_reserved_order_count": self.activated_reserved_order_count,
+            "activated_creator_count": self.activated_creator_count,
             "protected_creator_count": self.protected_creator_count,
             "creator_bids": list(self.creator_bids),
+            "activatable_creator_bids": list(self.activatable_creator_bids),
+            "activated_creator_bids": list(self.activated_creator_bids),
             "protected_creator_bids": list(self.protected_creator_bids),
             "overdue_reserved_grants": [
                 record.to_payload() for record in self.overdue_reserved_grants
@@ -357,7 +365,9 @@ def _load_overdue_reserved_paid_order_records(
     normalized_creator_bid = _normalize_bid(creator_bid)
     if normalized_creator_bid:
         query = query.filter(CreditLedgerEntry.creator_bid == normalized_creator_bid)
-    elif creator_bids:
+    elif creator_bids is not None:
+        if not creator_bids:
+            return []
         query = query.filter(CreditLedgerEntry.creator_bid.in_(sorted(creator_bids)))
 
     candidate_ledgers: list[tuple[CreditLedgerEntry, str]] = []
@@ -861,11 +871,6 @@ def repair_renewal_state_drift(
             CreditWalletBucket.created_at.asc(),
             CreditWalletBucket.id.asc(),
         ).all()
-        overdue_reserved_grants = _load_overdue_reserved_paid_order_records(
-            repaired_at=repaired_at,
-            creator_bid=normalized_creator_bid,
-        )
-
         creator_bids: list[str] = []
         seen_creator_bids: set[str] = set()
         for row in stale_subscriptions:
@@ -878,6 +883,11 @@ def repair_renewal_state_drift(
             if candidate and candidate not in seen_creator_bids:
                 seen_creator_bids.add(candidate)
                 creator_bids.append(candidate)
+        overdue_reserved_grants = _load_overdue_reserved_paid_order_records(
+            repaired_at=repaired_at,
+            creator_bid=normalized_creator_bid,
+            creator_bids=None if normalized_creator_bid else seen_creator_bids,
+        )
         for record in overdue_reserved_grants:
             candidate = _normalize_bid(record.creator_bid)
             if candidate and candidate not in seen_creator_bids:
@@ -898,9 +908,13 @@ def repair_renewal_state_drift(
                 expired_credits=0,
                 dry_run=dry_run,
                 overdue_reserved_grant_count=0,
+                activatable_creator_count=0,
                 activated_reserved_order_count=0,
+                activated_creator_count=0,
                 protected_creator_count=0,
                 creator_bids=[],
+                activatable_creator_bids=[],
+                activated_creator_bids=[],
                 protected_creator_bids=[],
                 overdue_reserved_grants=[],
             )
@@ -926,14 +940,19 @@ def repair_renewal_state_drift(
             overdue_reserved_order_bids_by_creator.setdefault(
                 _normalize_bid(record.creator_bid), []
             ).append(record.bill_order_bid)
+        activatable_creator_bids = sorted(overdue_reserved_order_bids_by_creator.keys())
 
         expired_bucket_count = 0
         expired_credits = 0.0
         updated_subscription_count = 0
         activated_reserved_order_count = 0
+        activated_creator_bids: list[str] = []
         protected_creator_bids: list[str] = []
 
         if not dry_run:
+            # Local import avoids a circular dependency with subscriptions.py.
+            from .subscriptions import grant_paid_order_credits
+
             for target_creator_bid in creator_bids:
                 candidate_order_bids = sorted(
                     {
@@ -945,8 +964,6 @@ def repair_renewal_state_drift(
                     }
                 )
                 if candidate_order_bids:
-                    from .subscriptions import grant_paid_order_credits
-
                     candidate_orders = (
                         BillingOrder.query.filter(
                             BillingOrder.deleted == 0,
@@ -966,6 +983,7 @@ def repair_renewal_state_drift(
                             for order in candidate_orders:
                                 grant_paid_order_credits(app, order)
                                 activated_reserved_order_count += 1
+                        activated_creator_bids.append(target_creator_bid)
 
                 remaining_reserved_records = _load_overdue_reserved_paid_order_records(
                     repaired_at=repaired_at,
@@ -983,6 +1001,7 @@ def repair_renewal_state_drift(
                 expired_bucket_count += int(expiration_payload.bucket_count or 0)
                 expired_credits += float(expiration_payload.expired_credits or 0)
 
+            protected_creator_bid_set = set(protected_creator_bids)
             changed_subscriptions = (
                 BillingSubscription.query.filter(
                     BillingSubscription.deleted == 0,
@@ -997,18 +1016,15 @@ def repair_renewal_state_drift(
             if changed_subscriptions:
                 with unit_of_work():
                     for subscription in changed_subscriptions:
-                        if _normalize_bid(subscription.creator_bid) in set(
-                            protected_creator_bids
+                        if (
+                            _normalize_bid(subscription.creator_bid)
+                            in protected_creator_bid_set
                         ):
                             continue
                         subscription.status = BILLING_SUBSCRIPTION_STATUS_EXPIRED
                         subscription.updated_at = repaired_at
                         db.session.add(subscription)
                         updated_subscription_count += 1
-        else:
-            protected_creator_bids = sorted(
-                overdue_reserved_order_bids_by_creator.keys()
-            )
 
         return RenewalStateDriftRepairResult(
             status="dry_run" if dry_run else "repaired",
@@ -1021,9 +1037,13 @@ def repair_renewal_state_drift(
             expired_credits=expired_credits,
             dry_run=dry_run,
             overdue_reserved_grant_count=len(scoped_overdue_reserved_grants),
+            activatable_creator_count=len(activatable_creator_bids),
             activated_reserved_order_count=activated_reserved_order_count,
+            activated_creator_count=len(activated_creator_bids),
             protected_creator_count=len(protected_creator_bids),
             creator_bids=creator_bids,
+            activatable_creator_bids=activatable_creator_bids,
+            activated_creator_bids=activated_creator_bids,
             protected_creator_bids=protected_creator_bids,
             overdue_reserved_grants=scoped_overdue_reserved_grants,
         )

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -347,7 +347,8 @@ def _normalize_json_dict(payload: object) -> dict[str, Any]:
 
 
 def _json_extract_text(column: Any, path: str) -> Any:
-    dialect_name = (db.session.bind.dialect.name if db.session.bind else "").lower()
+    bind = db.session.get_bind()
+    dialect_name = bind.dialect.name.lower() if bind is not None else ""
     extracted = func.json_extract(column, path)
     if dialect_name == "mysql":
         return func.json_unquote(extracted)

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -1090,7 +1090,10 @@ def repair_renewal_state_drift(
 
         if not dry_run:
             # Local import avoids a circular dependency with subscriptions.py.
-            from .subscriptions import grant_paid_order_credits
+            from .subscriptions import (
+                IncompleteReservedGrantActivationError,
+                grant_paid_order_credits,
+            )
 
             for target_creator_bid in creator_bids:
                 candidate_order_bids = sorted(
@@ -1118,20 +1121,29 @@ def repair_renewal_state_drift(
                         .all()
                     )
                     if candidate_orders:
-                        with unit_of_work():
-                            for order in candidate_orders:
-                                activation_snapshot = (
-                                    _capture_reserved_grant_activation_snapshot(order)
-                                )
-                                grant_paid_order_credits(app, order)
-                                if _reserved_grant_activation_completed(
-                                    order, activation_snapshot
-                                ):
-                                    activated_reserved_order_count += 1
-                                    if target_creator_bid not in activated_creator_bids:
-                                        activated_creator_bids.append(
-                                            target_creator_bid
+                        try:
+                            with unit_of_work():
+                                for order in candidate_orders:
+                                    activation_snapshot = (
+                                        _capture_reserved_grant_activation_snapshot(
+                                            order
                                         )
+                                    )
+                                    grant_paid_order_credits(app, order)
+                                    if _reserved_grant_activation_completed(
+                                        order, activation_snapshot
+                                    ):
+                                        activated_reserved_order_count += 1
+                                        if (
+                                            target_creator_bid
+                                            not in activated_creator_bids
+                                        ):
+                                            activated_creator_bids.append(
+                                                target_creator_bid
+                                            )
+                        except IncompleteReservedGrantActivationError:
+                            protected_creator_bids.append(target_creator_bid)
+                            continue
 
                 remaining_reserved_records = _load_overdue_reserved_paid_order_records(
                     repaired_at=repaired_at,

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -355,83 +355,22 @@ def _json_extract_text(column: Any, path: str) -> Any:
     return extracted
 
 
-@dataclass(slots=True, frozen=True)
-class ReservedGrantActivationSnapshot:
-    grant_ledger_bid: str
-    wallet_bucket_bid: str
-    grant_amount: Decimal
-    reserved_credits: Decimal
-
-
 def _extract_order_bid_from_renewal_event(event: BillingRenewalEvent) -> str:
     payload = _normalize_json_dict(event.payload_json)
     return _normalize_bid(payload.get("bill_order_bid"))
 
 
-def _capture_reserved_grant_activation_snapshot(
-    order: BillingOrder,
-) -> ReservedGrantActivationSnapshot | None:
-    grant_entry = (
-        CreditLedgerEntry.query.filter(
-            CreditLedgerEntry.deleted == 0,
-            CreditLedgerEntry.creator_bid == order.creator_bid,
-            CreditLedgerEntry.idempotency_key == f"grant:{order.bill_order_bid}",
+def _collect_overdue_reserved_order_bids(
+    *, repaired_at: datetime, creator_bid: str
+) -> set[str]:
+    return {
+        _normalize_bid(record.bill_order_bid)
+        for record in _load_overdue_reserved_paid_order_records(
+            repaired_at=repaired_at,
+            creator_bid=creator_bid,
         )
-        .order_by(CreditLedgerEntry.id.desc())
-        .first()
-    )
-    if grant_entry is None or not _normalize_bid(grant_entry.wallet_bucket_bid):
-        return None
-    bucket = (
-        CreditWalletBucket.query.filter(
-            CreditWalletBucket.deleted == 0,
-            CreditWalletBucket.wallet_bucket_bid == grant_entry.wallet_bucket_bid,
-        )
-        .order_by(CreditWalletBucket.id.desc())
-        .first()
-    )
-    if bucket is None:
-        return None
-    return ReservedGrantActivationSnapshot(
-        grant_ledger_bid=grant_entry.ledger_bid,
-        wallet_bucket_bid=bucket.wallet_bucket_bid,
-        grant_amount=_to_decimal(grant_entry.amount),
-        reserved_credits=_to_decimal(bucket.reserved_credits),
-    )
-
-
-def _reserved_grant_activation_completed(
-    order: BillingOrder,
-    snapshot: ReservedGrantActivationSnapshot | None,
-) -> bool:
-    if snapshot is None:
-        return False
-    grant_entry = (
-        CreditLedgerEntry.query.filter(
-            CreditLedgerEntry.deleted == 0,
-            CreditLedgerEntry.ledger_bid == snapshot.grant_ledger_bid,
-        )
-        .order_by(CreditLedgerEntry.id.desc())
-        .first()
-    )
-    bucket = (
-        CreditWalletBucket.query.filter(
-            CreditWalletBucket.deleted == 0,
-            CreditWalletBucket.wallet_bucket_bid == snapshot.wallet_bucket_bid,
-        )
-        .order_by(CreditWalletBucket.id.desc())
-        .first()
-    )
-    if grant_entry is None or bucket is None:
-        return False
-    metadata = _normalize_json_dict(grant_entry.metadata_json)
-    if str(metadata.get("bucket_credit_state") or "").strip().lower() == "reserved":
-        return False
-    moved_reserved_amount = _quantize_credit_amount(
-        snapshot.reserved_credits - _to_decimal(bucket.reserved_credits)
-    )
-    expected_amount = _quantize_credit_amount(snapshot.grant_amount)
-    return moved_reserved_amount == expected_amount
+        if _normalize_bid(record.bill_order_bid)
+    }
 
 
 def _load_overdue_reserved_paid_order_records(
@@ -1105,6 +1044,7 @@ def repair_renewal_state_drift(
                         if _normalize_bid(order_bid)
                     }
                 )
+                candidate_orders: list[BillingOrder] = []
                 if candidate_order_bids:
                     candidate_orders = (
                         BillingOrder.query.filter(
@@ -1120,30 +1060,28 @@ def repair_renewal_state_drift(
                         )
                         .all()
                     )
-                    if candidate_orders:
-                        try:
-                            with unit_of_work():
-                                for order in candidate_orders:
-                                    activation_snapshot = (
-                                        _capture_reserved_grant_activation_snapshot(
-                                            order
-                                        )
-                                    )
-                                    grant_paid_order_credits(app, order)
-                                    if _reserved_grant_activation_completed(
-                                        order, activation_snapshot
-                                    ):
-                                        activated_reserved_order_count += 1
-                                        if (
-                                            target_creator_bid
-                                            not in activated_creator_bids
-                                        ):
-                                            activated_creator_bids.append(
-                                                target_creator_bid
-                                            )
-                        except IncompleteReservedGrantActivationError:
-                            protected_creator_bids.append(target_creator_bid)
-                            continue
+                if candidate_orders:
+                    reserved_order_bids_before = _collect_overdue_reserved_order_bids(
+                        repaired_at=repaired_at,
+                        creator_bid=target_creator_bid,
+                    )
+                    try:
+                        with unit_of_work():
+                            for order in candidate_orders:
+                                grant_paid_order_credits(app, order)
+                    except IncompleteReservedGrantActivationError:
+                        protected_creator_bids.append(target_creator_bid)
+                        continue
+                    reserved_order_bids_after = _collect_overdue_reserved_order_bids(
+                        repaired_at=repaired_at,
+                        creator_bid=target_creator_bid,
+                    )
+                    activated_order_bids = (
+                        reserved_order_bids_before - reserved_order_bids_after
+                    )
+                    if activated_order_bids:
+                        activated_reserved_order_count += len(activated_order_bids)
+                        activated_creator_bids.append(target_creator_bid)
 
                 remaining_reserved_records = _load_overdue_reserved_paid_order_records(
                     repaired_at=repaired_at,

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -346,6 +346,14 @@ def _normalize_json_dict(payload: object) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
+def _json_extract_text(column: Any, path: str) -> Any:
+    dialect_name = (db.session.bind.dialect.name if db.session.bind else "").lower()
+    extracted = func.json_extract(column, path)
+    if dialect_name == "mysql":
+        return func.json_unquote(extracted)
+    return extracted
+
+
 @dataclass(slots=True, frozen=True)
 class ReservedGrantActivationSnapshot:
     grant_ledger_bid: str
@@ -539,7 +547,7 @@ def _load_overdue_reserved_paid_order_creator_bids(
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_limit = int(limit) if limit is not None and int(limit) > 0 else None
     bill_order_bid_expr = func.coalesce(
-        func.json_extract(CreditLedgerEntry.metadata_json, "$.bill_order_bid"),
+        _json_extract_text(CreditLedgerEntry.metadata_json, "$.bill_order_bid"),
         CreditLedgerEntry.source_bid,
     )
     query = (
@@ -555,7 +563,7 @@ def _load_overdue_reserved_paid_order_creator_bids(
             CreditLedgerEntry.consumable_from <= repaired_at,
             func.lower(
                 func.coalesce(
-                    func.json_extract(
+                    _json_extract_text(
                         CreditLedgerEntry.metadata_json, "$.bucket_credit_state"
                     ),
                     "",

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -416,7 +416,10 @@ def _load_overdue_reserved_paid_order_records(
     candidate_creator_bids: set[str] = set()
     for ledger in query.all():
         metadata = _normalize_json_dict(ledger.metadata_json)
-        if str(metadata.get("bucket_credit_state") or "").strip().lower() != "reserved":
+        if (
+            str(metadata.get("bucket_credit_state") or "").strip().lower()
+            == "available"
+        ):
             continue
         bill_order_bid = _normalize_optional_metadata_bid(
             metadata.get("bill_order_bid")
@@ -529,7 +532,7 @@ def _load_overdue_reserved_paid_order_creator_bids(
                     "",
                 )
             )
-            == "reserved",
+            != "available",
             BillingOrder.deleted == 0,
             BillingOrder.status == BILLING_ORDER_STATUS_PAID,
         )

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -15,6 +15,7 @@ from flaskr.service.billing.consts import (
     BILLING_MODE_RECURRING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
@@ -62,7 +63,7 @@ from flaskr.service.billing.subscriptions import (
     ensure_subscription_renewal_order,
     sync_subscription_lifecycle_events,
 )
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 from tests.common.fixtures.bill_products import build_bill_products
 
 
@@ -1579,6 +1580,166 @@ def test_expire_event_releases_reserved_subscription_renewal_on_same_bucket(
         assert "activated_at" in grant_entry.metadata_json
         assert expire_entry.wallet_bucket_bid == bucket.wallet_bucket_bid
         assert expire_entry.amount == Decimal("-3.0000000000")
+
+
+def test_expire_event_fails_when_reserved_renewal_activation_is_incomplete(
+    billing_renewal_app: Flask,
+) -> None:
+    current_cycle_start = now_utc() - timedelta(days=30)
+    current_cycle_end = now_utc() - timedelta(minutes=1)
+    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+
+    with billing_renewal_app.app_context():
+        subscription = BillingSubscription(
+            subscription_bid="sub-pingxx-expire-reserved-fail",
+            creator_bid="creator-renewal-1",
+            product_bid="bill-product-plan-monthly",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="pingxx",
+            provider_subscription_id="",
+            provider_customer_id="customer-sub-pingxx-expire-reserved-fail",
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=current_cycle_end,
+            cancel_at_period_end=0,
+            next_product_bid="",
+            metadata_json={},
+            created_at=current_cycle_start,
+            updated_at=current_cycle_start,
+        )
+        order = BillingOrder(
+            bill_order_bid="bill-pingxx-expire-reserved-fail-1",
+            creator_bid=subscription.creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=9900,
+            paid_amount=9900,
+            payment_provider="pingxx",
+            channel="alipay_qr",
+            provider_reference_id="ch_pingxx_expire_reserved_fail_1",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=current_cycle_end - timedelta(days=5),
+            metadata_json={
+                "provider_reference_type": "charge",
+                "renewal_cycle_start_at": to_utc_iso(current_cycle_end),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        event = _create_renewal_event(
+            "renewal-expire-reserved-fail-1",
+            subscription.subscription_bid,
+            subscription.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+            scheduled_at=current_cycle_end,
+        )
+        wallet = _create_wallet(
+            subscription.creator_bid,
+            available_credits="3.0000000000",
+            lifetime_granted_credits="8.0000000000",
+        )
+        wallet.reserved_credits = Decimal("4.0000000000")
+        dao.db.session.add(subscription)
+        dao.db.session.add(order)
+        dao.db.session.add(wallet)
+        dao.db.session.add(
+            CreditWalletBucket(
+                wallet_bucket_bid="bucket-pingxx-expire-reserved-fail-1",
+                wallet_bid=wallet.wallet_bid,
+                creator_bid=subscription.creator_bid,
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                source_bid="bill-start-expire-reserved-fail-1",
+                priority=20,
+                original_credits=Decimal("8.0000000000"),
+                available_credits=Decimal("3.0000000000"),
+                reserved_credits=Decimal("4.0000000000"),
+                consumed_credits=Decimal("0"),
+                expired_credits=Decimal("0"),
+                effective_from=current_cycle_start,
+                effective_to=current_cycle_end,
+                status=CREDIT_BUCKET_STATUS_ACTIVE,
+                metadata_json={
+                    "bill_order_bid": "bill-start-expire-reserved-fail-1",
+                },
+                created_at=current_cycle_start,
+                updated_at=current_cycle_start,
+            )
+        )
+        dao.db.session.add(
+            CreditLedgerEntry(
+                ledger_bid="ledger-pingxx-expire-reserved-fail-1",
+                creator_bid=subscription.creator_bid,
+                wallet_bid=wallet.wallet_bid,
+                wallet_bucket_bid="bucket-pingxx-expire-reserved-fail-1",
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                source_bid="bill-pingxx-expire-reserved-fail-1",
+                idempotency_key="grant:bill-pingxx-expire-reserved-fail-1",
+                amount=Decimal("5.0000000000"),
+                balance_after=Decimal("3.0000000000"),
+                expires_at=next_cycle_end,
+                consumable_from=current_cycle_end,
+                metadata_json={
+                    "bill_order_bid": "bill-pingxx-expire-reserved-fail-1",
+                    "subscription_bid": "sub-pingxx-expire-reserved-fail",
+                    "product_bid": "bill-product-plan-monthly",
+                    "payment_provider": "pingxx",
+                    "grant_reason": "subscription_renewal",
+                    "bucket_credit_state": "reserved",
+                    "reserved_until": to_utc_iso(current_cycle_end),
+                },
+                created_at=current_cycle_end - timedelta(days=5),
+                updated_at=current_cycle_end - timedelta(days=5),
+            )
+        )
+        dao.db.session.add(event)
+        dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        billing_renewal_app,
+        renewal_event_bid="renewal-expire-reserved-fail-1",
+    )
+
+    assert payload["status"] == "failed"
+    assert payload["bill_order_bid"] == "bill-pingxx-expire-reserved-fail-1"
+    assert payload["event_status"] == "failed"
+
+    with billing_renewal_app.app_context():
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid="sub-pingxx-expire-reserved-fail"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid=subscription.creator_bid
+        ).one()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-pingxx-expire-reserved-fail-1"
+        ).one()
+        grant_entry = CreditLedgerEntry.query.filter_by(
+            ledger_bid="ledger-pingxx-expire-reserved-fail-1"
+        ).one()
+        event = BillingRenewalEvent.query.filter_by(
+            renewal_event_bid="renewal-expire-reserved-fail-1"
+        ).one()
+        expire_entries = CreditLedgerEntry.query.filter_by(
+            creator_bid=subscription.creator_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        ).all()
+
+        assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+        assert subscription.current_period_start_at == current_cycle_start
+        assert subscription.current_period_end_at == current_cycle_end
+        assert wallet.available_credits == Decimal("3.0000000000")
+        assert wallet.reserved_credits == Decimal("4.0000000000")
+        assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+        assert bucket.available_credits == Decimal("3.0000000000")
+        assert bucket.reserved_credits == Decimal("4.0000000000")
+        assert bucket.effective_to == current_cycle_end
+        assert grant_entry.metadata_json["bucket_credit_state"] == "reserved"
+        assert grant_entry.expires_at == next_cycle_end
+        assert event.status == BILLING_RENEWAL_EVENT_STATUS_FAILED
+        assert event.last_error == "paid_renewal_activation_failed"
+        assert expire_entries == []
 
 
 def test_run_billing_renewal_event_retries_latest_failed_renewal_order(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -59,6 +59,7 @@ from flaskr.service.billing.wallets import (
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.metering.models import BillUsageRecord
+from flaskr.util.datetime import to_utc_iso
 
 
 @pytest.fixture
@@ -1264,8 +1265,8 @@ def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
             status=BILLING_ORDER_STATUS_PAID,
             paid_at=datetime(2026, 4, 7, 0, 0, 0),
             metadata_json={
-                "renewal_cycle_start_at": datetime(2026, 4, 8, 0, 0, 0).isoformat(),
-                "renewal_cycle_end_at": datetime(2026, 5, 8, 0, 0, 0).isoformat(),
+                "renewal_cycle_start_at": to_utc_iso(datetime(2026, 4, 8, 0, 0, 0)),
+                "renewal_cycle_end_at": to_utc_iso(datetime(2026, 5, 8, 0, 0, 0)),
             },
         )
         bucket = CreditWalletBucket(
@@ -1367,8 +1368,8 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             status=BILLING_ORDER_STATUS_PAID,
             paid_at=datetime(2026, 4, 7, 0, 0, 0),
             metadata_json={
-                "renewal_cycle_start_at": boundary_at.isoformat(),
-                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
             },
         )
         bucket = CreditWalletBucket(
@@ -1421,12 +1422,21 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             repair_before=boundary_at + timedelta(minutes=1),
             dry_run=False,
         )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(bucket)
 
     assert payload["activated_reserved_order_count"] == 0
     assert payload["activated_creator_count"] == 0
+    assert payload["updated_subscription_count"] == 0
+    assert payload["expired_bucket_count"] == 0
     assert payload["activated_creator_bids"] == []
     assert payload["protected_creator_count"] == 1
     assert payload["protected_creator_bids"] == [creator_bid]
+    assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+    assert subscription.current_period_end_at == boundary_at
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("1000.0000000000")
+    assert bucket.reserved_credits == Decimal("1000.0000000000")
 
 
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -84,6 +84,29 @@ def billing_wallet_lifecycle_app():
         dao.db.drop_all()
 
 
+def _create_monthly_plan_product(
+    product_bid: str,
+    *,
+    credit_amount: Decimal = Decimal("1000.0000000000"),
+) -> BillingProduct:
+    return BillingProduct(
+        product_bid=product_bid,
+        product_code=product_bid,
+        product_type=1,
+        display_name_i18n_key=f"billing.product.{product_bid}",
+        description_i18n_key=f"billing.product.{product_bid}.description",
+        status=1,
+        billing_mode=2,
+        billing_interval=2,
+        billing_interval_count=1,
+        credit_amount=credit_amount,
+        currency="CNY",
+        price_amount=0,
+        allocation_interval=2,
+        auto_renew_enabled=1,
+    )
+
+
 def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:
@@ -924,6 +947,7 @@ def test_repair_renewal_state_drift_dry_run_reports_overdue_reserved_paid_grant(
             current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
             current_period_end_at=boundary_at,
         )
+        product = _create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=wallet.creator_bid,
@@ -996,7 +1020,9 @@ def test_repair_renewal_state_drift_dry_run_reports_overdue_reserved_paid_grant(
             payload_json={"bill_order_bid": order.bill_order_bid},
             processed_at=None,
         )
-        dao.db.session.add_all([wallet, subscription, order, bucket, ledger, event])
+        dao.db.session.add_all(
+            [wallet, subscription, product, order, bucket, ledger, event]
+        )
         dao.db.session.commit()
 
         payload = repair_renewal_state_drift(
@@ -1251,6 +1277,7 @@ def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
             current_period_start_at=datetime(2026, 4, 1, 0, 0, 0),
             current_period_end_at=datetime(2026, 5, 1, 0, 0, 0),
         )
+        product = _create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=creator_bid,
@@ -1307,7 +1334,7 @@ def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
                 "bucket_credit_state": "reserved",
             },
         )
-        dao.db.session.add_all([wallet, subscription, order, bucket, ledger])
+        dao.db.session.add_all([wallet, subscription, product, order, bucket, ledger])
         dao.db.session.commit()
 
         payload = repair_renewal_state_drift(
@@ -1353,6 +1380,7 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
             current_period_end_at=boundary_at,
         )
+        product = _create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=creator_bid,
@@ -1409,9 +1437,15 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
                 "bucket_credit_state": "reserved",
             },
         )
-        dao.db.session.add_all([wallet, subscription, order, bucket, ledger])
+        dao.db.session.add_all([wallet, subscription, product, order, bucket, ledger])
         dao.db.session.commit()
 
+        dry_payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
         payload = repair_renewal_state_drift(
             billing_wallet_lifecycle_app,
             creator_bid=creator_bid,
@@ -1422,6 +1456,9 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
         dao.db.session.refresh(bucket)
         dao.db.session.refresh(ledger)
 
+    assert dry_payload["activatable_creator_bids"] == []
+    assert dry_payload["protected_creator_bids"] == [creator_bid]
+    assert dry_payload["manual_review_creator_bids"] == [creator_bid]
     assert payload["activated_reserved_order_count"] == 0
     assert payload["activated_creator_count"] == 0
     assert payload["updated_subscription_count"] == 0
@@ -1435,6 +1472,352 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
     assert bucket.available_credits == Decimal("1000.0000000000")
     assert bucket.reserved_credits == Decimal("500.0000000000")
     assert ledger.metadata_json["bucket_credit_state"] == "reserved"
+
+
+def test_repair_renewal_state_drift_blocks_cycle_when_subscription_grant_missing(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-missing-subscription-grant"
+    subscription_bid = "subscription-renewal-drift-missing-subscription-grant"
+    product_bid = "bill-product-renewal-drift-missing-subscription-grant"
+    first_order_bid = "order-renewal-drift-missing-subscription-grant-1"
+    missing_order_bid = "order-renewal-drift-missing-subscription-grant-2"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-missing-subscription-grant",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid=product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        first_order = BillingOrder(
+            bill_order_bid=first_order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=first_order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        missing_order = BillingOrder(
+            bill_order_bid=missing_order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=missing_order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 1, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-missing-subscription-grant",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=first_order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": first_order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-missing-subscription-grant",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=first_order_bid,
+            idempotency_key=f"grant:{first_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": first_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(product_bid),
+                first_order,
+                missing_order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["activatable_creator_bids"] == []
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
+
+
+def test_repair_renewal_state_drift_all_scope_falls_back_to_source_bid(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-source-bid-fallback"
+    order_bid = "order-renewal-drift-source-bid-fallback"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-source-bid-fallback",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid="subscription-renewal-drift-source-bid-fallback",
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-source-bid-fallback",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 4, 1, 0, 0, 0),
+            current_period_end_at=datetime(2026, 5, 1, 0, 0, 0),
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-source-bid-fallback",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-source-bid-fallback",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": "",
+                "subscription_bid": subscription.subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["creator_bids"] == [creator_bid]
+    assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == order_bid
+    assert payload["activatable_creator_bids"] == [creator_bid]
+
+
+def test_repair_renewal_state_drift_blocks_when_campaign_bonus_grant_missing(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-missing-campaign-grant"
+    subscription_bid = "subscription-renewal-drift-missing-campaign-grant"
+    order_bid = "order-renewal-drift-missing-campaign-grant"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-missing-campaign-grant",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-missing-campaign-grant",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            campaign_bid="campaign-renewal-drift-missing-campaign-grant",
+            campaign_bonus_credit_amount=Decimal("100.0000000000"),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-missing-campaign-grant",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-missing-campaign-grant",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["activatable_creator_bids"] == []
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
 
 
 def test_repair_renewal_state_drift_blocks_same_order_when_bonus_only_would_succeed(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -2005,6 +2005,222 @@ def test_repair_renewal_state_drift_blocks_multi_order_cycle_atomically(
     assert ledger_b.metadata_json["bucket_credit_state"] == "reserved"
 
 
+def test_repair_renewal_state_drift_counts_all_activated_orders_in_shared_cycle(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-multi-order-success"
+    subscription_bid = "subscription-renewal-drift-multi-order-success"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-multi-order-success",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1050.0000000000"),
+            lifetime_granted_credits=Decimal("1050.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-multi-order-success-a",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        product_a = BillingProduct(
+            product_bid="bill-product-renewal-drift-multi-order-success-a",
+            product_code="repair-multi-order-success-a",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_multi_order_success_a",
+            description_i18n_key="billing.product.repair_multi_order_success_a.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("50.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        product_b = BillingProduct(
+            product_bid="bill-product-renewal-drift-multi-order-success-b",
+            product_code="repair-multi-order-success-b",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_multi_order_success_b",
+            description_i18n_key="billing.product.repair_multi_order_success_b.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("1000.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        order_a = BillingOrder(
+            bill_order_bid="order-renewal-drift-multi-order-success-a",
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_a.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-multi-order-success-a",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        order_b = BillingOrder(
+            bill_order_bid="order-renewal-drift-multi-order-success-b",
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_b.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-multi-order-success-b",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 1, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket_a = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-multi-order-success-a",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_a.bill_order_bid,
+            priority=20,
+            original_credits=Decimal("50.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("50.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_a.bill_order_bid},
+        )
+        bucket_b = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-multi-order-success-b",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_b.bill_order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_b.bill_order_bid},
+        )
+        ledger_a = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-multi-order-success-a",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket_a.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_a.bill_order_bid,
+            idempotency_key=f"grant:{order_a.bill_order_bid}",
+            amount=Decimal("50.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_a.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        ledger_b = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-multi-order-success-b",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket_b.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_b.bill_order_bid,
+            idempotency_key=f"grant:{order_b.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_b.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                product_a,
+                product_b,
+                order_a,
+                order_b,
+                bucket_a,
+                bucket_b,
+                ledger_a,
+                ledger_b,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(wallet)
+        dao.db.session.refresh(bucket_a)
+        dao.db.session.refresh(bucket_b)
+        dao.db.session.refresh(ledger_a)
+        dao.db.session.refresh(ledger_b)
+
+    assert payload["activated_reserved_order_count"] == 2
+    assert payload["activated_creator_count"] == 1
+    assert payload["activated_creator_bids"] == [creator_bid]
+    assert payload["protected_creator_bids"] == []
+    assert subscription.current_period_start_at == boundary_at
+    assert subscription.current_period_end_at == next_cycle_end
+    assert wallet.available_credits == Decimal("1050.0000000000")
+    assert wallet.reserved_credits == Decimal("0E-10")
+    assert bucket_a.available_credits == Decimal("50.0000000000")
+    assert bucket_a.reserved_credits == Decimal("0E-10")
+    assert bucket_b.available_credits == Decimal("1000.0000000000")
+    assert bucket_b.reserved_credits == Decimal("0E-10")
+    assert ledger_a.metadata_json["bucket_credit_state"] == "available"
+    assert ledger_b.metadata_json["bucket_credit_state"] == "available"
+
+
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1604,6 +1604,256 @@ def test_repair_renewal_state_drift_blocks_cycle_when_subscription_grant_missing
     assert payload["manual_review_creator_bids"] == [creator_bid]
 
 
+def test_repair_renewal_state_drift_blocks_unknown_subscription_grant_state(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-unknown-subscription-state"
+    subscription_bid = "subscription-renewal-drift-unknown-subscription-state"
+    order_bid = "order-renewal-drift-unknown-subscription-state"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-unknown-subscription-state",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-unknown-subscription-state",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-unknown-subscription-state",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-unknown-subscription-state",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "unknown",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        dry_payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(bucket)
+        dao.db.session.refresh(ledger)
+
+    assert dry_payload["activatable_creator_bids"] == []
+    assert dry_payload["protected_creator_bids"] == [creator_bid]
+    assert dry_payload["manual_review_creator_bids"] == [creator_bid]
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
+    assert payload["updated_subscription_count"] == 0
+    assert payload["expired_bucket_count"] == 0
+    assert subscription.current_period_end_at == boundary_at
+    assert bucket.reserved_credits == Decimal("1000.0000000000")
+    assert ledger.metadata_json["bucket_credit_state"] == "unknown"
+
+
+def test_repair_renewal_state_drift_blocks_short_subscription_grant_amount(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-short-subscription-amount"
+    subscription_bid = "subscription-renewal-drift-short-subscription-amount"
+    order_bid = "order-renewal-drift-short-subscription-amount"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-short-subscription-amount",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1.0000000000"),
+            lifetime_granted_credits=Decimal("1.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-short-subscription-amount",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-short-subscription-amount",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-short-subscription-amount",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        dry_payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(bucket)
+        dao.db.session.refresh(ledger)
+
+    assert dry_payload["activatable_creator_bids"] == []
+    assert dry_payload["protected_creator_bids"] == [creator_bid]
+    assert dry_payload["manual_review_creator_bids"] == [creator_bid]
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
+    assert payload["updated_subscription_count"] == 0
+    assert payload["expired_bucket_count"] == 0
+    assert subscription.current_period_end_at == boundary_at
+    assert bucket.reserved_credits == Decimal("1.0000000000")
+    assert ledger.metadata_json["bucket_credit_state"] == "reserved"
+
+
 def test_repair_renewal_state_drift_all_scope_falls_back_to_source_bid(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1222,6 +1222,213 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
     assert ledger.metadata_json["bucket_credit_state"] == "available"
 
 
+def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    repaired_at = datetime(2026, 4, 8, 0, 1, 0)
+    creator_bid = "creator-renewal-drift-reserved-only"
+    subscription_bid = "subscription-renewal-drift-reserved-only"
+    order_bid = "order-renewal-drift-reserved-only"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-reserved-only",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-reserved-only",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 4, 1, 0, 0, 0),
+            current_period_end_at=datetime(2026, 5, 1, 0, 0, 0),
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-reserved-only",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": datetime(2026, 4, 8, 0, 0, 0).isoformat(),
+                "renewal_cycle_end_at": datetime(2026, 5, 8, 0, 0, 0).isoformat(),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-reserved-only",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-reserved-only",
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 5, 1, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-reserved-only"},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-reserved-only",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order.bill_order_bid,
+            idempotency_key=f"grant:{order.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=datetime(2026, 5, 8, 0, 0, 0),
+            consumable_from=datetime(2026, 4, 8, 0, 0, 0),
+            metadata_json={
+                "bill_order_bid": order.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all([wallet, subscription, order, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            repair_before=repaired_at,
+            dry_run=True,
+        )
+
+    assert payload["status"] == "dry_run"
+    assert payload["creator_count"] == 1
+    assert payload["creator_bids"] == [creator_bid]
+    assert payload["stale_subscription_count"] == 0
+    assert payload["stale_bucket_count"] == 0
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["activatable_creator_bids"] == [creator_bid]
+
+
+def test_repair_renewal_state_drift_counts_only_successful_activations(
+    billing_wallet_lifecycle_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-activation-fails"
+    subscription_bid = "subscription-renewal-drift-activation-fails"
+    order_bid = "order-renewal-drift-activation-fails"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-activation-fails",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("2000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-activation-fails",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-activation-fails",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": boundary_at.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-activation-fails",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-activation-fails",
+            priority=20,
+            original_credits=Decimal("2000.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-activation-fails"},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-activation-fails",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order.bill_order_bid,
+            idempotency_key=f"grant:{order.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all([wallet, subscription, order, bucket, ledger])
+        dao.db.session.commit()
+
+        monkeypatch.setattr(
+            "flaskr.service.billing.subscriptions.grant_paid_order_credits",
+            lambda app, order: False,
+        )
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["activated_creator_count"] == 0
+    assert payload["activated_creator_bids"] == []
+    assert payload["protected_creator_count"] == 1
+    assert payload["protected_creator_bids"] == [creator_bid]
+
+
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1003,19 +1003,48 @@ def test_repair_renewal_state_drift_dry_run_reports_overdue_reserved_paid_grant(
             repair_before=boundary_at + timedelta(minutes=1),
             dry_run=True,
         )
+        dao.db.session.expire_all()
+        wallet = CreditWallet.query.filter_by(creator_bid=creator_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-renewal-drift-protected-dry-run"
+        ).one()
+        ledger = CreditLedgerEntry.query.filter_by(ledger_bid=ledger_bid).one()
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid=subscription_bid
+        ).one()
+        event = BillingRenewalEvent.query.filter_by(
+            renewal_event_bid="renewal-event-protected-dry-run"
+        ).one()
 
     assert payload["status"] == "dry_run"
     assert payload["creator_count"] == 1
     assert payload["stale_subscription_count"] == 1
     assert payload["stale_bucket_count"] == 1
     assert payload["overdue_reserved_grant_count"] == 1
-    assert payload["protected_creator_count"] == 1
-    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["activatable_creator_count"] == 1
+    assert payload["activatable_creator_bids"] == [creator_bid]
+    assert payload["activated_creator_count"] == 0
+    assert payload["activated_creator_bids"] == []
+    assert payload["protected_creator_count"] == 0
+    assert payload["protected_creator_bids"] == []
     assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == order_bid
     assert payload["overdue_reserved_grants"][0]["grant_ledger_bid"] == ledger_bid
     assert payload["overdue_reserved_grants"][0]["renewal_event_bids"] == [
         "renewal-event-protected-dry-run"
     ]
+    assert (
+        payload["overdue_reserved_grants"][0]["consumable_from"]
+        == "2026-04-08T00:00:00Z"
+    )
+    assert payload["overdue_reserved_grants"][0]["paid_at"] == "2026-04-07T00:00:00Z"
+    assert wallet.reserved_credits == Decimal("1000.0000000000")
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.effective_to == boundary_at
+    assert bucket.reserved_credits == Decimal("1000.0000000000")
+    assert ledger.metadata_json["bucket_credit_state"] == "reserved"
+    assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+    assert subscription.current_period_end_at == boundary_at
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
 
 
 def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_expiry(
@@ -1171,8 +1200,13 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
 
     assert payload["status"] == "repaired"
     assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["activatable_creator_count"] == 1
+    assert payload["activatable_creator_bids"] == [creator_bid]
     assert payload["activated_reserved_order_count"] == 1
+    assert payload["activated_creator_count"] == 1
+    assert payload["activated_creator_bids"] == [creator_bid]
     assert payload["protected_creator_count"] == 0
+    assert payload["protected_creator_bids"] == []
     assert payload["expired_bucket_count"] == 0
     assert payload["updated_subscription_count"] == 0
     assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -11,8 +11,12 @@ from sqlalchemy.orm.exc import ObjectDeletedError
 
 import flaskr.dao as dao
 from flaskr.service.billing.consts import (
+    BILLING_ORDER_STATUS_PAID,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_METRIC_LLM_INPUT_TOKENS,
+    BILLING_RENEWAL_EVENT_STATUS_PENDING,
+    BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
     CREDIT_BUCKET_CATEGORY_FREE,
@@ -34,6 +38,8 @@ from flaskr.service.billing.consts import (
 )
 from flaskr.service.billing.models import (
     BillingOrder,
+    BillingProduct,
+    BillingRenewalEvent,
     BillingSubscription,
     CreditLedgerEntry,
     CreditUsageRate,
@@ -885,6 +891,301 @@ def test_repair_renewal_state_drift_expires_bucket_and_subscription(
     assert subscription.status == BILLING_SUBSCRIPTION_STATUS_EXPIRED
     assert wallet.available_credits == Decimal("0E-10")
     assert len(ledgers) == 1
+
+
+def test_repair_renewal_state_drift_dry_run_reports_overdue_reserved_paid_grant(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-protected"
+    subscription_bid = "subscription-renewal-drift-protected-dry-run"
+    order_bid = "order-renewal-drift-protected-dry-run"
+    ledger_bid = "ledger-renewal-drift-protected-dry-run"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-protected-dry-run",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("2000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=wallet.creator_bid,
+            product_bid="bill-product-renewal-drift-protected",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=wallet.creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid="bill-product-renewal-drift-protected",
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-protected-dry-run",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": boundary_at.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-protected-dry-run",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-dry-run",
+            priority=20,
+            original_credits=Decimal("2000.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-dry-run"},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid=ledger_bid,
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order.bill_order_bid,
+            idempotency_key=f"grant:{order.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order.bill_order_bid,
+                "subscription_bid": subscription.subscription_bid,
+                "product_bid": order.product_bid,
+                "payment_provider": order.payment_provider,
+                "grant_reason": "subscription",
+                "bucket_credit_state": "reserved",
+                "reserved_until": boundary_at.isoformat(),
+            },
+        )
+        event = BillingRenewalEvent(
+            renewal_event_bid="renewal-event-protected-dry-run",
+            subscription_bid=subscription.subscription_bid,
+            creator_bid=wallet.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+            scheduled_at=boundary_at,
+            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            attempt_count=0,
+            last_error="",
+            payload_json={"bill_order_bid": order.bill_order_bid},
+            processed_at=None,
+        )
+        dao.db.session.add_all([wallet, subscription, order, bucket, ledger, event])
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["status"] == "dry_run"
+    assert payload["creator_count"] == 1
+    assert payload["stale_subscription_count"] == 1
+    assert payload["stale_bucket_count"] == 1
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["protected_creator_count"] == 1
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == order_bid
+    assert payload["overdue_reserved_grants"][0]["grant_ledger_bid"] == ledger_bid
+    assert payload["overdue_reserved_grants"][0]["renewal_event_bids"] == [
+        "renewal-event-protected-dry-run"
+    ]
+
+
+def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_expiry(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-protected-apply"
+    subscription_bid = "subscription-renewal-drift-protected-apply"
+    product_bid = "bill-product-renewal-drift-protected-apply"
+    order_bid = "order-renewal-drift-protected-apply"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-protected-apply",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("2000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=wallet.creator_bid,
+            product_bid=product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="manual",
+            provider_subscription_id="",
+            provider_customer_id="",
+            billing_anchor_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+            grace_period_end_at=None,
+            cancel_at_period_end=0,
+            next_product_bid="",
+            last_renewed_at=datetime(2026, 3, 8, 0, 0, 0),
+            last_failed_at=None,
+            metadata_json={},
+        )
+        product = BillingProduct(
+            product_bid=product_bid,
+            product_code="repair-protected-monthly",
+            product_type=1,
+            display_name_i18n_key="billing.product.protected_monthly",
+            description_i18n_key="billing.product.protected_monthly.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("1000.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=wallet.creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product.product_bid,
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-protected-apply",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": boundary_at.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-protected-apply",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-apply",
+            priority=20,
+            original_credits=Decimal("2000.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-apply"},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-protected-apply",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order.bill_order_bid,
+            idempotency_key=f"grant:{order.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order.bill_order_bid,
+                "subscription_bid": subscription.subscription_bid,
+                "product_bid": order.product_bid,
+                "payment_provider": order.payment_provider,
+                "grant_reason": "subscription",
+                "bucket_credit_state": "reserved",
+                "reserved_until": boundary_at.isoformat(),
+            },
+        )
+        event = BillingRenewalEvent(
+            renewal_event_bid="renewal-event-protected-apply",
+            subscription_bid=subscription.subscription_bid,
+            creator_bid=wallet.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+            scheduled_at=boundary_at,
+            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            attempt_count=0,
+            last_error="",
+            payload_json={"bill_order_bid": order.bill_order_bid},
+            processed_at=None,
+        )
+        dao.db.session.add_all(
+            [wallet, subscription, product, order, bucket, ledger, event]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        wallet = CreditWallet.query.filter_by(creator_bid=creator_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-renewal-drift-protected-apply"
+        ).one()
+        ledger = CreditLedgerEntry.query.filter_by(
+            ledger_bid="ledger-renewal-drift-protected-apply"
+        ).one()
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid=subscription_bid
+        ).one()
+
+    assert payload["status"] == "repaired"
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["activated_reserved_order_count"] == 1
+    assert payload["protected_creator_count"] == 0
+    assert payload["expired_bucket_count"] == 0
+    assert payload["updated_subscription_count"] == 0
+    assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+    assert subscription.current_period_start_at == boundary_at
+    assert subscription.current_period_end_at == next_cycle_end
+    assert wallet.available_credits == Decimal("1000.0000000000")
+    assert wallet.reserved_credits == Decimal("0E-10")
+    assert bucket.source_bid == order_bid
+    assert bucket.available_credits == Decimal("1000.0000000000")
+    assert bucket.reserved_credits == Decimal("0E-10")
+    assert bucket.effective_from == boundary_at
+    assert bucket.effective_to == next_cycle_end
+    assert ledger.metadata_json["bucket_credit_state"] == "available"
 
 
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1326,7 +1326,6 @@ def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
 
 def test_repair_renewal_state_drift_counts_only_successful_activations(
     billing_wallet_lifecycle_app: Flask,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     boundary_at = datetime(2026, 4, 8, 0, 0, 0)
     next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
@@ -1380,9 +1379,9 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-current-activation-fails",
             priority=20,
-            original_credits=Decimal("2000.0000000000"),
+            original_credits=Decimal("1500.0000000000"),
             available_credits=Decimal("1000.0000000000"),
-            reserved_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("500.0000000000"),
             consumed_credits=Decimal("0"),
             expired_credits=Decimal("0"),
             effective_from=datetime(2026, 3, 8, 0, 0, 0),
@@ -1400,7 +1399,7 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             source_bid=order.bill_order_bid,
             idempotency_key=f"grant:{order.bill_order_bid}",
             amount=Decimal("1000.0000000000"),
-            balance_after=Decimal("1000.0000000000"),
+            balance_after=Decimal("500.0000000000"),
             expires_at=next_cycle_end,
             consumable_from=boundary_at,
             metadata_json={
@@ -1412,10 +1411,6 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
         dao.db.session.add_all([wallet, subscription, order, bucket, ledger])
         dao.db.session.commit()
 
-        monkeypatch.setattr(
-            "flaskr.service.billing.subscriptions.grant_paid_order_credits",
-            lambda app, order: False,
-        )
         payload = repair_renewal_state_drift(
             billing_wallet_lifecycle_app,
             creator_bid=creator_bid,
@@ -1424,6 +1419,7 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
         )
         dao.db.session.refresh(subscription)
         dao.db.session.refresh(bucket)
+        dao.db.session.refresh(ledger)
 
     assert payload["activated_reserved_order_count"] == 0
     assert payload["activated_creator_count"] == 0
@@ -1436,7 +1432,8 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
     assert subscription.current_period_end_at == boundary_at
     assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
     assert bucket.available_credits == Decimal("1000.0000000000")
-    assert bucket.reserved_credits == Decimal("1000.0000000000")
+    assert bucket.reserved_credits == Decimal("500.0000000000")
+    assert ledger.metadata_json["bucket_credit_state"] == "reserved"
 
 
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -29,6 +29,7 @@ from flaskr.service.billing.consts import (
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
     CREDIT_LEDGER_ENTRY_TYPE_REFUND,
     CREDIT_ROUNDING_MODE_CEIL,
+    CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
     CREDIT_SOURCE_TYPE_MANUAL,
     CREDIT_SOURCE_TYPE_REFUND,
     CREDIT_SOURCE_TYPE_SUBSCRIPTION,
@@ -1434,6 +1435,574 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
     assert bucket.available_credits == Decimal("1000.0000000000")
     assert bucket.reserved_credits == Decimal("500.0000000000")
     assert ledger.metadata_json["bucket_credit_state"] == "reserved"
+
+
+def test_repair_renewal_state_drift_blocks_same_order_when_bonus_only_would_succeed(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-bonus-only-success"
+    subscription_bid = "subscription-renewal-drift-bonus-only-success"
+    product_bid = "bill-product-renewal-drift-bonus-only-success"
+    order_bid = "order-renewal-drift-bonus-only-success"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-bonus-only-success",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("600.0000000000"),
+            lifetime_granted_credits=Decimal("1600.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid=product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        product = BillingProduct(
+            product_bid=product_bid,
+            product_code="repair-bonus-only-success",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_bonus_only_success",
+            description_i18n_key="billing.product.repair_bonus_only_success.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("1000.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-bonus-only-success",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            campaign_bid="campaign-bonus-only-success",
+            campaign_bonus_credit_amount=Decimal("100.0000000000"),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        subscription_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-bonus-only-success-subscription",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-bonus-only-success",
+            priority=20,
+            original_credits=Decimal("1500.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("500.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-bonus-only-success"},
+        )
+        bonus_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-bonus-only-success-bonus",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("100.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("100.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "grant_reason": "campaign_bonus",
+            },
+        )
+        subscription_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-bonus-only-success-subscription",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=subscription_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("500.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        bonus_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-bonus-only-success-bonus",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bonus_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+            source_bid=order_bid,
+            idempotency_key=f"grant:campaign_bonus:{order_bid}",
+            amount=Decimal("100.0000000000"),
+            balance_after=Decimal("500.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "campaign_bid": order.campaign_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                product,
+                order,
+                subscription_bucket,
+                bonus_bucket,
+                subscription_ledger,
+                bonus_ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(subscription_bucket)
+        dao.db.session.refresh(bonus_bucket)
+        dao.db.session.refresh(subscription_ledger)
+        dao.db.session.refresh(bonus_ledger)
+
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["activated_creator_bids"] == []
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["updated_subscription_count"] == 0
+    assert payload["expired_bucket_count"] == 0
+    assert subscription.current_period_end_at == boundary_at
+    assert subscription_bucket.reserved_credits == Decimal("500.0000000000")
+    assert bonus_bucket.reserved_credits == Decimal("100.0000000000")
+    assert subscription_ledger.metadata_json["bucket_credit_state"] == "reserved"
+    assert bonus_ledger.metadata_json["bucket_credit_state"] == "reserved"
+
+
+def test_repair_renewal_state_drift_blocks_same_order_when_subscription_only_would_succeed(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-subscription-only-success"
+    subscription_bid = "subscription-renewal-drift-subscription-only-success"
+    product_bid = "bill-product-renewal-drift-subscription-only-success"
+    order_bid = "order-renewal-drift-subscription-only-success"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-subscription-only-success",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1050.0000000000"),
+            lifetime_granted_credits=Decimal("2050.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid=product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        product = BillingProduct(
+            product_bid=product_bid,
+            product_code="repair-subscription-only-success",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_subscription_only_success",
+            description_i18n_key="billing.product.repair_subscription_only_success.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("1000.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-subscription-only-success",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            campaign_bid="campaign-subscription-only-success",
+            campaign_bonus_credit_amount=Decimal("100.0000000000"),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        subscription_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-subscription-only-success-subscription",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-subscription-only-success",
+            priority=20,
+            original_credits=Decimal("2000.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-subscription-only-success"},
+        )
+        bonus_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-subscription-only-success-bonus",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("100.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("50.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "grant_reason": "campaign_bonus",
+            },
+        )
+        subscription_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-subscription-only-success-subscription",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=subscription_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        bonus_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-subscription-only-success-bonus",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bonus_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+            source_bid=order_bid,
+            idempotency_key=f"grant:campaign_bonus:{order_bid}",
+            amount=Decimal("100.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "campaign_bid": order.campaign_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                product,
+                order,
+                subscription_bucket,
+                bonus_bucket,
+                subscription_ledger,
+                bonus_ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(subscription_bucket)
+        dao.db.session.refresh(bonus_bucket)
+        dao.db.session.refresh(subscription_ledger)
+        dao.db.session.refresh(bonus_ledger)
+
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["activated_creator_bids"] == []
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert subscription.current_period_end_at == boundary_at
+    assert subscription_bucket.reserved_credits == Decimal("1000.0000000000")
+    assert bonus_bucket.reserved_credits == Decimal("50.0000000000")
+    assert subscription_ledger.metadata_json["bucket_credit_state"] == "reserved"
+    assert bonus_ledger.metadata_json["bucket_credit_state"] == "reserved"
+
+
+def test_repair_renewal_state_drift_blocks_multi_order_cycle_atomically(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-multi-order-blocked"
+    subscription_bid = "subscription-renewal-drift-multi-order-blocked"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-multi-order-blocked",
+            creator_bid=creator_bid,
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("550.0000000000"),
+            lifetime_granted_credits=Decimal("1550.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-multi-order-blocked-a",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        product_a = BillingProduct(
+            product_bid="bill-product-renewal-drift-multi-order-blocked-a",
+            product_code="repair-multi-order-blocked-a",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_multi_order_blocked_a",
+            description_i18n_key="billing.product.repair_multi_order_blocked_a.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("50.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        product_b = BillingProduct(
+            product_bid="bill-product-renewal-drift-multi-order-blocked-b",
+            product_code="repair-multi-order-blocked-b",
+            product_type=1,
+            display_name_i18n_key="billing.product.repair_multi_order_blocked_b",
+            description_i18n_key="billing.product.repair_multi_order_blocked_b.description",
+            status=1,
+            billing_mode=2,
+            billing_interval=2,
+            billing_interval_count=1,
+            credit_amount=Decimal("1000.0000000000"),
+            currency="CNY",
+            price_amount=0,
+            allocation_interval=2,
+            auto_renew_enabled=1,
+        )
+        order_a = BillingOrder(
+            bill_order_bid="order-renewal-drift-multi-order-blocked-a",
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_a.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-multi-order-blocked-a",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 0, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        order_b = BillingOrder(
+            bill_order_bid="order-renewal-drift-multi-order-blocked-b",
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=product_b.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id="repair-multi-order-blocked-b",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=datetime(2026, 4, 7, 0, 1, 0),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket_a = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-multi-order-blocked-a",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-multi-order-blocked-a",
+            priority=20,
+            original_credits=Decimal("1050.0000000000"),
+            available_credits=Decimal("1000.0000000000"),
+            reserved_credits=Decimal("50.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-current-multi-order-blocked-a"},
+        )
+        bucket_b = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-multi-order-blocked-b",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-current-multi-order-blocked-b",
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("500.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": order_b.bill_order_bid},
+        )
+        ledger_a = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-multi-order-blocked-a",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket_a.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_a.bill_order_bid,
+            idempotency_key=f"grant:{order_a.bill_order_bid}",
+            amount=Decimal("50.0000000000"),
+            balance_after=Decimal("50.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_a.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        ledger_b = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-multi-order-blocked-b",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket_b.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_b.bill_order_bid,
+            idempotency_key=f"grant:{order_b.bill_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("50.0000000000"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_b.bill_order_bid,
+                "subscription_bid": subscription_bid,
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                product_a,
+                product_b,
+                order_a,
+                order_b,
+                bucket_a,
+                bucket_b,
+                ledger_a,
+                ledger_b,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=False,
+        )
+        dao.db.session.refresh(subscription)
+        dao.db.session.refresh(bucket_a)
+        dao.db.session.refresh(bucket_b)
+        dao.db.session.refresh(ledger_a)
+        dao.db.session.refresh(ledger_b)
+
+    assert payload["activated_reserved_order_count"] == 0
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert subscription.current_period_end_at == boundary_at
+    assert bucket_a.reserved_credits == Decimal("50.0000000000")
+    assert bucket_b.reserved_credits == Decimal("500.0000000000")
+    assert ledger_a.metadata_json["bucket_credit_state"] == "reserved"
+    assert ledger_b.metadata_json["bucket_credit_state"] == "reserved"
 
 
 def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -939,11 +939,17 @@ def test_referral_plan_reward_boundary_releases_all_due_reserved_cycle_grants(
             ]
             == "available"
         )
+        assert ledgers["ledger-referral-boundary-primary"].balance_after == Decimal(
+            "50.0000000000"
+        )
         assert (
             ledgers["ledger-referral-boundary-reward"].metadata_json[
                 "bucket_credit_state"
             ]
             == "available"
+        )
+        assert ledgers["ledger-referral-boundary-reward"].balance_after == Decimal(
+            "1050.0000000000"
         )
         assert len(expire_entries) == 1
         assert expire_entries[0].amount == Decimal("-200.0000000000")


### PR DESCRIPTION
Summary
- enforce reserved renewal cycle preflight from paid orders so missing or invalid grants block partial activation
- keep activated grant ledger balance snapshots ordered per grant instead of overwriting them with the final wallet balance
- make repair dry-run reuse activation preflight and expose manual-review creator classification
- normalize empty JSON bill_order_bid values before falling back to source_bid during reserved grant scans
- sync activated reserved renewal ledger balances after the final wallet snapshot so trial-boundary reward renewals keep accurate balance snapshots
- detect overdue reserved paid grants during renewal drift repair and surface their order / ledger evidence in the dry-run payload
- apply overdue paid grants before expiring stale creator state so paid renewals do not get auto-expired first
- keep creators protected from stale expiry when reserved paid-grant evidence still remains after the repair pass

Verification
- python scripts/check_dev_tools.py
- cd src/api && pytest -q tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_cli.py -q
- cd src/api && pytest tests/service/billing/test_referral_plan_rewards.py::test_referral_plan_reward_releases_reserved_trial_reward_at_boundary -q
- cd src/api && pytest tests/service/billing/test_referral_plan_rewards.py -q
- cd src/api && pytest tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_billing_wallet_lifecycle.py -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/ -q
- cd src/api && python -m ruff check flaskr/service/billing/subscriptions.py

- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_referral_plan_rewards.py tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_billing_wallet_lifecycle.py -q
- cd src/api && .venv/bin/python -m ruff check flaskr/service/billing/subscriptions.py flaskr/service/billing/wallets.py tests/service/billing/test_referral_plan_rewards.py tests/service/billing/test_billing_wallet_lifecycle.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded renewal-state repair to include “overdue reserved” paid grants with creator breakdowns and per-grant evidence (including renewal-event bid details).
* **Bug Fixes**
  * Renewal reserved-credit activation now uses preflight + post-verify checks; insufficient or incomplete activation blocks progression.
  * Paid renewal activation failures now report consistent failed results with the related bill order identifier.
* **Tests**
  * Added/extended coverage for overdue reserved drift (dry-run vs apply), reserved-only creators, activation failure handling, and atomic blocking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->