### PR TITLE
feat: migrate langfuse tracing to python sdk v3

### DIFF
--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import re
 import uuid
 from typing import Any
 
@@ -7,6 +8,45 @@ from flask import Flask, request
 from langfuse import Langfuse
 
 from flaskr.common.log import thread_local
+
+# Langfuse SDK v3 is OTel based: trace ids must be 32 lowercase hex chars and
+# parent/child links are derived from the span object hierarchy instead of the
+# explicit trace_id/parent_observation_id kwargs the v2 SDK accepted. The
+# handle classes below keep the v2-style call surface (trace.span(),
+# span.generation(), generation.end(output=...)) so call sites stay unchanged.
+
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+_OBSERVATION_KEYS = {
+    "name",
+    "input",
+    "output",
+    "metadata",
+    "version",
+    "level",
+    "status_message",
+}
+_GENERATION_KEYS = _OBSERVATION_KEYS | {
+    "completion_start_time",
+    "model",
+    "model_parameters",
+    "usage_details",
+    "cost_details",
+    "prompt",
+}
+_TRACE_KEYS = {
+    "name",
+    "user_id",
+    "session_id",
+    "version",
+    "input",
+    "output",
+    "metadata",
+    "tags",
+    "public",
+}
+# v2-era link kwargs that no longer exist in SDK v3; parenthood is implicit.
+_LINK_KEYS = {"trace_id", "parent_observation_id", "id"}
 
 
 class MockClient:
@@ -40,8 +80,19 @@ def get_request_id() -> str:
     return request_id
 
 
+def coerce_langfuse_trace_id(raw: str | None = None) -> str:
+    # SDK v3 only accepts W3C trace ids (32 lowercase hex). Non-conforming
+    # request ids are mapped deterministically via create_trace_id(seed=...)
+    # so the same request always lands on the same Langfuse trace.
+    if isinstance(raw, str) and _TRACE_ID_RE.match(raw):
+        return raw
+    if isinstance(raw, str) and raw:
+        return Langfuse.create_trace_id(seed=raw)
+    return Langfuse.create_trace_id()
+
+
 def get_request_trace_id() -> str:
-    return get_request_id() or uuid.uuid4().hex
+    return coerce_langfuse_trace_id(get_request_id() or uuid.uuid4().hex)
 
 
 def resolve_langfuse_trace_id(observation: Any, trace_id: str | None = None) -> str:
@@ -61,6 +112,8 @@ def resolve_langfuse_trace_id(observation: Any, trace_id: str | None = None) -> 
 def build_langfuse_observation_link(
     observation: Any, trace_id: str | None = None
 ) -> dict[str, str]:
+    # Kept for logging/correlation. The handle classes drop these keys before
+    # calling into SDK v3, where the span hierarchy already encodes the link.
     observation_link: dict[str, str] = {}
     resolved_trace_id = resolve_langfuse_trace_id(observation, trace_id)
     parent_observation_id = (
@@ -70,7 +123,7 @@ def build_langfuse_observation_link(
     )
     if resolved_trace_id:
         observation_link["trace_id"] = resolved_trace_id
-    if parent_observation_id:
+    if isinstance(parent_observation_id, str) and parent_observation_id:
         observation_link["parent_observation_id"] = parent_observation_id
     return observation_link
 
@@ -190,15 +243,116 @@ def compact_langfuse_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     return {key: value for key, value in payload.items() if _has_langfuse_value(value)}
 
 
+def _usage_to_details(usage: Any) -> dict[str, int] | None:
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        details = {
+            key: int(usage[key])
+            for key in ("input", "output", "total")
+            if usage.get(key) is not None
+        }
+        return details or None
+    details = {}
+    for key in ("input", "output", "total"):
+        value = getattr(usage, key, None)
+        if value is not None:
+            details[key] = int(value)
+    return details or None
+
+
+def _map_observation_kwargs(
+    kwargs: dict[str, Any], allowed: set[str]
+) -> dict[str, Any]:
+    mapped = dict(kwargs)
+    for key in _LINK_KEYS:
+        mapped.pop(key, None)
+    usage = mapped.pop("usage", None)
+    if usage is not None and "usage_details" not in mapped:
+        usage_details = _usage_to_details(usage)
+        if usage_details:
+            mapped["usage_details"] = usage_details
+    return compact_langfuse_payload(
+        {key: value for key, value in mapped.items() if key in allowed}
+    )
+
+
+class LangfuseObservationHandle:
+    """v2-style facade over a Langfuse SDK v3 span or generation."""
+
+    def __init__(self, delegate: Any, trace_id: str = ""):
+        self._delegate = delegate
+        delegate_trace_id = getattr(delegate, "trace_id", "")
+        self.trace_id = trace_id or (
+            delegate_trace_id if isinstance(delegate_trace_id, str) else ""
+        )
+
+    @property
+    def id(self) -> str:
+        delegate_id = getattr(self._delegate, "id", "")
+        return delegate_id if isinstance(delegate_id, str) else ""
+
+    def span(self, **kwargs) -> "LangfuseObservationHandle":
+        payload = _map_observation_kwargs(kwargs, _OBSERVATION_KEYS)
+        payload.setdefault("name", "span")
+        child = self._delegate.start_span(**payload)
+        return LangfuseObservationHandle(child, self.trace_id)
+
+    def generation(self, **kwargs) -> "LangfuseObservationHandle":
+        payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
+        payload.setdefault("name", "generation")
+        child = self._delegate.start_generation(**payload)
+        return LangfuseObservationHandle(child, self.trace_id)
+
+    def update(self, **kwargs) -> "LangfuseObservationHandle":
+        payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
+        if payload:
+            self._delegate.update(**payload)
+        return self
+
+    def end(self, **kwargs) -> "LangfuseObservationHandle":
+        # SDK v3 end() only accepts end_time; flush attribute updates first.
+        payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
+        if payload:
+            self._delegate.update(**payload)
+        self._delegate.end()
+        return self
+
+    def update_trace(self, **kwargs) -> "LangfuseObservationHandle":
+        payload = _map_observation_kwargs(kwargs, _TRACE_KEYS)
+        if payload:
+            self._delegate.update_trace(**payload)
+        return self
+
+
+class LangfuseTraceHandle(LangfuseObservationHandle):
+    """v2-style trace facade; trace attributes live on the root span in v3."""
+
+    def update(self, **kwargs) -> "LangfuseTraceHandle":
+        self.update_trace(**kwargs)
+        return self
+
+
 def create_trace_with_root_span(
     *,
     client: Any,
     trace_payload: dict[str, Any],
     root_span_payload: dict[str, Any],
 ):
-    trace = client.trace(**compact_langfuse_payload(trace_payload))
-    root_span = trace.span(**compact_langfuse_payload(root_span_payload))
-    return trace, root_span
+    trace_payload = compact_langfuse_payload(trace_payload)
+    root_payload = _map_observation_kwargs(root_span_payload, _OBSERVATION_KEYS)
+    raw_trace_id = trace_payload.pop("id", None)
+    trace_id = coerce_langfuse_trace_id(
+        raw_trace_id if isinstance(raw_trace_id, str) else None
+    )
+    root_payload.setdefault("name", trace_payload.get("name") or "trace")
+    root_span = client.start_span(
+        trace_context={"trace_id": trace_id},
+        **root_payload,
+    )
+    trace = LangfuseTraceHandle(root_span, trace_id)
+    trace.update(**trace_payload)
+    return trace, LangfuseObservationHandle(root_span, trace_id)
 
 
 def update_langfuse_trace(trace: Any, payload: dict[str, Any] | None = None, **kwargs):
@@ -226,7 +380,9 @@ def finalize_langfuse_trace(
     trace_payload: dict[str, Any] | None = None,
     root_span_payload: dict[str, Any] | None = None,
 ):
+    # Update trace attributes before ending the root span: in SDK v3 trace
+    # attributes are written through the (still open) root span.
+    update_langfuse_trace(trace, payload=trace_payload)
     if root_span is not None:
         root_span.end(**compact_langfuse_payload(root_span_payload))
-    update_langfuse_trace(trace, payload=trace_payload)
     return trace

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -301,7 +301,9 @@ class LangfuseObservationHandle:
     def generation(self, **kwargs) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
         payload.setdefault("name", "generation")
-        child = self._delegate.start_generation(**payload)
+        # start_generation() is deprecated in SDK v3; start_observation() is
+        # the v4-compatible replacement.
+        child = self._delegate.start_observation(as_type="generation", **payload)
         return LangfuseObservationHandle(child, self.trace_id)
 
     def event(self, **kwargs) -> "LangfuseObservationHandle":

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -304,6 +304,12 @@ class LangfuseObservationHandle:
         child = self._delegate.start_generation(**payload)
         return LangfuseObservationHandle(child, self.trace_id)
 
+    def event(self, **kwargs) -> "LangfuseObservationHandle":
+        payload = _map_observation_kwargs(kwargs, _OBSERVATION_KEYS)
+        payload.setdefault("name", "event")
+        child = self._delegate.create_event(**payload)
+        return LangfuseObservationHandle(child, self.trace_id)
+
     def update(self, **kwargs) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
         if payload:

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -318,10 +318,14 @@ class LangfuseObservationHandle:
 
     def end(self, **kwargs) -> "LangfuseObservationHandle":
         # SDK v3 end() only accepts end_time; flush attribute updates first.
+        end_time = kwargs.pop("end_time", None)
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
         if payload:
             self._delegate.update(**payload)
-        self._delegate.end()
+        if end_time is not None:
+            self._delegate.end(end_time=end_time)
+        else:
+            self._delegate.end()
         return self
 
     def update_trace(self, **kwargs) -> "LangfuseObservationHandle":

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -16,10 +16,8 @@ os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 import litellm  # noqa: E402
 from flask import Flask, current_app
-from langfuse.client import StatefulSpanClient
-from langfuse.model import ModelUsage
-
 from flaskr.api.langfuse import (
+    LangfuseObservationHandle,
     build_langfuse_observation_link,
     get_request_id,
     resolve_langfuse_trace_id,
@@ -707,7 +705,7 @@ def get_litellm_params_and_model(model: str):
 def invoke_llm(
     app: Flask,
     user_id: str,
-    span: StatefulSpanClient,
+    span: LangfuseObservationHandle,
     model: str,
     message: str,
     system: str = None,
@@ -800,12 +798,11 @@ def invoke_llm(
             res_usage = getattr(res, "usage", None)
             if res_usage:
                 input_cache_tokens = _extract_input_cache(res_usage)
-                usage = ModelUsage(
-                    unit="TOKENS",
-                    input=res_usage.prompt_tokens,
-                    output=res_usage.completion_tokens,
-                    total=res_usage.total_tokens,
-                )
+                usage = {
+                    "input": res_usage.prompt_tokens,
+                    "output": res_usage.completion_tokens,
+                    "total": res_usage.total_tokens,
+                }
     else:
         raise_error_with_args(
             "server.llm.modelNotSupported",
@@ -886,7 +883,7 @@ def invoke_llm(
 def chat_llm(
     app: Flask,
     user_id: str,
-    span: StatefulSpanClient,
+    span: LangfuseObservationHandle,
     model: str,
     messages: list,
     json: bool = False,
@@ -970,12 +967,11 @@ def chat_llm(
                 res_usage = getattr(res, "usage", None)
                 if res_usage:
                     input_cache_tokens = _extract_input_cache(res_usage)
-                    usage = ModelUsage(
-                        unit="TOKENS",
-                        input=res_usage.prompt_tokens,
-                        output=res_usage.completion_tokens,
-                        total=res_usage.total_tokens,
-                    )
+                    usage = {
+                        "input": res_usage.prompt_tokens,
+                        "output": res_usage.completion_tokens,
+                        "total": res_usage.total_tokens,
+                    }
         except Exception as exc:
             if not (_is_litellm_repeated_stream_chunk_error(exc) and response_text):
                 raise

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -57,8 +57,8 @@ from flaskr.service.learn.models import (
     LearnGeneratedElement,
 )
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
-from langfuse.client import StatefulTraceClient
 from ...api.langfuse import (
+    LangfuseTraceHandle,
     MockClient,
     create_trace_with_root_span,
     finalize_langfuse_trace,
@@ -240,7 +240,7 @@ def _resolve_runtime_language_context(
 class RUNLLMProvider(LLMProvider):
     app: Flask
     llm_settings: LLMSettings
-    trace: StatefulTraceClient
+    trace: LangfuseTraceHandle
     parent_observation: Any
     trace_args: dict
     usage_context: UsageContext
@@ -250,7 +250,7 @@ class RUNLLMProvider(LLMProvider):
         self,
         app: Flask,
         llm_settings: LLMSettings,
-        trace: StatefulTraceClient,
+        trace: LangfuseTraceHandle,
         parent_observation: Any,
         trace_args: dict,
         usage_context: UsageContext,
@@ -1503,7 +1503,7 @@ class RunScriptContextV2:
     _trace_args: dict
     _trace_id: str
     _shifu_info: ShifuInfoDto
-    _trace: Union[StatefulTraceClient, MockClient]
+    _trace: Union[LangfuseTraceHandle, MockClient]
     _trace_root_span: Any
     _input_type: str
     _input: str

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from flask import Flask
 from flaskr.api.langfuse import (
+    LangfuseTraceHandle,
     normalize_langfuse_input_value,
     update_langfuse_observation,
     update_langfuse_trace,
@@ -52,7 +53,6 @@ from flaskr.service.shifu.consts import (
 )
 from flaskr.service.shifu.shifu_struct_manager import ShifuOutlineItemDto
 from flaskr.service.user.repository import UserAggregate
-from langfuse.client import StatefulTraceClient
 
 check_text_with_llm_response = None
 LLMSettings = None
@@ -258,7 +258,7 @@ def _append_context_langfuse_output(context: Any, value: str) -> None:
 def _finalize_ask_trace(
     *,
     context: Any,
-    trace: StatefulTraceClient,
+    trace: LangfuseTraceHandle,
     parent_observation: Any | None,
     span: Any,
     trace_args: dict,
@@ -287,7 +287,7 @@ def handle_input_ask(
     input: str,
     outline_item_info: ShifuOutlineItemDto,
     trace_args: dict,
-    trace: StatefulTraceClient,
+    trace: LangfuseTraceHandle,
     is_preview: bool = False,
     last_position: int = -1,
     anchor_element_bid: str = "",

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -58,7 +58,7 @@ jsonpatch==1.33
 jsonpointer==3.0.0
 jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
-langfuse==2.39.3
+langfuse==3.15.0
 Mako==1.3.12
 MarkupSafe==2.1.5
 marshmallow==3.26.2

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -26,9 +26,10 @@ class _FakeObservation:
         self.last_span = child
         return child
 
-    def start_generation(self, **kwargs):
-        child = _FakeObservation("generation", **kwargs)
-        self.generations.append(child)
+    def start_observation(self, as_type="span", **kwargs):
+        child = _FakeObservation(as_type, **kwargs)
+        if as_type == "generation":
+            self.generations.append(child)
         return child
 
     def update(self, **kwargs):

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -5,53 +5,65 @@ from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 from flaskr.service.learn.ask_provider_adapters import AskProviderError
 
 
-class _FakeGeneration:
-    def __init__(self, **kwargs):
+class _FakeObservation:
+    """Mimics a Langfuse SDK v3 span/generation object."""
+
+    def __init__(self, kind: str = "span", **kwargs):
+        self.kind = kind
         self.kwargs = kwargs
-        self.end_kwargs = {}
-
-    def end(self, **kwargs):
-        self.end_kwargs = kwargs
-
-
-class _FakeSpan:
-    def __init__(self):
+        self.updates = []
+        self.trace_updates = []
+        self.ended = False
+        self.trace_id = "f" * 32
+        self.id = f"fake-{kind}-id"
         self.generations = []
-        self.end_kwargs = {}
-
-    def generation(self, **kwargs):
-        generation = _FakeGeneration(**kwargs)
-        self.generations.append(generation)
-        return generation
-
-    def end(self, **kwargs):
-        self.end_kwargs = kwargs
-
-
-class _FakeTrace:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-        self.updated = {}
         self.span_calls = []
         self.last_span = None
 
-    def span(self, **kwargs):
+    def start_span(self, **kwargs):
         self.span_calls.append(kwargs)
-        self.last_span = _FakeSpan()
-        return self.last_span
+        child = _FakeObservation("span", **kwargs)
+        self.last_span = child
+        return child
+
+    def start_generation(self, **kwargs):
+        child = _FakeObservation("generation", **kwargs)
+        self.generations.append(child)
+        return child
 
     def update(self, **kwargs):
-        self.updated = kwargs
+        self.updates.append(kwargs)
+
+    def update_trace(self, **kwargs):
+        self.trace_updates.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+    @property
+    def end_kwargs(self):
+        merged = {}
+        for item in self.updates:
+            merged.update(item)
+        return merged
+
+    @property
+    def updated(self):
+        merged = {}
+        for item in self.trace_updates:
+            merged.update(item)
+        return merged
 
 
 class _FakeLangfuseClient:
     def __init__(self):
         self.traces = []
 
-    def trace(self, **kwargs):
-        trace = _FakeTrace(**kwargs)
-        self.traces.append(trace)
-        return trace
+    def start_span(self, trace_context=None, **kwargs):
+        root = _FakeObservation("span", **kwargs)
+        root.trace_context = trace_context or {}
+        self.traces.append(root)
+        return root
 
 
 def _mock_authenticated_user(
@@ -126,15 +138,16 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
     assert len(fake_langfuse.traces) == 1
     trace = fake_langfuse.traces[0]
     assert trace.kwargs["input"] == "hello"
-    assert trace.last_span is not None
-    assert len(trace.last_span.generations) == 1
-    generation = trace.last_span.generations[0]
+    # With SDK v3 the generation hangs directly off the root span.
+    assert len(trace.generations) == 1
+    generation = trace.generations[0]
     assert generation.kwargs["model"] == "dify"
     assert generation.end_kwargs["metadata"]["provider_config"]["config"][
         "api_key"
     ] == ("[REDACTED]")
     assert generation.end_kwargs["output"] == "provider result"
-    assert trace.last_span.end_kwargs["output"] == "provider result"
+    assert generation.ended
+    assert trace.end_kwargs["output"] == "provider result"
     assert trace.updated["output"] == "provider result"
 
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -105,9 +105,10 @@ class _FakeObservation:
     def start_span(self, **kwargs):
         return _FakeObservation("span", **kwargs)
 
-    def start_generation(self, **kwargs):
-        child = _FakeObservation("generation", **kwargs)
-        self.generations.append(child)
+    def start_observation(self, as_type="span", **kwargs):
+        child = _FakeObservation(as_type, **kwargs)
+        if as_type == "generation":
+            self.generations.append(child)
         return child
 
     def update(self, **kwargs):

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -89,37 +89,60 @@ _install_litellm_stub()
 _install_openai_responses_stub()
 
 
-class _FakeSpan:
-    def __init__(self, **kwargs):
+class _FakeObservation:
+    """Mimics a Langfuse SDK v3 span/generation object."""
+
+    def __init__(self, kind: str = "span", **kwargs):
+        self.kind = kind
         self.kwargs = kwargs
-        self.end_kwargs = {}
+        self.updates = []
+        self.trace_updates = []
+        self.ended = False
+        self.trace_id = "f" * 32
+        self.id = f"fake-{kind}-id"
+        self.generations = []
 
-    def end(self, **kwargs):
-        self.end_kwargs = kwargs
+    def start_span(self, **kwargs):
+        return _FakeObservation("span", **kwargs)
 
-
-class _FakeTrace:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-        self.updated = {}
-        self.last_span = None
-
-    def span(self, **kwargs):
-        self.last_span = _FakeSpan(**kwargs)
-        return self.last_span
+    def start_generation(self, **kwargs):
+        child = _FakeObservation("generation", **kwargs)
+        self.generations.append(child)
+        return child
 
     def update(self, **kwargs):
-        self.updated = kwargs
+        self.updates.append(kwargs)
+
+    def update_trace(self, **kwargs):
+        self.trace_updates.append(kwargs)
+
+    def end(self):
+        self.ended = True
+
+    @property
+    def end_kwargs(self):
+        merged = {}
+        for item in self.updates:
+            merged.update(item)
+        return merged
+
+    @property
+    def updated(self):
+        merged = {}
+        for item in self.trace_updates:
+            merged.update(item)
+        return merged
 
 
 class _FakeLangfuseClient:
     def __init__(self):
         self.traces = []
 
-    def trace(self, **kwargs):
-        trace = _FakeTrace(**kwargs)
-        self.traces.append(trace)
-        return trace
+    def start_span(self, trace_context=None, **kwargs):
+        root = _FakeObservation("span", **kwargs)
+        root.trace_context = trace_context or {}
+        self.traces.append(root)
+        return root
 
 
 def test_make_ask_prompt_fills_content_and_keeps_runtime_placeholders():
@@ -181,9 +204,9 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch):
     trace = fake_langfuse.traces[0]
     assert trace.kwargs["name"] == "shifu_summary"
     assert trace.kwargs["input"] == "Summarize this lesson"
-    assert trace.last_span is not None
-    assert trace.last_span.kwargs["input"] == "Summarize this lesson"
-    assert trace.last_span.end_kwargs["output"] == "summary result"
+    # With SDK v3 the root span carries both span and trace attributes.
+    assert trace.end_kwargs["output"] == "summary result"
+    assert trace.ended
     assert trace.updated["output"] == "summary result"
 
 

--- a/src/api/tests/test_langfuse.py
+++ b/src/api/tests/test_langfuse.py
@@ -1,3 +1,4 @@
+import re
 import types
 import unittest
 from unittest.mock import patch
@@ -6,10 +7,30 @@ from flask import Flask
 
 from flaskr.api.langfuse import (
     MockClient,
+    coerce_langfuse_trace_id,
     get_request_trace_id,
     resolve_langfuse_trace_id,
 )
 from flaskr.common.log import thread_local
+
+TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+class CoerceTraceIdTests(unittest.TestCase):
+    def test_passes_through_valid_w3c_trace_id(self):
+        valid = "0123456789abcdef0123456789abcdef"
+        self.assertEqual(coerce_langfuse_trace_id(valid), valid)
+
+    def test_maps_arbitrary_ids_deterministically(self):
+        first = coerce_langfuse_trace_id("my-request-id")
+        second = coerce_langfuse_trace_id("my-request-id")
+        self.assertEqual(first, second)
+        self.assertRegex(first, TRACE_ID_RE)
+        self.assertNotEqual(first, coerce_langfuse_trace_id("other-request-id"))
+
+    def test_generates_random_id_when_seed_missing(self):
+        generated = coerce_langfuse_trace_id(None)
+        self.assertRegex(generated, TRACE_ID_RE)
 
 
 class RequestTraceIdTests(unittest.TestCase):
@@ -23,7 +44,10 @@ class RequestTraceIdTests(unittest.TestCase):
         thread_local.request_id = "thread-local-request-id"
 
         with app.test_request_context(headers={"X-Request-ID": "header-request-id"}):
-            self.assertEqual(get_request_trace_id(), "thread-local-request-id")
+            self.assertEqual(
+                get_request_trace_id(),
+                coerce_langfuse_trace_id("thread-local-request-id"),
+            )
 
     def test_falls_back_to_request_header(self):
         if hasattr(thread_local, "request_id"):
@@ -34,15 +58,18 @@ class RequestTraceIdTests(unittest.TestCase):
         original_request = get_request_trace_id.__globals__["request"]
         get_request_trace_id.__globals__["request"] = fake_request
         try:
-            self.assertEqual(get_request_trace_id(), "header-request-id")
+            self.assertEqual(
+                get_request_trace_id(),
+                coerce_langfuse_trace_id("header-request-id"),
+            )
         finally:
             get_request_trace_id.__globals__["request"] = original_request
 
-    def test_generates_uuid_when_request_id_is_missing(self):
-        fake_uuid = types.SimpleNamespace(hex="generated-request-id")
+    def test_uses_generated_uuid_when_request_id_is_missing(self):
+        fake_uuid = types.SimpleNamespace(hex="0123456789abcdef0123456789abcdef")
 
         with patch("flaskr.api.langfuse.uuid.uuid4", return_value=fake_uuid):
-            self.assertEqual(get_request_trace_id(), "generated-request-id")
+            self.assertEqual(get_request_trace_id(), fake_uuid.hex)
 
 
 class ResolveLangfuseTraceIdTests(unittest.TestCase):
@@ -68,10 +95,16 @@ class ResolveLangfuseTraceIdTests(unittest.TestCase):
         # ``trace_id``. That object must never be used as the trace id.
         thread_local.request_id = "request-trace-id"
 
-        self.assertEqual(resolve_langfuse_trace_id(MockClient()), "request-trace-id")
+        self.assertEqual(
+            resolve_langfuse_trace_id(MockClient()),
+            coerce_langfuse_trace_id("request-trace-id"),
+        )
 
     def test_ignores_empty_string_trace_ids(self):
         thread_local.request_id = "request-trace-id"
         observation = types.SimpleNamespace(trace_id="")
 
-        self.assertEqual(resolve_langfuse_trace_id(observation, ""), "request-trace-id")
+        self.assertEqual(
+            resolve_langfuse_trace_id(observation, ""),
+            coerce_langfuse_trace_id("request-trace-id"),
+        )


### PR DESCRIPTION
## Summary

Migrates backend Langfuse tracing from Python SDK v2 (`langfuse==2.39.3`) to the OTel-based SDK v3 (`langfuse==3.15.0`).

This is the first step of the Langfuse platform v4 upgrade: SDK v2 ingestion is rejected once the platform reaches v4 default mode, while SDK v3 is compatible with both the current self-hosted server (3.163.0, requires >= 3.63.0) and v4. Landing the SDK migration first means later server upgrades need no coordinated backend release.

## Changes

- `flaskr/api/langfuse.py`: rewritten around SDK v3. New `LangfuseObservationHandle` / `LangfuseTraceHandle` facades keep the v2-style call surface (`trace.span()`, `span.generation()`, `end(output=...)`) so call sites stay unchanged. Trace attributes are written through the still-open root span; `usage` payloads map to `usage_details`; v2-era `trace_id`/`parent_observation_id` link kwargs are dropped (hierarchy is implicit in v3).
- Request ids are coerced into deterministic W3C trace ids via `Langfuse.create_trace_id(seed=...)`, so the same request always lands on the same trace and `bill_usage.trace_id` matches the Langfuse UI.
- `flaskr/api/llm/__init__.py`, `service/learn/context_v2.py`, `service/learn/handle_input_ask.py`: replaced removed `StatefulTraceClient`/`StatefulSpanClient`/`ModelUsage` imports with the new handle types and plain usage dicts. No business-logic changes.
- Tests: fakes and assertions updated to the SDK v3 object shape; new coverage for deterministic trace-id coercion.

## Verification

- Full backend suite: 2382 passed, 15 skipped; `lefthook run pre-commit --all-files` clean.
- Deployed to the dev environment (image `20260802-6bd1a22`) against the production self-hosted Langfuse 3.163.0:
  - container-level smoke: trace + generation with `usage_details` confirmed via the public API (correct name, user, output, and 3/5 token usage);
  - real lesson run: trace `e271b9a0b6b8444a93983eed4ef9bf26` shows the expected hierarchy (trace -> root span -> 3 `run_llm` generations) with correct aggregated usage (11,640 prompt -> 1,829 completion) and session/user attribution.

## Notes for reviewers

- Trace trees gain one level compared to v2: trace attributes now live on the root span, and child spans/generations hang off it. No data is lost; dashboards keyed by trace name/user/session are unaffected.
- When Langfuse is not configured the existing `MockClient` path is preserved and all handles degrade to no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Upgraded Langfuse integration to SDK v3 for improved observability.
  * Improved trace and observation handling, including nested spans and generations.
  * Standardized trace IDs and token usage data for more consistent monitoring.
  * Preserved compatibility with existing tracing and observation workflows.

* **Tests**
  * Expanded coverage for trace ID conversion, fallback behavior, observation updates, nested generation handling, and completion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->