### PR TITLE
fix: skip non-speakable segments for tencent_texttovoice

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -79,7 +79,12 @@ _EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "volcengine"}
 _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
 _TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}
-_NON_SPEAKABLE_TTS_SKIP_PROVIDERS = {"minimax", "tencent", "volcengine"}
+_NON_SPEAKABLE_TTS_SKIP_PROVIDERS = {
+    "minimax",
+    "tencent",
+    "tencent_texttovoice",
+    "volcengine",
+}
 
 _VISUAL_SLIDE_KINDS = frozenset(
     {

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -336,7 +336,10 @@ class TestStreamingSynthesisRetries:
     @patch("flaskr.service.tts.tts_usage_recorder.record_tts_segment_usage")
     @patch("flaskr.service.tts.streaming_tts.synthesize_text")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
-    @pytest.mark.parametrize("tts_provider", ["tencent", "volcengine", "minimax"])
+    @pytest.mark.parametrize(
+        "tts_provider",
+        ["tencent", "tencent_texttovoice", "volcengine", "minimax"],
+    )
     def test_non_speakable_segment_skips_configured_provider_call(
         self,
         mock_is_configured,


### PR DESCRIPTION
## Source

Feishu ops alerts on 2026-07-31 08:24–08:30 (Asia/Shanghai), repeated across three `new-shifu-api` pods for course `8f35ae59536e4478973b6a9d379e81b4`, generated block `9951ba85687444c58bfdca4ce994b5e1`:

- `TTS segment 0/4 failed: Tencent TextToVoice error InvalidParameter.InvalidText` with `provider=tencent_texttovoice text_len=3 text_preview='---'`
- Followed by `RuntimeError: TTS stream finalized without audio_complete` in `_yield_run_tts_audio_events`

## Root cause

`StreamingTTSProcessor` already skips segments without any Unicode letter or number before calling the provider, but the skip set `_NON_SPEAKABLE_TTS_SKIP_PROVIDERS` only contained `minimax`, `tencent`, and `volcengine`. The newer `tencent_texttovoice` provider was not in the set, so markdown separators such as `---` produced by segmentation were still sent to Tencent, which rejects text without valid words. The failed segments then left the stream without an `audio_complete` event.

This is complementary to #2150: that PR filters listen elements whose whole text is non-speakable, while this change covers non-speakable segments produced by intra-element segmentation for the `tencent_texttovoice` provider.

## Changes

- Add `tencent_texttovoice` to `_NON_SPEAKABLE_TTS_SKIP_PROVIDERS` in `streaming_tts.py`.
- Extend the existing parametrized regression test `test_non_speakable_segment_skips_configured_provider_call` to cover `tencent_texttovoice`.

## Verification

- `cd src/api && python -m pytest tests/service/tts/test_streaming_tts_finalize_segmentation.py -q` → 22 passed
- `ruff check` and `ruff format --check` on the two changed files → passed
- lefthook pre-commit hooks (architecture boundaries, translations, uow ratchet, ruff) → all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)