### PR TITLE
fix: capture protocol forensics when listen select hits desync

### DIFF
--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -89,7 +89,14 @@ def _describe_desynced_connection(result, connection) -> str:
             readable, _, _ = select_module.select([sock], [], [], 0)
             if readable:
                 pending = sock.recv(64, socket_module.MSG_PEEK)
-                parts.append(f"socket_pending_hex={pending.hex()}")
+                # Log only the MySQL packet header (3-byte length, 1-byte
+                # sequence) plus the first payload byte that identifies the
+                # packet type (0x00 OK / 0xff ERR / 0xfe EOF / other =
+                # column-count or row data). That is enough to classify the
+                # stale response without serializing row payloads - which
+                # could contain learner content - into the log.
+                parts.append(f"socket_pending_len>={len(pending)}")
+                parts.append(f"socket_pending_header_hex={pending[:5].hex()}")
             else:
                 parts.append("socket_pending=none")
         except Exception as probe_error:  # noqa: BLE001 - forensics only

--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import contextlib
 import json
+import select as select_module
+import socket as socket_module
 
+from flask import current_app
 from flaskr.dao import db
 from sqlalchemy import bindparam, text
 from sqlalchemy.exc import ResourceClosedError
+
+
 from flaskr.service.learn.learn_dtos import (
     AudioCompleteDTO,
     AudioSegmentDTO,
@@ -36,6 +41,60 @@ from flaskr.service.learn.models import (
     LearnGeneratedElement,
 )
 from flaskr.service.learn.type_state_machine import TypeInput
+
+
+def _describe_desynced_connection(result, connection) -> str:
+    """Collect protocol-level forensics after a desynced SELECT.
+
+    When this SELECT consumes a stale response packet, the DBAPI cursor holds
+    the fingerprint of the response it actually read: an OK packet from an
+    interleaved INSERT/UPDATE shows up as rowcount/lastrowid with a None
+    description. Together with the server-side connection id (joinable
+    against performance_schema on RDS), the pymysql protocol sequence number,
+    and a peek at any bytes still pending on the socket, this identifies what
+    the desynced exchange was - without guessing.
+    """
+    parts = []
+    cursor = getattr(result, "cursor", None)
+    if cursor is not None:
+        parts.append(f"cursor.rowcount={getattr(cursor, 'rowcount', None)}")
+        parts.append(f"cursor.lastrowid={getattr(cursor, 'lastrowid', None)}")
+        parts.append(
+            f"cursor.description={'set' if getattr(cursor, 'description', None) else None}"
+        )
+    raw = None
+    with contextlib.suppress(Exception):
+        raw = connection.connection.dbapi_connection
+    if raw is None:
+        parts.append("raw_connection=unavailable")
+        return " ".join(parts)
+    with contextlib.suppress(Exception):
+        parts.append(f"server_thread_id={raw.thread_id()}")
+    parts.append(f"next_seq_id={getattr(raw, '_next_seq_id', None)}")
+    prev = getattr(raw, "_result", None)
+    if prev is not None:
+        parts.append(
+            "last_result(affected_rows={}, insert_id={}, server_status={}, "
+            "unbuffered_active={}, field_count={})".format(
+                getattr(prev, "affected_rows", None),
+                getattr(prev, "insert_id", None),
+                getattr(prev, "server_status", None),
+                getattr(prev, "unbuffered_active", None),
+                getattr(prev, "field_count", None),
+            )
+        )
+    sock = getattr(raw, "_sock", None)
+    if sock is not None:
+        try:
+            readable, _, _ = select_module.select([sock], [], [], 0)
+            if readable:
+                pending = sock.recv(64, socket_module.MSG_PEEK)
+                parts.append(f"socket_pending_hex={pending.hex()}")
+            else:
+                parts.append("socket_pending=none")
+        except Exception as probe_error:  # noqa: BLE001 - forensics only
+            parts.append(f"socket_probe_error={probe_error!r}")
+    return " ".join(parts)
 
 
 class ListenElementRunPersistenceMixin:
@@ -148,10 +207,17 @@ class ListenElementRunPersistenceMixin:
         except ResourceClosedError:
             # A rowless result for this SELECT means the connection's protocol
             # stream is desynced (the query consumed a stale response packet
-            # left over from an interrupted operation). Invalidate the raw
-            # DBAPI connection so the poisoned connection is dropped from the
-            # pool instead of failing every later request that checks it out;
-            # the caller's rollback then completes on session state alone.
+            # left over from an interrupted operation). Capture the protocol
+            # fingerprint of what the SELECT actually read BEFORE invalidating,
+            # then invalidate the raw DBAPI connection so the poisoned
+            # connection is dropped from the pool instead of failing every
+            # later request that checks it out; the caller's rollback then
+            # completes on session state alone.
+            with contextlib.suppress(Exception):
+                current_app.logger.error(
+                    "Listen element SELECT hit a desynced connection; forensics: %s",
+                    _describe_desynced_connection(result, connection),
+                )
             with contextlib.suppress(Exception):
                 connection.invalidate()
             raise

--- a/src/api/tests/common/test_i18n_loader.py
+++ b/src/api/tests/common/test_i18n_loader.py
@@ -1,9 +1,15 @@
-import os
 from pathlib import Path
 
+import pytest
 from flask import Flask
 
-from flaskr.i18n import _translations, load_translations, set_language, _ as t
+from flaskr.i18n import (
+    _translations,
+    clear_language,
+    load_translations,
+    set_language,
+    _ as t,
+)
 
 
 def _shared_i18n_root() -> Path:
@@ -11,8 +17,17 @@ def _shared_i18n_root() -> Path:
     return Path(__file__).resolve().parents[3] / "i18n"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_i18n_state(monkeypatch):
+    # SHARED_I18N_ROOT is restored by monkeypatch; the thread-local language
+    # set via set_language() must be cleared so later tests (e.g. ask provider
+    # adapters asserting en-US messages) are not affected by test order.
+    monkeypatch.setenv("SHARED_I18N_ROOT", str(_shared_i18n_root()))
+    yield
+    clear_language()
+
+
 def test_load_and_translate_basic():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     # Load translations from shared JSON
@@ -28,7 +43,6 @@ def test_load_and_translate_basic():
 
 
 def test_french_language_loads_shared_translations():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -39,7 +53,6 @@ def test_french_language_loads_shared_translations():
 
 
 def test_language_fallback_to_default():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -50,7 +63,6 @@ def test_language_fallback_to_default():
 
 
 def test_existing_language_missing_key_falls_back_to_default():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)
@@ -68,7 +80,6 @@ def test_existing_language_missing_key_falls_back_to_default():
 
 
 def test_flat_section_namespace_loading():
-    os.environ["SHARED_I18N_ROOT"] = str(_shared_i18n_root())
     app = Flask(__name__)
 
     load_translations(app)

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -190,3 +190,60 @@ def test_deactivate_active_element_rows_retires_rows_without_touching_others(app
         ).all()
 
         assert [row.status for row in rows] == [0, 0, 1]
+
+
+def test_desync_forensics_capture_fingerprints_the_stale_response():
+    from flaskr.service.learn.listen_element_run_persistence import (
+        _describe_desynced_connection,
+    )
+
+    class _FakeCursor:
+        rowcount = 1
+        lastrowid = 4242
+        description = None
+
+    class _FakeResult:
+        cursor = _FakeCursor()
+
+    class _FakePrevResult:
+        affected_rows = 1
+        insert_id = 4242
+        server_status = 3
+        unbuffered_active = False
+        field_count = 0
+
+    class _FakeRaw:
+        _next_seq_id = 7
+        _result = _FakePrevResult()
+        _sock = None
+
+        def thread_id(self):
+            return 555001
+
+    class _FakeConnection:
+        class connection:
+            dbapi_connection = _FakeRaw()
+
+    described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
+
+    assert "cursor.rowcount=1" in described
+    assert "cursor.lastrowid=4242" in described
+    assert "cursor.description=None" in described
+    assert "server_thread_id=555001" in described
+    assert "next_seq_id=7" in described
+    assert "insert_id=4242" in described
+
+
+def test_desync_forensics_survives_missing_raw_connection():
+    from flaskr.service.learn.listen_element_run_persistence import (
+        _describe_desynced_connection,
+    )
+
+    class _FakeResult:
+        cursor = None
+
+    class _FakeConnection:
+        connection = None
+
+    described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
+    assert "raw_connection=unavailable" in described

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -247,3 +247,42 @@ def test_desync_forensics_survives_missing_raw_connection():
 
     described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
     assert "raw_connection=unavailable" in described
+
+
+def test_desync_forensics_logs_only_packet_header_not_payload():
+    import socket as socket_module
+
+    from flaskr.service.learn.listen_element_run_persistence import (
+        _describe_desynced_connection,
+    )
+
+    left, right = socket_module.socketpair()
+    try:
+        # 4-byte MySQL packet header + payload containing sensitive text.
+        right.sendall(bytes.fromhex("2a000005") + b"\xfeSENSITIVE-LEARNER-CONTENT")
+
+        class _FakeRaw:
+            _next_seq_id = 3
+            _result = None
+            _sock = left
+
+            def thread_id(self):
+                return 1
+
+        class _FakeConnection:
+            class connection:
+                dbapi_connection = None
+
+        _FakeConnection.connection.dbapi_connection = _FakeRaw()
+
+        class _FakeResult:
+            cursor = None
+
+        described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
+
+        assert "socket_pending_header_hex=2a000005fe" in described
+        assert "SENSITIVE" not in described
+        assert "socket_pending_len>=" in described
+    finally:
+        left.close()
+        right.close()


### PR DESCRIPTION
## Problem

The intermittent listen-run `ResourceClosedError` persists (latest 2026-08-04 11:16/11:19) on pods containing every candidate fix so far: #2232 (probe + invalidate), ai_shifu_saas_plugin#4 (fork-leaked engine), #2244 (langfuse post_fork reinit), #2252 (pool desync probes — zero hits, which proves the desync arises while the crashing request holds the connection), and #2256 (buffered pagination replacing yield_per). Four rounds of mechanism-based fixes have not stopped it, so the next step is evidence, not another hypothesis.

## Approach

When the row-id SELECT raises `ResourceClosedError`, log a protocol-level fingerprint of the connection **before** invalidating it:

- `cursor.rowcount` / `cursor.lastrowid` / `cursor.description`: if the SELECT consumed a stale OK packet from an interleaved INSERT/UPDATE, these identify that statement — `lastrowid` can even be joined against table data to find the exact row the misattributed response belonged to.
- pymysql `_next_seq_id` and last-result state (`affected_rows`, `insert_id`, `server_status`, `unbuffered_active`, `field_count`): reconstructs where in the protocol exchange the stream diverged.
- `thread_id()`: the server-side connection id, joinable against RDS `performance_schema.events_statements_history` to see the full statement sequence on that connection.
- A zero-timeout `select()` + `MSG_PEEK` of up to 64 pending bytes: the raw fingerprint of whatever is still unread on the wire.

Everything is wrapped defensively (each probe degrades to a marker string), and the log goes through the app logger so it carries request context and reaches alerting.

## Testing

- Extended `test_listen_element_run_persistence.py`: fingerprint fields present for a populated fake connection; degraded output when the raw connection is unavailable.
- `tests/service/learn`: 395 passed.
- `lefthook run pre-commit --all-files`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of database connection synchronization errors during listening activity processing.
  - Added richer diagnostic information to help identify and resolve intermittent connection failures more quickly.

- **Tests**
  - Strengthened coverage for connection-error diagnostics and isolated language-loading tests to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->