### PR TITLE
fix: keep credit pack credits frozen instead of expired

### DIFF
--- a/docs/billing-subscription-design.md
+++ b/docs/billing-subscription-design.md
@@ -813,7 +813,7 @@ v1 的改造要求：
 - 当前实现中，subscription lifecycle 已由 `src/api/flaskr/service/billing/subscriptions.py` 维护：`subscription_start/subscription_upgrade/subscription_renewal` 的 paid apply 会推进 `bill_subscriptions` 周期字段，并同步维护 `bill_renewal_events`
 - 当前实现中，`bill_usage -> credit_ledger_entries` 的多维度结算 helper 已由 `src/api/flaskr/service/billing/settlement.py` 落地；`billing.settle_usage` task entrypoint 已由 `src/api/flaskr/service/billing/tasks.py` 提供，`record_llm_usage` / `record_tts_usage` 会在 billable 的 root usage 落库后投递该异步入口，Celery app factory、worker/beat 基础设施和 creator 维度串行化仍留在后续任务
 - 当前实现中，`credit_wallet_buckets` 已承担 source bucket snapshot：paid grant 会按 order type 创建 `subscription` / `topup` bucket，wallet 总余额与冻结余额会从 bucket 表重算，consume 结算会把扣空 bucket 推进到 `exhausted`
-- 当前实现中，topup bucket / ledger 仍可能携带 subscription-window 字段；这些字段只能视为可消费资格窗口，不表示积分包所有权过期。产品规则是积分包积分不过期，订阅失效时只是冻结/不可消耗，恢复有效套餐后解冻/恢复可消耗
+- 当前实现中，topup bucket / ledger 仍可能携带 subscription-window 字段；这些字段只能视为可消费资格窗口，不表示积分包所有权过期。产品规则是积分包积分不过期，订阅失效时只是冻结/不可消耗，恢复有效套餐后解冻/恢复可消耗；bucket expiration 不会把 topup bucket 迁移为 ownership expired，续订或恢复套餐会把 topup 可消费窗口重新对齐到当前套餐周期
 - 当前实现中，usage settlement 已固定按 `subscription > topup` 扣减；同优先级内按 `effective_to` 最早优先，再按 `created_at` 最早优先，`effective_to = null` 排在最后；历史 `free` bucket 会在运行时归并进 `subscription/topup`
 - 当前实现中，LLM usage 已拆成 `input`、`cache`、`output` 三个 billing metric 独立计算费率与扣分，并把每个 metric 的 breakdown 写入 `credit_ledger_entries.metadata`
 - 当前实现中，TTS usage 已支持两种 billing mode：有 `tts_request_count` 费率时按次扣分；未配置按次费率时回退到 `tts_output_chars`，再回退到 `tts_input_chars` 的按字数扣分
@@ -1093,7 +1093,7 @@ v1 需要新增：
 - bucket 扣减顺序固定为：`subscription > topup`；同优先级内按 `effective_to` 最早优先，再按 `created_at` 最早优先
 - `gift`、正向人工补偿、退款返还不再形成第三类可消费 credits；它们仅保留为 `source_type`，bucket 统一归到 `subscription/topup`
 - 一条 usage 可以拆成多个 bucket 扣减，但默认只生成一条聚合 `consume` ledger；bucket 明细保留在 `metadata.bucket_breakdown[]`
-- bucket 过期任务只扫描 `credit_wallet_buckets`；对可过期的套餐积分写 `expire` ledger 并把 bucket 关闭；积分包积分不得因订阅失效或套餐周期结束被表达为所有权过期
+- bucket 过期任务只扫描 `credit_wallet_buckets`；对可过期的套餐积分写 `expire` ledger 并把 bucket 关闭；积分包积分不得因订阅失效或套餐周期结束被表达为所有权过期，topup bucket 由有效套餐资格控制可消费性
 - 结算幂等 key 应至少以 `bill_usage.usage_bid` 为核心保证 usage 级去重；bucket 级扣减明细保留在 metadata 里
 - 当前实现中，`src/api/flaskr/service/billing/settlement.py` 已支持：
   - LLM `input/cache/output` 三维 rate 匹配与扣分
@@ -1540,7 +1540,7 @@ type CreatorBrandingConfig = {
 - webhook 幂等、乱序到达、sync 补偿、防重复发放或重复扣分
 - 最近一次 provider 摘要是否只覆盖写入关联 `bill_orders.metadata`，同时同步更新 provider raw snapshot
 - 找不到关联订单的 webhook 是否按 ignore 处理且不落库存档
-- 可过期套餐积分 bucket 过期后是否停止参与 admission / settlement，并生成 `expire` ledger；积分包积分是否仅因无有效套餐被冻结/不可消耗，而不是被过期扣除
+- 可过期套餐积分 bucket 过期后是否停止参与 admission / settlement，并生成 `expire` ledger；积分包积分是否仅因无有效套餐被冻结/不可消耗、不会生成 ownership expire ledger，恢复套餐后是否重新可消费
 - `credit_wallets`、`credit_wallet_buckets` 与 `credit_ledger_entries` 三者是否保持一致
 - 旧 `/order` 学员购课流程是否未被破坏
 - `CELERY_TASK_ALWAYS_EAGER=1` 时 billing 集成测试可同步执行

--- a/docs/billing-subscription-design.md
+++ b/docs/billing-subscription-design.md
@@ -814,6 +814,7 @@ v1 的改造要求：
 - 当前实现中，`bill_usage -> credit_ledger_entries` 的多维度结算 helper 已由 `src/api/flaskr/service/billing/settlement.py` 落地；`billing.settle_usage` task entrypoint 已由 `src/api/flaskr/service/billing/tasks.py` 提供，`record_llm_usage` / `record_tts_usage` 会在 billable 的 root usage 落库后投递该异步入口，Celery app factory、worker/beat 基础设施和 creator 维度串行化仍留在后续任务
 - 当前实现中，`credit_wallet_buckets` 已承担 source bucket snapshot：paid grant 会按 order type 创建 `subscription` / `topup` bucket，wallet 总余额与冻结余额会从 bucket 表重算，consume 结算会把扣空 bucket 推进到 `exhausted`
 - 当前实现中，topup bucket / ledger 仍可能携带 subscription-window 字段；这些字段只能视为可消费资格窗口，不表示积分包所有权过期。产品规则是积分包积分不过期，订阅失效时只是冻结/不可消耗，恢复有效套餐后解冻/恢复可消耗；bucket expiration 不会把 topup bucket 迁移为 ownership expired，续订或恢复套餐会把 topup 可消费窗口重新对齐到当前套餐周期
+- 当前实现中，历史上已被旧逻辑错误过期的 paid topup bucket 只允许通过显式订单白名单修复：先 dry-run `flask console billing restore-expired-topup-buckets --bill-order-bid <bill_order_bid>`，确认匹配已付款 topup order、expired bucket、同周期 expire ledger 和金额后，再追加 `--apply`；该工具会恢复 bucket ownership，并写入 `adjustment` ledger 留存审计
 - 当前实现中，usage settlement 已固定按 `subscription > topup` 扣减；同优先级内按 `effective_to` 最早优先，再按 `created_at` 最早优先，`effective_to = null` 排在最后；历史 `free` bucket 会在运行时归并进 `subscription/topup`
 - 当前实现中，LLM usage 已拆成 `input`、`cache`、`output` 三个 billing metric 独立计算费率与扣分，并把每个 metric 的 breakdown 写入 `credit_ledger_entries.metadata`
 - 当前实现中，TTS usage 已支持两种 billing mode：有 `tts_request_count` 费率时按次扣分；未配置按次费率时回退到 `tts_output_chars`，再回退到 `tts_input_chars` 的按字数扣分

--- a/docs/design-docs/billing-credit-domain-terminology.md
+++ b/docs/design-docs/billing-credit-domain-terminology.md
@@ -101,10 +101,9 @@ campaign bonus 等历史/内部标识，必须按实际业务归属映射为套�
 
 积分包冻结/解冻是后续 R3/R5 的重要边界：产品规则是积分包积分不过期，
 订阅失效时只是冻结。当前代码中 topup bucket 仍可能带有 subscription-window
-字段；后续修改周期过期、bucket expiration 或 allocation 模型时，必须把这些字段
-视为可消费资格窗口，而不是积分包所有权过期。当前实现仍会将部分积分包 bucket
-执行过期，属于已知实现差距，将由后续 Billing PR 修复。由于当前没有确认真实
-线上错账风险，该项并入 R3/R5，不单独作为当前 correctness PR。
+字段；周期过期和 bucket expiration 只能把这些字段视为可消费资格窗口，
+不能表达积分包所有权过期。恢复有效套餐后，topup bucket 的可消费窗口应重新
+对齐到当前套餐周期。
 
 Runtime admission 当前语义应保持：
 

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -117,6 +117,7 @@ from .wallets import (
     repair_credit_bucket_runtime_statuses,
     repair_expire_ledger_bucket_drift,
     repair_renewal_state_drift,
+    restore_wrongly_expired_credit_pack_buckets,
 )
 
 _PRODUCT_TYPE_LABELS = {
@@ -877,6 +878,38 @@ def register_billing_commands(console) -> None:
         payload = repair_topup_grant_expiries(
             current_app,
             creator_bid=creator_bid,
+        )
+        _echo_payload(payload)
+
+    @billing_group.command(name="restore-expired-topup-buckets")
+    @click.option(
+        "--bill-order-bid",
+        "bill_order_bids",
+        multiple=True,
+        help="Paid topup order bid to restore. Repeat for multiple orders.",
+    )
+    @click.option(
+        "--apply",
+        "apply_changes",
+        is_flag=True,
+        help="Persist bucket and wallet repairs. Defaults to dry-run.",
+    )
+    @with_appcontext
+    def restore_expired_topup_buckets_command(
+        bill_order_bids: tuple[str, ...],
+        apply_changes: bool,
+    ) -> None:
+        """Restore explicitly listed credit pack buckets expired by old logic."""
+
+        if not any(str(bid or "").strip() for bid in bill_order_bids):
+            raise click.ClickException(
+                "Pass at least one --bill-order-bid for expired topup bucket restore."
+            )
+
+        payload = restore_wrongly_expired_credit_pack_buckets(
+            current_app,
+            bill_order_bids=list(bill_order_bids),
+            dry_run=not apply_changes,
         )
         _echo_payload(payload)
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -1036,10 +1036,7 @@ def _realign_active_credit_bucket_effective_to(
     if bucket.effective_from is not None and bucket.effective_from > effective_from:
         return
     if bucket.effective_to is not None:
-        if include_effective_to_boundary:
-            if bucket.effective_to < effective_from:
-                return
-        elif bucket.effective_to <= effective_from:
+        if not include_effective_to_boundary and bucket.effective_to <= effective_from:
             return
     if bucket.effective_to != effective_to:
         bucket.effective_to = effective_to

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -53,8 +53,10 @@ from .consts import (
     CREDIT_SOURCE_TYPE_TOPUP,
 )
 from .bucket_categories import (
+    load_billing_order_type_by_bid,
     resolve_bucket_category_from_order_type,
     resolve_credit_bucket_priority,
+    resolve_wallet_bucket_runtime_category,
 )
 from .credit_mutations import (
     activate_reserved_grant_credit,
@@ -1025,45 +1027,79 @@ def _realign_active_credit_bucket_effective_to(
     if effective_to is None:
         return
 
-    bucket = load_primary_credit_bucket_by_category(
+    buckets = _load_active_credit_buckets_by_runtime_category(
         creator_bid,
         bucket_category=bucket_category,
     )
-    if bucket is None:
+    if not buckets:
         return
 
     now = now_utc()
-    if bucket.effective_from is not None and bucket.effective_from > effective_from:
-        return
-    if bucket.effective_to is not None:
-        if not include_effective_to_boundary and bucket.effective_to <= effective_from:
-            return
-    if bucket.effective_to != effective_to:
-        bucket.effective_to = effective_to
-        bucket.updated_at = now
-        db.session.add(bucket)
+    for bucket in buckets:
+        if bucket.effective_from is not None and bucket.effective_from > effective_from:
+            continue
+        if bucket.effective_to is not None:
+            if (
+                not include_effective_to_boundary
+                and bucket.effective_to <= effective_from
+            ):
+                continue
+        if bucket.effective_to != effective_to:
+            bucket.effective_to = effective_to
+            bucket.updated_at = now
+            db.session.add(bucket)
 
-    grant_entry_filters = [
-        CreditLedgerEntry.deleted == 0,
-        CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
-        CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-    ]
-    if not include_effective_to_boundary:
-        grant_entry_filters.append(
-            (
-                CreditLedgerEntry.expires_at.is_(None)
-                | (CreditLedgerEntry.expires_at >= effective_from)
-            ),
+        grant_entry_filters = [
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+        ]
+        if not include_effective_to_boundary:
+            grant_entry_filters.append(
+                (
+                    CreditLedgerEntry.expires_at.is_(None)
+                    | (CreditLedgerEntry.expires_at >= effective_from)
+                ),
+            )
+        grant_entries = (
+            CreditLedgerEntry.query.filter(*grant_entry_filters)
+            .order_by(CreditLedgerEntry.id.asc())
+            .all()
         )
-    grant_entries = (
-        CreditLedgerEntry.query.filter(*grant_entry_filters)
-        .order_by(CreditLedgerEntry.id.asc())
+        for entry in grant_entries:
+            entry.expires_at = effective_to
+            entry.updated_at = now
+            db.session.add(entry)
+
+
+def _load_active_credit_buckets_by_runtime_category(
+    creator_bid: str,
+    *,
+    bucket_category: int,
+) -> list[CreditWalletBucket]:
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    if not normalized_creator_bid:
+        return []
+
+    rows = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.creator_bid == normalized_creator_bid,
+            CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+            CreditWalletBucket.available_credits > 0,
+        )
+        .order_by(CreditWalletBucket.created_at.asc(), CreditWalletBucket.id.asc())
         .all()
     )
-    for entry in grant_entries:
-        entry.expires_at = effective_to
-        entry.updated_at = now
-        db.session.add(entry)
+    return [
+        row
+        for row in rows
+        if resolve_wallet_bucket_runtime_category(
+            row,
+            load_order_type=load_billing_order_type_by_bid,
+        )
+        == bucket_category
+    ]
 
 
 def _build_bucket_metadata_from_order(order: BillingOrder) -> dict[str, Any]:

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -1043,16 +1043,20 @@ def _realign_active_credit_bucket_effective_to(
         bucket.updated_at = now
         db.session.add(bucket)
 
-    grant_entries = (
-        CreditLedgerEntry.query.filter(
-            CreditLedgerEntry.deleted == 0,
-            CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
-            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    grant_entry_filters = [
+        CreditLedgerEntry.deleted == 0,
+        CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+        CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    ]
+    if not include_effective_to_boundary:
+        grant_entry_filters.append(
             (
                 CreditLedgerEntry.expires_at.is_(None)
                 | (CreditLedgerEntry.expires_at >= effective_from)
             ),
         )
+    grant_entries = (
+        CreditLedgerEntry.query.filter(*grant_entry_filters)
         .order_by(CreditLedgerEntry.id.asc())
         .all()
     )

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -2256,11 +2256,23 @@ def _refresh_frozen_credit_pack_wallet_snapshots(
 
         try:
             with db.session.begin_nested():
-                refresh_credit_wallet_snapshot(wallet, snapshot_at=snapshot_at)
+                available_credits, reserved_credits = (
+                    calculate_credit_wallet_snapshot_values(
+                        wallet,
+                        snapshot_at=snapshot_at,
+                    )
+                )
+                if (
+                    _quantize_credit_amount(wallet.available_credits)
+                    == available_credits
+                    and _quantize_credit_amount(wallet.reserved_credits)
+                    == reserved_credits
+                ):
+                    continue
                 persist_credit_wallet_snapshot(
                     wallet,
-                    available_credits=wallet.available_credits,
-                    reserved_credits=wallet.reserved_credits,
+                    available_credits=available_credits,
+                    reserved_credits=reserved_credits,
                     updated_at=snapshot_at,
                 )
         except RuntimeError as exc:

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -1937,6 +1937,8 @@ def repair_expire_ledger_bucket_drift(
                 ).append(ledger)
 
         for bucket in candidate_buckets:
+            if _is_credit_pack_runtime_bucket(bucket):
+                continue
             bucket_ledgers = sorted(
                 (
                     ledger
@@ -2110,6 +2112,7 @@ def _expire_credit_wallet_buckets_in_session(
         )
 
     wallets: dict[str, CreditWallet] = {}
+    frozen_credit_pack_wallet_bids: set[str] = set()
     expired_total = _ZERO
     expired_count = 0
     for bucket in buckets:
@@ -2124,6 +2127,9 @@ def _expire_credit_wallet_buckets_in_session(
             or bucket.effective_to is None
             or bucket.effective_to > cutoff
         ):
+            continue
+        if _is_credit_pack_runtime_bucket(bucket):
+            frozen_credit_pack_wallet_bids.add(bucket.wallet_bid)
             continue
 
         available = _to_decimal(bucket.available_credits)
@@ -2214,11 +2220,64 @@ def _expire_credit_wallet_buckets_in_session(
         expired_total += available
         expired_count += 1
 
+    _refresh_frozen_credit_pack_wallet_snapshots(
+        frozen_credit_pack_wallet_bids,
+        wallets=wallets,
+        snapshot_at=cutoff,
+    )
+
     return WalletExpirationResult(
         status="expired" if expired_count else "noop",
         creator_bid=normalized_creator_bid or None,
         bucket_count=expired_count,
         expired_credits=_credit_decimal_to_number(expired_total),
+    )
+
+
+def _refresh_frozen_credit_pack_wallet_snapshots(
+    wallet_bids: set[str],
+    *,
+    wallets: dict[str, CreditWallet],
+    snapshot_at: datetime,
+) -> None:
+    for wallet_bid in sorted(wallet_bids):
+        wallet = wallets.get(wallet_bid)
+        if wallet is None:
+            wallet = _load_credit_wallet_by_wallet_bid(wallet_bid)
+            if wallet is None:
+                continue
+            wallets[wallet_bid] = wallet
+
+        if (
+            load_primary_active_subscription(wallet.creator_bid, as_of=snapshot_at)
+            is not None
+        ):
+            continue
+
+        try:
+            with db.session.begin_nested():
+                refresh_credit_wallet_snapshot(wallet, snapshot_at=snapshot_at)
+                persist_credit_wallet_snapshot(
+                    wallet,
+                    available_credits=wallet.available_credits,
+                    reserved_credits=wallet.reserved_credits,
+                    updated_at=snapshot_at,
+                )
+        except RuntimeError as exc:
+            if str(exc) != "credit_wallet_version_conflict":
+                raise
+            db.session.refresh(wallet)
+
+
+def _is_credit_pack_runtime_bucket(bucket: CreditWalletBucket) -> bool:
+    """Return whether a bucket represents non-expiring credit pack ownership."""
+
+    return (
+        resolve_wallet_bucket_runtime_category(
+            bucket,
+            load_order_type=load_billing_order_type_by_bid,
+        )
+        == CREDIT_BUCKET_CATEGORY_TOPUP
     )
 
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -21,6 +21,7 @@ from flaskr.util.datetime import now_utc, to_utc_iso
 from .consts import (
     ACTIVE_SUBSCRIPTION_STATUSES,
     BILLING_ORDER_STATUS_PAID,
+    BILLING_ORDER_TYPE_TOPUP,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
@@ -223,6 +224,71 @@ class ExpireLedgerBucketDriftRepairResult:
             "bucket_count": self.bucket_count,
             "repaired_bucket_count": self.repaired_bucket_count,
             "manual_review_count": self.manual_review_count,
+            "dry_run": self.dry_run,
+            "buckets": [bucket.to_payload() for bucket in self.buckets],
+        }
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_task_payload()[key]
+
+
+@dataclass(slots=True, frozen=True)
+class ExpiredCreditPackBucketRestoreRecord:
+    bill_order_bid: str
+    creator_bid: str | None
+    wallet_bid: str | None
+    wallet_bucket_bid: str | None
+    previous_available_credits: int | float
+    available_credits: int | float
+    previous_expired_credits: int | float
+    expired_credits: int | float
+    previous_status: int | None
+    status: int | None
+    restored_credits: int | float
+    repair_action: str
+    repair_reason: str
+    changed: bool
+    ledger_bid: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "bill_order_bid": self.bill_order_bid,
+            "creator_bid": self.creator_bid,
+            "wallet_bid": self.wallet_bid,
+            "wallet_bucket_bid": self.wallet_bucket_bid,
+            "previous_available_credits": self.previous_available_credits,
+            "available_credits": self.available_credits,
+            "previous_expired_credits": self.previous_expired_credits,
+            "expired_credits": self.expired_credits,
+            "previous_status": self.previous_status,
+            "status": self.status,
+            "restored_credits": self.restored_credits,
+            "repair_action": self.repair_action,
+            "repair_reason": self.repair_reason,
+            "changed": self.changed,
+            "ledger_bid": self.ledger_bid,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ExpiredCreditPackBucketRestoreResult:
+    status: str
+    bill_order_bids: list[str]
+    order_count: int
+    repaired_bucket_count: int
+    manual_review_count: int
+    noop_count: int
+    dry_run: bool
+    buckets: list[ExpiredCreditPackBucketRestoreRecord] = field(default_factory=list)
+
+    def to_task_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "bill_order_bids": list(self.bill_order_bids),
+            "order_count": self.order_count,
+            "repaired_bucket_count": self.repaired_bucket_count,
+            "manual_review_count": self.manual_review_count,
+            "noop_count": self.noop_count,
             "dry_run": self.dry_run,
             "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
@@ -2078,6 +2144,387 @@ def repair_expire_ledger_bucket_drift(
             dry_run=dry_run,
             buckets=records,
         )
+
+
+def restore_wrongly_expired_credit_pack_buckets(
+    app: Flask,
+    *,
+    bill_order_bids: list[str] | tuple[str, ...],
+    dry_run: bool = True,
+) -> ExpiredCreditPackBucketRestoreResult:
+    """Restore explicitly scoped credit pack buckets expired before this fix."""
+
+    normalized_order_bids = list(
+        dict.fromkeys(_normalize_bid(bid) for bid in bill_order_bids)
+    )
+    normalized_order_bids = [bid for bid in normalized_order_bids if bid]
+    if not normalized_order_bids:
+        return ExpiredCreditPackBucketRestoreResult(
+            status="noop",
+            bill_order_bids=[],
+            order_count=0,
+            repaired_bucket_count=0,
+            manual_review_count=0,
+            noop_count=0,
+            dry_run=dry_run,
+        )
+
+    repaired_at = now_utc()
+    with app.app_context():
+        if dry_run:
+            records = _build_expired_credit_pack_restore_records(
+                app,
+                bill_order_bids=normalized_order_bids,
+                repaired_at=repaired_at,
+                dry_run=True,
+            )
+        else:
+            with unit_of_work():
+                records = _build_expired_credit_pack_restore_records(
+                    app,
+                    bill_order_bids=normalized_order_bids,
+                    repaired_at=repaired_at,
+                    dry_run=False,
+                )
+
+        repaired_count = sum(1 for record in records if record.changed)
+        manual_review_count = sum(
+            1 for record in records if record.repair_action == "manual_review"
+        )
+        noop_count = sum(1 for record in records if record.repair_action == "noop")
+        return ExpiredCreditPackBucketRestoreResult(
+            status=(
+                "dry_run"
+                if dry_run
+                else "repaired"
+                if repaired_count
+                else "manual_review"
+                if manual_review_count
+                else "noop"
+            ),
+            bill_order_bids=normalized_order_bids,
+            order_count=len(normalized_order_bids),
+            repaired_bucket_count=repaired_count,
+            manual_review_count=manual_review_count,
+            noop_count=noop_count,
+            dry_run=dry_run,
+            buckets=records,
+        )
+
+
+def _build_expired_credit_pack_restore_records(
+    app: Flask,
+    *,
+    bill_order_bids: list[str],
+    repaired_at: datetime,
+    dry_run: bool,
+) -> list[ExpiredCreditPackBucketRestoreRecord]:
+    records: list[ExpiredCreditPackBucketRestoreRecord] = []
+    orders = {
+        order.bill_order_bid: order
+        for order in BillingOrder.query.filter(
+            BillingOrder.deleted == 0,
+            BillingOrder.bill_order_bid.in_(bill_order_bids),
+        ).all()
+    }
+
+    for bill_order_bid in bill_order_bids:
+        order = orders.get(bill_order_bid)
+        if order is None:
+            records.append(
+                _build_expired_credit_pack_restore_record(
+                    bill_order_bid=bill_order_bid,
+                    repair_action="manual_review",
+                    repair_reason="billing_order_not_found",
+                )
+            )
+            continue
+        if (
+            int(order.order_type or 0) != BILLING_ORDER_TYPE_TOPUP
+            or int(order.status or 0) != BILLING_ORDER_STATUS_PAID
+            or order.paid_at is None
+        ):
+            records.append(
+                _build_expired_credit_pack_restore_record(
+                    bill_order_bid=bill_order_bid,
+                    creator_bid=order.creator_bid,
+                    repair_action="manual_review",
+                    repair_reason="billing_order_is_not_paid_topup",
+                )
+            )
+            continue
+
+        buckets = CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.creator_bid == order.creator_bid,
+            CreditWalletBucket.source_bid == bill_order_bid,
+        ).all()
+        runtime_buckets = [
+            bucket for bucket in buckets if _is_credit_pack_runtime_bucket(bucket)
+        ]
+        if len(runtime_buckets) != 1:
+            records.append(
+                _build_expired_credit_pack_restore_record(
+                    bill_order_bid=bill_order_bid,
+                    creator_bid=order.creator_bid,
+                    repair_action="manual_review",
+                    repair_reason=(
+                        "credit_pack_bucket_not_found"
+                        if not runtime_buckets
+                        else "multiple_credit_pack_buckets_found"
+                    ),
+                )
+            )
+            continue
+
+        bucket = runtime_buckets[0]
+        existing_repair = _load_existing_expired_credit_pack_restore_ledger(
+            creator_bid=bucket.creator_bid,
+            bill_order_bid=bill_order_bid,
+        )
+        if existing_repair is not None:
+            records.append(
+                _build_expired_credit_pack_restore_record(
+                    bill_order_bid=bill_order_bid,
+                    creator_bid=bucket.creator_bid,
+                    wallet_bid=bucket.wallet_bid,
+                    wallet_bucket_bid=bucket.wallet_bucket_bid,
+                    previous_available_credits=bucket.available_credits,
+                    available_credits=bucket.available_credits,
+                    previous_expired_credits=bucket.expired_credits,
+                    expired_credits=bucket.expired_credits,
+                    previous_status=bucket.status,
+                    status=bucket.status,
+                    restored_credits=existing_repair.amount,
+                    repair_action="noop",
+                    repair_reason="already_repaired",
+                    ledger_bid=existing_repair.ledger_bid,
+                )
+            )
+            continue
+
+        previous_available = _quantize_credit_amount(bucket.available_credits)
+        previous_expired = _quantize_credit_amount(bucket.expired_credits)
+        previous_status = int(bucket.status or 0)
+        restore_amount = previous_expired
+        next_available = _quantize_credit_amount(previous_available + restore_amount)
+        next_expired = _ZERO
+        can_repair, repair_reason, expire_ledgers = (
+            _validate_expired_credit_pack_restore_candidate(
+                bucket,
+                restore_amount=restore_amount,
+            )
+        )
+        record = _build_expired_credit_pack_restore_record(
+            bill_order_bid=bill_order_bid,
+            creator_bid=bucket.creator_bid,
+            wallet_bid=bucket.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            previous_available_credits=previous_available,
+            available_credits=next_available if can_repair else previous_available,
+            previous_expired_credits=previous_expired,
+            expired_credits=next_expired if can_repair else previous_expired,
+            previous_status=previous_status,
+            status=CREDIT_BUCKET_STATUS_ACTIVE if can_repair else previous_status,
+            restored_credits=restore_amount if can_repair else _ZERO,
+            repair_action="repair" if can_repair else "manual_review",
+            repair_reason=repair_reason,
+            changed=can_repair,
+        )
+        records.append(record)
+
+        if dry_run or not can_repair:
+            continue
+
+        bucket.available_credits = next_available
+        bucket.expired_credits = next_expired
+        bucket.status = CREDIT_BUCKET_STATUS_ACTIVE
+        bucket.updated_at = repaired_at
+        db.session.add(bucket)
+        db.session.flush()
+
+        wallet = _load_credit_wallet_by_wallet_bid(bucket.wallet_bid)
+        if wallet is None:
+            raise RuntimeError("credit_pack_restore_wallet_missing")
+        available_credits, reserved_credits = calculate_credit_wallet_snapshot_values(
+            wallet,
+            snapshot_at=repaired_at,
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid=generate_id(app),
+            creator_bid=bucket.creator_bid,
+            wallet_bid=bucket.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bill_order_bid,
+            idempotency_key=_build_expired_credit_pack_restore_idempotency_key(
+                bill_order_bid
+            ),
+            amount=restore_amount,
+            balance_after=available_credits,
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={
+                "repair_reason": "restore_wrongly_expired_credit_pack_bucket",
+                "bill_order_bid": bill_order_bid,
+                "wallet_bucket_bid": bucket.wallet_bucket_bid,
+                "restored_expired_credits": _credit_decimal_to_number(restore_amount),
+                "previous_status": previous_status,
+                "previous_available_credits": _credit_decimal_to_number(
+                    previous_available
+                ),
+                "previous_expired_credits": _credit_decimal_to_number(previous_expired),
+                "expire_ledger_bids": [ledger.ledger_bid for ledger in expire_ledgers],
+                "repaired_at": to_utc_iso(repaired_at),
+            },
+        )
+        if (
+            _quantize_credit_amount(wallet.available_credits) != available_credits
+            or _quantize_credit_amount(wallet.reserved_credits) != reserved_credits
+        ):
+            persist_credit_wallet_snapshot(
+                wallet,
+                available_credits=available_credits,
+                reserved_credits=reserved_credits,
+                updated_at=repaired_at,
+            )
+        db.session.add(ledger)
+        records[-1] = _build_expired_credit_pack_restore_record(
+            bill_order_bid=bill_order_bid,
+            creator_bid=bucket.creator_bid,
+            wallet_bid=bucket.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            previous_available_credits=previous_available,
+            available_credits=next_available,
+            previous_expired_credits=previous_expired,
+            expired_credits=next_expired,
+            previous_status=previous_status,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            restored_credits=restore_amount,
+            repair_action="repair",
+            repair_reason=repair_reason,
+            changed=True,
+            ledger_bid=ledger.ledger_bid,
+        )
+
+    return records
+
+
+def _build_expired_credit_pack_restore_record(
+    *,
+    bill_order_bid: str,
+    creator_bid: str | None = None,
+    wallet_bid: str | None = None,
+    wallet_bucket_bid: str | None = None,
+    previous_available_credits: Decimal | Any = _ZERO,
+    available_credits: Decimal | Any = _ZERO,
+    previous_expired_credits: Decimal | Any = _ZERO,
+    expired_credits: Decimal | Any = _ZERO,
+    previous_status: int | None = None,
+    status: int | None = None,
+    restored_credits: Decimal | Any = _ZERO,
+    repair_action: str,
+    repair_reason: str,
+    changed: bool = False,
+    ledger_bid: str | None = None,
+) -> ExpiredCreditPackBucketRestoreRecord:
+    return ExpiredCreditPackBucketRestoreRecord(
+        bill_order_bid=bill_order_bid,
+        creator_bid=creator_bid,
+        wallet_bid=wallet_bid,
+        wallet_bucket_bid=wallet_bucket_bid,
+        previous_available_credits=_credit_decimal_to_number(
+            _quantize_credit_amount(previous_available_credits)
+        ),
+        available_credits=_credit_decimal_to_number(
+            _quantize_credit_amount(available_credits)
+        ),
+        previous_expired_credits=_credit_decimal_to_number(
+            _quantize_credit_amount(previous_expired_credits)
+        ),
+        expired_credits=_credit_decimal_to_number(
+            _quantize_credit_amount(expired_credits)
+        ),
+        previous_status=previous_status,
+        status=status,
+        restored_credits=_credit_decimal_to_number(
+            _quantize_credit_amount(restored_credits)
+        ),
+        repair_action=repair_action,
+        repair_reason=repair_reason,
+        changed=changed,
+        ledger_bid=ledger_bid,
+    )
+
+
+def _validate_expired_credit_pack_restore_candidate(
+    bucket: CreditWalletBucket,
+    *,
+    restore_amount: Decimal,
+) -> tuple[bool, str, list[CreditLedgerEntry]]:
+    if int(bucket.status or 0) != CREDIT_BUCKET_STATUS_EXPIRED:
+        return False, "bucket_is_not_expired", []
+    if restore_amount <= _ZERO:
+        return False, "bucket_has_no_expired_credits", []
+    if _to_decimal(bucket.reserved_credits) != _ZERO:
+        return False, "bucket_has_reserved_credits", []
+    if _to_decimal(bucket.available_credits) != _ZERO:
+        return False, "bucket_has_available_credits", []
+
+    expected_remaining = _quantize_credit_amount(
+        _to_decimal(bucket.original_credits)
+        - _to_decimal(bucket.consumed_credits)
+        - _to_decimal(bucket.reserved_credits)
+        - _to_decimal(bucket.available_credits)
+    )
+    if expected_remaining != restore_amount:
+        return False, "bucket_balance_shape_mismatch", []
+
+    expire_ledgers = (
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.creator_bid == bucket.creator_bid,
+            CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        )
+        .order_by(CreditLedgerEntry.id.asc())
+        .all()
+    )
+    matching_ledgers = [
+        ledger
+        for ledger in expire_ledgers
+        if _is_matching_expire_ledger_for_bucket(ledger, bucket)
+    ]
+    if not matching_ledgers:
+        return False, "matching_expire_ledger_not_found", expire_ledgers
+    expired_amount = _quantize_credit_amount(
+        sum((abs(_to_decimal(ledger.amount)) for ledger in matching_ledgers), _ZERO)
+    )
+    if expired_amount != restore_amount:
+        return False, "expire_ledger_amount_mismatch", matching_ledgers
+    return True, "expired_credit_pack_bucket_matches_expire_ledger", matching_ledgers
+
+
+def _load_existing_expired_credit_pack_restore_ledger(
+    *,
+    creator_bid: str,
+    bill_order_bid: str,
+) -> CreditLedgerEntry | None:
+    return (
+        CreditLedgerEntry.query.filter(
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.creator_bid == creator_bid,
+            CreditLedgerEntry.idempotency_key
+            == _build_expired_credit_pack_restore_idempotency_key(bill_order_bid),
+        )
+        .order_by(CreditLedgerEntry.id.desc())
+        .first()
+    )
+
+
+def _build_expired_credit_pack_restore_idempotency_key(bill_order_bid: str) -> str:
+    return f"restore_expired_topup:{_normalize_bid(bill_order_bid)}"
 
 
 def _expire_credit_wallet_buckets_in_session(

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -390,6 +390,83 @@ def test_billing_repair_topup_expiry_cli_prints_helper_payload(
     assert payload["kwargs"]["creator_bid"] == "creator-cli-1"
 
 
+def test_billing_restore_expired_topup_buckets_cli_requires_order_bid(
+    billing_cli_runner,
+) -> None:
+    result = billing_cli_runner.invoke(
+        args=["console", "billing", "restore-expired-topup-buckets"]
+    )
+
+    assert result.exit_code != 0
+    assert (
+        "Pass at least one --bill-order-bid for expired topup bucket restore."
+        in result.output
+    )
+
+
+def test_billing_restore_expired_topup_buckets_cli_prints_helper_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.restore_wrongly_expired_credit_pack_buckets",
+        lambda app, **kwargs: {
+            "status": "dry_run",
+            "repaired_bucket_count": 2,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "restore-expired-topup-buckets",
+            "--bill-order-bid",
+            "order-cli-1",
+            "--bill-order-bid",
+            "order-cli-2",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "dry_run"
+    assert payload["kwargs"]["bill_order_bids"] == ["order-cli-1", "order-cli-2"]
+    assert payload["kwargs"]["dry_run"] is True
+
+
+def test_billing_restore_expired_topup_buckets_cli_apply_persists_payload(
+    billing_cli_runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "flaskr.service.billing.cli.restore_wrongly_expired_credit_pack_buckets",
+        lambda app, **kwargs: {
+            "status": "repaired",
+            "repaired_bucket_count": 1,
+            "kwargs": kwargs,
+        },
+    )
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "restore-expired-topup-buckets",
+            "--bill-order-bid",
+            "order-cli-1",
+            "--apply",
+        ]
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "repaired"
+    assert payload["kwargs"]["bill_order_bids"] == ["order-cli-1"]
+    assert payload["kwargs"]["dry_run"] is False
+
+
 def test_billing_repair_bucket_status_cli_requires_explicit_scope(
     billing_cli_runner,
 ) -> None:

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -402,32 +402,29 @@ def test_run_billing_renewal_event_applies_expire(
 
         assert subscription.status == BILLING_SUBSCRIPTION_STATUS_EXPIRED
         assert wallet.available_credits == Decimal("0E-10")
-        assert len(ledger_entries) == 2
+        assert len(ledger_entries) == 1
         assert [entry.wallet_bucket_bid for entry in ledger_entries] == [
             "bucket-expire-subscription-1",
-            "bucket-expire-topup-1",
         ]
         assert [entry.amount for entry in ledger_entries] == [
             Decimal("-5.0000000000"),
-            Decimal("-2.5000000000"),
         ]
         assert [entry.balance_after for entry in ledger_entries] == [
             Decimal("2.5000000000"),
-            Decimal("0E-10"),
         ]
         assert (
             buckets["bucket-expire-subscription-1"].status
             == CREDIT_BUCKET_STATUS_EXPIRED
         )
-        assert buckets["bucket-expire-topup-1"].status == CREDIT_BUCKET_STATUS_EXPIRED
+        assert buckets["bucket-expire-topup-1"].status == CREDIT_BUCKET_STATUS_ACTIVE
         assert buckets["bucket-expire-subscription-1"].expired_credits == Decimal(
             "5.0000000000"
         )
-        assert buckets["bucket-expire-topup-1"].expired_credits == Decimal(
+        assert buckets["bucket-expire-topup-1"].expired_credits == Decimal("0")
+        assert buckets["bucket-expire-subscription-1"].available_credits == Decimal("0")
+        assert buckets["bucket-expire-topup-1"].available_credits == Decimal(
             "2.5000000000"
         )
-        assert buckets["bucket-expire-subscription-1"].available_credits == Decimal("0")
-        assert buckets["bucket-expire-topup-1"].available_credits == Decimal("0")
 
 
 def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replayed(

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -34,6 +34,7 @@ from flaskr.service.billing.consts import (
     CREDIT_BUCKET_STATUS_EXPIRED,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
     CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+    CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
     CREDIT_SOURCE_TYPE_SUBSCRIPTION,
     CREDIT_SOURCE_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -1341,7 +1342,7 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
         )
         wallet = _create_wallet(
             subscription.creator_bid,
-            available_credits="4.0000000000",
+            available_credits="6.0000000000",
         )
         dao.db.session.add(subscription)
         dao.db.session.add(order)
@@ -1358,6 +1359,20 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
                 effective_from=current_cycle_start,
                 effective_to=current_cycle_end,
                 created_at=current_cycle_start,
+            )
+        )
+        dao.db.session.add(
+            _create_bucket(
+                wallet.wallet_bid,
+                subscription.creator_bid,
+                "bucket-pingxx-expire-paid-bonus-1",
+                available_credits="2.0000000000",
+                source_bid="order-topup-pingxx-expire-paid-1",
+                source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+                category=CREDIT_BUCKET_CATEGORY_TOPUP,
+                effective_from=current_cycle_start,
+                effective_to=current_cycle_end,
+                created_at=current_cycle_start + timedelta(seconds=1),
             )
         )
         dao.db.session.add(
@@ -1379,6 +1394,25 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
                 updated_at=current_cycle_start,
             )
         )
+        dao.db.session.add(
+            CreditLedgerEntry(
+                ledger_bid="ledger-pingxx-expire-paid-bonus-1",
+                creator_bid=subscription.creator_bid,
+                wallet_bid=wallet.wallet_bid,
+                wallet_bucket_bid="bucket-pingxx-expire-paid-bonus-1",
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+                source_bid="order-topup-pingxx-expire-paid-1",
+                idempotency_key="grant:campaign_bonus:order-topup-pingxx-expire-paid-1",
+                amount=Decimal("2.0000000000"),
+                balance_after=Decimal("6.0000000000"),
+                expires_at=current_cycle_end,
+                consumable_from=current_cycle_start,
+                metadata_json={"grant_reason": "campaign_bonus"},
+                created_at=current_cycle_start + timedelta(seconds=1),
+                updated_at=current_cycle_start + timedelta(seconds=1),
+            )
+        )
         dao.db.session.add(event)
         dao.db.session.commit()
 
@@ -1398,8 +1432,17 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
         bucket = CreditWalletBucket.query.filter_by(
             wallet_bucket_bid="bucket-pingxx-expire-paid-1"
         ).one()
+        bonus_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-pingxx-expire-paid-bonus-1"
+        ).one()
         grant_entry = CreditLedgerEntry.query.filter_by(
             ledger_bid="ledger-pingxx-expire-paid-1"
+        ).one()
+        bonus_grant_entry = CreditLedgerEntry.query.filter_by(
+            ledger_bid="ledger-pingxx-expire-paid-bonus-1"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            wallet_bid=f"wallet-{subscription.creator_bid}"
         ).one()
         expire_entries = CreditLedgerEntry.query.filter_by(
             creator_bid=subscription.creator_bid,
@@ -1412,6 +1455,11 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
         assert bucket.available_credits == Decimal("4.0000000000")
         assert bucket.effective_to == next_cycle_end
         assert grant_entry.expires_at == next_cycle_end
+        assert bonus_bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+        assert bonus_bucket.available_credits == Decimal("2.0000000000")
+        assert bonus_bucket.effective_to == next_cycle_end
+        assert bonus_grant_entry.expires_at == next_cycle_end
+        assert wallet.available_credits == Decimal("6.0000000000")
         assert expire_entries == []
 
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -25,6 +25,7 @@ from flaskr.service.billing.consts import (
     CREDIT_BUCKET_STATUS_ACTIVE,
     CREDIT_BUCKET_STATUS_EXHAUSTED,
     CREDIT_BUCKET_STATUS_EXPIRED,
+    CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
     CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
     CREDIT_LEDGER_ENTRY_TYPE_REFUND,
@@ -57,6 +58,7 @@ from flaskr.service.billing.wallets import (
     repair_expire_ledger_bucket_drift,
     repair_renewal_state_drift,
     rebuild_credit_wallet_snapshots,
+    restore_wrongly_expired_credit_pack_buckets,
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.metering.models import BillUsageRecord
@@ -4383,6 +4385,240 @@ def test_repair_expire_ledger_bucket_drift_skips_credit_pack_bucket(
     assert bucket.expired_credits == Decimal("0")
     assert wallet.available_credits == Decimal("2.5000000000")
     assert wallet.version == 0
+
+
+def test_restore_wrongly_expired_credit_pack_bucket_dry_run_does_not_write(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet, bucket = _seed_wrongly_expired_credit_pack_bucket(
+            creator_bid="creator-restore-topup-dry-run",
+            wallet_bid="wallet-restore-topup-dry-run",
+            bucket_bid="bucket-restore-topup-dry-run",
+            order_bid="order-restore-topup-dry-run",
+            original=Decimal("250.0000000000"),
+            consumed=Decimal("0"),
+            expired=Decimal("250.0000000000"),
+        )
+
+        payload = restore_wrongly_expired_credit_pack_buckets(
+            billing_wallet_lifecycle_app,
+            bill_order_bids=["order-restore-topup-dry-run"],
+            dry_run=True,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid=bucket.wallet_bucket_bid
+        ).one()
+        adjustment_count = CreditLedgerEntry.query.filter_by(
+            creator_bid=wallet.creator_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
+        ).count()
+
+    assert payload["status"] == "dry_run"
+    assert payload["repaired_bucket_count"] == 1
+    assert payload["buckets"][0]["repair_action"] == "repair"
+    assert payload["buckets"][0]["restored_credits"] == 250
+    assert bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+    assert bucket.available_credits == Decimal("0")
+    assert bucket.expired_credits == Decimal("250.0000000000")
+    assert adjustment_count == 0
+
+
+def test_restore_wrongly_expired_credit_pack_bucket_restores_frozen_ownership(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet, bucket = _seed_wrongly_expired_credit_pack_bucket(
+            creator_bid="creator-restore-topup-apply",
+            wallet_bid="wallet-restore-topup-apply",
+            bucket_bid="bucket-restore-topup-apply",
+            order_bid="order-restore-topup-apply",
+            original=Decimal("250.0000000000"),
+            consumed=Decimal("136.8500000000"),
+            expired=Decimal("113.1500000000"),
+        )
+        original_wallet_version = wallet.version
+
+        payload = restore_wrongly_expired_credit_pack_buckets(
+            billing_wallet_lifecycle_app,
+            bill_order_bids=["order-restore-topup-apply"],
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid=bucket.wallet_bucket_bid
+        ).one()
+        wallet = CreditWallet.query.filter_by(wallet_bid=wallet.wallet_bid).one()
+        adjustment = CreditLedgerEntry.query.filter_by(
+            creator_bid=wallet.creator_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
+        ).one()
+
+    assert payload["status"] == "repaired"
+    assert payload["repaired_bucket_count"] == 1
+    assert payload["manual_review_count"] == 0
+    assert payload["buckets"][0]["restored_credits"] == 113.15
+    assert payload["buckets"][0]["ledger_bid"] == adjustment.ledger_bid
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("113.1500000000")
+    assert bucket.consumed_credits == Decimal("136.8500000000")
+    assert bucket.expired_credits == Decimal("0E-10")
+    assert wallet.available_credits == Decimal("0E-10")
+    assert wallet.version == original_wallet_version
+    assert adjustment.amount == Decimal("113.1500000000")
+    assert adjustment.balance_after == Decimal("0E-10")
+    assert adjustment.metadata_json["repair_reason"] == (
+        "restore_wrongly_expired_credit_pack_bucket"
+    )
+
+
+def test_restore_wrongly_expired_credit_pack_bucket_is_idempotent(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        _seed_wrongly_expired_credit_pack_bucket(
+            creator_bid="creator-restore-topup-idempotent",
+            wallet_bid="wallet-restore-topup-idempotent",
+            bucket_bid="bucket-restore-topup-idempotent",
+            order_bid="order-restore-topup-idempotent",
+            original=Decimal("250.0000000000"),
+            consumed=Decimal("0"),
+            expired=Decimal("250.0000000000"),
+        )
+
+        first_payload = restore_wrongly_expired_credit_pack_buckets(
+            billing_wallet_lifecycle_app,
+            bill_order_bids=["order-restore-topup-idempotent"],
+            dry_run=False,
+        )
+        second_payload = restore_wrongly_expired_credit_pack_buckets(
+            billing_wallet_lifecycle_app,
+            bill_order_bids=["order-restore-topup-idempotent"],
+            dry_run=False,
+        )
+
+        adjustment_count = CreditLedgerEntry.query.filter_by(
+            creator_bid="creator-restore-topup-idempotent",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
+        ).count()
+
+    assert first_payload["status"] == "repaired"
+    assert second_payload["status"] == "noop"
+    assert second_payload["noop_count"] == 1
+    assert second_payload["buckets"][0]["repair_reason"] == "already_repaired"
+    assert adjustment_count == 1
+
+
+def test_restore_wrongly_expired_credit_pack_bucket_requires_matching_expire_ledger(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        _seed_wrongly_expired_credit_pack_bucket(
+            creator_bid="creator-restore-topup-manual",
+            wallet_bid="wallet-restore-topup-manual",
+            bucket_bid="bucket-restore-topup-manual",
+            order_bid="order-restore-topup-manual",
+            original=Decimal("250.0000000000"),
+            consumed=Decimal("0"),
+            expired=Decimal("250.0000000000"),
+            expire_ledger_amount=Decimal("-1.0000000000"),
+        )
+
+        payload = restore_wrongly_expired_credit_pack_buckets(
+            billing_wallet_lifecycle_app,
+            bill_order_bids=["order-restore-topup-manual"],
+            dry_run=False,
+        )
+
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-restore-topup-manual"
+        ).one()
+        adjustment_count = CreditLedgerEntry.query.filter_by(
+            creator_bid="creator-restore-topup-manual",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_ADJUSTMENT,
+        ).count()
+
+    assert payload["status"] == "manual_review"
+    assert payload["manual_review_count"] == 1
+    assert payload["buckets"][0]["repair_reason"] == "expire_ledger_amount_mismatch"
+    assert bucket.status == CREDIT_BUCKET_STATUS_EXPIRED
+    assert bucket.expired_credits == Decimal("250.0000000000")
+    assert adjustment_count == 0
+
+
+def _seed_wrongly_expired_credit_pack_bucket(
+    *,
+    creator_bid: str,
+    wallet_bid: str,
+    bucket_bid: str,
+    order_bid: str,
+    original: Decimal,
+    consumed: Decimal,
+    expired: Decimal,
+    expire_ledger_amount: Decimal | None = None,
+) -> tuple[CreditWallet, CreditWalletBucket]:
+    effective_from = datetime(2026, 4, 1, 0, 0, 0)
+    effective_to = datetime(2026, 4, 30, 0, 0, 0)
+    wallet = CreditWallet(
+        wallet_bid=wallet_bid,
+        creator_bid=creator_bid,
+        available_credits=Decimal("0"),
+        reserved_credits=Decimal("0"),
+        lifetime_granted_credits=original,
+        lifetime_consumed_credits=consumed,
+        last_settled_usage_id=0,
+        version=0,
+    )
+    order = BillingOrder(
+        bill_order_bid=order_bid,
+        creator_bid=creator_bid,
+        order_type=BILLING_ORDER_TYPE_TOPUP,
+        product_bid=f"product-{order_bid}",
+        status=BILLING_ORDER_STATUS_PAID,
+        paid_at=datetime(2026, 4, 1, 0, 0, 0),
+    )
+    bucket = CreditWalletBucket(
+        wallet_bucket_bid=bucket_bid,
+        wallet_bid=wallet_bid,
+        creator_bid=creator_bid,
+        bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+        source_type=CREDIT_SOURCE_TYPE_TOPUP,
+        source_bid=order_bid,
+        priority=30,
+        original_credits=original,
+        available_credits=Decimal("0"),
+        reserved_credits=Decimal("0"),
+        consumed_credits=consumed,
+        expired_credits=expired,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        status=CREDIT_BUCKET_STATUS_EXPIRED,
+        metadata_json={},
+    )
+    expire_ledger = CreditLedgerEntry(
+        ledger_bid=f"ledger-{order_bid}",
+        creator_bid=creator_bid,
+        wallet_bid=wallet_bid,
+        wallet_bucket_bid=bucket_bid,
+        entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        source_type=CREDIT_SOURCE_TYPE_TOPUP,
+        source_bid=order_bid,
+        idempotency_key=_build_expire_ledger_idempotency_key(
+            bucket_bid,
+            effective_to=effective_to,
+        ),
+        amount=expire_ledger_amount if expire_ledger_amount is not None else -expired,
+        balance_after=Decimal("0"),
+        expires_at=effective_to,
+        consumable_from=effective_from,
+        metadata_json={},
+    )
+    dao.db.session.add_all([wallet, order, bucket, expire_ledger])
+    dao.db.session.commit()
+    return wallet, bucket
 
 
 def test_grant_refund_return_credits_creates_subscription_bucket_and_refund_ledger(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -127,10 +127,10 @@ def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
                 wallet_bucket_bid="bucket-expire-1",
                 wallet_bid=wallet.wallet_bid,
                 creator_bid="creator-expire-1",
-                bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-                source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
                 source_bid="order-topup-expire-1",
-                priority=30,
+                priority=20,
                 original_credits=Decimal("2.5000000000"),
                 available_credits=Decimal("2.5000000000"),
                 reserved_credits=Decimal("0"),
@@ -173,6 +173,69 @@ def test_expire_credit_wallet_buckets_marks_bucket_expired_and_writes_ledger(
         assert ledger.balance_after == Decimal("0E-10")
 
 
+def test_expire_credit_wallet_buckets_skips_credit_pack_bucket(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-topup-skip",
+            creator_bid="creator-expire-topup-skip",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("2.5000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-topup-skip",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-topup-skip",
+            priority=30,
+            original_credits=Decimal("2.5000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket])
+        dao.db.session.commit()
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid=wallet.creator_bid,
+            expire_before=datetime(2026, 4, 8, 0, 0, 0),
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-topup-skip"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-topup-skip"
+        ).one()
+        ledgers = CreditLedgerEntry.query.filter_by(
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+        ).all()
+
+    assert payload["status"] == "noop"
+    assert payload["bucket_count"] == 0
+    assert payload["expired_credits"] == 0
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("2.5000000000")
+    assert bucket.expired_credits == Decimal("0")
+    assert wallet.available_credits == Decimal("0E-10")
+    assert ledgers == []
+
+
 def test_expire_credit_wallet_buckets_uses_actual_mutation_time_for_bucket_update(
     billing_wallet_lifecycle_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
@@ -196,10 +259,10 @@ def test_expire_credit_wallet_buckets_uses_actual_mutation_time_for_bucket_updat
             wallet_bucket_bid="bucket-expire-mutation-time",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-mutation-time",
-            priority=30,
+            priority=20,
             original_credits=Decimal("2.5000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("0"),
@@ -261,10 +324,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_with_conflicting_ledger(
                     wallet_bucket_bid=bid,
                     wallet_bid=wallet.wallet_bid,
                     creator_bid="creator-expire-race",
-                    bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-                    source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                    bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                    source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
                     source_bid=source,
-                    priority=30,
+                    priority=20,
                     original_credits=Decimal(amount),
                     available_credits=Decimal(amount),
                     reserved_credits=Decimal("0"),
@@ -287,7 +350,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_with_conflicting_ledger(
                 wallet_bid=wallet.wallet_bid,
                 wallet_bucket_bid="bucket-conflict",
                 entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-                source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
                 source_bid="order-conflict",
                 idempotency_key=_build_expire_ledger_idempotency_key(
                     "bucket-conflict",
@@ -341,10 +404,10 @@ def test_expire_credit_wallet_buckets_allows_reused_bucket_after_legacy_expire(
             wallet_bucket_bid="bucket-expire-reused-legacy",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-reused-legacy-second-cycle",
-            priority=30,
+            priority=20,
             original_credits=Decimal("15.0000000000"),
             available_credits=Decimal("5.0000000000"),
             reserved_credits=Decimal("0"),
@@ -365,7 +428,7 @@ def test_expire_credit_wallet_buckets_allows_reused_bucket_after_legacy_expire(
                     wallet_bid=wallet.wallet_bid,
                     wallet_bucket_bid=bucket.wallet_bucket_bid,
                     entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-                    source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                    source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
                     source_bid="order-expire-reused-legacy-first-cycle",
                     idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
                     amount=Decimal("-2.5000000000"),
@@ -436,10 +499,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_realigned_during_refresh(
             wallet_bucket_bid="bucket-expire-realigned",
             wallet_bid=wallet.wallet_bid,
             creator_bid="creator-expire-realigned",
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-topup-realigned",
-            priority=30,
+            priority=20,
             original_credits=Decimal("4.0000000000"),
             available_credits=Decimal("4.0000000000"),
             reserved_credits=Decimal("0"),
@@ -520,10 +583,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
             wallet_bucket_bid="bucket-expire-consumed-before-write",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-consumed-before-write",
-            priority=30,
+            priority=20,
             original_credits=Decimal("4.0000000000"),
             available_credits=Decimal("4.0000000000"),
             reserved_credits=Decimal("0"),
@@ -538,10 +601,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
             wallet_bucket_bid="bucket-expire-consumed-before-write-ok",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-consumed-before-write-ok",
-            priority=30,
+            priority=20,
             original_credits=Decimal("2.0000000000"),
             available_credits=Decimal("2.0000000000"),
             reserved_credits=Decimal("0"),
@@ -642,10 +705,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
             wallet_bucket_bid="bucket-expire-extended-before-write",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-extended-before-write",
-            priority=30,
+            priority=20,
             original_credits=Decimal("4.0000000000"),
             available_credits=Decimal("4.0000000000"),
             reserved_credits=Decimal("0"),
@@ -660,10 +723,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
             wallet_bucket_bid="bucket-expire-extended-before-write-ok",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-extended-before-write-ok",
-            priority=30,
+            priority=20,
             original_credits=Decimal("2.0000000000"),
             available_credits=Decimal("2.0000000000"),
             reserved_credits=Decimal("0"),
@@ -841,10 +904,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
             wallet_bucket_bid="bucket-expire-refresh-skip",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-refresh-skip",
-            priority=30,
+            priority=20,
             original_credits=Decimal("4.0000000000"),
             available_credits=Decimal("4.0000000000"),
             reserved_credits=Decimal("0"),
@@ -859,10 +922,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
             wallet_bucket_bid="bucket-expire-refresh-ok",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-refresh-ok",
-            priority=30,
+            priority=20,
             original_credits=Decimal("5.0000000000"),
             available_credits=Decimal("5.0000000000"),
             reserved_credits=Decimal("0"),
@@ -933,10 +996,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_when_refresh_raises_deleted(
             wallet_bucket_bid="bucket-expire-refresh-error",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-refresh-error",
-            priority=30,
+            priority=20,
             original_credits=Decimal("3.0000000000"),
             available_credits=Decimal("3.0000000000"),
             reserved_credits=Decimal("0"),
@@ -951,10 +1014,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_when_refresh_raises_deleted(
             wallet_bucket_bid="bucket-expire-refresh-error-ok",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-refresh-error-ok",
-            priority=30,
+            priority=20,
             original_credits=Decimal("5.0000000000"),
             available_credits=Decimal("5.0000000000"),
             reserved_credits=Decimal("0"),
@@ -1034,10 +1097,10 @@ def test_expire_credit_wallet_buckets_skips_bucket_on_wallet_version_conflict(
                     wallet_bucket_bid=bid,
                     wallet_bid=wallet.wallet_bid,
                     creator_bid="creator-version-race",
-                    bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-                    source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                    bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+                    source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
                     source_bid=f"order-{bid}",
-                    priority=30,
+                    priority=20,
                     original_credits=Decimal(amount),
                     available_credits=Decimal(amount),
                     reserved_credits=Decimal("0"),
@@ -1470,9 +1533,9 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
         wallet = CreditWallet(
             wallet_bid="wallet-renewal-drift-protected-apply",
             creator_bid=creator_bid,
-            available_credits=Decimal("1000.0000000000"),
+            available_credits=Decimal("1500.0000000000"),
             reserved_credits=Decimal("1000.0000000000"),
-            lifetime_granted_credits=Decimal("2000.0000000000"),
+            lifetime_granted_credits=Decimal("2500.0000000000"),
             lifetime_consumed_credits=Decimal("0"),
             last_settled_usage_id=0,
             version=0,
@@ -1548,6 +1611,24 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
             status=CREDIT_BUCKET_STATUS_ACTIVE,
             metadata_json={"bill_order_bid": "order-current-apply"},
         )
+        topup_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-renewal-drift-topup-unfreeze",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-topup-unfreeze",
+            priority=30,
+            original_credits=Decimal("500.0000000000"),
+            available_credits=Decimal("500.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 3, 8, 0, 0, 0),
+            effective_to=boundary_at - timedelta(days=1),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={"bill_order_bid": "order-topup-unfreeze"},
+        )
         ledger = CreditLedgerEntry(
             ledger_bid="ledger-renewal-drift-protected-apply",
             creator_bid=wallet.creator_bid,
@@ -1584,7 +1665,7 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
             processed_at=None,
         )
         dao.db.session.add_all(
-            [wallet, subscription, product, order, bucket, ledger, event]
+            [wallet, subscription, product, order, bucket, topup_bucket, ledger, event]
         )
         dao.db.session.commit()
 
@@ -1606,6 +1687,9 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
         subscription = BillingSubscription.query.filter_by(
             subscription_bid=subscription_bid
         ).one()
+        topup_bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-renewal-drift-topup-unfreeze"
+        ).one()
 
     assert payload["status"] == "repaired"
     assert payload["overdue_reserved_grant_count"] == 1
@@ -1621,13 +1705,17 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
     assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
     assert subscription.current_period_start_at == boundary_at
     assert subscription.current_period_end_at == next_cycle_end
-    assert wallet.available_credits == Decimal("1000.0000000000")
+    assert wallet.available_credits == Decimal("1500.0000000000")
     assert wallet.reserved_credits == Decimal("0E-10")
     assert bucket.source_bid == order_bid
     assert bucket.available_credits == Decimal("1000.0000000000")
     assert bucket.reserved_credits == Decimal("0E-10")
     assert bucket.effective_from == boundary_at
     assert bucket.effective_to == next_cycle_end
+    assert topup_bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert topup_bucket.available_credits == Decimal("500.0000000000")
+    assert topup_bucket.expired_credits == Decimal("0")
+    assert topup_bucket.effective_to == next_cycle_end
     assert ledger.metadata_json["bucket_credit_state"] == "available"
 
 
@@ -3733,10 +3821,10 @@ def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(
             wallet_bucket_bid="bucket-expire-ledger-drift-dry-run",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-dry-run",
-            priority=30,
+            priority=20,
             original_credits=Decimal("10.0000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("0"),
@@ -3753,7 +3841,7 @@ def test_repair_expire_ledger_bucket_drift_dry_run_reports_without_writing(
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid=bucket.source_bid,
             idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
             amount=Decimal("-2.5000000000"),
@@ -3807,10 +3895,10 @@ def test_repair_expire_ledger_bucket_drift_applies_bucket_and_wallet_snapshot(
             wallet_bucket_bid="bucket-expire-ledger-drift-apply",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-apply",
-            priority=30,
+            priority=20,
             original_credits=Decimal("10.0000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("0"),
@@ -3827,7 +3915,7 @@ def test_repair_expire_ledger_bucket_drift_applies_bucket_and_wallet_snapshot(
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid=bucket.source_bid,
             idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
             amount=Decimal("-2.5000000000"),
@@ -3887,10 +3975,10 @@ def test_repair_expire_ledger_bucket_drift_accepts_cycle_scoped_expire_key(
             wallet_bucket_bid="bucket-expire-ledger-drift-cycle-key",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-cycle-key",
-            priority=30,
+            priority=20,
             original_credits=Decimal("10.0000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("0"),
@@ -3907,7 +3995,7 @@ def test_repair_expire_ledger_bucket_drift_accepts_cycle_scoped_expire_key(
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid=bucket.source_bid,
             idempotency_key=_build_expire_ledger_idempotency_key(
                 bucket.wallet_bucket_bid,
@@ -3964,10 +4052,10 @@ def test_repair_expire_ledger_bucket_drift_keeps_existing_expired_amount(
             wallet_bucket_bid="bucket-expire-ledger-drift-counted",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-counted",
-            priority=30,
+            priority=20,
             original_credits=Decimal("10.0000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("0"),
@@ -3984,7 +4072,7 @@ def test_repair_expire_ledger_bucket_drift_keeps_existing_expired_amount(
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid=bucket.source_bid,
             idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
             amount=Decimal("-2.5000000000"),
@@ -4034,10 +4122,10 @@ def test_repair_expire_ledger_bucket_drift_skips_reused_bucket_for_manual_review
             wallet_bucket_bid="bucket-expire-ledger-drift-reused",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-reused-second-cycle",
-            priority=30,
+            priority=20,
             original_credits=Decimal("15.0000000000"),
             available_credits=Decimal("5.0000000000"),
             reserved_credits=Decimal("0"),
@@ -4054,7 +4142,7 @@ def test_repair_expire_ledger_bucket_drift_skips_reused_bucket_for_manual_review
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-reused-first-cycle",
             idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
             amount=Decimal("-2.5000000000"),
@@ -4112,10 +4200,10 @@ def test_repair_expire_ledger_bucket_drift_sets_exhausted_for_reserved_bucket(
             wallet_bucket_bid="bucket-expire-ledger-drift-reserved",
             wallet_bid=wallet.wallet_bid,
             creator_bid=wallet.creator_bid,
-            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid="order-expire-ledger-drift-reserved",
-            priority=30,
+            priority=20,
             original_credits=Decimal("10.0000000000"),
             available_credits=Decimal("2.5000000000"),
             reserved_credits=Decimal("1.0000000000"),
@@ -4132,7 +4220,7 @@ def test_repair_expire_ledger_bucket_drift_sets_exhausted_for_reserved_bucket(
             wallet_bid=wallet.wallet_bid,
             wallet_bucket_bid=bucket.wallet_bucket_bid,
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
             source_bid=bucket.source_bid,
             idempotency_key=f"expire:{bucket.wallet_bucket_bid}",
             amount=Decimal("-2.5000000000"),
@@ -4169,6 +4257,84 @@ def test_repair_expire_ledger_bucket_drift_sets_exhausted_for_reserved_bucket(
     assert bucket.expired_credits == Decimal("2.5000000000")
     assert wallet.available_credits == Decimal("0E-10")
     assert wallet.reserved_credits == Decimal("1.0000000000")
+
+
+def test_repair_expire_ledger_bucket_drift_skips_credit_pack_bucket(
+    billing_wallet_lifecycle_app: Flask,
+) -> None:
+    with billing_wallet_lifecycle_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid="wallet-expire-ledger-drift-topup-skip",
+            creator_bid="creator-expire-ledger-drift-topup-skip",
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("10.0000000000"),
+            lifetime_consumed_credits=Decimal("7.5000000000"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-expire-ledger-drift-topup-skip",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=wallet.creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-expire-ledger-drift-topup-skip",
+            priority=30,
+            original_credits=Decimal("10.0000000000"),
+            available_credits=Decimal("2.5000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("7.5000000000"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=datetime(2026, 4, 7, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        ledger = CreditLedgerEntry(
+            ledger_bid="ledger-expire-ledger-drift-topup-skip",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=bucket.source_bid,
+            idempotency_key=_build_expire_ledger_idempotency_key(
+                bucket.wallet_bucket_bid,
+                effective_to=bucket.effective_to,
+            ),
+            amount=Decimal("-2.5000000000"),
+            balance_after=Decimal("0"),
+            expires_at=bucket.effective_to,
+            consumable_from=bucket.effective_from,
+            metadata_json={},
+        )
+        dao.db.session.add_all([wallet, bucket, ledger])
+        dao.db.session.commit()
+
+        payload = repair_expire_ledger_bucket_drift(
+            billing_wallet_lifecycle_app,
+            wallet_bucket_bid=bucket.wallet_bucket_bid,
+            repair_before=datetime(2026, 4, 8, 0, 0, 0),
+            dry_run=False,
+        )
+
+        dao.db.session.expire_all()
+        bucket = CreditWalletBucket.query.filter_by(
+            wallet_bucket_bid="bucket-expire-ledger-drift-topup-skip"
+        ).one()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-ledger-drift-topup-skip"
+        ).one()
+
+    assert payload["status"] == "noop"
+    assert payload["bucket_count"] == 0
+    assert payload["repaired_bucket_count"] == 0
+    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+    assert bucket.available_credits == Decimal("2.5000000000")
+    assert bucket.expired_credits == Decimal("0")
+    assert wallet.available_credits == Decimal("2.5000000000")
+    assert wallet.version == 0
 
 
 def test_grant_refund_return_credits_creates_subscription_bucket_and_refund_ledger(
@@ -4957,10 +5123,10 @@ def test_usage_split_and_bucket_expiry_keep_wallet_bucket_and_ledger_consistent(
             .order_by(CreditLedgerEntry.id.asc())
             .all()
         )
-        expire_entry = CreditLedgerEntry.query.filter_by(
+        expire_entries = CreditLedgerEntry.query.filter_by(
             wallet_bucket_bid="bucket-consistency-topup",
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
-        ).one()
+        ).all()
 
         assert settle_payload["status"] == "settled"
         assert settle_payload["entry_count"] == 1
@@ -4977,13 +5143,12 @@ def test_usage_split_and_bucket_expiry_keep_wallet_bucket_and_ledger_consistent(
             "bucket-consistency-sub",
         ]
 
-        assert expire_payload["status"] == "expired"
-        assert expire_payload["bucket_count"] == 1
-        assert expire_payload["expired_credits"] == 2
-        assert expire_entry.amount == Decimal("-2.0000000000")
-        assert expire_entry.balance_after == Decimal("0E-10")
+        assert expire_payload["status"] == "noop"
+        assert expire_payload["bucket_count"] == 0
+        assert expire_payload["expired_credits"] == 0
+        assert expire_entries == []
 
-        assert wallet.available_credits == Decimal("0E-10")
+        assert wallet.available_credits == Decimal("2.0000000000")
         assert wallet.reserved_credits == Decimal("0E-10")
         assert wallet.lifetime_consumed_credits == Decimal("2.5000000000")
 
@@ -4995,13 +5160,11 @@ def test_usage_split_and_bucket_expiry_keep_wallet_bucket_and_ledger_consistent(
         assert buckets["bucket-consistency-sub"].consumed_credits == Decimal(
             "1.5000000000"
         )
-        assert buckets["bucket-consistency-topup"].available_credits == Decimal("0")
-        assert buckets["bucket-consistency-topup"].expired_credits == Decimal(
+        assert buckets["bucket-consistency-topup"].available_credits == Decimal(
             "2.0000000000"
         )
-        assert (
-            buckets["bucket-consistency-topup"].status == CREDIT_BUCKET_STATUS_EXPIRED
-        )
+        assert buckets["bucket-consistency-topup"].expired_credits == Decimal("0")
+        assert buckets["bucket-consistency-topup"].status == CREDIT_BUCKET_STATUS_ACTIVE
 
         bucket_available_total = sum(
             (bucket.available_credits for bucket in buckets.values()),
@@ -5027,8 +5190,8 @@ def test_usage_split_and_bucket_expiry_keep_wallet_bucket_and_ledger_consistent(
 
         assert bucket_available_total == wallet.available_credits
         assert bucket_consumed_total == Decimal("2.5000000000")
-        assert bucket_expired_total == Decimal("2.0000000000")
-        assert ledger_reduction_total == Decimal("4.5000000000")
+        assert bucket_expired_total == Decimal("0")
+        assert ledger_reduction_total == Decimal("2.5000000000")
         for bucket in buckets.values():
             assert bucket.original_credits == (
                 bucket.available_credits

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle.py
@@ -226,14 +226,30 @@ def test_expire_credit_wallet_buckets_skips_credit_pack_bucket(
             entry_type=CREDIT_LEDGER_ENTRY_TYPE_EXPIRE,
         ).all()
 
+        assert payload["status"] == "noop"
+        assert payload["bucket_count"] == 0
+        assert payload["expired_credits"] == 0
+        assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
+        assert bucket.available_credits == Decimal("2.5000000000")
+        assert bucket.expired_credits == Decimal("0")
+        assert wallet.available_credits == Decimal("0E-10")
+        first_wallet_version = wallet.version
+        assert ledgers == []
+
+        payload = expire_credit_wallet_buckets(
+            billing_wallet_lifecycle_app,
+            creator_bid="creator-expire-topup-skip",
+            expire_before=datetime(2026, 4, 9, 0, 0, 0),
+        )
+
+        dao.db.session.expire_all()
+        wallet = CreditWallet.query.filter_by(
+            creator_bid="creator-expire-topup-skip"
+        ).one()
+
     assert payload["status"] == "noop"
-    assert payload["bucket_count"] == 0
-    assert payload["expired_credits"] == 0
-    assert bucket.status == CREDIT_BUCKET_STATUS_ACTIVE
-    assert bucket.available_credits == Decimal("2.5000000000")
-    assert bucket.expired_credits == Decimal("0")
     assert wallet.available_credits == Decimal("0E-10")
-    assert ledgers == []
+    assert wallet.version == first_wallet_version
 
 
 def test_expire_credit_wallet_buckets_uses_actual_mutation_time_for_bucket_update(
@@ -1652,6 +1668,24 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
                 "reserved_until": boundary_at.isoformat(),
             },
         )
+        topup_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-renewal-drift-topup-unfreeze",
+            creator_bid=wallet.creator_bid,
+            wallet_bid=wallet.wallet_bid,
+            wallet_bucket_bid=topup_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=topup_bucket.source_bid,
+            idempotency_key=f"grant:{topup_bucket.source_bid}",
+            amount=Decimal("500.0000000000"),
+            balance_after=Decimal("1500.0000000000"),
+            expires_at=topup_bucket.effective_to,
+            consumable_from=topup_bucket.effective_from,
+            metadata_json={
+                "bill_order_bid": topup_bucket.source_bid,
+                "grant_reason": "topup",
+            },
+        )
         event = BillingRenewalEvent(
             renewal_event_bid="renewal-event-protected-apply",
             subscription_bid=subscription.subscription_bid,
@@ -1665,7 +1699,17 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
             processed_at=None,
         )
         dao.db.session.add_all(
-            [wallet, subscription, product, order, bucket, topup_bucket, ledger, event]
+            [
+                wallet,
+                subscription,
+                product,
+                order,
+                bucket,
+                topup_bucket,
+                ledger,
+                topup_ledger,
+                event,
+            ]
         )
         dao.db.session.commit()
 
@@ -1689,6 +1733,9 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
         ).one()
         topup_bucket = CreditWalletBucket.query.filter_by(
             wallet_bucket_bid="bucket-renewal-drift-topup-unfreeze"
+        ).one()
+        topup_ledger = CreditLedgerEntry.query.filter_by(
+            ledger_bid="ledger-renewal-drift-topup-unfreeze"
         ).one()
 
     assert payload["status"] == "repaired"
@@ -1716,6 +1763,7 @@ def test_repair_renewal_state_drift_applies_overdue_reserved_paid_grant_before_e
     assert topup_bucket.available_credits == Decimal("500.0000000000")
     assert topup_bucket.expired_credits == Decimal("0")
     assert topup_bucket.effective_to == next_cycle_end
+    assert topup_ledger.expires_at == next_cycle_end
     assert ledger.metadata_json["bucket_credit_state"] == "available"
 
 


### PR DESCRIPTION
## Summary
- prevent credit pack/topup buckets from being ownership-expired when subscription windows lapse
- refresh wallet snapshots so lapsed plans freeze credit pack consumption without deducting owned pack credits
- realign credit pack consumability windows when an effective plan is restored
- update billing credit terminology/design docs and focused regression coverage

## Verification
- cd src/api && pytest tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_admission.py tests/service/billing/test_billing_renewal_execution.py -q
- cd src/api && .venv/bin/pytest tests/service/billing/ -q
- cd src/api && .venv/bin/ruff check flaskr/service/billing/wallets.py flaskr/service/billing/subscriptions.py tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_renewal_execution.py
- cd src/api && .venv/bin/ruff format --check flaskr/service/billing/wallets.py flaskr/service/billing/subscriptions.py tests/service/billing/test_billing_wallet_lifecycle.py tests/service/billing/test_billing_renewal_execution.py
- python scripts/check_repo_harness.py
- git diff --check
- PATH="/Users/iris/.local/bin:/Users/iris/.codex/tmp/arg0/codex-arg0uEUkmK:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" python scripts/check_dev_tools.py
- PATH="/Users/iris/.local/bin:/Users/iris/.codex/tmp/arg0/codex-arg0uEUkmK:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" lefthook run pre-commit --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected billing credit expiration behavior so subscription credits write appropriate expire ledger entries, while eligible top-up credits are frozen/unfrozen (and do not generate ownership-expire entries).
  * Excluded credit-pack (top-up) buckets from wallet expiration and expire-ledger drift repairs.
  * Realigned effective time windows for active buckets and refreshed frozen top-up wallet snapshots after subscription restoration.
* **New Features**
  * Added a billing repair workflow and CLI command to restore wrongly expired credit-pack buckets (dry-run vs apply), with idempotency and manual-review when amounts mismatch.
* **Documentation**
  * Clarified top-up “subscription-window” semantics and expiration vs consumable eligibility rules.
* **Tests**
  * Updated and expanded tests to match the corrected expiration/repair behavior and new restore workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->