### PR TITLE
fix: avoid racing bucket expiration writes

### DIFF
--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -2150,15 +2150,12 @@ def _expire_credit_wallet_buckets_in_session(
         # sees the pending bucket update.
         try:
             with db.session.begin_nested():
-                bucket.available_credits = _ZERO
-                bucket.expired_credits = _quantize_credit_amount(
-                    _to_decimal(bucket.expired_credits) + available
-                )
-                if _to_decimal(bucket.reserved_credits) > _ZERO:
-                    sync_credit_bucket_status(bucket)
-                else:
-                    bucket.status = CREDIT_BUCKET_STATUS_EXPIRED
-                db.session.add(bucket)
+                if not _expire_bucket_available_credits_if_unchanged(
+                    bucket,
+                    available=available,
+                    cutoff=cutoff,
+                ):
+                    continue
 
                 refresh_credit_wallet_snapshot(
                     wallet,
@@ -2220,6 +2217,54 @@ def _expire_credit_wallet_buckets_in_session(
         bucket_count=expired_count,
         expired_credits=_credit_decimal_to_number(expired_total),
     )
+
+
+def _expire_bucket_available_credits_if_unchanged(
+    bucket: CreditWalletBucket,
+    *,
+    available: Decimal,
+    cutoff: datetime,
+) -> bool:
+    """Expire a bucket only if its refreshed balance/window still match."""
+
+    if bucket.id is None or bucket.effective_to is None:
+        return False
+
+    expected_available = _quantize_credit_amount(available)
+    expected_expired = _quantize_credit_amount(bucket.expired_credits)
+    expected_reserved = _quantize_credit_amount(bucket.reserved_credits)
+    next_expired = _quantize_credit_amount(expected_expired + expected_available)
+    next_status = (
+        CREDIT_BUCKET_STATUS_EXHAUSTED
+        if expected_reserved > _ZERO
+        else CREDIT_BUCKET_STATUS_EXPIRED
+    )
+    updated_rows = CreditWalletBucket.query.filter(
+        CreditWalletBucket.deleted == 0,
+        CreditWalletBucket.id == bucket.id,
+        CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+        CreditWalletBucket.effective_to == bucket.effective_to,
+        CreditWalletBucket.available_credits == expected_available,
+        CreditWalletBucket.expired_credits == expected_expired,
+        CreditWalletBucket.reserved_credits == expected_reserved,
+    ).update(
+        {
+            "available_credits": _ZERO,
+            "expired_credits": next_expired,
+            "status": next_status,
+            "updated_at": cutoff,
+        },
+        synchronize_session=False,
+    )
+    if updated_rows != 1:
+        db.session.expire(bucket)
+        return False
+
+    bucket.available_credits = _ZERO
+    bucket.expired_credits = next_expired
+    bucket.status = next_status
+    bucket.updated_at = cutoff
+    return True
 
 
 def sync_credit_bucket_status(bucket: CreditWalletBucket) -> int:

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -2128,8 +2128,11 @@ def _expire_credit_wallet_buckets_in_session(
 
         available = _to_decimal(bucket.available_credits)
         if available <= _ZERO:
-            sync_credit_bucket_status(bucket)
-            db.session.add(bucket)
+            _sync_empty_available_bucket_status_if_unchanged(
+                bucket,
+                available=available,
+                mutation_at=now_utc(),
+            )
             continue
 
         wallet = wallets.get(bucket.wallet_bid)
@@ -2263,6 +2266,46 @@ def _expire_bucket_available_credits_if_unchanged(
     bucket.available_credits = _ZERO
     bucket.expired_credits = next_expired
     bucket.status = next_status
+    bucket.updated_at = mutation_at
+    return True
+
+
+def _sync_empty_available_bucket_status_if_unchanged(
+    bucket: CreditWalletBucket,
+    *,
+    available: Decimal,
+    mutation_at: datetime,
+) -> bool:
+    """Mark an ended empty bucket exhausted only if it stayed empty."""
+
+    if bucket.id is None or bucket.effective_to is None:
+        return False
+
+    expected_available = _quantize_credit_amount(available)
+    expected_expired = _quantize_credit_amount(bucket.expired_credits)
+    expected_reserved = _quantize_credit_amount(bucket.reserved_credits)
+    updated_rows = CreditWalletBucket.query.filter(
+        CreditWalletBucket.deleted == 0,
+        CreditWalletBucket.id == bucket.id,
+        CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+        CreditWalletBucket.effective_to == bucket.effective_to,
+        CreditWalletBucket.available_credits == expected_available,
+        CreditWalletBucket.expired_credits == expected_expired,
+        CreditWalletBucket.reserved_credits == expected_reserved,
+    ).update(
+        {
+            "available_credits": _ZERO,
+            "status": CREDIT_BUCKET_STATUS_EXHAUSTED,
+            "updated_at": mutation_at,
+        },
+        synchronize_session=False,
+    )
+    if updated_rows != 1:
+        db.session.expire(bucket)
+        return False
+
+    bucket.available_credits = _ZERO
+    bucket.status = CREDIT_BUCKET_STATUS_EXHAUSTED
     bucket.updated_at = mutation_at
     return True
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -2153,7 +2153,7 @@ def _expire_credit_wallet_buckets_in_session(
                 if not _expire_bucket_available_credits_if_unchanged(
                     bucket,
                     available=available,
-                    cutoff=cutoff,
+                    mutation_at=now_utc(),
                 ):
                     continue
 
@@ -2223,7 +2223,7 @@ def _expire_bucket_available_credits_if_unchanged(
     bucket: CreditWalletBucket,
     *,
     available: Decimal,
-    cutoff: datetime,
+    mutation_at: datetime,
 ) -> bool:
     """Expire a bucket only if its refreshed balance/window still match."""
 
@@ -2252,7 +2252,7 @@ def _expire_bucket_available_credits_if_unchanged(
             "available_credits": _ZERO,
             "expired_credits": next_expired,
             "status": next_status,
-            "updated_at": cutoff,
+            "updated_at": mutation_at,
         },
         synchronize_session=False,
     )
@@ -2263,7 +2263,7 @@ def _expire_bucket_available_credits_if_unchanged(
     bucket.available_credits = _ZERO
     bucket.expired_credits = next_expired
     bucket.status = next_status
-    bucket.updated_at = cutoff
+    bucket.updated_at = mutation_at
     return True
 
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -173,6 +173,66 @@ def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
         assert ledger.balance_after == Decimal("0E-10")
 
 
+def test_expire_credit_wallet_buckets_uses_actual_mutation_time_for_bucket_update(
+    billing_wallet_lifecycle_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.billing import wallets as wallets_mod
+
+    cutoff = datetime(2026, 4, 8, 0, 0, 0)
+    mutation_at = datetime(2026, 4, 9, 12, 30, 0)
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-mutation-time",
+            creator_bid="creator-expire-mutation-time",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-mutation-time",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-mutation-time",
+            priority=30,
+            original_credits=Decimal("2.5000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+            created_at=datetime(2026, 4, 1, 0, 0, 0),
+            updated_at=datetime(2026, 4, 1, 0, 0, 0),
+        )
+        dao.db.session.add_all([wallet, bucket])
+        dao.db.session.commit()
+        monkeypatch.setattr(wallets_mod, "now_utc", lambda: mutation_at)
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            expire_before=cutoff,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-mutation-time"
+        ).one()
+
+    assert payload["bucket_count"] == 1
+    assert bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+    assert bucket.updated_at == mutation_at
+    assert bucket.updated_at != cutoff
+
+
 def test_expire_credit_wallet_buckets_skips_bucket_with_conflicting_ledger(
     billing_wallet_lifecycle_app: Flask,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -439,6 +439,236 @@ def test_expire_credit_wallet_buckets_skips_bucket_realigned_during_refresh(
         assert ledgers == []
 
 
+def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
+    billing_wallet_lifecycle_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.billing import wallets as wallets_mod
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-consumed-before-write",
+            creator_bid="creator-expire-consumed-before-write",
+            available_credits=Decimal("6.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("6.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        skipped_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-consumed-before-write",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-consumed-before-write",
+            priority=30,
+            original_credits=Decimal("4.0000000000"),
+            available_credits=Decimal("4.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ok_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-consumed-before-write-ok",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-consumed-before-write-ok",
+            priority=30,
+            original_credits=Decimal("2.0000000000"),
+            available_credits=Decimal("2.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, skipped_bucket, ok_bucket])
+        dao.db.session.commit()
+
+        real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
+        changed = {"done": False}
+
+        def _consume_before_expire(target_bucket, **kwargs):
+            if (
+                not changed["done"]
+                and target_bucket.wallet_bucket_bid
+                == "bucket-expire-consumed-before-write"
+            ):
+                changed["done"] = True
+                CreditWalletBucket.query.filter(
+                    CreditWalletBucket.id == target_bucket.id
+                ).update(
+                    {
+                        "available_credits": Decimal("1.0000000000"),
+                        "consumed_credits": Decimal("3.0000000000"),
+                    },
+                    synchronize_session=False,
+                )
+                CreditWallet.query.filter(CreditWallet.id == wallet.id).update(
+                    {
+                        "available_credits": Decimal("3.0000000000"),
+                        "lifetime_consumed_credits": Decimal("3.0000000000"),
+                    },
+                    synchronize_session=False,
+                )
+                dao.db.session.flush()
+            return real_expire(target_bucket, **kwargs)
+
+        monkeypatch.setattr(
+            wallets_mod,
+            "_expire_bucket_available_credits_if_unchanged",
+            _consume_before_expire,
+        )
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            expire_before=datetime(2026, 4, 8, 0, 0, 0),
+        )
+
+        dao.db.session.expire_all()
+        skipped_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-consumed-before-write"
+        ).one()
+        ok_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-consumed-before-write-ok"
+        ).one()
+        skipped_ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid="bucket-expire-consumed-before-write"
+        ).all()
+        ok_ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid="bucket-expire-consumed-before-write-ok"
+        ).all()
+
+    assert payload["bucket_count"] == 1
+    assert payload["expired_credits"] == 2
+    assert skipped_bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert skipped_bucket.available_credits == Decimal("1.0000000000")
+    assert skipped_bucket.expired_credits == Decimal("0")
+    assert skipped_ledgers == []
+    assert ok_bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+    assert len(ok_ledgers) == 1
+
+
+def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
+    billing_wallet_lifecycle_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.billing import wallets as wallets_mod
+
+    future_effective_to = datetime(2026, 4, 30, 0, 0, 0)
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-extended-before-write",
+            creator_bid="creator-expire-extended-before-write",
+            available_credits=Decimal("6.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("6.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        skipped_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-extended-before-write",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-extended-before-write",
+            priority=30,
+            original_credits=Decimal("4.0000000000"),
+            available_credits=Decimal("4.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ok_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-extended-before-write-ok",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-extended-before-write-ok",
+            priority=30,
+            original_credits=Decimal("2.0000000000"),
+            available_credits=Decimal("2.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, skipped_bucket, ok_bucket])
+        dao.db.session.commit()
+
+        real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
+        changed = {"done": False}
+
+        def _extend_before_expire(target_bucket, **kwargs):
+            if (
+                not changed["done"]
+                and target_bucket.wallet_bucket_bid
+                == "bucket-expire-extended-before-write"
+            ):
+                changed["done"] = True
+                CreditWalletBucket.query.filter(
+                    CreditWalletBucket.id == target_bucket.id
+                ).update(
+                    {"effective_to": future_effective_to},
+                    synchronize_session=False,
+                )
+                dao.db.session.flush()
+            return real_expire(target_bucket, **kwargs)
+
+        monkeypatch.setattr(
+            wallets_mod,
+            "_expire_bucket_available_credits_if_unchanged",
+            _extend_before_expire,
+        )
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            expire_before=datetime(2026, 4, 8, 0, 0, 0),
+        )
+
+        dao.db.session.expire_all()
+        skipped_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-extended-before-write"
+        ).one()
+        ok_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-extended-before-write-ok"
+        ).one()
+        skipped_ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid="bucket-expire-extended-before-write"
+        ).all()
+
+    assert payload["bucket_count"] == 1
+    assert payload["expired_credits"] == 2
+    assert skipped_bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert skipped_bucket.available_credits == Decimal("4.0000000000")
+    assert skipped_bucket.expired_credits == Decimal("0")
+    assert skipped_bucket.effective_to == future_effective_to
+    assert skipped_ledgers == []
+    assert ok_bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+
+
 def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
     billing_wallet_lifecycle_app: Flask,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -729,6 +729,97 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
     assert ok_bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
 
 
+def test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_write(
+    billing_wallet_lifecycle_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.billing import wallets as wallets_mod
+
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-empty-released-before-status",
+            creator_bid="creator-expire-empty-released-before-status",
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("3.0000000000"),
+            lifetime_granted_credits=Decimal("3.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-empty-released-before-status",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-expire-empty-released-before-status",
+            priority=20,
+            original_credits=Decimal("3.0000000000"),
+            available_credits=Decimal("0"),
+            reserved_credits=Decimal("3.0000000000"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket])
+        dao.db.session.commit()
+
+        real_sync = wallets_mod._sync_empty_available_bucket_status_if_unchanged
+        changed = {"done": False}
+
+        def _release_before_status_sync(target_bucket, **kwargs):
+            if not changed["done"]:
+                changed["done"] = True
+                CreditWalletBucket.query.filter(
+                    CreditWalletBucket.id == target_bucket.id
+                ).update(
+                    {
+                        "available_credits": Decimal("3.0000000000"),
+                        "reserved_credits": Decimal("0"),
+                    },
+                    synchronize_session=False,
+                )
+                CreditWallet.query.filter(CreditWallet.id == wallet.id).update(
+                    {
+                        "available_credits": Decimal("3.0000000000"),
+                        "reserved_credits": Decimal("0"),
+                    },
+                    synchronize_session=False,
+                )
+                dao.db.session.flush()
+            return real_sync(target_bucket, **kwargs)
+
+        monkeypatch.setattr(
+            wallets_mod,
+            "_sync_empty_available_bucket_status_if_unchanged",
+            _release_before_status_sync,
+        )
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            expire_before=datetime(2026, 4, 8, 0, 0, 0),
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-empty-released-before-status"
+        ).one()
+        ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid=bucket.wallet_bucket_bid
+        ).all()
+
+    assert payload["status"] == "noop"
+    assert payload["bucket_count"] == 0
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("3.0000000000")
+    assert bucket.reserved_credits == Decimal("0")
+    assert ledgers == []
+
+
 def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
     billing_wallet_lifecycle_app: Flask,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Add a conditional bucket expiration write so stale bucket snapshots are skipped when balance, expiry window, reserved amount, or status changes before the expire ledger is written.
- Apply the same conditional guard to the empty-available status sync branch so concurrent releases are not overwritten as exhausted.
- Keep the existing per-bucket savepoint behavior: one skipped/conflicting bucket does not abort the rest of the batch.
- Add regression coverage for concurrent consumption, concurrent expiry extension, delayed cutoff mutation timestamps, and concurrent release before empty-bucket status sync.

## Verification
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_wallet_lifecycle.py::test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_write tests/service/billing/test_billing_wallet_lifecycle.py::test_expire_credit_wallet_buckets_uses_actual_mutation_time_for_bucket_update tests/service/billing/test_billing_wallet_lifecycle.py::test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write tests/service/billing/test_billing_wallet_lifecycle.py::test_expire_credit_wallet_buckets_skips_bucket_extended_before_write -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_wallet_lifecycle.py -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_referral_plan_rewards.py -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/ -q
- cd src/api && .venv/bin/python -m ruff check flaskr/service/billing/wallets.py tests/service/billing/test_billing_wallet_lifecycle.py
- git diff --check
- python scripts/check_dev_tools.py
- lefthook run pre-commit --all-files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit bucket expiration to safely handle concurrent changes without applying stale updates.
  * Expired credits are now only applied when the bucket’s stored balance and expiration window still match the expected state.
  * Expiration processing now uses the bucket’s actual update time to determine which buckets to expire.
  * In a batch, any bucket that changes right before expiry is skipped, while other eligible buckets continue expiring normally.
* **Tests**
  * Added coverage for concurrency/mutation correctness and skip scenarios during the wallet lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->