### PR TITLE
fix: retry empty audio from tencent texttovoice segments

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -78,7 +78,7 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 _tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
 
 _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"
-_EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "volcengine"}
+_EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "tencent_texttovoice", "volcengine"}
 _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
 _TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}

--- a/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
@@ -1,0 +1,29 @@
+import pytest
+
+from flaskr.service.tts.streaming_tts import _is_retryable_empty_audio_error
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["", "tencent", "tencent_texttovoice", "volcengine"],
+)
+def test_empty_audio_is_retryable_for_all_tts_providers(provider):
+    error = ValueError(f"No audio data received from provider {provider or 'auto'}")
+    assert _is_retryable_empty_audio_error(error, provider) is True
+
+
+def test_empty_audio_retry_matches_tencent_texttovoice_error_message():
+    # The exact message raised by tencent_texttovoice_provider must keep
+    # matching the retry detector's substring.
+    error = ValueError("No audio data received from Tencent TextToVoice")
+    assert _is_retryable_empty_audio_error(error, "tencent_texttovoice") is True
+
+
+def test_non_empty_audio_errors_are_not_retryable():
+    error = ValueError("Tencent TextToVoice error AuthFailure: bad secret")
+    assert _is_retryable_empty_audio_error(error, "tencent_texttovoice") is False
+
+
+def test_unknown_provider_is_not_retryable():
+    error = ValueError("No audio data received")
+    assert _is_retryable_empty_audio_error(error, "some_future_provider") is False


### PR DESCRIPTION
## Problem

Production alert on 2026-08-03 16:45: two listen-mode TTS segments failed with `No audio data received from Tencent TextToVoice` (`provider=tencent_texttovoice model=premium`).

Usage data shows this is a transient upstream glitch, not a systematic failure: `tencent_texttovoice/premium` completed 607 successful segment syntheses that same day (~0.3% one-off failure rate).

Streaming TTS already retries empty-audio responses once per segment, but the allowlist predates the four-tier TTS rollout (#2200):

```python
_EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "volcengine"}
```

The new `tencent_texttovoice` provider was never added, so a single empty-audio response fails the segment immediately — the legacy `tencent` provider would have retried the same condition.

## Changes

- Added `tencent_texttovoice` to `_EMPTY_AUDIO_RETRY_PROVIDERS`.
- New `test_streaming_tts_empty_audio_retry.py`: retry detector accepts all four providers, matches the exact error message raised by `tencent_texttovoice_provider`, and still rejects non-empty-audio errors and unknown providers.

## Testing

- `tests/service/tts`: 157 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)