### PR TITLE
refactor: centralize billing cycle window resolution

### DIFF
--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -3513,26 +3513,33 @@ def resolve_creator_limit_state(app: Flask, creator_bid: str) -> dict[str, Any]:
             .first()
         )
         available = _to_decimal(getattr(wallet, "available_credits", _ZERO))
-        policy = load_credit_notification_policy()
-        softlimit = policy.get("softlimit")
-        softlimit_enabled = isinstance(softlimit, dict) and _coerce_bool(
-            softlimit.get("enabled")
-        )
-        disable_debug = isinstance(softlimit, dict) and _coerce_bool(
-            softlimit.get("disable_debug", True)
-        )
-        threshold_payload = (
-            softlimit.get("threshold") if isinstance(softlimit, dict) else {}
-        )
-        threshold = _ZERO
-        if isinstance(threshold_payload, dict):
-            threshold = _decimal_from_policy(threshold_payload.get("value"), _ZERO)
-        if available <= _ZERO:
-            state = LIMIT_STATE_HARDLIMIT
-        elif softlimit_enabled and available <= threshold:
-            state = LIMIT_STATE_SOFTLIMIT
-        else:
-            state = LIMIT_STATE_NORMAL
+        return build_creator_limit_state_for_available_credits(available)
+
+
+def build_creator_limit_state_for_available_credits(
+    available_credits: Decimal,
+) -> dict[str, Any]:
+    available = _to_decimal(available_credits)
+    policy = load_credit_notification_policy()
+    softlimit = policy.get("softlimit")
+    softlimit_enabled = isinstance(softlimit, dict) and _coerce_bool(
+        softlimit.get("enabled")
+    )
+    disable_debug = isinstance(softlimit, dict) and _coerce_bool(
+        softlimit.get("disable_debug", True)
+    )
+    threshold_payload = (
+        softlimit.get("threshold") if isinstance(softlimit, dict) else {}
+    )
+    threshold = _ZERO
+    if isinstance(threshold_payload, dict):
+        threshold = _decimal_from_policy(threshold_payload.get("value"), _ZERO)
+    if available <= _ZERO:
+        state = LIMIT_STATE_HARDLIMIT
+    elif softlimit_enabled and available <= threshold:
+        state = LIMIT_STATE_SOFTLIMIT
+    else:
+        state = LIMIT_STATE_NORMAL
     return {
         "state": state,
         "debug_allowed": not (state == LIMIT_STATE_SOFTLIMIT and disable_debug),

--- a/src/api/flaskr/service/billing/cycle_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_transitions.py
@@ -1,0 +1,92 @@
+"""Cycle window resolution helpers for billing state transitions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Callable
+
+from .consts import (
+    BILLING_INTERVAL_DAY,
+    BILLING_INTERVAL_MONTH,
+    BILLING_INTERVAL_YEAR,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_TOPUP,
+)
+from .queries import (
+    extract_resolved_order_cycle_end_at,
+    extract_resolved_order_cycle_start_at,
+)
+
+
+def resolve_order_effective_from(
+    *,
+    order: Any,
+    default_effective_from: datetime,
+    load_subscription_by_bid: Callable[[str], Any | None],
+) -> datetime:
+    if order.order_type != BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
+        return default_effective_from
+    metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
+    renewal_cycle_start_at = extract_resolved_order_cycle_start_at(metadata)
+    if renewal_cycle_start_at is not None:
+        return renewal_cycle_start_at
+    subscription = load_subscription_by_bid(order.subscription_bid)
+    if (
+        subscription is None
+        or subscription.current_period_end_at is None
+        or subscription.current_period_end_at <= default_effective_from
+    ):
+        return default_effective_from
+    return subscription.current_period_end_at
+
+
+def resolve_order_effective_to(
+    *,
+    order: Any,
+    product: Any,
+    effective_from: datetime,
+    load_subscription_by_bid: Callable[[str], Any | None],
+    resolve_topup_effective_to: Callable[[str, datetime], datetime | None],
+    is_self_managed_order: Callable[[Any], bool],
+    calculate_provider_cycle_end: Callable[[Any, datetime], datetime | None],
+    calculate_self_managed_cycle_end: Callable[[Any, datetime], datetime | None],
+) -> datetime | None:
+    if order.order_type == BILLING_ORDER_TYPE_TOPUP:
+        return resolve_topup_effective_to(order.creator_bid, effective_from)
+
+    metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
+    resolved_cycle_end_at = extract_resolved_order_cycle_end_at(metadata)
+    if resolved_cycle_end_at is not None:
+        return resolved_cycle_end_at
+
+    if (
+        order.subscription_bid
+        and order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_START
+    ):
+        subscription = load_subscription_by_bid(order.subscription_bid)
+        if (
+            subscription is not None
+            and subscription.current_period_start_at == effective_from
+            and subscription.current_period_end_at is not None
+            and subscription.current_period_end_at > effective_from
+        ):
+            return subscription.current_period_end_at
+
+    interval = int(product.billing_interval or 0)
+    interval_count = max(int(product.billing_interval_count or 0), 0)
+    if interval_count <= 0:
+        return None
+    if interval == BILLING_INTERVAL_DAY:
+        if is_self_managed_order(order):
+            return calculate_self_managed_cycle_end(product, effective_from)
+        return effective_from + timedelta(days=interval_count)
+    if interval == BILLING_INTERVAL_MONTH:
+        if is_self_managed_order(order):
+            return calculate_self_managed_cycle_end(product, effective_from)
+        return calculate_provider_cycle_end(product, effective_from)
+    if interval == BILLING_INTERVAL_YEAR:
+        if is_self_managed_order(order):
+            return calculate_self_managed_cycle_end(product, effective_from)
+        return calculate_provider_cycle_end(product, effective_from)
+    return None

--- a/src/api/flaskr/service/billing/operation_credits.py
+++ b/src/api/flaskr/service/billing/operation_credits.py
@@ -21,6 +21,7 @@ from . import primitives as billing_primitives
 from .bucket_categories import (
     build_wallet_bucket_runtime_sort_key,
     load_billing_order_type_by_bid,
+    wallet_bucket_requires_active_subscription,
 )
 from .charges import build_metric_charge
 from .consts import (
@@ -33,6 +34,7 @@ from .consts import (
     CREDIT_SOURCE_TYPE_USAGE,
 )
 from .models import CreditLedgerEntry, CreditWallet, CreditWalletBucket
+from .subscriptions import load_effective_topup_subscription
 from .wallets import persist_credit_wallet_snapshot, sync_credit_bucket_status
 
 
@@ -462,6 +464,19 @@ def _load_active_buckets(
         row
         for row in rows
         if billing_primitives.to_decimal(row.available_credits) > _ZERO
+    ]
+    has_active_subscription = (
+        load_effective_topup_subscription(wallet.creator_bid, as_of=operation_at)
+        is not None
+    )
+    candidates = [
+        row
+        for row in candidates
+        if has_active_subscription
+        or not wallet_bucket_requires_active_subscription(
+            row,
+            load_order_type=load_billing_order_type_by_bid,
+        )
     ]
     candidates.sort(
         key=lambda row: build_wallet_bucket_runtime_sort_key(

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -101,6 +101,7 @@ from .queries import (
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
 from .primitives import credit_decimal_to_number
+from .primitives import is_billing_enabled
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
 from .serializers import (
@@ -619,7 +620,16 @@ def build_billing_overview(
             )
             wallet_payload.reserved_credits = credit_decimal_to_number(reserved_credits)
         subscription_payload = _serialize_subscription(app, subscription)
-        limit_state = build_creator_limit_state_for_available_credits(available_credits)
+        limit_state = (
+            build_creator_limit_state_for_available_credits(available_credits)
+            if is_billing_enabled()
+            else {
+                "state": "normal",
+                "debug_allowed": True,
+                "available_credits": "0",
+                "softlimit_threshold": "0",
+            }
+        )
         softlimit_threshold = limit_state.get("softlimit_threshold")
         return BillingOverviewDTO(
             creator_bid=normalized_creator_bid,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -52,7 +52,7 @@ from .bucket_categories import (
     build_wallet_bucket_runtime_sort_key,
     load_billing_order_type_by_bid,
 )
-from .credit_notifications import resolve_creator_limit_state
+from .credit_notifications import build_creator_limit_state_for_available_credits
 from .dtos import (
     AdminBillingDailyLedgerSummaryPageDTO,
     AdminBillingFocusTeacherDTO,
@@ -606,6 +606,7 @@ def build_billing_overview(
         subscription = _load_current_subscription(normalized_creator_bid)
 
         wallet_payload = _serialize_wallet(wallet)
+        available_credits = Decimal("0")
         if wallet is not None:
             available_credits, reserved_credits = (
                 calculate_credit_wallet_snapshot_values(
@@ -618,7 +619,7 @@ def build_billing_overview(
             )
             wallet_payload.reserved_credits = credit_decimal_to_number(reserved_credits)
         subscription_payload = _serialize_subscription(app, subscription)
-        limit_state = resolve_creator_limit_state(app, normalized_creator_bid)
+        limit_state = build_creator_limit_state_for_available_credits(available_credits)
         softlimit_threshold = limit_state.get("softlimit_threshold")
         return BillingOverviewDTO(
             creator_bid=normalized_creator_bid,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -118,7 +118,10 @@ from .serializers import (
     serialize_wallet_bucket as _serialize_wallet_bucket,
 )
 from .trials import resolve_new_creator_trial_offer as _resolve_new_creator_trial_offer
-from .wallets import adjust_credit_wallet_balance
+from .wallets import (
+    adjust_credit_wallet_balance,
+    calculate_credit_wallet_snapshot_values,
+)
 
 _OPERATOR_PRODUCT_FILTER_LANGUAGES = ("zh-CN", "en-US", "fr-FR")
 _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
@@ -603,6 +606,17 @@ def build_billing_overview(
         subscription = _load_current_subscription(normalized_creator_bid)
 
         wallet_payload = _serialize_wallet(wallet)
+        if wallet is not None:
+            available_credits, reserved_credits = (
+                calculate_credit_wallet_snapshot_values(
+                    wallet,
+                    snapshot_at=now_utc(),
+                )
+            )
+            wallet_payload.available_credits = credit_decimal_to_number(
+                available_credits
+            )
+            wallet_payload.reserved_credits = credit_decimal_to_number(reserved_credits)
         subscription_payload = _serialize_subscription(app, subscription)
         limit_state = resolve_creator_limit_state(app, normalized_creator_bid)
         softlimit_threshold = limit_state.get("softlimit_threshold")

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -40,6 +40,7 @@ from .consts import (
     BILLING_SUBSCRIPTION_STATUS_LABELS,
     BILLING_SUBSCRIPTION_STATUS_PAUSED,
     BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
+    CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_CATEGORY_LABELS,
     CREDIT_BUCKET_STATUS_LABELS,
     CREDIT_LEDGER_ENTRY_TYPE_LABELS,
@@ -91,6 +92,7 @@ from .primitives import (
     credit_decimal_to_number,
     normalize_bid,
     normalize_json_object,
+    to_decimal,
 )
 from .queries import load_product_code_map
 
@@ -490,18 +492,24 @@ def serialize_wallet_bucket(
     app: Flask,
     row: CreditWalletBucket,
 ) -> BillingWalletBucketDTO:
-    runtime_status = CREDIT_BUCKET_STATUS_LABELS.get(row.status, "active")
-    if (
-        runtime_status == "active"
-        and row.effective_to is not None
-        and row.effective_to <= now_utc()
-    ):
-        runtime_status = "expired"
-
     category_code = resolve_wallet_bucket_runtime_category(
         row,
         load_order_type=load_billing_order_type_by_bid,
     )
+    current_at = now_utc()
+    runtime_status = CREDIT_BUCKET_STATUS_LABELS.get(row.status, "active")
+    if (
+        runtime_status == "active"
+        and row.effective_to is not None
+        and row.effective_to <= current_at
+        and not (
+            category_code == CREDIT_BUCKET_CATEGORY_TOPUP
+            and to_decimal(row.available_credits) > 0
+            and (row.effective_from is None or row.effective_from <= current_at)
+        )
+    ):
+        runtime_status = "expired"
+
     return BillingWalletBucketDTO(
         wallet_bucket_bid=row.wallet_bucket_bid,
         category=CREDIT_BUCKET_CATEGORY_LABELS.get(category_code, "subscription"),

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -16,9 +16,6 @@ from flaskr.util.uuid import generate_id
 from flaskr.util.datetime import now_utc
 
 from .consts import (
-    BILLING_INTERVAL_DAY,
-    BILLING_INTERVAL_MONTH,
-    BILLING_INTERVAL_YEAR,
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
@@ -62,6 +59,10 @@ from .credit_mutations import (
     activate_reserved_grant_credit,
     reserved_grant_state as _shared_reserved_grant_state,
 )
+from .cycle_transitions import (
+    resolve_order_effective_from as _resolve_order_effective_from,
+    resolve_order_effective_to as _resolve_order_effective_to,
+)
 from .dtos import BillingSubscriptionDTO
 from .models import (
     BillingOrder,
@@ -84,7 +85,6 @@ from .preorders import (
 )
 from .queries import (
     extract_order_metadata_datetime as _extract_order_metadata_datetime,
-    extract_resolved_order_cycle_end_at as _extract_resolved_order_cycle_end_at,
     extract_resolved_order_cycle_start_at as _extract_resolved_order_cycle_start_at,
     calculate_billing_cycle_end as _calc_provider_cycle_end,
     calculate_self_managed_billing_cycle_end_after_boundary as _calc_self_managed_cycle_end_after_boundary,
@@ -2452,62 +2452,31 @@ def _resolve_credit_bucket_effective_to(
     product: BillingProduct,
     effective_from: datetime,
 ) -> datetime | None:
-    if order.order_type == BILLING_ORDER_TYPE_TOPUP:
-        return _resolve_topup_bucket_effective_to(
-            creator_bid=order.creator_bid,
-            effective_from=effective_from,
-        )
-
-    metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
-    resolved_cycle_end_at = _extract_resolved_order_cycle_end_at(metadata)
-    if resolved_cycle_end_at is not None:
-        return resolved_cycle_end_at
-
-    if (
-        order.subscription_bid
-        and order.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_START
-    ):
-        subscription = _load_subscription_by_bid(order.subscription_bid)
-        if (
-            subscription is not None
-            and subscription.current_period_start_at == effective_from
-            and subscription.current_period_end_at is not None
-            and subscription.current_period_end_at > effective_from
-        ):
-            return subscription.current_period_end_at
-
-    interval = int(product.billing_interval or 0)
-    interval_count = max(int(product.billing_interval_count or 0), 0)
-    if interval_count <= 0:
-        return None
-    if interval == BILLING_INTERVAL_DAY:
-        if _is_self_managed_billing_order(order):
-            return _calc_self_managed_cycle_end(
-                product,
-                cycle_start_at=effective_from,
+    return _resolve_order_effective_to(
+        order=order,
+        product=product,
+        effective_from=effective_from,
+        load_subscription_by_bid=_load_subscription_by_bid,
+        resolve_topup_effective_to=lambda creator_bid, from_at: (
+            _resolve_topup_bucket_effective_to(
+                creator_bid=creator_bid,
+                effective_from=from_at,
             )
-        return effective_from + timedelta(days=interval_count)
-    if interval == BILLING_INTERVAL_MONTH:
-        if _is_self_managed_billing_order(order):
-            return _calc_self_managed_cycle_end(
-                product,
-                cycle_start_at=effective_from,
+        ),
+        is_self_managed_order=_is_self_managed_billing_order,
+        calculate_provider_cycle_end=lambda resolved_product, cycle_start_at: (
+            _calc_provider_cycle_end(
+                resolved_product,
+                cycle_start_at=cycle_start_at,
             )
-        return _calc_provider_cycle_end(
-            product,
-            cycle_start_at=effective_from,
-        )
-    if interval == BILLING_INTERVAL_YEAR:
-        if _is_self_managed_billing_order(order):
-            return _calc_self_managed_cycle_end(
-                product,
-                cycle_start_at=effective_from,
+        ),
+        calculate_self_managed_cycle_end=lambda resolved_product, cycle_start_at: (
+            _calc_self_managed_cycle_end(
+                resolved_product,
+                cycle_start_at=cycle_start_at,
             )
-        return _calc_provider_cycle_end(
-            product,
-            cycle_start_at=effective_from,
-        )
-    return None
+        ),
+    )
 
 
 def _is_self_managed_billing_order(order: BillingOrder) -> bool:
@@ -2875,20 +2844,11 @@ def _resolve_credit_bucket_effective_from(
     order: BillingOrder,
     default_effective_from: datetime,
 ) -> datetime:
-    if order.order_type != BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL:
-        return default_effective_from
-    metadata = order.metadata_json if isinstance(order.metadata_json, dict) else {}
-    renewal_cycle_start_at = _extract_resolved_order_cycle_start_at(metadata)
-    if renewal_cycle_start_at is not None:
-        return renewal_cycle_start_at
-    subscription = _load_subscription_by_bid(order.subscription_bid)
-    if (
-        subscription is None
-        or subscription.current_period_end_at is None
-        or subscription.current_period_end_at <= default_effective_from
-    ):
-        return default_effective_from
-    return subscription.current_period_end_at
+    return _resolve_order_effective_from(
+        order=order,
+        default_effective_from=default_effective_from,
+        load_subscription_by_bid=_load_subscription_by_bid,
+    )
 
 
 def _sync_subscription_lifecycle_events(

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from flaskr.service.billing.consts import (
+    BILLING_INTERVAL_MONTH,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_TOPUP,
+)
+from flaskr.service.billing.cycle_transitions import (
+    resolve_order_effective_from,
+    resolve_order_effective_to,
+)
+
+
+def test_resolve_order_effective_from_prefers_order_cycle_metadata() -> None:
+    default_effective_from = datetime(2026, 7, 1, 0, 0, 0)
+    cycle_start_at = datetime(2026, 7, 31, 0, 0, 0)
+    order = SimpleNamespace(
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        subscription_bid="subscription-cycle",
+        metadata_json={"renewal_cycle_start_at": cycle_start_at.isoformat()},
+    )
+
+    effective_from = resolve_order_effective_from(
+        order=order,
+        default_effective_from=default_effective_from,
+        load_subscription_by_bid=lambda _: None,
+    )
+
+    assert effective_from == cycle_start_at
+
+
+def test_resolve_order_effective_from_uses_subscription_boundary_for_early_renewal() -> (
+    None
+):
+    default_effective_from = datetime(2026, 7, 1, 0, 0, 0)
+    subscription_boundary = datetime(2026, 7, 31, 0, 0, 0)
+    order = SimpleNamespace(
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        subscription_bid="subscription-cycle",
+        metadata_json={},
+    )
+    subscription = SimpleNamespace(current_period_end_at=subscription_boundary)
+
+    effective_from = resolve_order_effective_from(
+        order=order,
+        default_effective_from=default_effective_from,
+        load_subscription_by_bid=lambda _: subscription,
+    )
+
+    assert effective_from == subscription_boundary
+
+
+def test_resolve_order_effective_to_uses_topup_subscription_window() -> None:
+    effective_from = datetime(2026, 7, 1, 0, 0, 0)
+    effective_to = datetime(2026, 7, 31, 0, 0, 0)
+    order = SimpleNamespace(
+        order_type=BILLING_ORDER_TYPE_TOPUP,
+        creator_bid="creator-cycle",
+        subscription_bid="",
+        metadata_json={},
+    )
+    product = SimpleNamespace(
+        billing_interval=BILLING_INTERVAL_MONTH,
+        billing_interval_count=1,
+    )
+
+    resolved = resolve_order_effective_to(
+        order=order,
+        product=product,
+        effective_from=effective_from,
+        load_subscription_by_bid=lambda _: None,
+        resolve_topup_effective_to=lambda creator_bid, from_at: effective_to,
+        is_self_managed_order=lambda _: False,
+        calculate_provider_cycle_end=lambda _, cycle_start_at: None,
+        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+    )
+
+    assert resolved == effective_to
+
+
+def test_resolve_order_effective_to_prefers_existing_subscription_start_window() -> (
+    None
+):
+    effective_from = datetime(2026, 7, 1, 0, 0, 0)
+    effective_to = datetime(2026, 7, 31, 0, 0, 0)
+    order = SimpleNamespace(
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+        creator_bid="creator-cycle",
+        subscription_bid="subscription-cycle",
+        metadata_json={},
+    )
+    product = SimpleNamespace(
+        billing_interval=BILLING_INTERVAL_MONTH,
+        billing_interval_count=1,
+    )
+    subscription = SimpleNamespace(
+        current_period_start_at=effective_from,
+        current_period_end_at=effective_to,
+    )
+
+    resolved = resolve_order_effective_to(
+        order=order,
+        product=product,
+        effective_from=effective_from,
+        load_subscription_by_bid=lambda _: subscription,
+        resolve_topup_effective_to=lambda creator_bid, from_at: None,
+        is_self_managed_order=lambda _: False,
+        calculate_provider_cycle_end=lambda _, cycle_start_at: None,
+        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+    )
+
+    assert resolved == effective_to
+
+
+def test_resolve_order_effective_to_uses_provider_cycle_calculator() -> None:
+    effective_from = datetime(2026, 7, 1, 0, 0, 0)
+    effective_to = datetime(2026, 8, 1, 0, 0, 0)
+    order = SimpleNamespace(
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        creator_bid="creator-cycle",
+        subscription_bid="subscription-cycle",
+        metadata_json={},
+    )
+    product = SimpleNamespace(
+        billing_interval=BILLING_INTERVAL_MONTH,
+        billing_interval_count=1,
+    )
+
+    resolved = resolve_order_effective_to(
+        order=order,
+        product=product,
+        effective_from=effective_from,
+        load_subscription_by_bid=lambda _: None,
+        resolve_topup_effective_to=lambda creator_bid, from_at: None,
+        is_self_managed_order=lambda _: False,
+        calculate_provider_cycle_end=lambda _, cycle_start_at: effective_to,
+        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+    )
+
+    assert resolved == effective_to

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -814,6 +814,25 @@ class TestBillingRoutes:
         assert bucket_payload["data"]["items"][0]["priority"] == 20
         assert bucket_payload["data"]["items"][2]["source_bid"] == "topup-1"
 
+    def test_overview_recalculates_wallet_snapshot_for_current_balance(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+        with app.app_context():
+            wallet = CreditWallet.query.filter(
+                CreditWallet.wallet_bid == "wallet-1",
+            ).one()
+            wallet.available_credits = Decimal("0")
+            wallet.reserved_credits = Decimal("0")
+            dao.db.session.add(wallet)
+            dao.db.session.commit()
+
+            overview = build_billing_overview(app, "creator-1")
+
+            assert overview.wallet.available_credits == 120.5
+            assert overview.wallet.reserved_credits == 0
+            assert wallet.available_credits == Decimal("0")
+
     def test_overview_marks_stale_active_subscription_expired_without_db_update(
         self, billing_test_client
     ) -> None:

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -836,9 +836,16 @@ class TestBillingRoutes:
             assert wallet.available_credits == Decimal("0")
 
     def test_overview_limit_state_uses_current_consumable_bucket_balance(
-        self, billing_test_client
+        self,
+        billing_test_client,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         app = billing_test_client.application
+        monkeypatch.setattr(
+            billing_read_models_module,
+            "is_billing_enabled",
+            lambda: True,
+        )
         with app.app_context():
             wallet = CreditWallet.query.filter(
                 CreditWallet.wallet_bid == "wallet-1",
@@ -861,6 +868,34 @@ class TestBillingRoutes:
 
             assert overview.wallet.available_credits == 0
             assert overview.credit_status == "hardlimit"
+
+    def test_overview_limit_state_remains_normal_when_billing_disabled(
+        self,
+        billing_test_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        app = billing_test_client.application
+        monkeypatch.setattr(
+            billing_read_models_module,
+            "is_billing_enabled",
+            lambda: False,
+        )
+        with app.app_context():
+            wallet = CreditWallet.query.filter(
+                CreditWallet.wallet_bid == "wallet-1",
+            ).one()
+            wallet.available_credits = Decimal("0")
+            for bucket in CreditWalletBucket.query.filter(
+                CreditWalletBucket.wallet_bid == "wallet-1",
+            ).all():
+                bucket.available_credits = Decimal("0")
+            dao.db.session.commit()
+
+            overview = build_billing_overview(app, "creator-1")
+
+            assert overview.wallet.available_credits == 0
+            assert overview.credit_status == "normal"
+            assert overview.debug_allowed is True
 
     def test_overview_marks_stale_active_subscription_expired_without_db_update(
         self, billing_test_client

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -831,7 +831,36 @@ class TestBillingRoutes:
 
             assert overview.wallet.available_credits == 120.5
             assert overview.wallet.reserved_credits == 0
+            assert overview.credit_status == "normal"
+            assert overview.debug_allowed is True
             assert wallet.available_credits == Decimal("0")
+
+    def test_overview_limit_state_uses_current_consumable_bucket_balance(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+        with app.app_context():
+            wallet = CreditWallet.query.filter(
+                CreditWallet.wallet_bid == "wallet-1",
+            ).one()
+            wallet.available_credits = Decimal("20.0000000000")
+            subscription = BillingSubscription.query.filter(
+                BillingSubscription.subscription_bid == "sub-1",
+            ).one()
+            subscription.current_period_end_at = datetime(2026, 4, 5, 0, 0, 0)
+            for bucket in CreditWalletBucket.query.filter(
+                CreditWalletBucket.wallet_bid == "wallet-1",
+            ).all():
+                if bucket.wallet_bucket_bid == "bucket-topup":
+                    bucket.available_credits = Decimal("20.0000000000")
+                else:
+                    bucket.available_credits = Decimal("0")
+            dao.db.session.commit()
+
+            overview = build_billing_overview(app, "creator-1")
+
+            assert overview.wallet.available_credits == 0
+            assert overview.credit_status == "hardlimit"
 
     def test_overview_marks_stale_active_subscription_expired_without_db_update(
         self, billing_test_client
@@ -1108,6 +1137,36 @@ class TestBillingRoutes:
         assert bucket_map["bucket-free"]["status"] == "expired"
         assert bucket_map["bucket-subscription"]["status"] == "expired"
         assert bucket_map["bucket-topup"]["status"] == "active"
+
+    def test_wallet_buckets_keep_owned_topup_visible_after_old_window_ends(
+        self,
+        billing_test_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "flaskr.service.billing.serializers.now_utc",
+            lambda: datetime(2026, 5, 1, 12, 0, 0),
+        )
+        app = billing_test_client.application
+        with app.app_context():
+            bucket = CreditWalletBucket.query.filter(
+                CreditWalletBucket.wallet_bucket_bid == "bucket-topup",
+            ).one()
+            bucket.effective_to = datetime(2026, 4, 5, 0, 0, 0)
+            bucket.available_credits = Decimal("15.3800000000")
+            dao.db.session.commit()
+
+        payload = billing_test_client.get("/api/billing/wallet-buckets").get_json(
+            force=True
+        )
+        bucket_map = {
+            item["wallet_bucket_bid"]: item for item in payload["data"]["items"]
+        }
+
+        assert payload["code"] == 0
+        assert bucket_map["bucket-topup"]["category"] == "topup"
+        assert bucket_map["bucket-topup"]["status"] == "active"
+        assert bucket_map["bucket-topup"]["available_credits"] == 15.38
 
     def test_billing_public_builders_return_dto_instances(
         self,

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -9,15 +9,19 @@ import pytest
 import flaskr.dao as dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_TTS_REQUEST_COUNT,
+    BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     CREDIT_BUCKET_CATEGORY_FREE,
+    CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_STATUS_ACTIVE,
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
     CREDIT_LEDGER_ENTRY_TYPE_HOLD,
     CREDIT_LEDGER_ENTRY_TYPE_RELEASE,
     CREDIT_ROUNDING_MODE_CEIL,
+    CREDIT_SOURCE_TYPE_TOPUP,
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from flaskr.service.billing.models import (
+    BillingSubscription,
     CreditLedgerEntry,
     CreditUsageRate,
     CreditWallet,
@@ -295,6 +299,79 @@ def test_reserve_operation_credits_rejects_insufficient_balance(
     assert exc_info.value.code == ERROR_CODE["server.billing.creditInsufficient"]
 
 
+def test_reserve_operation_credits_freezes_topup_without_active_subscription(
+    operation_credit_app: Flask,
+) -> None:
+    from flaskr.service.billing.operation_credits import reserve_operation_credits
+
+    creator_bid = "creator-frozen-topup"
+    with operation_credit_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid=f"wallet-{creator_bid}",
+            creator_bid=creator_bid,
+            available_credits=Decimal("15.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("15.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid=f"bucket-{creator_bid}",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=f"topup-{creator_bid}",
+            priority=30,
+            original_credits=Decimal("15.0000000000"),
+            available_credits=Decimal("15.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 1, 1, 0, 0, 0),
+            effective_to=datetime(2099, 1, 1, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        subscription = BillingSubscription(
+            subscription_bid=f"subscription-{creator_bid}",
+            creator_bid=creator_bid,
+            product_bid="product-plan-expired",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 1, 1, 0, 0, 0),
+            current_period_end_at=datetime(2026, 1, 15, 0, 0, 0),
+        )
+        dao.db.session.add_all([wallet, bucket, subscription])
+        dao.db.session.commit()
+
+    with pytest.raises(AppException) as exc_info:
+        reserve_operation_credits(
+            operation_credit_app,
+            creator_bid=creator_bid,
+            amount=Decimal("1.0000000000"),
+            operation_type="voice_clone",
+            operation_bid="voice-bid-frozen-topup",
+            metadata={},
+        )
+
+    assert exc_info.value.code == ERROR_CODE["server.billing.creditInsufficient"]
+    with operation_credit_app.app_context():
+        wallet = CreditWallet.query.filter_by(creator_bid=creator_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(creator_bid=creator_bid).one()
+        assert wallet.available_credits == Decimal("15.0000000000")
+        assert wallet.reserved_credits == Decimal("0E-10")
+        assert bucket.available_credits == Decimal("15.0000000000")
+        assert bucket.reserved_credits == Decimal("0E-10")
+        assert (
+            CreditLedgerEntry.query.filter_by(
+                creator_bid=creator_bid,
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_HOLD,
+            ).count()
+            == 0
+        )
+
+
 def test_operation_credit_mutations_request_wallet_and_bucket_locks(
     operation_credit_app: Flask,
     monkeypatch,
@@ -319,15 +396,15 @@ def test_operation_credit_mutations_request_wallet_and_bucket_locks(
 
     def spy_load_wallet(creator_bid: str, *, lock: bool = False):
         wallet_lock_calls.append(lock)
-        return real_load_wallet(creator_bid)
+        return real_load_wallet(creator_bid, lock=lock)
 
     def spy_load_active_buckets(wallet, operation_at, *, lock: bool = False):
         active_bucket_lock_calls.append(lock)
-        return real_load_active_buckets(wallet, operation_at)
+        return real_load_active_buckets(wallet, operation_at, lock=lock)
 
     def spy_iter_hold_buckets(hold, *, lock: bool = False):
         hold_bucket_lock_calls.append(lock)
-        return real_iter_hold_buckets(hold)
+        return real_iter_hold_buckets(hold, lock=lock)
 
     monkeypatch.setattr(operation_credits, "_load_wallet", spy_load_wallet)
     monkeypatch.setattr(

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -301,9 +301,14 @@ def test_reserve_operation_credits_rejects_insufficient_balance(
 
 def test_reserve_operation_credits_freezes_topup_without_active_subscription(
     operation_credit_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from flaskr.service.billing.operation_credits import reserve_operation_credits
 
+    monkeypatch.setattr(
+        "flaskr.service.billing.operation_credits.now_utc",
+        lambda: datetime(2026, 1, 16, 0, 0, 0),
+    )
     creator_bid = "creator-frozen-topup"
     with operation_credit_app.app_context():
         wallet = CreditWallet(
@@ -406,9 +411,14 @@ def test_reserve_operation_credits_freezes_topup_without_active_subscription(
 
 def test_reserve_operation_credits_rejects_topup_after_consumption_window(
     operation_credit_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from flaskr.service.billing.operation_credits import reserve_operation_credits
 
+    monkeypatch.setattr(
+        "flaskr.service.billing.operation_credits.now_utc",
+        lambda: datetime(2026, 1, 16, 0, 0, 0),
+    )
     creator_bid = "creator-expired-topup-window"
     with operation_credit_app.app_context():
         wallet = CreditWallet(

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -370,6 +370,38 @@ def test_reserve_operation_credits_freezes_topup_without_active_subscription(
             ).count()
             == 0
         )
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid=f"subscription-{creator_bid}"
+        ).one()
+        subscription.current_period_start_at = datetime(2026, 1, 1, 0, 0, 0)
+        subscription.current_period_end_at = datetime(2099, 1, 1, 0, 0, 0)
+        dao.db.session.commit()
+
+    reservation = reserve_operation_credits(
+        operation_credit_app,
+        creator_bid=creator_bid,
+        amount=Decimal("1.0000000000"),
+        operation_type="voice_clone",
+        operation_bid="voice-bid-frozen-topup",
+        metadata={},
+    )
+
+    assert reservation.status == "reserved"
+    assert reservation.wallet_bucket_bids == [f"bucket-{creator_bid}"]
+    with operation_credit_app.app_context():
+        wallet = CreditWallet.query.filter_by(creator_bid=creator_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(creator_bid=creator_bid).one()
+        assert wallet.available_credits == Decimal("14.0000000000")
+        assert wallet.reserved_credits == Decimal("1.0000000000")
+        assert bucket.available_credits == Decimal("14.0000000000")
+        assert bucket.reserved_credits == Decimal("1.0000000000")
+        assert (
+            CreditLedgerEntry.query.filter_by(
+                creator_bid=creator_bid,
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_HOLD,
+            ).count()
+            == 1
+        )
 
 
 def test_operation_credit_mutations_request_wallet_and_bucket_locks(

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -404,6 +404,73 @@ def test_reserve_operation_credits_freezes_topup_without_active_subscription(
         )
 
 
+def test_reserve_operation_credits_rejects_topup_after_consumption_window(
+    operation_credit_app: Flask,
+) -> None:
+    from flaskr.service.billing.operation_credits import reserve_operation_credits
+
+    creator_bid = "creator-expired-topup-window"
+    with operation_credit_app.app_context():
+        wallet = CreditWallet(
+            wallet_bid=f"wallet-{creator_bid}",
+            creator_bid=creator_bid,
+            available_credits=Decimal("15.0000000000"),
+            reserved_credits=Decimal("0"),
+            lifetime_granted_credits=Decimal("15.0000000000"),
+            lifetime_consumed_credits=Decimal("0"),
+            last_settled_usage_id=0,
+            version=0,
+        )
+        bucket = CreditWalletBucket(
+            wallet_bucket_bid=f"bucket-{creator_bid}",
+            wallet_bid=wallet.wallet_bid,
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=f"topup-{creator_bid}",
+            priority=30,
+            original_credits=Decimal("15.0000000000"),
+            available_credits=Decimal("15.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 1, 1, 0, 0, 0),
+            effective_to=datetime(2026, 1, 15, 0, 0, 0),
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+            metadata_json={},
+        )
+        subscription = BillingSubscription(
+            subscription_bid=f"subscription-{creator_bid}",
+            creator_bid=creator_bid,
+            product_bid="product-plan-active",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            current_period_start_at=datetime(2026, 1, 1, 0, 0, 0),
+            current_period_end_at=datetime(2099, 1, 1, 0, 0, 0),
+        )
+        dao.db.session.add_all([wallet, bucket, subscription])
+        dao.db.session.commit()
+
+    with pytest.raises(AppException) as exc_info:
+        reserve_operation_credits(
+            operation_credit_app,
+            creator_bid=creator_bid,
+            amount=Decimal("1.0000000000"),
+            operation_type="voice_clone",
+            operation_bid="voice-bid-expired-topup-window",
+            metadata={},
+        )
+
+    assert exc_info.value.code == ERROR_CODE["server.billing.creditInsufficient"]
+    with operation_credit_app.app_context():
+        assert (
+            CreditLedgerEntry.query.filter_by(
+                creator_bid=creator_bid,
+                entry_type=CREDIT_LEDGER_ENTRY_TYPE_HOLD,
+            ).count()
+            == 0
+        )
+
+
 def test_operation_credit_mutations_request_wallet_and_bucket_locks(
     operation_credit_app: Flask,
     monkeypatch,

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -735,7 +735,7 @@ describe('AdminLayout', () => {
     ).toHaveAttribute('href', '/admin/referral');
   });
 
-  test('hides the credits section when available credits are zero', () => {
+  test('renders zero when available credits are zero', () => {
     mockUseBillingOverview.mockReturnValue({
       data: buildBillingOverview({ availableCredits: 0, subscription: null }),
       error: undefined,
@@ -756,10 +756,12 @@ describe('AdminLayout', () => {
       'data-href',
       '/admin/billing?tab=packages',
     );
-    expect(screen.queryByText(/0(?:\.0+)?/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('admin-billing-sidebar-card')).toHaveTextContent(
+      '0',
+    );
     expect(
-      screen.getByText('module.billing.sidebar.placeholderValue'),
-    ).toBeInTheDocument();
+      screen.queryByText('module.billing.sidebar.placeholderValue'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('link', {
         name: 'module.billing.sidebar.usageCta',

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -756,9 +756,9 @@ describe('AdminLayout', () => {
       'data-href',
       '/admin/billing?tab=packages',
     );
-    expect(screen.getByTestId('admin-billing-sidebar-card')).toHaveTextContent(
-      '0',
-    );
+    expect(
+      screen.getByTestId('admin-billing-sidebar-balance'),
+    ).toHaveTextContent('0');
     expect(
       screen.queryByText('module.billing.sidebar.placeholderValue'),
     ).not.toBeInTheDocument();

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -584,7 +584,7 @@ describe('BillingCreditDetailsPanel', () => {
     ).toBeInTheDocument();
   });
 
-  test('does not count topup buckets when there is no active subscription', () => {
+  test('shows held topup credits when there is no active subscription', () => {
     mockUseBillingOverview.mockReturnValue({
       data: {
         creator_bid: 'creator-1',
@@ -660,12 +660,11 @@ describe('BillingCreditDetailsPanel', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      within(topupLabel.closest('.grid') as HTMLElement).getByText('0.00'),
+      within(topupLabel.closest('.grid') as HTMLElement).getByText('1,000.00'),
     ).toBeInTheDocument();
-    expect(screen.queryByText('1,000.00')).not.toBeInTheDocument();
   });
 
-  test('does not count topup buckets when the subscription period has ended', () => {
+  test('shows held topup credits when the subscription period has ended', () => {
     const overview = mockUseBillingOverview().data;
     mockUseBillingOverview.mockReturnValue({
       data: {
@@ -704,9 +703,8 @@ describe('BillingCreditDetailsPanel', () => {
     const topupLabel = screen.getByText('module.billing.ledger.category.topup');
 
     expect(
-      within(topupLabel.closest('.grid') as HTMLElement).getByText('0.00'),
+      within(topupLabel.closest('.grid') as HTMLElement).getByText('1,000.00'),
     ).toBeInTheDocument();
-    expect(screen.queryByText('1,000.00')).not.toBeInTheDocument();
   });
 
   test('shows a tooltip for topup availability when the topup bucket has no expiry', async () => {

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -93,7 +93,7 @@ function buildCategorySummary(
         bucket.status === 'active' &&
         Number(bucket.available_credits || 0) > 0 &&
         (category === 'topup'
-          ? hasActiveSubscription && hasBucketStarted(bucket, now)
+          ? hasBucketStarted(bucket, now)
           : isBucketInCurrentWindow(bucket, now) &&
             (hasActiveSubscription ||
               !bucketRequiresActiveSubscription(bucket))),

--- a/src/cook-web/src/components/billing/BillingSidebarCard.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.tsx
@@ -28,12 +28,11 @@ export function BillingSidebarCard({
 }: BillingSidebarCardProps) {
   const { t } = useTranslation();
   const router = useRouter();
-  const availableCredits = overview?.wallet.available_credits ?? 0;
-  const shouldShowCredits = availableCredits > 0;
-  const creditsValue =
-    !isLoading && shouldShowCredits
-      ? formatBillingCreditBalance(availableCredits)
-      : t('module.billing.sidebar.placeholderValue');
+  const availableCredits = overview?.wallet?.available_credits;
+  const shouldShowCredits = !isLoading && availableCredits != null;
+  const creditsValue = shouldShowCredits
+    ? formatBillingCreditBalance(availableCredits ?? 0)
+    : t('module.billing.sidebar.placeholderValue');
 
   const expiryCountdown = !isLoading
     ? formatBillingExpiryCountdown(

--- a/src/cook-web/src/components/billing/BillingSidebarCard.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.tsx
@@ -90,7 +90,12 @@ export function BillingSidebarCard({
           <span className='shrink-0'>
             {t('module.billing.sidebar.nonMemberBalanceTitle')}
           </span>
-          <span className='truncate pr-1'>{creditsValue}</span>
+          <span
+            className='truncate pr-1'
+            data-testid='admin-billing-sidebar-balance'
+          >
+            {creditsValue}
+          </span>
         </div>
         <div className='flex min-w-0 items-center justify-between gap-3 pt-2.5 text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-normal,400)] leading-[var(--text-sm-line-height,20px)] text-[rgba(10,10,10,0.45)]'>
           <div className='min-w-0'>

--- a/src/i18n/en-US/modules/backend/billing.json
+++ b/src/i18n/en-US/modules/backend/billing.json
@@ -19,7 +19,7 @@
     "notificationPolicySaveFailed": "Failed to save the credit notification policy. Please try again later.",
     "referralRewardProductMismatch": "Referral reward package configuration does not match the billing product. Contact an administrator to review the campaign setup.",
     "subscriptionCheckoutBusy": "The package purchase request is still being processed. Please try again later.",
-    "subscriptionInactive": "An active subscription is required. Credit pack credits can only be purchased or used within the subscription period.",
+    "subscriptionInactive": "Please buy a credit plan first. Credit packs can be used only while the account has an active credit plan.",
     "subscriptionPreorderAlreadyExists": "A package preorder is already pending for this subscription.",
     "subscriptionPreorderProviderUnsupported": "Package preorder is currently supported only for self-managed payment channels.",
     "subscriptionPreorderTargetInvalid": "Package preorder only supports renewing the same package or switching to a lower-tier package at the cycle boundary.",

--- a/src/i18n/fr-FR/modules/backend/billing.json
+++ b/src/i18n/fr-FR/modules/backend/billing.json
@@ -19,7 +19,7 @@
     "notificationPolicySaveFailed": "Échec de l’enregistrement de la règle de notification des crédits. Veuillez réessayer plus tard.",
     "referralRewardProductMismatch": "La configuration du forfait de récompense d’invitation ne correspond pas au produit de facturation. Contactez un administrateur pour vérifier la campagne.",
     "subscriptionCheckoutBusy": "La demande d’achat du forfait est en cours de traitement. Veuillez réessayer plus tard.",
-    "subscriptionInactive": "Un abonnement actif est requis. Les crédits du pack de crédits ne peuvent être achetés ou utilisés que pendant la période d’abonnement.",
+    "subscriptionInactive": "Veuillez d’abord acheter un forfait de crédits. Les packs de crédits ne peuvent être utilisés que lorsque le compte dispose d’un forfait de crédits actif.",
     "subscriptionPreorderAlreadyExists": "Une précommande de forfait est déjà en attente pour cet abonnement.",
     "subscriptionPreorderProviderUnsupported": "La précommande de forfait est actuellement prise en charge uniquement pour les canaux de paiement autogérés.",
     "subscriptionPreorderTargetInvalid": "La précommande de forfait prend uniquement en charge le renouvellement du même forfait ou le passage à un forfait inférieur en fin de cycle.",

--- a/src/i18n/zh-CN/modules/backend/billing.json
+++ b/src/i18n/zh-CN/modules/backend/billing.json
@@ -19,7 +19,7 @@
     "notificationPolicySaveFailed": "积分通知策略保存失败，请稍后重试。",
     "referralRewardProductMismatch": "邀请奖励套餐配置与计费商品不匹配，请联系管理员检查活动配置。",
     "subscriptionCheckoutBusy": "当前套餐购买请求正在处理中，请稍后重试。",
-    "subscriptionInactive": "需要先拥有有效套餐；积分包只能在套餐有效期内购买和使用",
+    "subscriptionInactive": "请先购买积分套餐；账户下存在有效期内的积分套餐时，才可以使用积分包。",
     "subscriptionPreorderAlreadyExists": "当前套餐已有待生效的预购订单，请先处理后再发起新的预购",
     "subscriptionPreorderProviderUnsupported": "套餐预购当前仅支持自管支付渠道",
     "subscriptionPreorderTargetInvalid": "套餐预购仅支持续购当前套餐或在周期结束时切换到更低档套餐",


### PR DESCRIPTION
## Summary
- add a small billing cycle transition helper for order effective window resolution
- keep existing subscription wrapper functions and behavior intact
- make billing overview return the current wallet balance from bucket state so stale wallet snapshots do not hide newly granted credits
- show `0` credits in the admin sidebar instead of the placeholder when the loaded balance is zero
- freeze credit pack buckets in operation reservations when no active plan exists, while keeping held credit pack balances visible in billing details
- clarify the frozen credit-pack prompt and tighten review-requested regressions for balance rendering and plan reactivation
- keep overview credit status/debug permission aligned with the same consumable balance projection and keep owned credit packs visible after old consumption windows end

## Scope
- Billing-R3 first step: cycle-window parsing plus the dev02 balance-display and frozen credit-pack regressions found during validation
- no grant activation changes
- no bucket expiration changes
- no subscription status transition changes
- no repair, audit, schema, or migration changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved billing cycle effective start/end boundary handling for renewals, top-ups, and subscription starts, with safer fallbacks when data is missing.
  - Billing overview now recalculates available/reserved credits from the current wallet snapshot and derives limit state based on current consumable balances.
  - Operation credit reservations now correctly deny top-ups when there’s no active effective top-up subscription or when outside the allowed consumption window.
  - Billing UI now consistently shows `0` available credits and properly reflects held/top-up credits.
- **Refactor**
  - Centralized cycle effective boundary logic for reuse across billing flows.
- **Localization**
  - Updated `subscriptionInactive` billing message copy (EN/FR/ZH).
- **Tests**
  - Added/expanded unit and UI tests for cycle transitions, overview/sidebar rendering, and reservation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


