### PR TITLE
fix: discard interrupted db sessions instead of trusting them

### DIFF
--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -1,3 +1,5 @@
+import collections
+import contextlib
 import itertools
 
 from flask import Flask
@@ -6,7 +8,13 @@ from flask_sqlalchemy import SQLAlchemy
 from redis import Redis
 from sqlalchemy import event
 from sqlalchemy import pool as sa_pool
-from sqlalchemy.exc import DisconnectionError, OperationalError
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import (
+    DisconnectionError,
+    OperationalError,
+    ResourceClosedError,
+    SQLAlchemyError,
+)
 import functools
 import random
 import select as select_module
@@ -123,6 +131,68 @@ def _reject_desynced_connection_on_checkout(
         )
 
 
+# Ring buffer of recent statements per DBAPI connection, plus a pre-execute
+# probe. Production forensics (2026-08-04 12:20) proved the desync happens
+# WITHIN one connection: a statement's response goes unread (an interrupted
+# exchange whose exception was swallowed somewhere), and every later command
+# silently consumes the PREVIOUS command's response - an INSERT reading an
+# INSERT's OK packet looks perfectly normal - until a SELECT meets an OK
+# packet (ResourceClosedError) or an INSERT meets a result set (FlushError:
+# NULL identity key). Probing the socket immediately before each execute
+# catches the off-by-one at the first statement after it arises, and the
+# journal's tail names the statement whose exchange was interrupted.
+_STATEMENT_JOURNAL_KEY = "dao_statement_journal"
+_STATEMENT_JOURNAL_SIZE = 25
+_STATEMENT_SNIPPET_CHARS = 90
+
+
+def _statement_journal(connection) -> collections.deque:
+    journal = connection.info.get(_STATEMENT_JOURNAL_KEY)
+    if journal is None:
+        journal = collections.deque(maxlen=_STATEMENT_JOURNAL_SIZE)
+        connection.info[_STATEMENT_JOURNAL_KEY] = journal
+    return journal
+
+
+@event.listens_for(Engine, "before_cursor_execute")
+def _intercept_desync_before_execute(
+    conn, cursor, statement, parameters, context, executemany
+):
+    dbapi_connection = getattr(conn.connection, "dbapi_connection", None)
+    if dbapi_connection is None:
+        return
+    if _socket_has_unread_data(dbapi_connection):
+        journal = list(_statement_journal(conn))
+        _pool_diagnostics_logger().error(
+            "DB connection has an unread response before executing a new "
+            "statement (off-by-one protocol desync). The LAST journal entry "
+            "is the statement whose exchange was interrupted. journal=%s "
+            "next_statement=%r",
+            journal,
+            statement[:_STATEMENT_SNIPPET_CHARS],
+        )
+        with contextlib.suppress(Exception):
+            conn.invalidate()
+        raise DisconnectionError(
+            "connection has an unread response from a previous statement "
+            "(interrupted exchange); refusing to execute on a desynced stream"
+        )
+
+
+@event.listens_for(Engine, "after_cursor_execute")
+def _journal_statement_after_execute(
+    conn, cursor, statement, parameters, context, executemany
+):
+    with contextlib.suppress(Exception):
+        _statement_journal(conn).append(
+            (
+                statement[:_STATEMENT_SNIPPET_CHARS],
+                getattr(cursor, "rowcount", None),
+                getattr(cursor, "lastrowid", None),
+            )
+        )
+
+
 # MySQL error codes that indicate a transient locking conflict; the current
 # transaction is already rolled back by the server, so re-running it is the
 # documented remedy.
@@ -143,20 +213,138 @@ def _is_retryable_operational_error(exc: OperationalError) -> bool:
     )
 
 
-def _rollback_quietly() -> None:
+# MySQL client-side error codes whose presence means the connection's
+# response stream can no longer be trusted:
+#   2013 Lost connection during query - the response was half read
+#   2014 Command Out of Sync - a response was consumed out of order (the
+#        direct symptom of an off-by-one desynced stream)
+_PROTOCOL_INTERRUPT_ERRNOS = frozenset({2013, 2014})
+
+
+def is_protocol_interrupt_error(exc: BaseException) -> bool:
+    """Return True when the exception implies a desynced response stream.
+
+    Such a connection must be discarded, never rolled back: a ROLLBACK on a
+    desynced stream consumes another stale packet and perpetuates the
+    off-by-one.
+    """
+    if isinstance(exc, (ResourceClosedError, DisconnectionError)):
+        return True
+    for candidate in (exc, getattr(exc, "orig", None)):
+        args = getattr(candidate, "args", ())
+        if args and isinstance(args[0], int) and args[0] in _PROTOCOL_INTERRUPT_ERRNOS:
+            return True
+    return False
+
+
+def is_abnormal_stream_termination(exc: BaseException | None) -> bool:
+    """Return True for terminations that may have interrupted a DB exchange.
+
+    GeneratorExit (client walked away from a streaming generator) and
+    non-Exception BaseExceptions (GreenletExit from a rolling deploy,
+    SystemExit, KeyboardInterrupt) can be injected at any gevent IO switch
+    point - including mid-exchange, leaving an unread response owed on the
+    wire. Protocol-interrupt errors are the same condition already observed.
+    Server-delivered errors (IntegrityError, deadlocks, business exceptions)
+    are NOT abnormal: the response arrived intact and rollback stays safe.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, GeneratorExit):
+        return True
+    if not isinstance(exc, Exception):
+        return True
+    return is_protocol_interrupt_error(exc)
+
+
+def invalidate_session(*, source: str, session=None) -> bool:
+    """Discard the session's connection instead of returning it to the pool.
+
+    ``Session.invalidate()`` rolls back the session state WITHOUT emitting
+    anything on the wire and marks the raw DBAPI connection as discarded -
+    the documented remedy for gevent-style interruptions. The scoped_session
+    proxy does NOT forward ``invalidate`` (SQLAlchemy 2.0.x), so the real
+    Session must be resolved by calling the registry first; a plain
+    ``db.session.invalidate()`` raises AttributeError and silently does
+    nothing when wrapped in a broad except.
+    """
+    target = (
+        session if session is not None else (db.session if db is not None else None)
+    )
+    if target is None:
+        return False
+    try:
+        if not hasattr(target, "invalidate") and callable(target):
+            target = target()
+        target.invalidate()
+        return True
+    except Exception:  # noqa: BLE001 - termination cleanup must not raise
+        _pool_diagnostics_logger().warning(
+            "%s: session invalidate failed", source, exc_info=True
+        )
+        return False
+
+
+def cleanup_session_after(
+    exc: BaseException | None, *, source: str, session=None
+) -> str:
+    """Classify a termination and clean the session accordingly.
+
+    Abnormal (stream-interrupting) terminations invalidate the connection;
+    everything else rolls back as before. A rollback that itself fails means
+    the connection is already broken, so it escalates to invalidate. Returns
+    "invalidated" | "rolled_back" | "noop" for test assertions.
+    """
+    if exc is not None and is_abnormal_stream_termination(exc):
+        invalidate_session(source=source, session=session)
+        return "invalidated"
+    target = (
+        session if session is not None else (db.session if db is not None else None)
+    )
+    if target is None:
+        return "noop"
+    try:
+        target.rollback()
+        return "rolled_back"
+    except Exception:  # noqa: BLE001 - escalate, never raise from cleanup
+        _pool_diagnostics_logger().warning(
+            "%s: rollback failed; escalating to session invalidate",
+            source,
+            exc_info=True,
+        )
+        invalidate_session(source=source, session=session)
+        return "invalidated"
+
+
+def _rollback_quietly() -> bool:
     """
     Roll back the current session after a failed transaction. An OperationalError
     leaves the session in a broken state, so this must run on every catch -
     including non-retryable errors and the final attempt - otherwise later
-    operations in the same context raise InvalidRequestError. Best-effort: a
-    rollback failure is logged rather than masking the original error.
+    operations in the same context raise InvalidRequestError. A rollback
+    failure means the connection itself is broken: escalate to invalidate and
+    report failure so the caller stops retrying on it.
     """
     if db is None:
-        return
+        return True
     try:
         db.session.rollback()
+        return True
+    except SQLAlchemyError as rollback_exc:
+        # A database-layer rollback failure means the connection itself is
+        # broken; escalate to invalidate and tell the caller to stop
+        # retrying on it.
+        logger.warning(
+            "retry_on_deadlock rollback failed: %s; invalidating session",
+            rollback_exc,
+        )
+        invalidate_session(source="retry_on_deadlock rollback failure")
+        return False
     except Exception as rollback_exc:  # noqa: BLE001 - best-effort cleanup
+        # Environmental failures (e.g. no app context in unit tests) keep the
+        # legacy tolerant behavior: log and let the retry loop proceed.
         logger.warning("retry_on_deadlock rollback failed: %s", rollback_exc)
+        return True
 
 
 def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
@@ -165,7 +353,10 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
     lock wait timeout (1205). The failed transaction is rolled back on every
     caught error so the session is left clean; retryable errors are retried with
     exponential backoff plus jitter, while non-retryable errors and the final
-    attempt propagate unchanged.
+    attempt propagate unchanged. Protocol-interrupt errors (2013/2014) mean the
+    connection's response stream is desynced: the session is invalidated and
+    the error propagates immediately - neither rollback nor retry is safe on
+    that connection.
     """
 
     def decorator(func):
@@ -177,7 +368,13 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
                     return func(*args, **kwargs)
                 except OperationalError as exc:
                     attempt += 1
-                    _rollback_quietly()
+                    if is_protocol_interrupt_error(exc):
+                        invalidate_session(
+                            source="retry_on_deadlock protocol interrupt"
+                        )
+                        raise
+                    if not _rollback_quietly():
+                        raise
                     if attempt >= max_attempts or not _is_retryable_operational_error(
                         exc
                     ):

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -5,7 +5,7 @@ from flask import Flask, Response, request, stream_with_context
 from pydantic import ValidationError
 from sqlalchemy import select
 
-from flaskr.dao import db
+from flaskr.dao import db, invalidate_session, is_protocol_interrupt_error
 from flaskr.framework.plugin.inject import inject
 from flaskr.i18n import get_current_language
 from flaskr.route.common import make_common_response, bypass_token_validation
@@ -97,6 +97,10 @@ def _stream_sse_response(
                 yield _to_sse_data_line(message)
         except GeneratorExit:
             app.logger.info(close_log)
+            # The close may have interrupted a DB exchange mid-stream:
+            # discard the connection so the finally's remove does not send a
+            # ROLLBACK on a possibly desynced stream.
+            invalidate_session(source="learn stream_sse_response close")
             raise
         except AppException as exc:
             app.logger.warning("%s: %s (code: %s)", error_log, exc, exc.code)
@@ -107,6 +111,8 @@ def _stream_sse_response(
                 yield _to_sse_data_line(terminal_event_factory())
         except Exception as exc:
             app.logger.error(error_log, exc_info=True)
+            if is_protocol_interrupt_error(exc):
+                invalidate_session(source="learn stream_sse_response desync")
             if error_event_factory is None:
                 raise
             yield _to_sse_data_line(error_event_factory(exc))
@@ -135,15 +141,21 @@ def _stream_passthrough_response(
             yield from message_iter_factory()
         except GeneratorExit:
             app.logger.info(close_log)
+            invalidate_session(source="learn stream_passthrough_response close")
             raise
         except RuntimeError as exc:
             if _is_generator_close_error(exc):
+                # RuntimeError("generator ignored GeneratorExit") is the close
+                # in disguise: same interrupted-exchange risk as GeneratorExit.
                 app.logger.info(close_log)
+                invalidate_session(source="learn stream_passthrough_response close")
                 return
             app.logger.error(error_log, exc_info=True)
             raise
-        except Exception:
+        except Exception as exc:
             app.logger.error(error_log, exc_info=True)
+            if is_protocol_interrupt_error(exc):
+                invalidate_session(source="learn stream_passthrough_response desync")
             raise
         finally:
             _release_db_session(app, source="learn stream_passthrough_response")

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -24,7 +24,7 @@ from flaskr.service.learn.learn_dtos import (
     RunStatusDTO,
 )
 from flaskr.common.cache_provider import cache as cache_provider
-from flaskr.dao import db
+from flaskr.dao import db, invalidate_session, is_protocol_interrupt_error
 from flaskr.service.learn.const import INPUT_TYPE_ASK
 from flaskr.service.shifu.shifu_struct_manager import (
     get_shifu_dto,
@@ -62,29 +62,9 @@ def _remove_db_session_safely(app: Flask, *, source: str) -> None:
         app.logger.warning("%s db session cleanup failed", source, exc_info=True)
 
 
-# MySQL client error codes that mean the connection's protocol stream is no
-# longer trustworthy: 2013 "Lost connection during query" leaves a response
-# half-read; 2014 "Command Out of Sync" means a response was consumed out of
-# order (the off-by-one desync this module's probes exist for).
-_DESYNC_MYSQL_ERRNOS = frozenset({2013, 2014})
-
-
-def _is_protocol_desync_error(exc: BaseException) -> bool:
-    """Return True when ``exc`` implies the DB protocol stream is desynced.
-
-    ResourceClosedError on a SELECT is the canonical victim symptom of an
-    off-by-one response stream. For DBAPI errors, inspect the MySQL errno on
-    the original driver exception (SQLAlchemy wraps it) as well as on the
-    exception itself (raw pymysql errors escape unwrapped from low-level
-    paths such as rollback).
-    """
-    if isinstance(exc, ResourceClosedError):
-        return True
-    for candidate in (exc, getattr(exc, "orig", None)):
-        args = getattr(candidate, "args", ())
-        if args and isinstance(args[0], int) and args[0] in _DESYNC_MYSQL_ERRNOS:
-            return True
-    return False
+# Shared termination classification lives in flaskr.dao; keep the historical
+# module-level name because tests and callers import it from here.
+_is_protocol_desync_error = is_protocol_interrupt_error
 
 
 def _discard_session_connection(app: Flask, *, source: str) -> None:
@@ -93,16 +73,13 @@ def _discard_session_connection(app: Flask, *, source: str) -> None:
     Used when the streaming generator terminates abnormally: the close (or a
     protocol error) can leave an unconsumed response owed on the wire, and
     rolling back on such a connection consumes stale packets and returns a
-    poisoned connection to the pool. ``Session.invalidate()`` rolls back the
-    session state without emitting anything on the connection and discards
-    the raw DBAPI connection. The pool-level probes in ``flaskr/dao`` only
-    see stale bytes that have already arrived at the socket; discarding the
-    connection deterministically closes that arrival race.
+    poisoned connection to the pool. Delegates to the shared dao helper,
+    which resolves the REAL Session through the scoped registry -
+    scoped_session does not proxy ``Session.invalidate``, so calling
+    ``db.session.invalidate()`` directly raises AttributeError and silently
+    does nothing.
     """
-    try:
-        db.session.invalidate()
-    except Exception:
-        app.logger.warning("%s session invalidate failed", source, exc_info=True)
+    invalidate_session(source=source, session=db.session)
 
 
 # Number of connection checkouts to probe before giving up: the pool may hold
@@ -149,10 +126,10 @@ def _ensure_healthy_db_connection(app: Flask) -> None:
                 _CONNECTION_PROBE_ATTEMPTS,
                 exc,
             )
-        with contextlib.suppress(Exception):
-            db.session.connection().invalidate()
-        with contextlib.suppress(Exception):
-            db.session.rollback()
+        # Session.invalidate() both resets the session state WITHOUT emitting
+        # SQL and discards the raw connection - a rollback here would send a
+        # ROLLBACK on the very stream that just proved desynced.
+        _discard_session_connection(app, source="db connection probe failure")
     if last_error is not None:
         raise last_error
     raise RuntimeError(
@@ -467,7 +444,12 @@ def run_script_inner(
             if reload_generated_block_bid or reload_element_bid:
                 if stop_event and stop_event.is_set():
                     app.logger.info("run_script_inner cancelled before reload")
-                    db.session.rollback()
+                    # Cancellation means the client walked away mid-stream: an
+                    # exchange may have been interrupted, so discard rather
+                    # than roll back on a possibly desynced connection.
+                    _discard_session_connection(
+                        app, source="run_script_inner stop_event cancel"
+                    )
                     return
                 yield from _iter_run_events(
                     run_script_context.reload(
@@ -488,7 +470,9 @@ def run_script_inner(
                 )
                 if stop_event and stop_event.is_set():
                     app.logger.info("run_script_inner cancelled by stop_event")
-                    db.session.rollback()
+                    _discard_session_connection(
+                        app, source="run_script_inner stop_event cancel"
+                    )
                     return
                 app.logger.info("run_script_context.run")
                 yield from _iter_run_events(
@@ -790,6 +774,8 @@ def run_script(
                     element_adapter=element_adapter,
                     manage_app_context=False,
                 )
+                producer_exc: BaseException | None = None
+                exhausted = False
                 try:
                     for item in res:
                         if stop_event.is_set():
@@ -799,17 +785,37 @@ def run_script(
                                 output_queue.put(("data", converted_item))
                             continue
                         output_queue.put(("data", item))
+                    else:
+                        # for/else: only a fully exhausted generator reaches
+                        # here - every break (stop_event) leaves it False.
+                        exhausted = True
                 except Exception as exc:
+                    producer_exc = exc
                     if stop_event.is_set():
                         app.logger.info(
                             "run_script producer stopped due to client disconnect: %s",
                             type(exc).__name__,
                         )
-                        return
-                    output_queue.put(("error", exc))
+                    else:
+                        output_queue.put(("error", exc))
+                except BaseException as exc:  # noqa: BLE001 - GreenletExit etc.
+                    producer_exc = exc
+                    raise
                 finally:
                     with contextlib.suppress(Exception):
                         res.close()
+                    if not exhausted or producer_exc is not None:
+                        # Anything short of natural exhaustion may have
+                        # interrupted a DB exchange (the close above injects
+                        # GeneratorExit into the generator's yield point, and
+                        # element_adapter.process runs outside the generator's
+                        # own cleanup). Discard the connection; when
+                        # run_script_inner already invalidated and removed the
+                        # session this resolves a fresh registry Session and
+                        # invalidating it is a harmless no-op.
+                        _discard_session_connection(
+                            app, source="run_script producer abort"
+                        )
                     _remove_db_session_safely(app, source="run_script producer")
                     output_queue.put(("done", None))
 

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -1,0 +1,138 @@
+"""Termination classification and session invalidation contract.
+
+Core of the connection-desync fix: terminations that may have interrupted a
+DB exchange must discard the connection (Session.invalidate), while
+server-delivered errors keep the legacy rollback. Also pins the
+scoped_session proxy gap that silently no-op'ed the first version of this
+fix in production: scoped_session does NOT forward ``invalidate``, so the
+helper must resolve the real Session via the registry call form.
+"""
+
+import logging
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import (
+    DisconnectionError,
+    IntegrityError,
+    OperationalError,
+    ResourceClosedError,
+)
+
+from flaskr.dao import (
+    cleanup_session_after,
+    db,
+    invalidate_session,
+    is_abnormal_stream_termination,
+    is_protocol_interrupt_error,
+)
+
+
+class _FakeGreenletExit(BaseException):
+    pass
+
+
+def _operational(errno: int) -> OperationalError:
+    exc = OperationalError("STMT", {}, Exception())
+    exc.orig.args = (errno, "message")
+    return exc
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (GeneratorExit(), True),
+        (_FakeGreenletExit(), True),
+        (ResourceClosedError("no rows"), True),
+        (DisconnectionError("desynced"), True),
+        (_operational(2013), True),
+        (_operational(2014), True),
+        (Exception(2014, "raw pymysql Command Out of Sync"), True),
+        (None, False),
+        (ValueError("business"), False),
+        (IntegrityError("STMT", {}, Exception()), False),
+        (_operational(1213), False),
+        (_operational(1205), False),
+    ],
+)
+def test_abnormal_termination_classification(exc, expected):
+    assert is_abnormal_stream_termination(exc) is expected
+
+
+def test_protocol_interrupt_checks_orig_and_self():
+    assert is_protocol_interrupt_error(_operational(2014)) is True
+    assert is_protocol_interrupt_error(Exception(2013, "raw")) is True
+    assert is_protocol_interrupt_error(_operational(1213)) is False
+
+
+def test_scoped_session_does_not_proxy_invalidate():
+    # This gap is WHY invalidate_session must resolve the real Session via
+    # the registry call form: db.session.invalidate() raises AttributeError
+    # and, wrapped in a broad except, silently does nothing (the production
+    # no-op that kept the desync alive through an entire fix generation).
+    assert not hasattr(db.session, "invalidate")
+
+
+def test_invalidate_session_works_on_real_scoped_session(app, caplog):
+    with app.app_context():
+        db.session.execute(text("SELECT 1"))
+        with caplog.at_level(logging.WARNING):
+            assert invalidate_session(source="test real scoped") is True
+    assert "invalidate failed" not in caplog.text
+
+
+def test_invalidate_session_uses_fake_sessions_directly():
+    calls = []
+
+    class _Fake:
+        def invalidate(self):
+            calls.append(1)
+
+    assert invalidate_session(source="test fake", session=_Fake()) is True
+    assert calls == [1]
+
+
+def test_cleanup_rolls_back_on_server_delivered_errors():
+    events = []
+
+    class _Fake:
+        def invalidate(self):
+            events.append("invalidate")
+
+        def rollback(self):
+            events.append("rollback")
+
+    outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
+    assert outcome == "rolled_back"
+    assert events == ["rollback"]
+
+
+def test_cleanup_invalidates_on_interrupting_terminations():
+    events = []
+
+    class _Fake:
+        def invalidate(self):
+            events.append("invalidate")
+
+        def rollback(self):
+            events.append("rollback")
+
+    outcome = cleanup_session_after(GeneratorExit(), source="t", session=_Fake())
+    assert outcome == "invalidated"
+    assert events == ["invalidate"]
+
+
+def test_cleanup_escalates_to_invalidate_when_rollback_fails():
+    events = []
+
+    class _Fake:
+        def invalidate(self):
+            events.append("invalidate")
+
+        def rollback(self):
+            events.append("rollback")
+            raise RuntimeError("rollback broke")
+
+    outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
+    assert outcome == "invalidated"
+    assert events == ["rollback", "invalidate"]

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -1,0 +1,76 @@
+"""Pre-execute interception of off-by-one protocol desync.
+
+Production forensics proved the desync arises within one connection: a
+statement's response goes unread and every later command consumes the
+previous command's response. The engine-level listeners must catch the
+off-by-one at the first statement after it arises and name the interrupted
+statement via the per-connection journal.
+"""
+
+import socket
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DisconnectionError
+
+import flaskr.dao as dao
+from flaskr.dao import db
+
+
+def test_statement_journal_records_recent_statements(app):
+    with app.app_context():
+        db.session.execute(text("SELECT 1"))
+        db.session.execute(text("SELECT 2"))
+        connection = db.session.connection()
+        journal = list(connection.info.get(dao._STATEMENT_JOURNAL_KEY) or [])
+        db.session.rollback()
+
+    statements = [entry[0] for entry in journal]
+    assert any("SELECT 1" in s for s in statements)
+    assert any("SELECT 2" in s for s in statements)
+
+
+def test_pre_execute_probe_blocks_desynced_connection():
+    left, right = socket.socketpair()
+    try:
+
+        class _FakeRaw:
+            _sock = left
+
+        class _FakeFairy:
+            dbapi_connection = _FakeRaw()
+
+        class _FakeConn:
+            connection = _FakeFairy()
+            info = {}
+            invalidated_count = 0
+
+            def invalidate(self):
+                type(self).invalidated_count += 1
+
+        conn = _FakeConn()
+
+        # Clean socket: probe passes.
+        dao._intercept_desync_before_execute(conn, None, "SELECT 1", None, None, False)
+
+        # An unread response appears (interrupted previous exchange): the
+        # next execute must be refused and the connection invalidated.
+        right.sendall(b"\x07\x00\x00\x01\x00stale")
+        with pytest.raises(DisconnectionError):
+            dao._intercept_desync_before_execute(
+                conn, None, "SELECT id FROM t", None, None, False
+            )
+        assert _FakeConn.invalidated_count == 1
+    finally:
+        left.close()
+        right.close()
+
+
+def test_pre_execute_probe_ignores_drivers_without_socket(app):
+    # SQLite connections expose no _sock; the whole suite running on SQLite
+    # exercises this path implicitly, but assert the direct call is a no-op.
+    with app.app_context():
+        connection = db.session.connection()
+        dbapi_connection = connection.connection.dbapi_connection
+        assert dao._socket_has_unread_data(dbapi_connection) is False
+        db.session.rollback()

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -26,6 +26,10 @@ for _key in list(ENV_VARS.keys()):
     os.environ.pop(_key, None)
 
 # Force SQLite for tests unless explicitly overridden.
+# NOTE: this MUST stay a file-backed database (not :memory:). The
+# session-termination principle invalidates connections on abnormal
+# stream terminations; on an in-memory SQLite (StaticPool) an
+# invalidate would destroy the entire database mid-test.
 _test_db_uri = os.environ.get("TEST_SQLALCHEMY_DATABASE_URI")
 _test_db_dir = None
 if not _test_db_uri:

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -118,13 +118,15 @@ def test_mid_stream_close_discards_staged_block_and_rerun_resumes(
         generator = _open_run_generator(app, user_bid, golden_shifu, input_type="start")
         _consume_until_streaming(generator)
         # Production trigger: run_script's producer finally block calls
-        # res.close(); GeneratorExit -> rollback in run_script_inner.
+        # res.close(); GeneratorExit -> session invalidate in
+        # run_script_inner (connection discarded, transaction implicitly
+        # rolled back by the close).
         generator.close()
 
     blocks_after_close, records_after_close = _load_rows(app, user_bid)
 
     # The staged streamed-block row (generated_content == "") must have been
-    # discarded by the GeneratorExit rollback: no durable empty block.
+    # discarded when the invalidated connection closed: no durable empty block.
     assert all(block["content"] != "" for block in blocks_after_close), (
         f"durable empty generated block leaked: {blocks_after_close}"
     )

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -201,10 +201,11 @@ def test_failed_finalize_leaves_staged_block_state_uncorrupted(
 
 def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app):
     """Session-level model of a mid-stream disconnect: block N finalized
-    (durable step), block N+1 staged when the session rolls back — the same
-    add/flush/rollback sequence the producer's GeneratorExit handler in
-    ``runscript_v2`` performs, exercised here directly against the recorder
-    session rather than through the generator chain. The re-run must see
+    (durable step), block N+1 staged when the session's connection is
+    invalidated — the same add/flush/invalidate sequence the producer's
+    GeneratorExit handler in ``runscript_v2`` performs, exercised here
+    directly against the recorder session rather than through the generator
+    chain. The re-run must see
     block N and the advanced cursor, and no trace of block N+1. An
     end-to-end test driving the real generator ``.close()`` through
     ``run_script_inner`` is a PR3 follow-up (see the B6 ExecPlan)."""
@@ -223,8 +224,11 @@ def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app):
         block_position=4,
     )
 
-    # Block 4 starts streaming: staged only, then the client disconnects and
-    # the producer rolls the session back.
+    # Block 4 starts streaming: staged only, then the client disconnects.
+    # Production performs Session.invalidate() (connection discarded; the
+    # staged transaction dies with it); on this fixture's in-memory SQLite an
+    # invalidate would destroy the whole database, so model the same
+    # staged-rows-vanish effect with a rollback.
     staged = _build_block("gb-staged-0004", 4)
     dao.db.session.add(staged)
     dao.db.session.flush()

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -1,0 +1,152 @@
+"""Stream response helpers must discard the session connection on close.
+
+Both SSE helpers wrap streaming generators consumed by WSGI; a client
+walking away injects GeneratorExit (or its RuntimeError disguise) at the
+yield point, which may have interrupted a DB exchange deeper in the stack.
+The helpers must invalidate the session BEFORE the finally-remove would
+otherwise roll back on a possibly desynced connection.
+"""
+
+import pytest
+from sqlalchemy.exc import ResourceClosedError
+
+from flaskr.service.learn import routes as learn_routes
+
+
+@pytest.fixture()
+def invalidations(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        learn_routes,
+        "invalidate_session",
+        lambda *, source, session=None: calls.append(source) or True,
+    )
+    monkeypatch.setattr(
+        learn_routes, "_release_db_session", lambda _app, *, source: None
+    )
+    return calls
+
+
+def _iter_stream(app, helper, iter_factory):
+    with app.test_request_context("/"):
+        response = helper(
+            app,
+            message_iter_factory=iter_factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        return response.response
+
+
+def test_sse_close_invalidates_session(app, invalidations):
+    def factory():
+        yield {"type": "chunk"}
+        yield {"type": "chunk2"}
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_sse_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        stream = iter(response.response)
+        next(stream)
+        stream.close()
+
+    assert invalidations == ["learn stream_sse_response close"]
+
+
+def test_sse_protocol_error_invalidates_session(app, invalidations):
+    def factory():
+        yield {"type": "chunk"}
+        raise ResourceClosedError("desynced")
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_sse_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        stream = iter(response.response)
+        next(stream)
+        with pytest.raises(ResourceClosedError):
+            next(stream)
+
+    assert invalidations == ["learn stream_sse_response desync"]
+
+
+def test_sse_business_error_does_not_invalidate(app, invalidations):
+    def factory():
+        yield {"type": "chunk"}
+        raise ValueError("business")
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_sse_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        stream = iter(response.response)
+        next(stream)
+        with pytest.raises(ValueError):
+            next(stream)
+
+    assert invalidations == []
+
+
+def test_passthrough_close_invalidates_session(app, invalidations):
+    def factory():
+        yield "data: 1\n\n"
+        yield "data: 2\n\n"
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_passthrough_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        stream = iter(response.response)
+        next(stream)
+        stream.close()
+
+    assert invalidations == ["learn stream_passthrough_response close"]
+
+
+def test_passthrough_close_disguised_as_runtime_error(app, invalidations):
+    def factory():
+        yield "data: 1\n\n"
+        raise RuntimeError("generator ignored GeneratorExit")
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_passthrough_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        stream = iter(response.response)
+        next(stream)
+        with pytest.raises(StopIteration):
+            next(stream)
+
+    assert invalidations == ["learn stream_passthrough_response close"]
+
+
+def test_passthrough_normal_exhaustion_does_not_invalidate(app, invalidations):
+    def factory():
+        yield "data: 1\n\n"
+
+    with app.test_request_context("/"):
+        response = learn_routes._stream_passthrough_response(
+            app,
+            message_iter_factory=factory,
+            close_log="closed",
+            error_log="failed",
+        )
+        assert list(response.response) == ["data: 1\n\n"]
+
+    assert invalidations == []

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -29,7 +29,11 @@ class _FakeSession:
         self._behaviours = list(behaviours)
         self.executed = 0
         self.rollbacks = 0
+        self.invalidations = 0
         self._connection = _FakeConnection()
+
+    def invalidate(self):
+        self.invalidations += 1
 
     def execute(self, _statement, params):
         self.executed += 1
@@ -73,8 +77,8 @@ def test_probe_invalidates_desynced_connection_and_retries(app, monkeypatch):
     _ensure_healthy_db_connection(app)
 
     assert session.executed == 2
-    assert session._connection.invalidated == 1
-    assert session.rollbacks == 1
+    assert session.invalidations == 1
+    assert session.rollbacks == 0
 
 
 def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch):
@@ -83,7 +87,7 @@ def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch):
     _ensure_healthy_db_connection(app)
 
     assert session.executed == 2
-    assert session._connection.invalidated == 1
+    assert session.invalidations == 1
 
 
 def test_probe_raises_after_exhausting_attempts(app, monkeypatch):
@@ -93,7 +97,8 @@ def test_probe_raises_after_exhausting_attempts(app, monkeypatch):
         _ensure_healthy_db_connection(app)
 
     assert session.executed == 3
-    assert session._connection.invalidated == 3
+    assert session.invalidations == 3
+    assert session.rollbacks == 0
 
 
 def test_probe_raises_on_persistent_echo_mismatch(app, monkeypatch):

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -223,7 +223,7 @@ def test_natural_exhaustion_never_invalidates(app, monkeypatch):
         generator = _start_stream(app)
         remaining = list(generator)
 
-    assert remaining[-1] == "chunk-2" if remaining else True
+    assert remaining == ["chunk-2"]
     assert session.invalidations == 0
     assert session.rollbacks == 0
     assert session.commits >= 1

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -178,3 +178,63 @@ def test_desync_error_classifier_covers_symptom_family():
     wrapped_deadlock = OperationalError("UPDATE ...", {}, Exception())
     wrapped_deadlock.orig.args = (1213, "Deadlock found")
     assert not _is_protocol_desync_error(wrapped_deadlock)
+
+
+def test_stop_event_cancellation_invalidates_instead_of_rollback(app, monkeypatch):
+    import threading
+
+    session = _patch_run_dependencies(monkeypatch, ["chunk-1"])
+
+    class _TwoRoundContext(_StubRunContext):
+        # Two has_next rounds so the stop_event check at the loop boundary
+        # fires between them.
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            # Each loop round consumes TWO steps: the while condition and the
+            # has_next() call inside the log line.
+            self._steps = iter([True, True, True, True, False])
+
+    monkeypatch.setattr(runscript_v2, "RunScriptContextV2", _TwoRoundContext)
+    stop_event = threading.Event()
+
+    with app.app_context():
+        generator = run_script_inner(
+            app=app,
+            user_bid="user-1",
+            shifu_bid="shifu-1",
+            outline_bid="outline-1",
+            manage_app_context=False,
+            stop_event=stop_event,
+        )
+        assert next(generator) == "chunk-1"
+        # Cancellation between events: semantically a client walk-away.
+        stop_event.set()
+        with pytest.raises(StopIteration):
+            next(generator)
+
+    assert session.invalidations == 1
+    assert session.rollbacks == 0
+
+
+def test_natural_exhaustion_never_invalidates(app, monkeypatch):
+    session = _patch_run_dependencies(monkeypatch, ["chunk-1", "chunk-2"])
+
+    with app.app_context():
+        generator = _start_stream(app)
+        remaining = list(generator)
+
+    assert remaining[-1] == "chunk-2" if remaining else True
+    assert session.invalidations == 0
+    assert session.rollbacks == 0
+    assert session.commits >= 1
+
+
+def test_discard_helper_works_on_real_scoped_session(app, caplog):
+    import logging
+
+    from flaskr.service.learn.runscript_v2 import _discard_session_connection
+
+    with app.app_context():
+        with caplog.at_level(logging.WARNING):
+            _discard_session_connection(app, source="real session smoke")
+    assert "invalidate failed" not in caplog.text

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -98,3 +98,58 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch):
     with pytest.raises(OperationalError):
         other_error()
     assert fake_db.session.rollback.call_count == 1
+
+
+def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
+    import flaskr.dao as dao
+
+    invalidations = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+    calls = {"n": 0}
+
+    @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
+    def desynced():
+        calls["n"] += 1
+        raise _operational_error(2014)
+
+    with pytest.raises(OperationalError):
+        desynced()
+
+    assert calls["n"] == 1  # no retry on a desynced stream
+    assert invalidations == ["retry_on_deadlock protocol interrupt"]
+
+
+def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
+    import flaskr.dao as dao
+
+    invalidations = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    class _BrokenSession:
+        def rollback(self):
+            raise OperationalError("ROLLBACK", {}, Exception())
+
+    class _FakeDb:
+        session = _BrokenSession()
+
+    monkeypatch.setattr(dao, "db", _FakeDb)
+    calls = {"n": 0}
+
+    @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
+    def deadlocked():
+        calls["n"] += 1
+        raise _operational_error(1213)
+
+    with pytest.raises(OperationalError):
+        deadlocked()
+
+    assert calls["n"] == 1  # rollback failure aborts the retry loop
+    assert invalidations == ["retry_on_deadlock rollback failure"]


### PR DESCRIPTION
## The architectural answer to the desync saga

Seven rounds of fixes (#2232, ai_shifu_saas_plugin#4, #2244, #2252, #2256, #2260, #2261) each removed a real hazard but did not stop the intermittent listen-run failures (`ResourceClosedError`, 2014 `Command Out of Sync`, `FlushError: NULL identity key`, SSL bad record mac). The #2260 protocol forensics settled the mechanism: the desync arises **within one connection** — a statement's response goes unread when a gevent interruption (client disconnect, deploy killing greenlets) lands mid-exchange, and every later command silently consumes the previous command's response until a SELECT meets an OK packet.

Interruption sources are endemic to the gevent × synchronous-MySQL × long-SSE architecture and cannot be enumerated away. The architectural fix is one principle: **a session whose exchange may have been interrupted must have its connection discarded (`Session.invalidate()`, the documented remedy — its docstring literally uses gevent as the example), never rolled back and re-trusted.**

## The smoking gun

That principle was already implemented once (`_discard_session_connection`, wired to GeneratorExit and desync paths). **It has never executed in production**: the `scoped_session` proxy does not forward `Session.invalidate`, so `db.session.invalidate()` raised `AttributeError` straight into a broad `except` — leaving only a warning. Production logs show **11 `session invalidate failed` warnings in 12 hours**: one silent no-op per client disconnect, through an entire fix generation. The helper now resolves the real Session via the registry call form, and a regression test pins the proxy gap so it cannot regress silently.

## Changes

**`flaskr/dao` — shared termination classification** (single source of truth):
- `is_protocol_interrupt_error` / `is_abnormal_stream_termination`: GeneratorExit, non-Exception BaseExceptions (GreenletExit), ResourceClosedError / DisconnectionError, errno 2013/2014 (on the exception or its `.orig`) → interrupting. Server-delivered errors (IntegrityError, 1213/1205 deadlocks, business exceptions) → NOT interrupting; their rollback-and-retry idioms are untouched.
- `invalidate_session` (registry-resolving, duck-typed for test fakes) and `cleanup_session_after` (classify → invalidate or rollback; rollback failure escalates to invalidate).
- `retry_on_deadlock`: protocol-interrupt errors invalidate and propagate immediately (neither rollback nor retry is safe on a desynced stream); a database-level rollback failure aborts the retry loop. Deadlock behavior (1213/1205) unchanged.
- Includes the pre-execute desync interception + per-connection statement journal (off-by-one caught at the first statement after it arises; the journal tail names the interrupted statement).

**`runscript_v2`**: stop_event cancellation branches now discard instead of rollback (cancellation = client walk-away); the producer tracks natural exhaustion via `for/else` and discards on any non-exhausted or exceptional exit (BaseException included) — covering interruptions in `element_adapter.process` that the generator's own handlers cannot see; the probe-failure path collapses invalidate-then-rollback into one `Session.invalidate()`.

**`routes`**: both SSE helpers now invalidate on GeneratorExit and its `RuntimeError("generator ignored GeneratorExit")` disguise (the passthrough helper previously had NO session handling on those paths), and on detected protocol-interrupt exceptions.

## Testing

- New `test_dao_session_termination.py`: full classification matrix, **the scoped_session proxy-gap regression**, real-scoped-session invalidate smoke (no warning), duck-typing, rollback-escalation.
- Extended stream-abort tests: stop_event cancellation invalidates; **natural exhaustion never invalidates** (pins the exhaustion flag); real-session smoke for the fixed helper.
- New `test_learn_stream_response_cleanup.py`: close / disguised-close / protocol-error invalidate, business error and normal exhaustion do not.
- Extended `test_retry_on_deadlock`: 2014 → invalidate, no retry; rollback failure → escalate, stop retrying.
- Updated the tests that had pinned the old rollback semantics (disconnect e2e comments, recorder modeling, probe assertions to session-level, lock-test fakes).
- **Full backend suite: 2,511 passed, 15 skipped.**

## Verification after rollout

1. `session invalidate failed` warnings must drop to zero (direct proof the no-op is fixed).
2. The alert family and all three observability layers (pool probes, pre-execute interception, #2260 forensics) should go silent.
3. Known trade-off: connection churn rises on disconnect storms since invalidation now actually happens — pool is 20+20 with millisecond reconnects; watch pool waits during the observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection recovery after interrupted or desynchronized exchanges.
  * Streaming requests now safely discard affected connections when clients disconnect or streams fail.
  * Deadlock retries now stop promptly when connection integrity or rollback cleanup is compromised.

* **Tests**
  * Added coverage for stream cancellation, connection invalidation, cleanup behavior, and retry failure scenarios.
  * Expanded validation for normal stream completion and server-reported errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->