### PR TITLE
fix: reduce reserved repair dry run noise

### DIFF
--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from flask import Flask
-from sqlalchemy import case, func
+from sqlalchemy import case, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import ObjectDeletedError
 
@@ -416,10 +416,10 @@ def _load_overdue_reserved_paid_order_records(
     candidate_creator_bids: set[str] = set()
     for ledger in query.all():
         metadata = _normalize_json_dict(ledger.metadata_json)
-        if (
-            str(metadata.get("bucket_credit_state") or "").strip().lower()
-            == "available"
-        ):
+        state = _normalize_bucket_credit_state(metadata.get("bucket_credit_state"))
+        if state == "available":
+            continue
+        if not state and not _ledger_bucket_has_reserved_credits(ledger):
             continue
         bill_order_bid = _normalize_optional_metadata_bid(
             metadata.get("bill_order_bid")
@@ -499,6 +499,26 @@ def _load_overdue_reserved_paid_order_records(
     return records
 
 
+def _normalize_bucket_credit_state(value: Any) -> str:
+    state = str(value or "").strip().lower()
+    return "" if state == "null" else state
+
+
+def _ledger_bucket_has_reserved_credits(ledger: CreditLedgerEntry) -> bool:
+    wallet_bucket_bid = _normalize_bid(ledger.wallet_bucket_bid)
+    if not wallet_bucket_bid:
+        return False
+    bucket = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.wallet_bucket_bid == wallet_bucket_bid,
+        )
+        .order_by(CreditWalletBucket.id.desc())
+        .first()
+    )
+    return bucket is not None and _to_decimal(bucket.reserved_credits) > _ZERO
+
+
 def _load_overdue_reserved_paid_order_creator_bids(
     *,
     repaired_at: datetime,
@@ -513,26 +533,42 @@ def _load_overdue_reserved_paid_order_creator_bids(
         ),
         _sql_null_if_empty_or_json_null(CreditLedgerEntry.source_bid),
     )
+    state_expr = func.lower(
+        func.trim(
+            func.coalesce(
+                _json_extract_text(
+                    CreditLedgerEntry.metadata_json, "$.bucket_credit_state"
+                ),
+                "",
+            )
+        )
+    )
     query = (
         db.session.query(CreditLedgerEntry.creator_bid)
         .join(
             BillingOrder,
             BillingOrder.bill_order_bid == bill_order_bid_expr,
         )
+        .outerjoin(
+            CreditWalletBucket,
+            (
+                (CreditWalletBucket.deleted == 0)
+                & (
+                    CreditWalletBucket.wallet_bucket_bid
+                    == CreditLedgerEntry.wallet_bucket_bid
+                )
+            ),
+        )
         .filter(
             CreditLedgerEntry.deleted == 0,
             CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
             CreditLedgerEntry.consumable_from.isnot(None),
             CreditLedgerEntry.consumable_from <= repaired_at,
-            func.lower(
-                func.coalesce(
-                    _json_extract_text(
-                        CreditLedgerEntry.metadata_json, "$.bucket_credit_state"
-                    ),
-                    "",
-                )
-            )
-            != "available",
+            state_expr != "available",
+            or_(
+                ~state_expr.in_(["", "null"]),
+                CreditWalletBucket.reserved_credits > _ZERO,
+            ),
             BillingOrder.deleted == 0,
             BillingOrder.status == BILLING_ORDER_STATUS_PAID,
         )

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -411,21 +411,31 @@ def _load_overdue_reserved_paid_order_records(
             return []
         query = query.filter(CreditLedgerEntry.creator_bid.in_(sorted(creator_bids)))
 
-    candidate_ledgers: list[tuple[CreditLedgerEntry, str]] = []
-    candidate_order_bids: set[str] = set()
-    candidate_creator_bids: set[str] = set()
-    for ledger in query.all():
+    ledgers = query.all()
+    eligible_ledgers: list[tuple[CreditLedgerEntry, str, str, str]] = []
+    missing_state_bucket_bids: set[str] = set()
+    for ledger in ledgers:
         metadata = _normalize_json_dict(ledger.metadata_json)
         state = _normalize_bucket_credit_state(metadata.get("bucket_credit_state"))
         if state == "available":
             continue
-        if not state and not _ledger_bucket_has_reserved_credits(ledger):
-            continue
-        bill_order_bid = _normalize_optional_metadata_bid(
-            metadata.get("bill_order_bid")
-        ) or _normalize_optional_metadata_bid(ledger.source_bid)
+        bill_order_bid = _extract_ledger_bill_order_bid(ledger, metadata)
         if not bill_order_bid:
             continue
+        wallet_bucket_bid = _normalize_bid(ledger.wallet_bucket_bid)
+        if not state and wallet_bucket_bid:
+            missing_state_bucket_bids.add(wallet_bucket_bid)
+        eligible_ledgers.append((ledger, bill_order_bid, state, wallet_bucket_bid))
+
+    reserved_buckets_by_bid = _load_reserved_buckets_by_bid(missing_state_bucket_bids)
+    candidate_ledgers: list[tuple[CreditLedgerEntry, str]] = []
+    candidate_order_bids: set[str] = set()
+    candidate_creator_bids: set[str] = set()
+    for ledger, bill_order_bid, state, wallet_bucket_bid in eligible_ledgers:
+        if not state:
+            bucket = reserved_buckets_by_bid.get(wallet_bucket_bid)
+            if bucket is None or not _bucket_matches_order_bid(bucket, bill_order_bid):
+                continue
         candidate_ledgers.append((ledger, bill_order_bid))
         candidate_order_bids.add(bill_order_bid)
         candidate_creator_bids.add(_normalize_bid(ledger.creator_bid))
@@ -504,19 +514,52 @@ def _normalize_bucket_credit_state(value: Any) -> str:
     return "" if state == "null" else state
 
 
-def _ledger_bucket_has_reserved_credits(ledger: CreditLedgerEntry) -> bool:
-    wallet_bucket_bid = _normalize_bid(ledger.wallet_bucket_bid)
-    if not wallet_bucket_bid:
-        return False
-    bucket = (
+def _extract_ledger_bill_order_bid(
+    ledger: CreditLedgerEntry, metadata: dict[str, Any] | None = None
+) -> str:
+    normalized_metadata = _normalize_json_dict(metadata or ledger.metadata_json)
+    return _normalize_optional_metadata_bid(
+        normalized_metadata.get("bill_order_bid")
+    ) or _normalize_optional_metadata_bid(ledger.source_bid)
+
+
+def _load_reserved_buckets_by_bid(
+    wallet_bucket_bids: set[str],
+) -> dict[str, CreditWalletBucket]:
+    normalized_bids = sorted({_normalize_bid(bid) for bid in wallet_bucket_bids if bid})
+    if not normalized_bids:
+        return {}
+    buckets = (
         CreditWalletBucket.query.filter(
             CreditWalletBucket.deleted == 0,
-            CreditWalletBucket.wallet_bucket_bid == wallet_bucket_bid,
+            CreditWalletBucket.wallet_bucket_bid.in_(normalized_bids),
         )
         .order_by(CreditWalletBucket.id.desc())
-        .first()
+        .all()
     )
-    return bucket is not None and _to_decimal(bucket.reserved_credits) > _ZERO
+    reserved_buckets_by_bid: dict[str, CreditWalletBucket] = {}
+    for bucket in buckets:
+        wallet_bucket_bid = _normalize_bid(bucket.wallet_bucket_bid)
+        if (
+            wallet_bucket_bid
+            and wallet_bucket_bid not in reserved_buckets_by_bid
+            and _to_decimal(bucket.reserved_credits) > _ZERO
+        ):
+            reserved_buckets_by_bid[wallet_bucket_bid] = bucket
+    return reserved_buckets_by_bid
+
+
+def _bucket_matches_order_bid(bucket: CreditWalletBucket, bill_order_bid: str) -> bool:
+    normalized_order_bid = _normalize_bid(bill_order_bid)
+    if not normalized_order_bid:
+        return False
+    metadata = _normalize_json_dict(bucket.metadata_json)
+    bucket_order_bids = {
+        _normalize_optional_metadata_bid(bucket.source_bid),
+        _normalize_optional_metadata_bid(metadata.get("bill_order_bid")),
+        _normalize_optional_metadata_bid(metadata.get("billing_order_bid")),
+    }
+    return normalized_order_bid in bucket_order_bids
 
 
 def _load_overdue_reserved_paid_order_creator_bids(
@@ -532,6 +575,15 @@ def _load_overdue_reserved_paid_order_creator_bids(
             _json_extract_text(CreditLedgerEntry.metadata_json, "$.bill_order_bid")
         ),
         _sql_null_if_empty_or_json_null(CreditLedgerEntry.source_bid),
+    )
+    bucket_source_order_bid_expr = _sql_null_if_empty_or_json_null(
+        CreditWalletBucket.source_bid
+    )
+    bucket_bill_order_bid_expr = _sql_null_if_empty_or_json_null(
+        _json_extract_text(CreditWalletBucket.metadata_json, "$.bill_order_bid")
+    )
+    bucket_billing_order_bid_expr = _sql_null_if_empty_or_json_null(
+        _json_extract_text(CreditWalletBucket.metadata_json, "$.billing_order_bid")
     )
     state_expr = func.lower(
         func.trim(
@@ -553,6 +605,8 @@ def _load_overdue_reserved_paid_order_creator_bids(
             CreditWalletBucket,
             (
                 (CreditWalletBucket.deleted == 0)
+                & (CreditLedgerEntry.wallet_bucket_bid != "")
+                & (CreditWalletBucket.wallet_bucket_bid != "")
                 & (
                     CreditWalletBucket.wallet_bucket_bid
                     == CreditLedgerEntry.wallet_bucket_bid
@@ -567,7 +621,14 @@ def _load_overdue_reserved_paid_order_creator_bids(
             state_expr != "available",
             or_(
                 ~state_expr.in_(["", "null"]),
-                CreditWalletBucket.reserved_credits > _ZERO,
+                (
+                    (CreditWalletBucket.reserved_credits > _ZERO)
+                    & (
+                        (bucket_source_order_bid_expr == bill_order_bid_expr)
+                        | (bucket_bill_order_bid_expr == bill_order_bid_expr)
+                        | (bucket_billing_order_bid_expr == bill_order_bid_expr)
+                    )
+                ),
             ),
             BillingOrder.deleted == 0,
             BillingOrder.status == BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1963,6 +1963,377 @@ def test_repair_renewal_state_drift_ignores_legacy_missing_state_without_reserve
     assert payload["manual_review_creator_bids"] == []
 
 
+def test_repair_renewal_state_drift_keeps_missing_state_with_matching_reserved_bucket(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-missing-state-matching-bucket"
+    subscription_bid = "subscription-renewal-drift-missing-state-matching-bucket"
+    order_bid = "order-renewal-drift-missing-state-matching-bucket"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-missing-state-matching-bucket",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-missing-state-matching-bucket",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=boundary_at,
+            current_period_end_at=next_cycle_end,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=boundary_at - timedelta(days=1),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-missing-state-matching-bucket",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="",
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"billing_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-missing-state-matching-bucket",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "grant_reason": "subscription",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["creator_bids"] == [creator_bid]
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == order_bid
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
+
+
+def test_repair_renewal_state_drift_keeps_missing_state_from_seeded_creator_scan(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-missing-state-seeded-scan"
+    subscription_bid = "subscription-renewal-drift-missing-state-seeded-scan"
+    order_bid = "order-renewal-drift-missing-state-seeded-scan"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-missing-state-seeded-scan",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-missing-state-seeded-scan",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
+            current_period_end_at=boundary_at,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=boundary_at - timedelta(days=1),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-missing-state-seeded-scan",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-missing-state-seeded-scan",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=boundary_at,
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "grant_reason": "subscription",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["stale_subscription_count"] == 1
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == order_bid
+    assert payload["protected_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == [creator_bid]
+
+
+def test_repair_renewal_state_drift_ignores_shared_bucket_legacy_missing_state(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    old_boundary_at = datetime(2026, 3, 8, 0, 0, 0)
+    current_boundary_at = datetime(2026, 4, 8, 0, 0, 0)
+    next_cycle_end = datetime(2026, 5, 8, 0, 0, 0)
+    creator_bid = "creator-renewal-drift-shared-bucket-missing-state"
+    subscription_bid = "subscription-renewal-drift-shared-bucket-missing-state"
+    old_order_bid = "order-renewal-drift-shared-bucket-legacy"
+    current_order_bid = "order-renewal-drift-shared-bucket-current"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-shared-bucket-missing-state",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            lifetime_granted_credits=Decimal("2000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-shared-bucket-missing-state",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=current_boundary_at,
+            current_period_end_at=next_cycle_end,
+        )
+        old_order = BillingOrder(
+            bill_order_bid=old_order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=old_order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=old_boundary_at - timedelta(days=1),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(old_boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(current_boundary_at),
+            },
+        )
+        current_order = BillingOrder(
+            bill_order_bid=current_order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=current_order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=current_boundary_at - timedelta(days=1),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(current_boundary_at),
+                "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-shared-bucket-missing-state",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=current_order_bid,
+            priority=20,
+            original_credits=Decimal("2000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("1000.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=current_boundary_at,
+            effective_to=next_cycle_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": current_order_bid},
+        )
+        old_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-shared-bucket-legacy",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=old_order_bid,
+            idempotency_key=f"grant:{old_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=current_boundary_at,
+            consumable_from=old_boundary_at,
+            metadata_json={
+                "bill_order_bid": old_order_bid,
+                "subscription_bid": subscription_bid,
+                "grant_reason": "subscription",
+            },
+        )
+        current_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-shared-bucket-current",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=current_order_bid,
+            idempotency_key=f"grant:{current_order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("0"),
+            expires_at=next_cycle_end,
+            consumable_from=current_boundary_at,
+            metadata_json={
+                "bill_order_bid": current_order_bid,
+                "subscription_bid": subscription_bid,
+                "grant_reason": "subscription",
+                "bucket_credit_state": "reserved",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                old_order,
+                current_order,
+                bucket,
+                old_ledger,
+                current_ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            repair_before=current_boundary_at + timedelta(minutes=1),
+            dry_run=True,
+        )
+
+    assert payload["creator_bids"] == [creator_bid]
+    assert payload["overdue_reserved_grant_count"] == 1
+    assert payload["overdue_reserved_grants"][0]["bill_order_bid"] == current_order_bid
+    assert payload["activatable_creator_bids"] == [creator_bid]
+    assert payload["manual_review_creator_bids"] == []
+
+
 def test_repair_renewal_state_drift_all_scope_falls_back_to_source_bid(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -1854,6 +1854,115 @@ def test_repair_renewal_state_drift_blocks_short_subscription_grant_amount(
     assert ledger.metadata_json["bucket_credit_state"] == "reserved"
 
 
+def test_repair_renewal_state_drift_ignores_legacy_missing_state_without_reserved(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    repaired_at = datetime(2026, 7, 28, 0, 0, 0)
+    period_end = repaired_at + timedelta(days=30)
+    creator_bid = "creator-renewal-drift-legacy-missing-state"
+    subscription_bid = "subscription-renewal-drift-legacy-missing-state"
+    order_bid = "order-renewal-drift-legacy-missing-state"
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-renewal-drift-legacy-missing-state",
+            creator_bid=creator_bid,
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("1000.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        subscription = BillingSubscription(
+            subscription_bid=subscription_bid,
+            creator_bid=creator_bid,
+            product_bid="bill-product-renewal-drift-legacy-missing-state",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=repaired_at,
+            current_period_end_at=period_end,
+        )
+        order = BillingOrder(
+            bill_order_bid=order_bid,
+            creator_bid=creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription_bid,
+            currency="CNY",
+            payable_amount=0,
+            paid_amount=0,
+            payment_provider="manual",
+            channel="manual",
+            provider_reference_id=order_bid,
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=repaired_at - timedelta(days=1),
+            metadata_json={
+                "renewal_cycle_start_at": to_utc_iso(repaired_at - timedelta(days=1)),
+                "renewal_cycle_end_at": to_utc_iso(period_end),
+            },
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-legacy-missing-state",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            priority=20,
+            original_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("1000.0000000000"),
+            effective_from=repaired_at - timedelta(days=1),
+            effective_to=period_end,
+            status=CREDIT_BUCKET_STATUS_EXPIRED,
+            metadata_json={"bill_order_bid": order_bid},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-legacy-missing-state",
+            creator_bid=creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid=order_bid,
+            idempotency_key=f"grant:{order_bid}",
+            amount=Decimal("1000.0000000000"),
+            balance_after=Decimal("1000.0000000000"),
+            expires_at=period_end,
+            consumable_from=repaired_at - timedelta(days=1),
+            metadata_json={
+                "bill_order_bid": order_bid,
+                "subscription_bid": subscription_bid,
+                "grant_reason": "subscription",
+            },
+        )
+        dao.db.session.add_all(
+            [
+                wallet,
+                subscription,
+                _create_monthly_plan_product(subscription.product_bid),
+                order,
+                bucket,
+                ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        payload = repair_renewal_state_drift(
+            billing_wallet_lifecycle_app,
+            creator_bid=creator_bid,
+            repair_before=repaired_at,
+            dry_run=True,
+        )
+
+    assert payload["status"] == "noop"
+    assert payload["overdue_reserved_grant_count"] == 0
+    assert payload["protected_creator_bids"] == []
+    assert payload["manual_review_creator_bids"] == []
+
+
 def test_repair_renewal_state_drift_all_scope_falls_back_to_source_bid(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:


### PR DESCRIPTION
## Changed
- Exclude legacy grant ledgers with missing bucket credit state from renewal repair candidates when the linked bucket no longer has reserved credits.
- Keep missing-state grant ledgers only when the bucket still has reserved credits and the bucket attribution matches the same billing order.
- Keep abnormal explicit states protected, while avoiding shared-bucket legacy noise that can block newer actionable reservations.
- Batch-load bucket reserved state for missing-state ledgers to avoid per-ledger bucket queries.
- Add regression coverage for zero-reserved legacy grants, matching reserved bucket attribution, Python-side creator scans, and shared-bucket old/new order attribution.

## Verification
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_wallet_lifecycle.py::test_repair_renewal_state_drift_ignores_legacy_missing_state_without_reserved tests/service/billing/test_billing_wallet_lifecycle.py::test_repair_renewal_state_drift_keeps_missing_state_with_matching_reserved_bucket tests/service/billing/test_billing_wallet_lifecycle.py::test_repair_renewal_state_drift_keeps_missing_state_from_seeded_creator_scan tests/service/billing/test_billing_wallet_lifecycle.py::test_repair_renewal_state_drift_ignores_shared_bucket_legacy_missing_state -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_referral_plan_rewards.py -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/ -q
- cd src/api && .venv/bin/python -m ruff check flaskr/service/billing/wallets.py tests/service/billing/test_billing_wallet_lifecycle.py
- git diff --check
- python scripts/check_dev_tools.py
- lefthook run pre-commit --all-files
- dry-run after review fix: repair-renewal-state-drift --all --limit 100 => overdue_reserved_grant_count=0, manual_review_creator_count=0, activatable_creator_count=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet repair behavior for legacy billing records when reservation state is missing, empty, or explicitly null.
  * Reduced false-positive repair attempts when there are no reserved credits to validate.
  * Enhanced overdue reserved grant detection by using the most relevant available reserved-credit evidence.

* **Tests**
  * Added new pytest cases for dry-run renewal state drift checks to validate “no-op” and “retain missing state” outcomes across multiple legacy missing-state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
