### PR TITLE
fix: recover listen runs from desynced MySQL connections

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1789,6 +1789,10 @@ class RunScriptContextV2:
         parent_language = get_current_language()
         parent_shifu_context = get_shifu_context_snapshot()
         poll_timeout = max(float(idle_poll_interval or 0.0), 0.01)
+        # Consumer-side stop signal: without it a producer that outlives the
+        # 1s join below keeps streaming until the LLM response ends, holding
+        # its DB session and connection long after the caller moved on.
+        consumer_stopped = threading.Event()
 
         def _produce() -> None:
             with self.app.app_context():
@@ -1796,7 +1800,7 @@ class RunScriptContextV2:
                 apply_shifu_context_snapshot(parent_shifu_context)
                 try:
                     for item in stream_result:
-                        if self._stop_requested():
+                        if consumer_stopped.is_set() or self._stop_requested():
                             break
                         result_queue.put(("item", item))
                 except Exception as exc:
@@ -1835,10 +1839,12 @@ class RunScriptContextV2:
                     raise payload
                 break
         finally:
-            producer_thread.join(timeout=1.0)
+            consumer_stopped.set()
+            producer_thread.join(timeout=5.0)
             if producer_thread.is_alive():
                 self.app.logger.warning(
-                    "mdflow stream producer thread did not stop in time"
+                    "mdflow stream producer thread did not stop in time; "
+                    "it will exit at the next stream chunk boundary"
                 )
 
     def _get_current_attend(self, outline_bid: str) -> LearnProgressRecord:

--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import json
 
 from flaskr.dao import db
 from sqlalchemy import bindparam, text
+from sqlalchemy.exc import ResourceClosedError
 from flaskr.service.learn.learn_dtos import (
     AudioCompleteDTO,
     AudioSegmentDTO,
@@ -130,7 +132,8 @@ class ListenElementRunPersistenceMixin:
         # avoids the ORM query/result path that triggered the listen-mode
         # ResourceClosedError / Command Out of Sync failure while still seeing
         # rows flushed earlier in the same transaction.
-        result = db.session.connection().execute(
+        connection = db.session.connection()
+        result = connection.execute(
             self._ACTIVE_ELEMENT_ROW_ID_SQL,
             {
                 "run_session_bid": self.run_session_bid,
@@ -142,8 +145,19 @@ class ListenElementRunPersistenceMixin:
             return [
                 int(row_id) for (row_id,) in result.fetchall() if row_id is not None
             ]
+        except ResourceClosedError:
+            # A rowless result for this SELECT means the connection's protocol
+            # stream is desynced (the query consumed a stale response packet
+            # left over from an interrupted operation). Invalidate the raw
+            # DBAPI connection so the poisoned connection is dropped from the
+            # pool instead of failing every later request that checks it out;
+            # the caller's rollback then completes on session state alone.
+            with contextlib.suppress(Exception):
+                connection.invalidate()
+            raise
         finally:
-            result.close()
+            with contextlib.suppress(Exception):
+                result.close()
 
     def _deactivate_active_element_rows(
         self,

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -4,10 +4,13 @@ import queue
 import threading
 import time
 import traceback
+import uuid
 from datetime import datetime
 from typing import Any, Generator, Optional
 
 from flask import Flask
+from sqlalchemy import text as sa_text
+from sqlalchemy.exc import InterfaceError, OperationalError, ResourceClosedError
 
 from flaskr.service.common.models import AppException, raise_error
 from flaskr.service.user.repository import load_user_aggregate
@@ -57,6 +60,62 @@ def _remove_db_session_safely(app: Flask, *, source: str) -> None:
         db.session.remove()
     except Exception:
         app.logger.warning("%s db session cleanup failed", source, exc_info=True)
+
+
+# Number of connection checkouts to probe before giving up: the pool may hold
+# more than one poisoned connection, so retry a couple of fresh checkouts.
+_CONNECTION_PROBE_ATTEMPTS = 3
+
+
+def _ensure_healthy_db_connection(app: Flask) -> None:
+    """Drop pooled connections whose MySQL protocol stream is desynced.
+
+    A streaming run interrupted mid-IO can return a connection to the pool
+    with an unread response packet still buffered. pool_pre_ping cannot catch
+    this: the ping reads the stale packet and "succeeds", leaving every later
+    query on that connection off by one response, which surfaces as
+    ResourceClosedError on SELECTs and pymysql 2014 "Command Out of Sync" on
+    rollback. Probe with a nonce echo before the run touches business tables;
+    on any mismatch invalidate the connection and retry on a fresh checkout.
+    The probe leaves the session transaction open so the run keeps using the
+    verified connection.
+    """
+    last_error: Exception | None = None
+    for attempt in range(1, _CONNECTION_PROBE_ATTEMPTS + 1):
+        nonce = uuid.uuid4().hex
+        try:
+            echoed = db.session.execute(
+                sa_text("SELECT :nonce"), {"nonce": nonce}
+            ).scalar()
+            if echoed == nonce:
+                return
+            last_error = None
+            app.logger.warning(
+                "db connection probe echoed %r instead of the nonce "
+                "(attempt %d/%d); invalidating desynced connection",
+                echoed,
+                attempt,
+                _CONNECTION_PROBE_ATTEMPTS,
+            )
+        except (ResourceClosedError, OperationalError, InterfaceError) as exc:
+            last_error = exc
+            app.logger.warning(
+                "db connection probe failed (attempt %d/%d); "
+                "invalidating desynced connection: %s",
+                attempt,
+                _CONNECTION_PROBE_ATTEMPTS,
+                exc,
+            )
+        with contextlib.suppress(Exception):
+            db.session.connection().invalidate()
+        with contextlib.suppress(Exception):
+            db.session.rollback()
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError(
+        "db connection probe kept returning mismatched results; "
+        "no healthy connection available"
+    )
 
 
 def _get_max_parallel_ask_count(app: Flask) -> int:
@@ -251,6 +310,7 @@ def run_script_inner(
         run_script_context: RunScriptContextV2 | None = None
         resolved_shifu_bid = shifu_bid
         try:
+            _ensure_healthy_db_connection(app)
             user_info = load_user_aggregate(user_bid)
             if not user_info:
                 raise_error("USER.USER_NOT_FOUND")

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -1,0 +1,45 @@
+import threading
+import time
+import types
+
+from flaskr.service.learn.context_v2 import RunScriptContextV2
+
+_PRODUCER_THREAD_NAME = "mdflow_stream_result_producer"
+
+
+def _make_context_stub(app):
+    stub = types.SimpleNamespace(app=app)
+    stub._stop_requested = lambda: False
+    stub._stop_if_requested = lambda: None
+    return stub
+
+
+def test_stream_producer_stops_when_consumer_exits_early(app):
+    stop_streaming = threading.Event()
+
+    def endless_stream():
+        index = 0
+        while not stop_streaming.is_set():
+            yield index
+            index += 1
+            time.sleep(0.01)
+
+    stub = _make_context_stub(app)
+    iterator = RunScriptContextV2._iter_stream_result_with_idle_callback(
+        stub,
+        endless_stream(),
+        idle_callback=None,
+    )
+
+    try:
+        assert next(iterator) == ("item", 0)
+    finally:
+        # Close the consumer mid-stream: the finally block must signal the
+        # producer thread to stop instead of letting it stream forever.
+        iterator.close()
+        stop_streaming.set()
+
+    assert not any(
+        thread.name == _PRODUCER_THREAD_NAME and thread.is_alive()
+        for thread in threading.enumerate()
+    )

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -1,4 +1,8 @@
+import pytest
+from sqlalchemy.exc import ResourceClosedError
+
 from flaskr.dao import db
+from flaskr.service.learn import listen_element_run_persistence
 from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 from flaskr.service.learn.models import LearnGeneratedElement
 
@@ -94,6 +98,59 @@ def test_find_active_element_row_ids_sees_rows_flushed_in_current_transaction(ap
         assert len(row_ids) == 1
         assert row_ids[0] == LearnGeneratedElement.query.first().id
         db.session.rollback()
+
+
+def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkeypatch):
+    class _DesyncedResult:
+        def fetchall(self):
+            raise ResourceClosedError(
+                "This result object does not return rows. "
+                "It has been closed automatically."
+            )
+
+        def close(self):
+            pass
+
+    class _FakeConnection:
+        def __init__(self):
+            self.invalidated = 0
+
+        def execute(self, *_args, **_kwargs):
+            return _DesyncedResult()
+
+        def invalidate(self):
+            self.invalidated += 1
+
+    class _FakeSession:
+        def __init__(self, connection):
+            self._connection = connection
+
+        def connection(self):
+            return self._connection
+
+    fake_connection = _FakeConnection()
+
+    class _FakeDb:
+        session = _FakeSession(fake_connection)
+
+    monkeypatch.setattr(listen_element_run_persistence, "db", _FakeDb)
+
+    with app.app_context():
+        adapter = ListenElementRunAdapter(
+            app,
+            shifu_bid="shifu-a",
+            outline_bid="outline-a",
+            user_bid="user-a",
+            run_session_bid="run-a",
+        )
+
+        with pytest.raises(ResourceClosedError):
+            adapter._find_active_element_row_ids(
+                generated_block_bid="block-a",
+                element_bids=["element-a"],
+            )
+
+    assert fake_connection.invalidated == 1
 
 
 def test_deactivate_active_element_rows_retires_rows_without_touching_others(app):

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -1,0 +1,103 @@
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from flaskr.service.learn import runscript_v2
+from flaskr.service.learn.runscript_v2 import _ensure_healthy_db_connection
+
+
+class _EchoResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.invalidated = 0
+
+    def invalidate(self):
+        self.invalidated += 1
+
+
+class _FakeSession:
+    """Scripted session: each execute() consumes the next behaviour."""
+
+    def __init__(self, behaviours):
+        # behaviours: list of "ok" | "raise" | any-fixed-echo-value
+        self._behaviours = list(behaviours)
+        self.executed = 0
+        self.rollbacks = 0
+        self._connection = _FakeConnection()
+
+    def execute(self, _statement, params):
+        self.executed += 1
+        behaviour = self._behaviours.pop(0)
+        if behaviour == "ok":
+            return _EchoResult(params["nonce"])
+        if behaviour == "raise":
+            raise OperationalError(
+                "SELECT :nonce",
+                params,
+                Exception("(2014, 'Command Out of Sync')"),
+            )
+        return _EchoResult(behaviour)
+
+    def connection(self):
+        return self._connection
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def _patch_session(monkeypatch, behaviours):
+    session = _FakeSession(behaviours)
+
+    class _FakeDb:
+        pass
+
+    _FakeDb.session = session
+    monkeypatch.setattr(runscript_v2, "db", _FakeDb)
+    return session
+
+
+def test_probe_passes_on_healthy_connection(app):
+    with app.app_context():
+        _ensure_healthy_db_connection(app)
+
+
+def test_probe_invalidates_desynced_connection_and_retries(app, monkeypatch):
+    session = _patch_session(monkeypatch, ["raise", "ok"])
+
+    _ensure_healthy_db_connection(app)
+
+    assert session.executed == 2
+    assert session._connection.invalidated == 1
+    assert session.rollbacks == 1
+
+
+def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch):
+    session = _patch_session(monkeypatch, ["stale-packet-value", "ok"])
+
+    _ensure_healthy_db_connection(app)
+
+    assert session.executed == 2
+    assert session._connection.invalidated == 1
+
+
+def test_probe_raises_after_exhausting_attempts(app, monkeypatch):
+    session = _patch_session(monkeypatch, ["raise", "raise", "raise"])
+
+    with pytest.raises(OperationalError):
+        _ensure_healthy_db_connection(app)
+
+    assert session.executed == 3
+    assert session._connection.invalidated == 3
+
+
+def test_probe_raises_on_persistent_echo_mismatch(app, monkeypatch):
+    _patch_session(monkeypatch, ["bad-1", "bad-2", "bad-3"])
+
+    with pytest.raises(RuntimeError):
+        _ensure_healthy_db_connection(app)

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -16,6 +16,16 @@ from flaskr.service.learn.learn_dtos import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _skip_connection_probe(monkeypatch):
+    # These tests exercise run-script locking and orchestration with minimal
+    # fake sessions; the connection health probe has its own dedicated tests
+    # in test_runscript_v2_connection_probe.py.
+    monkeypatch.setattr(
+        runscript_v2, "_ensure_healthy_db_connection", lambda _app: None
+    )
+
+
 class FakeLock:
     def __init__(self, acquire_results: list[bool]):
         self._acquire_results = list(acquire_results)


### PR DESCRIPTION
## Problem

Production listen-mode runs intermittently fail with:

```
sqlalchemy.exc.ResourceClosedError: This result object does not return rows.
pymysql.err.OperationalError: (2014, 'Command Out of Sync')
```

The failure surfaces in `_find_active_element_row_ids` when persisting listen audio segment patches. PR #2122 previously reworked this lookup into a single Core SELECT, but the error still occurs on the reworked path, so the query shape was not the root cause.

## Diagnosis

All recent production occurrences share the same profile: the failing requests die within ~100 ms of stream start, on the **reload/replay path** that runs no LLM and no TTS concurrency of its own. This means the failing request is a *victim*: it checks out a pooled MySQL connection whose protocol stream was already desynced (an unread response packet left buffered by a previously interrupted streaming run).

`pool_pre_ping` cannot catch this state: the ping reads the stale packet and "succeeds", leaving every later query on that connection off by one response. The first SELECT then consumes a rowless stale packet (`ResourceClosedError`), and the subsequent rollback trips pymysql 2014.

## Changes

1. **Connection health probe at run start** (`runscript_v2.py`): before the run touches business tables, execute a nonce-echo `SELECT` and verify the echoed value. On mismatch or a connection-protocol error, invalidate the connection and retry on a fresh checkout (up to 3 attempts). The probe leaves the session transaction open so the run keeps using the verified connection. This both heals the victim request and evicts poisoned connections from the pool.
2. **Invalidate on desync in the row-id lookup** (`listen_element_run_persistence.py`): when `fetchall()` raises `ResourceClosedError`, invalidate the underlying DBAPI connection before re-raising, so the poisoned connection is dropped instead of being returned to the pool and the caller's rollback completes on session state alone.
3. **Stop leaked stream producer threads** (`context_v2.py`): `_iter_stream_result_with_idle_callback` now sets a consumer-stop event in its `finally` block and joins for up to 5 s, so a producer thread that outlives the consumer exits at the next chunk boundary instead of streaming until the LLM response ends while holding a DB session and connection. This closes one source of interrupted streaming work.

## Testing

- New: `test_runscript_v2_connection_probe.py` (healthy pass-through, invalidate-and-retry on error and on echo mismatch, give-up behaviour).
- New: `test_context_v2_stream_producer_stop.py` (producer thread exits after early consumer close).
- Extended: `test_listen_element_run_persistence.py` (connection invalidated when the SELECT returns a rowless result).
- `tests/service/learn`: 382 passed, 5 skipped.
- `lefthook run pre-commit --all-files`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming responses now stop promptly when the caller closes the stream or requests cancellation.
  - Improved handling of interrupted or unavailable database connections during lesson and script operations.
  - Database connections are now checked and recovered automatically before running scripts, reducing failures caused by stale or unhealthy connections.
  - Added safer cleanup and recovery when database results become unavailable during active lesson processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->