### PR TITLE
refactor: centralize billing renewal event transitions

### DIFF
--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -50,6 +50,11 @@ from .queries import (
     extract_resolved_order_cycle_start_at as _extract_resolved_order_cycle_start_at,
 )
 from .reserved_renewal_activation import IncompleteReservedGrantActivationError
+from .renewal_event_transitions import (
+    complete_renewal_event as _complete_renewal_event,
+    fail_renewal_event as _fail_renewal_event,
+    release_renewal_event as _release_renewal_event,
+)
 from .subscriptions import (
     activate_subscription_for_paid_order as _activate_subscription_for_paid_order,
     ensure_subscription_renewal_order,
@@ -929,33 +934,6 @@ def _claim_target_renewal_event(
         creator_bid=creator_bid,
     )
     return "claimed", claimed
-
-
-def _release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
-    event.updated_at = now
-    db.session.add(event)
-
-
-def _complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
-    event.last_error = ""
-    event.processed_at = now
-    event.updated_at = now
-    db.session.add(event)
-
-
-def _fail_renewal_event(
-    event: BillingRenewalEvent,
-    *,
-    now: datetime,
-    error: str,
-) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_FAILED
-    event.last_error = str(error or "")[:255]
-    event.processed_at = now
-    event.updated_at = now
-    db.session.add(event)
 
 
 def _load_target_renewal_event(

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -1,0 +1,185 @@
+"""Renewal event persistence transitions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from flask import Flask
+
+from flaskr.dao import db
+from flaskr.util.datetime import now_utc
+from flaskr.util.uuid import generate_id
+
+from .consts import (
+    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
+    BILLING_RENEWAL_EVENT_STATUS_PENDING,
+    BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+    BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
+    BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
+    BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
+    BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+    BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    BILLING_RENEWAL_EVENT_TYPE_RETRY,
+    BILLING_SUBSCRIPTION_STATUS_LABELS,
+)
+from .models import BillingRenewalEvent, BillingSubscription
+from .primitives import normalize_bid as _normalize_bid
+from .primitives import normalize_json_object as _normalize_json_object
+from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
+
+MANAGED_RENEWAL_EVENT_TYPES = (
+    BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    BILLING_RENEWAL_EVENT_TYPE_RETRY,
+    BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
+    BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
+    BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+)
+
+PENDING_RENEWAL_EVENT_STATUSES = (
+    BILLING_RENEWAL_EVENT_STATUS_PENDING,
+    BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
+)
+
+
+def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
+    event.updated_at = now
+    db.session.add(event)
+
+
+def complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
+    event.status = BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    event.last_error = ""
+    event.processed_at = now
+    event.updated_at = now
+    db.session.add(event)
+
+
+def fail_renewal_event(
+    event: BillingRenewalEvent,
+    *,
+    now: datetime,
+    error: str,
+) -> None:
+    event.status = BILLING_RENEWAL_EVENT_STATUS_FAILED
+    event.last_error = str(error or "")[:255]
+    event.processed_at = now
+    event.updated_at = now
+    db.session.add(event)
+
+
+def build_subscription_renewal_event_payload(
+    subscription: BillingSubscription,
+) -> dict[str, Any]:
+    return _normalize_json_object(
+        {
+            "subscription_bid": subscription.subscription_bid,
+            "creator_bid": subscription.creator_bid,
+            "product_bid": subscription.product_bid,
+            "next_product_bid": _normalize_bid(subscription.next_product_bid) or None,
+            "status": BILLING_SUBSCRIPTION_STATUS_LABELS.get(
+                subscription.status,
+                "draft",
+            ),
+            "cancel_at_period_end": bool(subscription.cancel_at_period_end),
+        }
+    ).to_metadata_json()
+
+
+def upsert_subscription_renewal_event(
+    app: Flask,
+    subscription: BillingSubscription,
+    *,
+    event_type: int,
+    scheduled_at: datetime,
+) -> None:
+    normalized_scheduled_at = _normalize_mysql_datetime(scheduled_at)
+    payload = build_subscription_renewal_event_payload(subscription)
+    event = (
+        BillingRenewalEvent.query.filter(
+            BillingRenewalEvent.deleted == 0,
+            BillingRenewalEvent.subscription_bid == subscription.subscription_bid,
+            BillingRenewalEvent.event_type == event_type,
+            BillingRenewalEvent.scheduled_at == normalized_scheduled_at,
+        )
+        .order_by(BillingRenewalEvent.id.desc())
+        .first()
+    )
+    if event is None:
+        event = BillingRenewalEvent(
+            renewal_event_bid=generate_id(app),
+            subscription_bid=subscription.subscription_bid,
+            creator_bid=subscription.creator_bid,
+            event_type=event_type,
+            scheduled_at=normalized_scheduled_at,
+            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            attempt_count=0,
+            last_error="",
+            payload_json=payload,
+            processed_at=None,
+        )
+    else:
+        event.creator_bid = subscription.creator_bid
+        event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
+        event.last_error = ""
+        event.payload_json = payload
+        event.processed_at = None
+        event.updated_at = now_utc()
+
+    db.session.add(event)
+    cancel_stale_subscription_renewal_events(
+        subscription.subscription_bid,
+        event_type=event_type,
+        keep_scheduled_at=normalized_scheduled_at,
+    )
+
+
+def cancel_stale_subscription_renewal_events(
+    subscription_bid: str,
+    *,
+    event_type: int,
+    keep_scheduled_at: datetime,
+) -> None:
+    rows = (
+        BillingRenewalEvent.query.filter(
+            BillingRenewalEvent.deleted == 0,
+            BillingRenewalEvent.subscription_bid == subscription_bid,
+            BillingRenewalEvent.event_type == event_type,
+            BillingRenewalEvent.status.in_(PENDING_RENEWAL_EVENT_STATUSES),
+            BillingRenewalEvent.scheduled_at != keep_scheduled_at,
+        )
+        .order_by(BillingRenewalEvent.id.desc())
+        .all()
+    )
+    now = now_utc()
+    for row in rows:
+        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
+        row.processed_at = now
+        row.updated_at = now
+        db.session.add(row)
+
+
+def cancel_subscription_renewal_events(
+    subscription_bid: str,
+    *,
+    event_types: tuple[int, ...] = MANAGED_RENEWAL_EVENT_TYPES,
+) -> None:
+    rows = (
+        BillingRenewalEvent.query.filter(
+            BillingRenewalEvent.deleted == 0,
+            BillingRenewalEvent.subscription_bid == subscription_bid,
+            BillingRenewalEvent.event_type.in_(event_types),
+            BillingRenewalEvent.status.in_(PENDING_RENEWAL_EVENT_STATUSES),
+        )
+        .order_by(BillingRenewalEvent.id.desc())
+        .all()
+    )
+    now = now_utc()
+    for row in rows:
+        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
+        row.processed_at = now
+        row.updated_at = now
+        db.session.add(row)

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -22,10 +22,6 @@ from .consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE,
-    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
-    BILLING_RENEWAL_EVENT_STATUS_FAILED,
-    BILLING_RENEWAL_EVENT_STATUS_PENDING,
-    BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
     BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
@@ -35,7 +31,6 @@ from .consts import (
     BILLING_SUBSCRIPTION_STATUS_CANCELED,
     BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
-    BILLING_SUBSCRIPTION_STATUS_LABELS,
     BILLING_SUBSCRIPTION_STATUS_PAUSED,
     BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
@@ -66,7 +61,6 @@ from .dtos import BillingSubscriptionDTO
 from .models import (
     BillingOrder,
     BillingProduct,
-    BillingRenewalEvent,
     BillingSubscription,
     CreditLedgerEntry,
     CreditWallet,
@@ -91,6 +85,10 @@ from .reserved_renewal_activation import (
     sync_activated_reserved_renewal_ledger_balances as _sync_activated_reserved_renewal_ledger_balances,
     validate_reserved_renewal_cycle_activation,  # noqa: F401
 )
+from .renewal_event_transitions import (
+    cancel_subscription_renewal_events as _cancel_subscription_renewal_events,
+    upsert_subscription_renewal_event as _upsert_subscription_renewal_event,
+)
 from .queries import (
     extract_order_metadata_datetime as _extract_order_metadata_datetime,
     calculate_billing_cycle_end as _calc_provider_cycle_end,
@@ -105,7 +103,6 @@ from .queries import (
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
 from .primitives import normalize_json_value as _normalize_json_value
-from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
 from .serializers import serialize_subscription as _serialize_subscription
@@ -118,20 +115,6 @@ from .wallets import (
     sync_credit_bucket_status,
 )
 from .value_objects import JsonObjectMap
-
-_MANAGED_RENEWAL_EVENT_TYPES = (
-    BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
-    BILLING_RENEWAL_EVENT_TYPE_RETRY,
-    BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
-    BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
-    BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
-)
-
-_PENDING_RENEWAL_EVENT_STATUSES = (
-    BILLING_RENEWAL_EVENT_STATUS_PENDING,
-    BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
-    BILLING_RENEWAL_EVENT_STATUS_FAILED,
-)
 
 
 SELF_MANAGED_BILLING_PROVIDERS = {"pingxx", "alipay", "wechatpay", "manual"}
@@ -2250,114 +2233,6 @@ def _sync_subscription_lifecycle_events(
             BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
         ),
     )
-
-
-def _upsert_subscription_renewal_event(
-    app: Flask,
-    subscription: BillingSubscription,
-    *,
-    event_type: int,
-    scheduled_at: datetime,
-) -> None:
-    normalized_scheduled_at = _normalize_mysql_datetime(scheduled_at)
-    payload = _normalize_json_object(
-        {
-            "subscription_bid": subscription.subscription_bid,
-            "creator_bid": subscription.creator_bid,
-            "product_bid": subscription.product_bid,
-            "next_product_bid": _normalize_bid(subscription.next_product_bid) or None,
-            "status": BILLING_SUBSCRIPTION_STATUS_LABELS.get(
-                subscription.status,
-                "draft",
-            ),
-            "cancel_at_period_end": bool(subscription.cancel_at_period_end),
-        }
-    )
-    event = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription.subscription_bid,
-            BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.scheduled_at == normalized_scheduled_at,
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .first()
-    )
-    if event is None:
-        event = BillingRenewalEvent(
-            renewal_event_bid=generate_id(app),
-            subscription_bid=subscription.subscription_bid,
-            creator_bid=subscription.creator_bid,
-            event_type=event_type,
-            scheduled_at=normalized_scheduled_at,
-            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
-            attempt_count=0,
-            last_error="",
-            payload_json=payload.to_metadata_json(),
-            processed_at=None,
-        )
-    else:
-        event.creator_bid = subscription.creator_bid
-        event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
-        event.last_error = ""
-        event.payload_json = payload.to_metadata_json()
-        event.processed_at = None
-        event.updated_at = now_utc()
-
-    db.session.add(event)
-    _cancel_stale_subscription_renewal_events(
-        subscription.subscription_bid,
-        event_type=event_type,
-        keep_scheduled_at=normalized_scheduled_at,
-    )
-
-
-def _cancel_stale_subscription_renewal_events(
-    subscription_bid: str,
-    *,
-    event_type: int,
-    keep_scheduled_at: datetime,
-) -> None:
-    rows = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription_bid,
-            BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.status.in_(_PENDING_RENEWAL_EVENT_STATUSES),
-            BillingRenewalEvent.scheduled_at != keep_scheduled_at,
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .all()
-    )
-    now = now_utc()
-    for row in rows:
-        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
-        row.processed_at = now
-        row.updated_at = now
-        db.session.add(row)
-
-
-def _cancel_subscription_renewal_events(
-    subscription_bid: str,
-    *,
-    event_types: tuple[int, ...] = _MANAGED_RENEWAL_EVENT_TYPES,
-) -> None:
-    rows = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription_bid,
-            BillingRenewalEvent.event_type.in_(event_types),
-            BillingRenewalEvent.status.in_(_PENDING_RENEWAL_EVENT_STATUSES),
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .all()
-    )
-    now = now_utc()
-    for row in rows:
-        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
-        row.processed_at = now
-        row.updated_at = now
-        db.session.add(row)
 
 
 activate_subscription_for_paid_order = _activate_subscription_for_paid_order


### PR DESCRIPTION
## Summary
- add a dedicated billing renewal event transition module
- move renewal event release, completion, and failure state writes out of renewal.py
- move subscription renewal event upsert and cancellation helpers out of subscriptions.py
- keep subscription lifecycle sync and renewal execution entry points unchanged
- preserve existing event payload, status, timestamp, and cancellation behavior

## Scope
- Billing R3-D minimal equivalent extraction
- no schema or migration changes
- no new billing business rules
- no reserved grant activation behavior changes
- no admission, settlement, history repair, or ledger append-only behavior changes
- no MySQL concurrency test expansion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable handling for subscription renewal events, including creation, updates, completion, failure, and cancellation.
  * Renewal events now prevent stale or duplicate pending events from remaining active.
  * Subscription renewal details are consistently refreshed when events are scheduled.

* **Bug Fixes**
  * Improved persistence of renewal-event status, timestamps, and error information throughout the event lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->