### PR TITLE
test: isolate i18n loader tests from thread-local language state

### DIFF
--- a/src/api/tests/common/test_i18n_loader.py
+++ b/src/api/tests/common/test_i18n_loader.py
@@ -1,9 +1,15 @@
-import os
 from pathlib import Path
 
+import pytest
 from flask import Flask
 
-from flaskr.i18n import _translations, load_translations, set_language, _ as t
+from flaskr.i18n import (
+    _translations,
+    clear_language,
+    load_translations,
+    set_language,
+    _ as t,
+)
 
 
 def _shared_i18n_root() -> Path:
@@ -11,8 +17,17 @@ def _shared_i18n_root() -> Path:
     return Path(__file__).resolve().parents[3] / "i18n"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_i18n_state(monkeypatch):
+    # SHARED_I18N_ROOT is restored by monkeypatch; the thread-local language
+    # set via set_language() must be cleared so later tests (e.g. ask provider
+    # adapters asserting en-US messages) are not affected by test order.
+    monkeypatch.setenv("SHARED_I18N_ROOT", str(_shared_i18n_root()))
+    yield
+    clear_language()
+
+
 def test_load_and_translate_basic():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     # Load translations from shared JSON
@@ -28,7 +43,6 @@ def test_load_and_translate_basic():
 
 
 def test_french_language_loads_shared_translations():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -39,7 +53,6 @@ def test_french_language_loads_shared_translations():
 
 
 def test_language_fallback_to_default():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -50,7 +63,6 @@ def test_language_fallback_to_default():
 
 
 def test_existing_language_missing_key_falls_back_to_default():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -68,7 +80,6 @@ def test_existing_language_missing_key_falls_back_to_default():
 
 
 def test_flat_section_namespace_loading():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)


### PR DESCRIPTION
## Summary

Running `tests/common/` before `tests/service/learn/test_ask_provider_adapters.py` made two adapter tests fail:

- `test_get_biji_knowledge_adapter_api_error_includes_message_and_reason`
- `test_get_biji_knowledge_adapter_maps_business_errors_to_user_messages`

Both assert en-US `user_message` content, but they received French text.

## Root cause

`tests/common/test_i18n_loader.py` calls `set_language(...)` (zh-CN / fr-FR) and never resets the module-level thread-local language in `flaskr.i18n`. The last test in the file leaves the language at `fr-FR`, so any later test that relies on the default `en-US` translation sees French messages. (The one test setting `de-DE` did not trigger the failure because unsupported languages fall back to en-US — consistent with the bisection results.)

The tests also assigned `os.environ["SHARED_I18N_ROOT"]` directly without restoring it; harmless today (it resolves to the same path as the default candidate list) but not hygienic.

## Fix

Added an autouse fixture in `test_i18n_loader.py` that:

- sets `SHARED_I18N_ROOT` via `monkeypatch.setenv` (auto-restored), replacing the per-test `os.environ` assignments
- calls `clear_language()` after each test, matching the existing cleanup pattern used in `tests/service/tts/test_tts_config_options.py`

## Verification

All three orderings pass with conda env `ai-shifu` (Python 3.12):

```
pytest tests/common/ tests/service/learn/test_ask_provider_adapters.py  # 209 passed (was 2 failed)
pytest tests/service/learn/test_ask_provider_adapters.py tests/common/test_i18n_loader.py  # 36 passed
pytest tests/common/test_i18n_loader.py  # 5 passed
```

`lefthook run pre-commit --all-files`: all backend checks green (ruff, harness, boundaries). The eslint warnings it reports are pre-existing on main in untouched frontend files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved translation test isolation by automatically configuring the shared internationalization environment.
  * Ensured language state is reset after each test, reducing cross-test interference.
  * Simplified repeated test setup while preserving existing translation assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->