### PR TITLE
fix: keep retake action visible after reset

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -23,7 +23,32 @@ interface MockChatMobileHeaderProps {
 
 interface MockChatUiProps {
   lessonId?: string;
+  lessonUpdate?: (value: {
+    id: string;
+    status: string;
+    status_value: string;
+  }) => void;
 }
+
+type ResetChapterEventHandler = (
+  event: CustomEvent<{
+    chapter_id: string;
+    lesson_id: string;
+  }>,
+) => Promise<void>;
+
+const getResetChapterEventHandler = () => {
+  const { shifu: mockedShifu } = jest.requireMock('@/c-service/Shifu') as {
+    shifu: {
+      events: {
+        addEventListener: jest.Mock;
+      };
+    };
+  };
+  return mockedShifu.events.addEventListener.mock.calls.find(
+    ([eventType]) => eventType === 'RESET_CHAPTER',
+  )?.[1] as ResetChapterEventHandler | undefined;
+};
 
 const mockChatMobileHeader = jest.fn(
   ({ lessonId, lessonTitle }: MockChatMobileHeaderProps) => (
@@ -425,24 +450,7 @@ describe('ChatPage profile onboarding gate', () => {
 
     await screen.findByTestId('chat-ui');
 
-    const { shifu: mockedShifu } = jest.requireMock('@/c-service/Shifu') as {
-      shifu: {
-        events: {
-          addEventListener: jest.Mock;
-        };
-      };
-    };
-    const resetChapterEventHandler =
-      mockedShifu.events.addEventListener.mock.calls.find(
-        ([eventType]) => eventType === 'RESET_CHAPTER',
-      )?.[1] as
-        | ((
-            event: CustomEvent<{
-              chapter_id: string;
-              lesson_id: string;
-            }>,
-          ) => Promise<void>)
-        | undefined;
+    const resetChapterEventHandler = getResetChapterEventHandler();
 
     expect(resetChapterEventHandler).toBeDefined();
 
@@ -467,6 +475,56 @@ describe('ChatPage profile onboarding gate', () => {
       status_value: 'in_progress',
     });
     expect(mockUpdateSelectedLesson).toHaveBeenCalledWith('lesson-1', true);
+  });
+
+  test('preserves a newer lesson status received while the reset tree reloads', async () => {
+    let resolveReloadTree: (value: unknown) => void = () => {};
+    mockReloadTree.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveReloadTree = resolve;
+      }),
+    );
+
+    render(<ChatPage />);
+
+    await screen.findByTestId('chat-ui');
+
+    const resetChapterEventHandler = getResetChapterEventHandler();
+    const latestChatUiCall =
+      mockChatUi.mock.calls[mockChatUi.mock.calls.length - 1];
+    const lessonUpdate = latestChatUiCall?.[0].lessonUpdate;
+
+    expect(resetChapterEventHandler).toBeDefined();
+    expect(lessonUpdate).toBeDefined();
+
+    const resetPromise = resetChapterEventHandler?.(
+      new CustomEvent('RESET_CHAPTER', {
+        detail: {
+          chapter_id: 'chapter-1',
+          lesson_id: 'lesson-1',
+        },
+      }),
+    );
+
+    lessonUpdate?.({
+      id: 'lesson-1',
+      status: 'completed',
+      status_value: 'completed',
+    });
+
+    resolveReloadTree(null);
+    await resetPromise;
+
+    expect(mockUpdateLesson).toHaveBeenLastCalledWith('lesson-1', {
+      id: 'lesson-1',
+      status: 'completed',
+      status_value: 'completed',
+    });
+    expect(mockUpdateLesson).not.toHaveBeenCalledWith('lesson-1', {
+      id: 'lesson-1',
+      status: 'in_progress',
+      status_value: 'in_progress',
+    });
   });
 
   test('surfaces the backend onboarding error message when submit fails', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -9,6 +9,8 @@ const mockRefreshUserInfo = jest.fn();
 const mockUpdateCourseId = jest.fn();
 const mockLoadTree = jest.fn();
 const mockReloadTree = jest.fn();
+const mockUpdateLesson = jest.fn();
+const mockUpdateSelectedLesson = jest.fn();
 const mockUpdateLessonId = jest.fn();
 const mockUpdateChapterId = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -217,10 +219,10 @@ jest.mock('./hooks/useLessonTree', () => ({
     selectedLessonId: mockSelectedLessonId,
     loadTree: mockLoadTree,
     reloadTree: mockReloadTree,
-    updateSelectedLesson: jest.fn(),
+    updateSelectedLesson: mockUpdateSelectedLesson,
     toggleCollapse: jest.fn(),
     getCurrElement: jest.fn().mockResolvedValue(null),
-    updateLesson: jest.fn(),
+    updateLesson: mockUpdateLesson,
     updateChapterStatus: jest.fn(),
     getChapterByLesson: jest.fn(() => ({
       id: 'chapter-1',
@@ -328,6 +330,7 @@ describe('ChatPage profile onboarding gate', () => {
     mockCompleteProfileOnboarding.mockResolvedValue({
       completed: true,
     });
+    mockReloadTree.mockResolvedValue(null);
     mockRefreshUserInfo.mockResolvedValue(undefined);
   });
 
@@ -408,6 +411,62 @@ describe('ChatPage profile onboarding gate', () => {
 
     const chatUi = await screen.findByTestId('chat-ui');
     expect(chatUi).toHaveAttribute('data-lesson-id', 'lesson-new');
+  });
+
+  test('keeps a retaken lesson in progress after reloading its reset tree state', async () => {
+    let resolveReloadTree: (value: unknown) => void = () => {};
+    mockReloadTree.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveReloadTree = resolve;
+      }),
+    );
+
+    render(<ChatPage />);
+
+    await screen.findByTestId('chat-ui');
+
+    const { shifu: mockedShifu } = jest.requireMock('@/c-service/Shifu') as {
+      shifu: {
+        events: {
+          addEventListener: jest.Mock;
+        };
+      };
+    };
+    const resetChapterEventHandler =
+      mockedShifu.events.addEventListener.mock.calls.find(
+        ([eventType]) => eventType === 'RESET_CHAPTER',
+      )?.[1] as
+        | ((
+            event: CustomEvent<{
+              chapter_id: string;
+              lesson_id: string;
+            }>,
+          ) => Promise<void>)
+        | undefined;
+
+    expect(resetChapterEventHandler).toBeDefined();
+
+    const resetPromise = resetChapterEventHandler?.(
+      new CustomEvent('RESET_CHAPTER', {
+        detail: {
+          chapter_id: 'chapter-1',
+          lesson_id: 'lesson-1',
+        },
+      }),
+    );
+
+    expect(mockReloadTree).toHaveBeenCalledWith('chapter-1', 'lesson-1');
+    expect(mockUpdateLesson).not.toHaveBeenCalled();
+
+    resolveReloadTree(null);
+    await resetPromise;
+
+    expect(mockUpdateLesson).toHaveBeenCalledWith('lesson-1', {
+      id: 'lesson-1',
+      status: 'in_progress',
+      status_value: 'in_progress',
+    });
+    expect(mockUpdateSelectedLesson).toHaveBeenCalledWith('lesson-1', true);
   });
 
   test('surfaces the backend onboarding error message when submit fails', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -28,7 +28,7 @@ import {
 import { useUserStore } from '@/store';
 import { useDisclosure } from '@/c-common/hooks/useDisclosure';
 import { useTracking } from '@/c-common/hooks/useTracking';
-import { useLessonTree } from './hooks/useLessonTree';
+import { useLessonTree, type LessonTreeLesson } from './hooks/useLessonTree';
 import {
   applyLessonSelection,
   resolveRequestedLessonId,
@@ -78,6 +78,8 @@ const PayModalM = dynamic(() => import('./Components/Pay/PayModalM'), {
 const PayModal = dynamic(() => import('./Components/Pay/PayModal'), {
   ssr: false,
 });
+
+type LessonUpdate = Pick<LessonTreeLesson, 'id'> & Partial<LessonTreeLesson>;
 
 // import LoginModal from './Components/Login/LoginModal';
 
@@ -717,8 +719,14 @@ export default function ChatPage() {
     }
   };
 
+  const lessonUpdateSequenceRef = useRef(0);
+  const latestLessonUpdatesRef = useRef(
+    new Map<string, { sequence: number; value: LessonUpdate }>(),
+  );
   const onLessonUpdate = useCallback(
-    val => {
+    (val: LessonUpdate) => {
+      const sequence = ++lessonUpdateSequenceRef.current;
+      latestLessonUpdatesRef.current.set(val.id, { sequence, value: val });
       updateLesson(val.id, val);
     },
     [updateLesson],
@@ -862,12 +870,20 @@ export default function ChatPage() {
   useEffect(() => {
     const resetChapterEventHandler = async e => {
       const targetLessonId = e.detail.lesson_id;
+      const lessonUpdateSequenceBeforeReload = lessonUpdateSequenceRef.current;
       await reloadTree(e.detail.chapter_id, targetLessonId);
-      onLessonUpdate({
-        id: targetLessonId,
-        status: LESSON_STATUS_VALUE.LEARNING,
-        status_value: LESSON_STATUS_VALUE.LEARNING,
-      });
+      const latestLessonUpdate =
+        latestLessonUpdatesRef.current.get(targetLessonId);
+      onLessonUpdate(
+        latestLessonUpdate &&
+          latestLessonUpdate.sequence > lessonUpdateSequenceBeforeReload
+          ? latestLessonUpdate.value
+          : {
+              id: targetLessonId,
+              status: LESSON_STATUS_VALUE.LEARNING,
+              status_value: LESSON_STATUS_VALUE.LEARNING,
+            },
+      );
       updateSelectedLesson(targetLessonId, true);
       onGoChapter(targetLessonId);
       if (mobileStyle) {

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -16,6 +16,7 @@ import {
   inWechat,
   inMiniProgram,
 } from '@/c-constants/uiConstants';
+import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import { EVENT_NAMES, events } from './events';
 
 import {
@@ -862,6 +863,11 @@ export default function ChatPage() {
     const resetChapterEventHandler = async e => {
       const targetLessonId = e.detail.lesson_id;
       await reloadTree(e.detail.chapter_id, targetLessonId);
+      onLessonUpdate({
+        id: targetLessonId,
+        status: LESSON_STATUS_VALUE.LEARNING,
+        status_value: LESSON_STATUS_VALUE.LEARNING,
+      });
       updateSelectedLesson(targetLessonId, true);
       onGoChapter(targetLessonId);
       if (mobileStyle) {
@@ -898,6 +904,7 @@ export default function ChatPage() {
     gotoLogin,
     mobileStyle,
     onGoChapter,
+    onLessonUpdate,
     onNavClose,
     reloadTree,
     updateSelectedLesson,


### PR DESCRIPTION
## Summary

- restore the retaken lesson's local status after the reset course tree reload completes
- preserve any newer stream-driven lesson status that arrives while the tree reload is pending
- prevent both the transient not-started snapshot and the fallback in-progress update from regressing the catalog state
- cover the no-newer-update and completed-during-reload orderings with focused regression tests

## Verification

- npm run test -- --runTestsByPath 'src/app/c/[[...id]]/page.test.tsx' (8 passed)
- npm run type-check
- npm run lint
- python3 scripts/check_dev_tools.py
- lefthook run pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chapter retaking after a reset event to restore the correct lesson state, including both status and status value.
  * Ensured reset/reload reconciles with any newer pending lesson updates, preventing older reset results from overwriting more recent chat updates.
  * Lessons are now reliably updated and marked as selected after reloading, preserving the correct lesson/chapter context.
* **Tests**
  * Expanded Jest coverage for reset/reload behavior with dedicated mutation mocks and new async assertions for status, status value, and selection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->