### PR TITLE
fix: key scoped sessions on unique context tokens

### DIFF
--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -1,4 +1,7 @@
+import itertools
+
 from flask import Flask
+from flask.globals import app_ctx
 from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 from sqlalchemy import event
@@ -18,6 +21,32 @@ logger = logging.getLogger(__name__)
 # create a global db object
 db = None
 redis_client = None
+
+# Session scope tokens must never repeat. Flask-SQLAlchemy's stock scope
+# function keys the scoped-session registry on id(app_ctx) - a CPython memory
+# address that is recycled as soon as a context is garbage collected. With
+# high-frequency context churn (streaming requests plus nested app contexts
+# in hot paths), a new context can be allocated at the address of a dead one;
+# if the dead context's session ever escaped teardown (an interrupted
+# cleanup under gevent), the new context SILENTLY ADOPTS the leftover session
+# and its checked-out connection. Two greenlets then interleave commands on
+# one MySQL connection - observed in production as paired failures in the
+# same second: an INSERT losing its OK packet (FlushError: NULL identity
+# key) while another context's SELECT consumed it (ResourceClosedError),
+# followed by 2014 Command Out of Sync. A monotonically increasing token
+# stamped on each context makes scope keys unique for the process lifetime:
+# a leaked session can no longer be adopted, only leak - which pool
+# recycling and the desync probes already handle.
+_app_ctx_scope_counter = itertools.count(1)
+
+
+def _unique_app_ctx_scope() -> int:
+    ctx = app_ctx._get_current_object()
+    token = ctx.__dict__.get("_dao_session_scope_token")
+    if token is None:
+        token = next(_app_ctx_scope_counter)
+        ctx.__dict__["_dao_session_scope_token"] = token
+    return token
 
 
 def _socket_has_unread_data(dbapi_connection) -> bool:
@@ -226,7 +255,7 @@ def init_db(app: Flask):
     app.config["SQLALCHEMY_ENGINE_OPTIONS"] = existing_options
 
     if db is None:
-        db = SQLAlchemy()
+        db = SQLAlchemy(session_options={"scopefunc": _unique_app_ctx_scope})
     db.init_app(app)
 
     # Enable formatted SQL output in the development environment

--- a/src/api/flaskr/service/shifu/demo_courses.py
+++ b/src/api/flaskr/service/shifu/demo_courses.py
@@ -107,26 +107,50 @@ def is_builtin_demo_shifu(app: Flask, shifu_bid: str) -> bool:
     return False
 
 
+_DEMO_METADATA_CACHE_TTL_SECONDS = 300
+_demo_metadata_cache: dict[str, tuple[float, list[tuple[str, str]]]] = {}
+
+
 def _load_shifu_demo_metadata(app: Flask, shifu_bid: str) -> list[tuple[str, str]]:
+    """Load (title, created_user_bid) pairs for the demo-course check.
+
+    This runs on the TTS/LLM billing hot path (every synthesized segment),
+    so results are cached per shifu for a few minutes - demo classification
+    inputs practically never change. The queries deliberately run on the
+    CALLER's session and app context: pushing a nested app context here
+    created and tore down a scoped session per call, and that context churn
+    is exactly what allowed scope-key collisions with concurrent contexts.
+    Billing callers always run inside an app context.
+    """
+    import time as time_module
+
     from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 
-    with app.app_context():
-        metadata: list[tuple[str, str]] = []
-        for model in (DraftShifu, PublishedShifu):
-            row = (
-                model.query.filter(
-                    model.shifu_bid == shifu_bid,
-                    model.deleted == 0,
-                )
-                .order_by(model.id.desc())
-                .first()
+    cached = _demo_metadata_cache.get(shifu_bid)
+    now = time_module.monotonic()
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    metadata: list[tuple[str, str]] = []
+    for model in (DraftShifu, PublishedShifu):
+        row = (
+            model.query.filter(
+                model.shifu_bid == shifu_bid,
+                model.deleted == 0,
             )
-            if row is None:
-                continue
-            metadata.append(
-                (
-                    str(getattr(row, "title", "") or "").strip(),
-                    str(getattr(row, "created_user_bid", "") or "").strip(),
-                )
+            .order_by(model.id.desc())
+            .first()
+        )
+        if row is None:
+            continue
+        metadata.append(
+            (
+                str(getattr(row, "title", "") or "").strip(),
+                str(getattr(row, "created_user_bid", "") or "").strip(),
             )
-        return metadata
+        )
+    _demo_metadata_cache[shifu_bid] = (
+        now + _DEMO_METADATA_CACHE_TTL_SECONDS,
+        metadata,
+    )
+    return metadata

--- a/src/api/tests/common/test_unique_session_scope.py
+++ b/src/api/tests/common/test_unique_session_scope.py
@@ -1,0 +1,64 @@
+"""Unique scoped-session scope tokens across app contexts.
+
+The stock Flask-SQLAlchemy scope function keys sessions on id(app_ctx) - a
+recycled memory address. These tests pin the replacement's contract: a
+stable token within one context, a NEW token for every context (so a later
+context can never adopt a dead context's registry slot), and normal session
+lifecycle via teardown.
+"""
+
+import pytest
+
+from flaskr.dao import _unique_app_ctx_scope, db
+
+
+def test_scope_token_is_stable_within_a_context(app):
+    with app.app_context():
+        first = _unique_app_ctx_scope()
+        second = _unique_app_ctx_scope()
+        assert first == second
+
+
+def test_scope_token_never_repeats_across_contexts(app):
+    tokens = []
+    for _ in range(50):
+        with app.app_context():
+            tokens.append(_unique_app_ctx_scope())
+    # id(app_ctx) would collide across this loop (the context object is
+    # freed each iteration and the allocator reuses the address); the token
+    # must not.
+    assert len(set(tokens)) == len(tokens)
+
+
+def test_nested_contexts_get_distinct_tokens(app):
+    with app.app_context():
+        outer = _unique_app_ctx_scope()
+        with app.app_context():
+            inner = _unique_app_ctx_scope()
+            assert inner != outer
+        assert _unique_app_ctx_scope() == outer
+
+
+def test_sessions_are_isolated_per_context_and_removed_on_teardown(app):
+    with app.app_context():
+        outer_token = _unique_app_ctx_scope()
+        outer_session = db.session()
+        with app.app_context():
+            inner_token = _unique_app_ctx_scope()
+            inner_session = db.session()
+            assert inner_session is not outer_session
+        # Back in the outer context the registry must still resolve to the
+        # outer session (the nested teardown removed only its own slot).
+        assert db.session() is outer_session
+
+    # Both slots created by this test must be cleaned up by teardown - a
+    # lingering slot would be exactly the leaked-session condition the
+    # unique tokens defend against.
+    registry_map = db.session.registry.registry
+    assert outer_token not in registry_map
+    assert inner_token not in registry_map
+
+
+def test_scope_raises_outside_app_context():
+    with pytest.raises(RuntimeError):
+        _unique_app_ctx_scope()


### PR DESCRIPTION
## Breakthrough evidence

The 2026-08-04 11:37 alerts finally captured **both halves of one interleaved exchange**, in the same second on the same pod:

- **11:37:07.802** — a listen run's INSERT flush failed with `FlushError: NULL identity key`: the INSERT **never received its OK packet** (no insert_id).
- **11:37:08.742** — a background TTS finalize greenlet (`No_Client_IP/No_URL`) failed inside `demo_courses._load_shifu_demo_metadata`: its SELECT **consumed an OK packet that wasn't its own** (`ResourceClosedError`, then 2014 on the nested context's teardown rollback).

One statement losing exactly the packet another context consumed means two independent scoped sessions were talking on **one MySQL connection**. The pool never hands one connection to two owners — but the scoped-session registry can:

## Mechanism

Flask-SQLAlchemy keys its scoped-session registry on `id(app_ctx)` — a CPython memory address that is recycled the moment a context is garbage collected. The traceback also exposed a previously unnoticed hot path: `_load_shifu_demo_metadata` pushes a **nested app context on every synthesized audio segment** (billing's `_resolve_billable → is_builtin_demo_shifu`), i.e. constant context churn during every listen run. If any context's teardown is ever interrupted under gevent (cleanup involves network IO — rollback/close — with yield points), its session survives in the registry at a soon-to-be-recycled address; the next context allocated at that address **silently adopts the leftover session and its checked-out connection**, and two greenlets interleave on one wire. This also explains why every previous fix (#2232, plugin#4, #2244, #2252 — whose pool probes correctly reported zero hits, since nothing dirty ever crossed the pool — and #2256) reduced churn or contained damage but could not stop the failures.

## Changes

1. `session_options={"scopefunc": _unique_app_ctx_scope}` (an officially supported hook): every app context is lazily stamped with a monotonically increasing token, and the registry is keyed on that token. Addresses can recycle freely — a scope key never repeats within a process, so a leaked session can no longer be adopted, only leak (which pool recycling, pre_ping, and the #2252 probes already handle).
2. `_load_shifu_demo_metadata` no longer pushes a nested app context (billing callers always run inside one) and caches results per shifu for 5 minutes — demo-course classification inputs practically never change, and this removes a per-segment session churn hot spot.

## Testing

- New `test_unique_session_scope.py`: token stable within a context, unique across 50 sequential contexts (where `id()` demonstrably recycles), nested contexts isolated, both registry slots cleaned by teardown, RuntimeError outside a context (stock behavior preserved).
- **Full backend suite: 2,478 passed, 15 skipped** — this touches every session lookup, so the whole suite was run, not a subset.
- `lefthook run pre-commit --all-files`: clean.

## Relation to #2260

The forensics capture merged today stays in place and remains valuable: if any desync still occurs after this fix, its fingerprint will say so. If this mechanism was the cause, both the alerts and the forensics stay silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)