### PR TITLE
feat: add configurable default TTS voice model

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -1116,6 +1116,10 @@ TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON=""
 # Type: float
 TTS_CHARS_PER_LLM_TOKEN="0.216"
 
+# Default TTS model preselected by editor UI and CLI when the creator has not explicitly chosen one. Use provider/model format, e.g. tencent_texttovoice/large-model; use provider/default for providers without model selection. Must be one of the exposed model options (TTS_ALLOWED_MODELS when set); empty or invalid values fall back to the first option. Only marks is_default in the TTS config payload; it does not relax strict runtime TTS validation.
+# (Optional - default: )
+TTS_DEFAULT_MODEL=""
+
 # Maximum characters per TTS segment
 # (Optional - default: 300)
 # Type: int

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -249,6 +249,17 @@ def _parse_allowed_tts_model_keys() -> list[str]:
     return keys
 
 
+def _parse_default_tts_model_key() -> str:
+    value = str(get_config("TTS_DEFAULT_MODEL") or "").strip()
+    if not value:
+        return ""
+    if "/" not in value:
+        logger.warning("Ignoring invalid TTS_DEFAULT_MODEL: %s", value)
+        return ""
+    provider, model = value.split("/", 1)
+    return _normalize_tts_model_key(provider, model)
+
+
 def _parse_tts_display_names() -> dict:
     configured = get_config("TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON")
     if isinstance(configured, dict):
@@ -480,15 +491,26 @@ def _build_tts_model_options(provider_payloads: list[tuple[str, dict]]) -> list[
             options.append(option)
 
     allowed_keys = _parse_allowed_tts_model_keys()
-    if not allowed_keys:
-        return options
+    if allowed_keys:
+        option_map = {option["value"]: option for option in options}
+        filtered = [option_map[key] for key in allowed_keys if key in option_map]
+        missing = [key for key in allowed_keys if key not in option_map]
+        if missing:
+            logger.warning(
+                "Ignoring unavailable TTS_ALLOWED_MODELS entries: %s", missing
+            )
+        options = filtered
 
-    option_map = {option["value"]: option for option in options}
-    filtered = [option_map[key] for key in allowed_keys if key in option_map]
-    missing = [key for key in allowed_keys if key not in option_map]
-    if missing:
-        logger.warning("Ignoring unavailable TTS_ALLOWED_MODELS entries: %s", missing)
-    return filtered
+    default_key = _parse_default_tts_model_key()
+    if default_key and default_key not in {option["value"] for option in options}:
+        logger.warning(
+            "Ignoring TTS_DEFAULT_MODEL not in available model options: %s",
+            default_key,
+        )
+        default_key = ""
+    for option in options:
+        option["is_default"] = option["value"] == default_key
+    return options
 
 
 def get_all_provider_configs() -> dict:

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1535,6 +1535,22 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         group="tts",
         required=False,
     ),
+    "TTS_DEFAULT_MODEL": EnvVar(
+        name="TTS_DEFAULT_MODEL",
+        default="",
+        description=(
+            "Default TTS model preselected by editor UI and CLI when the "
+            "creator has not explicitly chosen one. Use provider/model format, "
+            "e.g. tencent_texttovoice/large-model; use provider/default for "
+            "providers without model selection. Must be one of the exposed "
+            "model options (TTS_ALLOWED_MODELS when set); empty or invalid "
+            "values fall back to the first option. Only marks is_default in "
+            "the TTS config payload; it does not relax strict runtime TTS "
+            "validation."
+        ),
+        group="tts",
+        required=False,
+    ),
     "TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON": EnvVar(
         name="TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON",
         default="",

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -70,6 +70,9 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
             }
         ),
     )
+    # Keep the is_default assertions hermetic even when the surrounding
+    # environment configures a default model.
+    monkeypatch.delenv("TTS_DEFAULT_MODEL", raising=False)
 
     try:
         set_language("zh-CN")

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -87,12 +87,14 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
         "provider": "minimax",
         "model": "speech-01-turbo",
         "credit_multiplier_label": "2x",
+        "is_default": False,
     }
     assert config["model_options"][1] == {
         "value": "baidu/default",
         "label": "Baidu Default",
         "provider": "baidu",
         "model": "",
+        "is_default": False,
     }
 
 
@@ -340,8 +342,9 @@ def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch):
 
 
 def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
-    """The local three-tier lineup: tencent premium first (default), then
-    tencent large-model, then volcengine seed-tts-2.0, with zh display names."""
+    """The local three-tier lineup: tencent premium first, then tencent
+    large-model (configured default), then volcengine seed-tts-2.0, with zh
+    display names. The default marker must not reorder the allowlist."""
     import json as json_module
 
     import flaskr.api.tts as tts_api
@@ -395,6 +398,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
             }
         ),
     )
+    monkeypatch.setenv("TTS_DEFAULT_MODEL", "tencent_texttovoice/large-model")
 
     try:
         set_language("zh-CN")
@@ -407,3 +411,101 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
         ("tencent_texttovoice/large-model", "标准语音"),
         ("volcengine/seed-tts-2.0", "旗舰语音"),
     ]
+    assert [item["is_default"] for item in config["model_options"]] == [
+        False,
+        True,
+        False,
+    ]
+
+
+def _patch_two_provider_registry(monkeypatch, tts_api):
+    monkeypatch.setattr(
+        tts_api,
+        "_PROVIDER_REGISTRY",
+        {"minimax": _FakeMinimaxProvider, "baidu": _FakeBaiduProvider},
+    )
+    monkeypatch.setattr(tts_api, "_PROVIDER_PRIORITY", ("minimax", "baidu"))
+    monkeypatch.setattr(
+        tts_api, "_resolve_credit_multiplier_label", lambda provider, model: None
+    )
+
+
+def test_tts_default_model_marks_provider_only_option(monkeypatch):
+    import flaskr.api.tts as tts_api
+
+    _patch_two_provider_registry(monkeypatch, tts_api)
+    monkeypatch.setenv("TTS_ALLOWED_MODELS", "minimax/speech-01-turbo,baidu/default")
+    monkeypatch.setenv("TTS_DEFAULT_MODEL", "baidu/default")
+
+    config = tts_api.get_all_provider_configs()
+
+    assert [
+        (item["value"], item["is_default"]) for item in config["model_options"]
+    ] == [
+        ("minimax/speech-01-turbo", False),
+        ("baidu/default", True),
+    ]
+
+
+def test_tts_default_model_applies_without_allowlist(monkeypatch):
+    import flaskr.api.tts as tts_api
+
+    _patch_two_provider_registry(monkeypatch, tts_api)
+    monkeypatch.delenv("TTS_ALLOWED_MODELS", raising=False)
+    monkeypatch.setenv("TTS_DEFAULT_MODEL", "minimax/speech-01-hd")
+
+    config = tts_api.get_all_provider_configs()
+
+    assert [
+        (item["value"], item["is_default"]) for item in config["model_options"]
+    ] == [
+        ("minimax/speech-01-turbo", False),
+        ("minimax/speech-01-hd", True),
+        ("baidu/default", False),
+    ]
+
+
+def test_tts_default_model_invalid_format_falls_back(monkeypatch, caplog):
+    import logging
+
+    import flaskr.api.tts as tts_api
+
+    _patch_two_provider_registry(monkeypatch, tts_api)
+    monkeypatch.setenv("TTS_ALLOWED_MODELS", "minimax/speech-01-turbo")
+    monkeypatch.setenv("TTS_DEFAULT_MODEL", "speech-01-turbo")
+
+    with caplog.at_level(logging.WARNING):
+        config = tts_api.get_all_provider_configs()
+
+    assert [item["is_default"] for item in config["model_options"]] == [False]
+    assert "Ignoring invalid TTS_DEFAULT_MODEL" in caplog.text
+
+
+def test_tts_default_model_outside_allowlist_falls_back(monkeypatch, caplog):
+    import logging
+
+    import flaskr.api.tts as tts_api
+
+    _patch_two_provider_registry(monkeypatch, tts_api)
+    monkeypatch.setenv("TTS_ALLOWED_MODELS", "minimax/speech-01-turbo,baidu/default")
+    # Exposed by the provider but excluded from the allowlist, so it must not
+    # be marked as default.
+    monkeypatch.setenv("TTS_DEFAULT_MODEL", "minimax/speech-01-hd")
+
+    with caplog.at_level(logging.WARNING):
+        config = tts_api.get_all_provider_configs()
+
+    assert [item["is_default"] for item in config["model_options"]] == [False, False]
+    assert "TTS_DEFAULT_MODEL not in available model options" in caplog.text
+
+
+def test_tts_default_model_unset_leaves_all_options_non_default(monkeypatch):
+    import flaskr.api.tts as tts_api
+
+    _patch_two_provider_registry(monkeypatch, tts_api)
+    monkeypatch.setenv("TTS_ALLOWED_MODELS", "minimax/speech-01-turbo,baidu/default")
+    monkeypatch.delenv("TTS_DEFAULT_MODEL", raising=False)
+
+    config = tts_api.get_all_provider_configs()
+
+    assert [item["is_default"] for item in config["model_options"]] == [False, False]

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -96,6 +96,7 @@ import {
 import {
   buildTtsModelOptionValue,
   filterTtsVoicesForModel,
+  getDefaultTtsModelOption,
   normalizeTtsModelOptions,
   parseTtsModelOptionValue,
   type TtsModelOption,
@@ -537,7 +538,7 @@ export default function ShifuSettingDialog({
   const resolvedProvider = (() => {
     const provider = (ttsProvider || '').trim();
     const fallbackProvider =
-      ttsConfig?.model_options?.[0]?.provider ||
+      getDefaultTtsModelOption(ttsConfig?.model_options || [])?.provider ||
       ttsConfig?.providers?.[0]?.name ||
       '';
     if (!provider) {
@@ -557,7 +558,7 @@ export default function ShifuSettingDialog({
     if (currentValue && options.some(option => option.value === currentValue)) {
       return;
     }
-    const fallback = options[0];
+    const fallback = getDefaultTtsModelOption(options)!;
     setTtsProvider(fallback.provider);
     setTtsModel(fallback.model);
   }, [resolvedProvider, ttsEnabled, ttsModel, ttsConfig]);
@@ -903,7 +904,7 @@ export default function ShifuSettingDialog({
     if (ttsModelOptions.length > 0) {
       const currentValue = buildTtsModelOptionValue(resolvedProvider, ttsModel);
       const modelValues = new Set(ttsModelOptions.map(option => option.value));
-      const fallbackModel = ttsModelOptions[0];
+      const fallbackModel = getDefaultTtsModelOption(ttsModelOptions)!;
       if (ttsEnabled) {
         if (!currentValue || !modelValues.has(currentValue)) {
           setTtsProvider(fallbackModel.provider);
@@ -1091,7 +1092,7 @@ export default function ShifuSettingDialog({
       try {
         const providerForSubmit =
           resolvedProvider ||
-          ttsConfig?.model_options?.[0]?.provider ||
+          getDefaultTtsModelOption(ttsConfig?.model_options || [])?.provider ||
           ttsConfig?.providers?.[0]?.name ||
           '';
         const askProviderForSubmit =

--- a/src/cook-web/src/components/shifu-setting/tts-model-options.test.ts
+++ b/src/cook-web/src/components/shifu-setting/tts-model-options.test.ts
@@ -1,6 +1,7 @@
 import {
   buildTtsModelOptionValue,
   filterTtsVoicesForModel,
+  getDefaultTtsModelOption,
   normalizeTtsModelOptions,
   parseTtsModelOptionValue,
 } from './tts-model-options';
@@ -79,5 +80,72 @@ describe('tts-model-options', () => {
     expect(filterTtsVoicesForModel(annotatedVoices, '')).toEqual(
       annotatedVoices,
     );
+  });
+
+  test('normalizes the backend is_default marker', () => {
+    const options = normalizeTtsModelOptions([
+      {
+        value: 'tencent_texttovoice/premium',
+        label: 'Basic Voice',
+        provider: 'tencent_texttovoice',
+        model: 'premium',
+        is_default: false,
+      },
+      {
+        value: 'tencent_texttovoice/large-model',
+        label: 'Standard Voice',
+        provider: 'tencent_texttovoice',
+        model: 'large-model',
+        is_default: true,
+      },
+    ]);
+
+    expect(options.map(option => option.isDefault)).toEqual([false, true]);
+  });
+
+  test('selects the default option with first-option fallback', () => {
+    const options = normalizeTtsModelOptions([
+      {
+        value: 'tencent_texttovoice/premium',
+        label: 'Basic Voice',
+        provider: 'tencent_texttovoice',
+        model: 'premium',
+      },
+      {
+        value: 'tencent_texttovoice/large-model',
+        label: 'Standard Voice',
+        provider: 'tencent_texttovoice',
+        model: 'large-model',
+        is_default: true,
+      },
+    ]);
+
+    // The declared default wins even when it is not the first option, so the
+    // dropdown order stays untouched.
+    expect(getDefaultTtsModelOption(options)?.value).toBe(
+      'tencent_texttovoice/large-model',
+    );
+
+    // Without a declared default (older backend payloads), fall back to the
+    // first option to preserve the legacy behavior.
+    const legacyOptions = normalizeTtsModelOptions([
+      {
+        value: 'tencent_texttovoice/premium',
+        label: 'Basic Voice',
+        provider: 'tencent_texttovoice',
+        model: 'premium',
+      },
+      {
+        value: 'minimax/speech-2.8-turbo',
+        label: 'Premium Voice',
+        provider: 'minimax',
+        model: 'speech-2.8-turbo',
+      },
+    ]);
+    expect(getDefaultTtsModelOption(legacyOptions)?.value).toBe(
+      'tencent_texttovoice/premium',
+    );
+
+    expect(getDefaultTtsModelOption([])).toBeUndefined();
   });
 });

--- a/src/cook-web/src/components/shifu-setting/tts-model-options.ts
+++ b/src/cook-web/src/components/shifu-setting/tts-model-options.ts
@@ -85,10 +85,16 @@ export const normalizeTtsModelOptions = (list: any): TtsModelOption[] => {
         model,
         creditMultiplier,
         creditMultiplierLabel,
+        isDefault: Boolean(item.is_default ?? item.isDefault),
       };
     })
     .filter((item): item is TtsModelOption => Boolean(item));
 };
+
+export const getDefaultTtsModelOption = (
+  options: TtsModelOption[],
+): TtsModelOption | undefined =>
+  options.find(option => option.isDefault) || options[0];
 
 export const filterTtsVoicesForModel = (
   voices: TtsVoiceOption[],


### PR DESCRIPTION
## Summary

Course Listen Mode currently has an implicit default voice: both the course settings editor and shifu-cli independently hardcode "first item of `model_options`" (the first entry of `TTS_ALLOWED_MODELS`) when TTS is enabled without an explicit model choice. This PR makes the default an explicit backend-declared setting so operators can promote a specific tier (e.g. the standard voice `tencent_texttovoice/large-model`) as the default **without reordering the voice list**.

## Changes

**Backend**
- New optional env `TTS_DEFAULT_MODEL` (`provider/model` format, `provider/default` for providers without model selection).
- `_build_tts_model_options()` now marks each option with `is_default` after allowlist filtering. The default must be one of the exposed options; empty/invalid values log a warning and leave every option unmarked (consumers fall back to the first option, preserving current behavior).
- This only annotates the `/tts/config` payload. `validate_tts_settings_strict` and the save/publish/learn paths are untouched: courses always store explicit voice settings, so changing the env never silently affects already-configured courses.
- Mirrors the existing LLM model options contract (`is_default` on each option).

**Frontend (cook-web)**
- `normalizeTtsModelOptions` maps `is_default` → `isDefault`; new `getDefaultTtsModelOption` helper (`find(isDefault) || first`).
- The four `model_options[0]` fallbacks in `ShifuSetting.tsx` (resolved provider, enable effect, sanitize effect, submit) now go through the helper. Fallbacks still only apply when no valid selection exists, so explicitly chosen voices are never overridden.

## Tests

- Backend: `tests/service/tts/test_tts_config_options.py` — default marking with allowlist order preserved, provider-only default, no-allowlist mode, invalid format / outside-allowlist warnings, unset default. 15 passed.
- Frontend: `tts-model-options.test.ts` — `is_default` normalization, default selection with first-option fallback. 5 passed.

## Rollout note

The env is not set anywhere yet; without it this PR is behavior-neutral (all options unmarked → first-option fallback). Production enablement happens separately in deploy-config by setting `TTS_DEFAULT_MODEL=tencent_texttovoice/large-model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable default text-to-speech model selection for the editor and CLI.
  * Default models are validated against available options, with automatic fallback when unavailable or invalid.
  * The selected default is clearly identified without changing model option order.

* **Bug Fixes**
  * Improved fallback handling when no model has been selected or configured.
  * Added safeguards for malformed or unsupported default model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->