### PR TITLE
fix: rebuild langfuse otel state per worker after fork

### DIFF
--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -34,3 +34,28 @@ def post_fork(server, worker):
                 engine.dispose(close=False)
     except Exception:  # pragma: no cover - defensive: never kill a booting worker
         worker.log.exception("post_fork engine dispose failed")
+
+    # Langfuse SDK v3 keeps per-public-key ResourceManager singletons and
+    # registers a global OpenTelemetry TracerProvider during master preload.
+    # Both carry live httpx/TLS connections and a batch-export worker that
+    # were created in the master; inherited across fork they are shared by
+    # every worker, interleaving TLS records on the exporter connection
+    # (observed as "SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC") and leaving
+    # stale IO watchers behind. Drop the inherited singletons WITHOUT
+    # flushing (a flush would write to the shared connection, which is the
+    # exact failure being prevented), reset the OTel global so a fresh
+    # provider can be registered, then rebuild the client in this worker.
+    try:
+        from langfuse._client.resource_manager import LangfuseResourceManager
+        from opentelemetry import trace as otel_trace_api
+        from opentelemetry.util._once import Once
+
+        from flaskr.api.langfuse import init_langfuse
+
+        LangfuseResourceManager._instances.clear()
+        otel_trace_api._TRACER_PROVIDER = None
+        otel_trace_api._TRACER_PROVIDER_SET_ONCE = Once()
+
+        init_langfuse(flask_app)
+    except Exception:  # pragma: no cover - defensive: never kill a booting worker
+        worker.log.exception("post_fork langfuse reinit failed")

--- a/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
+++ b/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
@@ -1,0 +1,79 @@
+"""Verify the post_fork Langfuse reset sequence rebuilds fresh SDK state.
+
+The gunicorn post_fork hook clears the LangfuseResourceManager singleton
+registry and resets the global OpenTelemetry tracer provider so each worker
+builds its own exporter state instead of reusing connections inherited from
+the preloaded master. These tests exercise that reset sequence directly:
+after the reset, constructing a client again must produce a NEW resource
+manager (not the cached one) and a NEW tracer provider.
+"""
+
+import pytest
+
+pytest.importorskip("langfuse")
+pytest.importorskip("opentelemetry")
+
+from langfuse import Langfuse  # noqa: E402
+from langfuse._client.resource_manager import LangfuseResourceManager  # noqa: E402
+from opentelemetry import trace as otel_trace_api  # noqa: E402
+from opentelemetry.util._once import Once  # noqa: E402
+
+
+def _reset_langfuse_after_fork():
+    # Mirrors the sequence in src/api/gunicorn.conf.py post_fork. Kept in
+    # sync manually; the assertions below are what the hook relies on.
+    LangfuseResourceManager._instances.clear()
+    otel_trace_api._TRACER_PROVIDER = None
+    otel_trace_api._TRACER_PROVIDER_SET_ONCE = Once()
+
+
+@pytest.fixture(autouse=True)
+def _clean_singletons():
+    _reset_langfuse_after_fork()
+    yield
+    _reset_langfuse_after_fork()
+
+
+def _make_client() -> Langfuse:
+    # tracing_enabled default triggers resource-manager creation; no network
+    # traffic happens until a flush, which these tests never perform.
+    return Langfuse(
+        public_key="pk-test-post-fork",
+        secret_key="sk-test-post-fork",
+        host="http://localhost:9",
+    )
+
+
+def test_reset_clears_singleton_registry_and_rebuilds_resources():
+    client = _make_client()
+    first_resources = client._resources
+    assert LangfuseResourceManager._instances
+
+    # Without a reset the SDK returns the cached (fork-inherited) manager.
+    cached = _make_client()
+    assert cached._resources is first_resources
+
+    _reset_langfuse_after_fork()
+    assert not LangfuseResourceManager._instances
+
+    rebuilt = _make_client()
+    assert rebuilt._resources is not first_resources
+
+
+def test_reset_allows_registering_a_fresh_tracer_provider():
+    _make_client()
+    first_provider = otel_trace_api.get_tracer_provider()
+    assert not isinstance(first_provider, otel_trace_api.ProxyTracerProvider)
+
+    _reset_langfuse_after_fork()
+
+    # After the reset the global returns to the proxy state, so the next
+    # client registers a brand-new provider instead of attaching another
+    # span processor to the master's provider.
+    assert isinstance(
+        otel_trace_api.get_tracer_provider(), otel_trace_api.ProxyTracerProvider
+    )
+    _make_client()
+    second_provider = otel_trace_api.get_tracer_provider()
+    assert not isinstance(second_provider, otel_trace_api.ProxyTracerProvider)
+    assert second_provider is not first_provider


### PR DESCRIPTION
## Problem

After the saas-plugin fork-leak fix (ai_shifu_saas_plugin#4) shipped, two related failures still occurred in production:

- `ResourceClosedError` on listen-run SELECTs (2026-08-03 10:08, on a pod generation that already contained the plugin fix), and
- `litellm.MidStreamFallbackError: ... [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC]` on an LLM stream (10:57) — a corrupted TLS record stream.

A corrupted TLS stream and a desynced MySQL protocol stream appearing in the same deployment point to the same class of root cause: connection state created in the preloaded gunicorn master being shared across forked workers.

`init_langfuse` runs in `create_app` — i.e. during master preload. Langfuse SDK v3 then creates a per-public-key `LangfuseResourceManager` singleton (httpx/TLS client, batch span exporter and its worker thread) and registers a **global** OpenTelemetry `TracerProvider`. All of that is inherited by every worker at fork:

- workers exporting spans over the same inherited TLS connection interleave TLS records (SSL bad record mac);
- the master-created batch worker and its IO watchers are stale in children, and simply re-calling `Langfuse()` in a worker is a no-op — the SDK returns the cached singleton, and even a rebuilt manager would attach to the master's global `TracerProvider` (with the old exporter still attached), because `set_tracer_provider` only honors the first call.

The timeline matches: the failures first appeared hours after the Langfuse SDK v3 migration (#2231) reached production.

## Changes

`gunicorn.conf.py` `post_fork` now, after the existing SQLAlchemy engine dispose:

1. clears `LangfuseResourceManager._instances` **without flushing** (a flush would write to the fork-shared connection — the exact failure being prevented);
2. resets the OTel global tracer provider (`_TRACER_PROVIDER = None`, fresh `Once`), returning it to the proxy state;
3. re-runs `init_langfuse(flask_app)` so each worker builds its own resource manager, exporter connection, and tracer provider.

All steps are wrapped defensively so a failure can never kill a booting worker.

## Testing

- New `tests/common/test_gunicorn_post_fork_langfuse.py` verifies the reset sequence: the singleton registry is cleared and a rebuilt client gets a NEW resource manager (without the reset, the SDK provably returns the cached one), and the global tracer provider returns to proxy state and a NEW provider is registered afterwards. No network traffic is involved (no flushes).
- `lefthook run pre-commit --all-files`: clean.

## Deploy note

This file ships via the API image (`COPY gunicorn.conf.p[y]` in the CI Dockerfile). After rollout, worker boot logs should show one "Initializing Langfuse client" per worker (4x) instead of only once in the master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)