### PR TITLE
feat: show limited-time promo tag on the premium voice option

### DIFF
--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -12,7 +12,7 @@ TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON; note the mapping is easy to mix up):
     internal model  | voice types      | sample rate | UI display name (zh-CN)
     --------------- | ---------------- | ----------- | -----------------------
     premium         | 101xxx (精品音色) | 16000       | 基础语音
-    large-model     | 501xxx/601xxx    | 24000       | 精品语音
+    large-model     | 501xxx/601xxx    | 24000       | 标准语音
                       (大模型音色)
 
 Credentials: TENCENT_TTS_SECRET_ID / TENCENT_TTS_SECRET_KEY (shared with the

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -390,7 +390,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
         json_module.dumps(
             {
                 "tencent_texttovoice/premium": {"zh-CN": "基础语音"},
-                "tencent_texttovoice/large-model": {"zh-CN": "精品语音"},
+                "tencent_texttovoice/large-model": {"zh-CN": "标准语音"},
                 "volcengine/seed-tts-2.0": {"zh-CN": "旗舰语音"},
             }
         ),
@@ -404,6 +404,6 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
 
     assert [(item["value"], item["label"]) for item in config["model_options"]] == [
         ("tencent_texttovoice/premium", "基础语音"),
-        ("tencent_texttovoice/large-model", "精品语音"),
+        ("tencent_texttovoice/large-model", "标准语音"),
         ("volcengine/seed-tts-2.0", "旗舰语音"),
     ]

--- a/src/cook-web/src/components/model-list/ModelList.test.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.test.tsx
@@ -169,6 +169,45 @@ describe('ModelList', () => {
     ).toBeNull();
   });
 
+  test('renders promo badge only for options that carry a promoLabel', () => {
+    render(
+      <ModelList
+        value='minimax/speech-2.8-turbo'
+        onChange={() => undefined}
+        showDefaultOption={false}
+        options={[
+          {
+            value: 'minimax/speech-2.8-turbo',
+            label: 'Premium Voice',
+            creditMultiplierLabel: '22x',
+            promoLabel: 'Limited-time 90% off',
+          },
+          {
+            value: 'tencent_texttovoice/premium',
+            label: 'Basic Voice',
+            creditMultiplierLabel: '2x',
+          },
+        ]}
+      />,
+    );
+
+    // Promo badge shows in both the trigger and the dropdown option, next to
+    // the untouched multiplier badge.
+    expect(screen.getAllByText('Limited-time 90% off')).toHaveLength(2);
+    expect(screen.getAllByText('22x')).toHaveLength(2);
+
+    const basicOption = screen
+      .getByText('Basic Voice')
+      .closest('[role="option"]');
+    expect(basicOption).toBeTruthy();
+    expect(
+      within(basicOption as HTMLElement).queryByText('Limited-time 90% off'),
+    ).toBeNull();
+    expect(
+      within(basicOption as HTMLElement).getByText('2x'),
+    ).toBeInTheDocument();
+  });
+
   test('refreshes model options on open with a short ttl', () => {
     const initialNow = Date.now() + 1_000_000;
     const nowSpy = jest.spyOn(Date, 'now');

--- a/src/cook-web/src/components/model-list/ModelList.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.tsx
@@ -19,16 +19,23 @@ function ModelOptionLabel({
   label,
   creditMultiplier,
   creditMultiplierLabel,
+  promoLabel,
 }: {
   label: string;
   creditMultiplier?: number | null;
   creditMultiplierLabel?: string;
+  promoLabel?: string;
 }) {
   const multiplierLabel =
     creditMultiplierLabel || (creditMultiplier ? `${creditMultiplier}x` : '');
   return (
     <span className='flex w-full min-w-0 items-center'>
       <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+      {promoLabel ? (
+        <span className='ml-2 shrink-0 rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 text-xs font-medium leading-none text-destructive'>
+          {promoLabel}
+        </span>
+      ) : null}
       {multiplierLabel ? (
         <span className='ml-2 shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-medium leading-none text-primary'>
           {multiplierLabel}
@@ -128,6 +135,7 @@ export default function ModelList({
                 label={selectedOption.label}
                 creditMultiplier={selectedOption.creditMultiplier}
                 creditMultiplierLabel={selectedOption.creditMultiplierLabel}
+                promoLabel={selectedOption.promoLabel}
               />
             ) : (
               t('common.core.selectModel')
@@ -163,6 +171,7 @@ export default function ModelList({
                 label={item.label}
                 creditMultiplier={item.creditMultiplier}
                 creditMultiplierLabel={item.creditMultiplierLabel}
+                promoLabel={item.promoLabel}
               />
             </SelectItem>
           );

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -105,6 +105,10 @@ import {
   ONBOARDING_TARGET_IDS,
 } from '@/lib/onboardingTargets';
 
+// Temporary display-only promo tag on TTS model options; remove when the
+// campaign ends. Credit multipliers stay admin-configured and untouched.
+const TTS_PROMO_MODEL_VALUES = new Set(['minimax/speech-2.8-turbo']);
+
 interface Shifu {
   description: string;
   bid: string;
@@ -564,8 +568,16 @@ export default function ShifuSettingDialog({
     ttsConfig?.providers[0];
 
   const ttsModelOptions = useMemo(
-    () => ttsConfig?.model_options || [],
-    [ttsConfig?.model_options],
+    () =>
+      (ttsConfig?.model_options || []).map(option =>
+        TTS_PROMO_MODEL_VALUES.has(option.value)
+          ? {
+              ...option,
+              promoLabel: t('module.shifuSetting.ttsPromoBadge'),
+            }
+          : option,
+      ),
+    [t, ttsConfig?.model_options],
   );
   const ttsModelSelectValue = buildTtsModelOptionValue(
     resolvedProvider,

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -3293,6 +3293,7 @@ export type I18nKey =
   | 'module.shifuSetting.ttsPreview'
   | 'module.shifuSetting.ttsPreviewLoading'
   | 'module.shifuSetting.ttsPreviewStop'
+  | 'module.shifuSetting.ttsPromoBadge'
   | 'module.shifuSetting.ttsProvider'
   | 'module.shifuSetting.ttsProviderHint'
   | 'module.shifuSetting.ttsProviderRequiredDesc'

--- a/src/cook-web/src/types/shifu.ts
+++ b/src/cook-web/src/types/shifu.ts
@@ -15,6 +15,7 @@ export interface ModelOption {
   label: string;
   creditMultiplier?: number | null;
   creditMultiplierLabel?: string;
+  promoLabel?: string;
   isDefault?: boolean;
 }
 

--- a/src/i18n/en-US/modules/shifu-setting.json
+++ b/src/i18n/en-US/modules/shifu-setting.json
@@ -248,6 +248,7 @@
   "ttsPreview": "Preview current voice",
   "ttsPreviewLoading": "Generating preview...",
   "ttsPreviewStop": "Stop",
+  "ttsPromoBadge": "Limited-time 95% off",
   "ttsProvider": "Provider",
   "ttsProviderHint": "Choose the provider used to generate lesson narration",
   "ttsProviderRequiredDesc": "Please choose a voice provider before enabling listen mode.",

--- a/src/i18n/fr-FR/modules/shifu-setting.json
+++ b/src/i18n/fr-FR/modules/shifu-setting.json
@@ -248,6 +248,7 @@
   "ttsPreview": "Prévisualiser la voix actuelle",
   "ttsPreviewLoading": "Génération de l’aperçu…",
   "ttsPreviewStop": "Arrêter",
+  "ttsPromoBadge": "-95 % durée limitée",
   "ttsProvider": "Fournisseur",
   "ttsProviderHint": "Choisir le fournisseur utilisé pour générer la narration",
   "ttsProviderRequiredDesc": "Veuillez choisir un fournisseur vocal avant d’activer le mode écoute.",

--- a/src/i18n/fr-FR/modules/shifu-setting.json
+++ b/src/i18n/fr-FR/modules/shifu-setting.json
@@ -248,7 +248,7 @@
   "ttsPreview": "Prévisualiser la voix actuelle",
   "ttsPreviewLoading": "Génération de l’aperçu…",
   "ttsPreviewStop": "Arrêter",
-  "ttsPromoBadge": "-95 % durée limitée",
+  "ttsPromoBadge": "Offre limitée : -95 %",
   "ttsProvider": "Fournisseur",
   "ttsProviderHint": "Choisir le fournisseur utilisé pour générer la narration",
   "ttsProviderRequiredDesc": "Veuillez choisir un fournisseur vocal avant d’activer le mode écoute.",

--- a/src/i18n/zh-CN/modules/shifu-setting.json
+++ b/src/i18n/zh-CN/modules/shifu-setting.json
@@ -248,6 +248,7 @@
   "ttsPreview": "试听当前选择",
   "ttsPreviewLoading": "正在生成试听...",
   "ttsPreviewStop": "停止",
+  "ttsPromoBadge": "限时0.5折",
   "ttsProvider": "服务商",
   "ttsProviderHint": "选择用来生成讲课语音的服务商",
   "ttsProviderRequiredDesc": "开启听课模式后，请先选择语音服务商。",


### PR DESCRIPTION
## Summary

- Add a display-only promo badge (zh "限时0.5折" / en "Limited-time 95% off" / fr "-95 % durée limitée") next to the premium voice option (`minimax/speech-2.8-turbo`) in the course voice model picker, shown in both the dropdown list and the selected trigger.
- The badge is driven by a temporary frontend constant (`TTS_PROMO_MODEL_VALUES` in `ShifuSetting.tsx`) and shared i18n copy; remove the constant and the `ttsPromoBadge` keys when the campaign ends.
- Credit multipliers are untouched: the existing multiplier badge stays admin-configured and renders independently next to the new promo badge.
- Also corrects a stale tier mapping in the Tencent TextToVoice provider header comment and backend test fixtures: the large-model tier displays as 标准语音 (Standard Voice); 精品语音 (Premium Voice) is the MiniMax tier in current deployments.

## Verification

- `cd src/cook-web && npm run test -- src/components/model-list/` — 4 passed (includes new promo badge test)
- `cd src/cook-web && npm run type-check` — clean
- `cd src/cook-web && npm run lint` — passes (remaining warnings pre-existing)
- `cd src/api && pytest tests/service/tts/test_tts_config_options.py -q` — 10 passed
- Manually verified locally against the local Docker backend that the picker renders with the local TTS tier config; the settings dialog itself sits behind creator login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added promotional badges for eligible text-to-speech models in the selected model and dropdown list.
  * Added localized promotional messaging in English, French, and Chinese.
  * Updated the Tencent large-model display name to “Standard Voice.”

* **Bug Fixes**
  * Ensured promotional labels appear only for models with an active promotion while preserving credit multiplier badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->