### PR TITLE
test: cover renewal activation defer boundaries

### DIFF
--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -62,17 +62,20 @@ def _build_app() -> Flask:
 
 def _renewal_order(
     *,
+    bill_order_bid: str = "order-renewal-activation-boundary",
+    subscription_bid: str = "subscription-renewal-activation-boundary",
+    creator_bid: str = "creator-renewal-activation-boundary",
     metadata_json: dict | None = None,
     payment_provider: str = "pingxx",
     paid_at: datetime | None | object = _UNSET,
     order_type: int = BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
 ) -> BillingOrder:
     return BillingOrder(
-        bill_order_bid="order-renewal-activation-boundary",
-        creator_bid="creator-renewal-activation-boundary",
+        bill_order_bid=bill_order_bid,
+        creator_bid=creator_bid,
         order_type=order_type,
         product_bid="bill-product-renewal-boundary",
-        subscription_bid="subscription-renewal-activation-boundary",
+        subscription_bid=subscription_bid,
         currency="CNY",
         payable_amount=0,
         paid_amount=0,
@@ -312,11 +315,15 @@ def test_subscription_renewal_activation_does_not_defer_when_guard_fails(
     )
 
 
-def test_force_activation_advances_future_deferred_renewal() -> None:
+def test_force_activation_advances_future_deferred_renewal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app = _build_app()
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
     next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
+    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
 
     with app.app_context():
         dao.db.create_all()
@@ -345,11 +352,96 @@ def test_force_activation_advances_future_deferred_renewal() -> None:
             current_period_start_at=current_cycle_start,
             current_period_end_at=current_cycle_end,
         )
-        order = _renewal_order(
+        forced_subscription = BillingSubscription(
+            subscription_bid="subscription-renewal-activation-force",
+            creator_bid="creator-renewal-activation-boundary",
+            product_bid=product.product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="manual",
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=current_cycle_end,
+        )
+        order_metadata = {
+            "checkout_type": "referral_invitation_reward",
+            "referral_invitation_reward": True,
+            "renewal_cycle_start_at": current_cycle_end.isoformat(),
+            "renewal_cycle_end_at": next_cycle_end.isoformat(),
+        }
+        deferred_order = _renewal_order(
+            bill_order_bid="order-renewal-activation-defer",
             payment_provider="manual",
+            metadata_json=order_metadata.copy(),
+        )
+        forced_order = _renewal_order(
+            bill_order_bid="order-renewal-activation-force",
+            subscription_bid=forced_subscription.subscription_bid,
+            payment_provider="manual",
+            metadata_json=order_metadata.copy(),
+        )
+        dao.db.session.add_all(
+            [product, subscription, forced_subscription, deferred_order, forced_order]
+        )
+        dao.db.session.commit()
+
+        deferred = subscriptions_mod._activate_subscription_for_paid_order(
+            app,
+            deferred_order,
+            force=False,
+        )
+        activated = subscriptions_mod._activate_subscription_for_paid_order(
+            app,
+            forced_order,
+            force=True,
+        )
+        dao.db.session.flush()
+
+    assert deferred is False
+    assert activated is True
+    assert subscription.current_period_start_at == current_cycle_start
+    assert subscription.current_period_end_at == current_cycle_end
+    assert forced_subscription.current_period_start_at == current_cycle_end
+    assert forced_subscription.current_period_end_at == next_cycle_end
+
+
+def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app()
+    current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
+    current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
+    next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
+    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_cycle_end)
+
+    with app.app_context():
+        dao.db.create_all()
+        product = BillingProduct(
+            product_bid="bill-product-renewal-boundary",
+            product_code="renewal-boundary",
+            product_type=BILLING_PRODUCT_TYPE_PLAN,
+            billing_mode=BILLING_MODE_RECURRING,
+            billing_interval=BILLING_INTERVAL_MONTH,
+            billing_interval_count=1,
+            display_name_i18n_key="billing.product.renewal_boundary",
+            description_i18n_key="billing.product.renewal_boundary.description",
+            currency="CNY",
+            price_amount=0,
+            credit_amount=Decimal("1000.0000000000"),
+            allocation_interval=ALLOCATION_INTERVAL_PER_CYCLE,
+            auto_renew_enabled=1,
+            status=BILLING_PRODUCT_STATUS_ACTIVE,
+        )
+        subscription = BillingSubscription(
+            subscription_bid="subscription-renewal-activation-boundary",
+            creator_bid="creator-renewal-activation-boundary",
+            product_bid=product.product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="pingxx",
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=current_cycle_end,
+        )
+        order = _renewal_order(
+            paid_at=current_cycle_end,
             metadata_json={
-                "checkout_type": "referral_invitation_reward",
-                "referral_invitation_reward": True,
                 "renewal_cycle_start_at": current_cycle_end.isoformat(),
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
@@ -360,7 +452,7 @@ def test_force_activation_advances_future_deferred_renewal() -> None:
         activated = subscriptions_mod._activate_subscription_for_paid_order(
             app,
             order,
-            force=True,
+            force=False,
         )
         dao.db.session.flush()
 

--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -407,10 +407,11 @@ def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = _build_app()
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
     next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
-    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_cycle_end)
+    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
 
     with app.app_context():
         dao.db.create_all()

--- a/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_transitions.py
@@ -9,8 +9,14 @@ import pytest
 import flaskr.dao as dao
 from flaskr.service.billing import subscriptions as subscriptions_mod
 from flaskr.service.billing.consts import (
+    ALLOCATION_INTERVAL_PER_CYCLE,
+    BILLING_INTERVAL_MONTH,
+    BILLING_MODE_RECURRING,
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+    BILLING_PRODUCT_STATUS_ACTIVE,
+    BILLING_PRODUCT_TYPE_PLAN,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     BILLING_SUBSCRIPTION_STATUS_CANCEL_SCHEDULED,
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
@@ -28,10 +34,14 @@ from flaskr.service.billing.cycle_state_transitions import (
 )
 from flaskr.service.billing.models import (
     BillingOrder,
+    BillingProduct,
     BillingSubscription,
     CreditLedgerEntry,
     CreditWalletBucket,
 )
+
+
+_UNSET = object()
 
 
 def _build_app() -> Flask:
@@ -48,6 +58,30 @@ def _build_app() -> Flask:
     )
     dao.db.init_app(app)
     return app
+
+
+def _renewal_order(
+    *,
+    metadata_json: dict | None = None,
+    payment_provider: str = "pingxx",
+    paid_at: datetime | None | object = _UNSET,
+    order_type: int = BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+) -> BillingOrder:
+    return BillingOrder(
+        bill_order_bid="order-renewal-activation-boundary",
+        creator_bid="creator-renewal-activation-boundary",
+        order_type=order_type,
+        product_bid="bill-product-renewal-boundary",
+        subscription_bid="subscription-renewal-activation-boundary",
+        currency="CNY",
+        payable_amount=0,
+        paid_amount=0,
+        payment_provider=payment_provider,
+        channel="manual",
+        status=BILLING_ORDER_STATUS_PAID,
+        paid_at=(datetime(2026, 4, 10, 0, 0, 0) if paid_at is _UNSET else paid_at),
+        metadata_json=metadata_json or {},
+    )
 
 
 def test_subscription_has_effective_cycle_uses_current_period_window() -> None:
@@ -140,6 +174,199 @@ def test_resolve_effective_subscription_cycle_window_rejects_invalid_windows() -
         resolve_effective_subscription_cycle_window(subscription, as_of=current_at)
         is None
     )
+
+
+def test_pingxx_renewal_activation_defers_before_cycle_start() -> None:
+    paid_at = datetime(2026, 4, 10, 0, 0, 0)
+    renewal_cycle_start = datetime(2026, 5, 1, 0, 0, 0)
+    order = _renewal_order(
+        paid_at=paid_at,
+        metadata_json={"renewal_cycle_start_at": renewal_cycle_start.isoformat()},
+    )
+
+    assert subscriptions_mod._should_defer_pingxx_renewal_activation(order) is True
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        _renewal_order(
+            metadata_json={
+                "applied_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+                "renewal_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+            },
+        ),
+        _renewal_order(
+            payment_provider="stripe",
+            metadata_json={
+                "renewal_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+            },
+        ),
+        _renewal_order(
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_START,
+            metadata_json={
+                "renewal_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+            },
+        ),
+        _renewal_order(
+            paid_at=None,
+            metadata_json={
+                "renewal_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+            },
+        ),
+    ],
+    ids=("applied", "non_pingxx", "non_renewal", "unpaid"),
+)
+def test_pingxx_renewal_activation_does_not_defer_when_guard_fails(
+    order: BillingOrder,
+) -> None:
+    assert subscriptions_mod._should_defer_pingxx_renewal_activation(order) is False
+
+
+@pytest.mark.parametrize(
+    ("metadata_json", "payment_provider"),
+    [
+        (
+            {"renewal_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat()},
+            "pingxx",
+        ),
+        (
+            {
+                "checkout_type": "subscription_preorder",
+                "preorder_state": "pending_effective",
+            },
+            "pingxx",
+        ),
+        (
+            {
+                "checkout_type": "referral_invitation_reward",
+                "referral_invitation_reward": True,
+            },
+            "manual",
+        ),
+    ],
+    ids=("pingxx", "preorder", "referral"),
+)
+def test_subscription_renewal_activation_defers_future_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    metadata_json: dict,
+    payment_provider: str,
+) -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    effective_from = datetime(2026, 5, 1, 0, 0, 0)
+    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
+    order = _renewal_order(
+        paid_at=current_at,
+        payment_provider=payment_provider,
+        metadata_json=metadata_json,
+    )
+
+    assert (
+        subscriptions_mod._should_defer_subscription_renewal_activation(
+            order,
+            effective_from=effective_from,
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    ("metadata_json", "effective_from"),
+    [
+        (
+            {
+                "checkout_type": "referral_invitation_reward",
+                "referral_invitation_reward": True,
+            },
+            datetime(2026, 4, 10, 0, 0, 0),
+        ),
+        (
+            {
+                "applied_cycle_start_at": datetime(2026, 5, 1, 0, 0, 0).isoformat(),
+                "checkout_type": "referral_invitation_reward",
+                "referral_invitation_reward": True,
+            },
+            datetime(2026, 5, 1, 0, 0, 0),
+        ),
+    ],
+    ids=("effective_now", "applied_cycle"),
+)
+def test_subscription_renewal_activation_does_not_defer_when_guard_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    metadata_json: dict,
+    effective_from: datetime,
+) -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
+    order = _renewal_order(
+        payment_provider="manual",
+        metadata_json=metadata_json,
+    )
+
+    assert (
+        subscriptions_mod._should_defer_subscription_renewal_activation(
+            order,
+            effective_from=effective_from,
+        )
+        is False
+    )
+
+
+def test_force_activation_advances_future_deferred_renewal() -> None:
+    app = _build_app()
+    current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
+    current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
+    next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
+
+    with app.app_context():
+        dao.db.create_all()
+        product = BillingProduct(
+            product_bid="bill-product-renewal-boundary",
+            product_code="renewal-boundary",
+            product_type=BILLING_PRODUCT_TYPE_PLAN,
+            billing_mode=BILLING_MODE_RECURRING,
+            billing_interval=BILLING_INTERVAL_MONTH,
+            billing_interval_count=1,
+            display_name_i18n_key="billing.product.renewal_boundary",
+            description_i18n_key="billing.product.renewal_boundary.description",
+            currency="CNY",
+            price_amount=0,
+            credit_amount=Decimal("1000.0000000000"),
+            allocation_interval=ALLOCATION_INTERVAL_PER_CYCLE,
+            auto_renew_enabled=1,
+            status=BILLING_PRODUCT_STATUS_ACTIVE,
+        )
+        subscription = BillingSubscription(
+            subscription_bid="subscription-renewal-activation-boundary",
+            creator_bid="creator-renewal-activation-boundary",
+            product_bid=product.product_bid,
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="manual",
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=current_cycle_end,
+        )
+        order = _renewal_order(
+            payment_provider="manual",
+            metadata_json={
+                "checkout_type": "referral_invitation_reward",
+                "referral_invitation_reward": True,
+                "renewal_cycle_start_at": current_cycle_end.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        dao.db.session.add_all([product, subscription, order])
+        dao.db.session.commit()
+
+        activated = subscriptions_mod._activate_subscription_for_paid_order(
+            app,
+            order,
+            force=True,
+        )
+        dao.db.session.flush()
+
+    assert activated is True
+    assert subscription.current_period_start_at == current_cycle_end
+    assert subscription.current_period_end_at == next_cycle_end
 
 
 @pytest.mark.parametrize(

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -246,6 +246,119 @@ def _create_bucket(
     )
 
 
+def _add_paid_renewal_with_reserved_grant(
+    *,
+    suffix: str,
+    current_cycle_start: datetime,
+    current_cycle_end: datetime,
+    next_cycle_end: datetime,
+    scheduled_at: datetime,
+    paid_at: datetime,
+) -> tuple[str, str, str, str, str]:
+    subscription_bid = f"sub-scheduled-paid-{suffix}"
+    order_bid = f"bill-scheduled-paid-{suffix}"
+    event_bid = f"renewal-scheduled-paid-{suffix}"
+    bucket_bid = f"bucket-scheduled-paid-{suffix}"
+    ledger_bid = f"ledger-scheduled-paid-{suffix}"
+    creator_bid = "creator-renewal-1"
+
+    subscription = BillingSubscription(
+        subscription_bid=subscription_bid,
+        creator_bid=creator_bid,
+        product_bid="bill-product-plan-monthly",
+        status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+        billing_provider="pingxx",
+        provider_subscription_id="",
+        provider_customer_id=f"customer-{subscription_bid}",
+        current_period_start_at=current_cycle_start,
+        current_period_end_at=current_cycle_end,
+        cancel_at_period_end=0,
+        next_product_bid="",
+        metadata_json={},
+        created_at=current_cycle_start,
+        updated_at=current_cycle_start,
+    )
+    order = BillingOrder(
+        bill_order_bid=order_bid,
+        creator_bid=creator_bid,
+        order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+        product_bid=subscription.product_bid,
+        subscription_bid=subscription.subscription_bid,
+        currency="CNY",
+        payable_amount=9900,
+        paid_amount=9900,
+        payment_provider="pingxx",
+        channel="alipay_qr",
+        provider_reference_id=f"ch_{suffix}",
+        status=BILLING_ORDER_STATUS_PAID,
+        paid_at=paid_at,
+        metadata_json={
+            "provider_reference_type": "charge",
+            "renewal_cycle_start_at": current_cycle_end.isoformat(),
+            "renewal_cycle_end_at": next_cycle_end.isoformat(),
+        },
+    )
+    event = _create_renewal_event(
+        event_bid,
+        subscription.subscription_bid,
+        subscription.creator_bid,
+        event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+        scheduled_at=scheduled_at,
+    )
+    wallet = _create_wallet(
+        subscription.creator_bid,
+        available_credits="3.0000000000",
+        lifetime_granted_credits="8.0000000000",
+    )
+    bucket = CreditWalletBucket(
+        wallet_bucket_bid=bucket_bid,
+        wallet_bid=wallet.wallet_bid,
+        creator_bid=subscription.creator_bid,
+        bucket_category=CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
+        source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+        source_bid=f"bill-current-{suffix}",
+        priority=20,
+        original_credits=Decimal("8.0000000000"),
+        available_credits=Decimal("3.0000000000"),
+        reserved_credits=Decimal("5.0000000000"),
+        consumed_credits=Decimal("0"),
+        expired_credits=Decimal("0"),
+        effective_from=current_cycle_start,
+        effective_to=current_cycle_end,
+        status=CREDIT_BUCKET_STATUS_ACTIVE,
+        metadata_json={"bill_order_bid": f"bill-current-{suffix}"},
+        created_at=current_cycle_start,
+        updated_at=current_cycle_start,
+    )
+    grant_entry = CreditLedgerEntry(
+        ledger_bid=ledger_bid,
+        creator_bid=subscription.creator_bid,
+        wallet_bid=wallet.wallet_bid,
+        wallet_bucket_bid=bucket.wallet_bucket_bid,
+        entry_type=CREDIT_LEDGER_ENTRY_TYPE_GRANT,
+        source_type=CREDIT_SOURCE_TYPE_SUBSCRIPTION,
+        source_bid=order.bill_order_bid,
+        idempotency_key=f"grant:{order.bill_order_bid}",
+        amount=Decimal("5.0000000000"),
+        balance_after=Decimal("3.0000000000"),
+        expires_at=next_cycle_end,
+        consumable_from=current_cycle_end,
+        metadata_json={
+            "bill_order_bid": order.bill_order_bid,
+            "subscription_bid": subscription.subscription_bid,
+            "product_bid": subscription.product_bid,
+            "payment_provider": "pingxx",
+            "grant_reason": "subscription_renewal",
+            "bucket_credit_state": "reserved",
+            "reserved_until": current_cycle_end.isoformat(),
+        },
+        created_at=paid_at,
+        updated_at=paid_at,
+    )
+    dao.db.session.add_all([subscription, order, event, wallet, bucket, grant_entry])
+    return subscription_bid, order_bid, event_bid, bucket_bid, ledger_bid
+
+
 def test_claim_billing_renewal_event_persists_processing_state(
     billing_renewal_app: Flask,
 ) -> None:
@@ -1187,6 +1300,57 @@ def test_run_billing_renewal_event_releases_future_event_back_to_pending(
         assert event.processed_at is None
 
 
+def test_run_billing_renewal_event_does_not_advance_future_paid_renewal(
+    billing_renewal_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_at = datetime(2026, 4, 10, 0, 0, 0)
+    current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
+    current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
+    next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
+    monkeypatch.setattr(billing_renewal, "now_utc", lambda: current_at)
+
+    with billing_renewal_app.app_context():
+        subscription_bid, order_bid, event_bid, bucket_bid, ledger_bid = (
+            _add_paid_renewal_with_reserved_grant(
+                suffix="future",
+                current_cycle_start=current_cycle_start,
+                current_cycle_end=current_cycle_end,
+                next_cycle_end=next_cycle_end,
+                scheduled_at=current_cycle_end,
+                paid_at=current_at - timedelta(days=1),
+            )
+        )
+        dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        billing_renewal_app,
+        renewal_event_bid=event_bid,
+    )
+
+    assert payload["status"] == "deferred_until_scheduled_at"
+    assert payload["event_status"] == "pending"
+
+    with billing_renewal_app.app_context():
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid=subscription_bid
+        ).one()
+        order = BillingOrder.query.filter_by(bill_order_bid=order_bid).one()
+        event = BillingRenewalEvent.query.filter_by(renewal_event_bid=event_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(wallet_bucket_bid=bucket_bid).one()
+        grant_entry = CreditLedgerEntry.query.filter_by(ledger_bid=ledger_bid).one()
+
+        assert event.status == BILLING_RENEWAL_EVENT_STATUS_PENDING
+        assert event.processed_at is None
+        assert subscription.current_period_start_at == current_cycle_start
+        assert subscription.current_period_end_at == current_cycle_end
+        assert "applied_cycle_start_at" not in order.metadata_json
+        assert "applied_cycle_end_at" not in order.metadata_json
+        assert bucket.available_credits == Decimal("3.0000000000")
+        assert bucket.reserved_credits == Decimal("5.0000000000")
+        assert grant_entry.metadata_json["bucket_credit_state"] == "reserved"
+
+
 def test_run_billing_renewal_event_executes_at_exact_scheduled_time(
     billing_renewal_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
@@ -1197,74 +1361,47 @@ def test_run_billing_renewal_event_executes_at_exact_scheduled_time(
     monkeypatch.setattr(billing_renewal, "now_utc", lambda: current_cycle_end)
 
     with billing_renewal_app.app_context():
-        subscription = BillingSubscription(
-            subscription_bid="sub-scheduled-equal-paid",
-            creator_bid="creator-renewal-1",
-            product_bid="bill-product-plan-monthly",
-            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
-            billing_provider="pingxx",
-            provider_subscription_id="",
-            provider_customer_id="customer-sub-scheduled-equal-paid",
-            current_period_start_at=current_cycle_start,
-            current_period_end_at=current_cycle_end,
-            cancel_at_period_end=0,
-            next_product_bid="",
-            metadata_json={},
-            created_at=current_cycle_start,
-            updated_at=current_cycle_start,
+        subscription_bid, order_bid, event_bid, bucket_bid, ledger_bid = (
+            _add_paid_renewal_with_reserved_grant(
+                suffix="equal",
+                current_cycle_start=current_cycle_start,
+                current_cycle_end=current_cycle_end,
+                next_cycle_end=next_cycle_end,
+                paid_at=current_cycle_end - timedelta(days=5),
+                scheduled_at=current_cycle_end,
+            )
         )
-        order = BillingOrder(
-            bill_order_bid="bill-scheduled-equal-paid-1",
-            creator_bid=subscription.creator_bid,
-            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
-            product_bid=subscription.product_bid,
-            subscription_bid=subscription.subscription_bid,
-            currency="CNY",
-            payable_amount=9900,
-            paid_amount=9900,
-            payment_provider="pingxx",
-            channel="alipay_qr",
-            provider_reference_id="ch_scheduled_equal_paid_1",
-            status=BILLING_ORDER_STATUS_PAID,
-            paid_at=current_cycle_end - timedelta(days=5),
-            metadata_json={
-                "provider_reference_type": "charge",
-                "renewal_cycle_start_at": current_cycle_end.isoformat(),
-                "renewal_cycle_end_at": next_cycle_end.isoformat(),
-            },
-        )
-        event = _create_renewal_event(
-            "renewal-scheduled-equal-paid-1",
-            subscription.subscription_bid,
-            subscription.creator_bid,
-            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
-            scheduled_at=current_cycle_end,
-        )
-        dao.db.session.add_all([subscription, order, event])
         dao.db.session.commit()
 
     payload = run_billing_renewal_event(
         billing_renewal_app,
-        renewal_event_bid="renewal-scheduled-equal-paid-1",
+        renewal_event_bid=event_bid,
     )
 
     assert payload["status"] == "applied"
     assert payload["subscription_status"] == "active"
     assert payload["event_status"] == "succeeded"
-    assert payload["bill_order_bid"] == "bill-scheduled-equal-paid-1"
+    assert payload["bill_order_bid"] == order_bid
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription.query.filter_by(
-            subscription_bid="sub-scheduled-equal-paid"
+            subscription_bid=subscription_bid
         ).one()
-        event = BillingRenewalEvent.query.filter_by(
-            renewal_event_bid="renewal-scheduled-equal-paid-1"
-        ).one()
+        event = BillingRenewalEvent.query.filter_by(renewal_event_bid=event_bid).one()
+        bucket = CreditWalletBucket.query.filter_by(wallet_bucket_bid=bucket_bid).one()
+        grant_entry = CreditLedgerEntry.query.filter_by(ledger_bid=ledger_bid).one()
+
         assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
         assert subscription.current_period_start_at == current_cycle_end
         assert subscription.current_period_end_at == next_cycle_end
         assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
         assert event.processed_at is not None
+        assert bucket.source_bid == order_bid
+        assert bucket.available_credits == Decimal("5.0000000000")
+        assert bucket.reserved_credits == Decimal("0")
+        assert grant_entry.consumable_from == current_cycle_end
+        assert grant_entry.expires_at == next_cycle_end
+        assert grant_entry.metadata_json["bucket_credit_state"] == "available"
 
 
 def test_run_billing_renewal_event_queues_subscription_renewal_order(

--- a/src/api/tests/service/billing/test_billing_renewal_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_execution.py
@@ -1187,6 +1187,86 @@ def test_run_billing_renewal_event_releases_future_event_back_to_pending(
         assert event.processed_at is None
 
 
+def test_run_billing_renewal_event_executes_at_exact_scheduled_time(
+    billing_renewal_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
+    current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
+    next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
+    monkeypatch.setattr(billing_renewal, "now_utc", lambda: current_cycle_end)
+
+    with billing_renewal_app.app_context():
+        subscription = BillingSubscription(
+            subscription_bid="sub-scheduled-equal-paid",
+            creator_bid="creator-renewal-1",
+            product_bid="bill-product-plan-monthly",
+            status=BILLING_SUBSCRIPTION_STATUS_ACTIVE,
+            billing_provider="pingxx",
+            provider_subscription_id="",
+            provider_customer_id="customer-sub-scheduled-equal-paid",
+            current_period_start_at=current_cycle_start,
+            current_period_end_at=current_cycle_end,
+            cancel_at_period_end=0,
+            next_product_bid="",
+            metadata_json={},
+            created_at=current_cycle_start,
+            updated_at=current_cycle_start,
+        )
+        order = BillingOrder(
+            bill_order_bid="bill-scheduled-equal-paid-1",
+            creator_bid=subscription.creator_bid,
+            order_type=BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
+            product_bid=subscription.product_bid,
+            subscription_bid=subscription.subscription_bid,
+            currency="CNY",
+            payable_amount=9900,
+            paid_amount=9900,
+            payment_provider="pingxx",
+            channel="alipay_qr",
+            provider_reference_id="ch_scheduled_equal_paid_1",
+            status=BILLING_ORDER_STATUS_PAID,
+            paid_at=current_cycle_end - timedelta(days=5),
+            metadata_json={
+                "provider_reference_type": "charge",
+                "renewal_cycle_start_at": current_cycle_end.isoformat(),
+                "renewal_cycle_end_at": next_cycle_end.isoformat(),
+            },
+        )
+        event = _create_renewal_event(
+            "renewal-scheduled-equal-paid-1",
+            subscription.subscription_bid,
+            subscription.creator_bid,
+            event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
+            scheduled_at=current_cycle_end,
+        )
+        dao.db.session.add_all([subscription, order, event])
+        dao.db.session.commit()
+
+    payload = run_billing_renewal_event(
+        billing_renewal_app,
+        renewal_event_bid="renewal-scheduled-equal-paid-1",
+    )
+
+    assert payload["status"] == "applied"
+    assert payload["subscription_status"] == "active"
+    assert payload["event_status"] == "succeeded"
+    assert payload["bill_order_bid"] == "bill-scheduled-equal-paid-1"
+
+    with billing_renewal_app.app_context():
+        subscription = BillingSubscription.query.filter_by(
+            subscription_bid="sub-scheduled-equal-paid"
+        ).one()
+        event = BillingRenewalEvent.query.filter_by(
+            renewal_event_bid="renewal-scheduled-equal-paid-1"
+        ).one()
+        assert subscription.status == BILLING_SUBSCRIPTION_STATUS_ACTIVE
+        assert subscription.current_period_start_at == current_cycle_end
+        assert subscription.current_period_end_at == next_cycle_end
+        assert event.status == BILLING_RENEWAL_EVENT_STATUS_SUCCEEDED
+        assert event.processed_at is not None
+
+
 def test_run_billing_renewal_event_queues_subscription_renewal_order(
     billing_renewal_app: Flask,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Added focused renewal activation defer tests for Ping++ early renewals, preorder renewals, referral renewals, applied-cycle metadata, and immediate effective boundaries.
- Strengthened force activation coverage by freezing time and proving `force=False` defers while `force=True` advances the same future renewal window.
- Added real paid-renewal caller coverage for `scheduled_at > now` deferral, `scheduled_at == now` execution, reserved grant state, and Ping++ `paid_at == renewal_cycle_start_at` equality.
- Kept this PR test-only with no billing runtime behavior changes.
