### PR TITLE
fix: hide pending credit grants from ledger views

### DIFF
--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -144,7 +144,7 @@ def _filter_out_reserved_credit_grant_ledgers(query):
             )
         )
     )
-    return query.filter(bucket_credit_state_expr != "reserved")
+    return query.filter(bucket_credit_state_expr.notin_(("reserved", "absorbed")))
 
 
 def _parse_stat_date(value: str) -> datetime.date | None:

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from flask import Flask
-from sqlalchemy import case, or_, select
+from sqlalchemy import and_, case, or_, select
 
 from flaskr.dao import db
 from flaskr.i18n import _ as translate
@@ -145,6 +145,42 @@ def _filter_out_reserved_credit_grant_ledgers(query):
         )
     )
     return query.filter(bucket_credit_state_expr.notin_(("reserved", "absorbed")))
+
+
+def _ledger_visible_at_sort_expr():
+    bucket_credit_state_expr = db.func.lower(
+        db.func.trim(
+            db.func.coalesce(
+                CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
+                "",
+            )
+        )
+    )
+    activated_at_expr = db.func.trim(
+        db.func.replace(
+            db.func.replace(
+                db.func.coalesce(
+                    CreditLedgerEntry.metadata_json["activated_at"].as_string(),
+                    "",
+                ),
+                "T",
+                " ",
+            ),
+            "Z",
+            "",
+        )
+    )
+    return case(
+        (
+            and_(
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                bucket_credit_state_expr == "available",
+                activated_at_expr != "",
+            ),
+            activated_at_expr,
+        ),
+        else_=CreditLedgerEntry.created_at,
+    )
 
 
 def _parse_stat_date(value: str) -> datetime.date | None:
@@ -701,7 +737,7 @@ def build_billing_ledger_page(
             CreditLedgerEntry.creator_bid == normalized_creator_bid,
         )
         query = _filter_out_reserved_credit_grant_ledgers(query).order_by(
-            CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc()
+            _ledger_visible_at_sort_expr().desc(), CreditLedgerEntry.id.desc()
         )
         total = query.order_by(None).count()
         if total == 0:

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -135,6 +135,18 @@ _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
 )
 
 
+def _filter_out_reserved_credit_grant_ledgers(query):
+    bucket_credit_state_expr = db.func.lower(
+        db.func.trim(
+            db.func.coalesce(
+                CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
+                "",
+            )
+        )
+    )
+    return query.filter(bucket_credit_state_expr != "reserved")
+
+
 def _parse_stat_date(value: str) -> datetime.date | None:
     normalized_value = str(value or "").strip()
     if not normalized_value:
@@ -687,7 +699,10 @@ def build_billing_ledger_page(
         query = CreditLedgerEntry.query.filter(
             CreditLedgerEntry.deleted == 0,
             CreditLedgerEntry.creator_bid == normalized_creator_bid,
-        ).order_by(CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc())
+        )
+        query = _filter_out_reserved_credit_grant_ledgers(query).order_by(
+            CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc()
+        )
         total = query.order_by(None).count()
         if total == 0:
             return BillingLedgerPageDTO(

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from flask import Flask
-from sqlalchemy import and_, case, or_, select
+from sqlalchemy import case, or_, select
 
 from flaskr.dao import db
 from flaskr.i18n import _ as translate
@@ -145,42 +145,6 @@ def _filter_out_reserved_credit_grant_ledgers(query):
         )
     )
     return query.filter(bucket_credit_state_expr.notin_(("reserved", "absorbed")))
-
-
-def _ledger_visible_at_sort_expr():
-    bucket_credit_state_expr = db.func.lower(
-        db.func.trim(
-            db.func.coalesce(
-                CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
-                "",
-            )
-        )
-    )
-    activated_at_expr = db.func.trim(
-        db.func.replace(
-            db.func.replace(
-                db.func.coalesce(
-                    CreditLedgerEntry.metadata_json["activated_at"].as_string(),
-                    "",
-                ),
-                "T",
-                " ",
-            ),
-            "Z",
-            "",
-        )
-    )
-    return case(
-        (
-            and_(
-                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-                bucket_credit_state_expr == "available",
-                activated_at_expr != "",
-            ),
-            activated_at_expr,
-        ),
-        else_=CreditLedgerEntry.created_at,
-    )
 
 
 def _parse_stat_date(value: str) -> datetime.date | None:
@@ -737,7 +701,7 @@ def build_billing_ledger_page(
             CreditLedgerEntry.creator_bid == normalized_creator_bid,
         )
         query = _filter_out_reserved_credit_grant_ledgers(query).order_by(
-            _ledger_visible_at_sort_expr().desc(), CreditLedgerEntry.id.desc()
+            CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc()
         )
         total = query.order_by(None).count()
         if total == 0:

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional
 
 from flask import Flask
-from sqlalchemy import and_, case, or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import aliased
 
 from flaskr.dao import db
@@ -100,42 +100,6 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserPackageGrantResultDTO,
     AdminOperationUserReferralRewardSummaryDTO,
 )
-
-
-def _operator_credit_ledger_visible_at_sort_expr():
-    bucket_credit_state_expr = db.func.lower(
-        db.func.trim(
-            db.func.coalesce(
-                CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
-                "",
-            )
-        )
-    )
-    activated_at_expr = db.func.trim(
-        db.func.replace(
-            db.func.replace(
-                db.func.coalesce(
-                    CreditLedgerEntry.metadata_json["activated_at"].as_string(),
-                    "",
-                ),
-                "T",
-                " ",
-            ),
-            "Z",
-            "",
-        )
-    )
-    return case(
-        (
-            and_(
-                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
-                bucket_credit_state_expr == "available",
-                activated_at_expr != "",
-            ),
-            activated_at_expr,
-        ),
-        else_=CreditLedgerEntry.created_at,
-    )
 
 
 def grant_operator_user_credits(
@@ -531,8 +495,7 @@ def get_operator_user_credits(
                 )
 
         order_by_query = query.order_by(
-            _operator_credit_ledger_visible_at_sort_expr().desc(),
-            CreditLedgerEntry.id.desc(),
+            CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc()
         )
         total = query.count()
         page_offset = (safe_page_index - 1) * safe_page_size

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -346,6 +346,15 @@ def get_operator_user_credits(
             CreditLedgerEntry.deleted == 0,
             CreditLedgerEntry.creator_bid == normalized_user_bid,
         )
+        bucket_credit_state_expr = db.func.lower(
+            db.func.trim(
+                db.func.coalesce(
+                    CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
+                    "",
+                )
+            )
+        )
+        query = query.filter(bucket_credit_state_expr != "reserved")
 
         if start_time:
             query = query.filter(CreditLedgerEntry.created_at >= start_time)

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -354,7 +354,7 @@ def get_operator_user_credits(
                 )
             )
         )
-        query = query.filter(bucket_credit_state_expr != "reserved")
+        query = query.filter(bucket_credit_state_expr.notin_(("reserved", "absorbed")))
 
         if start_time:
             query = query.filter(CreditLedgerEntry.created_at >= start_time)

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional
 
 from flask import Flask
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, case, or_
 from sqlalchemy.orm import aliased
 
 from flaskr.dao import db
@@ -100,6 +100,42 @@ from flaskr.service.shifu.admin_dtos import (
     AdminOperationUserPackageGrantResultDTO,
     AdminOperationUserReferralRewardSummaryDTO,
 )
+
+
+def _operator_credit_ledger_visible_at_sort_expr():
+    bucket_credit_state_expr = db.func.lower(
+        db.func.trim(
+            db.func.coalesce(
+                CreditLedgerEntry.metadata_json["bucket_credit_state"].as_string(),
+                "",
+            )
+        )
+    )
+    activated_at_expr = db.func.trim(
+        db.func.replace(
+            db.func.replace(
+                db.func.coalesce(
+                    CreditLedgerEntry.metadata_json["activated_at"].as_string(),
+                    "",
+                ),
+                "T",
+                " ",
+            ),
+            "Z",
+            "",
+        )
+    )
+    return case(
+        (
+            and_(
+                CreditLedgerEntry.entry_type == CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                bucket_credit_state_expr == "available",
+                activated_at_expr != "",
+            ),
+            activated_at_expr,
+        ),
+        else_=CreditLedgerEntry.created_at,
+    )
 
 
 def grant_operator_user_credits(
@@ -495,7 +531,8 @@ def get_operator_user_credits(
                 )
 
         order_by_query = query.order_by(
-            CreditLedgerEntry.created_at.desc(), CreditLedgerEntry.id.desc()
+            _operator_credit_ledger_visible_at_sort_expr().desc(),
+            CreditLedgerEntry.id.desc(),
         )
         total = query.count()
         page_offset = (safe_page_index - 1) * safe_page_size

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1415,6 +1415,55 @@ class TestBillingRoutes:
 
         assert ledger_page.items[0].created_at == datetime(2026, 4, 6, 10, 0)
 
+    def test_build_billing_ledger_page_hides_reserved_grants_until_available(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+
+        with app.app_context():
+            dao.db.session.add_all(
+                [
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-reserved-renewal",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="bucket-subscription",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                        source_bid="order-reserved-renewal",
+                        idempotency_key="grant:order-reserved-renewal",
+                        amount=Decimal("1000.0000000000"),
+                        balance_after=Decimal("1098.0000000000"),
+                        expires_at=datetime(2026, 6, 1, 0, 0, 0),
+                        consumable_from=datetime(2026, 5, 1, 0, 0, 0),
+                        metadata_json={"bucket_credit_state": "reserved"},
+                        created_at=datetime(2026, 4, 7, 10, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 10, 0, 0),
+                    )
+                ]
+            )
+            dao.db.session.commit()
+
+        ledger_page = build_billing_ledger_page(app, "creator-1", page_size=10)
+
+        assert ledger_page.total == 2
+        assert {item.ledger_bid for item in ledger_page.items} == {
+            "ledger-consume",
+            "ledger-grant",
+        }
+
+        with app.app_context():
+            reserved_ledger = CreditLedgerEntry.query.filter_by(
+                ledger_bid="ledger-reserved-renewal"
+            ).one()
+            reserved_ledger.metadata_json = {"bucket_credit_state": "available"}
+            dao.db.session.commit()
+
+        activated_page = build_billing_ledger_page(app, "creator-1", page_size=10)
+
+        assert activated_page.total == 3
+        assert activated_page.items[0].ledger_bid == "ledger-reserved-renewal"
+
     def test_build_billing_ledger_page_uses_draft_course_name_for_non_prod_usage(
         self, billing_test_client
     ) -> None:

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1437,8 +1437,8 @@ class TestBillingRoutes:
                         expires_at=datetime(2026, 6, 1, 0, 0, 0),
                         consumable_from=datetime(2026, 5, 1, 0, 0, 0),
                         metadata_json={"bucket_credit_state": "reserved"},
-                        created_at=datetime(2026, 4, 7, 10, 0, 0),
-                        updated_at=datetime(2026, 4, 7, 10, 0, 0),
+                        created_at=datetime(2026, 4, 4, 10, 0, 0),
+                        updated_at=datetime(2026, 4, 4, 10, 0, 0),
                     ),
                     CreditLedgerEntry(
                         ledger_bid="ledger-absorbed-renewal",
@@ -1473,7 +1473,10 @@ class TestBillingRoutes:
             reserved_ledger = CreditLedgerEntry.query.filter_by(
                 ledger_bid="ledger-reserved-renewal"
             ).one()
-            reserved_ledger.metadata_json = {"bucket_credit_state": "available"}
+            reserved_ledger.metadata_json = {
+                "bucket_credit_state": "available",
+                "activated_at": "2026-04-08T10:00:00Z",
+            }
             dao.db.session.commit()
 
         activated_page = build_billing_ledger_page(app, "creator-1", page_size=10)

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1439,7 +1439,24 @@ class TestBillingRoutes:
                         metadata_json={"bucket_credit_state": "reserved"},
                         created_at=datetime(2026, 4, 7, 10, 0, 0),
                         updated_at=datetime(2026, 4, 7, 10, 0, 0),
-                    )
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-absorbed-renewal",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="bucket-subscription",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+                        source_bid="order-absorbed-renewal",
+                        idempotency_key="grant:order-absorbed-renewal",
+                        amount=Decimal("2000.0000000000"),
+                        balance_after=Decimal("98.0000000000"),
+                        expires_at=datetime(2026, 6, 1, 0, 0, 0),
+                        consumable_from=datetime(2026, 5, 1, 0, 0, 0),
+                        metadata_json={"bucket_credit_state": " AbSoRbEd "},
+                        created_at=datetime(2026, 4, 7, 11, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 11, 0, 0),
+                    ),
                 ]
             )
             dao.db.session.commit()

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1437,8 +1437,8 @@ class TestBillingRoutes:
                         expires_at=datetime(2026, 6, 1, 0, 0, 0),
                         consumable_from=datetime(2026, 5, 1, 0, 0, 0),
                         metadata_json={"bucket_credit_state": "reserved"},
-                        created_at=datetime(2026, 4, 4, 10, 0, 0),
-                        updated_at=datetime(2026, 4, 4, 10, 0, 0),
+                        created_at=datetime(2026, 4, 7, 10, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 10, 0, 0),
                     ),
                     CreditLedgerEntry(
                         ledger_bid="ledger-absorbed-renewal",
@@ -1473,10 +1473,7 @@ class TestBillingRoutes:
             reserved_ledger = CreditLedgerEntry.query.filter_by(
                 ledger_bid="ledger-reserved-renewal"
             ).one()
-            reserved_ledger.metadata_json = {
-                "bucket_credit_state": "available",
-                "activated_at": "2026-04-08T10:00:00Z",
-            }
+            reserved_ledger.metadata_json = {"bucket_credit_state": "available"}
             dao.db.session.commit()
 
         activated_page = build_billing_ledger_page(app, "creator-1", page_size=10)

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1550,6 +1550,92 @@ def test_get_operator_user_credits_returns_summary_and_paginated_ledger(app):
     assert result.items[0].note_code == ""
 
 
+def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
+    with app.app_context():
+        _seed_user(
+            app,
+            user_bid="credits-reserved-grant-user",
+            identify="credits-reserved-grant@example.com",
+            nickname="Reserved Grant",
+            state=USER_STATE_PAID,
+            is_creator=True,
+            created_at=datetime(2026, 4, 9, 9, 0, 0),
+            updated_at=datetime(2026, 4, 9, 10, 0, 0),
+            providers=[("email", "credits-reserved-grant@example.com")],
+        )
+        _seed_credit_wallet(
+            creator_bid="credits-reserved-grant-user",
+            wallet_bid="wallet-credits-reserved-grant-user",
+            available_credits="5.0000000000",
+        )
+        _seed_credit_ledger_entry(
+            creator_bid="credits-reserved-grant-user",
+            wallet_bid="wallet-credits-reserved-grant-user",
+            wallet_bucket_bid="bucket-reserved-grant-user",
+            ledger_bid="ledger-available-grant",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-available-grant",
+            amount="5.0000000000",
+            balance_after="5.0000000000",
+            created_at=datetime(2026, 4, 18, 8, 0, 0),
+            metadata_json={"bucket_credit_state": "available"},
+        )
+        _seed_credit_ledger_entry(
+            creator_bid="credits-reserved-grant-user",
+            wallet_bid="wallet-credits-reserved-grant-user",
+            wallet_bucket_bid="bucket-reserved-grant-user",
+            ledger_bid="ledger-reserved-grant",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-reserved-grant",
+            amount="1000.0000000000",
+            balance_after="5.0000000000",
+            created_at=datetime(2026, 4, 18, 9, 0, 0),
+            metadata_json={"bucket_credit_state": "reserved"},
+        )
+
+        all_result = get_operator_user_credits(
+            app,
+            user_bid="credits-reserved-grant-user",
+            page_index=1,
+            page_size=20,
+        )
+        grant_result = get_operator_user_credits(
+            app,
+            user_bid="credits-reserved-grant-user",
+            page_index=1,
+            page_size=20,
+            filters={"credit_type": "grant"},
+        )
+
+        reserved_entry = CreditLedgerEntry.query.filter_by(
+            ledger_bid="ledger-reserved-grant"
+        ).one()
+        reserved_entry.metadata_json = {"bucket_credit_state": "available"}
+        db.session.add(reserved_entry)
+        db.session.commit()
+        activated_result = get_operator_user_credits(
+            app,
+            user_bid="credits-reserved-grant-user",
+            page_index=1,
+            page_size=20,
+            filters={"credit_type": "grant"},
+        )
+
+    assert [item.ledger_bid for item in all_result.items] == ["ledger-available-grant"]
+    assert all_result.total == 1
+    assert [item.ledger_bid for item in grant_result.items] == [
+        "ledger-available-grant"
+    ]
+    assert grant_result.total == 1
+    assert [item.ledger_bid for item in activated_result.items] == [
+        "ledger-reserved-grant",
+        "ledger-available-grant",
+    ]
+    assert activated_result.total == 2
+
+
 def test_get_operator_user_credits_handles_invalid_source_type(app):
     with app.app_context():
         _seed_user(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1591,7 +1591,7 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
             source_bid="order-reserved-grant",
             amount="1000.0000000000",
             balance_after="5.0000000000",
-            created_at=datetime(2026, 4, 18, 9, 0, 0),
+            created_at=datetime(2026, 4, 17, 9, 0, 0),
             metadata_json={"bucket_credit_state": " ReSeRvEd "},
         )
         _seed_credit_ledger_entry(
@@ -1625,7 +1625,10 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
         reserved_entry = CreditLedgerEntry.query.filter_by(
             ledger_bid="ledger-reserved-grant"
         ).one()
-        reserved_entry.metadata_json = {"bucket_credit_state": "available"}
+        reserved_entry.metadata_json = {
+            "bucket_credit_state": "available",
+            "activated_at": "2026-04-19T09:00:00Z",
+        }
         db.session.add(reserved_entry)
         db.session.commit()
         activated_result = get_operator_user_credits(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1591,7 +1591,7 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
             source_bid="order-reserved-grant",
             amount="1000.0000000000",
             balance_after="5.0000000000",
-            created_at=datetime(2026, 4, 17, 9, 0, 0),
+            created_at=datetime(2026, 4, 18, 9, 0, 0),
             metadata_json={"bucket_credit_state": " ReSeRvEd "},
         )
         _seed_credit_ledger_entry(
@@ -1625,10 +1625,7 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
         reserved_entry = CreditLedgerEntry.query.filter_by(
             ledger_bid="ledger-reserved-grant"
         ).one()
-        reserved_entry.metadata_json = {
-            "bucket_credit_state": "available",
-            "activated_at": "2026-04-19T09:00:00Z",
-        }
+        reserved_entry.metadata_json = {"bucket_credit_state": "available"}
         db.session.add(reserved_entry)
         db.session.commit()
         activated_result = get_operator_user_credits(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1592,7 +1592,7 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
             amount="1000.0000000000",
             balance_after="5.0000000000",
             created_at=datetime(2026, 4, 18, 9, 0, 0),
-            metadata_json={"bucket_credit_state": "reserved"},
+            metadata_json={"bucket_credit_state": " ReSeRvEd "},
         )
 
         all_result = get_operator_user_credits(

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1594,6 +1594,19 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
             created_at=datetime(2026, 4, 18, 9, 0, 0),
             metadata_json={"bucket_credit_state": " ReSeRvEd "},
         )
+        _seed_credit_ledger_entry(
+            creator_bid="credits-reserved-grant-user",
+            wallet_bid="wallet-credits-reserved-grant-user",
+            wallet_bucket_bid="bucket-reserved-grant-user",
+            ledger_bid="ledger-absorbed-grant",
+            entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+            source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+            source_bid="order-absorbed-grant",
+            amount="2000.0000000000",
+            balance_after="5.0000000000",
+            created_at=datetime(2026, 4, 18, 10, 0, 0),
+            metadata_json={"bucket_credit_state": " AbSoRbEd "},
+        )
 
         all_result = get_operator_user_credits(
             app,


### PR DESCRIPTION
## Summary
- hide credit ledger rows marked as `bucket_credit_state=reserved` from operator user credit detail pages
- hide the same reserved grant rows from the creator billing ledger used by `admin/billing?tab=details`
- keep prepaid package and referral reward credits out of visible ledger tables until activation changes them to `available`
- add regression coverage for both operator user credit details and creator billing ledger views

## Scope
- read-model filtering only for ledger/detail display surfaces
- no wallet, bucket, or ledger mutation changes
- no schema or migration changes
- no frontend changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved and absorbed credit grants are now excluded from operator credit results and billing ledgers.
  * Available credit grants are ordered by activation date, with a fallback to creation date.
  * Credit entries become visible automatically once their status changes to available.
  * Filtering consistently handles differences in capitalization and surrounding whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->