### PR TITLE
fix: align credit expiry details

### DIFF
--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -317,7 +317,7 @@ export function BillingCreditDetailsPanel({
               <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-end px-[var(--spacing-2,8px)] text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
                 {t('module.billing.details.table.balance')}
               </div>
-              <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-center px-[var(--spacing-2,8px)] text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
+              <div className='flex h-[var(--height-h-10,40px)] min-w-[85px] items-center justify-end px-[var(--spacing-2,8px)] text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-muted-foreground,#737373)]'>
                 {t('module.billing.details.table.validUntil')}
               </div>
             </div>
@@ -344,7 +344,7 @@ export function BillingCreditDetailsPanel({
                         i18n.language,
                       )}
                     </div>
-                    <div className='px-[var(--spacing-2,8px)] py-4 text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
+                    <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
                       <CategoryValidityCell
                         availableCredits={row.availableCredits}
                         emptyValidityLabel={emptyValidityLabel}

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -344,7 +344,7 @@ export function BillingCreditDetailsPanel({
                         i18n.language,
                       )}
                     </div>
-                    <div className='px-[var(--spacing-2,8px)] py-4 text-right text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
+                    <div className='px-[var(--spacing-2,8px)] py-4 text-center text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-medium,500)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-foreground,#0A0A0A)]'>
                       <CategoryValidityCell
                         availableCredits={row.availableCredits}
                         emptyValidityLabel={emptyValidityLabel}


### PR DESCRIPTION
## Summary
- Align the credit details validity column header to the right.
- Keep validity values centered so date text and the no-expiration tooltip row remain visually balanced.
- Keep the change scoped to `BillingCreditDetailsPanel` layout classes.

