### PR TITLE
fix: test markdown-flow-ui input focus fix on dev01

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.6",
+        "markdown-flow-ui": "0.2.7-dev.1",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13549,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.6.tgz",
-      "integrity": "sha512-k0pFgQ+41Bf9XyTu1AHEwjC0iWUvjV0ng4mc78RHwhr/z1Nook/TRFlY80dL0ptbTrZF3QG/fhtceVvwB78Zhw==",
+      "version": "0.2.7-dev.1",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.7-dev.1.tgz",
+      "integrity": "sha512-1l+Lg0Ma9nIShM8bzrxUgnBJpExMluhF/GYL9zslaqgjnNSjRp7qg3n8mQG6F5mBfQRv47vCBxCsy+yGS1qalQ==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.6",
+    "markdown-flow-ui": "0.2.7-dev.1",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- Pin `markdown-flow-ui` to `0.2.7-dev.1` for dev01 validation.
- Pick up the Slide interaction input focus fix from `ai-shifu/markdown-flow-ui#211`.

## Root cause

Mobile and related Slide interaction input flows can lose focus when overlay rerenders rebuild the markdown interaction textarea. The upstream dev package contains renderer and interaction state stabilization for validation.

## Impact

QA can validate that mobile interaction textareas keep focus and typed values when the keyboard or overlay rerenders affect the Slide interaction block.

## Validation

- `Bump markdown-flow-ui` workflow passed.
- `cd src/cook-web && npm run lint` passed via branch self-review.
- `pre-commit run -a` is still failing in the branch self-review gate; this appears to be the existing repository-wide gate issue and is not specific to the dependency pin.

## Notes

This branch pins a dev package and must not merge to `main`. Replace it with a release version before production merge.