### PR TITLE
fix: keep listen subtitles aligned with audio

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -265,6 +265,87 @@ describe('ListenModeSlideRenderer', () => {
     ]);
   });
 
+  it('keeps slide subtitle cues aligned with streamed segment audio', () => {
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Hello',
+            element_bid: 'content-1',
+            is_speakable: true,
+            payload: {
+              audio: {
+                subtitle_cues: [
+                  {
+                    text: 'stale payload cue',
+                    start_ms: 1000,
+                    end_ms: 1400,
+                    segment_index: 0,
+                    position: 0,
+                  },
+                ],
+              },
+            },
+            audioTracks: [
+              {
+                position: 0,
+                audioUrl: '/api/storage/default/tts-audio/complete.mp3',
+                isAudioStreaming: false,
+                audioSegments: [
+                  {
+                    segmentIndex: 0,
+                    audioData: 'streamed-audio',
+                    durationMs: 400,
+                    isFinal: true,
+                    position: 0,
+                    subtitleCues: [
+                      {
+                        text: 'streamed segment cue.',
+                        start_ms: 0,
+                        end_ms: 400,
+                        segment_index: 0,
+                        position: 0,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+      />,
+    );
+
+    const slideProps = getMockSlide().mock.calls[0]?.[0] as
+      | { elementList?: Array<Record<string, unknown>> }
+      | undefined;
+    const contentElement = slideProps?.elementList?.find(
+      element => element.blockBid === 'content-1',
+    );
+
+    expect(contentElement?.audio_segments).toEqual([
+      expect.objectContaining({
+        segment_index: 0,
+        audio_data: 'streamed-audio',
+        duration_ms: 400,
+        is_final: true,
+        position: 0,
+      }),
+    ]);
+    expect(contentElement?.subtitle_cues).toEqual([
+      {
+        text: 'streamed segment cue',
+        start_ms: 0,
+        end_ms: 400,
+        segment_index: 0,
+        position: 0,
+      },
+    ]);
+  });
+
   it('passes a stable listen player class for footer-safe positioning', () => {
     render(
       <ListenModeSlideRenderer

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -428,9 +428,22 @@ describe('listenModeUtils', () => {
     ]);
   });
 
-  it('falls back to audio track subtitle cues when payload cues are absent', () => {
+  it('uses audio track subtitle cues before payload cues to match the active audio source', () => {
     const subtitleCues = resolveListenSlideSubtitleCues(
       createContentItem({
+        payload: {
+          audio: {
+            subtitle_cues: [
+              {
+                text: '旧的完整音频字幕。',
+                start_ms: 3000,
+                end_ms: 3900,
+                segment_index: 0,
+                position: 1,
+              },
+            ],
+          },
+        },
         audioTracks: [
           {
             position: 1,
@@ -455,6 +468,56 @@ describe('listenModeUtils', () => {
         end_ms: 900,
         segment_index: 0,
         position: 1,
+      },
+    ]);
+  });
+
+  it('uses segment subtitle cues before complete-track cues while streamed segments are preserved', () => {
+    const subtitleCues = resolveListenSlideSubtitleCues(
+      createContentItem({
+        audioTracks: [
+          {
+            position: 0,
+            audioUrl: 'https://example.com/complete.mp3',
+            subtitleCues: [
+              {
+                text: '完整音频字幕。',
+                start_ms: 100,
+                end_ms: 1000,
+                segment_index: 0,
+                position: 0,
+              },
+            ],
+            audioSegments: [
+              {
+                segmentIndex: 0,
+                audioData: 'streamed-audio',
+                durationMs: 900,
+                isFinal: true,
+                position: 0,
+                subtitleCues: [
+                  {
+                    text: '流式片段字幕。',
+                    start_ms: 0,
+                    end_ms: 900,
+                    segment_index: 0,
+                    position: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(subtitleCues).toEqual([
+      {
+        text: '流式片段字幕',
+        start_ms: 0,
+        end_ms: 900,
+        segment_index: 0,
+        position: 0,
       },
     ]);
   });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -522,6 +522,184 @@ describe('listenModeUtils', () => {
     ]);
   });
 
+  it('uses the latest cumulative streamed subtitle cue snapshot', () => {
+    const subtitleCues = resolveListenSlideSubtitleCues(
+      createContentItem({
+        audioTracks: [
+          {
+            position: 0,
+            audioSegments: [
+              {
+                segmentIndex: 0,
+                audioData: 'segment-0-audio',
+                durationMs: 1000,
+                isFinal: true,
+                position: 0,
+                subtitleCues: [
+                  {
+                    text: '第一句。',
+                    start_ms: 0,
+                    end_ms: 1000,
+                  },
+                ],
+              },
+              {
+                segmentIndex: 1,
+                audioData: 'segment-1-audio',
+                durationMs: 1000,
+                isFinal: true,
+                position: 0,
+                subtitleCues: [
+                  {
+                    text: '第一句。',
+                    start_ms: 0,
+                    end_ms: 1000,
+                  },
+                  {
+                    text: '第二句。',
+                    start_ms: 1000,
+                    end_ms: 2000,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(subtitleCues).toEqual([
+      {
+        text: '第一句',
+        start_ms: 0,
+        end_ms: 1000,
+        segment_index: 0,
+        position: 0,
+      },
+      {
+        text: '第二句',
+        start_ms: 1000,
+        end_ms: 2000,
+        segment_index: 0,
+        position: 0,
+      },
+    ]);
+  });
+
+  it('uses lower-priority subtitle cues when streamed cues are invalid', () => {
+    const subtitleCues = resolveListenSlideSubtitleCues(
+      createContentItem({
+        payload: {
+          audio: {
+            subtitle_cues: [
+              {
+                text: 'payload 字幕。',
+                start_ms: 1000,
+                end_ms: 2000,
+                position: 0,
+              },
+            ],
+          },
+        },
+        audioTracks: [
+          {
+            position: 0,
+            subtitleCues: [
+              {
+                text: 'track 字幕。',
+                start_ms: 0,
+                end_ms: 1000,
+              },
+            ],
+            audioSegments: [
+              {
+                segmentIndex: 0,
+                audioData: 'invalid-segment-audio',
+                durationMs: 1000,
+                isFinal: true,
+                position: 0,
+                subtitleCues: [
+                  {
+                    text: '',
+                    start_ms: 0,
+                    end_ms: 1000,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(subtitleCues).toEqual([
+      {
+        text: 'track 字幕',
+        start_ms: 0,
+        end_ms: 1000,
+        segment_index: 0,
+        position: 0,
+      },
+    ]);
+  });
+
+  it('uses payload subtitle cues when audio track cues are invalid', () => {
+    const subtitleCues = resolveListenSlideSubtitleCues(
+      createContentItem({
+        payload: {
+          audio: {
+            subtitle_cues: [
+              {
+                text: 'payload 字幕。',
+                start_ms: 1000,
+                end_ms: 2000,
+                position: 0,
+              },
+            ],
+          },
+        },
+        audioTracks: [
+          {
+            position: 0,
+            subtitleCues: [
+              {
+                text: '',
+                start_ms: 0,
+                end_ms: 1000,
+              },
+            ],
+            audioSegments: [
+              {
+                segmentIndex: 0,
+                audioData: 'invalid-segment-audio',
+                durationMs: 1000,
+                isFinal: true,
+                position: 0,
+                subtitleCues: [
+                  {
+                    text: '',
+                    start_ms: 0,
+                    end_ms: 1000,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(subtitleCues).toEqual([
+      {
+        text: 'payload 字幕',
+        start_ms: 1000,
+        end_ms: 2000,
+        segment_index: 0,
+        position: 0,
+      },
+    ]);
+  });
+
   it('strips disallowed trailing punctuation from subtitle cues', () => {
     const subtitleCues = resolveListenSlideSubtitleCues(
       createContentItem({

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -126,28 +126,45 @@ const normalizeRawSubtitleCues = (
     : undefined;
 };
 
-const resolveAudioTrackSubtitleCues = (
-  tracks: AudioTrack[] = [],
-): unknown[] => {
-  return sortByPosition(tracks).flatMap(track => {
-    const segmentSubtitleCues = sortSegmentsByIndex(
-      track.audioSegments ?? [],
-    ).flatMap(segment =>
-      (segment.subtitleCues ?? []).map(cue => ({
-        ...cue,
-        position: cue.position ?? segment.position ?? track.position,
-      })),
-    );
-
-    if (segmentSubtitleCues.length > 0) {
-      return segmentSubtitleCues;
+const assignSubtitleCuePosition = (
+  rawSubtitleCues: unknown[] = [],
+  position?: number,
+) =>
+  rawSubtitleCues.map(cue => {
+    if (!cue || typeof cue !== 'object') {
+      return cue;
     }
 
-    if (track.subtitleCues?.length) {
-      return track.subtitleCues.map(cue => ({
-        ...cue,
-        position: cue.position ?? track.position,
-      }));
+    const rawCue = cue as Record<string, unknown>;
+    return {
+      ...rawCue,
+      position: rawCue.position ?? position,
+    };
+  });
+
+const resolveAudioTrackSubtitleCues = (
+  tracks: AudioTrack[] = [],
+): ElementSubtitleCue[] => {
+  return sortByPosition(tracks).flatMap(track => {
+    const sortedSegments = sortSegmentsByIndex(track.audioSegments ?? []);
+    for (const segment of [...sortedSegments].reverse()) {
+      const segmentSubtitleCues = normalizeRawSubtitleCues(
+        assignSubtitleCuePosition(
+          segment.subtitleCues,
+          segment.position ?? track.position,
+        ),
+      );
+
+      if (segmentSubtitleCues) {
+        return segmentSubtitleCues;
+      }
+    }
+
+    const trackSubtitleCues = normalizeRawSubtitleCues(
+      assignSubtitleCuePosition(track.subtitleCues, track.position),
+    );
+    if (trackSubtitleCues) {
+      return trackSubtitleCues;
     }
 
     return [];
@@ -161,7 +178,7 @@ export const resolveListenSlideSubtitleCues = (
     item.audioTracks ?? [],
   );
   if (trackSubtitleCues.length > 0) {
-    return normalizeRawSubtitleCues(trackSubtitleCues);
+    return trackSubtitleCues;
   }
 
   const audioPayload = item.payload?.audio as

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -130,6 +130,19 @@ const resolveAudioTrackSubtitleCues = (
   tracks: AudioTrack[] = [],
 ): unknown[] => {
   return sortByPosition(tracks).flatMap(track => {
+    const segmentSubtitleCues = sortSegmentsByIndex(
+      track.audioSegments ?? [],
+    ).flatMap(segment =>
+      (segment.subtitleCues ?? []).map(cue => ({
+        ...cue,
+        position: cue.position ?? segment.position ?? track.position,
+      })),
+    );
+
+    if (segmentSubtitleCues.length > 0) {
+      return segmentSubtitleCues;
+    }
+
     if (track.subtitleCues?.length) {
       return track.subtitleCues.map(cue => ({
         ...cue,
@@ -137,35 +150,24 @@ const resolveAudioTrackSubtitleCues = (
       }));
     }
 
-    return sortSegmentsByIndex(track.audioSegments ?? []).flatMap(segment =>
-      (segment.subtitleCues ?? []).map(cue => ({
-        ...cue,
-        position: cue.position ?? segment.position ?? track.position,
-      })),
-    );
+    return [];
   });
 };
 
 export const resolveListenSlideSubtitleCues = (
   item: ListenSlideSubtitleCueSource,
 ): ElementSubtitleCue[] | undefined => {
-  const audioPayload = item.payload?.audio as
-    | StudyRecordAudioPayload
-    | undefined;
-  const payloadSubtitleCues = normalizeRawSubtitleCues(
-    audioPayload?.subtitle_cues,
-  );
-
-  if (payloadSubtitleCues?.length) {
-    return payloadSubtitleCues;
-  }
-
   const trackSubtitleCues = resolveAudioTrackSubtitleCues(
     item.audioTracks ?? [],
   );
-  return trackSubtitleCues.length > 0
-    ? normalizeRawSubtitleCues(trackSubtitleCues)
-    : undefined;
+  if (trackSubtitleCues.length > 0) {
+    return normalizeRawSubtitleCues(trackSubtitleCues);
+  }
+
+  const audioPayload = item.payload?.audio as
+    | StudyRecordAudioPayload
+    | undefined;
+  return normalizeRawSubtitleCues(audioPayload?.subtitle_cues);
 };
 
 export const normalizeAudioTracks = (item: ChatContentItem): AudioTrack[] => {


### PR DESCRIPTION
## Summary
- Align listen-mode subtitle cue selection with the active audio source.
- Prefer streamed segment subtitle cues, then audio track cues, then payload fallback cues.
- Add unit and renderer coverage to prevent stale payload subtitle timing from being paired with streamed audio.

## Root Cause
Listen-mode slide audio and subtitle metadata were resolved independently. Audio playback could use `audioTracks` and preserved streamed `audioSegments`, while subtitles could still prefer `payload.audio.subtitle_cues`, allowing stale or complete-audio timing metadata to drift from the actual streamed audio source.

## Validation
- `npm run test -- listenModeUtils.test.ts ListenModeSlideRenderer.test.tsx`
- `npm run type-check`
- `npm run lint`
- `git diff --check`
- `python scripts/check_dev_tools.py`

## Notes
- `branch_context_manager.py pre-pr-review` could not be refreshed in this execution environment because the command was blocked by the local permission reviewer after PATH adjustment. The underlying commit pre-commit hooks ran successfully during commit, and `branch_context_manager.py pre-push-check` reported only the stale self-review warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle synchronization in Listen mode by prioritizing subtitle cues derived from streamed audio segments.
  * Ensured slide subtitle cues use the correct segment timing (start/end) and positional metadata.
  * Prevented stale subtitle cues from overriding cue data derived from streamed audio when available.
* **Tests**
  * Added/updated Listen mode subtitle cue resolution tests to verify cue precedence and streamed-cue selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->