### PR TITLE
fix: upgrade markdown-flow to 0.3.1 to stop next-interaction note leaking into content

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -125,4 +125,4 @@ zope.event==5.0
 zope.interface==7.1.1
 bcrypt==4.2.1
 --extra-index-url https://pypi.org/simple/
-markdown-flow==0.3.0
+markdown-flow==0.3.1

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -28,7 +28,7 @@ def test_alembic_migrations_have_single_head():
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
 
-    assert heads == ["a7c4e9f1b2d3"]
+    assert heads == ["b8d5f0a2c3e4"]
 
 
 def _get_base_mysql_uri() -> str:


### PR DESCRIPTION
## Context

Since the next-interaction feature shipped (markdown-flow 0.3.0, 2026-07-29), models occasionally reproduce the internal guidance note ("The next interaction will appear immediately after this content...") verbatim inside generated lesson content — 5 occurrences between 07-29 and 08-04 (~0.2-0.7% of content blocks), surfacing raw English instruction text to learners. Example trace: lesson_runtime run_llm 2026-08-04 10:10 CST.

## Fix

markdown-flow 0.3.1 ([markdown-flow-agent-py#75](https://github.com/ai-shifu/markdown-flow-agent-py/pull/75)) delimits the note with a house-style Markdown heading (`# Next Interaction Note`), adds an explicit never-quote sentence to the note itself, and adds a base-system-prompt rule referencing the section by name — including copies inside earlier conversation turns (history is replayed byte-exact since #2253).

This PR bumps the pinned dependency. Cache impact: stored `generation_prompt` rows replay their original bytes (self-consistent); the base system prompt change invalidates provider prefix caches once per conversation, then they re-stabilize.

## Also included: stale alembic head assertion fix

`tests/migrations/test_fresh_mysql_upgrade.py::test_alembic_migrations_have_single_head` hardcodes the expected single head; #2253 added migration `b8d5f0a2c3e4` without updating it. #2253's incremental CI never selected the test, so the failure stayed latent on main and detonates on any branch whose incremental selection picks it up (it failed #2255's backend-tests check this way; #2255 was merged before the fix commit landed on its branch). This PR carries the one-line assertion update.

## Tests

`tests/service/learn/` + `tests/test_llm.py` against markdown-flow 0.3.1: 420 passed, 5 skipped. `tests/migrations/test_fresh_mysql_upgrade.py`: 1 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)