### PR TITLE
feat: adopt native no-variable interaction support from markdown-flow

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -27,6 +27,7 @@ from markdown_flow import (
     BlockType,
     InteractionParser,
     replace_variables_in_text,
+    USER_ANSWER_CONTEXT_KEY,
 )
 from markdown_flow.llm import LLMResult
 from flask import Flask
@@ -571,16 +572,20 @@ class MdflowContextV2:
                     )
                 else:
                     # No-variable interaction (e.g. plain button choice
-                    # ?[A | B | C]): markdown-flow has no variable to recover
-                    # the learner's choice from and would collapse the turn
-                    # into {user: "ok"} + {assistant: "ok"}, dropping the
-                    # actual selection. Use the selection captured in
-                    # generated_content instead; if it is empty, skip the turn
-                    # rather than fabricate an "ok".
-                    user_content = (generated_block.generated_content or "").strip()
-                    if user_content:
-                        message_list.append({"role": "user", "content": user_content})
-                        message_list.append({"role": "assistant", "content": "ok"})
+                    # ?[A | B | C]): hand the raw syntax to markdown-flow with
+                    # the learner's answer attached via USER_ANSWER_CONTEXT_KEY.
+                    # The library expands it into {user: answer} +
+                    # {assistant: "ok"}, or skips the turn when the answer is
+                    # empty (never answered).
+                    message_list.append(
+                        {
+                            "role": "assistant",
+                            "content": block.content or "",
+                            USER_ANSWER_CONTEXT_KEY: (
+                                generated_block.generated_content or ""
+                            ).strip(),
+                        }
+                    )
         return message_list
 
 
@@ -2668,6 +2673,11 @@ class RunScriptContextV2:
         )
         # Backward compatible: some clients may still send `{input: [...]}` or a single
         # unnamed key even when the interaction expects a specific variable.
+        # TODO(non-assignment rollout): markdown-flow >= 0.3.0 merges values
+        # from any key for no-variable interactions, and the web client now
+        # submits the canonical "input" key. Drop this remap once the
+        # "input"-key frontend has been fully rolled out for one release
+        # cycle (older cached clients may still send the legacy keys).
         if expected_variable and expected_variable not in user_input_param:
             if "input" in user_input_param and len(user_input_param) == 1:
                 app.logger.warning(
@@ -2808,7 +2818,30 @@ class RunScriptContextV2:
         fall through to the completion tail.
         """
         run_script_info = state.run_script_info
-        if not parsed_interaction.get("variable"):
+        validate_result = state.mdflow_context.process(
+            block_index=run_script_info.block_position,
+            mode=ProcessMode.COMPLETE,
+            user_input=user_input_param,
+            context=state.message_list,
+            variables=state.user_profile,
+        )
+
+        if (
+            validate_result.metadata is not None
+            and validate_result.metadata.get("interaction_type")
+            == "non_assignment_button"
+        ):
+            # No-variable interaction: markdown-flow normalized the answer
+            # (button display -> value, free text passed through) into
+            # metadata["answer"]. Persist the normalized value so the context
+            # rebuild feeds the canonical answer back to the LLM.
+            answer_values = validate_result.metadata.get("answer") or []
+            normalized_answer = ",".join(
+                str(value) for value in answer_values if value is not None
+            )
+            if normalized_answer != (generated_block.generated_content or ""):
+                generated_block.generated_content = normalized_answer
+                self._recorder.save_generated_block(generated_block)
             self._can_continue = True
             self._run_type = RunType.OUTPUT
             self._recorder.update_progress_pointer(
@@ -2817,13 +2850,6 @@ class RunScriptContextV2:
                 block_position=run_script_info.block_position + 1,
             )
             return True
-        validate_result = state.mdflow_context.process(
-            block_index=run_script_info.block_position,
-            mode=ProcessMode.COMPLETE,
-            user_input=user_input_param,
-            context=state.message_list,
-            variables=state.user_profile,
-        )
 
         if validate_result.variables is not None and len(validate_result.variables) > 0:
             profile_to_save: list[ProfileToSave] = []

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2835,10 +2835,15 @@ class RunScriptContextV2:
             # (button display -> value, free text passed through) into
             # metadata["answer"]. Persist the normalized value so the context
             # rebuild feeds the canonical answer back to the LLM.
-            answer_values = validate_result.metadata.get("answer") or []
-            normalized_answer = ",".join(
-                str(value) for value in answer_values if value is not None
-            )
+            answer_values = validate_result.metadata.get("answer")
+            if isinstance(answer_values, list):
+                normalized_answer = ",".join(
+                    str(value) for value in answer_values if value is not None
+                )
+            elif answer_values is None:
+                normalized_answer = ""
+            else:
+                normalized_answer = str(answer_values)
             if normalized_answer != (generated_block.generated_content or ""):
                 generated_block.generated_content = normalized_answer
                 self._recorder.save_generated_block(generated_block)

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -125,4 +125,4 @@ zope.event==5.0
 zope.interface==7.1.1
 bcrypt==4.2.1
 --extra-index-url https://pypi.org/simple/
-markdown-flow==0.2.86
+markdown-flow==0.3.0

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -115,6 +115,7 @@ from flaskr.service.learn.context_v2 import (
     RunScriptPreviewContextV2,
     _PreviewContextStore,
 )
+from markdown_flow import MarkdownFlow, USER_ANSWER_CONTEXT_KEY
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.learn_dtos import (
     ElementType,
@@ -2166,11 +2167,12 @@ class BuildContextFromBlocksTests(unittest.TestCase):
 
 
 class BuildContextNoVariableInteractionTests(unittest.TestCase):
-    """No-variable interactions carry a real learner answer, but markdown-flow
-    has no variable to recover it from and would collapse the turn into
-    {user: "ok"} + {assistant: "ok"}, dropping the answer.
-    build_context_from_blocks must reuse the value captured in
-    generated_content, and skip the turn entirely when it is empty."""
+    """No-variable interactions carry a real learner answer with no variable
+    to recover it from. build_context_from_blocks attaches the answer stored
+    in generated_content to the interaction message via the user_answer
+    extension field (markdown-flow >= 0.3.0); the library then expands it
+    into {user: answer} + {assistant: "ok"}, or skips the turn when the
+    answer is empty."""
 
     DOC = (
         "Content one.\n"
@@ -2179,6 +2181,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
         "---\n"
         "Second content."
     )
+    INTERACTION = "?[网络招聘网站 | 猎头公司 | 人才测评 | 培训业务]"
 
     def _blocks(self, selection):
         return [
@@ -2194,7 +2197,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             ),
         ]
 
-    def test_selection_reused_instead_of_collapsing_to_ok(self):
+    def test_selection_attached_via_user_answer_field(self):
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
@@ -2206,31 +2209,72 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             [
                 {"role": "user", "content": "Content one."},
                 {"role": "assistant", "content": "reply zero"},
-                {"role": "user", "content": "猎头公司"},
-                {"role": "assistant", "content": "ok"},
+                {
+                    "role": "assistant",
+                    "content": self.INTERACTION,
+                    USER_ANSWER_CONTEXT_KEY: "猎头公司",
+                },
             ],
         )
-        # No raw ?[...] leaks and the user turn is the real choice, not "ok".
-        self.assertTrue(all("?[" not in m["content"] for m in messages))
 
-    def test_empty_selection_skips_the_interaction_turn(self):
+    def test_empty_selection_carries_empty_user_answer(self):
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
                 self._blocks("   "), self.DOC, {}
             )
 
-        # Only the content block survives; the empty interaction contributes
-        # nothing rather than a fabricated {user: "ok"} pair.
+        # The empty answer travels with the message; the library skips the
+        # turn instead of fabricating a {user: "ok"} pair.
         self.assertEqual(
-            messages,
+            messages[-1],
+            {
+                "role": "assistant",
+                "content": self.INTERACTION,
+                USER_ANSWER_CONTEXT_KEY: "",
+            },
+        )
+
+    def test_library_expands_answer_and_skips_empty_turns(self):
+        """End-to-end: the context built here goes through markdown-flow's
+        message transform and comes out with the real answer, no raw ?[...]
+        syntax, and no fabricated "ok" for unanswered interactions."""
+        app = Flask(__name__)
+        with app.app_context():
+            answered = MdflowContextV2.build_context_from_blocks(
+                self._blocks("猎头公司"), self.DOC, {}
+            )
+            unanswered = MdflowContextV2.build_context_from_blocks(
+                self._blocks(""), self.DOC, {}
+            )
+
+        mdflow = MarkdownFlow(self.DOC)
+        transformed = mdflow._transform_context_messages(answered, {})
+        self.assertEqual(
+            transformed,
+            [
+                {"role": "user", "content": "Content one."},
+                {"role": "assistant", "content": "reply zero"},
+                {"role": "user", "content": "猎头公司"},
+                {"role": "assistant", "content": "ok"},
+            ],
+        )
+        self.assertTrue(all("?[" not in m["content"] for m in transformed))
+        self.assertTrue(
+            all(USER_ANSWER_CONTEXT_KEY not in m for m in transformed),
+            "extension fields must never reach the LLM",
+        )
+
+        transformed_empty = mdflow._transform_context_messages(unanswered, {})
+        self.assertEqual(
+            transformed_empty,
             [
                 {"role": "user", "content": "Content one."},
                 {"role": "assistant", "content": "reply zero"},
             ],
         )
 
-    def test_variable_free_text_input_reuses_the_learner_answer(self):
+    def test_variable_free_text_input_carries_the_learner_answer(self):
         document = "Content one.\n---\n?[...What is your name?]\n---\nSecond content."
         app = Flask(__name__)
         with app.app_context():
@@ -2239,15 +2283,16 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             )
 
         self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "Content one."},
-                {"role": "assistant", "content": "reply zero"},
-                {"role": "user", "content": "Alice"},
-                {"role": "assistant", "content": "ok"},
-            ],
+            messages[-1],
+            {
+                "role": "assistant",
+                "content": "?[...What is your name?]",
+                USER_ANSWER_CONTEXT_KEY: "Alice",
+            },
         )
-        self.assertTrue(all("?[" not in message["content"] for message in messages))
+        transformed = MarkdownFlow(document)._transform_context_messages(messages, {})
+        self.assertIn({"role": "user", "content": "Alice"}, transformed)
+        self.assertTrue(all("?[" not in m["content"] for m in transformed))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

No-variable interactions (`?[Option A | Option B]`) are handled today by two host-side workarounds that bypass markdown-flow, introduced as temporary in #2087:

1. `build_context_from_blocks` hand-builds the `{user: answer}` + `{assistant: "ok"}` turns from `generated_content`, because the library used to collapse no-variable interactions into a literal `{user: "ok"}` and drop the learner's choice.
2. `_phase_validate_input_and_advance` skips `mdflow.process()` entirely for no-variable interactions and advances the cursor by hand.

markdown-flow 0.3.0 (ai-shifu/markdown-flow-agent-py#74) makes this capability native, so the workarounds can go.

## What

- `requirements.txt`: `markdown-flow` 0.2.86 → **0.3.0**
- `build_context_from_blocks`: the no-variable branch now emits the raw interaction message with the learner's answer attached via the library's `user_answer` extension field (`USER_ANSWER_CONTEXT_KEY`). The library expands it into the user/assistant turns, skips unanswered turns, and strips extension fields before the LLM sees the messages.
- `_phase_validate_input_and_advance`: no-variable input now goes through `mdflow.process()` like everything else. The library merges input values from any key, normalizes button display → value, and returns the canonical answer in `metadata["answer"]`; we persist that into `generated_content` (so `Save//save-action` stores `save-action`, not the display text) before advancing the cursor.
- The legacy input-key remap is kept with a TODO: drop it one release cycle after the `"input"`-key frontend (follow-up PR) is fully rolled out.
- `_sys_pay` / `_sys_login` / next-chapter system buttons are untouched (business semantics, not part of this contract).

## Verification

- `tests/service/learn/test_context_v2.py` no-variable suite rewritten against the new contract, including an end-to-end case proving the built context passes through markdown-flow's transform with the real answer, no raw `?[...]` leakage, no fabricated "ok" for unanswered turns, and no extension-field leakage
- `pytest tests/service/learn tests/service/shifu`: **681 passed, 5 skipped** (conda `ai-shifu`, markdown-flow 0.3.0 installed from the library branch)

## Blocked on

- [ ] ai-shifu/markdown-flow-agent-py#74 merged and `markdown-flow==0.3.0` published to PyPI (until then `pip install -r requirements.txt` cannot resolve — hence draft)

Frontend counterpart (drop the render adapter, unify the `input` submit key) comes as a separate PR on top of markdown-flow-ui 0.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of interactions without variables so learner selections are preserved correctly.
  * Empty selections are now skipped instead of generating placeholder responses.
  * Non-assignment button responses are normalized and saved consistently.
* **Bug Fixes**
  * Prevented raw interaction markup and internal answer metadata from appearing in generated context.
  * Updated interaction processing to produce accurate learner and assistant turns.
* **Tests**
  * Expanded coverage for empty, non-empty, and end-to-end interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->