### PR TITLE
feat: expose bucket credit asset kinds

### DIFF
--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -201,6 +201,7 @@ class BillingEntitlementsDTO(BillingBaseDTO):
 class BillingWalletBucketDTO(BillingBaseDTO):
     wallet_bucket_bid: str
     category: str
+    credit_asset_kind: str = "unknown"
     source_type: str
     source_bid: str
     available_credits: int | float

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -51,9 +51,11 @@ from .campaigns import resolve_catalog_campaign_payload
 from .bucket_categories import (
     OrderTypeLoader,
     build_wallet_bucket_runtime_sort_key,
-    load_billing_order_type_by_bid,
 )
-from .credit_grant_allocation_views import build_credit_grant_view
+from .credit_grant_allocation_views import (
+    build_credit_allocation_view,
+    build_credit_grant_view,
+)
 from .credit_notifications import build_creator_limit_state_for_available_credits
 from .dtos import (
     AdminBillingDailyLedgerSummaryPageDTO,
@@ -675,15 +677,73 @@ def build_billing_wallet_buckets(
             .order_by(CreditWalletBucket.id.asc())
             .all()
         )
+        load_order_type = _build_wallet_bucket_order_type_loader(
+            rows,
+            creator_bid=normalized_creator_bid,
+        )
         rows.sort(
             key=lambda row: build_wallet_bucket_runtime_sort_key(
                 row,
-                load_order_type=load_billing_order_type_by_bid,
+                load_order_type=load_order_type,
             )
         )
-        return BillingWalletBucketListDTO(
-            items=[_serialize_wallet_bucket(app, row) for row in rows]
-        )
+        items = []
+        for row in rows:
+            allocation_view = build_credit_allocation_view(
+                row,
+                load_order_type=load_order_type,
+            )
+            items.append(
+                _serialize_wallet_bucket(
+                    app,
+                    row,
+                    category_code=allocation_view.runtime_bucket_category,
+                    credit_asset_kind=allocation_view.asset_kind,
+                )
+            )
+        return BillingWalletBucketListDTO(items=items)
+
+
+def _build_wallet_bucket_order_type_loader(
+    rows: list[CreditWalletBucket],
+    *,
+    creator_bid: str,
+) -> OrderTypeLoader:
+    order_bids = {
+        _normalize_bid(_normalize_json_object(row.metadata_json).get("bill_order_bid"))
+        for row in rows
+    }
+    order_bids.discard("")
+
+    return _build_creator_order_type_loader(order_bids, creator_bid=creator_bid)
+
+
+def _build_creator_order_type_loader(
+    order_bids: set[str],
+    *,
+    creator_bid: str,
+) -> OrderTypeLoader:
+    safe_order_bids = {_normalize_bid(order_bid) for order_bid in order_bids}
+    safe_order_bids.discard("")
+
+    orders = (
+        BillingOrder.query.filter(
+            BillingOrder.deleted == 0,
+            BillingOrder.creator_bid == _normalize_bid(creator_bid),
+            BillingOrder.bill_order_bid.in_(safe_order_bids),
+        ).all()
+        if safe_order_bids
+        else []
+    )
+    order_type_by_bid = {
+        _normalize_bid(order.bill_order_bid): int(order.order_type or 0)
+        for order in orders
+    }
+
+    def _load_order_type(order_bid: str) -> int | None:
+        return order_type_by_bid.get(_normalize_bid(order_bid))
+
+    return _load_order_type
 
 
 def _load_ledger_bucket_map(
@@ -725,24 +785,7 @@ def _build_ledger_page_order_type_loader(
     )
     order_bids.discard("")
 
-    orders = (
-        BillingOrder.query.filter(
-            BillingOrder.deleted == 0,
-            BillingOrder.creator_bid == _normalize_bid(creator_bid),
-            BillingOrder.bill_order_bid.in_(order_bids),
-        ).all()
-        if order_bids
-        else []
-    )
-    order_type_by_bid = {
-        _normalize_bid(order.bill_order_bid): int(order.order_type or 0)
-        for order in orders
-    }
-
-    def _load_order_type(order_bid: str) -> int | None:
-        return order_type_by_bid.get(_normalize_bid(order_bid))
-
-    return _load_order_type
+    return _build_creator_order_type_loader(order_bids, creator_bid=creator_bid)
 
 
 def build_billing_ledger_page(

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -50,9 +50,10 @@ from .consts import (
 from .campaigns import resolve_catalog_campaign_payload
 from .bucket_categories import (
     OrderTypeLoader,
-    build_wallet_bucket_runtime_sort_key,
+    resolve_credit_bucket_priority,
 )
 from .credit_grant_allocation_views import (
+    CreditAllocationView,
     build_credit_allocation_view,
     build_credit_grant_view,
 )
@@ -681,18 +682,21 @@ def build_billing_wallet_buckets(
             rows,
             creator_bid=normalized_creator_bid,
         )
-        rows.sort(
-            key=lambda row: build_wallet_bucket_runtime_sort_key(
+        bucket_views = [
+            (
                 row,
-                load_order_type=load_order_type,
+                build_credit_allocation_view(
+                    row,
+                    load_order_type=load_order_type,
+                ),
             )
+            for row in rows
+        ]
+        bucket_views.sort(
+            key=lambda pair: _wallet_bucket_view_sort_key(pair[0], pair[1])
         )
         items = []
-        for row in rows:
-            allocation_view = build_credit_allocation_view(
-                row,
-                load_order_type=load_order_type,
-            )
+        for row, allocation_view in bucket_views:
             items.append(
                 _serialize_wallet_bucket(
                     app,
@@ -702,6 +706,19 @@ def build_billing_wallet_buckets(
                 )
             )
         return BillingWalletBucketListDTO(items=items)
+
+
+def _wallet_bucket_view_sort_key(
+    row: CreditWalletBucket,
+    allocation_view: CreditAllocationView,
+) -> tuple[int, bool, datetime, datetime, int]:
+    return (
+        resolve_credit_bucket_priority(allocation_view.runtime_bucket_category),
+        row.effective_to is None,
+        row.effective_to or datetime.max,
+        row.created_at or datetime.min,
+        int(row.id or 0),
+    )
 
 
 def _build_wallet_bucket_order_type_loader(

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -491,10 +491,17 @@ def build_billing_alerts(
 def serialize_wallet_bucket(
     app: Flask,
     row: CreditWalletBucket,
+    *,
+    category_code: int | None = None,
+    credit_asset_kind: str = "unknown",
 ) -> BillingWalletBucketDTO:
-    category_code = resolve_wallet_bucket_runtime_category(
-        row,
-        load_order_type=load_billing_order_type_by_bid,
+    runtime_category_code = (
+        resolve_wallet_bucket_runtime_category(
+            row,
+            load_order_type=load_billing_order_type_by_bid,
+        )
+        if category_code is None
+        else int(category_code)
     )
     current_at = now_utc()
     runtime_status = CREDIT_BUCKET_STATUS_LABELS.get(row.status, "active")
@@ -503,7 +510,7 @@ def serialize_wallet_bucket(
         and row.effective_to is not None
         and row.effective_to <= current_at
         and not (
-            category_code == CREDIT_BUCKET_CATEGORY_TOPUP
+            runtime_category_code == CREDIT_BUCKET_CATEGORY_TOPUP
             and to_decimal(row.available_credits) > 0
             and (row.effective_from is None or row.effective_from <= current_at)
         )
@@ -512,13 +519,16 @@ def serialize_wallet_bucket(
 
     return BillingWalletBucketDTO(
         wallet_bucket_bid=row.wallet_bucket_bid,
-        category=CREDIT_BUCKET_CATEGORY_LABELS.get(category_code, "subscription"),
+        category=CREDIT_BUCKET_CATEGORY_LABELS.get(
+            runtime_category_code, "subscription"
+        ),
+        credit_asset_kind=str(credit_asset_kind or "unknown"),
         source_type=CREDIT_SOURCE_TYPE_LABELS.get(row.source_type, "manual"),
         source_bid=row.source_bid,
         available_credits=credit_decimal_to_number(row.available_credits),
         effective_from=row.effective_from,
         effective_to=row.effective_to,
-        priority=resolve_credit_bucket_priority(category_code),
+        priority=resolve_credit_bucket_priority(runtime_category_code),
         status=runtime_status,
     )
 

--- a/src/api/tests/service/billing/test_billing_dtos.py
+++ b/src/api/tests/service/billing/test_billing_dtos.py
@@ -172,6 +172,7 @@ def test_billing_dto_json_serializes_metric_breakdowns_and_bucket_lists() -> Non
             {
                 "wallet_bucket_bid": "bucket-1",
                 "category": "subscription",
+                "credit_asset_kind": "unknown",
                 "source_type": "subscription",
                 "source_bid": "sub-1",
                 "available_credits": 97.5,

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1209,6 +1209,105 @@ class TestBillingRoutes:
         assert bucket_map["bucket-topup"]["status"] == "active"
         assert bucket_map["bucket-topup"]["available_credits"] == 15.38
 
+    def test_wallet_bucket_order_lookup_is_page_scoped(
+        self, billing_test_client
+    ) -> None:
+        app = billing_test_client.application
+
+        with app.app_context():
+            order_select_count = 0
+
+            def _count_order_selects(_conn, _cursor, statement, *_args):
+                nonlocal order_select_count
+                if "bill_orders" in statement.lower():
+                    order_select_count += 1
+
+            event.listen(dao.db.engine, "before_cursor_execute", _count_order_selects)
+            try:
+                bucket_list = build_billing_wallet_buckets(app, "creator-1")
+            finally:
+                event.remove(
+                    dao.db.engine,
+                    "before_cursor_execute",
+                    _count_order_selects,
+                )
+
+            assert order_select_count == 0
+            assert len(bucket_list.items) == 3
+
+            dao.db.session.add(
+                BillingOrder(
+                    bill_order_bid="order-shared-topup",
+                    creator_bid="creator-1",
+                    order_type=BILLING_ORDER_TYPE_TOPUP,
+                    product_bid="bill-product-topup-100",
+                    status=BILLING_ORDER_STATUS_PAID,
+                    paid_at=datetime(2026, 4, 7, 9, 0, 0),
+                )
+            )
+            dao.db.session.add_all(
+                [
+                    CreditWalletBucket(
+                        wallet_bucket_bid="bucket-shared-order-1",
+                        wallet_bid="wallet-1",
+                        creator_bid="creator-1",
+                        bucket_category=0,
+                        source_type=CREDIT_SOURCE_TYPE_GIFT,
+                        source_bid="gift-shared-order-1",
+                        priority=4,
+                        original_credits=Decimal("3.0000000000"),
+                        available_credits=Decimal("3.0000000000"),
+                        reserved_credits=Decimal("0"),
+                        consumed_credits=Decimal("0"),
+                        expired_credits=Decimal("0"),
+                        effective_from=datetime(2026, 4, 7, 9, 0, 0),
+                        effective_to=None,
+                        status=CREDIT_BUCKET_STATUS_ACTIVE,
+                        metadata_json={"bill_order_bid": "order-shared-topup"},
+                        created_at=datetime(2026, 4, 7, 9, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 9, 0, 0),
+                    ),
+                    CreditWalletBucket(
+                        wallet_bucket_bid="bucket-shared-order-2",
+                        wallet_bid="wallet-1",
+                        creator_bid="creator-1",
+                        bucket_category=0,
+                        source_type=CREDIT_SOURCE_TYPE_GIFT,
+                        source_bid="gift-shared-order-2",
+                        priority=5,
+                        original_credits=Decimal("4.0000000000"),
+                        available_credits=Decimal("4.0000000000"),
+                        reserved_credits=Decimal("0"),
+                        consumed_credits=Decimal("0"),
+                        expired_credits=Decimal("0"),
+                        effective_from=datetime(2026, 4, 7, 10, 0, 0),
+                        effective_to=None,
+                        status=CREDIT_BUCKET_STATUS_ACTIVE,
+                        metadata_json={"bill_order_bid": "order-shared-topup"},
+                        created_at=datetime(2026, 4, 7, 10, 0, 0),
+                        updated_at=datetime(2026, 4, 7, 10, 0, 0),
+                    ),
+                ]
+            )
+            dao.db.session.commit()
+
+            order_select_count = 0
+            event.listen(dao.db.engine, "before_cursor_execute", _count_order_selects)
+            try:
+                bucket_list = build_billing_wallet_buckets(app, "creator-1")
+            finally:
+                event.remove(
+                    dao.db.engine,
+                    "before_cursor_execute",
+                    _count_order_selects,
+                )
+
+        bucket_map = {item.wallet_bucket_bid: item for item in bucket_list.items}
+
+        assert order_select_count == 1
+        assert bucket_map["bucket-shared-order-1"].credit_asset_kind == "pack_credits"
+        assert bucket_map["bucket-shared-order-2"].credit_asset_kind == "pack_credits"
+
     def test_billing_public_builders_return_dto_instances(
         self,
         billing_test_client,

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -814,7 +814,10 @@ class TestBillingRoutes:
             "bucket-topup",
         ]
         assert bucket_payload["data"]["items"][0]["category"] == "subscription"
+        assert bucket_payload["data"]["items"][0]["credit_asset_kind"] == "plan_credits"
         assert bucket_payload["data"]["items"][0]["priority"] == 20
+        assert bucket_payload["data"]["items"][1]["credit_asset_kind"] == "plan_credits"
+        assert bucket_payload["data"]["items"][2]["credit_asset_kind"] == "pack_credits"
         assert bucket_payload["data"]["items"][2]["source_bid"] == "topup-1"
 
     def test_overview_recalculates_wallet_snapshot_for_current_balance(

--- a/src/cook-web/src/types/billing.ts
+++ b/src/cook-web/src/types/billing.ts
@@ -288,6 +288,7 @@ export type BillingSubscription = {
 export type BillingWalletBucket = {
   wallet_bucket_bid: string;
   category: BillingBucketCategory;
+  credit_asset_kind: BillingCreditAssetKind;
   source_type: BillingBucketSourceType;
   source_bid: string;
   available_credits: number;


### PR DESCRIPTION
## Summary

Expose the read-only `credit_asset_kind` classification on billing wallet bucket responses.

## Scope

- Add `credit_asset_kind` to wallet bucket DTOs and frontend billing bucket types.
- Reuse the existing Credit Allocation interpretation layer for `/billing/wallet-buckets`.
- Keep wallet bucket sorting, runtime category, and asset-kind classification on the same page-scoped, creator-scoped order-type loader.
- Preserve runtime behavior: no schema changes, bucket mutations, ledger writes, admission changes, settlement changes, or historical repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing wallet buckets now include the credit asset type, such as plan credits or pack credits.
  * Bucket details more accurately reflect their category, labels, priority, expiration handling, and display order.
  * Added support for credit asset types in billing responses and application interfaces.

* **Bug Fixes**
  * Corrected wallet bucket classification and ordering across billing views.
  * Improved consistency between bucket details and their underlying credit allocations.
  * Ensured order information is retrieved only when needed for the displayed buckets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->