### PR TITLE
test: clarify billing test helper APIs

### DIFF
--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -8,7 +7,6 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 from flask import Flask, jsonify, request
-
 
 import flaskr.common.config as common_config
 
@@ -117,12 +115,87 @@ from tests.service.billing.route_loader import (
     load_register_billing_routes,
 )
 
+__all__ = [
+    "ALLOCATION_INTERVAL_PER_CYCLE",
+    "BILLING_CAMPAIGN_BENEFIT_TYPE_DISCOUNT",
+    "BILLING_CAMPAIGN_DISCOUNT_TYPE_FIXED",
+    "BILLING_INTERVAL_DAY",
+    "BILLING_MODE_RECURRING",
+    "BILLING_ORDER_STATUS_CANCELED",
+    "BILLING_ORDER_STATUS_PAID",
+    "BILLING_ORDER_STATUS_PENDING",
+    "BILLING_ORDER_STATUS_REFUNDED",
+    "BILLING_ORDER_STATUS_TIMEOUT",
+    "BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL",
+    "BILLING_ORDER_TYPE_SUBSCRIPTION_START",
+    "BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE",
+    "BILLING_ORDER_TYPE_TOPUP",
+    "BILLING_PRODUCT_STATUS_ACTIVE",
+    "BILLING_PRODUCT_TYPE_PLAN",
+    "BILLING_RENEWAL_EVENT_STATUS_CANCELED",
+    "BILLING_RENEWAL_EVENT_STATUS_PENDING",
+    "BILLING_RENEWAL_EVENT_TYPE_CANCEL_EFFECTIVE",
+    "BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE",
+    "BILLING_RENEWAL_EVENT_TYPE_EXPIRE",
+    "BILLING_RENEWAL_EVENT_TYPE_RENEWAL",
+    "BILLING_RENEWAL_EVENT_TYPE_RETRY",
+    "BILLING_SUBSCRIPTION_STATUS_ACTIVE",
+    "BILLING_SUBSCRIPTION_STATUS_DRAFT",
+    "BILLING_SUBSCRIPTION_STATUS_EXPIRED",
+    "BILLING_SUBSCRIPTION_STATUS_PAST_DUE",
+    "BILLING_TRIAL_PRODUCT_BID",
+    "BillingCampaign",
+    "BillingCampaignProduct",
+    "BillingOrder",
+    "BillingProduct",
+    "BillingRenewalEvent",
+    "BillingSubscription",
+    "CREDIT_BUCKET_CATEGORY_FREE",
+    "CREDIT_BUCKET_CATEGORY_SUBSCRIPTION",
+    "CREDIT_BUCKET_CATEGORY_TOPUP",
+    "CREDIT_BUCKET_STATUS_ACTIVE",
+    "CREDIT_BUCKET_STATUS_EXPIRED",
+    "CREDIT_LEDGER_ENTRY_TYPE_GRANT",
+    "CREDIT_LEDGER_ENTRY_TYPE_REFUND",
+    "CREDIT_SOURCE_TYPE_GIFT",
+    "CREDIT_SOURCE_TYPE_REFUND",
+    "CREDIT_SOURCE_TYPE_SUBSCRIPTION",
+    "CREDIT_SOURCE_TYPE_TOPUP",
+    "CreditLedgerEntry",
+    "CreditWallet",
+    "CreditWalletBucket",
+    "Decimal",
+    "ERROR_CODE",
+    "PingxxOrder",
+    "StripeOrder",
+    "add_active_subscription",
+    "add_trial_subscription_state",
+    "apply_billing_subscription_provider_update",
+    "billing_checkout_module",
+    "billing_subscriptions_module",
+    "billing_write_client",
+    "billing_write_routes_module",
+    "calculate_self_managed_billing_cycle_end",
+    "dao",
+    "datetime",
+    "grant_paid_order_credits",
+    "mark_preorder_effective_applied",
+    "normalize_mysql_datetime",
+    "now_utc",
+    "repair_topup_grant_expiries",
+    "seed_creator_user",
+    "self_managed_cycle_end_after_boundary",
+    "sync_subscription_lifecycle_events",
+    "timedelta",
+    "to_utc_iso",
+]
+
 register_billing_routes = load_register_billing_routes()
 
 billing_write_routes_module = load_billing_routes_module()
 
 
-def _self_managed_cycle_end_after_boundary(
+def self_managed_cycle_end_after_boundary(
     product: BillingProduct,
     boundary_at: datetime,
 ) -> datetime:
@@ -139,7 +212,7 @@ def _reset_config_cache(*keys: str) -> None:
         common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
 
 
-def _add_active_subscription(
+def add_active_subscription(
     app: Flask,
     *,
     creator_bid: str = "creator-1",
@@ -171,7 +244,7 @@ def _add_active_subscription(
         dao.db.session.commit()
 
 
-def _seed_creator_user(app: Flask, *, creator_bid: str = "creator-1") -> None:
+def seed_creator_user(app: Flask, *, creator_bid: str = "creator-1") -> None:
     with app.app_context():
         entity = create_user_entity(
             user_bid=creator_bid,
@@ -185,7 +258,7 @@ def _seed_creator_user(app: Flask, *, creator_bid: str = "creator-1") -> None:
         dao.db.session.commit()
 
 
-def _add_trial_subscription_state(
+def add_trial_subscription_state(
     app: Flask,
     *,
     creator_bid: str = "creator-1",

--- a/src/api/tests/service/billing/cycle_state_test_helpers.py
+++ b/src/api/tests/service/billing/cycle_state_test_helpers.py
@@ -31,8 +31,15 @@ from flaskr.service.billing.models import (
 
 _UNSET = object()
 
+__all__ = [
+    "add_reserved_renewal_activation_state",
+    "build_cycle_state_app",
+    "create_cycle_state_renewal_order",
+    "create_cycle_state_renewal_product",
+]
 
-def _build_app() -> Flask:
+
+def build_cycle_state_app() -> Flask:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -48,7 +55,7 @@ def _build_app() -> Flask:
     return app
 
 
-def _renewal_order(
+def create_cycle_state_renewal_order(
     *,
     bill_order_bid: str = "order-renewal-activation-boundary",
     subscription_bid: str = "subscription-renewal-activation-boundary",
@@ -75,7 +82,7 @@ def _renewal_order(
     )
 
 
-def _renewal_product() -> BillingProduct:
+def create_cycle_state_renewal_product() -> BillingProduct:
     return BillingProduct(
         product_bid="bill-product-renewal-boundary",
         product_code="renewal-boundary",
@@ -94,7 +101,7 @@ def _renewal_product() -> BillingProduct:
     )
 
 
-def _add_reserved_renewal_activation_state(
+def add_reserved_renewal_activation_state(
     *,
     product: BillingProduct,
     subscription: BillingSubscription,

--- a/src/api/tests/service/billing/renewal_execution_test_helpers.py
+++ b/src/api/tests/service/billing/renewal_execution_test_helpers.py
@@ -32,8 +32,18 @@ from flaskr.service.billing.queries import (
 )
 from flaskr.util.datetime import now_utc
 
+__all__ = [
+    "add_paid_renewal_with_reserved_grant",
+    "create_credit_bucket",
+    "create_credit_wallet",
+    "create_renewal_event",
+    "create_renewal_subscription",
+    "self_managed_cycle_end",
+    "self_managed_cycle_end_after_boundary",
+]
 
-def _self_managed_cycle_end(
+
+def self_managed_cycle_end(
     cycle_start_at: datetime,
     *,
     interval: int = BILLING_INTERVAL_MONTH,
@@ -50,7 +60,7 @@ def _self_managed_cycle_end(
     return cycle_end_at
 
 
-def _self_managed_cycle_end_after_boundary(
+def self_managed_cycle_end_after_boundary(
     cycle_boundary_at: datetime,
     *,
     interval: int = BILLING_INTERVAL_MONTH,
@@ -67,7 +77,7 @@ def _self_managed_cycle_end_after_boundary(
     return cycle_end_at
 
 
-def _create_subscription(
+def create_renewal_subscription(
     subscription_bid: str,
     *,
     creator_bid: str = "creator-renewal-1",
@@ -99,7 +109,7 @@ def _create_subscription(
     )
 
 
-def _create_renewal_event(
+def create_renewal_event(
     renewal_event_bid: str,
     subscription_bid: str,
     creator_bid: str,
@@ -122,7 +132,7 @@ def _create_renewal_event(
     )
 
 
-def _create_wallet(
+def create_credit_wallet(
     creator_bid: str,
     *,
     available_credits: str,
@@ -143,7 +153,7 @@ def _create_wallet(
     )
 
 
-def _create_bucket(
+def create_credit_bucket(
     wallet_bid: str,
     creator_bid: str,
     bucket_bid: str,
@@ -188,7 +198,7 @@ def _create_bucket(
     )
 
 
-def _add_paid_renewal_with_reserved_grant(
+def add_paid_renewal_with_reserved_grant(
     *,
     suffix: str,
     current_cycle_start: datetime,
@@ -240,14 +250,14 @@ def _add_paid_renewal_with_reserved_grant(
             "renewal_cycle_end_at": next_cycle_end.isoformat(),
         },
     )
-    event = _create_renewal_event(
+    event = create_renewal_event(
         event_bid,
         subscription.subscription_bid,
         subscription.creator_bid,
         event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
         scheduled_at=scheduled_at,
     )
-    wallet = _create_wallet(
+    wallet = create_credit_wallet(
         subscription.creator_bid,
         available_credits="3.0000000000",
         lifetime_granted_credits="8.0000000000",

--- a/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
@@ -24,13 +24,13 @@ from flaskr.service.billing.models import (
     CreditLedgerEntry,
     CreditWalletBucket,
 )
-from tests.service.billing.cycle_state_test_helpers import _build_app
+from tests.service.billing.cycle_state_test_helpers import build_cycle_state_app
 
 
 def test_realign_active_topup_bucket_effective_to_updates_bucket_and_grant_ledgers() -> (
     None
 ):
-    app = _build_app()
+    app = build_cycle_state_app()
     creator_bid = "creator-cycle-state-topup"
     cycle_start = datetime(2026, 4, 10, 0, 0, 0)
     cycle_end = datetime(2026, 5, 10, 0, 0, 0)
@@ -145,7 +145,7 @@ def test_realign_active_topup_bucket_effective_to_updates_bucket_and_grant_ledge
 def test_apply_paid_subscription_cycle_state_advances_renewal_and_realigns_topup() -> (
     None
 ):
-    app = _build_app()
+    app = build_cycle_state_app()
     creator_bid = "creator-cycle-state-renewal"
     cycle_start = datetime(2026, 6, 1, 0, 0, 0)
     cycle_end = datetime(2026, 7, 1, 0, 0, 0)

--- a/src/api/tests/service/billing/test_billing_cycle_state_repair.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_repair.py
@@ -22,7 +22,7 @@ from flaskr.service.billing.models import (
     CreditLedgerEntry,
     CreditWalletBucket,
 )
-from tests.service.billing.cycle_state_test_helpers import _build_app
+from tests.service.billing.cycle_state_test_helpers import build_cycle_state_app
 
 
 @pytest.mark.parametrize(
@@ -140,7 +140,7 @@ def test_repair_paid_reserved_grant_handles_cycle_window_boundaries(
     expected_bucket_start: datetime,
     expected_bucket_end: datetime,
 ) -> None:
-    app = _build_app()
+    app = build_cycle_state_app()
     repair_at = datetime(2026, 4, 10, 0, 0, 0)
     creator_bid = "creator-invalid-cycle-caller"
     subscription_bid = "subscription-invalid-cycle-caller"

--- a/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
+++ b/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
@@ -21,17 +21,17 @@ from flaskr.service.billing.models import (
     CreditWalletBucket,
 )
 from tests.service.billing.cycle_state_test_helpers import (
-    _add_reserved_renewal_activation_state,
-    _build_app,
-    _renewal_order,
-    _renewal_product,
+    add_reserved_renewal_activation_state,
+    build_cycle_state_app,
+    create_cycle_state_renewal_order,
+    create_cycle_state_renewal_product,
 )
 
 
 def test_pingxx_renewal_activation_defers_before_cycle_start() -> None:
     paid_at = datetime(2026, 4, 10, 0, 0, 0)
     renewal_cycle_start = datetime(2026, 5, 1, 0, 0, 0)
-    order = _renewal_order(
+    order = create_cycle_state_renewal_order(
         paid_at=paid_at,
         metadata_json={"renewal_cycle_start_at": renewal_cycle_start.isoformat()},
     )
@@ -72,7 +72,7 @@ def test_pingxx_renewal_activation_defers_before_cycle_start() -> None:
 def test_pingxx_renewal_activation_does_not_defer_when_guard_fails(
     order_kwargs: dict,
 ) -> None:
-    order = _renewal_order(**order_kwargs)
+    order = create_cycle_state_renewal_order(**order_kwargs)
 
     assert subscriptions_mod._should_defer_pingxx_renewal_activation(order) is False
 
@@ -109,7 +109,7 @@ def test_subscription_renewal_activation_defers_future_boundary(
     current_at = datetime(2026, 4, 10, 0, 0, 0)
     effective_from = datetime(2026, 5, 1, 0, 0, 0)
     monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
-    order = _renewal_order(
+    order = create_cycle_state_renewal_order(
         paid_at=current_at,
         payment_provider=payment_provider,
         metadata_json=metadata_json,
@@ -152,7 +152,7 @@ def test_subscription_renewal_activation_does_not_defer_when_guard_fails(
 ) -> None:
     current_at = datetime(2026, 4, 10, 0, 0, 0)
     monkeypatch.setattr(subscriptions_mod, "now_utc", lambda: current_at)
-    order = _renewal_order(
+    order = create_cycle_state_renewal_order(
         payment_provider="manual",
         metadata_json=metadata_json,
     )
@@ -169,7 +169,7 @@ def test_subscription_renewal_activation_does_not_defer_when_guard_fails(
 def test_force_activation_advances_future_deferred_renewal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app = _build_app()
+    app = build_cycle_state_app()
     current_at = datetime(2026, 4, 10, 0, 0, 0)
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
@@ -178,7 +178,7 @@ def test_force_activation_advances_future_deferred_renewal(
 
     with app.app_context():
         dao.db.create_all()
-        product = _renewal_product()
+        product = create_cycle_state_renewal_product()
         subscription = BillingSubscription(
             subscription_bid="subscription-renewal-activation-boundary",
             creator_bid="creator-renewal-activation-boundary",
@@ -203,12 +203,12 @@ def test_force_activation_advances_future_deferred_renewal(
             "renewal_cycle_start_at": current_cycle_end.isoformat(),
             "renewal_cycle_end_at": next_cycle_end.isoformat(),
         }
-        deferred_order = _renewal_order(
+        deferred_order = create_cycle_state_renewal_order(
             bill_order_bid="order-renewal-activation-defer",
             payment_provider="manual",
             metadata_json=order_metadata.copy(),
         )
-        forced_order = _renewal_order(
+        forced_order = create_cycle_state_renewal_order(
             bill_order_bid="order-renewal-activation-force",
             subscription_bid=forced_subscription.subscription_bid,
             payment_provider="manual",
@@ -242,7 +242,7 @@ def test_force_activation_advances_future_deferred_renewal(
 def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app = _build_app()
+    app = build_cycle_state_app()
     current_at = datetime(2026, 4, 10, 0, 0, 0)
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
@@ -251,7 +251,7 @@ def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
 
     with app.app_context():
         dao.db.create_all()
-        product = _renewal_product()
+        product = create_cycle_state_renewal_product()
         subscription = BillingSubscription(
             subscription_bid="subscription-renewal-activation-boundary",
             creator_bid="creator-renewal-activation-boundary",
@@ -261,7 +261,7 @@ def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
             current_period_start_at=current_cycle_start,
             current_period_end_at=current_cycle_end,
         )
-        order = _renewal_order(
+        order = create_cycle_state_renewal_order(
             paid_at=current_cycle_end,
             metadata_json={
                 "renewal_cycle_start_at": current_cycle_end.isoformat(),
@@ -286,7 +286,7 @@ def test_pingxx_renewal_activation_applies_at_exact_cycle_start(
 def test_force_activation_does_not_bypass_preorder_state_guard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app = _build_app()
+    app = build_cycle_state_app()
     current_at = datetime(2026, 5, 1, 0, 0, 0)
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
@@ -295,7 +295,7 @@ def test_force_activation_does_not_bypass_preorder_state_guard(
 
     with app.app_context():
         dao.db.create_all()
-        product = _renewal_product()
+        product = create_cycle_state_renewal_product()
         subscription = BillingSubscription(
             subscription_bid="subscription-renewal-activation-boundary",
             creator_bid="creator-renewal-activation-boundary",
@@ -305,7 +305,7 @@ def test_force_activation_does_not_bypass_preorder_state_guard(
             current_period_start_at=current_cycle_start,
             current_period_end_at=current_cycle_end,
         )
-        order = _renewal_order(
+        order = create_cycle_state_renewal_order(
             metadata_json={
                 "checkout_type": "subscription_preorder",
                 "preorder_state": "effective_applied",
@@ -313,7 +313,7 @@ def test_force_activation_does_not_bypass_preorder_state_guard(
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        wallet, bucket, grant_entry = _add_reserved_renewal_activation_state(
+        wallet, bucket, grant_entry = add_reserved_renewal_activation_state(
             product=product,
             subscription=subscription,
             order=order,
@@ -353,7 +353,7 @@ def test_force_activation_does_not_bypass_preorder_state_guard(
 def test_force_activation_is_idempotent_for_reserved_renewal_grant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    app = _build_app()
+    app = build_cycle_state_app()
     current_cycle_start = datetime(2026, 4, 1, 0, 0, 0)
     current_cycle_end = datetime(2026, 5, 1, 0, 0, 0)
     next_cycle_end = datetime(2026, 6, 1, 0, 0, 0)
@@ -361,7 +361,7 @@ def test_force_activation_is_idempotent_for_reserved_renewal_grant(
 
     with app.app_context():
         dao.db.create_all()
-        product = _renewal_product()
+        product = create_cycle_state_renewal_product()
         subscription = BillingSubscription(
             subscription_bid="subscription-renewal-activation-boundary",
             creator_bid="creator-renewal-activation-boundary",
@@ -371,14 +371,14 @@ def test_force_activation_is_idempotent_for_reserved_renewal_grant(
             current_period_start_at=current_cycle_start,
             current_period_end_at=current_cycle_end,
         )
-        order = _renewal_order(
+        order = create_cycle_state_renewal_order(
             bill_order_bid="order-renewal-activation-idempotent",
             metadata_json={
                 "renewal_cycle_start_at": current_cycle_end.isoformat(),
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        _add_reserved_renewal_activation_state(
+        add_reserved_renewal_activation_state(
             product=product,
             subscription=subscription,
             order=order,

--- a/src/api/tests/service/billing/test_billing_renewal_event_basics.py
+++ b/src/api/tests/service/billing/test_billing_renewal_event_basics.py
@@ -45,10 +45,10 @@ from flaskr.util.datetime import now_utc
 
 
 from tests.service.billing.renewal_execution_test_helpers import (
-    _create_bucket,
-    _create_renewal_event,
-    _create_subscription,
-    _create_wallet,
+    create_credit_bucket,
+    create_renewal_event,
+    create_renewal_subscription,
+    create_credit_wallet,
 )
 
 
@@ -59,8 +59,8 @@ def test_claim_billing_renewal_event_persists_processing_state(
     billing_renewal_app: Flask,
 ) -> None:
     with billing_renewal_app.app_context():
-        subscription = _create_subscription("sub-claim-1")
-        event = _create_renewal_event(
+        subscription = create_renewal_subscription("sub-claim-1")
+        event = create_renewal_event(
             "renewal-claim-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -91,9 +91,9 @@ def test_run_billing_renewal_event_applies_cancel_effective(
     billing_renewal_app: Flask,
 ) -> None:
     with billing_renewal_app.app_context():
-        subscription = _create_subscription("sub-cancel-1")
+        subscription = create_renewal_subscription("sub-cancel-1")
         subscription.cancel_at_period_end = 1
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-cancel-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -129,15 +129,15 @@ def test_run_billing_renewal_event_applies_expire(
 ) -> None:
     period_end_at = now_utc() - timedelta(minutes=1)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-expire-1",
             current_period_end_at=period_end_at,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="7.5000000000",
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-expire-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -148,7 +148,7 @@ def test_run_billing_renewal_event_applies_expire(
         dao.db.session.add(wallet)
         dao.db.session.add_all(
             [
-                _create_bucket(
+                create_credit_bucket(
                     wallet.wallet_bid,
                     subscription.creator_bid,
                     "bucket-expire-subscription-1",
@@ -160,7 +160,7 @@ def test_run_billing_renewal_event_applies_expire(
                     effective_to=period_end_at,
                     created_at=period_end_at - timedelta(days=30),
                 ),
-                _create_bucket(
+                create_credit_bucket(
                     wallet.wallet_bid,
                     subscription.creator_bid,
                     "bucket-expire-topup-1",
@@ -242,15 +242,15 @@ def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replaye
 ) -> None:
     period_end_at = now_utc() - timedelta(minutes=1)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-expire-replay-1",
             current_period_end_at=period_end_at,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="3.0000000000",
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-expire-replay-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -260,7 +260,7 @@ def test_run_billing_renewal_event_does_not_duplicate_expire_ledger_when_replaye
         dao.db.session.add(subscription)
         dao.db.session.add(wallet)
         dao.db.session.add(
-            _create_bucket(
+            create_credit_bucket(
                 wallet.wallet_bid,
                 subscription.creator_bid,
                 "bucket-expire-replay-1",
@@ -302,14 +302,14 @@ def test_manual_trial_subscription_schedules_and_applies_expire(
 ) -> None:
     period_end_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-trial-expire-1",
             product_bid=BILLING_TRIAL_PRODUCT_BID,
             billing_provider="manual",
             provider_subscription_id="",
             current_period_end_at=period_end_at,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="100.0000000000",
         )
@@ -317,7 +317,7 @@ def test_manual_trial_subscription_schedules_and_applies_expire(
         dao.db.session.add(wallet)
         dao.db.session.flush()
         dao.db.session.add(
-            _create_bucket(
+            create_credit_bucket(
                 wallet.wallet_bid,
                 subscription.creator_bid,
                 "bucket-trial-expire-1",
@@ -382,14 +382,14 @@ def test_trial_expire_event_sync_reuses_second_precision_scheduled_at(
         period_end_at.replace(microsecond=499999)
     ) == period_end_at.replace(microsecond=0)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-trial-expire-precision",
             product_bid=BILLING_TRIAL_PRODUCT_BID,
             billing_provider="manual",
             provider_subscription_id="",
             current_period_end_at=period_end_at,
         )
-        stale_event = _create_renewal_event(
+        stale_event = create_renewal_event(
             "renewal-trial-expire-precision",
             subscription.subscription_bid,
             subscription.creator_bid,

--- a/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
@@ -37,10 +37,10 @@ from flaskr.util.datetime import now_utc, to_utc_iso
 
 
 from tests.service.billing.renewal_execution_test_helpers import (
-    _create_bucket,
-    _create_renewal_event,
-    _create_wallet,
-    _self_managed_cycle_end_after_boundary,
+    create_credit_bucket,
+    create_renewal_event,
+    create_credit_wallet,
+    self_managed_cycle_end_after_boundary,
 )
 
 
@@ -52,7 +52,7 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=30)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -91,14 +91,14 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-expire-paid-1",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="6.0000000000",
         )
@@ -106,7 +106,7 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
         dao.db.session.add(order)
         dao.db.session.add(wallet)
         dao.db.session.add(
-            _create_bucket(
+            create_credit_bucket(
                 wallet.wallet_bid,
                 subscription.creator_bid,
                 "bucket-pingxx-expire-paid-1",
@@ -120,7 +120,7 @@ def test_expire_event_activates_paid_pingxx_renewal_instead_of_expiring(
             )
         )
         dao.db.session.add(
-            _create_bucket(
+            create_credit_bucket(
                 wallet.wallet_bid,
                 subscription.creator_bid,
                 "bucket-pingxx-expire-paid-bonus-1",
@@ -226,7 +226,7 @@ def test_expire_event_releases_reserved_subscription_renewal_on_same_bucket(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=30)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -265,14 +265,14 @@ def test_expire_event_releases_reserved_subscription_renewal_on_same_bucket(
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-expire-reserved-1",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="3.0000000000",
             lifetime_granted_credits="8.0000000000",
@@ -390,7 +390,7 @@ def test_expire_event_allows_shared_bucket_after_activated_grant_was_consumed(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=30)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -449,14 +449,14 @@ def test_expire_event_allows_shared_bucket_after_activated_grant_was_consumed(
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-shared-bucket-consumed",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="2.0000000000",
             lifetime_granted_credits="10.0000000000",
@@ -582,7 +582,7 @@ def test_expire_event_fails_when_reserved_renewal_activation_is_incomplete(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=30)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -621,14 +621,14 @@ def test_expire_event_fails_when_reserved_renewal_activation_is_incomplete(
                 "renewal_cycle_end_at": to_utc_iso(next_cycle_end),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-expire-reserved-fail-1",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_EXPIRE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="3.0000000000",
             lifetime_granted_credits="8.0000000000",

--- a/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
@@ -41,10 +41,10 @@ from flaskr.util.datetime import now_utc
 
 
 from tests.service.billing.renewal_execution_test_helpers import (
-    _create_renewal_event,
-    _create_subscription,
-    _create_wallet,
-    _self_managed_cycle_end_after_boundary,
+    create_renewal_event,
+    create_renewal_subscription,
+    create_credit_wallet,
+    self_managed_cycle_end_after_boundary,
 )
 
 
@@ -56,13 +56,13 @@ def test_run_billing_renewal_event_applies_downgrade_and_reschedules_renewal(
 ) -> None:
     next_period_end = now_utc() + timedelta(days=30)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-downgrade-1",
             product_bid="bill-product-plan-yearly",
             next_product_bid="bill-product-plan-monthly",
             current_period_end_at=next_period_end,
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-downgrade-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -102,10 +102,10 @@ def test_run_billing_downgrade_event_applies_paid_preorder_with_referral_reward(
     current_cycle_start = now_utc() - timedelta(days=35)
     preorder_snapshot_cycle_end = now_utc() - timedelta(days=5)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    preorder_snapshot_next_cycle_end = _self_managed_cycle_end_after_boundary(
+    preorder_snapshot_next_cycle_end = self_managed_cycle_end_after_boundary(
         preorder_snapshot_cycle_end
     )
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -170,14 +170,14 @@ def test_run_billing_downgrade_event_applies_paid_preorder_with_referral_reward(
             created_at=current_cycle_end - timedelta(days=4),
             updated_at=current_cycle_end - timedelta(days=4),
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-preorder-downgrade-1",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="3.0000000000",
             lifetime_granted_credits="105.0000000000",
@@ -376,7 +376,7 @@ def test_run_billing_same_plan_preorder_starts_new_cycle_at_boundary(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=35)
     current_cycle_end = now_utc() - timedelta(minutes=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(
@@ -420,14 +420,14 @@ def test_run_billing_same_plan_preorder_starts_new_cycle_at_boundary(
                 "renewal_cycle_end_at": next_cycle_end.isoformat(),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-preorder-same-plan-1",
             subscription.subscription_bid,
             subscription.creator_bid,
             event_type=BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
             scheduled_at=current_cycle_end,
         )
-        wallet = _create_wallet(
+        wallet = create_credit_wallet(
             subscription.creator_bid,
             available_credits="3.0000000000",
             lifetime_granted_credits="10.0000000000",
@@ -533,7 +533,7 @@ def test_ensure_subscription_renewal_order_preserves_preorder_metadata(
 ) -> None:
     current_cycle_start = now_utc() - timedelta(days=30)
     current_cycle_end = now_utc() + timedelta(days=1)
-    next_cycle_end = _self_managed_cycle_end_after_boundary(current_cycle_end)
+    next_cycle_end = self_managed_cycle_end_after_boundary(current_cycle_end)
 
     with billing_renewal_app.app_context():
         subscription = BillingSubscription(

--- a/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
@@ -24,8 +24,8 @@ from flaskr.util.datetime import now_utc
 
 
 from tests.service.billing.renewal_execution_test_helpers import (
-    _create_renewal_event,
-    _create_subscription,
+    create_renewal_event,
+    create_renewal_subscription,
 )
 
 
@@ -48,7 +48,7 @@ def test_run_billing_renewal_event_retries_latest_failed_renewal_order(
     cycle_start = now_utc()
     cycle_end = cycle_start + timedelta(days=30)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-retry-1",
             current_period_end_at=cycle_start,
         )
@@ -72,7 +72,7 @@ def test_run_billing_renewal_event_retries_latest_failed_renewal_order(
                 "renewal_cycle_end_at": cycle_end.isoformat(),
             },
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-retry-1",
             subscription.subscription_bid,
             subscription.creator_bid,

--- a/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
@@ -36,10 +36,10 @@ from flaskr.util.datetime import now_utc
 
 
 from tests.service.billing.renewal_execution_test_helpers import (
-    _add_paid_renewal_with_reserved_grant,
-    _create_renewal_event,
-    _create_subscription,
-    _self_managed_cycle_end_after_boundary,
+    add_paid_renewal_with_reserved_grant,
+    create_renewal_event,
+    create_renewal_subscription,
+    self_managed_cycle_end_after_boundary,
 )
 
 
@@ -50,8 +50,8 @@ def test_run_billing_renewal_event_releases_future_event_back_to_pending(
     billing_renewal_app: Flask,
 ) -> None:
     with billing_renewal_app.app_context():
-        subscription = _create_subscription("sub-future-1")
-        event = _create_renewal_event(
+        subscription = create_renewal_subscription("sub-future-1")
+        event = create_renewal_event(
             "renewal-future-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -92,7 +92,7 @@ def test_run_billing_renewal_event_does_not_advance_future_paid_renewal(
 
     with billing_renewal_app.app_context():
         subscription_bid, order_bid, event_bid, bucket_bid, ledger_bid = (
-            _add_paid_renewal_with_reserved_grant(
+            add_paid_renewal_with_reserved_grant(
                 suffix="future",
                 current_cycle_start=current_cycle_start,
                 current_cycle_end=current_cycle_end,
@@ -142,7 +142,7 @@ def test_run_billing_renewal_event_executes_at_exact_scheduled_time(
 
     with billing_renewal_app.app_context():
         subscription_bid, order_bid, event_bid, bucket_bid, ledger_bid = (
-            _add_paid_renewal_with_reserved_grant(
+            add_paid_renewal_with_reserved_grant(
                 suffix="equal",
                 current_cycle_start=current_cycle_start,
                 current_cycle_end=current_cycle_end,
@@ -198,10 +198,10 @@ def test_run_billing_renewal_event_queues_subscription_renewal_order(
     )
 
     with billing_renewal_app.app_context():
-        subscription = _create_subscription("sub-unsupported-1")
+        subscription = create_renewal_subscription("sub-unsupported-1")
         subscription.provider_subscription_id = "sub_provider_unsupported_1"
         subscription_bid = subscription.subscription_bid
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-unsupported-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -238,13 +238,13 @@ def test_run_billing_renewal_event_queues_pingxx_order_without_provider_sync(
 ) -> None:
     cycle_end = now_utc() - timedelta(hours=1)
     with billing_renewal_app.app_context():
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-pingxx-renewal-1",
             current_period_end_at=cycle_end,
             billing_provider="pingxx",
             provider_subscription_id="",
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-pingxx-1",
             subscription.subscription_bid,
             subscription.creator_bid,
@@ -277,7 +277,7 @@ def test_run_billing_renewal_event_writes_daily_cycle_metadata(
     billing_renewal_app: Flask,
 ) -> None:
     cycle_end = now_utc() - timedelta(hours=1)
-    expected_cycle_end = _self_managed_cycle_end_after_boundary(
+    expected_cycle_end = self_managed_cycle_end_after_boundary(
         cycle_end,
         interval=BILLING_INTERVAL_DAY,
         interval_count=7,
@@ -309,14 +309,14 @@ def test_run_billing_renewal_event_writes_daily_cycle_metadata(
                 sort_order=15,
             )
         )
-        subscription = _create_subscription(
+        subscription = create_renewal_subscription(
             "sub-daily-renewal-1",
             product_bid="bill-product-plan-daily",
             current_period_end_at=cycle_end,
             billing_provider="pingxx",
             provider_subscription_id="",
         )
-        event = _create_renewal_event(
+        event = create_renewal_event(
             "renewal-daily-1",
             subscription.subscription_bid,
             subscription.creator_bid,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
@@ -45,7 +45,7 @@ from flaskr.service.billing.wallets import (
 from flaskr.util.datetime import to_utc_iso
 
 from tests.service.billing.wallet_lifecycle_test_helpers import (
-    _create_monthly_plan_product,
+    create_monthly_plan_product,
 )
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
@@ -298,7 +298,7 @@ def test_repair_renewal_state_drift_dry_run_reports_overdue_reserved_paid_grant(
             current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
             current_period_end_at=boundary_at,
         )
-        product = _create_monthly_plan_product(subscription.product_bid)
+        product = create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=wallet.creator_bid,
@@ -685,7 +685,7 @@ def test_repair_renewal_state_drift_all_scope_includes_reserved_only_creator(
             current_period_start_at=datetime(2026, 4, 1, 0, 0, 0),
             current_period_end_at=datetime(2026, 5, 1, 0, 0, 0),
         )
-        product = _create_monthly_plan_product(subscription.product_bid)
+        product = create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=creator_bid,
@@ -788,7 +788,7 @@ def test_repair_renewal_state_drift_counts_only_successful_activations(
             current_period_start_at=datetime(2026, 3, 8, 0, 0, 0),
             current_period_end_at=boundary_at,
         )
-        product = _create_monthly_plan_product(subscription.product_bid)
+        product = create_monthly_plan_product(subscription.product_bid)
         order = BillingOrder(
             bill_order_bid=order_bid,
             creator_bid=creator_bid,
@@ -991,7 +991,7 @@ def test_repair_renewal_state_drift_blocks_cycle_when_subscription_grant_missing
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(product_bid),
+                create_monthly_plan_product(product_bid),
                 first_order,
                 missing_order,
                 bucket,
@@ -1100,7 +1100,7 @@ def test_repair_renewal_state_drift_blocks_unknown_subscription_grant_state(
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1225,7 +1225,7 @@ def test_repair_renewal_state_drift_blocks_short_subscription_grant_amount(
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1350,7 +1350,7 @@ def test_repair_renewal_state_drift_ignores_legacy_missing_state_without_reserve
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1459,7 +1459,7 @@ def test_repair_renewal_state_drift_keeps_missing_state_with_matching_reserved_b
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1568,7 +1568,7 @@ def test_repair_renewal_state_drift_keeps_missing_state_from_seeded_creator_scan
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1719,7 +1719,7 @@ def test_repair_renewal_state_drift_ignores_shared_bucket_legacy_missing_state(
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 old_order,
                 current_order,
                 bucket,
@@ -1829,7 +1829,7 @@ def test_repair_renewal_state_drift_all_scope_falls_back_to_source_bid(
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,
@@ -1938,7 +1938,7 @@ def test_repair_renewal_state_drift_blocks_when_campaign_bonus_grant_missing(
             [
                 wallet,
                 subscription,
-                _create_monthly_plan_product(subscription.product_bid),
+                create_monthly_plan_product(subscription.product_bid),
                 order,
                 bucket,
                 ledger,

--- a/src/api/tests/service/billing/test_billing_write_routes_preorder.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_preorder.py
@@ -27,7 +27,7 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     CreditWalletBucket,
     Decimal,
     ERROR_CODE,
-    _self_managed_cycle_end_after_boundary,
+    self_managed_cycle_end_after_boundary,
     billing_checkout_module,
     billing_subscriptions_module,
     calculate_self_managed_billing_cycle_end,
@@ -552,7 +552,7 @@ class TestBillingWriteRoutesPreorder:
             assert wallet.reserved_credits == Decimal("5.0000000000")
             assert grant_ledger.metadata_json["bucket_credit_state"] == "reserved"
             assert grant_ledger.consumable_from == current_period_end
-            assert grant_ledger.expires_at == _self_managed_cycle_end_after_boundary(
+            assert grant_ledger.expires_at == self_managed_cycle_end_after_boundary(
                 product,
                 current_period_end,
             )
@@ -826,7 +826,7 @@ class TestBillingWriteRoutesPreorder:
                 subscription_bid="sub-preorder-same-plan-sync",
                 event_type=BILLING_RENEWAL_EVENT_TYPE_DOWNGRADE_EFFECTIVE,
             ).first()
-            expected_cycle_end = _self_managed_cycle_end_after_boundary(
+            expected_cycle_end = self_managed_cycle_end_after_boundary(
                 product,
                 current_period_end,
             )

--- a/src/api/tests/service/billing/test_billing_write_routes_refund_auth.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_refund_auth.py
@@ -18,7 +18,7 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     CreditWallet,
     CreditWalletBucket,
     StripeOrder,
-    _add_active_subscription,
+    add_active_subscription,
 )
 
 
@@ -33,7 +33,7 @@ class TestBillingWriteRoutesRefundAuth:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-refund-stripe-1")
+        add_active_subscription(app, subscription_bid="sub-topup-refund-stripe-1")
 
         checkout = client.post(
             "/api/billing/topups/checkout",
@@ -108,7 +108,7 @@ class TestBillingWriteRoutesRefundAuth:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-refund-pingxx-1")
+        add_active_subscription(app, subscription_bid="sub-topup-refund-pingxx-1")
 
         checkout = client.post(
             "/api/billing/topups/checkout",

--- a/src/api/tests/service/billing/test_billing_write_routes_topup.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_topup.py
@@ -26,9 +26,9 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     Decimal,
     PingxxOrder,
     StripeOrder,
-    _add_active_subscription,
-    _add_trial_subscription_state,
-    _seed_creator_user,
+    add_active_subscription,
+    add_trial_subscription_state,
+    seed_creator_user,
     dao,
     now_utc,
     repair_topup_grant_expiries,
@@ -47,7 +47,7 @@ class TestBillingWriteRoutesTopup:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-paid-1")
+        add_active_subscription(app, subscription_bid="sub-topup-paid-1")
 
         checkout = client.post(
             "/api/billing/topups/checkout",
@@ -113,7 +113,7 @@ class TestBillingWriteRoutesTopup:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-stripe-1")
+        add_active_subscription(app, subscription_bid="sub-topup-stripe-1")
 
         checkout = client.post(
             "/api/billing/topups/checkout",
@@ -140,7 +140,7 @@ class TestBillingWriteRoutesTopup:
         now = now_utc()
         current_period_start_at = now - timedelta(days=3)
         current_period_end_at = now + timedelta(days=27)
-        _add_active_subscription(
+        add_active_subscription(
             app,
             subscription_bid="sub-topup-active-1",
             current_period_start_at=current_period_start_at,
@@ -181,7 +181,7 @@ class TestBillingWriteRoutesTopup:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
         current_period_end_at = now_utc() + timedelta(days=30)
-        _add_active_subscription(
+        add_active_subscription(
             app,
             subscription_bid="sub-topup-repeat-1",
             current_period_end_at=current_period_end_at,
@@ -249,8 +249,8 @@ class TestBillingWriteRoutesTopup:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
 
-        _seed_creator_user(app, creator_bid="creator-1")
-        _add_trial_subscription_state(
+        seed_creator_user(app, creator_bid="creator-1")
+        add_trial_subscription_state(
             app,
             subscription_bid="sub-trial-paid-then-topup",
             bill_order_bid="bill-trial-paid-then-topup",
@@ -344,8 +344,8 @@ class TestBillingWriteRoutesTopup:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
 
-        _seed_creator_user(app, creator_bid="creator-1")
-        _add_trial_subscription_state(
+        seed_creator_user(app, creator_bid="creator-1")
+        add_trial_subscription_state(
             app,
             subscription_bid="sub-trial-topup-then-paid",
             bill_order_bid="bill-trial-topup-then-paid",
@@ -590,7 +590,7 @@ class TestBillingWriteRoutesTopup:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-default-provider-1")
+        add_active_subscription(app, subscription_bid="sub-topup-default-provider-1")
 
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
@@ -622,7 +622,7 @@ class TestBillingWriteRoutesTopup:
     ) -> None:
         client = billing_write_client["client"]
         app = billing_write_client["app"]
-        _add_active_subscription(app, subscription_bid="sub-topup-rebuild-1")
+        add_active_subscription(app, subscription_bid="sub-topup-rebuild-1")
 
         with app.app_context():
             existing_free_credit_created_at = now_utc()

--- a/src/api/tests/service/billing/wallet_lifecycle_test_helpers.py
+++ b/src/api/tests/service/billing/wallet_lifecycle_test_helpers.py
@@ -4,8 +4,10 @@ from decimal import Decimal
 
 from flaskr.service.billing.models import BillingProduct
 
+__all__ = ["create_monthly_plan_product"]
 
-def _create_monthly_plan_product(
+
+def create_monthly_plan_product(
     product_bid: str,
     *,
     credit_amount: Decimal = Decimal("1000.0000000000"),


### PR DESCRIPTION
## Summary

- Rename shared billing test helpers from private-style names to public helper APIs.
- Make helper exports explicit with `__all__` and remove the write-route helper F401 suppression.
- Keep the change test-only with no production behavior changes.
- Verified targeted billing test groups, the full billing suite, ruff, diff checks, dev-tool checks, and lefthook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized billing test helper names and made shared helpers explicitly available for reuse.
  * Updated billing test scenarios to use the shared helper names without changing test coverage, behavior, or assertions.
* **Tests**
  * Improved consistency across billing cycle-state, renewal, wallet lifecycle, and write-route test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->