### PR TITLE
fix: prevent listen mode page dragging crash

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1479,9 +1479,7 @@ const ListenModeSlideRenderer = ({
     (element: SlideElement | undefined, index: number) => {
       const blockBid = (element as ListenSlideElement | undefined)?.blockBid;
       if (blockBid && blockBid !== 'empty-ppt') {
-        setCurrentStepBlockBid(prevBlockBid =>
-          prevBlockBid === blockBid ? prevBlockBid : blockBid,
-        );
+        setCurrentStepBlockBid(blockBid);
       }
 
       setPlaybackState(prevState => {
@@ -1651,19 +1649,13 @@ const ListenModeSlideRenderer = ({
 
   useLayoutEffect(() => {
     if (!shouldDelayTailInteractionFeedbackPrompt) {
-      setHasSettledTailInteraction(prevSettled =>
-        prevSettled ? prevSettled : true,
-      );
+      setHasSettledTailInteraction(true);
       return;
     }
 
-    setHasSettledTailInteraction(prevSettled =>
-      prevSettled ? false : prevSettled,
-    );
+    setHasSettledTailInteraction(false);
     const timer = window.setTimeout(() => {
-      setHasSettledTailInteraction(prevSettled =>
-        prevSettled ? prevSettled : true,
-      );
+      setHasSettledTailInteraction(true);
     }, LESSON_FEEDBACK_TAIL_INTERACTION_SETTLE_DELAY_MS);
 
     return () => {
@@ -1695,9 +1687,7 @@ const ListenModeSlideRenderer = ({
     setPlaybackState(prevState =>
       resetListenPlaybackStateForSequence(prevState, markerStepCount),
     );
-    setHasSettledTailInteraction(prevSettled =>
-      prevSettled ? false : prevSettled,
-    );
+    setHasSettledTailInteraction(false);
   }, [lessonId, markerSequenceKey, markerStepCount]);
 
   useEffect(() => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -45,6 +45,7 @@ import {
   buildListenMarkerSequenceKey,
   getListenMarkerIdentityKey,
   reconcileListenPlaybackStepCount,
+  resetListenPlaybackStateForSequence,
   resolveCurrentStepAudioCompletion,
   type ListenPlaybackState,
 } from './listenPlaybackState';
@@ -1478,7 +1479,9 @@ const ListenModeSlideRenderer = ({
     (element: SlideElement | undefined, index: number) => {
       const blockBid = (element as ListenSlideElement | undefined)?.blockBid;
       if (blockBid && blockBid !== 'empty-ppt') {
-        setCurrentStepBlockBid(blockBid);
+        setCurrentStepBlockBid(prevBlockBid =>
+          prevBlockBid === blockBid ? prevBlockBid : blockBid,
+        );
       }
 
       setPlaybackState(prevState => {
@@ -1648,13 +1651,19 @@ const ListenModeSlideRenderer = ({
 
   useLayoutEffect(() => {
     if (!shouldDelayTailInteractionFeedbackPrompt) {
-      setHasSettledTailInteraction(true);
+      setHasSettledTailInteraction(prevSettled =>
+        prevSettled ? prevSettled : true,
+      );
       return;
     }
 
-    setHasSettledTailInteraction(false);
+    setHasSettledTailInteraction(prevSettled =>
+      prevSettled ? false : prevSettled,
+    );
     const timer = window.setTimeout(() => {
-      setHasSettledTailInteraction(true);
+      setHasSettledTailInteraction(prevSettled =>
+        prevSettled ? prevSettled : true,
+      );
     }, LESSON_FEEDBACK_TAIL_INTERACTION_SETTLE_DELAY_MS);
 
     return () => {
@@ -1683,16 +1692,12 @@ const ListenModeSlideRenderer = ({
 
   useEffect(() => {
     previousMarkerStepKeyRef.current = '';
-    setPlaybackState({
-      currentStepIndex: -1,
-      totalStepCount: markerStepCount,
-      currentStepHasAudio: false,
-      currentStepHasBlockingInteraction: false,
-      hasCompletedCurrentStepAudio: false,
-      isAudioPlaying: false,
-      isAudioWaiting: false,
-    });
-    setHasSettledTailInteraction(false);
+    setPlaybackState(prevState =>
+      resetListenPlaybackStateForSequence(prevState, markerStepCount),
+    );
+    setHasSettledTailInteraction(prevSettled =>
+      prevSettled ? false : prevSettled,
+    );
   }, [lessonId, markerSequenceKey, markerStepCount]);
 
   useEffect(() => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackState.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackState.test.ts
@@ -1,6 +1,7 @@
 import {
   buildListenMarkerSequenceKey,
   reconcileListenPlaybackStepCount,
+  resetListenPlaybackStateForSequence,
   resolveCurrentStepAudioCompletion,
   type ListenPlaybackState,
 } from './listenPlaybackState';
@@ -111,6 +112,45 @@ describe('listenPlaybackState', () => {
 
     expect(nextState.currentStepIndex).toBe(-1);
     expect(nextState.totalStepCount).toBe(3);
+  });
+
+  it('keeps the same object when playback is already reset for the marker sequence', () => {
+    const resetState = buildPlaybackState({
+      currentStepIndex: -1,
+      totalStepCount: 3,
+      currentStepHasAudio: false,
+      currentStepHasBlockingInteraction: false,
+      hasCompletedCurrentStepAudio: false,
+      isAudioPlaying: false,
+      isAudioWaiting: false,
+    });
+
+    const nextState = resetListenPlaybackStateForSequence(resetState, 3);
+
+    expect(nextState).toBe(resetState);
+  });
+
+  it('resets playback only when marker sequence state still carries old step data', () => {
+    const nextState = resetListenPlaybackStateForSequence(
+      buildPlaybackState({
+        currentStepIndex: 1,
+        totalStepCount: 2,
+        currentStepHasAudio: true,
+        hasCompletedCurrentStepAudio: true,
+        isAudioPlaying: true,
+      }),
+      3,
+    );
+
+    expect(nextState).toEqual({
+      currentStepIndex: -1,
+      totalStepCount: 3,
+      currentStepHasAudio: false,
+      currentStepHasBlockingInteraction: false,
+      hasCompletedCurrentStepAudio: false,
+      isAudioPlaying: false,
+      isAudioWaiting: false,
+    });
   });
 
   it('resets completed audio when a marker gains audio after initially having none', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackState.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackState.ts
@@ -70,6 +70,33 @@ export const reconcileListenPlaybackStepCount = (
   };
 };
 
+export const resetListenPlaybackStateForSequence = (
+  state: ListenPlaybackState,
+  markerStepCount: number,
+): ListenPlaybackState => {
+  if (
+    state.currentStepIndex === -1 &&
+    state.totalStepCount === markerStepCount &&
+    !state.currentStepHasAudio &&
+    !state.currentStepHasBlockingInteraction &&
+    !state.hasCompletedCurrentStepAudio &&
+    !state.isAudioPlaying &&
+    !state.isAudioWaiting
+  ) {
+    return state;
+  }
+
+  return {
+    currentStepIndex: -1,
+    totalStepCount: markerStepCount,
+    currentStepHasAudio: false,
+    currentStepHasBlockingInteraction: false,
+    hasCompletedCurrentStepAudio: false,
+    isAudioPlaying: false,
+    isAudioWaiting: false,
+  };
+};
+
 export const resolveCurrentStepAudioCompletion = ({
   previousStepHasAudio,
   nextStepHasAudio,


### PR DESCRIPTION
## Summary
- Guard listen-mode step state updates so repeated slide callbacks reuse existing state when nothing changed.
- Add playback reset helper coverage for repeated marker-sequence resets.

## Notes
- Reported as an intermittent Windows/Edge crash when dragging to a blocked next step without existing learning progress.
- Focused Jest and lint checks passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Listen Mode playback state handling to prevent redundant updates.
  * Ensured playback state fully resets when the sequence changes.
  * Improved consistency when settling interactions at the end of playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->