### PR TITLE
fix: return creator_bid from admin entitlement grant

### DIFF
--- a/src/api/flaskr/service/billing/routes.py
+++ b/src/api/flaskr/service/billing/routes.py
@@ -478,7 +478,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
                 source="billing_admin_entitlement_grant",
                 created_new_user=created_new_user,
             )
-        return make_common_response(serialize_creator_entitlements(state))
+        # The create flow only knows the creator mobile; return the resolved
+        # creator_bid so the console can chain follow-up branding/domain calls
+        # right after the first grant.
+        response_payload = serialize_creator_entitlements(state).__json__()
+        response_payload["creator_bid"] = target_creator_bid
+        return make_common_response(response_payload)
 
     @app.route(admin_path_prefix + "/entitlements/<creator_bid>", methods=["POST"])
     def admin_bill_entitlement_grant_legacy_api(creator_bid: str):

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -929,6 +929,9 @@ class TestAdminBillingRoutes:
             assert entity is not None
             assert entity.is_creator == 1
             assert entity.state == 1102
+            # The console chains branding/domain calls right after the first
+            # grant, so the response must expose the resolved creator_bid.
+            assert payload["data"]["creator_bid"] == entity.user_bid
 
     def test_admin_billing_entitlements_can_filter_independent_configs(
         self,


### PR DESCRIPTION
## Summary

- In the admin console's create flow (operator enters only a creator mobile), the submit handler chains `grant → logo upload → branding save` and resolves the target from `response.creator_bid`. The grant endpoint serialized only `BillingEntitlementsDTO`, which has no `creator_bid`, so on the very first grant the follow-up upload and branding save were silently skipped — the operator had to submit a second time for the logo and logo link URL to persist (observed in production logs: first submit issues only the grant request, no `/branding/logo` or `/branding` calls follow).
- Fix: `POST /admin/billing/entitlements/grants` now includes the resolved `creator_bid` in its response payload, which the console already reads (`response as { creator_bid?: string }`).

## Validation

- Extended `test_admin_billing_entitlement_grant_accepts_creator_mobile` to assert the response exposes the created user's `creator_bid`.
- `python -m pytest tests/service/billing/test_admin_billing_routes.py` — 27 passed.
- `lefthook` pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin entitlement grant responses now include the resolved creator identifier.
  * This enables clients to use the creator identifier immediately in follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->