### PR TITLE
fix: fit follow-up buttons to translated labels

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -225,8 +225,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 64px;
+  width: auto;
+  min-width: 64px;
   height: 28px;
+  padding: 0 8px;
   gap: 4px;
   border: none;
   border-radius: 24px 0 0 24px;
@@ -235,6 +237,7 @@
   font-size: 14px;
   font-weight: 500;
   line-height: 1;
+  white-space: nowrap;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
 
   img {

--- a/src/cook-web/src/app/globals.css
+++ b/src/cook-web/src/app/globals.css
@@ -180,9 +180,10 @@ body.listen-mode-vh-fallback #root {
   }
   custom-button-after-content,
   .content-render-custom-button-after-content {
-    width: 58px;
+    width: auto;
+    min-width: 58px;
     height: 20px;
-    padding: 0;
+    padding: 0 8px;
     border: none;
     appearance: none;
     gap: 4px;

--- a/src/cook-web/src/c-components/ChatUi/InteractionBlock.scss
+++ b/src/cook-web/src/c-components/ChatUi/InteractionBlock.scss
@@ -16,11 +16,14 @@
 .ask-button {
   background: #55575e;
   color: rgba(255, 255, 255, var(--tw-text-opacity, 1));
-  width: 54px;
+  width: auto;
+  min-width: 54px;
   height: 22px;
+  padding: 0 8px;
   gap: 4px;
   font-size: 10px;
   line-height: 1;
+  white-space: nowrap;
   border-radius: 24px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   margin-right: 3px;
@@ -36,7 +39,7 @@
 
 .ask-button--content {
   background: var(--primary);
-  width: 58px;
+  min-width: 58px;
   height: 20px;
   font-size: 12px;
   font-weight: 500;


### PR DESCRIPTION
## Summary

- Preserve the existing compact widths as minimums while allowing follow-up buttons to expand for longer translations.
- Apply the behavior consistently to reading content, reading action bars, and the mobile listen-mode entry.
- Keep translated labels on one line with stable horizontal padding.

## Root cause

The visible follow-up buttons used fixed widths that predated French support, so longer labels such as `Demander` could extend beyond the button background.

## Benefit

Learners can read the complete follow-up action in Chinese, English, and French while shorter labels retain their previous compact size.

## Verification

- `python3 scripts/check_dev_tools.py`
- Prettier check for all changed stylesheets
- Focused Jest: 3 suites, 49 tests
- `npm run type-check`
- `npm run lint` (passes with existing repository warnings)
- `git diff --check`
- Browser layout QA across zh-CN, en-US, and fr-FR for all four text-bearing follow-up variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile ask and custom content buttons to size automatically based on their labels.
  * Added minimum widths and horizontal padding for better usability.
  * Prevented button text from wrapping, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->