### PR TITLE
refactor: centralize billing cycle state helpers

### DIFF
--- a/src/api/flaskr/service/billing/cycle_state_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_state_transitions.py
@@ -1,0 +1,135 @@
+"""State-transition helpers for billing cycle side effects."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from flaskr.dao import db
+from flaskr.util.datetime import now_utc
+
+from .bucket_categories import (
+    load_billing_order_type_by_bid,
+    resolve_wallet_bucket_runtime_category,
+)
+from .consts import (
+    CREDIT_BUCKET_CATEGORY_TOPUP,
+    CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+)
+from .models import BillingSubscription, CreditLedgerEntry, CreditWalletBucket
+from .primitives import normalize_bid as _normalize_bid
+
+
+def subscription_has_effective_cycle(
+    subscription: BillingSubscription | None,
+    *,
+    as_of: datetime,
+) -> bool:
+    return (
+        subscription is not None
+        and subscription.current_period_start_at is not None
+        and subscription.current_period_end_at is not None
+        and subscription.current_period_start_at <= as_of
+        and subscription.current_period_end_at > as_of
+    )
+
+
+def realign_active_topup_bucket_effective_to(
+    *,
+    creator_bid: str,
+    effective_from: datetime,
+    effective_to: datetime | None,
+) -> None:
+    realign_active_credit_bucket_effective_to(
+        creator_bid=creator_bid,
+        bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        include_effective_to_boundary=True,
+    )
+
+
+def realign_active_credit_bucket_effective_to(
+    *,
+    creator_bid: str,
+    bucket_category: int,
+    effective_from: datetime,
+    effective_to: datetime | None,
+    include_effective_to_boundary: bool,
+) -> None:
+    if effective_to is None:
+        return
+
+    buckets = load_active_credit_buckets_by_runtime_category(
+        creator_bid,
+        bucket_category=bucket_category,
+    )
+    if not buckets:
+        return
+
+    current_at = now_utc()
+    for bucket in buckets:
+        if bucket.effective_from is not None and bucket.effective_from > effective_from:
+            continue
+        if bucket.effective_to is not None:
+            if (
+                not include_effective_to_boundary
+                and bucket.effective_to <= effective_from
+            ):
+                continue
+        if bucket.effective_to != effective_to:
+            bucket.effective_to = effective_to
+            bucket.updated_at = current_at
+            db.session.add(bucket)
+
+        grant_entry_filters = [
+            CreditLedgerEntry.deleted == 0,
+            CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
+            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+        ]
+        if not include_effective_to_boundary:
+            grant_entry_filters.append(
+                (
+                    CreditLedgerEntry.expires_at.is_(None)
+                    | (CreditLedgerEntry.expires_at >= effective_from)
+                ),
+            )
+        grant_entries = (
+            CreditLedgerEntry.query.filter(*grant_entry_filters)
+            .order_by(CreditLedgerEntry.id.asc())
+            .all()
+        )
+        for entry in grant_entries:
+            entry.expires_at = effective_to
+            entry.updated_at = current_at
+            db.session.add(entry)
+
+
+def load_active_credit_buckets_by_runtime_category(
+    creator_bid: str,
+    *,
+    bucket_category: int,
+) -> list[CreditWalletBucket]:
+    normalized_creator_bid = _normalize_bid(creator_bid)
+    if not normalized_creator_bid:
+        return []
+
+    rows = (
+        CreditWalletBucket.query.filter(
+            CreditWalletBucket.deleted == 0,
+            CreditWalletBucket.creator_bid == normalized_creator_bid,
+            CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
+            CreditWalletBucket.available_credits > 0,
+        )
+        .order_by(CreditWalletBucket.created_at.asc(), CreditWalletBucket.id.asc())
+        .all()
+    )
+    return [
+        row
+        for row in rows
+        if resolve_wallet_bucket_runtime_category(
+            row,
+            load_order_type=load_billing_order_type_by_bid,
+        )
+        == bucket_category
+    ]

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -50,10 +50,8 @@ from .consts import (
     CREDIT_SOURCE_TYPE_TOPUP,
 )
 from .bucket_categories import (
-    load_billing_order_type_by_bid,
     resolve_bucket_category_from_order_type,
     resolve_credit_bucket_priority,
-    resolve_wallet_bucket_runtime_category,
 )
 from .credit_mutations import (
     activate_reserved_grant_credit,
@@ -62,6 +60,11 @@ from .credit_mutations import (
 from .cycle_transitions import (
     resolve_order_effective_from as _resolve_order_effective_from,
     resolve_order_effective_to as _resolve_order_effective_to,
+)
+from .cycle_state_transitions import (
+    realign_active_credit_bucket_effective_to as _realign_active_credit_bucket_effective_to,
+    realign_active_topup_bucket_effective_to as _realign_active_topup_bucket_effective_to,
+    subscription_has_effective_cycle as _subscription_has_effective_cycle,
 )
 from .dtos import BillingSubscriptionDTO
 from .models import (
@@ -1001,107 +1004,6 @@ def _cycle_has_reserved_activation_evidence(cycle_orders: list[BillingOrder]) ->
     return False
 
 
-def _realign_active_topup_bucket_effective_to(
-    *,
-    creator_bid: str,
-    effective_from: datetime,
-    effective_to: datetime | None,
-) -> None:
-    _realign_active_credit_bucket_effective_to(
-        creator_bid=creator_bid,
-        bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
-        effective_from=effective_from,
-        effective_to=effective_to,
-        include_effective_to_boundary=True,
-    )
-
-
-def _realign_active_credit_bucket_effective_to(
-    *,
-    creator_bid: str,
-    bucket_category: int,
-    effective_from: datetime,
-    effective_to: datetime | None,
-    include_effective_to_boundary: bool,
-) -> None:
-    if effective_to is None:
-        return
-
-    buckets = _load_active_credit_buckets_by_runtime_category(
-        creator_bid,
-        bucket_category=bucket_category,
-    )
-    if not buckets:
-        return
-
-    now = now_utc()
-    for bucket in buckets:
-        if bucket.effective_from is not None and bucket.effective_from > effective_from:
-            continue
-        if bucket.effective_to is not None:
-            if (
-                not include_effective_to_boundary
-                and bucket.effective_to <= effective_from
-            ):
-                continue
-        if bucket.effective_to != effective_to:
-            bucket.effective_to = effective_to
-            bucket.updated_at = now
-            db.session.add(bucket)
-
-        grant_entry_filters = [
-            CreditLedgerEntry.deleted == 0,
-            CreditLedgerEntry.wallet_bucket_bid == bucket.wallet_bucket_bid,
-            CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-        ]
-        if not include_effective_to_boundary:
-            grant_entry_filters.append(
-                (
-                    CreditLedgerEntry.expires_at.is_(None)
-                    | (CreditLedgerEntry.expires_at >= effective_from)
-                ),
-            )
-        grant_entries = (
-            CreditLedgerEntry.query.filter(*grant_entry_filters)
-            .order_by(CreditLedgerEntry.id.asc())
-            .all()
-        )
-        for entry in grant_entries:
-            entry.expires_at = effective_to
-            entry.updated_at = now
-            db.session.add(entry)
-
-
-def _load_active_credit_buckets_by_runtime_category(
-    creator_bid: str,
-    *,
-    bucket_category: int,
-) -> list[CreditWalletBucket]:
-    normalized_creator_bid = _normalize_bid(creator_bid)
-    if not normalized_creator_bid:
-        return []
-
-    rows = (
-        CreditWalletBucket.query.filter(
-            CreditWalletBucket.deleted == 0,
-            CreditWalletBucket.creator_bid == normalized_creator_bid,
-            CreditWalletBucket.status == CREDIT_BUCKET_STATUS_ACTIVE,
-            CreditWalletBucket.available_credits > 0,
-        )
-        .order_by(CreditWalletBucket.created_at.asc(), CreditWalletBucket.id.asc())
-        .all()
-    )
-    return [
-        row
-        for row in rows
-        if resolve_wallet_bucket_runtime_category(
-            row,
-            load_order_type=load_billing_order_type_by_bid,
-        )
-        == bucket_category
-    ]
-
-
 def _build_bucket_metadata_from_order(order: BillingOrder) -> dict[str, Any]:
     return _normalize_json_object(
         {
@@ -1496,12 +1398,9 @@ def _repair_existing_paid_order_grant_bucket(
     if is_reserved_grant:
         subscription = _load_subscription_by_bid(order.subscription_bid)
         has_current_available_balance = _to_decimal(bucket.available_credits) > 0
-        subscription_has_current_window = (
-            subscription is not None
-            and subscription.current_period_start_at is not None
-            and subscription.current_period_end_at is not None
-            and subscription.current_period_start_at <= now
-            and subscription.current_period_end_at > now
+        subscription_has_current_window = _subscription_has_effective_cycle(
+            subscription,
+            as_of=now,
         )
         if has_current_available_balance and subscription_has_current_window:
             current_period_start = subscription.current_period_start_at

--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from flask import Flask
+
+import flaskr.dao as dao
+from flaskr.service.billing.consts import (
+    BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+    CREDIT_BUCKET_CATEGORY_TOPUP,
+    CREDIT_BUCKET_STATUS_ACTIVE,
+    CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+    CREDIT_SOURCE_TYPE_TOPUP,
+)
+from flaskr.service.billing.cycle_state_transitions import (
+    realign_active_topup_bucket_effective_to,
+    subscription_has_effective_cycle,
+)
+from flaskr.service.billing.models import (
+    BillingSubscription,
+    CreditLedgerEntry,
+    CreditWalletBucket,
+)
+
+
+def _build_app() -> Flask:
+    app = Flask(__name__)
+    app.testing = True
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_BINDS={
+            "ai_shifu_saas": "sqlite:///:memory:",
+            "ai_shifu_admin": "sqlite:///:memory:",
+        },
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        TZ="UTC",
+    )
+    dao.db.init_app(app)
+    return app
+
+
+def test_subscription_has_effective_cycle_uses_current_period_window() -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    subscription = BillingSubscription(
+        subscription_bid="subscription-cycle-state",
+        creator_bid="creator-cycle-state",
+        status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+        current_period_start_at=current_at - timedelta(days=1),
+        current_period_end_at=current_at + timedelta(days=1),
+    )
+
+    assert subscription_has_effective_cycle(subscription, as_of=current_at) is True
+
+    subscription.current_period_end_at = current_at
+
+    assert subscription_has_effective_cycle(subscription, as_of=current_at) is False
+    assert subscription_has_effective_cycle(None, as_of=current_at) is False
+
+
+def test_realign_active_topup_bucket_effective_to_updates_bucket_and_grant_ledgers() -> (
+    None
+):
+    app = _build_app()
+    creator_bid = "creator-cycle-state-topup"
+    cycle_start = datetime(2026, 4, 10, 0, 0, 0)
+    cycle_end = datetime(2026, 5, 10, 0, 0, 0)
+    old_topup_end = datetime(2026, 4, 9, 0, 0, 0)
+
+    with app.app_context():
+        dao.db.create_all()
+        topup_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-cycle-state-topup",
+            wallet_bid="wallet-cycle-state-topup",
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-cycle-state-topup",
+            priority=30,
+            original_credits=Decimal("20.0000000000"),
+            available_credits=Decimal("20.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=old_topup_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+        )
+        future_topup_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-cycle-state-future-topup",
+            wallet_bid="wallet-cycle-state-topup",
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_TOPUP,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid="order-cycle-state-future-topup",
+            priority=30,
+            original_credits=Decimal("5.0000000000"),
+            available_credits=Decimal("5.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=cycle_start + timedelta(days=1),
+            effective_to=old_topup_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+        )
+        subscription_bucket = CreditWalletBucket(
+            wallet_bucket_bid="bucket-cycle-state-subscription",
+            wallet_bid="wallet-cycle-state-topup",
+            creator_bid=creator_bid,
+            bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-cycle-state-subscription",
+            priority=20,
+            original_credits=Decimal("50.0000000000"),
+            available_credits=Decimal("50.0000000000"),
+            reserved_credits=Decimal("0"),
+            consumed_credits=Decimal("0"),
+            expired_credits=Decimal("0"),
+            effective_from=datetime(2026, 4, 1, 0, 0, 0),
+            effective_to=old_topup_end,
+            status=CREDIT_BUCKET_STATUS_ACTIVE,
+        )
+        topup_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-cycle-state-topup",
+            creator_bid=creator_bid,
+            wallet_bid="wallet-cycle-state-topup",
+            wallet_bucket_bid=topup_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=topup_bucket.source_bid,
+            idempotency_key="grant:order-cycle-state-topup",
+            amount=Decimal("20.0000000000"),
+            balance_after=Decimal("20.0000000000"),
+            expires_at=old_topup_end,
+            consumable_from=topup_bucket.effective_from,
+        )
+        future_topup_ledger = CreditLedgerEntry(
+            ledger_bid="ledger-cycle-state-future-topup",
+            creator_bid=creator_bid,
+            wallet_bid="wallet-cycle-state-topup",
+            wallet_bucket_bid=future_topup_bucket.wallet_bucket_bid,
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_TOPUP,
+            source_bid=future_topup_bucket.source_bid,
+            idempotency_key="grant:order-cycle-state-future-topup",
+            amount=Decimal("5.0000000000"),
+            balance_after=Decimal("25.0000000000"),
+            expires_at=old_topup_end,
+            consumable_from=future_topup_bucket.effective_from,
+        )
+        dao.db.session.add_all(
+            [
+                topup_bucket,
+                future_topup_bucket,
+                subscription_bucket,
+                topup_ledger,
+                future_topup_ledger,
+            ]
+        )
+        dao.db.session.commit()
+
+        realign_active_topup_bucket_effective_to(
+            creator_bid=creator_bid,
+            effective_from=cycle_start,
+            effective_to=cycle_end,
+        )
+        dao.db.session.flush()
+
+        assert topup_bucket.effective_to == cycle_end
+        assert topup_ledger.expires_at == cycle_end
+        assert future_topup_bucket.effective_to == old_topup_end
+        assert future_topup_ledger.expires_at == old_topup_end
+        assert subscription_bucket.effective_to == old_topup_end

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -235,6 +235,75 @@ describe('BillingCreditDetailsPanel', () => {
     expect(screen.queryByText('1,300.00')).not.toBeInTheDocument();
   });
 
+  test('shows no validity date when active subscription credits are empty', () => {
+    mockUseBillingOverview.mockReturnValue({
+      data: {
+        ...mockUseBillingOverview().data,
+        wallet: {
+          available_credits: 65.38,
+          reserved_credits: 0,
+          lifetime_granted_credits: 1100,
+          lifetime_consumed_credits: 1034.62,
+        },
+      },
+      error: undefined,
+      isLoading: false,
+    });
+    mockUseBillingWalletBuckets.mockReturnValue({
+      data: {
+        items: [
+          {
+            wallet_bucket_bid: 'bucket-sub-empty',
+            category: 'subscription',
+            source_type: 'subscription',
+            source_bid: 'sub-1',
+            available_credits: 0,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-10-12T23:59:00',
+            priority: 20,
+            status: 'active',
+          },
+          {
+            wallet_bucket_bid: 'bucket-topup',
+            category: 'topup',
+            source_type: 'topup',
+            source_bid: 'topup-1',
+            available_credits: 65.38,
+            effective_from: '2026-04-01T00:00:00',
+            effective_to: '2026-10-20T23:59:00',
+            priority: 30,
+            status: 'active',
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<BillingCreditDetailsPanel />);
+
+    const subscriptionLabel = screen.getByText(
+      'module.billing.ledger.category.subscription',
+    );
+    const subscriptionRow = subscriptionLabel.closest('.grid');
+
+    expect(subscriptionRow).not.toBeNull();
+    expect(
+      within(subscriptionRow as HTMLElement).getByText('0.00'),
+    ).toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).getByText('--'),
+    ).toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).queryByText('2026-10-13 07:59'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(subscriptionRow as HTMLElement).queryByText(
+        'module.billing.ledger.neverExpires',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   test('revalidates wallet buckets after the overview snapshot loads', async () => {
     const refreshWalletBuckets = jest.fn();
     mockUseBillingWalletBuckets.mockReturnValue({

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -9,7 +9,8 @@ import { BillingCreditDetailsPanel } from './BillingCreditDetailsPanel';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) =>
+      key === 'module.billing.details.emptyValidityLabel' ? '--' : key,
     i18n: {
       language: 'zh-CN',
     },

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -177,7 +177,7 @@ function CategoryValidityCell({
   }
 
   return (
-    <div className='flex items-center justify-end gap-1.5'>
+    <div className='flex items-center justify-center gap-1.5'>
       <span>{topupAvailabilityLabel}</span>
       <TooltipProvider delayDuration={0}>
         <Tooltip>
@@ -315,7 +315,7 @@ export function BillingCreditDetailsPanel({
               <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-end px-[var(--spacing-2,8px)] text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
                 {t('module.billing.details.table.balance')}
               </div>
-              <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-end px-[var(--spacing-2,8px)] text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
+              <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-center px-[var(--spacing-2,8px)] text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
                 {t('module.billing.details.table.validUntil')}
               </div>
             </div>
@@ -342,7 +342,7 @@ export function BillingCreditDetailsPanel({
                         i18n.language,
                       )}
                     </div>
-                    <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
+                    <div className='px-[var(--spacing-2,8px)] py-4 text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
                       <CategoryValidityCell
                         availableCredits={row.availableCredits}
                         category={row.category}

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -45,6 +45,7 @@ type CategorySummaryRow = {
 
 const CATEGORY_ORDER: BillingBucketCategory[] = ['subscription', 'topup'];
 const SUBSCRIPTION_FREE_SOURCE_TYPES = new Set(['gift', 'manual']);
+const EMPTY_VALIDITY_LABEL = '--';
 
 function isBucketInCurrentWindow(
   bucket: BillingWalletBucket,
@@ -86,7 +87,7 @@ function buildCategorySummary(
   const { activeSubscriptionEffectiveTo, hasActiveSubscription } = options;
   const now = options.now || new Date();
 
-  return CATEGORY_ORDER.flatMap(category => {
+  return CATEGORY_ORDER.flatMap<CategorySummaryRow>(category => {
     const activeBuckets = buckets.filter(
       bucket =>
         bucket.category === category &&
@@ -104,10 +105,7 @@ function buildCategorySummary(
         {
           category,
           availableCredits: 0,
-          effectiveTo:
-            category === 'subscription' && hasActiveSubscription
-              ? activeSubscriptionEffectiveTo
-              : null,
+          effectiveTo: null,
         },
       ];
     }
@@ -150,6 +148,7 @@ function buildCategorySummary(
 }
 
 function CategoryValidityCell({
+  availableCredits,
   category,
   effectiveTo,
   locale,
@@ -157,6 +156,7 @@ function CategoryValidityCell({
   topupAvailabilityLabel,
   topupAvailabilityTooltip,
 }: {
+  availableCredits: number;
   category: BillingBucketCategory;
   effectiveTo: string | null;
   locale: string;
@@ -165,6 +165,10 @@ function CategoryValidityCell({
   topupAvailabilityTooltip: string;
 }) {
   if (category !== 'topup') {
+    if (availableCredits <= 0) {
+      return <>{EMPTY_VALIDITY_LABEL}</>;
+    }
+
     if (effectiveTo) {
       return <>{formatBillingCompactDateTime(effectiveTo, locale)}</>;
     }
@@ -340,6 +344,7 @@ export function BillingCreditDetailsPanel({
                     </div>
                     <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
                       <CategoryValidityCell
+                        availableCredits={row.availableCredits}
                         category={row.category}
                         effectiveTo={row.effectiveTo}
                         locale={i18n.language}

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -45,7 +45,6 @@ type CategorySummaryRow = {
 
 const CATEGORY_ORDER: BillingBucketCategory[] = ['subscription', 'topup'];
 const SUBSCRIPTION_FREE_SOURCE_TYPES = new Set(['gift', 'manual']);
-const EMPTY_VALIDITY_LABEL = '--';
 
 function isBucketInCurrentWindow(
   bucket: BillingWalletBucket,
@@ -152,6 +151,7 @@ function CategoryValidityCell({
   category,
   effectiveTo,
   locale,
+  emptyValidityLabel,
   neverExpiresLabel,
   topupAvailabilityLabel,
   topupAvailabilityTooltip,
@@ -160,13 +160,14 @@ function CategoryValidityCell({
   category: BillingBucketCategory;
   effectiveTo: string | null;
   locale: string;
+  emptyValidityLabel: string;
   neverExpiresLabel: string;
   topupAvailabilityLabel: string;
   topupAvailabilityTooltip: string;
 }) {
   if (category !== 'topup') {
     if (availableCredits <= 0) {
-      return <>{EMPTY_VALIDITY_LABEL}</>;
+      return <>{emptyValidityLabel}</>;
     }
 
     if (effectiveTo) {
@@ -257,6 +258,7 @@ export function BillingCreditDetailsPanel({
   const totalCreditsLabel = formatBillingCreditBalance(
     overview?.wallet.available_credits || 0,
   );
+  const emptyValidityLabel = t('module.billing.details.emptyValidityLabel');
   const neverExpiresLabel = t('module.billing.ledger.neverExpires');
   const topupAvailabilityLabel = t(
     'module.billing.details.topupAvailabilityLabel',
@@ -345,6 +347,7 @@ export function BillingCreditDetailsPanel({
                     <div className='px-[var(--spacing-2,8px)] py-4 text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
                       <CategoryValidityCell
                         availableCredits={row.availableCredits}
+                        emptyValidityLabel={emptyValidityLabel}
                         category={row.category}
                         effectiveTo={row.effectiveTo}
                         locale={i18n.language}

--- a/src/i18n/en-US/modules/billing.json
+++ b/src/i18n/en-US/modules/billing.json
@@ -527,6 +527,7 @@
     "actions": {
       "upgradeNow": "Upgrade now"
     },
+    "emptyValidityLabel": "--",
     "subtitle": "Review total credits, category balances, and the effective window for each credit source.",
     "table": {
       "balance": "Balance",

--- a/src/i18n/fr-FR/modules/billing.json
+++ b/src/i18n/fr-FR/modules/billing.json
@@ -527,6 +527,7 @@
     "actions": {
       "upgradeNow": "Mettre à niveau"
     },
+    "emptyValidityLabel": "--",
     "subtitle": "Consulter le total des crédits, les soldes par catégorie et la fenêtre effective de chaque source de crédits.",
     "table": {
       "balance": "Solde",

--- a/src/i18n/zh-CN/modules/billing.json
+++ b/src/i18n/zh-CN/modules/billing.json
@@ -527,6 +527,7 @@
     "actions": {
       "upgradeNow": "立即升级"
     },
+    "emptyValidityLabel": "--",
     "subtitle": "查看当前老师空间的总积分、各类积分余额以及对应有效期。",
     "table": {
       "balance": "余额",


### PR DESCRIPTION
## Summary
- add a dedicated billing cycle state transition helper module
- move effective subscription-cycle checks and active credit bucket window realignment out of subscriptions.py
- keep existing subscription activation and credit bucket behavior unchanged
- show a dash for subscription credit validity when the displayed subscription credit balance is zero
- add focused cycle state transition and billing credit details tests

## Scope
- Billing R3-B minimal equivalent extraction
- no schema or migration changes
- no admission, settlement, repair, or bucket expiration behavior changes
- no historical data repair
- includes a small billing details display follow-up found during dev02 validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added billing cycle transition handling to keep active credit and top-up validity periods aligned.
  - Improved detection of whether a subscription is currently within its effective billing cycle.

- **Bug Fixes**
  - Subscription credits with no available balance now display `--` instead of an expiry date or “never expires.”
  - Improved alignment of billing validity information in the credit details panel.

- **Tests**
  - Added coverage for billing cycle detection, credit realignment, and empty subscription balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->