### PR TITLE
refactor: extract subscription cycle window eligibility

### DIFF
--- a/src/api/flaskr/service/billing/cycle_state_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_state_transitions.py
@@ -35,6 +35,11 @@ def resolve_effective_subscription_cycle_window(
     *,
     as_of: datetime,
 ) -> SubscriptionCycleWindow | None:
+    """Return the time-valid current cycle window, without business advancement rules.
+
+    "Effective" only means start <= as_of < end. This helper does not validate
+    subscription status, parse order metadata, or decide whether a cycle may advance.
+    """
     if subscription is None:
         return None
 

--- a/src/api/flaskr/service/billing/cycle_state_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_state_transitions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 
 from flaskr.dao import db
@@ -23,17 +24,37 @@ from .models import BillingSubscription, CreditLedgerEntry, CreditWalletBucket
 from .primitives import normalize_bid as _normalize_bid
 
 
+@dataclass(frozen=True)
+class SubscriptionCycleWindow:
+    start_at: datetime
+    end_at: datetime
+
+
+def resolve_effective_subscription_cycle_window(
+    subscription: BillingSubscription | None,
+    *,
+    as_of: datetime,
+) -> SubscriptionCycleWindow | None:
+    if subscription is None:
+        return None
+
+    start_at = subscription.current_period_start_at
+    end_at = subscription.current_period_end_at
+    if start_at is None or end_at is None:
+        return None
+    if start_at > as_of or end_at <= as_of:
+        return None
+    return SubscriptionCycleWindow(start_at=start_at, end_at=end_at)
+
+
 def subscription_has_effective_cycle(
     subscription: BillingSubscription | None,
     *,
     as_of: datetime,
 ) -> bool:
     return (
-        subscription is not None
-        and subscription.current_period_start_at is not None
-        and subscription.current_period_end_at is not None
-        and subscription.current_period_start_at <= as_of
-        and subscription.current_period_end_at > as_of
+        resolve_effective_subscription_cycle_window(subscription, as_of=as_of)
+        is not None
     )
 
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -55,7 +55,7 @@ from .cycle_transitions import (
 from .cycle_state_transitions import (
     apply_paid_subscription_cycle_state as _apply_paid_subscription_cycle_state,
     realign_active_credit_bucket_effective_to as _realign_active_credit_bucket_effective_to,
-    subscription_has_effective_cycle as _subscription_has_effective_cycle,
+    resolve_effective_subscription_cycle_window as _resolve_effective_subscription_cycle_window,
 )
 from .dtos import BillingSubscriptionDTO
 from .models import (
@@ -883,18 +883,19 @@ def _repair_existing_paid_order_grant_bucket(
     if is_reserved_grant:
         subscription = _load_subscription_by_bid(order.subscription_bid)
         has_current_available_balance = _to_decimal(bucket.available_credits) > 0
-        subscription_has_current_window = _subscription_has_effective_cycle(
+        current_cycle_window = _resolve_effective_subscription_cycle_window(
             subscription,
             as_of=now,
         )
-        if has_current_available_balance and subscription_has_current_window:
-            current_period_start = subscription.current_period_start_at
-            current_period_end = subscription.current_period_end_at
+        if has_current_available_balance and current_cycle_window is not None:
             if bucket.effective_from is None or bucket.effective_from > now:
-                bucket.effective_from = current_period_start
+                bucket.effective_from = current_cycle_window.start_at
                 changed = True
-            if bucket.effective_to is None or bucket.effective_to > current_period_end:
-                bucket.effective_to = current_period_end
+            if (
+                bucket.effective_to is None
+                or bucket.effective_to > current_cycle_window.end_at
+            ):
+                bucket.effective_to = current_cycle_window.end_at
                 changed = True
     else:
         if effective_from is not None and bucket.effective_from != effective_from:

--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -102,7 +102,29 @@ def test_resolve_effective_subscription_cycle_window_rejects_invalid_windows() -
         is None
     )
 
+    subscription.current_period_start_at = current_at - timedelta(days=1)
+    subscription.current_period_end_at = None
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
+
+    subscription.current_period_start_at = current_at
+    subscription.current_period_end_at = current_at
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
+
+    subscription.current_period_start_at = current_at + timedelta(days=1)
+    subscription.current_period_end_at = current_at
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
+
     subscription.current_period_start_at = current_at + timedelta(seconds=1)
+    subscription.current_period_end_at = current_at + timedelta(days=1)
     assert (
         resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
         is None

--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -20,6 +20,7 @@ from flaskr.service.billing.consts import (
 from flaskr.service.billing.cycle_state_transitions import (
     apply_paid_subscription_cycle_state,
     realign_active_topup_bucket_effective_to,
+    resolve_effective_subscription_cycle_window,
     subscription_has_effective_cycle,
 )
 from flaskr.service.billing.models import (
@@ -61,6 +62,58 @@ def test_subscription_has_effective_cycle_uses_current_period_window() -> None:
 
     assert subscription_has_effective_cycle(subscription, as_of=current_at) is False
     assert subscription_has_effective_cycle(None, as_of=current_at) is False
+
+
+def test_resolve_effective_subscription_cycle_window_returns_current_window() -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    cycle_start = current_at
+    cycle_end = current_at + timedelta(days=30)
+    subscription = BillingSubscription(
+        subscription_bid="subscription-cycle-window",
+        creator_bid="creator-cycle-window",
+        status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+        current_period_start_at=cycle_start,
+        current_period_end_at=cycle_end,
+    )
+
+    window = resolve_effective_subscription_cycle_window(
+        subscription,
+        as_of=current_at,
+    )
+
+    assert window is not None
+    assert window.start_at == cycle_start
+    assert window.end_at == cycle_end
+
+
+def test_resolve_effective_subscription_cycle_window_rejects_invalid_windows() -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    subscription = BillingSubscription(
+        subscription_bid="subscription-cycle-window-invalid",
+        creator_bid="creator-cycle-window-invalid",
+        status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+        current_period_start_at=current_at - timedelta(days=1),
+        current_period_end_at=current_at + timedelta(days=1),
+    )
+
+    subscription.current_period_start_at = None
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
+
+    subscription.current_period_start_at = current_at + timedelta(seconds=1)
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
+
+    subscription.current_period_start_at = current_at - timedelta(days=1)
+    subscription.current_period_end_at = current_at
+    assert (
+        resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
+        is None
+    )
 
 
 def test_realign_active_topup_bucket_effective_to_updates_bucket_and_grant_ledgers() -> (


### PR DESCRIPTION
## Summary

- Extracted the active subscription cycle window check into `SubscriptionCycleWindow` and `resolve_effective_subscription_cycle_window`.
- Kept `subscription_has_effective_cycle` as a compatibility wrapper over the new helper.
- Reused the typed cycle window in reserved grant repair alignment instead of directly reading subscription period fields.
- Added focused white-box tests for valid, missing, future, and boundary-ended subscription cycle windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cycle validation for current, future, expired, and missing billing periods.
  * Ensured reserved grant bucket repairs use the active subscription cycle’s correct start and end dates.
  * Prevented invalid or zero-length billing periods from being treated as active.

* **Tests**
  * Added coverage for valid and invalid subscription cycle windows, including boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->