### PR TITLE
fix: harden renewal event concurrency

### DIFF
--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -112,12 +112,11 @@ def _load_subscription_by_bid_for_update(
     )
 
 
-def _ensure_renewal_event_claim_current(
-    event: BillingRenewalEvent,
-    *,
-    now: datetime,
-) -> None:
-    _assert_renewal_event_claim_current(event, now=now, touch=True)
+def _ensure_renewal_event_claim_current(event: BillingRenewalEvent) -> None:
+    # A PROCESSING event's updated_at is its short lease heartbeat.  Always
+    # use the check-time timestamp so stale recovery cannot immediately
+    # reclaim a long-running attempt after this guard succeeds.
+    _assert_renewal_event_claim_current(event, now=now_utc(), touch=True)
 
 
 def _is_subscription_obsolete(subscription: BillingSubscription) -> bool:
@@ -799,7 +798,7 @@ def _execute_subscription_renewal(
         if _is_subscription_obsolete(subscription):
             return _complete_obsolete_renewal_event(event, subscription, now=now)
 
-        _ensure_renewal_event_claim_current(event, now=now)
+        _ensure_renewal_event_claim_current(event)
         order = ensure_subscription_renewal_order(
             app,
             subscription,
@@ -844,7 +843,13 @@ def _execute_subscription_renewal(
     # commits its own session. Confirm claim ownership immediately before the
     # cross-transaction side effect, so stale workers stop before syncing.
     with unit_of_work():
-        _ensure_renewal_event_claim_current(event, now=now)
+        subscription = _load_subscription_by_bid_for_update(event.subscription_bid)
+        if subscription is None:
+            _fail_renewal_event(event, now=now_utc(), error="subscription_not_found")
+            return _result_from_event("failed", event, bill_order_bid=bill_order_bid)
+        if _is_subscription_obsolete(subscription):
+            return _complete_obsolete_renewal_event(event, subscription, now=now_utc())
+        _ensure_renewal_event_claim_current(event)
     result = _sync_billing_renewal_order(app, order=order, event=event)
     sync_status = str(result.status or "")
     # The provider sync commits in its OWN session; `order` and `event` held
@@ -887,13 +892,13 @@ def _execute_retry_or_reconcile(
     # persists its own results, so confirm claim ownership and subscription
     # lifecycle immediately before entering the cross-transaction side effect.
     with unit_of_work():
-        _ensure_renewal_event_claim_current(event, now=now)
         subscription = _load_subscription_by_bid_for_update(event.subscription_bid)
         if subscription is None:
             _fail_renewal_event(event, now=now, error="subscription_not_found")
             return _result_from_event("failed", event)
         if _is_subscription_obsolete(subscription):
             return _complete_obsolete_renewal_event(event, subscription, now=now)
+        _ensure_renewal_event_claim_current(event)
 
     result = retry_billing_renewal_event(
         app,

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -54,6 +54,7 @@ from .queries import (
 from .reserved_renewal_activation import IncompleteReservedGrantActivationError
 from .renewal_event_transitions import (
     RenewalEventClaimLostError,
+    assert_renewal_event_claim_current as _assert_renewal_event_claim_current,
     bind_renewal_event_claim as _bind_renewal_event_claim,
     complete_renewal_event as _complete_renewal_event,
     fail_renewal_event as _fail_renewal_event,
@@ -109,6 +110,21 @@ def _load_subscription_by_bid_for_update(
         .order_by(BillingSubscription.id.desc())
         .first()
     )
+
+
+def _ensure_renewal_event_claim_current(
+    event: BillingRenewalEvent,
+    *,
+    now: datetime,
+) -> None:
+    _assert_renewal_event_claim_current(event, now=now, touch=True)
+
+
+def _is_subscription_obsolete(subscription: BillingSubscription) -> bool:
+    return int(subscription.status or 0) in {
+        BILLING_SUBSCRIPTION_STATUS_CANCELED,
+        BILLING_SUBSCRIPTION_STATUS_EXPIRED,
+    }
 
 
 def _load_event_payload_renewal_order(
@@ -780,12 +796,10 @@ def _execute_subscription_renewal(
             _fail_renewal_event(event, now=now, error="subscription_not_found")
             return _result_from_event("failed", event)
 
-        if int(subscription.status or 0) in {
-            BILLING_SUBSCRIPTION_STATUS_CANCELED,
-            BILLING_SUBSCRIPTION_STATUS_EXPIRED,
-        }:
+        if _is_subscription_obsolete(subscription):
             return _complete_obsolete_renewal_event(event, subscription, now=now)
 
+        _ensure_renewal_event_claim_current(event, now=now)
         order = ensure_subscription_renewal_order(
             app,
             subscription,
@@ -827,7 +841,10 @@ def _execute_subscription_renewal(
 
     # Provider sync stays OUTSIDE any unit of work: it wraps a non-idempotent
     # external payment call and (see NOTE in _sync_billing_renewal_order)
-    # commits its own session.
+    # commits its own session. Confirm claim ownership immediately before the
+    # cross-transaction side effect, so stale workers stop before syncing.
+    with unit_of_work():
+        _ensure_renewal_event_claim_current(event, now=now)
     result = _sync_billing_renewal_order(app, order=order, event=event)
     sync_status = str(result.status or "")
     # The provider sync commits in its OWN session; `order` and `event` held
@@ -867,8 +884,17 @@ def _execute_retry_or_reconcile(
     now: datetime,
 ) -> RenewalEventResult:
     # The retry path ends in a non-idempotent payment-provider sync that
-    # persists its own results, so it runs OUTSIDE any unit of work here;
-    # only the terminal event transition below is this function's write.
+    # persists its own results, so confirm claim ownership and subscription
+    # lifecycle immediately before entering the cross-transaction side effect.
+    with unit_of_work():
+        _ensure_renewal_event_claim_current(event, now=now)
+        subscription = _load_subscription_by_bid_for_update(event.subscription_bid)
+        if subscription is None:
+            _fail_renewal_event(event, now=now, error="subscription_not_found")
+            return _result_from_event("failed", event)
+        if _is_subscription_obsolete(subscription):
+            return _complete_obsolete_renewal_event(event, subscription, now=now)
+
     result = retry_billing_renewal_event(
         app,
         renewal_event_bid=event.renewal_event_bid,

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -11,7 +11,7 @@ from flask import Flask
 from flaskr.dao import db, retry_on_deadlock
 from flaskr.dao import uow
 from flaskr.dao.uow import app_context_scope, unit_of_work
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, to_utc_iso
 
 from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
@@ -163,7 +163,7 @@ def _cancel_obsolete_renewal_order(
         dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
     )
     metadata["canceled_reason"] = reason
-    metadata["canceled_at"] = now.isoformat()
+    metadata["canceled_at"] = to_utc_iso(now)
     order.status = BILLING_ORDER_STATUS_CANCELED
     order.metadata_json = metadata
     order.updated_at = now

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -670,6 +670,20 @@ def _execute_subscription_renewal(
             _fail_renewal_event(event, now=now, error="subscription_not_found")
             return _result_from_event("failed", event)
 
+        if int(subscription.status or 0) in {
+            BILLING_SUBSCRIPTION_STATUS_CANCELED,
+            BILLING_SUBSCRIPTION_STATUS_EXPIRED,
+        }:
+            _complete_renewal_event(event, now=now)
+            return _result_from_event(
+                "already_applied",
+                event,
+                subscription_status=BILLING_SUBSCRIPTION_STATUS_LABELS.get(
+                    int(subscription.status or 0),
+                    "canceled",
+                ),
+            )
+
         order = ensure_subscription_renewal_order(
             app,
             subscription,

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -19,8 +19,10 @@ from .credit_notifications import (
 )
 from .consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
-    BILLING_ORDER_STATUS_PAID,
+    BILLING_ORDER_STATUS_CANCELED,
     BILLING_ORDER_STATUS_FAILED,
+    BILLING_ORDER_STATUS_INIT,
+    BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
@@ -66,7 +68,7 @@ from .subscriptions import (
     load_subscription_by_bid as _load_subscription_by_bid,
     sync_subscription_lifecycle_events as _sync_subscription_lifecycle_events,
 )
-from .models import BillingOrder, BillingRenewalEvent
+from .models import BillingOrder, BillingRenewalEvent, BillingSubscription
 from .primitives import normalize_bid as _normalize_bid
 from .wallets import _expire_credit_wallet_buckets_in_session
 
@@ -82,6 +84,100 @@ _TERMINAL_EVENT_STATUSES = (
 
 # Shared session-scope guard; see flaskr/dao/uow.py for the rationale.
 _app_context_scope = app_context_scope
+
+
+_OBSOLETE_RENEWAL_ORDER_STATUSES = (
+    BILLING_ORDER_STATUS_INIT,
+    BILLING_ORDER_STATUS_PENDING,
+    BILLING_ORDER_STATUS_FAILED,
+)
+
+
+def _load_subscription_by_bid_for_update(
+    subscription_bid: str,
+) -> BillingSubscription | None:
+    normalized_subscription_bid = _normalize_bid(subscription_bid)
+    if not normalized_subscription_bid:
+        return None
+    return (
+        BillingSubscription.query.filter(
+            BillingSubscription.deleted == 0,
+            BillingSubscription.subscription_bid == normalized_subscription_bid,
+        )
+        .populate_existing()
+        .with_for_update()
+        .order_by(BillingSubscription.id.desc())
+        .first()
+    )
+
+
+def _load_event_payload_renewal_order(
+    event: BillingRenewalEvent,
+) -> BillingOrder | None:
+    if not isinstance(event.payload_json, dict):
+        return None
+    bill_order_bid = _normalize_bid(event.payload_json.get("bill_order_bid"))
+    if not bill_order_bid:
+        return None
+    return (
+        BillingOrder.query.filter(
+            BillingOrder.deleted == 0,
+            BillingOrder.bill_order_bid == bill_order_bid,
+            BillingOrder.subscription_bid == event.subscription_bid,
+            BillingOrder.order_type == BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        )
+        .populate_existing()
+        .with_for_update()
+        .order_by(BillingOrder.id.desc())
+        .first()
+    )
+
+
+def _cancel_obsolete_renewal_order(
+    order: BillingOrder | None,
+    *,
+    now: datetime,
+    reason: str,
+) -> str | None:
+    if order is None:
+        return None
+    if int(order.status or 0) not in _OBSOLETE_RENEWAL_ORDER_STATUSES:
+        return order.bill_order_bid
+
+    metadata = (
+        dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
+    )
+    metadata["canceled_reason"] = reason
+    metadata["canceled_at"] = now.isoformat()
+    order.status = BILLING_ORDER_STATUS_CANCELED
+    order.metadata_json = metadata
+    order.updated_at = now
+    db.session.add(order)
+    return order.bill_order_bid
+
+
+def _complete_obsolete_renewal_event(
+    event: BillingRenewalEvent,
+    subscription: BillingSubscription,
+    *,
+    now: datetime,
+) -> RenewalEventResult:
+    status_label = BILLING_SUBSCRIPTION_STATUS_LABELS.get(
+        int(subscription.status or 0),
+        "canceled",
+    )
+    bill_order_bid = _cancel_obsolete_renewal_order(
+        _load_event_payload_renewal_order(event),
+        now=now,
+        reason=f"subscription_{status_label}",
+    )
+    _complete_renewal_event(event, now=now)
+    return _result_from_event(
+        "already_applied",
+        event,
+        bill_order_bid=bill_order_bid,
+        subscription_status=status_label,
+    )
 
 
 def _fail_paid_renewal_activation_event(
@@ -679,7 +775,7 @@ def _execute_subscription_renewal(
     # this same order through the payload link (and ensure_* reloads it by
     # cycle) instead of creating a second charge context.
     with unit_of_work():
-        subscription = _load_subscription_by_bid(event.subscription_bid)
+        subscription = _load_subscription_by_bid_for_update(event.subscription_bid)
         if subscription is None:
             _fail_renewal_event(event, now=now, error="subscription_not_found")
             return _result_from_event("failed", event)
@@ -688,15 +784,7 @@ def _execute_subscription_renewal(
             BILLING_SUBSCRIPTION_STATUS_CANCELED,
             BILLING_SUBSCRIPTION_STATUS_EXPIRED,
         }:
-            _complete_renewal_event(event, now=now)
-            return _result_from_event(
-                "already_applied",
-                event,
-                subscription_status=BILLING_SUBSCRIPTION_STATUS_LABELS.get(
-                    int(subscription.status or 0),
-                    "canceled",
-                ),
-            )
+            return _complete_obsolete_renewal_event(event, subscription, now=now)
 
         order = ensure_subscription_renewal_order(
             app,

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -51,6 +51,8 @@ from .queries import (
 )
 from .reserved_renewal_activation import IncompleteReservedGrantActivationError
 from .renewal_event_transitions import (
+    RenewalEventClaimLostError,
+    bind_renewal_event_claim as _bind_renewal_event_claim,
     complete_renewal_event as _complete_renewal_event,
     fail_renewal_event as _fail_renewal_event,
     release_renewal_event as _release_renewal_event,
@@ -234,36 +236,48 @@ def run_billing_renewal_event(
         if claim_status != "claimed":
             return _result_from_event(claim_status, event)
 
-        now = now_utc()
-        if event.scheduled_at and event.scheduled_at > now:
+        owns_transaction = not uow.in_unit_of_work()
+        try:
+            now = now_utc()
+            if event.scheduled_at and event.scheduled_at > now:
+                with unit_of_work():
+                    _release_renewal_event(event, now=now)
+                return _result_from_event("deferred_until_scheduled_at", event)
+
+            if (
+                int(event.event_type or 0)
+                == BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE
+            ):
+                return _execute_cancel_effective(app, event, now=now)
+            if (
+                int(event.event_type or 0)
+                == BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE
+            ):
+                return _execute_downgrade_effective(app, event, now=now)
+            if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_RENEWAL:
+                return _execute_subscription_renewal(app, event, now=now)
+            if int(event.event_type or 0) in {
+                BILLING_RENEWAL_EVENT_TYPE_RETRY,
+                BILLING_RENEWAL_EVENT_TYPE_RECONCILE,
+            }:
+                return _execute_retry_or_reconcile(app, event, now=now)
+            if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_EXPIRE:
+                return _execute_expire_subscription(app, event, now=now)
+
             with unit_of_work():
-                _release_renewal_event(event, now=now)
-            return _result_from_event("deferred_until_scheduled_at", event)
-
-        if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE:
-            return _execute_cancel_effective(app, event, now=now)
-        if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE:
-            return _execute_downgrade_effective(app, event, now=now)
-        if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_RENEWAL:
-            return _execute_subscription_renewal(app, event, now=now)
-        if int(event.event_type or 0) in {
-            BILLING_RENEWAL_EVENT_TYPE_RETRY,
-            BILLING_RENEWAL_EVENT_TYPE_RECONCILE,
-        }:
-            return _execute_retry_or_reconcile(app, event, now=now)
-        if int(event.event_type or 0) == BILLING_RENEWAL_EVENT_TYPE_EXPIRE:
-            return _execute_expire_subscription(app, event, now=now)
-
-        with unit_of_work():
-            _fail_renewal_event(
-                event,
-                now=now,
-                error=(
-                    "renewal_event_handler_not_implemented:"
-                    f"{BILLING_RENEWAL_EVENT_TYPE_LABELS.get(int(event.event_type or 0), event.event_type)}"
-                ),
-            )
-        return _result_from_event("failed", event)
+                _fail_renewal_event(
+                    event,
+                    now=now,
+                    error=(
+                        "renewal_event_handler_not_implemented:"
+                        f"{BILLING_RENEWAL_EVENT_TYPE_LABELS.get(int(event.event_type or 0), event.event_type)}"
+                    ),
+                )
+            return _result_from_event("failed", event)
+        except RenewalEventClaimLostError:
+            if not owns_transaction:
+                raise
+            return _result_from_lost_claim(event)
 
 
 def retry_billing_renewal_event(
@@ -947,6 +961,11 @@ def _claim_target_renewal_event(
         subscription_bid=subscription_bid,
         creator_bid=creator_bid,
     )
+    if claimed is not None:
+        _bind_renewal_event_claim(
+            claimed,
+            attempt_count=expected_attempt_count + 1,
+        )
     return "claimed", claimed
 
 
@@ -1035,4 +1054,27 @@ def _result_without_event(
         renewal_event_bid=_normalize_bid(renewal_event_bid) or None,
         subscription_bid=_normalize_bid(subscription_bid) or None,
         creator_bid=_normalize_bid(creator_bid) or None,
+    )
+
+
+def _result_from_lost_claim(event: BillingRenewalEvent) -> RenewalEventResult:
+    db.session.rollback()
+    db.session.expire_all()
+    current = _load_target_renewal_event(renewal_event_bid=event.renewal_event_bid)
+    if current is None:
+        return _result_without_event(
+            "event_not_found",
+            renewal_event_bid=event.renewal_event_bid,
+            subscription_bid=event.subscription_bid,
+            creator_bid=event.creator_bid,
+        )
+    status = (
+        "already_processed"
+        if int(current.status or 0) in _TERMINAL_EVENT_STATUSES
+        else "lost_claim"
+    )
+    return _result_from_event(
+        status,
+        current,
+        message="renewal_event_claim_lost",
     )

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -43,22 +43,64 @@ CANCELABLE_RENEWAL_EVENT_STATUSES = (
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
 )
 
+RESETTABLE_RENEWAL_EVENT_STATUSES = (
+    BILLING_RENEWAL_EVENT_STATUS_PENDING,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
+    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+)
+
+_TARGET_UPSERT_UNIQUE_KEY_NAME = "uq_bill_renewal_events_subscription_event_scheduled"
+_CLAIM_ATTEMPT_ATTR = "_billing_renewal_claim_attempt_count"
+
+
+class RenewalEventClaimLostError(RuntimeError):
+    """Raised when a worker no longer owns the event processing claim."""
+
+
+def bind_renewal_event_claim(
+    event: BillingRenewalEvent,
+    *,
+    attempt_count: int,
+) -> None:
+    setattr(event, _CLAIM_ATTEMPT_ATTR, int(attempt_count or 0))
+
+
+def _expected_claim_attempt_count(event: BillingRenewalEvent) -> int:
+    bound_attempt_count = getattr(event, _CLAIM_ATTEMPT_ATTR, None)
+    if bound_attempt_count is not None:
+        return int(bound_attempt_count or 0)
+    return int(event.attempt_count or 0)
+
+
+def _is_target_upsert_integrity_error(exc: IntegrityError) -> bool:
+    message = str(getattr(exc, "orig", exc))
+    return _TARGET_UPSERT_UNIQUE_KEY_NAME in message or (
+        "subscription_bid" in message
+        and "event_type" in message
+        and "scheduled_at" in message
+    )
+
 
 def _update_processing_renewal_event(
     event: BillingRenewalEvent,
     values: dict[str, Any],
-) -> bool:
+) -> None:
+    expected_attempt_count = _expected_claim_attempt_count(event)
     updated_rows = BillingRenewalEvent.query.filter(
         BillingRenewalEvent.deleted == 0,
         BillingRenewalEvent.id == event.id,
         BillingRenewalEvent.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+        BillingRenewalEvent.attempt_count == expected_attempt_count,
     ).update(values, synchronize_session=False)
     db.session.flush()
     db.session.expire(event)
-    return updated_rows == 1
+    if updated_rows != 1:
+        raise RenewalEventClaimLostError(
+            f"renewal_event_claim_lost:{event.renewal_event_bid}"
+        )
 
 
-def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> bool:
+def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
     return _update_processing_renewal_event(
         event,
         {
@@ -68,7 +110,7 @@ def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> bool:
     )
 
 
-def complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> bool:
+def complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
     return _update_processing_renewal_event(
         event,
         {
@@ -85,7 +127,7 @@ def fail_renewal_event(
     *,
     now: datetime,
     error: str,
-) -> bool:
+) -> None:
     return _update_processing_renewal_event(
         event,
         {
@@ -139,15 +181,23 @@ def _reset_subscription_renewal_event(
     *,
     payload: dict[str, Any],
 ) -> None:
-    if int(event.status or 0) == BILLING_RENEWAL_EVENT_STATUS_PROCESSING:
-        return
-    event.creator_bid = subscription.creator_bid
-    event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
-    event.last_error = ""
-    event.payload_json = payload
-    event.processed_at = None
-    event.updated_at = now_utc()
-    db.session.add(event)
+    BillingRenewalEvent.query.filter(
+        BillingRenewalEvent.deleted == 0,
+        BillingRenewalEvent.id == event.id,
+        BillingRenewalEvent.status.in_(RESETTABLE_RENEWAL_EVENT_STATUSES),
+    ).update(
+        {
+            "creator_bid": subscription.creator_bid,
+            "status": BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            "last_error": "",
+            "payload_json": payload,
+            "processed_at": None,
+            "updated_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    db.session.flush()
+    db.session.expire(event)
 
 
 def _build_subscription_renewal_event(
@@ -198,7 +248,9 @@ def upsert_subscription_renewal_event(
                 )
                 db.session.add(event)
                 db.session.flush()
-        except IntegrityError:
+        except IntegrityError as exc:
+            if not _is_target_upsert_integrity_error(exc):
+                raise
             event = _load_subscription_renewal_event(
                 subscription.subscription_bid,
                 event_type=event_type,
@@ -224,23 +276,21 @@ def cancel_stale_subscription_renewal_events(
     event_type: int,
     keep_scheduled_at: datetime,
 ) -> None:
-    rows = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription_bid,
-            BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
-            BillingRenewalEvent.scheduled_at != keep_scheduled_at,
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .all()
-    )
     now = now_utc()
-    for row in rows:
-        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
-        row.processed_at = now
-        row.updated_at = now
-        db.session.add(row)
+    BillingRenewalEvent.query.filter(
+        BillingRenewalEvent.deleted == 0,
+        BillingRenewalEvent.subscription_bid == subscription_bid,
+        BillingRenewalEvent.event_type == event_type,
+        BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
+        BillingRenewalEvent.scheduled_at != keep_scheduled_at,
+    ).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+            "processed_at": now,
+            "updated_at": now,
+        },
+        synchronize_session=False,
+    )
 
 
 def cancel_subscription_renewal_events(
@@ -248,19 +298,17 @@ def cancel_subscription_renewal_events(
     *,
     event_types: tuple[int, ...] = MANAGED_RENEWAL_EVENT_TYPES,
 ) -> None:
-    rows = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription_bid,
-            BillingRenewalEvent.event_type.in_(event_types),
-            BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .all()
-    )
     now = now_utc()
-    for row in rows:
-        row.status = BILLING_RENEWAL_EVENT_STATUS_CANCELED
-        row.processed_at = now
-        row.updated_at = now
-        db.session.add(row)
+    BillingRenewalEvent.query.filter(
+        BillingRenewalEvent.deleted == 0,
+        BillingRenewalEvent.subscription_bid == subscription_bid,
+        BillingRenewalEvent.event_type.in_(event_types),
+        BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
+    ).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+            "processed_at": now,
+            "updated_at": now,
+        },
+        synchronize_session=False,
+    )

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -120,17 +120,17 @@ def _load_subscription_renewal_event(
     *,
     event_type: int,
     scheduled_at: datetime,
+    for_update: bool = False,
 ) -> BillingRenewalEvent | None:
-    return (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription_bid,
-            BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.scheduled_at == scheduled_at,
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .first()
+    query = BillingRenewalEvent.query.filter(
+        BillingRenewalEvent.deleted == 0,
+        BillingRenewalEvent.subscription_bid == subscription_bid,
+        BillingRenewalEvent.event_type == event_type,
+        BillingRenewalEvent.scheduled_at == scheduled_at,
     )
+    if for_update:
+        query = query.populate_existing().with_for_update()
+    return query.order_by(BillingRenewalEvent.id.desc()).first()
 
 
 def _reset_subscription_renewal_event(
@@ -203,6 +203,7 @@ def upsert_subscription_renewal_event(
                 subscription.subscription_bid,
                 event_type=event_type,
                 scheduled_at=normalized_scheduled_at,
+                for_update=True,
             )
             if event is None:
                 raise

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -81,17 +81,33 @@ def _is_target_upsert_integrity_error(exc: IntegrityError) -> bool:
     )
 
 
+def assert_renewal_event_claim_current(
+    event: BillingRenewalEvent,
+    *,
+    now: datetime | None = None,
+    touch: bool = False,
+) -> None:
+    values: dict[str, Any] = {}
+    if touch and now is not None:
+        values["updated_at"] = now
+    _update_processing_renewal_event(event, values)
+
+
 def _update_processing_renewal_event(
     event: BillingRenewalEvent,
     values: dict[str, Any],
 ) -> None:
     expected_attempt_count = _expected_claim_attempt_count(event)
-    updated_rows = BillingRenewalEvent.query.filter(
+    query = BillingRenewalEvent.query.filter(
         BillingRenewalEvent.deleted == 0,
         BillingRenewalEvent.id == event.id,
         BillingRenewalEvent.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
         BillingRenewalEvent.attempt_count == expected_attempt_count,
-    ).update(values, synchronize_session=False)
+    )
+    if values:
+        updated_rows = query.update(values, synchronize_session=False)
+    else:
+        updated_rows = 1 if query.with_for_update().first() is not None else 0
     db.session.flush()
     db.session.expire(event)
     if updated_rows != 1:

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from flask import Flask
+from sqlalchemy.exc import IntegrityError
 
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc
@@ -37,25 +38,46 @@ MANAGED_RENEWAL_EVENT_TYPES = (
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
 )
 
-PENDING_RENEWAL_EVENT_STATUSES = (
+CANCELABLE_RENEWAL_EVENT_STATUSES = (
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
-    BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
 )
 
 
-def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
-    event.updated_at = now
-    db.session.add(event)
+def _update_processing_renewal_event(
+    event: BillingRenewalEvent,
+    values: dict[str, Any],
+) -> bool:
+    updated_rows = BillingRenewalEvent.query.filter(
+        BillingRenewalEvent.deleted == 0,
+        BillingRenewalEvent.id == event.id,
+        BillingRenewalEvent.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+    ).update(values, synchronize_session=False)
+    db.session.flush()
+    db.session.expire(event)
+    return updated_rows == 1
 
 
-def complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
-    event.last_error = ""
-    event.processed_at = now
-    event.updated_at = now
-    db.session.add(event)
+def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> bool:
+    return _update_processing_renewal_event(
+        event,
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_PENDING,
+            "updated_at": now,
+        },
+    )
+
+
+def complete_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> bool:
+    return _update_processing_renewal_event(
+        event,
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
+            "last_error": "",
+            "processed_at": now,
+            "updated_at": now,
+        },
+    )
 
 
 def fail_renewal_event(
@@ -63,12 +85,16 @@ def fail_renewal_event(
     *,
     now: datetime,
     error: str,
-) -> None:
-    event.status = BILLING_RENEWAL_EVENT_STATUS_FAILED
-    event.last_error = str(error or "")[:255]
-    event.processed_at = now
-    event.updated_at = now
-    db.session.add(event)
+) -> bool:
+    return _update_processing_renewal_event(
+        event,
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_FAILED,
+            "last_error": str(error or "")[:255],
+            "processed_at": now,
+            "updated_at": now,
+        },
+    )
 
 
 def build_subscription_renewal_event_payload(
@@ -89,6 +115,63 @@ def build_subscription_renewal_event_payload(
     ).to_metadata_json()
 
 
+def _load_subscription_renewal_event(
+    subscription_bid: str,
+    *,
+    event_type: int,
+    scheduled_at: datetime,
+) -> BillingRenewalEvent | None:
+    return (
+        BillingRenewalEvent.query.filter(
+            BillingRenewalEvent.deleted == 0,
+            BillingRenewalEvent.subscription_bid == subscription_bid,
+            BillingRenewalEvent.event_type == event_type,
+            BillingRenewalEvent.scheduled_at == scheduled_at,
+        )
+        .order_by(BillingRenewalEvent.id.desc())
+        .first()
+    )
+
+
+def _reset_subscription_renewal_event(
+    event: BillingRenewalEvent,
+    subscription: BillingSubscription,
+    *,
+    payload: dict[str, Any],
+) -> None:
+    if int(event.status or 0) == BILLING_RENEWAL_EVENT_STATUS_PROCESSING:
+        return
+    event.creator_bid = subscription.creator_bid
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
+    event.last_error = ""
+    event.payload_json = payload
+    event.processed_at = None
+    event.updated_at = now_utc()
+    db.session.add(event)
+
+
+def _build_subscription_renewal_event(
+    app: Flask,
+    subscription: BillingSubscription,
+    *,
+    event_type: int,
+    scheduled_at: datetime,
+    payload: dict[str, Any],
+) -> BillingRenewalEvent:
+    return BillingRenewalEvent(
+        renewal_event_bid=generate_id(app),
+        subscription_bid=subscription.subscription_bid,
+        creator_bid=subscription.creator_bid,
+        event_type=event_type,
+        scheduled_at=scheduled_at,
+        status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
+        attempt_count=0,
+        last_error="",
+        payload_json=payload,
+        processed_at=None,
+    )
+
+
 def upsert_subscription_renewal_event(
     app: Flask,
     subscription: BillingSubscription,
@@ -98,38 +181,35 @@ def upsert_subscription_renewal_event(
 ) -> None:
     normalized_scheduled_at = _normalize_mysql_datetime(scheduled_at)
     payload = build_subscription_renewal_event_payload(subscription)
-    event = (
-        BillingRenewalEvent.query.filter(
-            BillingRenewalEvent.deleted == 0,
-            BillingRenewalEvent.subscription_bid == subscription.subscription_bid,
-            BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.scheduled_at == normalized_scheduled_at,
-        )
-        .order_by(BillingRenewalEvent.id.desc())
-        .first()
+    event = _load_subscription_renewal_event(
+        subscription.subscription_bid,
+        event_type=event_type,
+        scheduled_at=normalized_scheduled_at,
     )
     if event is None:
-        event = BillingRenewalEvent(
-            renewal_event_bid=generate_id(app),
-            subscription_bid=subscription.subscription_bid,
-            creator_bid=subscription.creator_bid,
-            event_type=event_type,
-            scheduled_at=normalized_scheduled_at,
-            status=BILLING_RENEWAL_EVENT_STATUS_PENDING,
-            attempt_count=0,
-            last_error="",
-            payload_json=payload,
-            processed_at=None,
-        )
+        try:
+            with db.session.begin_nested():
+                event = _build_subscription_renewal_event(
+                    app,
+                    subscription,
+                    event_type=event_type,
+                    scheduled_at=normalized_scheduled_at,
+                    payload=payload,
+                )
+                db.session.add(event)
+                db.session.flush()
+        except IntegrityError:
+            event = _load_subscription_renewal_event(
+                subscription.subscription_bid,
+                event_type=event_type,
+                scheduled_at=normalized_scheduled_at,
+            )
+            if event is None:
+                raise
+            _reset_subscription_renewal_event(event, subscription, payload=payload)
     else:
-        event.creator_bid = subscription.creator_bid
-        event.status = BILLING_RENEWAL_EVENT_STATUS_PENDING
-        event.last_error = ""
-        event.payload_json = payload
-        event.processed_at = None
-        event.updated_at = now_utc()
+        _reset_subscription_renewal_event(event, subscription, payload=payload)
 
-    db.session.add(event)
     cancel_stale_subscription_renewal_events(
         subscription.subscription_bid,
         event_type=event_type,
@@ -148,7 +228,7 @@ def cancel_stale_subscription_renewal_events(
             BillingRenewalEvent.deleted == 0,
             BillingRenewalEvent.subscription_bid == subscription_bid,
             BillingRenewalEvent.event_type == event_type,
-            BillingRenewalEvent.status.in_(PENDING_RENEWAL_EVENT_STATUSES),
+            BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
             BillingRenewalEvent.scheduled_at != keep_scheduled_at,
         )
         .order_by(BillingRenewalEvent.id.desc())
@@ -172,7 +252,7 @@ def cancel_subscription_renewal_events(
             BillingRenewalEvent.deleted == 0,
             BillingRenewalEvent.subscription_bid == subscription_bid,
             BillingRenewalEvent.event_type.in_(event_types),
-            BillingRenewalEvent.status.in_(PENDING_RENEWAL_EVENT_STATUSES),
+            BillingRenewalEvent.status.in_(CANCELABLE_RENEWAL_EVENT_STATUSES),
         )
         .order_by(BillingRenewalEvent.id.desc())
         .all()

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -718,6 +718,7 @@ def test_renewal_event_cancels_existing_obsolete_order_for_canceled_subscription
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
     assert order.status == BILLING_ORDER_STATUS_CANCELED
     assert order.metadata_json["canceled_reason"] == "subscription_canceled"
+    assert order.metadata_json["canceled_at"].endswith("Z")
 
 
 def test_renewal_event_skips_obsolete_expired_subscription(

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -29,9 +29,12 @@ import pytest
 import flaskr.dao as dao
 from flaskr.dao import uow
 from flaskr.service.billing import renewal as billing_renewal
+from flaskr.service.billing import renewal_event_transitions
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+    BILLING_RENEWAL_EVENT_STATUS_FAILED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
@@ -387,3 +390,282 @@ def test_expire_notification_fires_after_commit_and_drops_on_rollback(
         renewal_event_bid="renewal-uow-notify"
     ).one()
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+
+
+def test_subscription_lifecycle_cancel_skips_processing_events(
+    renewal_uow_app: Flask,
+) -> None:
+    """Lifecycle sync must not cancel a worker that already claimed an event."""
+    subscription = _seed_subscription("sub-uow-cancel-processing")
+    pending = _seed_event(
+        "renewal-uow-cancel-pending",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    failed = _seed_event(
+        "renewal-uow-cancel-failed",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    processing = _seed_event(
+        "renewal-uow-cancel-processing",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    failed.status = BILLING_RENEWAL_EVENT_STATUS_FAILED
+    processing.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    dao.db.session.commit()
+    now = now_utc()
+
+    renewal_event_transitions.cancel_subscription_renewal_events(
+        subscription.subscription_bid,
+        event_types=(BILLING_RENEWAL_EVENT_TYPE_RENEWAL,),
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    pending = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid=pending.renewal_event_bid
+    ).one()
+    failed = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid=failed.renewal_event_bid
+    ).one()
+    processing = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid=processing.renewal_event_bid
+    ).one()
+    assert pending.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
+    assert pending.processed_at is not None
+    assert failed.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
+    assert failed.processed_at is not None
+    assert processing.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    assert processing.processed_at is None
+    assert processing.updated_at < now
+
+
+def test_upsert_preserves_existing_processing_event(
+    renewal_uow_app: Flask,
+) -> None:
+    """Lifecycle sync must not release an event that a worker already claimed."""
+    subscription = _seed_subscription("sub-uow-upsert-processing")
+    scheduled_at = now_utc() + timedelta(days=1)
+    event = _seed_event(
+        "renewal-uow-upsert-processing",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.scheduled_at = scheduled_at
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    event.attempt_count = 1
+    event.last_error = "worker has claimed"
+    event.payload_json = {"source": "claimed"}
+    dao.db.session.commit()
+
+    renewal_event_transitions.upsert_subscription_renewal_event(
+        renewal_uow_app,
+        subscription,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+        scheduled_at=scheduled_at,
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-upsert-processing"
+    ).one()
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    assert event.attempt_count == 1
+    assert event.last_error == "worker has claimed"
+    assert event.payload_json == {"source": "claimed"}
+
+
+def test_processing_event_release_does_not_overwrite_canceled_event(
+    renewal_uow_app: Flask,
+) -> None:
+    """A stale defer path cannot release a terminal event back to pending."""
+    _seed_subscription("sub-uow-stale-release")
+    event = _seed_event(
+        "renewal-uow-stale-release",
+        "sub-uow-stale-release",
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    dao.db.session.commit()
+
+    loaded_by_worker = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-release"
+    ).one()
+    BillingRenewalEvent.query.filter_by(
+        id=loaded_by_worker.id,
+    ).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+            "processed_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.flush()
+
+    updated = renewal_event_transitions.release_renewal_event(
+        loaded_by_worker,
+        now=now_utc(),
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-release"
+    ).one()
+    assert updated is False
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
+
+
+def test_processing_event_completion_does_not_overwrite_canceled_event(
+    renewal_uow_app: Flask,
+) -> None:
+    """A stale worker cannot mark an event succeeded after another transition."""
+    _seed_subscription("sub-uow-stale-complete")
+    event = _seed_event(
+        "renewal-uow-stale-complete",
+        "sub-uow-stale-complete",
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    dao.db.session.commit()
+
+    loaded_by_worker = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-complete"
+    ).one()
+    BillingRenewalEvent.query.filter_by(
+        id=loaded_by_worker.id,
+    ).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_CANCELED,
+            "processed_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.flush()
+
+    updated = renewal_event_transitions.complete_renewal_event(
+        loaded_by_worker,
+        now=now_utc(),
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-complete"
+    ).one()
+    assert updated is False
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
+
+
+def test_processing_event_failure_does_not_overwrite_succeeded_event(
+    renewal_uow_app: Flask,
+) -> None:
+    """A stale failure path cannot move a terminal event back to failed."""
+    _seed_subscription("sub-uow-stale-fail")
+    event = _seed_event(
+        "renewal-uow-stale-fail",
+        "sub-uow-stale-fail",
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    dao.db.session.commit()
+
+    loaded_by_worker = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-fail"
+    ).one()
+    BillingRenewalEvent.query.filter_by(
+        id=loaded_by_worker.id,
+    ).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
+            "processed_at": now_utc(),
+            "last_error": "",
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.flush()
+
+    updated = renewal_event_transitions.fail_renewal_event(
+        loaded_by_worker,
+        now=now_utc(),
+        error="late failure",
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-stale-fail"
+    ).one()
+    assert updated is False
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert event.last_error == ""
+
+
+def test_upsert_recovers_when_concurrent_insert_wins(
+    renewal_uow_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent lifecycle sync should reuse the unique-key winner."""
+    subscription = _seed_subscription("sub-uow-upsert-race")
+    scheduled_at = now_utc() + timedelta(days=1)
+    dao.db.session.commit()
+
+    original_load = renewal_event_transitions._load_subscription_renewal_event
+    calls = 0
+
+    def racing_load(subscription_bid: str, *, event_type: int, scheduled_at):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            winner = BillingRenewalEvent(
+                renewal_event_bid="renewal-uow-upsert-race-winner",
+                subscription_bid=subscription_bid,
+                creator_bid="stale-creator",
+                event_type=event_type,
+                scheduled_at=scheduled_at,
+                status=BILLING_RENEWAL_EVENT_STATUS_FAILED,
+                attempt_count=3,
+                last_error="stale failure",
+                payload_json={"source": "racing worker"},
+                processed_at=now_utc(),
+            )
+            dao.db.session.add(winner)
+            dao.db.session.flush()
+            return None
+        return original_load(
+            subscription_bid,
+            event_type=event_type,
+            scheduled_at=scheduled_at,
+        )
+
+    monkeypatch.setattr(
+        renewal_event_transitions,
+        "_load_subscription_renewal_event",
+        racing_load,
+    )
+
+    renewal_event_transitions.upsert_subscription_renewal_event(
+        renewal_uow_app,
+        subscription,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+        scheduled_at=scheduled_at,
+    )
+    dao.db.session.commit()
+    dao.db.session.expire_all()
+
+    events = BillingRenewalEvent.query.filter_by(
+        subscription_bid=subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    ).all()
+    assert len(events) == 1
+    event = events[0]
+    assert event.renewal_event_bid == "renewal-uow-upsert-race-winner"
+    assert event.creator_bid == CREATOR_BID
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
+    assert event.attempt_count == 3
+    assert event.last_error == ""
+    assert event.processed_at is None
+    assert event.payload_json["subscription_bid"] == subscription.subscription_bid

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 from flask import Flask
 import pytest
@@ -32,6 +33,7 @@ import flaskr.dao as dao
 from flaskr.dao import uow
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing import renewal_event_transitions
+from flaskr.service.billing import tasks as billing_tasks
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_CANCELED,
     BILLING_ORDER_STATUS_PAID,
@@ -914,6 +916,51 @@ def test_lost_claim_stops_before_renewal_order_or_provider_side_effects(
     ).one()
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
     assert event.attempt_count == 2
+
+
+def test_provider_guard_renews_lease_before_cross_transaction_sync(
+    renewal_uow_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale recovery cannot hand off a freshly guarded provider attempt."""
+    subscription = _seed_subscription("sub-uow-lease-before-provider")
+    event = _seed_event(
+        "renewal-uow-lease-before-provider",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    dao.db.session.commit()
+
+    recovery_counts: list[int] = []
+
+    def fake_sync(*_args, **_kwargs):
+        recovery_counts.append(
+            billing_tasks._recover_stale_processing_renewal_events(
+                stale_before=now_utc() - timedelta(minutes=30),
+            )
+        )
+        current = BillingRenewalEvent.query.filter_by(
+            renewal_event_bid="renewal-uow-lease-before-provider"
+        ).one()
+        assert current.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+        assert current.attempt_count == 1
+        return SimpleNamespace(status="pending", message="")
+
+    monkeypatch.setattr(billing_renewal, "_sync_billing_renewal_order", fake_sync)
+
+    payload = run_billing_renewal_event(
+        renewal_uow_app,
+        renewal_event_bid=event.renewal_event_bid,
+    )
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-lease-before-provider"
+    ).one()
+    assert recovery_counts == [0]
+    assert payload["status"] == "queued_for_reconcile"
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert event.attempt_count == 1
 
 
 @pytest.mark.parametrize(

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -530,19 +530,19 @@ def test_processing_event_release_does_not_overwrite_canceled_event(
         },
         synchronize_session=False,
     )
-    dao.db.session.flush()
-
-    updated = renewal_event_transitions.release_renewal_event(
-        loaded_by_worker,
-        now=now_utc(),
-    )
     dao.db.session.commit()
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        renewal_event_transitions.release_renewal_event(
+            loaded_by_worker,
+            now=now_utc(),
+        )
+    dao.db.session.rollback()
     dao.db.session.expire_all()
 
     event = BillingRenewalEvent.query.filter_by(
         renewal_event_bid="renewal-uow-stale-release"
     ).one()
-    assert updated is False
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
 
 
@@ -571,19 +571,19 @@ def test_processing_event_completion_does_not_overwrite_canceled_event(
         },
         synchronize_session=False,
     )
-    dao.db.session.flush()
-
-    updated = renewal_event_transitions.complete_renewal_event(
-        loaded_by_worker,
-        now=now_utc(),
-    )
     dao.db.session.commit()
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        renewal_event_transitions.complete_renewal_event(
+            loaded_by_worker,
+            now=now_utc(),
+        )
+    dao.db.session.rollback()
     dao.db.session.expire_all()
 
     event = BillingRenewalEvent.query.filter_by(
         renewal_event_bid="renewal-uow-stale-complete"
     ).one()
-    assert updated is False
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_CANCELED
 
 
@@ -613,20 +613,20 @@ def test_processing_event_failure_does_not_overwrite_succeeded_event(
         },
         synchronize_session=False,
     )
-    dao.db.session.flush()
-
-    updated = renewal_event_transitions.fail_renewal_event(
-        loaded_by_worker,
-        now=now_utc(),
-        error="late failure",
-    )
     dao.db.session.commit()
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        renewal_event_transitions.fail_renewal_event(
+            loaded_by_worker,
+            now=now_utc(),
+            error="late failure",
+        )
+    dao.db.session.rollback()
     dao.db.session.expire_all()
 
     event = BillingRenewalEvent.query.filter_by(
         renewal_event_bid="renewal-uow-stale-fail"
     ).one()
-    assert updated is False
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
     assert event.last_error == ""
 
@@ -693,6 +693,107 @@ def test_renewal_event_skips_obsolete_expired_subscription(
         ).count()
         == 0
     )
+
+
+def test_old_claim_cannot_complete_new_processing_attempt(
+    renewal_uow_app: Flask,
+) -> None:
+    """Attempt-count CAS prevents an old worker from finishing a new claim."""
+    _seed_subscription("sub-uow-claim-generation")
+    event = _seed_event(
+        "renewal-uow-claim-generation",
+        "sub-uow-claim-generation",
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    event.attempt_count = 1
+    dao.db.session.commit()
+
+    old_worker_event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-claim-generation"
+    ).one()
+    renewal_event_transitions.bind_renewal_event_claim(
+        old_worker_event,
+        attempt_count=1,
+    )
+    BillingRenewalEvent.query.filter_by(id=old_worker_event.id).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+            "attempt_count": 2,
+            "updated_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.commit()
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        renewal_event_transitions.complete_renewal_event(
+            old_worker_event,
+            now=now_utc(),
+        )
+    dao.db.session.rollback()
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-claim-generation"
+    ).one()
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    assert event.attempt_count == 2
+
+
+def test_lost_claim_rolls_back_business_side_effects(
+    renewal_uow_app: Flask,
+) -> None:
+    """Callers must not commit business writes when terminal CAS loses."""
+    subscription = _seed_subscription("sub-uow-lost-claim-rollback")
+    event = _seed_event(
+        "renewal-uow-lost-claim-rollback",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    event.attempt_count = 1
+    dao.db.session.commit()
+
+    old_worker_event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-lost-claim-rollback"
+    ).one()
+    renewal_event_transitions.bind_renewal_event_claim(
+        old_worker_event,
+        attempt_count=1,
+    )
+    BillingRenewalEvent.query.filter_by(id=old_worker_event.id).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+            "attempt_count": 2,
+            "updated_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.commit()
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        with uow.unit_of_work():
+            subscription = BillingSubscription.query.filter_by(
+                subscription_bid="sub-uow-lost-claim-rollback"
+            ).one()
+            subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCELED
+            dao.db.session.add(subscription)
+            renewal_event_transitions.complete_renewal_event(
+                old_worker_event,
+                now=now_utc(),
+            )
+    dao.db.session.expire_all()
+
+    subscription = BillingSubscription.query.filter_by(
+        subscription_bid="sub-uow-lost-claim-rollback"
+    ).one()
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-lost-claim-rollback"
+    ).one()
+    assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    assert event.attempt_count == 2
 
 
 def test_upsert_recovers_when_concurrent_insert_wins(

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -33,7 +33,9 @@ from flaskr.dao import uow
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing import renewal_event_transitions
 from flaskr.service.billing.consts import (
+    BILLING_ORDER_STATUS_CANCELED,
     BILLING_ORDER_STATUS_PAID,
+    BILLING_ORDER_STATUS_PENDING,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
@@ -661,6 +663,57 @@ def test_renewal_event_skips_obsolete_canceled_subscription(
         ).count()
         == 0
     )
+
+
+def test_renewal_event_cancels_existing_obsolete_order_for_canceled_subscription(
+    renewal_uow_app: Flask,
+) -> None:
+    """Obsolete subscriptions must not leave retryable renewal orders pending."""
+    now = now_utc()
+    subscription = _seed_subscription("sub-uow-obsolete-order")
+    subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCELED
+    event = _seed_event(
+        "renewal-uow-obsolete-order",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.payload_json = {"bill_order_bid": "bill-uow-obsolete-order"}
+    order = BillingOrder(
+        bill_order_bid="bill-uow-obsolete-order",
+        creator_bid=CREATOR_BID,
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        product_bid="bill-product-plan-monthly",
+        subscription_bid=subscription.subscription_bid,
+        currency="CNY",
+        payable_amount=990,
+        paid_amount=0,
+        payment_provider="stripe",
+        channel="subscription",
+        provider_reference_id="provider-sub-uow-obsolete-order",
+        status=BILLING_ORDER_STATUS_PENDING,
+        paid_at=None,
+        metadata_json={"renewal_event_bid": event.renewal_event_bid},
+        created_at=now,
+        updated_at=now,
+    )
+    dao.db.session.add(order)
+    dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        renewal_uow_app,
+        renewal_event_bid=event.renewal_event_bid,
+    )
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-obsolete-order"
+    ).one()
+    order = BillingOrder.query.filter_by(bill_order_bid="bill-uow-obsolete-order").one()
+    assert payload["status"] == "already_applied"
+    assert payload["bill_order_bid"] == "bill-uow-obsolete-order"
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert order.status == BILLING_ORDER_STATUS_CANCELED
+    assert order.metadata_json["canceled_reason"] == "subscription_canceled"
 
 
 def test_renewal_event_skips_obsolete_expired_subscription(

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -22,9 +22,11 @@ These tests pin the new semantics:
 from __future__ import annotations
 
 from datetime import timedelta
+from pathlib import Path
 
 from flask import Flask
 import pytest
+from sqlalchemy.orm import sessionmaker
 
 import flaskr.dao as dao
 from flaskr.dao import uow
@@ -38,6 +40,7 @@ from flaskr.service.billing.consts import (
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
     BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
     BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED,
+    BILLING_SUBSCRIPTION_STATUS_EXPIRED,
     BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
     BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
@@ -65,6 +68,30 @@ def renewal_uow_app() -> Flask:
         SQLALCHEMY_BINDS={
             "ai_shifu_saas": "sqlite:///:memory:",
             "ai_shifu_admin": "sqlite:///:memory:",
+        },
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        TZ="UTC",
+    )
+    dao.db.init_app(app)
+    with app.app_context():
+        dao.db.create_all()
+        dao.db.session.add_all(build_bill_products())
+        dao.db.session.commit()
+        yield app
+        dao.db.session.remove()
+        dao.db.drop_all()
+
+
+@pytest.fixture
+def renewal_uow_file_app(tmp_path: Path) -> Flask:
+    db_path = tmp_path / "renewal-uow.sqlite"
+    app = Flask(__name__)
+    app.testing = True
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{db_path}",
+        SQLALCHEMY_BINDS={
+            "ai_shifu_saas": f"sqlite:///{tmp_path / 'saas.sqlite'}",
+            "ai_shifu_admin": f"sqlite:///{tmp_path / 'admin.sqlite'}",
         },
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         TZ="UTC",
@@ -415,7 +442,7 @@ def test_subscription_lifecycle_cancel_skips_processing_events(
     failed.status = BILLING_RENEWAL_EVENT_STATUS_FAILED
     processing.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
     dao.db.session.commit()
-    now = now_utc()
+    processing_updated_at = processing.updated_at
 
     renewal_event_transitions.cancel_subscription_renewal_events(
         subscription.subscription_bid,
@@ -439,7 +466,7 @@ def test_subscription_lifecycle_cancel_skips_processing_events(
     assert failed.processed_at is not None
     assert processing.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
     assert processing.processed_at is None
-    assert processing.updated_at < now
+    assert processing.updated_at == processing_updated_at
 
 
 def test_upsert_preserves_existing_processing_event(
@@ -604,6 +631,70 @@ def test_processing_event_failure_does_not_overwrite_succeeded_event(
     assert event.last_error == ""
 
 
+def test_renewal_event_skips_obsolete_canceled_subscription(
+    renewal_uow_app: Flask,
+) -> None:
+    """A stale recovered renewal event cannot charge a canceled subscription."""
+    subscription = _seed_subscription("sub-uow-obsolete-renewal")
+    subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCELED
+    event = _seed_event(
+        "renewal-uow-obsolete-renewal",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        renewal_uow_app,
+        renewal_event_bid=event.renewal_event_bid,
+    )
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-obsolete-renewal"
+    ).one()
+    assert payload["status"] == "already_applied"
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert (
+        BillingOrder.query.filter_by(
+            subscription_bid=subscription.subscription_bid,
+        ).count()
+        == 0
+    )
+
+
+def test_renewal_event_skips_obsolete_expired_subscription(
+    renewal_uow_app: Flask,
+) -> None:
+    """A stale recovered renewal event cannot charge an expired subscription."""
+    subscription = _seed_subscription("sub-uow-expired-renewal")
+    subscription.status = BILLING_SUBSCRIPTION_STATUS_EXPIRED
+    event = _seed_event(
+        "renewal-uow-expired-renewal",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        renewal_uow_app,
+        renewal_event_bid=event.renewal_event_bid,
+    )
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-expired-renewal"
+    ).one()
+    assert payload["status"] == "already_applied"
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert (
+        BillingOrder.query.filter_by(
+            subscription_bid=subscription.subscription_bid,
+        ).count()
+        == 0
+    )
+
+
 def test_upsert_recovers_when_concurrent_insert_wins(
     renewal_uow_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
@@ -616,7 +707,13 @@ def test_upsert_recovers_when_concurrent_insert_wins(
     original_load = renewal_event_transitions._load_subscription_renewal_event
     calls = 0
 
-    def racing_load(subscription_bid: str, *, event_type: int, scheduled_at):
+    def racing_load(
+        subscription_bid: str,
+        *,
+        event_type: int,
+        scheduled_at,
+        for_update: bool = False,
+    ):
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -639,6 +736,7 @@ def test_upsert_recovers_when_concurrent_insert_wins(
             subscription_bid,
             event_type=event_type,
             scheduled_at=scheduled_at,
+            for_update=for_update,
         )
 
     monkeypatch.setattr(
@@ -666,6 +764,87 @@ def test_upsert_recovers_when_concurrent_insert_wins(
     assert event.creator_bid == CREATOR_BID
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
     assert event.attempt_count == 3
+    assert event.last_error == ""
+    assert event.processed_at is None
+    assert event.payload_json["subscription_bid"] == subscription.subscription_bid
+
+
+def test_upsert_recovers_when_cross_session_insert_wins(
+    renewal_uow_file_app: Flask,
+) -> None:
+    """Duplicate-key recovery reloads a winner committed by another session."""
+    subscription = _seed_subscription("sub-uow-upsert-cross-session")
+    scheduled_at = now_utc() + timedelta(days=1)
+    dao.db.session.commit()
+
+    original_load = renewal_event_transitions._load_subscription_renewal_event
+    calls: list[bool] = []
+
+    def racing_load(
+        subscription_bid: str,
+        *,
+        event_type: int,
+        scheduled_at,
+        for_update: bool = False,
+    ):
+        calls.append(for_update)
+        if len(calls) == 1:
+            Session = sessionmaker(bind=dao.db.engine)
+            other_session = Session()
+            try:
+                winner = BillingRenewalEvent(
+                    renewal_event_bid="renewal-uow-upsert-cross-session-winner",
+                    subscription_bid=subscription_bid,
+                    creator_bid="stale-creator",
+                    event_type=event_type,
+                    scheduled_at=scheduled_at,
+                    status=BILLING_RENEWAL_EVENT_STATUS_FAILED,
+                    attempt_count=2,
+                    last_error="stale failure",
+                    payload_json={"source": "other session"},
+                    processed_at=now_utc(),
+                )
+                other_session.add(winner)
+                other_session.commit()
+            finally:
+                other_session.close()
+            return None
+        return original_load(
+            subscription_bid,
+            event_type=event_type,
+            scheduled_at=scheduled_at,
+            for_update=for_update,
+        )
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        renewal_event_transitions,
+        "_load_subscription_renewal_event",
+        racing_load,
+    )
+    try:
+        renewal_event_transitions.upsert_subscription_renewal_event(
+            renewal_uow_file_app,
+            subscription,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+            scheduled_at=scheduled_at,
+        )
+        dao.db.session.commit()
+    finally:
+        monkeypatch.undo()
+    dao.db.session.expire_all()
+
+    events = BillingRenewalEvent.query.filter_by(
+        subscription_bid=subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    ).all()
+    assert calls == [False, True]
+    assert len(events) == 1
+    event = events[0]
+    assert event.renewal_event_bid == "renewal-uow-upsert-cross-session-winner"
+    assert event.creator_bid == CREATOR_BID
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
+    assert event.attempt_count == 2
     assert event.last_error == ""
     assert event.processed_at is None
     assert event.payload_json["subscription_bid"] == subscription.subscription_bid

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -45,7 +45,9 @@ from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
     BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE,
     BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+    BILLING_RENEWAL_EVENT_TYPE_RECONCILE,
     BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    BILLING_RENEWAL_EVENT_TYPE_RETRY,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     BILLING_SUBSCRIPTION_STATUS_CANCELED,
 )
@@ -847,6 +849,138 @@ def test_lost_claim_rolls_back_business_side_effects(
     assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
     assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
     assert event.attempt_count == 2
+
+
+def test_lost_claim_stops_before_renewal_order_or_provider_side_effects(
+    renewal_uow_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale attempt must stop before order creation or provider sync."""
+    subscription = _seed_subscription("sub-uow-lost-before-side-effect")
+    event = _seed_event(
+        "renewal-uow-lost-before-side-effect",
+        subscription.subscription_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_RENEWAL,
+    )
+    event.status = BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    event.attempt_count = 1
+    dao.db.session.commit()
+
+    old_worker_event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-lost-before-side-effect"
+    ).one()
+    renewal_event_transitions.bind_renewal_event_claim(
+        old_worker_event,
+        attempt_count=1,
+    )
+    BillingRenewalEvent.query.filter_by(id=old_worker_event.id).update(
+        {
+            "status": BILLING_RENEWAL_EVENT_STATUS_PROCESSING,
+            "attempt_count": 2,
+            "updated_at": now_utc(),
+        },
+        synchronize_session=False,
+    )
+    dao.db.session.commit()
+
+    monkeypatch.setattr(
+        billing_renewal,
+        "ensure_subscription_renewal_order",
+        lambda *_args, **_kwargs: pytest.fail("order creation must not run"),
+    )
+    monkeypatch.setattr(
+        billing_renewal,
+        "_sync_billing_renewal_order",
+        lambda *_args, **_kwargs: pytest.fail("provider sync must not run"),
+    )
+
+    with pytest.raises(renewal_event_transitions.RenewalEventClaimLostError):
+        billing_renewal._execute_subscription_renewal(
+            renewal_uow_app,
+            old_worker_event,
+            now=now_utc(),
+        )
+    dao.db.session.rollback()
+    dao.db.session.expire_all()
+
+    assert (
+        BillingOrder.query.filter_by(
+            subscription_bid=subscription.subscription_bid,
+        ).count()
+        == 0
+    )
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid="renewal-uow-lost-before-side-effect"
+    ).one()
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_PROCESSING
+    assert event.attempt_count == 2
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        BILLING_RENEWAL_EVENT_TYPE_RETRY,
+        BILLING_RENEWAL_EVENT_TYPE_RECONCILE,
+    ],
+)
+def test_retry_or_reconcile_skips_obsolete_subscription_before_provider_sync(
+    renewal_uow_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    event_type: int,
+) -> None:
+    """Recovered retry/reconcile events must not sync canceled subscriptions."""
+    now = now_utc()
+    subscription = _seed_subscription(f"sub-uow-obsolete-retry-{event_type}")
+    subscription.status = BILLING_SUBSCRIPTION_STATUS_CANCELED
+    event = _seed_event(
+        f"renewal-uow-obsolete-retry-{event_type}",
+        subscription.subscription_bid,
+        event_type=event_type,
+    )
+    event.payload_json = {"bill_order_bid": f"bill-uow-obsolete-retry-{event_type}"}
+    order = BillingOrder(
+        bill_order_bid=f"bill-uow-obsolete-retry-{event_type}",
+        creator_bid=CREATOR_BID,
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        product_bid="bill-product-plan-monthly",
+        subscription_bid=subscription.subscription_bid,
+        currency="CNY",
+        payable_amount=990,
+        paid_amount=0,
+        payment_provider="stripe",
+        channel="subscription",
+        provider_reference_id=f"provider-sub-uow-obsolete-retry-{event_type}",
+        status=BILLING_ORDER_STATUS_PENDING,
+        paid_at=None,
+        metadata_json={"renewal_event_bid": event.renewal_event_bid},
+        created_at=now,
+        updated_at=now,
+    )
+    dao.db.session.add(order)
+    dao.db.session.commit()
+
+    monkeypatch.setattr(
+        billing_renewal,
+        "_sync_billing_renewal_order",
+        lambda *_args, **_kwargs: pytest.fail("provider sync must not run"),
+    )
+
+    payload = run_billing_renewal_event(
+        renewal_uow_app,
+        renewal_event_bid=event.renewal_event_bid,
+    )
+    dao.db.session.expire_all()
+
+    event = BillingRenewalEvent.query.filter_by(
+        renewal_event_bid=f"renewal-uow-obsolete-retry-{event_type}"
+    ).one()
+    order = BillingOrder.query.filter_by(
+        bill_order_bid=f"bill-uow-obsolete-retry-{event_type}"
+    ).one()
+    assert payload["status"] == "already_applied"
+    assert payload["bill_order_bid"] == order.bill_order_bid
+    assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+    assert order.status == BILLING_ORDER_STATUS_CANCELED
 
 
 def test_upsert_recovers_when_concurrent_insert_wins(


### PR DESCRIPTION
## Summary
- Make renewal event upsert tolerant of unique-key races by reloading and reusing the winning row.
- Guard release, completion, and failure transitions so stale workers only update events that are still processing.
- Keep lifecycle cancellation from canceling processing renewal events while preserving stale-processing recovery.

## Scope
- Limits changes to billing renewal event persistence transitions and focused backend regression coverage.
- Does not change wallet, bucket, ledger, admission, settlement, credit pack, or historical repair behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancellation and synchronization operations from interfering with renewal events actively being processed.
  * Added safeguards against stale updates overwriting completed, failed, or canceled events.
  * Improved handling of concurrent renewal-event creation and updates.
  * Prevented renewal orders from being created for canceled or expired subscriptions.
  * Improved recovery and retry handling when renewal operations overlap.
  * Ensured failed processing rolls back related billing changes when ownership is lost.
  * Improved reliability of renewal event status updates and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->