### PR TITLE
fix: persist exact sent user message for prompt-cache-stable context rebuild

### DIFF
--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -556,12 +556,18 @@ class MdflowContextV2:
                 continue
             block = block_list[generated_block.position]
             if generated_block.type == BLOCK_TYPE_MDCONTENT_VALUE:
+                # Prefer the persisted exact user message sent to the LLM at
+                # generation time: replaying it verbatim keeps the rebuilt
+                # history byte-identical to previously sent requests so
+                # provider-side prefix caching keeps matching. Legacy rows
+                # without it fall back to re-rendering the block source with
+                # the current variables (one-time cache break, then stable).
+                stored_prompt = getattr(generated_block, "generation_prompt", "") or ""
                 message_list.append(
                     {
                         "role": "user",
-                        "content": replace_variables_in_text(
-                            block.content or "", variables
-                        )
+                        "content": stored_prompt
+                        or replace_variables_in_text(block.content or "", variables)
                         or "",
                     }
                 )
@@ -887,6 +893,10 @@ class RunScriptPreviewContextV2:
 
         content_chunks: list[str] = []
         langfuse_output_chunks: list[str] = []
+        # Holder for the exact user message markdown-flow sent to the LLM
+        # (LLMResult.prompt); the preview context stores it verbatim so the
+        # rebuilt history stays byte-identical to the sent request.
+        sent_prompt_chunks: list[str] = []
         preview_trace_input: str | None = None
         try:
             final_payload = preview_request.model_dump()
@@ -995,6 +1005,7 @@ class RunScriptPreviewContextV2:
                     is_user_input_validation=is_user_input_validation,
                     content_chunks=content_chunks,
                     langfuse_output_chunks=langfuse_output_chunks,
+                    sent_prompt_chunks=sent_prompt_chunks,
                 )
             )
             self._update_preview_context(
@@ -1003,6 +1014,7 @@ class RunScriptPreviewContextV2:
                 preview_request,
                 content_chunks,
                 current_block_content,
+                sent_prompt=(sent_prompt_chunks[0] if sent_prompt_chunks else ""),
             )
         finally:
             finalize_langfuse_trace(
@@ -1028,13 +1040,18 @@ class RunScriptPreviewContextV2:
         preview_request: PlaygroundPreviewRequest,
         content_chunks: list[str],
         current_block_content: str,
+        *,
+        sent_prompt: str = "",
     ) -> None:
         user_input_text = MdflowContextV2.flatten_user_input_map(
             preview_request.user_input
         )
         content_text = "".join(content_chunks).strip()
         if content_text:
-            user_message = user_input_text or current_block_content
+            # Prefer the exact prompt sent to the LLM over the locally
+            # re-rendered block content so the stored history replays the
+            # sent bytes verbatim (prefix-cache stable).
+            user_message = user_input_text or sent_prompt or current_block_content
         else:
             user_message = user_input_text
         assistant_message = content_text or None
@@ -1091,11 +1108,16 @@ class RunScriptPreviewContextV2:
         is_user_input_validation: bool,
         content_chunks: list[str],
         langfuse_output_chunks: list[str],
+        sent_prompt_chunks: list[str] | None = None,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         generated_block_bid = str(block_index)
         emitted_interaction = False
         raw_items = result if inspect.isgenerator(result) else [result]
         for llm_result in raw_items:
+            if sent_prompt_chunks is not None and not sent_prompt_chunks:
+                prompt_value = getattr(llm_result, "prompt", None)
+                if prompt_value:
+                    sent_prompt_chunks.append(str(prompt_value))
             for event in self._preview_events_from_result(
                 llm_result=llm_result,
                 outline_bid=outline_bid,
@@ -3222,6 +3244,10 @@ class RunScriptContextV2:
             generated_block.generated_block_bid
         )
         generated_content = ""
+        # Exact user message markdown-flow sent to the LLM for this block
+        # (LLMResult.prompt); persisted so context rebuilds replay the sent
+        # bytes verbatim and provider-side prefix caching keeps matching.
+        sent_prompt = ""
         tts_processor = None
         tts_enabled = bool(self._should_stream_tts())
         current_tts_stream_key: tuple[str, int] | None = None
@@ -3392,6 +3418,7 @@ class RunScriptContextV2:
                     if source == "idle":
                         yield payload
                         continue
+                    sent_prompt = getattr(payload, "prompt", None) or sent_prompt
                     for (
                         chunk_content,
                         stream_element_type,
@@ -3405,6 +3432,7 @@ class RunScriptContextV2:
             else:
                 # markdown-flow still returns a single LLMResult for some
                 # STREAM edge cases, such as preserved content.
+                sent_prompt = getattr(stream_result, "prompt", None) or sent_prompt
                 for (
                     chunk_content,
                     stream_element_type,
@@ -3442,6 +3470,14 @@ class RunScriptContextV2:
         # Continue the same run across subsequent blocks until we hit
         # an interaction block or reach outline completion.
         self._can_continue = next_block_position < len(block_list)
+        # Preserved-content blocks stream without an LLM prompt
+        # (LLMResult.prompt is unset); freeze today's rebuild rendering at
+        # generation time so future rebuilds stay byte-stable even after
+        # the referenced variables change.
+        if not sent_prompt:
+            sent_prompt = (
+                replace_variables_in_text(state.block.content or "", user_profile) or ""
+            )
         # Block-finalize step: streamed content + cursor advance
         # commit atomically once the stream has fully completed
         # (pending TTS/listen-element sidecar rows ride along).
@@ -3451,6 +3487,7 @@ class RunScriptContextV2:
             self._current_attend,
             status=LEARN_STATUS_IN_PROGRESS,
             block_position=next_block_position,
+            generation_prompt=sent_prompt,
         )
 
     def _phase_completion_tail(self) -> Generator[RunMarkdownFlowDTO, None, None]:

--- a/src/api/flaskr/service/learn/models.py
+++ b/src/api/flaskr/service/learn/models.py
@@ -152,6 +152,12 @@ class LearnGeneratedBlock(db.Model):
         default="",
         comment="Block content config(used for re-generate)",
     )
+    generation_prompt = Column(
+        Text,
+        nullable=False,
+        default="",
+        comment="Exact user message sent to the LLM when this block was generated",
+    )
     liked = Column(
         Integer,
         nullable=False,

--- a/src/api/flaskr/service/learn/run/recorder.py
+++ b/src/api/flaskr/service/learn/run/recorder.py
@@ -102,6 +102,7 @@ class RunRecorder:
         *,
         status: int,
         block_position: int,
+        generation_prompt: str = "",
     ) -> None:
         """Post-stream finalize: block content + progress cursor, atomically.
 
@@ -110,9 +111,14 @@ class RunRecorder:
         no reader can observe a streamed block without its position flip or
         vice versa; a failure here rolls both back, leaving the pre-stream
         state for the producer-level rollback/replay path.
+
+        ``generation_prompt`` is the exact user message sent to the LLM for
+        this block; persisting it lets context rebuilds replay the sent bytes
+        verbatim so provider-side prefix caching keeps matching.
         """
         with unit_of_work():
             generated_block.generated_content = generated_content
+            generated_block.generation_prompt = generation_prompt or ""
             if not getattr(generated_block, "id", None):
                 db.session.add(generated_block)
             attend.status = status

--- a/src/api/migrations/versions/b8d5f0a2c3e4_add_generation_prompt_to_generated_blocks.py
+++ b/src/api/migrations/versions/b8d5f0a2c3e4_add_generation_prompt_to_generated_blocks.py
@@ -1,0 +1,60 @@
+"""add generation_prompt to learn_generated_blocks
+
+Revision ID: b8d5f0a2c3e4
+Revises: a7c4e9f1b2d3
+Create Date: 2026-08-03 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b8d5f0a2c3e4"
+down_revision = "a7c4e9f1b2d3"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "learn_generated_blocks"
+COLUMN_NAME = "generation_prompt"
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    try:
+        columns = inspector.get_columns(table_name)
+    except Exception:
+        return False
+    return any(column["name"] == column_name for column in columns)
+
+
+def upgrade():
+    if not _table_exists(TABLE_NAME):
+        return
+    if _column_exists(TABLE_NAME, COLUMN_NAME):
+        return
+    with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                COLUMN_NAME,
+                sa.Text(),
+                nullable=False,
+                comment="Exact user message sent to the LLM when this block was generated",
+            )
+        )
+
+
+def downgrade():
+    if not _table_exists(TABLE_NAME):
+        return
+    if not _column_exists(TABLE_NAME, COLUMN_NAME):
+        return
+    with op.batch_alter_table(TABLE_NAME, schema=None) as batch_op:
+        batch_op.drop_column(COLUMN_NAME)

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -249,6 +249,45 @@ def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app):
     )
 
 
+def test_finalize_persists_generation_prompt(recorder_app):
+    """finalize_streamed_block stores the exact sent user message so context
+    rebuilds can replay it verbatim; omitting it defaults to empty string."""
+    attend = _seed_attend()
+    recorder = RunRecorder(recorder_app)
+
+    with_prompt = _build_block("gb-prompt-0001", 3)
+    dao.db.session.add(with_prompt)
+    dao.db.session.flush()
+    recorder.finalize_streamed_block(
+        with_prompt,
+        "block content",
+        attend,
+        status=LEARN_STATUS_IN_PROGRESS,
+        block_position=4,
+        generation_prompt="Sent user message with next-interaction suffix",
+    )
+
+    without_prompt = _build_block("gb-prompt-0002", 4)
+    dao.db.session.add(without_prompt)
+    dao.db.session.flush()
+    recorder.finalize_streamed_block(
+        without_prompt,
+        "next content",
+        attend,
+        status=LEARN_STATUS_IN_PROGRESS,
+        block_position=5,
+    )
+
+    stored = LearnGeneratedBlock.query.filter(
+        LearnGeneratedBlock.generated_block_bid == "gb-prompt-0001"
+    ).one()
+    assert stored.generation_prompt == "Sent user message with next-interaction suffix"
+    stored_default = LearnGeneratedBlock.query.filter(
+        LearnGeneratedBlock.generated_block_bid == "gb-prompt-0002"
+    ).one()
+    assert stored_default.generation_prompt == ""
+
+
 def test_commit_pending_step_makes_collaborator_writes_durable(recorder_app):
     """The transitional ask-path step commits rows staged elsewhere."""
     recorder = RunRecorder(recorder_app)

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -117,6 +117,7 @@ from flaskr.service.learn.context_v2 import (
     _PreviewContextStore,
 )
 from markdown_flow import MarkdownFlow, USER_ANSWER_CONTEXT_KEY
+from markdown_flow.llm import LLMResult
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.learn_dtos import (
     ElementType,
@@ -1955,6 +1956,71 @@ def _make_preview_store(
     return store, cache, doc
 
 
+class PreviewSentPromptCaptureTests(unittest.TestCase):
+    """The preview flow stores the exact user message markdown-flow sent to
+    the LLM (LLMResult.prompt) instead of a locally re-rendered block, so the
+    replayed preview context stays byte-identical to the sent request."""
+
+    def test_iter_preview_generated_events_captures_prompt(self):
+        app = Flask("preview-prompt-capture")
+        preview_ctx = RunScriptPreviewContextV2(app)
+        sent_prompt_chunks: list[str] = []
+
+        list(
+            preview_ctx._iter_preview_generated_events(
+                result=(
+                    chunk
+                    for chunk in [
+                        LLMResult(
+                            content="Hello preview",
+                            type="text",
+                            number=0,
+                            prompt="P-PREVIEW",
+                        )
+                    ]
+                ),
+                outline_bid="outline-1",
+                block_index=0,
+                current_block=types.SimpleNamespace(block_type="content"),
+                is_user_input_validation=False,
+                content_chunks=[],
+                langfuse_output_chunks=[],
+                sent_prompt_chunks=sent_prompt_chunks,
+            )
+        )
+
+        self.assertEqual(sent_prompt_chunks, ["P-PREVIEW"])
+
+    def test_update_preview_context_prefers_sent_prompt(self):
+        app = Flask("preview-prompt-store")
+        preview_ctx = RunScriptPreviewContextV2(app)
+        appended: list[tuple] = []
+        store = types.SimpleNamespace(
+            append_context=lambda *args: appended.append(args)
+        )
+        request = PlaygroundPreviewRequest(block_index=0)
+
+        preview_ctx._update_preview_context(
+            store,
+            "doc",
+            request,
+            ["generated "],
+            "re-rendered block",
+            sent_prompt="P-PREVIEW",
+        )
+        preview_ctx._update_preview_context(
+            store,
+            "doc",
+            request,
+            ["generated "],
+            "re-rendered block",
+        )
+
+        self.assertEqual(appended[0][2], "P-PREVIEW")
+        # Without a captured prompt the legacy rendering still applies.
+        self.assertEqual(appended[1][2], "re-rendered block")
+
+
 class PreviewContextStoreTruncationTests(unittest.TestCase):
     def _populate(self, store, doc, indices):
         for idx in indices:
@@ -2207,6 +2273,166 @@ class BuildContextFromBlocksTests(unittest.TestCase):
                 prev == "user" and cur == "user",
                 f"adjacent user messages in {roles}",
             )
+
+
+class BuildContextGenerationPromptReplayTests(unittest.TestCase):
+    """Content blocks replay the persisted generation_prompt verbatim so the
+    rebuilt history stays byte-identical to the request previously sent to
+    the LLM (keeping provider-side prefix caching effective); legacy rows
+    without it fall back to re-rendering the block source with the current
+    variables."""
+
+    DOC = (
+        "Content one {{nickname}}.\n"
+        "---\n"
+        "?[%{{nickname}} ...What is your name?]\n"
+        "---\n"
+        "Second content."
+    )
+
+    STORED_PROMPT = (
+        'Content one """UNKNOWN""".\n\n'
+        "The next interaction will appear immediately after this content."
+    )
+
+    def test_stored_prompt_replayed_verbatim_ignoring_current_variables(self):
+        blocks = [
+            types.SimpleNamespace(
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                position=0,
+                generated_content="reply zero",
+                generation_prompt=self.STORED_PROMPT,
+            ),
+        ]
+        app = Flask(__name__)
+        with app.app_context():
+            messages = MdflowContextV2.build_context_from_blocks(
+                blocks, self.DOC, {"nickname": "Alice"}
+            )
+
+        # The stored prompt wins even though nickname now resolves to Alice.
+        self.assertEqual(messages[0]["role"], "user")
+        self.assertEqual(messages[0]["content"], self.STORED_PROMPT)
+
+    def test_missing_or_empty_prompt_falls_back_to_current_rendering(self):
+        blocks = [
+            # Legacy row persisted before the column existed.
+            types.SimpleNamespace(
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                position=0,
+                generated_content="reply zero",
+            ),
+            # Row persisted with an empty prompt.
+            types.SimpleNamespace(
+                type=BLOCK_TYPE_MDCONTENT_VALUE,
+                position=2,
+                generated_content="reply two",
+                generation_prompt="",
+            ),
+        ]
+        app = Flask(__name__)
+        with app.app_context():
+            messages = MdflowContextV2.build_context_from_blocks(
+                blocks, self.DOC, {"nickname": "Alice"}
+            )
+
+        user_messages = [m for m in messages if m["role"] == "user"]
+        self.assertEqual(len(user_messages), 2)
+        self.assertIn("Alice", user_messages[0]["content"])
+        self.assertEqual(user_messages[1]["content"], "Second content.")
+
+
+class StreamContentBlockPromptCaptureTests(unittest.TestCase):
+    """_phase_stream_content_block captures LLMResult.prompt (the exact user
+    message markdown-flow sent to the LLM) and hands it to the recorder;
+    prompt-less streams (preserved content) freeze the variables-rendered
+    block source instead."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = Flask("stream-prompt-capture-tests")
+        cls.app.config.update(
+            SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+            SQLALCHEMY_BINDS={
+                "ai_shifu_saas": "sqlite:///:memory:",
+                "ai_shifu_admin": "sqlite:///:memory:",
+            },
+            SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        )
+        dao.db.init_app(cls.app)
+        with cls.app.app_context():
+            dao.db.create_all()
+
+    def _run_stream_phase(self, stream_items):
+        ctx = _make_context()
+        ctx.app = self.app
+        ctx._input_type = "normal"
+        ctx._preview_mode = False
+        ctx._listen = False
+        ctx._current_attend = types.SimpleNamespace(
+            progress_record_bid="progress-prompt-1",
+            shifu_bid="shifu-prompt-1",
+        )
+        # _recorder is a lazy read-only property backed by __dict__.
+        ctx.__dict__["_run_recorder"] = MagicMock()
+
+        def fake_stream():
+            yield from stream_items
+
+        mdflow_context = types.SimpleNamespace(process=lambda **kwargs: fake_stream())
+        attend = types.SimpleNamespace(shifu_bid="shifu-prompt-1")
+        state = types.SimpleNamespace(
+            run_script_info=types.SimpleNamespace(
+                attend=attend,
+                outline_bid="outline-prompt-1",
+                block_position=0,
+                mdflow="",
+            ),
+            block_list=[object(), object()],
+            user_profile={"nickname": "Alice"},
+            message_list=[],
+            llm_provider=MagicMock(),
+            mdflow_context=mdflow_context,
+            block=types.SimpleNamespace(content="Preserved {{nickname}} text."),
+        )
+        generated_block = LearnGeneratedBlock(
+            generated_block_bid="gb-prompt-capture-1",
+            progress_record_bid="progress-prompt-1",
+            user_bid="user-prompt-1",
+            outline_item_bid="outline-prompt-1",
+            shifu_bid="shifu-prompt-1",
+            position=0,
+            generated_content="",
+            block_content_conf="",
+            status=1,
+        )
+        with self.app.app_context():
+            events = list(
+                ctx._phase_stream_content_block(self.app, state, generated_block)
+            )
+            dao.db.session.rollback()
+        return ctx, events
+
+    def test_llm_prompt_captured_and_passed_to_finalize(self):
+        ctx, _events = self._run_stream_phase(
+            [
+                LLMResult(content="Hello ", type="text", number=0, prompt="P-EXACT"),
+                LLMResult(content="world", type="text", number=0, prompt="P-EXACT"),
+            ]
+        )
+        finalize_call = ctx._recorder.finalize_streamed_block.call_args
+        self.assertEqual(finalize_call.kwargs["generation_prompt"], "P-EXACT")
+        self.assertEqual(finalize_call.args[1], "Hello world")
+
+    def test_promptless_stream_falls_back_to_rendered_block_source(self):
+        ctx, _events = self._run_stream_phase(
+            [LLMResult(content="Preserved Alice text.", type="text", number=0)]
+        )
+        finalize_call = ctx._recorder.finalize_streamed_block.call_args
+        self.assertEqual(
+            finalize_call.kwargs["generation_prompt"],
+            'Preserved """Alice""" text.',
+        )
 
 
 class BuildContextNoVariableInteractionTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

When markdown-flow processes a content block, `_build_content_messages` layers extra text onto the user message it actually sends to the LLM: variable replacement (unset variables render as `UNKNOWN`), the preserved-content instruction, the `<output_language_instruction>` wrapper, and — since the next-interaction feature — a suffix describing the interaction block that immediately follows.

The backend, however, rebuilds conversation history on every request in `MdflowContextV2.build_context_from_blocks` using only the raw block source re-rendered with the **current** variables. The rebuilt history therefore never byte-matches the request previously sent:

1. Every request loses the provider-side prefix-cache increment for the newest turn (the last block's user message + generated content), because the rebuilt version of that turn drops the layered wrappers/suffix.
2. When a variable referenced by an early block gets assigned later, the rebuilt early history changes (`UNKNOWN` → actual value), moving the cache break point much earlier.

## Fix

markdown-flow already attaches the exact sent user message to every streamed chunk as `LLMResult.prompt`; the run flow was dropping it. This PR:

- Adds a `generation_prompt` TEXT column to `learn_generated_blocks` (Alembic migration `b8d5f0a2c3e4`, guarded add/drop).
- Captures `LLMResult.prompt` in `_phase_stream_content_block` (both the generator and single-result branches) and persists it via `RunRecorder.finalize_streamed_block`. Prompt-less streams (preserved content) freeze the variables-rendered block source at generation time instead.
- `build_context_from_blocks` replays the stored prompt verbatim; legacy rows without it fall back to the previous re-rendering (one-time cache break, then stable).
- Preview flow: `_iter_preview_generated_events` captures the prompt and `_update_preview_context` stores it in the preview context store instead of the locally re-rendered block content (same bug, Redis-backed, no migration).

## Explicitly out of scope (pre-existing behavior)

- The ask flow builds its own history with a different message shape and shares no cacheable prefix with the run flow — untouched.
- Mid-course output-language switches, `max_context_length` sliding-window truncation, and the per-request variable replacement inside the system/document prompt.

## Deployment note

Run `flask db upgrade` **before** rolling the new image: the rebuild path tolerates a missing column via `getattr`, but new-code INSERTs include the column and would fail without the migration. (CN prod: manual migration per the established process; US prod: init container handles it.)

## Tests

- `BuildContextGenerationPromptReplayTests`: stored prompt replayed verbatim ignoring current variables; missing/empty prompt falls back.
- `StreamContentBlockPromptCaptureTests`: `LLMResult.prompt` reaches `finalize_streamed_block`; prompt-less streams persist the frozen rendering.
- `PreviewSentPromptCaptureTests`: preview captures and prefers the sent prompt.
- `test_finalize_persists_generation_prompt`: recorder persistence + default.
- Full `tests/service/learn/` suite: 389 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)