### PR TITLE
fix: retry LLM stream once when the connection dies before first content

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -417,6 +417,82 @@ def _stream_litellm_completion(
         )
 
 
+# How many times to re-issue a streaming request whose connection died before
+# the first content token arrived.
+_STREAM_PRECONTENT_RETRY_ATTEMPTS = 1
+
+
+def _retryable_stream_error_types() -> tuple:
+    """Connection-level litellm stream errors that are safe to retry.
+
+    Resolved lazily via getattr because tests stub the litellm module without
+    an ``exceptions`` submodule. APIConnectionError covers connections that
+    die before the response starts; MidStreamFallbackError is litellm's
+    wrapper for an established stream dying mid-read (observed in production
+    as TLS record corruption on the provider path: DECRYPTION_FAILED_OR_
+    BAD_RECORD_MAC).
+    """
+    exceptions_mod = getattr(litellm, "exceptions", None)
+    resolved = []
+    for name in ("APIConnectionError", "MidStreamFallbackError"):
+        exc_type = getattr(exceptions_mod, name, None)
+        if isinstance(exc_type, type):
+            resolved.append(exc_type)
+    return tuple(resolved)
+
+
+def _iter_stream_with_precontent_retry(
+    app: Flask,
+    requested_model: str,
+    invoke_model: str,
+    messages: list,
+    params: dict,
+    kwargs: dict,
+):
+    """Yield litellm stream chunks, re-issuing the request when the stream
+    dies on a connection-level error before any content token arrived.
+
+    The built-in openai/litellm retries only cover request setup; an
+    established stream that dies mid-read (transient network corruption,
+    provider LB reset) surfaces as an exception from the chunk iterator and
+    kills the whole run. Re-issuing is only safe while no content has been
+    seen: nothing user-visible can be duplicated. Once content flowed, the
+    error is re-raised unchanged.
+    """
+    attempts = 0
+    while True:
+        response = _stream_litellm_completion(
+            app,
+            requested_model,
+            invoke_model,
+            messages,
+            params,
+            kwargs,
+        )
+        saw_content = False
+        try:
+            for res in response:
+                if len(res.choices) and res.choices[0].delta.content:
+                    saw_content = True
+                yield res
+            return
+        except Exception as exc:
+            attempts += 1
+            retryable = _retryable_stream_error_types()
+            if (
+                saw_content
+                or attempts > _STREAM_PRECONTENT_RETRY_ATTEMPTS
+                or not retryable
+                or not isinstance(exc, retryable)
+            ):
+                raise
+            _log_warning(
+                f"LLM stream for {invoke_model} failed before first content "
+                f"(attempt {attempts}/{_STREAM_PRECONTENT_RETRY_ATTEMPTS + 1}); "
+                f"reissuing request: {exc}"
+            )
+
+
 def _resolve_provider_for_model(model: str) -> Tuple[Optional[str], str]:
     alias = MODEL_ALIAS_MAP.get(model)
     if alias:
@@ -773,7 +849,7 @@ def invoke_llm(
                     "temperature": float(kwargs.get("temperature", 0.3)),
                 }
             )
-        response = _stream_litellm_completion(
+        response = _iter_stream_with_precontent_retry(
             app,
             model,
             invoke_model,
@@ -942,7 +1018,7 @@ def chat_llm(
                 }
             )
         kwargs["stream_options"] = {"include_usage": True}
-        response = _stream_litellm_completion(
+        response = _iter_stream_with_precontent_retry(
             app,
             model,
             invoke_model,

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -854,8 +854,12 @@ def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):
     assert span.generation_args["parent_observation_id"] == "span-2"
 
 
-class _RetryableStreamError(Exception):
-    """Stands in for litellm APIConnectionError/MidStreamFallbackError."""
+class _FakeAPIConnectionError(Exception):
+    """Stands in for litellm.exceptions.APIConnectionError."""
+
+
+class _FakeMidStreamFallbackError(Exception):
+    """Stands in for litellm.exceptions.MidStreamFallbackError."""
 
 
 def _stream_chunk(content):
@@ -868,12 +872,15 @@ def _stream_chunk(content):
 
 
 def _patch_retryable_stream_errors(monkeypatch):
+    # Distinct classes per exception name: a resolver that silently drops one
+    # of the names fails that class's parametrized retry test instead of
+    # being masked by a shared class.
     monkeypatch.setattr(
         llm.litellm,
         "exceptions",
         SimpleNamespace(
-            APIConnectionError=_RetryableStreamError,
-            MidStreamFallbackError=_RetryableStreamError,
+            APIConnectionError=_FakeAPIConnectionError,
+            MidStreamFallbackError=_FakeMidStreamFallbackError,
         ),
         raising=False,
     )
@@ -908,12 +915,17 @@ def _collect_retry_stream(app):
     )
 
 
-def test_stream_retries_connection_error_before_first_content(monkeypatch, app):
+@pytest.mark.parametrize(
+    "error_type", [_FakeAPIConnectionError, _FakeMidStreamFallbackError]
+)
+def test_stream_retries_connection_error_before_first_content(
+    monkeypatch, app, error_type
+):
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
         [
-            [_RetryableStreamError("bad record mac")],
+            [error_type("bad record mac")],
             [_stream_chunk("hello"), _stream_chunk(" world")],
         ],
     )
@@ -928,10 +940,10 @@ def test_stream_error_after_content_is_not_retried(monkeypatch, app):
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
-        [[_stream_chunk("partial"), _RetryableStreamError("mid-stream death")]],
+        [[_stream_chunk("partial"), _FakeMidStreamFallbackError("mid-stream death")]],
     )
 
-    with pytest.raises(_RetryableStreamError):
+    with pytest.raises(_FakeMidStreamFallbackError):
         _collect_retry_stream(app)
 
     assert calls["count"] == 1
@@ -942,12 +954,12 @@ def test_stream_retry_attempts_are_bounded(monkeypatch, app):
     calls = _patch_scripted_streams(
         monkeypatch,
         [
-            [_RetryableStreamError("first failure")],
-            [_RetryableStreamError("second failure")],
+            [_FakeAPIConnectionError("first failure")],
+            [_FakeMidStreamFallbackError("second failure")],
         ],
     )
 
-    with pytest.raises(_RetryableStreamError):
+    with pytest.raises(_FakeMidStreamFallbackError):
         _collect_retry_stream(app)
 
     assert calls["count"] == 2
@@ -968,10 +980,10 @@ def test_stream_retry_noop_when_exception_types_unavailable(monkeypatch, app):
     degrade to raising instead of crashing on type resolution."""
     monkeypatch.delattr(llm.litellm, "exceptions", raising=False)
     calls = _patch_scripted_streams(
-        monkeypatch, [[_RetryableStreamError("connection died")]]
+        monkeypatch, [[_FakeAPIConnectionError("connection died")]]
     )
 
-    with pytest.raises(_RetryableStreamError):
+    with pytest.raises(_FakeAPIConnectionError):
         _collect_retry_stream(app)
 
     assert calls["count"] == 1

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -852,3 +852,126 @@ def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):
 
     assert span.generation_args["trace_id"] == "request-trace-1"
     assert span.generation_args["parent_observation_id"] == "span-2"
+
+
+class _RetryableStreamError(Exception):
+    """Stands in for litellm APIConnectionError/MidStreamFallbackError."""
+
+
+def _stream_chunk(content):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(delta=SimpleNamespace(content=content), finish_reason=None)
+        ],
+        usage=None,
+    )
+
+
+def _patch_retryable_stream_errors(monkeypatch):
+    monkeypatch.setattr(
+        llm.litellm,
+        "exceptions",
+        SimpleNamespace(
+            APIConnectionError=_RetryableStreamError,
+            MidStreamFallbackError=_RetryableStreamError,
+        ),
+        raising=False,
+    )
+
+
+def _patch_scripted_streams(monkeypatch, scripts):
+    """Each call to _stream_litellm_completion consumes the next script;
+    a script is a list of chunks and/or exceptions raised in order."""
+    calls = {"count": 0}
+
+    def _factory(_app, _requested, _invoke, _messages, _params, _kwargs):
+        script = scripts[min(calls["count"], len(scripts) - 1)]
+        calls["count"] += 1
+
+        def _gen():
+            for item in script:
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+
+        return _gen()
+
+    monkeypatch.setattr(llm, "_stream_litellm_completion", _factory)
+    return calls
+
+
+def _collect_retry_stream(app):
+    return list(
+        llm._iter_stream_with_precontent_retry(
+            app, "qwen/test-model", "test-model", [], {}, {}
+        )
+    )
+
+
+def test_stream_retries_connection_error_before_first_content(monkeypatch, app):
+    _patch_retryable_stream_errors(monkeypatch)
+    calls = _patch_scripted_streams(
+        monkeypatch,
+        [
+            [_RetryableStreamError("bad record mac")],
+            [_stream_chunk("hello"), _stream_chunk(" world")],
+        ],
+    )
+
+    chunks = _collect_retry_stream(app)
+
+    assert [c.choices[0].delta.content for c in chunks] == ["hello", " world"]
+    assert calls["count"] == 2
+
+
+def test_stream_error_after_content_is_not_retried(monkeypatch, app):
+    _patch_retryable_stream_errors(monkeypatch)
+    calls = _patch_scripted_streams(
+        monkeypatch,
+        [[_stream_chunk("partial"), _RetryableStreamError("mid-stream death")]],
+    )
+
+    with pytest.raises(_RetryableStreamError):
+        _collect_retry_stream(app)
+
+    assert calls["count"] == 1
+
+
+def test_stream_retry_attempts_are_bounded(monkeypatch, app):
+    _patch_retryable_stream_errors(monkeypatch)
+    calls = _patch_scripted_streams(
+        monkeypatch,
+        [
+            [_RetryableStreamError("first failure")],
+            [_RetryableStreamError("second failure")],
+        ],
+    )
+
+    with pytest.raises(_RetryableStreamError):
+        _collect_retry_stream(app)
+
+    assert calls["count"] == 2
+
+
+def test_stream_non_retryable_error_raises_immediately(monkeypatch, app):
+    _patch_retryable_stream_errors(monkeypatch)
+    calls = _patch_scripted_streams(monkeypatch, [[ValueError("business error")]])
+
+    with pytest.raises(ValueError):
+        _collect_retry_stream(app)
+
+    assert calls["count"] == 1
+
+
+def test_stream_retry_noop_when_exception_types_unavailable(monkeypatch, app):
+    """The litellm test stub has no exceptions submodule; the wrapper must
+    degrade to raising instead of crashing on type resolution."""
+    monkeypatch.delattr(llm.litellm, "exceptions", raising=False)
+    calls = _patch_scripted_streams(
+        monkeypatch, [[_RetryableStreamError("connection died")]]
+    )
+
+    with pytest.raises(_RetryableStreamError):
+        _collect_retry_stream(app)
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Context

Production incident 2026-08-04 09:40 CST (and prior occurrences on 08-02/08-03): a learner run died with `litellm.MidStreamFallbackError` wrapping `[SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC]` while reading the LLM response stream, surfacing the generic error toast to the learner.

Investigation ruled out the fork-shared-connection family for the LLM path:
- litellm's openai clients are created lazily per worker after fork (the gunicorn master never issues an LLM call during preload; langfuse, the only preload-time TLS user, is already reset in `post_fork`).
- litellm builds its own `httpx.Client` with default limits (`keepalive_expiry=5s`), so long-idle keep-alive reuse through LB idle timeouts is not in play.
- In-process connection sharing is prevented by httpcore's pool locking.

What remains is transient corruption on the provider network path — TLS MAC verification correctly rejects the bytes and kills the connection. That is not eliminable client-side; the right response is bounded, safe retry.

## Fix

New `_iter_stream_with_precontent_retry` wraps both litellm streaming call sites (`invoke_llm`, `chat_llm`):

- If the chunk iterator raises a connection-level error (`APIConnectionError`, `MidStreamFallbackError`) **before any content token arrived**, re-issue the request once. Nothing user-visible existed, so nothing can be duplicated.
- Once content has flowed, or retries are exhausted, or the error is not connection-level, re-raise unchanged (current behavior).
- Exception types are resolved lazily via `getattr` because the test suite stubs the litellm module without an `exceptions` submodule; when unavailable the wrapper degrades to plain re-raise.

Built-in openai/litellm retries only cover request setup, not an established stream dying mid-read — hence the explicit wrapper.

## Tests

Five new tests in `tests/test_llm.py`: retry-then-succeed, no-retry-after-content, bounded attempts, non-retryable passthrough, and graceful degradation without `litellm.exceptions`. Regression: `tests/service/learn/` + `tests/test_llm.py` + `tests/api/` — 422 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of streaming AI responses by automatically retrying eligible connection failures before content begins.
  - Prevented retries after content has started or when errors are not retryable.
  - Ensured retry attempts remain bounded and failures are surfaced appropriately.

- **Tests**
  - Added coverage for retry behavior, retry limits, mid-stream failures, and unavailable error definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->