### PR TITLE
chore: bump markdown-flow-ui to 0.2.7

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -52,7 +52,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.6",
+        "markdown-flow-ui": "0.2.7",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13549,9 +13549,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.6.tgz",
-      "integrity": "sha512-k0pFgQ+41Bf9XyTu1AHEwjC0iWUvjV0ng4mc78RHwhr/z1Nook/TRFlY80dL0ptbTrZF3QG/fhtceVvwB78Zhw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.7.tgz",
+      "integrity": "sha512-JldEjoOWDTT15UG3EiectQ09+KbnQbdfbQ+6FKeD8A/ebz2U/PXBVdYhsyGK2VJxzAtesesk3KBtKt/uSUkOHA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -69,7 +69,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.6",
+    "markdown-flow-ui": "0.2.7",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

- Pin `src/cook-web` to the published `markdown-flow-ui@0.2.7` release.
- Refresh `src/cook-web/package-lock.json` for the new package tarball.

## Why

`markdown-flow-ui@0.2.7` contains the merged fix for mobile and desktop interaction input focus stability. This replaces the temporary `0.2.7-dev.*` test packages with the formal release version required for merging to `main`.

## Validation

- Confirmed `npm view markdown-flow-ui` reports `latest` / `version` as `0.2.7`.
- `python scripts/check_dev_tools.py` with `~/.local/bin` on `PATH`.
- Release pin check script: `markdown-flow-ui 0.2.7 is a release version`.
- `cd src/cook-web && npm run type-check`.
- `cd src/cook-web && npm run lint` (passed with existing warnings).

Related package PR: https://github.com/ai-shifu/markdown-flow-ui/pull/212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering interface to version 0.2.7 for improved compatibility and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->