### PR TITLE
refactor: expose credit asset kinds in ledger

### DIFF
--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -267,6 +267,7 @@ class BillingLedgerItemDTO(BillingBaseDTO):
     entry_type: str
     source_type: str
     source_bid: str
+    credit_asset_kind: str = "unknown"
     idempotency_key: str
     amount: int | float
     balance_after: int | float

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -49,6 +49,7 @@ from .consts import (
 )
 from .campaigns import resolve_catalog_campaign_payload
 from .bucket_categories import (
+    OrderTypeLoader,
     build_wallet_bucket_runtime_sort_key,
     load_billing_order_type_by_bid,
 )
@@ -709,8 +710,9 @@ def _load_ledger_bucket_map(
 def _build_ledger_page_order_type_loader(
     rows: list[CreditLedgerEntry],
     *,
+    creator_bid: str,
     bucket_map: dict[str, CreditWalletBucket],
-):
+) -> OrderTypeLoader:
     order_bids = {
         _normalize_bid(_normalize_json_object(row.metadata_json).get("bill_order_bid"))
         for row in rows
@@ -726,6 +728,7 @@ def _build_ledger_page_order_type_loader(
     orders = (
         BillingOrder.query.filter(
             BillingOrder.deleted == 0,
+            BillingOrder.creator_bid == _normalize_bid(creator_bid),
             BillingOrder.bill_order_bid.in_(order_bids),
         ).all()
         if order_bids
@@ -779,6 +782,7 @@ def build_billing_ledger_page(
         bucket_map = _load_ledger_bucket_map(rows, creator_bid=normalized_creator_bid)
         load_order_type = _build_ledger_page_order_type_loader(
             rows,
+            creator_bid=normalized_creator_bid,
             bucket_map=bucket_map,
         )
 

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -52,6 +52,7 @@ from .bucket_categories import (
     build_wallet_bucket_runtime_sort_key,
     load_billing_order_type_by_bid,
 )
+from .credit_grant_allocation_views import build_credit_grant_view
 from .credit_notifications import build_creator_limit_state_for_available_credits
 from .dtos import (
     AdminBillingDailyLedgerSummaryPageDTO,
@@ -684,6 +685,63 @@ def build_billing_wallet_buckets(
         )
 
 
+def _load_ledger_bucket_map(
+    rows: list[CreditLedgerEntry],
+    *,
+    creator_bid: str,
+) -> dict[str, CreditWalletBucket]:
+    bucket_bids = {
+        _normalize_bid(row.wallet_bucket_bid)
+        for row in rows
+        if _normalize_bid(row.wallet_bucket_bid)
+    }
+    if not bucket_bids:
+        return {}
+
+    buckets = CreditWalletBucket.query.filter(
+        CreditWalletBucket.deleted == 0,
+        CreditWalletBucket.creator_bid == _normalize_bid(creator_bid),
+        CreditWalletBucket.wallet_bucket_bid.in_(bucket_bids),
+    ).all()
+    return {_normalize_bid(bucket.wallet_bucket_bid): bucket for bucket in buckets}
+
+
+def _build_ledger_page_order_type_loader(
+    rows: list[CreditLedgerEntry],
+    *,
+    bucket_map: dict[str, CreditWalletBucket],
+):
+    order_bids = {
+        _normalize_bid(_normalize_json_object(row.metadata_json).get("bill_order_bid"))
+        for row in rows
+    }
+    order_bids.update(
+        _normalize_bid(
+            _normalize_json_object(bucket.metadata_json).get("bill_order_bid")
+        )
+        for bucket in bucket_map.values()
+    )
+    order_bids.discard("")
+
+    orders = (
+        BillingOrder.query.filter(
+            BillingOrder.deleted == 0,
+            BillingOrder.bill_order_bid.in_(order_bids),
+        ).all()
+        if order_bids
+        else []
+    )
+    order_type_by_bid = {
+        _normalize_bid(order.bill_order_bid): int(order.order_type or 0)
+        for order in orders
+    }
+
+    def _load_order_type(order_bid: str) -> int | None:
+        return order_type_by_bid.get(_normalize_bid(order_bid))
+
+    return _load_order_type
+
+
 def build_billing_ledger_page(
     app: Flask,
     creator_bid: str,
@@ -718,6 +776,11 @@ def build_billing_ledger_page(
         offset = (resolved_page - 1) * safe_page_size
         rows = query.offset(offset).limit(safe_page_size).all()
         usage_metadata_map = _build_usage_metadata_map(rows)
+        bucket_map = _load_ledger_bucket_map(rows, creator_bid=normalized_creator_bid)
+        load_order_type = _build_ledger_page_order_type_loader(
+            rows,
+            bucket_map=bucket_map,
+        )
 
         items = []
         for row in rows:
@@ -737,11 +800,17 @@ def build_billing_ledger_page(
                         },
                     }
 
+            credit_view = build_credit_grant_view(
+                row,
+                bucket=bucket_map.get(_normalize_bid(row.wallet_bucket_bid)),
+                load_order_type=load_order_type,
+            )
             items.append(
                 _serialize_ledger_entry(
                     app,
                     row,
                     metadata=metadata,
+                    credit_asset_kind=credit_view.asset_kind,
                 )
             )
 

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -528,6 +528,7 @@ def serialize_ledger_entry(
     row: CreditLedgerEntry,
     *,
     metadata: Any | None = None,
+    credit_asset_kind: str = "unknown",
 ) -> BillingLedgerItemDTO:
     return BillingLedgerItemDTO(
         ledger_bid=row.ledger_bid,
@@ -535,6 +536,7 @@ def serialize_ledger_entry(
         entry_type=CREDIT_LEDGER_ENTRY_TYPE_LABELS.get(row.entry_type, "grant"),
         source_type=CREDIT_SOURCE_TYPE_LABELS.get(row.source_type, "manual"),
         source_bid=row.source_bid,
+        credit_asset_kind=str(credit_asset_kind or "unknown"),
         idempotency_key=row.idempotency_key,
         amount=credit_decimal_to_number(row.amount),
         balance_after=credit_decimal_to_number(row.balance_after),

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1418,6 +1418,14 @@ class TestBillingRoutes:
                         status=BILLING_ORDER_STATUS_PAID,
                         paid_at=datetime(2026, 4, 7, 9, 30, 0),
                     ),
+                    BillingOrder(
+                        bill_order_bid="order-other-creator-topup",
+                        creator_bid="creator-2",
+                        order_type=BILLING_ORDER_TYPE_TOPUP,
+                        product_bid="bill-product-topup-100",
+                        status=BILLING_ORDER_STATUS_PAID,
+                        paid_at=datetime(2026, 4, 7, 9, 45, 0),
+                    ),
                 ]
             )
             dao.db.session.add(
@@ -1533,6 +1541,40 @@ class TestBillingRoutes:
                         created_at=datetime(2026, 4, 7, 13, 0, 0),
                         updated_at=datetime(2026, 4, 7, 13, 0, 0),
                     ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-internal-legacy",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_MANUAL,
+                        source_bid="manual-adjustment",
+                        idempotency_key="manual-adjustment-1",
+                        amount=Decimal("1.0000000000"),
+                        balance_after=Decimal("133.5000000000"),
+                        expires_at=None,
+                        consumable_from=datetime(2026, 4, 7, 14, 0, 0),
+                        metadata_json={},
+                        created_at=datetime(2026, 4, 7, 14, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 14, 0, 0),
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-cross-creator-order",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+                        source_bid="campaign-cross-creator",
+                        idempotency_key="campaign-cross-creator-1",
+                        amount=Decimal("2.0000000000"),
+                        balance_after=Decimal("135.5000000000"),
+                        expires_at=None,
+                        consumable_from=datetime(2026, 4, 7, 15, 0, 0),
+                        metadata_json={"bill_order_bid": "order-other-creator-topup"},
+                        created_at=datetime(2026, 4, 7, 15, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 15, 0, 0),
+                    ),
                 ]
             )
             dao.db.session.commit()
@@ -1566,6 +1608,8 @@ class TestBillingRoutes:
         assert asset_kind_by_bid["ledger-topup-grant"] == "pack_credits"
         assert asset_kind_by_bid["ledger-grant"] == "plan_credits"
         assert asset_kind_by_bid["ledger-consume"] == "plan_credits"
+        assert asset_kind_by_bid["ledger-internal-legacy"] == "internal_legacy"
+        assert asset_kind_by_bid["ledger-cross-creator-order"] == "unknown"
 
     def test_ledger_emits_utc_ignoring_request_timezone(
         self, billing_test_client

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 from flask import Flask, jsonify, request
 import pytest
+from sqlalchemy import event
 
 import flaskr.dao as dao
 from flaskr.service.billing.consts import (
@@ -31,7 +32,9 @@ from flaskr.service.billing.consts import (
     CREDIT_BUCKET_STATUS_ACTIVE,
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+    CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
     CREDIT_SOURCE_TYPE_GIFT,
+    CREDIT_SOURCE_TYPE_MANUAL,
     CREDIT_SOURCE_TYPE_SUBSCRIPTION,
     CREDIT_SOURCE_TYPE_TOPUP,
     CREDIT_SOURCE_TYPE_USAGE,
@@ -1389,6 +1392,180 @@ class TestBillingRoutes:
             ]
             == 2.5
         )
+        assert ledger_payload["data"]["items"][0]["credit_asset_kind"] == "plan_credits"
+
+    def test_billing_ledger_page_exposes_canonical_credit_asset_kind(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+
+        with app.app_context():
+            dao.db.session.add_all(
+                [
+                    BillingOrder(
+                        bill_order_bid="order-campaign-topup",
+                        creator_bid="creator-1",
+                        order_type=BILLING_ORDER_TYPE_TOPUP,
+                        product_bid="bill-product-topup-100",
+                        status=BILLING_ORDER_STATUS_PAID,
+                        paid_at=datetime(2026, 4, 7, 9, 0, 0),
+                    ),
+                    BillingOrder(
+                        bill_order_bid="order-bucket-plan",
+                        creator_bid="creator-1",
+                        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+                        product_bid="bill-product-plan-monthly",
+                        status=BILLING_ORDER_STATUS_PAID,
+                        paid_at=datetime(2026, 4, 7, 9, 30, 0),
+                    ),
+                ]
+            )
+            dao.db.session.add(
+                CreditWalletBucket(
+                    wallet_bucket_bid="bucket-gift-order-backed",
+                    wallet_bid="wallet-1",
+                    creator_bid="creator-1",
+                    bucket_category=0,
+                    source_type=CREDIT_SOURCE_TYPE_GIFT,
+                    source_bid="gift-order-backed",
+                    priority=4,
+                    original_credits=Decimal("6.0000000000"),
+                    available_credits=Decimal("6.0000000000"),
+                    reserved_credits=Decimal("0"),
+                    consumed_credits=Decimal("0"),
+                    expired_credits=Decimal("0"),
+                    effective_from=datetime(2026, 4, 7, 9, 30, 0),
+                    effective_to=datetime(2026, 5, 7, 9, 30, 0),
+                    status=CREDIT_BUCKET_STATUS_ACTIVE,
+                    metadata_json={"bill_order_bid": "order-bucket-plan"},
+                    created_at=datetime(2026, 4, 7, 9, 30, 0),
+                    updated_at=datetime(2026, 4, 7, 9, 30, 0),
+                )
+            )
+            dao.db.session.add_all(
+                [
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-topup-grant",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="bucket-topup",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_TOPUP,
+                        source_bid="topup-1",
+                        idempotency_key="grant-topup-1",
+                        amount=Decimal("20.0000000000"),
+                        balance_after=Decimal("120.5000000000"),
+                        expires_at=None,
+                        consumable_from=datetime(2026, 4, 3, 0, 0, 0),
+                        metadata_json={"bucket_credit_state": "available"},
+                        created_at=datetime(2026, 4, 7, 10, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 10, 0, 0),
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-bucket-order-backed",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="bucket-gift-order-backed",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_GIFT,
+                        source_bid="gift-order-backed",
+                        idempotency_key="grant-gift-order-backed",
+                        amount=Decimal("6.0000000000"),
+                        balance_after=Decimal("126.5000000000"),
+                        expires_at=datetime(2026, 5, 7, 9, 30, 0),
+                        consumable_from=datetime(2026, 4, 7, 9, 30, 0),
+                        metadata_json={"bucket_credit_state": "available"},
+                        created_at=datetime(2026, 4, 7, 9, 30, 0),
+                        updated_at=datetime(2026, 4, 7, 9, 30, 0),
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-referral-reward",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="bucket-subscription",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_MANUAL,
+                        source_bid="referral_reward",
+                        idempotency_key="operator_referral_reward:1",
+                        amount=Decimal("5.0000000000"),
+                        balance_after=Decimal("125.5000000000"),
+                        expires_at=datetime(2026, 5, 1, 0, 0, 0),
+                        consumable_from=datetime(2026, 4, 7, 11, 0, 0),
+                        metadata_json={
+                            "grant_type": "referral_reward",
+                            "reward_scene": "referral",
+                            "reward_program": "referral_reward",
+                        },
+                        created_at=datetime(2026, 4, 7, 11, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 11, 0, 0),
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-campaign-bonus-1",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+                        source_bid="campaign-1",
+                        idempotency_key="campaign-bonus-1",
+                        amount=Decimal("3.0000000000"),
+                        balance_after=Decimal("128.5000000000"),
+                        expires_at=None,
+                        consumable_from=datetime(2026, 4, 7, 12, 0, 0),
+                        metadata_json={"bill_order_bid": "order-campaign-topup"},
+                        created_at=datetime(2026, 4, 7, 12, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 12, 0, 0),
+                    ),
+                    CreditLedgerEntry(
+                        ledger_bid="ledger-campaign-bonus-2",
+                        creator_bid="creator-1",
+                        wallet_bid="wallet-1",
+                        wallet_bucket_bid="",
+                        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+                        source_type=CREDIT_SOURCE_TYPE_CAMPAIGN_BONUS,
+                        source_bid="campaign-1",
+                        idempotency_key="campaign-bonus-2",
+                        amount=Decimal("4.0000000000"),
+                        balance_after=Decimal("132.5000000000"),
+                        expires_at=None,
+                        consumable_from=datetime(2026, 4, 7, 13, 0, 0),
+                        metadata_json={"bill_order_bid": "order-campaign-topup"},
+                        created_at=datetime(2026, 4, 7, 13, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 13, 0, 0),
+                    ),
+                ]
+            )
+            dao.db.session.commit()
+
+        order_select_count = 0
+
+        def _count_order_selects(_conn, _cursor, statement, *_args):
+            nonlocal order_select_count
+            if "bill_orders" in statement.lower():
+                order_select_count += 1
+
+        with app.app_context():
+            event.listen(dao.db.engine, "before_cursor_execute", _count_order_selects)
+            try:
+                ledger_page = build_billing_ledger_page(app, "creator-1", page_size=10)
+            finally:
+                event.remove(
+                    dao.db.engine,
+                    "before_cursor_execute",
+                    _count_order_selects,
+                )
+        asset_kind_by_bid = {
+            item.ledger_bid: item.credit_asset_kind for item in ledger_page.items
+        }
+
+        assert order_select_count == 1
+        assert asset_kind_by_bid["ledger-bucket-order-backed"] == "plan_credits"
+        assert asset_kind_by_bid["ledger-campaign-bonus-1"] == "pack_credits"
+        assert asset_kind_by_bid["ledger-campaign-bonus-2"] == "pack_credits"
+        assert asset_kind_by_bid["ledger-referral-reward"] == "plan_credits"
+        assert asset_kind_by_bid["ledger-topup-grant"] == "pack_credits"
+        assert asset_kind_by_bid["ledger-grant"] == "plan_credits"
+        assert asset_kind_by_bid["ledger-consume"] == "plan_credits"
 
     def test_ledger_emits_utc_ignoring_request_timezone(
         self, billing_test_client

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -322,6 +322,7 @@ describe('resolveBillingLedgerReasonLabel', () => {
       entry_type: 'consume',
       source_type: 'usage',
       source_bid: `usage-${usageScene}`,
+      credit_asset_kind: 'plan_credits',
       idempotency_key: `usage-${usageScene}-bucket-free`,
       amount: -1,
       balance_after: 99,

--- a/src/cook-web/src/types/billing.ts
+++ b/src/cook-web/src/types/billing.ts
@@ -341,12 +341,19 @@ export type BillingLedgerMetadata = {
   bucket_breakdown?: BillingBucketBreakdownItem[];
 };
 
+export type BillingCreditAssetKind =
+  | 'plan_credits'
+  | 'pack_credits'
+  | 'internal_legacy'
+  | 'unknown';
+
 export type BillingLedgerItem = {
   ledger_bid: string;
   wallet_bucket_bid: string;
   entry_type: BillingLedgerEntryType;
   source_type: BillingBucketSourceType;
   source_bid: string;
+  credit_asset_kind: BillingCreditAssetKind;
   idempotency_key: string;
   amount: number;
   balance_after: number;


### PR DESCRIPTION
## Summary

Use the read-only Credit Grant / Allocation interpretation layer in the billing ledger read model.

## Scope

- Add `credit_asset_kind` to billing ledger DTOs and frontend ledger item types.
- Resolve canonical asset kinds for `/billing/ledger` rows using the read-only grant/allocation view layer.
- Load ledger buckets once per page before serialization, so bucket-backed entries can be classified without changing runtime behavior.
- Add backend coverage for subscription grants, top-up grants, referral rewards, and usage entries inheriting their bucket asset kind.
- No schema changes, wallet mutations, ledger mutations, admission, settlement, repair, or historical data changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Billing ledger entries now identify the type of credits involved, including plan credits, pack credits, and internal or unknown credits.
  - Credit classifications are consistently displayed for purchases, referrals, campaigns, top-ups, and other supported sources.

- **Bug Fixes**
  - Improved billing ledger classification for credit-related transactions.
  - Credit details are resolved efficiently when displaying ledger pages, including transactions associated with different credit sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->