### PR TITLE
fix: detect and drop desynced pooled MySQL connections

### DIFF
--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -2,9 +2,11 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 from sqlalchemy import event
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import pool as sa_pool
+from sqlalchemy.exc import DisconnectionError, OperationalError
 import functools
 import random
+import select as select_module
 import sqlparse
 import logging
 import time
@@ -16,6 +18,64 @@ logger = logging.getLogger(__name__)
 # create a global db object
 db = None
 redis_client = None
+
+
+def _socket_has_unread_data(dbapi_connection) -> bool:
+    """Return True when the DBAPI connection's socket has readable bytes.
+
+    A healthy pooled MySQL connection is silent between transactions: every
+    response has been consumed and the server never pushes unsolicited data.
+    Readable bytes therefore mean either an unread response left behind by an
+    interrupted operation (the protocol stream is desynced - the next query
+    on this connection would read the stale packet and fail with
+    ResourceClosedError / pymysql 2014 "Command Out of Sync") or a
+    server-initiated shutdown packet. Both make the connection unusable.
+
+    Only pymysql exposes the socket as ``_sock``; other drivers (e.g. SQLite
+    in tests) return False and are left to pool_pre_ping.
+    """
+    sock = getattr(dbapi_connection, "_sock", None)
+    if sock is None:
+        return False
+    try:
+        readable, _, _ = select_module.select([sock], [], [], 0)
+    except (OSError, ValueError):
+        # Closed or detached socket; pre_ping handles plain disconnects.
+        return False
+    return bool(readable)
+
+
+@event.listens_for(sa_pool.Pool, "checkin")
+def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_record):
+    if dbapi_connection is None:
+        return
+    if _socket_has_unread_data(dbapi_connection):
+        # stack_info identifies the code path that returned the poisoned
+        # connection - i.e. the request that interrupted a protocol exchange.
+        logger.error(
+            "DB connection returned to pool with unread protocol data; "
+            "invalidating it. The stack below is the checkin path of the "
+            "request that desynced this connection.",
+            stack_info=True,
+        )
+        connection_record.invalidate()
+
+
+@event.listens_for(sa_pool.Pool, "checkout")
+def _reject_desynced_connection_on_checkout(
+    dbapi_connection, connection_record, connection_proxy
+):
+    if _socket_has_unread_data(dbapi_connection):
+        logger.warning(
+            "Rejecting pooled DB connection with unread protocol data at "
+            "checkout; the pool will retry with a fresh connection."
+        )
+        # DisconnectionError makes the pool discard this connection and
+        # transparently retry the checkout with another one.
+        raise DisconnectionError(
+            "pooled connection has unread protocol data (desynced stream)"
+        )
+
 
 # MySQL error codes that indicate a transient locking conflict; the current
 # transaction is already rolled back by the server, so re-running it is the

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -39,10 +39,27 @@ def _socket_has_unread_data(dbapi_connection) -> bool:
         return False
     try:
         readable, _, _ = select_module.select([sock], [], [], 0)
-    except (OSError, ValueError):
-        # Closed or detached socket; pre_ping handles plain disconnects.
+    except (OSError, ValueError, TypeError):
+        # Closed, detached, or fd-less socket object; pre_ping handles plain
+        # disconnects, and event dispatch must never fail on the probe.
         return False
     return bool(readable)
+
+
+def _pool_diagnostics_logger():
+    """Log through the app logger when available.
+
+    The app logger carries the RequestFormatter (request-id / trace context)
+    and the alerting handlers; the bare module logger only reaches stderr.
+    Pool events usually fire inside an app context, but engine use outside
+    one (scripts, tests) must not break on logging.
+    """
+    try:
+        from flask import current_app
+
+        return current_app.logger
+    except Exception:  # noqa: BLE001 - outside app context
+        return logger
 
 
 @event.listens_for(sa_pool.Pool, "checkin")
@@ -52,7 +69,7 @@ def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_reco
     if _socket_has_unread_data(dbapi_connection):
         # stack_info identifies the code path that returned the poisoned
         # connection - i.e. the request that interrupted a protocol exchange.
-        logger.error(
+        _pool_diagnostics_logger().error(
             "DB connection returned to pool with unread protocol data; "
             "invalidating it. The stack below is the checkin path of the "
             "request that desynced this connection.",
@@ -66,7 +83,7 @@ def _reject_desynced_connection_on_checkout(
     dbapi_connection, connection_record, connection_proxy
 ):
     if _socket_has_unread_data(dbapi_connection):
-        logger.warning(
+        _pool_diagnostics_logger().warning(
             "Rejecting pooled DB connection with unread protocol data at "
             "checkout; the pool will retry with a fresh connection."
         )

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -54,6 +54,14 @@ def test_connection_without_socket_is_ignored():
     assert dao._socket_has_unread_data(_NoSock()) is False
 
 
+def test_unusable_socket_object_is_ignored():
+    class _BadSock:
+        # No fileno(): select.select raises TypeError for such objects.
+        _sock = object()
+
+    assert dao._socket_has_unread_data(_BadSock()) is False
+
+
 def test_pool_discards_connection_desynced_during_use(sock_pair):
     left, right = sock_pair
     dirty_conn = _FakePyMySQLConnection(left)
@@ -114,6 +122,7 @@ def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair):
         fairy2 = pool.connect()
         assert fairy2.dbapi_connection is not dirty_conn
         fairy2.close()
+        assert dirty_conn.closed is True
     finally:
         pool.dispose()
         clean_sock_b.close()

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -1,0 +1,119 @@
+"""Pool-level detection of desynced MySQL connections.
+
+A connection whose protocol stream is desynced (an interrupted operation left
+an unread response buffered) has readable bytes on its socket while idle.
+The pool listeners in flaskr.dao must drop such connections instead of
+recirculating them.
+"""
+
+import socket
+
+import pytest
+from sqlalchemy.pool import QueuePool
+
+import flaskr.dao as dao
+
+
+class _FakePyMySQLConnection:
+    """Minimal stand-in exposing the pymysql `_sock` attribute."""
+
+    def __init__(self, sock):
+        self._sock = sock
+        self.closed = False
+
+    # QueuePool reset/close hooks
+    def rollback(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture()
+def sock_pair():
+    left, right = socket.socketpair()
+    left.setblocking(False)
+    yield left, right
+    left.close()
+    right.close()
+
+
+def test_unread_data_detected(sock_pair):
+    left, right = sock_pair
+    conn = _FakePyMySQLConnection(left)
+    assert dao._socket_has_unread_data(conn) is False
+
+    right.sendall(b"\x01stale-packet")
+    assert dao._socket_has_unread_data(conn) is True
+
+
+def test_connection_without_socket_is_ignored():
+    class _NoSock:
+        pass
+
+    assert dao._socket_has_unread_data(_NoSock()) is False
+
+
+def test_pool_discards_connection_desynced_during_use(sock_pair):
+    left, right = sock_pair
+    dirty_conn = _FakePyMySQLConnection(left)
+    clean_sock_a, clean_sock_b = socket.socketpair()
+    connections = [
+        dirty_conn,
+        _FakePyMySQLConnection(clean_sock_a),
+    ]
+    made = []
+
+    def _creator():
+        conn = connections[len(made) % len(connections)]
+        made.append(conn)
+        return conn
+
+    pool = QueuePool(_creator, pool_size=1, max_overflow=0, reset_on_return=None)
+    try:
+        # First checkout hands out the (still clean) dirty_conn.
+        fairy = pool.connect()
+        assert fairy.dbapi_connection is dirty_conn
+
+        # Simulate an interrupted exchange: the server response arrives but
+        # is never consumed before the connection goes back to the pool.
+        right.sendall(b"\x02unconsumed-response")
+        fairy.close()  # checkin fires -> listener must invalidate
+
+        # The poisoned connection must not be handed out again.
+        fairy2 = pool.connect()
+        assert fairy2.dbapi_connection is not dirty_conn
+        fairy2.close()
+        assert dirty_conn.closed is True
+    finally:
+        pool.dispose()
+        clean_sock_b.close()
+
+
+def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair):
+    left, right = sock_pair
+    dirty_conn = _FakePyMySQLConnection(left)
+    clean_sock_a, clean_sock_b = socket.socketpair()
+    connections = [dirty_conn, _FakePyMySQLConnection(clean_sock_a)]
+    made = []
+
+    def _creator():
+        conn = connections[len(made) % len(connections)]
+        made.append(conn)
+        return conn
+
+    pool = QueuePool(_creator, pool_size=1, max_overflow=0, reset_on_return=None)
+    try:
+        fairy = pool.connect()
+        fairy.close()  # goes back clean
+
+        # Data arrives while the connection is parked in the pool (e.g. a
+        # server-side abort). Checkout must reject it and hand out a fresh
+        # connection transparently.
+        right.sendall(b"\x03server-abort")
+        fairy2 = pool.connect()
+        assert fairy2.dbapi_connection is not dirty_conn
+        fairy2.close()
+    finally:
+        pool.dispose()
+        clean_sock_b.close()

--- a/src/api/tests/test_study_record.py
+++ b/src/api/tests/test_study_record.py
@@ -7,6 +7,14 @@ from flaskr.service.shifu.consts import BLOCK_TYPE_CONTENT_VALUE
 
 def test_get_learn_record_returns_blocks(app):
     with app.app_context():
+        # Other test modules (e.g. the mdflow backfill tests) commit rows for
+        # the same shifu-1/outline-1/user-1 bids into the shared SQLite
+        # database; clear both tables so this test only sees its own rows
+        # regardless of execution order.
+        LearnGeneratedBlock.query.delete()
+        LearnProgressRecord.query.delete()
+        db.session.commit()
+
         progress = LearnProgressRecord(
             progress_record_bid="progress-1",
             shifu_bid="shifu-1",


### PR DESCRIPTION
## Problem

Listen runs still fail intermittently with `ResourceClosedError` / pymysql 2014 `Command Out of Sync` after three rounds of fixes (#2232 nonce probe + invalidate, ai_shifu_saas_plugin#4 fork-leak fix, #2244 langfuse post_fork reinit). The latest occurrences (2026-08-03 19:52) are on pods that contain all three fixes, so an unidentified source of protocol-stream desync remains.

Rather than guessing further, this PR makes the pool itself both **defend against** and **attribute** the desync.

## Approach

A healthy pooled MySQL connection is silent between transactions: every response has been consumed, and the server never pushes unsolicited data. Readable bytes on an idle pymysql socket therefore mean the protocol stream is desynced (an interrupted operation left an unread response buffered — the next query would consume the stale packet and fail) or the server initiated a shutdown. Either way the connection is unusable.

Two `sqlalchemy.pool.Pool` class-level listeners (they cover every engine in the process, including plugin-registered bind engines):

- **checkin**: if the socket has unread bytes, invalidate the connection and log at ERROR **with `stack_info`** — the checkin stack identifies the exact code path that interrupted a protocol exchange. The next production occurrence becomes directly attributable instead of a guessing game.
- **checkout**: if a parked connection has unread bytes (covers both a poisoned checkin that predates the listener and server-side aborts), raise `DisconnectionError` so the pool discards it and transparently retries with a fresh connection — the request proceeds normally instead of failing.

The probe is a zero-timeout `select()` (microseconds, gevent-compatible). Non-pymysql drivers (SQLite in tests) have no `_sock` and are skipped.

## Testing

- New `tests/common/test_pool_desync_detection.py`: detection primitive (unread data / clean / no socket), a real `QueuePool` dropping a connection poisoned during use (checkin path, connection closed and never handed out again), and checkout transparently replacing a connection that turned dirty while parked.
- `tests/service/learn` + `tests/common`: 559 passed, 5 skipped.
- `lefthook run pre-commit --all-files`: clean.

## Follow-up

Once the checkin ERROR fires in production, its stack pinpoints the desyncing code path and the actual root cause can be fixed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling to detect and discard connections with unread or desynchronized data.
  * Added safer handling for unavailable or closed connection sockets.
  * Automatically retries database checkouts when an invalid connection is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->