### PR TITLE
fix: show credit packs as no expiration

### DIFF
--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -169,6 +169,8 @@ describe('BillingCreditDetailsPanel', () => {
   });
 
   test('summarizes topup buckets as no-expiration credits across eligibility windows', () => {
+    jest.setSystemTime(new Date('2026-04-15T00:00:00Z'));
+
     mockUseBillingWalletBuckets.mockReturnValue({
       data: {
         items: [
@@ -191,6 +193,17 @@ describe('BillingCreditDetailsPanel', () => {
             available_credits: 400,
             effective_from: '2026-04-01T00:00:00',
             effective_to: '2026-11-20T23:59:00',
+            priority: 30,
+            status: 'active',
+          },
+          {
+            wallet_bucket_bid: 'bucket-topup-future',
+            category: 'topup',
+            source_type: 'topup',
+            source_bid: 'topup-future',
+            available_credits: 300,
+            effective_from: '2026-05-01T00:00:00',
+            effective_to: '2026-12-20T23:59:00',
             priority: 30,
             status: 'active',
           },
@@ -219,6 +232,7 @@ describe('BillingCreditDetailsPanel', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('2026-10-21 07:59')).not.toBeInTheDocument();
     expect(screen.queryByText('2026-11-21 07:59')).not.toBeInTheDocument();
+    expect(screen.queryByText('1,300.00')).not.toBeInTheDocument();
   });
 
   test('revalidates wallet buckets after the overview snapshot loads', async () => {
@@ -645,6 +659,50 @@ describe('BillingCreditDetailsPanel', () => {
         '15.00',
       ),
     ).toBeInTheDocument();
+    expect(
+      within(topupLabel.closest('.grid') as HTMLElement).getByText('0.00'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('1,000.00')).not.toBeInTheDocument();
+  });
+
+  test('does not count topup buckets when the subscription period has ended', () => {
+    const overview = mockUseBillingOverview().data;
+    mockUseBillingOverview.mockReturnValue({
+      data: {
+        ...overview,
+        subscription: {
+          ...overview.subscription,
+          status: 'active',
+          current_period_end_at: '2026-04-14T23:59:00Z',
+        },
+      },
+      error: undefined,
+      isLoading: false,
+    });
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: {
+        items: [
+          {
+            wallet_bucket_bid: 'bucket-topup-after-period',
+            category: 'topup',
+            source_type: 'topup',
+            source_bid: 'topup-1',
+            available_credits: 1000,
+            effective_from: '2026-04-01T00:00:00Z',
+            effective_to: '2026-10-20T23:59:00Z',
+            priority: 30,
+            status: 'active',
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    const topupLabel = screen.getByText('module.billing.ledger.category.topup');
+
     expect(
       within(topupLabel.closest('.grid') as HTMLElement).getByText('0.00'),
     ).toBeInTheDocument();

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -154,7 +154,10 @@ describe('BillingCreditDetailsPanel', () => {
     expect(screen.getByText('100.00')).toBeInTheDocument();
     expect(screen.getByText('1,000.00')).toBeInTheDocument();
     expect(screen.getByText('2026-10-13 07:59')).toBeInTheDocument();
-    expect(screen.getByText('2026-10-21 07:59')).toBeInTheDocument();
+    expect(
+      screen.getByText('module.billing.details.topupAvailabilityLabel'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('2026-10-21 07:59')).not.toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', {
@@ -163,6 +166,59 @@ describe('BillingCreditDetailsPanel', () => {
     );
 
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test('summarizes topup buckets as no-expiration credits across eligibility windows', () => {
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: {
+        items: [
+          {
+            wallet_bucket_bid: 'bucket-topup-primary',
+            category: 'topup',
+            source_type: 'topup',
+            source_bid: 'topup-1',
+            available_credits: 600,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-10-20T23:59:00',
+            priority: 30,
+            status: 'active',
+          },
+          {
+            wallet_bucket_bid: 'bucket-topup-bonus',
+            category: 'topup',
+            source_type: 'campaign_bonus',
+            source_bid: 'campaign-1',
+            available_credits: 400,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-11-20T23:59:00',
+            priority: 30,
+            status: 'active',
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    expect(
+      screen.getAllByText('module.billing.ledger.category.topup'),
+    ).toHaveLength(1);
+    const topupLabel = screen.getByText('module.billing.ledger.category.topup');
+    const topupRow = topupLabel.closest('.grid');
+
+    expect(topupRow).not.toBeNull();
+    expect(
+      within(topupRow as HTMLElement).getByText('1,000.00'),
+    ).toBeInTheDocument();
+    expect(
+      within(topupRow as HTMLElement).getByText(
+        'module.billing.details.topupAvailabilityLabel',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('2026-10-21 07:59')).not.toBeInTheDocument();
+    expect(screen.queryByText('2026-11-21 07:59')).not.toBeInTheDocument();
   });
 
   test('revalidates wallet buckets after the overview snapshot loads', async () => {
@@ -400,7 +456,7 @@ describe('BillingCreditDetailsPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('excludes future and expired buckets from the current credit summary', () => {
+  test('excludes future subscription buckets but keeps credit packs independent of expiry windows', () => {
     mockUseBillingOverview.mockReturnValue({
       data: {
         creator_bid: 'creator-1',
@@ -503,10 +559,14 @@ describe('BillingCreditDetailsPanel', () => {
       within(subscriptionRow as HTMLElement).getByText('245.81'),
     ).toBeInTheDocument();
     expect(screen.queryByText('1,684.76')).not.toBeInTheDocument();
-    expect(screen.queryByText('99.00')).not.toBeInTheDocument();
     expect(topupRow).not.toBeNull();
     expect(
-      within(topupRow as HTMLElement).getByText('0.00'),
+      within(topupRow as HTMLElement).getByText('99.00'),
+    ).toBeInTheDocument();
+    expect(
+      within(topupRow as HTMLElement).getByText(
+        'module.billing.details.topupAvailabilityLabel',
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -212,9 +212,13 @@ export function BillingCreditDetailsPanel({
     isLoading: bucketsLoading,
     mutate: refreshWalletBuckets,
   } = useBillingWalletBuckets();
+  const subscriptionPeriodEnd = parseBillingDateValue(
+    overview?.subscription?.current_period_end_at,
+  );
   const hasActiveSubscription = Boolean(
     overview?.subscription &&
-    !['canceled', 'expired', 'draft'].includes(overview.subscription.status),
+    !['canceled', 'expired', 'draft'].includes(overview.subscription.status) &&
+    (!subscriptionPeriodEnd || subscriptionPeriodEnd > new Date()),
   );
   const activeSubscriptionEffectiveTo =
     hasActiveSubscription && overview?.subscription?.current_period_end_at

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -59,6 +59,12 @@ function isBucketInCurrentWindow(
   );
 }
 
+function hasBucketStarted(bucket: BillingWalletBucket, now: Date): boolean {
+  const effectiveFrom = parseBillingDateValue(bucket.effective_from);
+
+  return !effectiveFrom || effectiveFrom <= now;
+}
+
 function bucketRequiresActiveSubscription(
   bucket: BillingWalletBucket,
 ): boolean {
@@ -86,8 +92,11 @@ function buildCategorySummary(
         bucket.category === category &&
         bucket.status === 'active' &&
         Number(bucket.available_credits || 0) > 0 &&
-        isBucketInCurrentWindow(bucket, now) &&
-        (hasActiveSubscription || !bucketRequiresActiveSubscription(bucket)),
+        (category === 'topup'
+          ? hasActiveSubscription && hasBucketStarted(bucket, now)
+          : isBucketInCurrentWindow(bucket, now) &&
+            (hasActiveSubscription ||
+              !bucketRequiresActiveSubscription(bucket))),
     );
 
     if (activeBuckets.length === 0) {
@@ -127,29 +136,16 @@ function buildCategorySummary(
       ];
     }
 
-    const grouped = new Map<string, CategorySummaryRow>();
-    activeBuckets.forEach(bucket => {
-      const effectiveTo = bucket.effective_to || null;
-      const groupKey = effectiveTo || '__never_expires__';
-      const existing = grouped.get(groupKey);
-
-      if (existing) {
-        existing.availableCredits += Number(bucket.available_credits || 0);
-        return;
-      }
-
-      grouped.set(groupKey, {
+    return [
+      {
         category,
-        availableCredits: Number(bucket.available_credits || 0),
-        effectiveTo,
-      });
-    });
-
-    return Array.from(grouped.values()).sort((left, right) =>
-      String(left.effectiveTo || '9999-12-31T23:59:59').localeCompare(
-        String(right.effectiveTo || '9999-12-31T23:59:59'),
-      ),
-    );
+        availableCredits: activeBuckets.reduce(
+          (total, bucket) => total + Number(bucket.available_credits || 0),
+          0,
+        ),
+        effectiveTo: null,
+      },
+    ];
   });
 }
 
@@ -168,11 +164,11 @@ function CategoryValidityCell({
   topupAvailabilityLabel: string;
   topupAvailabilityTooltip: string;
 }) {
-  if (effectiveTo) {
-    return <>{formatBillingCompactDateTime(effectiveTo, locale)}</>;
-  }
-
   if (category !== 'topup') {
+    if (effectiveTo) {
+      return <>{formatBillingCompactDateTime(effectiveTo, locale)}</>;
+    }
+
     return <>{neverExpiresLabel}</>;
   }
 


### PR DESCRIPTION
## Summary
- Aggregate credit pack buckets into one top-up row in the billing credit details panel.
- Ignore credit pack bucket expiry windows for display eligibility when an active subscription exists.
- Always show the credit pack no-expiration availability label instead of a stored bucket date.

## Verification
- cd src/cook-web && npm test -- BillingCreditDetailsPanel.test.tsx --runInBand
- cd src/cook-web && npm run lint -- --file src/components/billing/BillingCreditDetailsPanel.tsx --file src/components/billing/BillingCreditDetailsPanel.test.tsx
- cd src/cook-web && npm run type-check
- PATH="/Users/iris/.local/bin:/Users/iris/.codex/tmp/arg0/codex-arg0uEUkmK:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" python scripts/check_dev_tools.py
- /Users/iris/.codex/bin/branch_context_manager.py sync
- /Users/iris/.codex/bin/branch_context_manager.py report
- /Users/iris/.codex/bin/branch_context_manager.py pre-pr-review
- /Users/iris/.codex/bin/branch_context_manager.py pre-push-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing credit details for top-up credits, including more accurate eligibility and activeness handling.
  * Combined multiple top-up buckets into a single availability row and updated labels/tooltips.
  * Excluded future/expired top-up timestamps from the displayed totals; when the subscription period ends, top-up totals correctly show as zero.
* **Tests**
  * Updated and added coverage for top-up rendering, exclusions, and end-of-subscription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->