### PR TITLE
fix: log invalid recipient numbers as warnings

### DIFF
--- a/src/api/flaskr/api/sms/aliyun.py
+++ b/src/api/flaskr/api/sms/aliyun.py
@@ -8,6 +8,14 @@ from alibabacloud_tea_util.client import Client as UtilClient
 from flask import Flask
 
 
+RECIPIENT_INPUT_ERROR_CODES = {
+    # The recipient number failed provider-side format validation. This is
+    # caused by user input (e.g. a foreign number that matches the local
+    # 11-digit pattern), not by a system fault, so it must not page ops.
+    "isv.MOBILE_NUMBER_ILLEGAL",
+}
+
+
 def _body_value(
     response: dysmsapi_20170525_models.SendSmsResponse | None,
     field_name: str,
@@ -72,7 +80,9 @@ def send_sms_ali(
         if response_code != "OK":
             response_message = _body_value(res, "message")
             log_provider_failure = app.logger.error
-            if response_code == "isv.BUSINESS_LIMIT_CONTROL" and any(
+            if response_code in RECIPIENT_INPUT_ERROR_CODES:
+                log_provider_failure = app.logger.warning
+            elif response_code == "isv.BUSINESS_LIMIT_CONTROL" and any(
                 throttle_message in response_message
                 for throttle_message in ("触发号码天级流控", "触发小时级流控")
             ):

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -233,3 +233,47 @@ def test_send_sms_ali_logs_recipient_throttle_as_warning(
         for record in caplog.records
     )
     assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_send_sms_ali_logs_illegal_recipient_number_as_warning(monkeypatch, caplog):
+    from flaskr.api.sms import aliyun as sms_aliyun
+
+    class FakeClient:
+        def __init__(self, _config):
+            pass
+
+        def send_sms_with_options(self, request, runtime):
+            del request, runtime
+            return SimpleNamespace(
+                body=SimpleNamespace(
+                    code="isv.MOBILE_NUMBER_ILLEGAL",
+                    message="invalid mobile number format",
+                    request_id="req-illegal-number-1",
+                    biz_id=None,
+                )
+            )
+
+    monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
+
+    app = Flask("contract-sms-illegal-number")
+    app.config.update(
+        ALIBABA_CLOUD_SMS_ACCESS_KEY_ID="key",
+        ALIBABA_CLOUD_SMS_ACCESS_KEY_SECRET="secret",
+        ALIBABA_CLOUD_SMS_SIGN_NAME="TestSign",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = sms_aliyun.send_sms_ali(
+            app,
+            "14085986122",
+            template_code="TPL-VERIFY-001",
+            template_params={"code": "1234"},
+        )
+
+    assert result is None
+    assert any(
+        record.levelno == logging.WARNING
+        and "isv.MOBILE_NUMBER_ILLEGAL" in record.getMessage()
+        for record in caplog.records
+    )
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]


### PR DESCRIPTION
## Source

Feishu ops alert on 2026-07-31 03:47 (Asia/Shanghai) from `/api/user/send_sms_code`:

- `Aliyun SMS send failed for mobile=14085986122 template_code=SMS_505465097 code=isv.MOBILE_NUMBER_ILLEGAL message=手机号码格式错误`

## Root cause

`14085986122` is a US number (1-408-598-6122) typed without a country prefix. It happens to match the local validation pattern `^1\d{10}$` in `is_valid_sms_mobile`, so the request reached Aliyun, which rejected it with `isv.MOBILE_NUMBER_ILLEGAL`. `send_sms_ali` logged the non-OK provider response at ERROR level, and ERROR logs page ops through the alert webhook — but this failure is caused by user input, not by a system fault.

This complements the merged #2187, which demoted recipient-level throttling responses; that change does not cover `isv.MOBILE_NUMBER_ILLEGAL`.

## Changes

- Introduce `RECIPIENT_INPUT_ERROR_CODES` in `flaskr/api/sms/aliyun.py` containing `isv.MOBILE_NUMBER_ILLEGAL` and log matching provider rejections at WARNING instead of ERROR, composed with the throttle demotion from #2187 in the same non-OK branch.
- Keep the return value (`None`) and all other provider failures at ERROR unchanged.
- Add a contract test asserting the WARNING level and that no ERROR record is emitted for this code.

## Verification

- Rebased onto the latest `main` (includes #2187); the overlapping non-OK logging branch was merged so both demotions coexist.
- `cd src/api && python -m pytest tests/contract/test_sms_contract.py tests/test_sms_aliyun.py -q` → 9 passed (includes the #2187 throttle cases)
- `ruff check` and `ruff format --check` on the two changed files → passed
- lefthook pre-commit hooks (architecture boundaries, translations, uow ratchet, ruff) → all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)