### PR TITLE
fix: replace outline history streaming scans with buffered pagination

### DIFF
--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -88,6 +88,49 @@ def _get_latest_draft_log(shifu_bid: str, for_update: bool = False):
     return query.first()
 
 
+def iter_outline_item_versions_desc(
+    shifu_bid: str,
+    outline_bid: str,
+    *,
+    batch_size: int = 200,
+    max_rows: int | None = None,
+):
+    """Yield draft outline versions newest-first in buffered keyset batches.
+
+    Replaces yield_per/stream_results for these scans: a server-side cursor
+    left unexhausted by an early ``break`` keeps unread rows on the wire, and
+    draining them later is a long, interruptible IO that can return a
+    half-read connection to the pool (protocol desync - the ResourceClosedError
+    / 2014 Command Out of Sync family seen in production). Buffered
+    LIMIT batches are fully consumed per round-trip, so callers may stop
+    iterating at any point without leaving connection state behind. Keyset
+    pagination (id < last seen) keeps deep pages as cheap as the first one.
+    """
+    last_id: int | None = None
+    yielded = 0
+    while True:
+        query = DraftOutlineItem.query.filter(
+            DraftOutlineItem.shifu_bid == shifu_bid,
+            DraftOutlineItem.outline_item_bid == outline_bid,
+            DraftOutlineItem.deleted == 0,
+        )
+        if last_id is not None:
+            query = query.filter(DraftOutlineItem.id < last_id)
+        limit = batch_size
+        if max_rows is not None:
+            limit = min(batch_size, max_rows - yielded)
+            if limit <= 0:
+                return
+        batch = query.order_by(DraftOutlineItem.id.desc()).limit(limit).all()
+        if not batch:
+            return
+        yield from batch
+        yielded += len(batch)
+        if len(batch) < limit:
+            return
+        last_id = int(batch[-1].id)
+
+
 def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str):
     latest_version = (
         DraftOutlineItem.query.filter(
@@ -107,15 +150,10 @@ def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str):
 
     latest_content = latest_version.content or ""
     latest_content_revision = latest_version
-    recent_active_versions = (
-        DraftOutlineItem.query.filter(
-            DraftOutlineItem.shifu_bid == shifu_bid,
-            DraftOutlineItem.outline_item_bid == outline_bid,
-            DraftOutlineItem.deleted == 0,
-        )
-        .order_by(DraftOutlineItem.id.desc())
-        .limit(OUTLINE_CONTENT_LOOKBACK_LIMIT)
-        .yield_per(200)
+    recent_active_versions = iter_outline_item_versions_desc(
+        shifu_bid,
+        outline_bid,
+        max_rows=OUTLINE_CONTENT_LOOKBACK_LIMIT,
     )
     for version in recent_active_versions:
         if version.id == latest_version.id:

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -12,6 +12,7 @@ from flaskr.service.shifu.shifu_history_manager import (
     save_outline_history,
     get_shifu_draft_meta,
     get_shifu_draft_revision,
+    iter_outline_item_versions_desc,
     mask_contact_identifier,
 )
 from flaskr.service.profile.profile_manage import (
@@ -89,7 +90,7 @@ def cleanup_outline_history_versions(
     latest_id = int(latest_version.id)
     latest_content = latest_version.content or ""
     content_anchor_version = latest_version
-    for version in _query_outline_versions(shifu_bid, outline_bid):
+    for version in iter_outline_item_versions_desc(shifu_bid, outline_bid):
         if version.id == latest_version.id:
             continue
         if (version.content or "") != latest_content:
@@ -294,18 +295,6 @@ def parse_shifu_mdflow(
         return MdflowDTOParseResult(variables=dedup_vars, blocks_count=len(blocks))
 
 
-def _query_outline_versions(shifu_bid: str, outline_bid: str):
-    return (
-        DraftOutlineItem.query.filter(
-            DraftOutlineItem.shifu_bid == shifu_bid,
-            DraftOutlineItem.outline_item_bid == outline_bid,
-            DraftOutlineItem.deleted == 0,
-        )
-        .order_by(DraftOutlineItem.id.desc())
-        .yield_per(200)
-    )
-
-
 def get_shifu_mdflow_history(
     app: Flask,
     shifu_bid: str,
@@ -322,7 +311,7 @@ def get_shifu_mdflow_history(
         segment_content: str | None = None
         segment_oldest: DraftOutlineItem | None = None
 
-        for version in _query_outline_versions(shifu_bid, outline_bid):
+        for version in iter_outline_item_versions_desc(shifu_bid, outline_bid):
             current_content = version.content or ""
             if segment_content is None:
                 segment_content = current_content

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -1,0 +1,105 @@
+"""Buffered keyset pagination for outline version scans.
+
+These scans used yield_per (server-side cursors); an early break left an
+unexhausted result stream on the pooled connection. The helper must return
+the same newest-first sequence in fully-buffered batches and stay correct
+across batch boundaries and max_rows caps.
+"""
+
+from flaskr.dao import db
+from flaskr.service.shifu.models import DraftOutlineItem
+from flaskr.service.shifu.shifu_history_manager import (
+    iter_outline_item_versions_desc,
+)
+
+SHIFU = "shifu-history-pg"
+OUTLINE = "outline-history-pg"
+
+
+def _seed_versions(count: int) -> list[int]:
+    rows = []
+    for index in range(count):
+        rows.append(
+            DraftOutlineItem(
+                outline_item_bid=OUTLINE,
+                shifu_bid=SHIFU,
+                title=f"v{index}",
+                content=f"content-{index}",
+                position="01",
+                deleted=0,
+            )
+        )
+    db.session.add_all(rows)
+    db.session.commit()
+    return sorted((int(row.id) for row in rows), reverse=True)
+
+
+def _cleanup():
+    DraftOutlineItem.query.filter(DraftOutlineItem.shifu_bid == SHIFU).delete()
+    db.session.commit()
+
+
+def test_yields_all_versions_newest_first_across_batches(app):
+    with app.app_context():
+        _cleanup()
+        expected_ids = _seed_versions(7)
+
+        got = [
+            int(row.id)
+            for row in iter_outline_item_versions_desc(SHIFU, OUTLINE, batch_size=3)
+        ]
+
+        assert got == expected_ids
+        _cleanup()
+
+
+def test_max_rows_caps_the_scan(app):
+    with app.app_context():
+        _cleanup()
+        expected_ids = _seed_versions(6)
+
+        got = [
+            int(row.id)
+            for row in iter_outline_item_versions_desc(
+                SHIFU, OUTLINE, batch_size=2, max_rows=5
+            )
+        ]
+
+        assert got == expected_ids[:5]
+        _cleanup()
+
+
+def test_early_break_leaves_session_usable(app):
+    with app.app_context():
+        _cleanup()
+        expected_ids = _seed_versions(5)
+
+        iterator = iter_outline_item_versions_desc(SHIFU, OUTLINE, batch_size=2)
+        first = next(iterator)
+        assert int(first.id) == expected_ids[0]
+        # Caller breaks mid-scan; the session must remain fully usable.
+        iterator.close()
+
+        count = DraftOutlineItem.query.filter(
+            DraftOutlineItem.shifu_bid == SHIFU
+        ).count()
+        assert count == 5
+        _cleanup()
+
+
+def test_skips_deleted_versions(app):
+    with app.app_context():
+        _cleanup()
+        ids = _seed_versions(4)
+        DraftOutlineItem.query.filter(DraftOutlineItem.id == ids[1]).update(
+            {"deleted": 1}
+        )
+        db.session.commit()
+
+        got = [
+            int(row.id)
+            for row in iter_outline_item_versions_desc(SHIFU, OUTLINE, batch_size=2)
+        ]
+
+        assert got == [ids[0]] + ids[2:]
+        _cleanup()


### PR DESCRIPTION
## Problem

Listen runs keep failing intermittently with `ResourceClosedError` / pymysql 2014 `Command Out of Sync` (latest: 2026-08-04 10:22) on pods that already contain #2232, #2244, and #2252. The pool-level probes added in #2252 report **zero** hits at checkout/checkin, which narrows the mechanism decisively: the desync is produced **while a request holds the connection**, not by a poisoned connection circulating through the pool (the crashing request's connection is invalidated on failure and never reaches checkin).

Auditing every streaming query in the codebase found the candidate that matches this profile:

- `_get_latest_outline_content_log` (shifu_history_manager) and `get_shifu_mdflow_history` / `cleanup_outline_history_versions` (shifu_mdflow_funcs) iterate draft outline versions via `.yield_per(200)` — a **server-side cursor** on MySQL — and **break out of the loop early** by design (they stop at the first content change).
- An early break leaves the unread remainder of the result stream on the wire. Draining it later (pymysql does this implicitly before the next command, or on cursor close/GC) is a long, interruptible IO: outline content rows are tens of KB each and hot courses have hundreds to thousands of versions (production: up to 2,265 versions / 36 MB for one outline). Under gevent, an interruption mid-drain (client disconnect, deployment rollout killing greenlets) leaves the connection half-read.
- The failures cluster on specific courses (one outline accounts for most alerts), which matches a data-shape-dependent mechanism: whether the loop breaks early — and how much unread stream it leaves — depends on that course's version history.

These scans run in the cook-web editor endpoints, which share worker processes and the connection pool with listen runs.

## Changes

- New `iter_outline_item_versions_desc` helper in `shifu_history_manager`: buffered **keyset pagination** (`id < last_seen ORDER BY id DESC LIMIT n`) — every round-trip is fully consumed regardless of how the caller exits the loop, and deep pages stay as cheap as the first one.
- `_get_latest_outline_content_log`, `get_shifu_mdflow_history`, and `cleanup_outline_history_versions` now iterate through the helper; `_query_outline_versions` (the `yield_per` query factory) is removed.
- The remaining `yield_per` call sites (order/billing/admin) were audited: all of them run their loops to exhaustion, which pymysql handles safely, so they are left unchanged.

## Testing

- New `test_outline_history_buffered_pagination.py`: newest-first ordering across batch boundaries, `max_rows` capping, early-break leaving the session usable, and deleted-row filtering.
- `tests/service/shifu` + `tests/test_mdflow_adapter.py`: 332 passed.
- `lefthook run pre-commit --all-files`: clean.

## Relation to previous fixes

#2252's pool probes stay in place: if this fix removes the desync source, both the user-facing errors and the probes stay silent; if desyncs persist from yet another source, the checkin stack trace will attribute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)