### PR TITLE
fix: discard DB connection on abnormal stream termination instead of pooling it

### DIFF
--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -62,6 +62,49 @@ def _remove_db_session_safely(app: Flask, *, source: str) -> None:
         app.logger.warning("%s db session cleanup failed", source, exc_info=True)
 
 
+# MySQL client error codes that mean the connection's protocol stream is no
+# longer trustworthy: 2013 "Lost connection during query" leaves a response
+# half-read; 2014 "Command Out of Sync" means a response was consumed out of
+# order (the off-by-one desync this module's probes exist for).
+_DESYNC_MYSQL_ERRNOS = frozenset({2013, 2014})
+
+
+def _is_protocol_desync_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` implies the DB protocol stream is desynced.
+
+    ResourceClosedError on a SELECT is the canonical victim symptom of an
+    off-by-one response stream. For DBAPI errors, inspect the MySQL errno on
+    the original driver exception (SQLAlchemy wraps it) as well as on the
+    exception itself (raw pymysql errors escape unwrapped from low-level
+    paths such as rollback).
+    """
+    if isinstance(exc, ResourceClosedError):
+        return True
+    for candidate in (exc, getattr(exc, "orig", None)):
+        args = getattr(candidate, "args", ())
+        if args and isinstance(args[0], int) and args[0] in _DESYNC_MYSQL_ERRNOS:
+            return True
+    return False
+
+
+def _discard_session_connection(app: Flask, *, source: str) -> None:
+    """Drop the session's DB connection instead of returning it to the pool.
+
+    Used when the streaming generator terminates abnormally: the close (or a
+    protocol error) can leave an unconsumed response owed on the wire, and
+    rolling back on such a connection consumes stale packets and returns a
+    poisoned connection to the pool. ``Session.invalidate()`` rolls back the
+    session state without emitting anything on the connection and discards
+    the raw DBAPI connection. The pool-level probes in ``flaskr/dao`` only
+    see stale bytes that have already arrived at the socket; discarding the
+    connection deterministically closes that arrival race.
+    """
+    try:
+        db.session.invalidate()
+    except Exception:
+        app.logger.warning("%s session invalidate failed", source, exc_info=True)
+
+
 # Number of connection checkouts to probe before giving up: the pool may hold
 # more than one poisoned connection, so retry a couple of fresh checkouts.
 _CONNECTION_PROBE_ATTEMPTS = 3
@@ -462,11 +505,20 @@ def run_script_inner(
             db.session.commit()
             app.logger.info("BreakException")
         except GeneratorExit:
-            db.session.rollback()
+            # The close lands at an arbitrary yield point (client disconnect),
+            # so the connection's protocol state is unknowable: this is the
+            # exact checkin path the pool-level desync detector caught in
+            # production. Discard the connection instead of rolling back on it.
+            _discard_session_connection(app, source="run_script_inner GeneratorExit")
             app.logger.info("GeneratorExit")
-        except Exception:
+        except Exception as exc:
             _finalize_langfuse_if_available(run_script_context)
-            db.session.rollback()
+            if _is_protocol_desync_error(exc):
+                # Rolling back on a desynced connection consumes stale packets
+                # ("Command Out of Sync") and re-pools the poisoned stream.
+                _discard_session_connection(app, source="run_script_inner stream error")
+            else:
+                db.session.rollback()
             raise
         finally:
             _remove_db_session_safely(app, source="run_script_inner")

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -1,0 +1,180 @@
+"""Abnormal stream termination must discard the DB connection, not pool it.
+
+The pool-level desync detector (flaskr/dao checkin/checkout probes) caught a
+production connection returned with unread protocol data from exactly this
+path: producer ``res.close()`` -> ``except GeneratorExit`` ->
+``db.session.rollback()``. Rolling back on a connection whose protocol state
+is unknown consumes stale packets and re-pools a poisoned stream; the probes
+only see stale bytes that have already arrived at the socket, so they cannot
+close the arrival race. These tests pin the deterministic fix: GeneratorExit
+and protocol-desync errors invalidate the session's connection instead of
+rolling back on it.
+"""
+
+import types
+
+import pytest
+from sqlalchemy.exc import OperationalError, ResourceClosedError
+
+from flaskr.service.learn import runscript_v2
+from flaskr.service.learn.runscript_v2 import (
+    _is_protocol_desync_error,
+    run_script_inner,
+)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rollbacks = 0
+        self.commits = 0
+        self.invalidations = 0
+        self.removed = 0
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def commit(self):
+        self.commits += 1
+
+    def invalidate(self):
+        self.invalidations += 1
+
+    def remove(self):
+        self.removed += 1
+
+
+class _StubRunContext:
+    """Yields scripted items (or raises) through run(); has_next() once."""
+
+    script: list = []
+
+    def __init__(self, **_kwargs):
+        self._steps = iter([True, False])
+
+    def set_input(self, *_args, **_kwargs):
+        pass
+
+    def has_next(self):
+        return next(self._steps, False)
+
+    def run(self, _app):
+        for item in type(self).script:
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+
+def _patch_run_dependencies(monkeypatch, script):
+    session = _FakeSession()
+
+    class _FakeDb:
+        pass
+
+    _FakeDb.session = session
+    monkeypatch.setattr(runscript_v2, "db", _FakeDb)
+    monkeypatch.setattr(
+        runscript_v2, "_ensure_healthy_db_connection", lambda _app: None
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "load_user_aggregate",
+        lambda _bid: types.SimpleNamespace(user_id="user-1"),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_outline_item_dto",
+        lambda _app, _bid, _preview: types.SimpleNamespace(
+            bid="outline-1", shifu_bid="shifu-1", __json__=lambda: {}
+        ),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_shifu_dto",
+        lambda _app, _bid, _preview: types.SimpleNamespace(bid="shifu-1", price=0),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_shifu_struct",
+        lambda _app, _bid, _preview: types.SimpleNamespace(bid="shifu-1"),
+    )
+    _StubRunContext.script = list(script)
+    monkeypatch.setattr(runscript_v2, "RunScriptContextV2", _StubRunContext)
+    return session
+
+
+def _start_stream(app):
+    generator = run_script_inner(
+        app=app,
+        user_bid="user-1",
+        shifu_bid="shifu-1",
+        outline_bid="outline-1",
+        manage_app_context=False,
+    )
+    assert next(generator) == "chunk-1"
+    return generator
+
+
+def test_generator_exit_invalidates_connection_instead_of_rollback(app, monkeypatch):
+    session = _patch_run_dependencies(monkeypatch, ["chunk-1", "chunk-2"])
+
+    with app.app_context():
+        generator = _start_stream(app)
+        generator.close()
+
+    assert session.invalidations == 1
+    assert session.rollbacks == 0
+    assert session.removed == 1
+
+
+def test_desync_error_invalidates_connection_instead_of_rollback(app, monkeypatch):
+    session = _patch_run_dependencies(
+        monkeypatch,
+        [
+            "chunk-1",
+            ResourceClosedError(
+                "This result object does not return rows. "
+                "It has been closed automatically."
+            ),
+        ],
+    )
+
+    with app.app_context():
+        generator = _start_stream(app)
+        with pytest.raises(ResourceClosedError):
+            next(generator)
+
+    assert session.invalidations == 1
+    assert session.rollbacks == 0
+    assert session.removed == 1
+
+
+def test_ordinary_error_still_rolls_back_pooled_connection(app, monkeypatch):
+    session = _patch_run_dependencies(
+        monkeypatch, ["chunk-1", ValueError("business failure")]
+    )
+
+    with app.app_context():
+        generator = _start_stream(app)
+        with pytest.raises(ValueError):
+            next(generator)
+
+    assert session.invalidations == 0
+    assert session.rollbacks == 1
+    assert session.removed == 1
+
+
+def test_desync_error_classifier_covers_symptom_family():
+    assert _is_protocol_desync_error(ResourceClosedError("no rows"))
+    wrapped_2013 = OperationalError(
+        "INSERT ...",
+        {},
+        Exception(2013, "Lost connection to MySQL server during query"),
+    )
+    wrapped_2013.orig.args = (2013, "Lost connection to MySQL server during query")
+    assert _is_protocol_desync_error(wrapped_2013)
+    raw_2014 = Exception(2014, "Command Out of Sync")
+    assert _is_protocol_desync_error(raw_2014)
+    assert not _is_protocol_desync_error(ValueError("boom"))
+    wrapped_deadlock = OperationalError("UPDATE ...", {}, Exception())
+    wrapped_deadlock.orig.args = (1213, "Deadlock found")
+    assert not _is_protocol_desync_error(wrapped_deadlock)


### PR DESCRIPTION
## Context

Follow-up to #2232 (nonce precheck) and #2252 (pool-level desync probes). The #2252 checkin probe caught a poisoned connection in the act in production (2026-08-04 06:30 CST): the logged checkin stack is the listen-stream early-close path — producer `res.close()` → `except GeneratorExit` → `db.session.rollback()` — returning a connection to the pool with unread protocol data.

The probes have an inherent race: they can only see stale bytes that have **already arrived** at the socket. A response that lands after checkin (and before/after the next checkout probe) slips through, and the victim request then fails mid-stream with `ResourceClosedError` on a SELECT; its own `except Exception` rollback then runs on the desynced connection, producing the secondary `2014 Command Out of Sync` and re-pooling the poisoned stream. Both symptom clusters were observed in production logs on 2026-08-04 (00:05 and 06:30 CST).

## Fix

Make the abnormal-termination paths in `run_script_inner` discard the connection instead of rolling back on it:

- `except GeneratorExit` (client disconnect, lands at an arbitrary yield point, protocol state unknowable) → `db.session.invalidate()`. `Session.invalidate()` rolls back session state without emitting anything on the wire and closes the raw DBAPI connection.
- `except Exception` where the error indicates a desynced protocol stream (`ResourceClosedError`, MySQL errno 2013/2014 — wrapped or raw) → same invalidate; other business errors keep the existing rollback.

Cost: one discarded pooled connection per early client disconnect (a handful per hour); reconnects are millisecond-scale within the VPC.

The pool-level probes from #2252 stay in place as the second line of defense.

## Tests

New `test_runscript_v2_stream_abort_invalidate.py`:
- GeneratorExit invalidates instead of rolling back (and still removes the session).
- Desync errors (ResourceClosedError) invalidate instead of rolling back.
- Ordinary business errors keep the rollback path.
- Classifier covers wrapped/raw 2013/2014 and rejects deadlock 1213 / ValueError.

Full `tests/service/learn/` + `tests/common/test_pool_desync_detection.py`: 398 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted database streams to prevent stale connections from being reused.
  * Correctly invalidates connections affected by MySQL protocol errors while preserving rollback behavior for ordinary failures.
  * Improved reliability when streaming operations end unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->