### PR TITLE
fix: sync payment provider after Pingxx plan purchase

### DIFF
--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2185,6 +2185,18 @@ def _sync_pingxx_order(
         client_ip=str(charge.get("client_ip") or ""),
         extra=charge.get("extra"),
     )
+    if order.subscription_bid and target_status == BILLING_ORDER_STATUS_PAID:
+        subscription = _load_subscription_by_bid(order.subscription_bid)
+        if subscription is not None:
+            _apply_subscription_checkout_success(
+                app,
+                subscription,
+                payload=charge,
+                provider="pingxx",
+                event_type="manual_sync",
+                source="sync",
+            )
+
     return order_update
 
 

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2185,7 +2185,11 @@ def _sync_pingxx_order(
         client_ip=str(charge.get("client_ip") or ""),
         extra=charge.get("extra"),
     )
-    if order.subscription_bid and target_status == BILLING_ORDER_STATUS_PAID:
+    if (
+        order_update.applied
+        and order.subscription_bid
+        and target_status == BILLING_ORDER_STATUS_PAID
+    ):
         subscription = _load_subscription_by_bid(order.subscription_bid)
         if subscription is not None:
             _apply_subscription_checkout_success(

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -341,6 +341,19 @@ def handle_billing_pingxx_webhook(
             client_ip=str(charge.get("client_ip") or ""),
             extra=charge.get("extra"),
         )
+        if order.subscription_bid and target_status == BILLING_ORDER_STATUS_PAID:
+            from .subscriptions import load_subscription_by_bid
+
+            subscription = load_subscription_by_bid(order.subscription_bid)
+            if subscription is not None:
+                _apply_subscription_checkout_success(
+                    app,
+                    subscription,
+                    payload=charge,
+                    provider="pingxx",
+                    event_type=event_type or "charge.succeeded",
+                )
+
         order_update.stage_after_state_changes(app, order)
         db.session.commit()
         order_update.dispatch_after_commit(app)

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -341,7 +341,11 @@ def handle_billing_pingxx_webhook(
             client_ip=str(charge.get("client_ip") or ""),
             extra=charge.get("extra"),
         )
-        if order.subscription_bid and target_status == BILLING_ORDER_STATUS_PAID:
+        if (
+            order_update.applied
+            and order.subscription_bid
+            and target_status == BILLING_ORDER_STATUS_PAID
+        ):
             from .subscriptions import load_subscription_by_bid
 
             subscription = load_subscription_by_bid(order.subscription_bid)

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -13,6 +13,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
 )
 from flaskr.service.billing.models import (
@@ -383,6 +384,76 @@ class TestBillingPingxxCallbacks:
             assert wallet.available_credits == 20
             assert bucket.available_credits == 20
             assert ledger.amount == 20
+
+    def test_pingxx_callback_syncs_manual_trial_subscription_provider(
+        self, billing_callback_app
+    ) -> None:
+        with billing_callback_app.app_context():
+            now = datetime(2026, 4, 8, 12, 0, 0)
+            dao.db.session.add(
+                BillingSubscription(
+                    subscription_bid="sub-manual-trial-to-pingxx",
+                    creator_bid="creator-1",
+                    product_bid="bill-product-plan-trial",
+                    status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                    billing_provider="manual",
+                    current_period_start_at=now - timedelta(days=1),
+                    current_period_end_at=now + timedelta(days=14),
+                )
+            )
+            dao.db.session.add(
+                BillingOrder(
+                    bill_order_bid="bill-pingxx-trial-upgrade-1",
+                    creator_bid="creator-1",
+                    order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
+                    product_bid="bill-product-plan-monthly",
+                    subscription_bid="sub-manual-trial-to-pingxx",
+                    currency="CNY",
+                    payable_amount=9900,
+                    paid_amount=0,
+                    payment_provider="pingxx",
+                    channel="wx_pub_qr",
+                    provider_reference_id="ch_trial_upgrade_pingxx_1",
+                    status=BILLING_ORDER_STATUS_PENDING,
+                    failure_code="",
+                    failure_message="",
+                    metadata_json={"checkout_type": "subscription"},
+                )
+            )
+            dao.db.session.add(
+                _create_billing_pingxx_raw_snapshot(
+                    "bill-pingxx-trial-upgrade-1",
+                    "ch_trial_upgrade_pingxx_1",
+                )
+            )
+            dao.db.session.commit()
+
+            body = {
+                "type": "charge.succeeded",
+                "data": {
+                    "object": {
+                        "id": "ch_trial_upgrade_pingxx_1",
+                        "order_no": "bill-pingxx-trial-upgrade-1",
+                        "paid": True,
+                        "time_paid": 1785470453,
+                        "channel": "wx_pub_qr",
+                    }
+                },
+            }
+
+            payload, status_code = handle_billing_pingxx_webhook(
+                billing_callback_app, body
+            )
+
+            assert status_code == 200
+            assert payload["status"] == "paid"
+            subscription = BillingSubscription.query.filter_by(
+                subscription_bid="sub-manual-trial-to-pingxx"
+            ).one()
+            assert subscription.product_bid == "bill-product-plan-monthly"
+            assert subscription.billing_provider == "pingxx"
+            assert subscription.metadata_json["provider"] == "pingxx"
+            assert subscription.metadata_json["latest_source"] == "webhook"
 
     def test_pingxx_callback_reports_non_billing_payload(
         self, billing_callback_app

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -13,6 +13,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
 )
@@ -450,10 +451,26 @@ class TestBillingPingxxCallbacks:
             subscription = BillingSubscription.query.filter_by(
                 subscription_bid="sub-manual-trial-to-pingxx"
             ).one()
+            order = BillingOrder.query.filter_by(
+                bill_order_bid="bill-pingxx-trial-upgrade-1"
+            ).one()
+            assert order.status == BILLING_ORDER_STATUS_PAID
             assert subscription.product_bid == "bill-product-plan-monthly"
             assert subscription.billing_provider == "pingxx"
             assert subscription.metadata_json["provider"] == "pingxx"
             assert subscription.metadata_json["latest_source"] == "webhook"
+            subscription.cancel_at_period_end = 1
+            subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED
+            dao.db.session.commit()
+
+            duplicate_payload, duplicate_status = handle_billing_pingxx_webhook(
+                billing_callback_app, body
+            )
+
+            assert duplicate_status == 200
+            assert duplicate_payload["status"] == "paid"
+            assert subscription.cancel_at_period_end == 1
+            assert subscription.status == BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED
 
     def test_pingxx_callback_reports_non_billing_payload(
         self, billing_callback_app

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -15,6 +15,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PENDING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     BILLING_TRIAL_PRODUCT_BID,
@@ -636,6 +637,87 @@ def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
         ).one()
         notification = order.metadata_json["notifications"]["billing_paid_feishu"]
         assert notification["status"] == "pending"
+
+
+def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
+    billing_subscription_sms_app,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = billing_subscription_sms_app
+    _seed_creator(app)
+    paid_at = datetime(2026, 7, 31, 4, 0, 53)
+
+    class FakePingxxProvider:
+        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            assert provider_reference == "ch_trial_upgrade_sync_pingxx_1"
+            assert reference_type == "charge"
+            return PaymentNotificationResult(
+                order_bid="",
+                status="manual_sync",
+                provider_payload={
+                    "charge": {
+                        "id": provider_reference,
+                        "order_no": "billing-trial-upgrade-sync-1",
+                        "paid": True,
+                        "time_paid": _utc_epoch(paid_at),
+                        "channel": "wx_pub_qr",
+                    }
+                },
+                charge_id=provider_reference,
+            )
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.checkout.get_payment_provider",
+        lambda channel: FakePingxxProvider(),
+    )
+
+    with app.app_context():
+        dao.db.session.add(
+            BillingSubscription(
+                subscription_bid="sub-trial-upgrade-sync-1",
+                creator_bid="creator-1",
+                product_bid=BILLING_TRIAL_PRODUCT_BID,
+                status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+                billing_provider="manual",
+                current_period_start_at=paid_at - timedelta(days=1),
+                current_period_end_at=paid_at + timedelta(days=14),
+            )
+        )
+        dao.db.session.add(
+            BillingOrder(
+                bill_order_bid="billing-trial-upgrade-sync-1",
+                creator_bid="creator-1",
+                order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
+                product_bid="bill-product-plan-monthly",
+                subscription_bid="sub-trial-upgrade-sync-1",
+                currency="CNY",
+                payable_amount=9900,
+                paid_amount=0,
+                payment_provider="pingxx",
+                channel="wx_pub_qr",
+                provider_reference_id="ch_trial_upgrade_sync_pingxx_1",
+                status=BILLING_ORDER_STATUS_PENDING,
+                metadata_json={"checkout_type": "subscription"},
+            )
+        )
+        dao.db.session.commit()
+
+    payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-trial-upgrade-sync-1",
+        {},
+    )
+
+    assert payload.status == "paid"
+    with app.app_context():
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid="sub-trial-upgrade-sync-1"
+        ).one()
+        assert subscription.product_bid == "bill-product-plan-monthly"
+        assert subscription.billing_provider == "pingxx"
+        assert subscription.metadata_json["provider"] == "pingxx"
+        assert subscription.metadata_json["latest_source"] == "sync"
 
 
 def test_send_billing_paid_feishu_task_marks_sent(

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -18,6 +18,7 @@ from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+    BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
     BILLING_TRIAL_PRODUCT_BID,
 )
 from flaskr.service.billing.checkout import sync_billing_order
@@ -714,10 +715,32 @@ def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
         subscription = BillingSubscription.query.filter_by(
             subscription_bid="sub-trial-upgrade-sync-1"
         ).one()
+        order = BillingOrder.query.filter_by(
+            bill_order_bid="billing-trial-upgrade-sync-1"
+        ).one()
+        assert order.status == BILLING_ORDER_STATUS_PAID
         assert subscription.product_bid == "bill-product-plan-monthly"
         assert subscription.billing_provider == "pingxx"
         assert subscription.metadata_json["provider"] == "pingxx"
         assert subscription.metadata_json["latest_source"] == "sync"
+        subscription.cancel_at_period_end = 1
+        subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED
+        dao.db.session.commit()
+
+    duplicate_payload = sync_billing_order(
+        app,
+        "creator-1",
+        "billing-trial-upgrade-sync-1",
+        {},
+    )
+
+    assert duplicate_payload.status == "paid"
+    with app.app_context():
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid="sub-trial-upgrade-sync-1"
+        ).one()
+        assert subscription.cancel_at_period_end == 1
+        assert subscription.status == BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED
 
 
 def test_send_billing_paid_feishu_task_marks_sent(


### PR DESCRIPTION
## Summary
- sync subscription `billing_provider` on Ping++ webhook payment success
- sync subscription `billing_provider` on Ping++ manual order sync success
- add regression coverage for manual trial subscriptions upgraded through Ping++ paid plan orders

## Scope
- Ping++ subscription paid-success state sync only
- no schema or migration changes
- no wallet, bucket, or ledger mutation rule changes
- no frontend changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription upgrades so successful Pingxx payments correctly complete checkout.
  * Subscription details now update with the selected product, billing provider, and payment metadata after payment confirmation.
  * Fixed webhook processing to apply subscription changes when an upgrade payment is marked as paid.

* **Tests**
  * Added coverage for manual trial subscription upgrades through payment webhooks and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->