### PR TITLE
refactor: introduce credit mutation foundation

### DIFF
--- a/src/api/flaskr/service/billing/credit_mutations.py
+++ b/src/api/flaskr/service/billing/credit_mutations.py
@@ -1,0 +1,128 @@
+"""Shared credit state mutation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from flaskr.dao import db
+from flaskr.util.datetime import now_utc
+
+from .consts import CREDIT_BUCKET_STATUS_EXHAUSTED, CREDIT_BUCKET_STATUS_EXPIRED
+from .models import CreditLedgerEntry, CreditWalletBucket
+from .primitives import normalize_json_object, quantize_credit_amount, to_decimal
+from .wallets import sync_credit_bucket_status
+
+
+@dataclass(slots=True, frozen=True)
+class CreditMutationResult:
+    mutation_type: str
+    completed: bool
+    status: str
+    ledger_bid: str | None = None
+    wallet_bucket_bid: str | None = None
+    expected_amount: Decimal = Decimal("0")
+    moved_amount: Decimal = Decimal("0")
+    failure_reason: str | None = None
+
+
+def reserved_grant_state(grant_entry: CreditLedgerEntry) -> str:
+    metadata = normalize_json_object(grant_entry.metadata_json)
+    return str(metadata.get("bucket_credit_state") or "").strip().lower()
+
+
+def activate_reserved_grant_credit(
+    *,
+    grant_entry: CreditLedgerEntry | None,
+    bucket: CreditWalletBucket | None,
+    effective_from: datetime,
+    effective_to: datetime | None,
+    now: datetime | None = None,
+) -> CreditMutationResult:
+    """Move a reserved grant amount from bucket reserved credits to available."""
+
+    mutation_type = "reserved_grant_activate"
+    if grant_entry is None:
+        return CreditMutationResult(
+            mutation_type=mutation_type,
+            completed=False,
+            status="skipped",
+            failure_reason="missing_ledger",
+        )
+    if bucket is None:
+        return CreditMutationResult(
+            mutation_type=mutation_type,
+            completed=False,
+            status="skipped",
+            ledger_bid=grant_entry.ledger_bid,
+            failure_reason="missing_bucket",
+        )
+
+    metadata = normalize_json_object(grant_entry.metadata_json)
+    state = str(metadata.get("bucket_credit_state") or "").strip().lower()
+    if state != "reserved":
+        return CreditMutationResult(
+            mutation_type=mutation_type,
+            completed=False,
+            status="skipped",
+            ledger_bid=grant_entry.ledger_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            failure_reason=f"invalid_state:{state or 'missing'}",
+        )
+
+    grant_amount = quantize_credit_amount(to_decimal(grant_entry.amount))
+    reserved_credits = quantize_credit_amount(to_decimal(bucket.reserved_credits))
+    if grant_amount <= 0:
+        return CreditMutationResult(
+            mutation_type=mutation_type,
+            completed=False,
+            status="skipped",
+            ledger_bid=grant_entry.ledger_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            expected_amount=grant_amount,
+            failure_reason="invalid_amount",
+        )
+    if reserved_credits < grant_amount:
+        return CreditMutationResult(
+            mutation_type=mutation_type,
+            completed=False,
+            status="skipped",
+            ledger_bid=grant_entry.ledger_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            expected_amount=grant_amount,
+            failure_reason="insufficient_reserved",
+        )
+
+    mutation_time = now or now_utc()
+    bucket.reserved_credits = quantize_credit_amount(
+        to_decimal(bucket.reserved_credits) - grant_amount
+    )
+    bucket.available_credits = quantize_credit_amount(
+        to_decimal(bucket.available_credits) + grant_amount
+    )
+    bucket.effective_from = effective_from
+    bucket.effective_to = effective_to
+    bucket.updated_at = mutation_time
+    if int(bucket.status or 0) == CREDIT_BUCKET_STATUS_EXPIRED:
+        bucket.status = CREDIT_BUCKET_STATUS_EXHAUSTED
+    sync_credit_bucket_status(bucket)
+    db.session.add(bucket)
+
+    metadata["bucket_credit_state"] = "available"
+    metadata["activated_at"] = mutation_time.isoformat()
+    grant_entry.expires_at = effective_to
+    grant_entry.consumable_from = effective_from
+    grant_entry.metadata_json = metadata.to_metadata_json()
+    grant_entry.updated_at = mutation_time
+    db.session.add(grant_entry)
+
+    return CreditMutationResult(
+        mutation_type=mutation_type,
+        completed=True,
+        status="activated",
+        ledger_bid=grant_entry.ledger_bid,
+        wallet_bucket_bid=bucket.wallet_bucket_bid,
+        expected_amount=grant_amount,
+        moved_amount=grant_amount,
+    )

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -56,6 +56,10 @@ from .bucket_categories import (
     resolve_bucket_category_from_order_type,
     resolve_credit_bucket_priority,
 )
+from .credit_mutations import (
+    activate_reserved_grant_credit,
+    reserved_grant_state as _shared_reserved_grant_state,
+)
 from .dtos import BillingSubscriptionDTO
 from .models import (
     BillingOrder,
@@ -1109,8 +1113,7 @@ def _load_reserved_activation_bucket(
 
 
 def _reserved_grant_state(grant_entry: CreditLedgerEntry) -> str:
-    metadata = _normalize_json_object(grant_entry.metadata_json)
-    return str(metadata.get("bucket_credit_state") or "").strip().lower()
+    return _shared_reserved_grant_state(grant_entry)
 
 
 def _expected_subscription_grant_amount(order: BillingOrder) -> Decimal:
@@ -1744,7 +1747,6 @@ def _activate_reserved_subscription_grant_for_order(
         )
 
     now = now_utc()
-    release_amount = grant_amount
     bucket.wallet_bid = wallet.wallet_bid
     bucket.bucket_category = CREDIT_BUCKET_CATEGORY_SUBSCRIPTION
     bucket.source_type = resolve_bucket_source_type_for_category(
@@ -1755,32 +1757,22 @@ def _activate_reserved_subscription_grant_for_order(
     bucket.priority = resolve_credit_bucket_priority(
         CREDIT_BUCKET_CATEGORY_SUBSCRIPTION
     )
-    bucket.reserved_credits = _quantize_credit_amount(
-        _to_decimal(bucket.reserved_credits) - release_amount
-    )
-    bucket.available_credits = _quantize_credit_amount(
-        _to_decimal(bucket.available_credits) + release_amount
-    )
-    bucket.effective_from = effective_from
-    bucket.effective_to = effective_to
     if is_first_cycle_activation:
         bucket.metadata_json = {
             **(bucket.metadata_json if isinstance(bucket.metadata_json, dict) else {}),
             **_build_bucket_metadata_from_order(order),
             "bill_order_bid": attribution_order_bid or order.bill_order_bid,
         }
-    bucket.updated_at = now
-    _prepare_bucket_for_runtime_reuse(bucket)
-    sync_credit_bucket_status(bucket)
-    db.session.add(bucket)
 
-    metadata["bucket_credit_state"] = "available"
-    metadata["activated_at"] = now.isoformat()
-    grant_entry.expires_at = effective_to
-    grant_entry.consumable_from = effective_from
-    grant_entry.metadata_json = metadata.to_metadata_json()
-    grant_entry.updated_at = now
-    db.session.add(grant_entry)
+    mutation_result = activate_reserved_grant_credit(
+        grant_entry=grant_entry,
+        bucket=bucket,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        now=now,
+    )
+    if not mutation_result.completed:
+        return False
 
     refresh_credit_wallet_snapshot(wallet, snapshot_at=effective_from)
     persist_credit_wallet_snapshot(
@@ -1843,27 +1835,15 @@ def _activate_reserved_campaign_bonus_grant_for_order(
 
     wallet = _load_or_create_credit_wallet(app, order.creator_bid)
     now = now_utc()
-    release_amount = grant_amount
-    bucket.reserved_credits = _quantize_credit_amount(
-        _to_decimal(bucket.reserved_credits) - release_amount
+    mutation_result = activate_reserved_grant_credit(
+        grant_entry=grant_entry,
+        bucket=bucket,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        now=now,
     )
-    bucket.available_credits = _quantize_credit_amount(
-        _to_decimal(bucket.available_credits) + release_amount
-    )
-    bucket.effective_from = effective_from
-    bucket.effective_to = effective_to
-    bucket.updated_at = now
-    _prepare_bucket_for_runtime_reuse(bucket)
-    sync_credit_bucket_status(bucket)
-    db.session.add(bucket)
-
-    metadata["bucket_credit_state"] = "available"
-    metadata["activated_at"] = now.isoformat()
-    grant_entry.expires_at = effective_to
-    grant_entry.consumable_from = effective_from
-    grant_entry.metadata_json = metadata.to_metadata_json()
-    grant_entry.updated_at = now
-    db.session.add(grant_entry)
+    if not mutation_result.completed:
+        return False
 
     refresh_credit_wallet_snapshot(wallet, snapshot_at=effective_from)
     persist_credit_wallet_snapshot(


### PR DESCRIPTION
## Summary
- add a shared credit mutation helper for reserved grant activation
- reuse the helper from subscription and campaign bonus reserved grant activation paths
- keep existing renewal behavior, wallet snapshot persistence, and ledger balance updates unchanged

## Scope
- Billing-R1 foundation only
- no schema changes
- no data migration
- no checkout/provider/webhook changes

## Verification
- PATH="/Users/iris/.local/bin:/Users/iris/.codex/tmp/arg0/codex-arg0uEUkmK:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" python scripts/check_dev_tools.py
- cd src/api && .venv/bin/python -m ruff check flaskr/service/billing/credit_mutations.py flaskr/service/billing/subscriptions.py
- cd src/api && .venv/bin/python -m pytest tests/service/billing/test_billing_renewal_execution.py tests/service/billing/test_billing_wallet_lifecycle.py -q
- cd src/api && .venv/bin/python -m pytest tests/service/billing/ -q
- PATH="/Users/iris/.local/bin:/Users/iris/.codex/tmp/arg0/codex-arg0uEUkmK:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" lefthook run pre-commit --all-files

## Notes
- branch_context_manager pre-pr-review still reports the local pre-commit based check as failed, but repository lefthook pre-commit passed all checks.