### PR TITLE
fix: apply termination principle to remaining stream side paths

### DIFF
--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -455,6 +455,17 @@ def init_db(app: Flask):
         db = SQLAlchemy(session_options={"scopefunc": _unique_app_ctx_scope})
     db.init_app(app)
 
+    # Global last-resort guard: any interrupted path not covered by an
+    # explicit termination handler still funnels through the app-context
+    # teardown, where Flask-SQLAlchemy's remove() would roll back on the
+    # possibly desynced connection. Flask runs teardown callbacks in
+    # REVERSE registration order, so registering AFTER db.init_app makes
+    # this run BEFORE the extension's session removal.
+    @app.teardown_appcontext
+    def _invalidate_session_on_interrupted_teardown(exc):
+        if exc is not None and is_abnormal_stream_termination(exc):
+            invalidate_session(source="appcontext teardown interrupt")
+
     # Enable formatted SQL output in the development environment
     if app.debug:
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -36,7 +36,7 @@ from flaskr.common.i18n_utils import (
     resolve_markdownflow_output_language,
 )
 from flaskr.common.cache_provider import cache as cache_provider
-from flaskr.dao import db
+from flaskr.dao import db, invalidate_session
 from flaskr.service.shifu.shifu_struct_manager import (
     ShifuOutlineItemDto,
     ShifuInfoDto,
@@ -1820,16 +1820,36 @@ class RunScriptContextV2:
             with self.app.app_context():
                 set_language(parent_language)
                 apply_shifu_context_snapshot(parent_shifu_context)
+                produce_exc: BaseException | None = None
+                exhausted = False
                 try:
                     for item in stream_result:
                         if consumer_stopped.is_set() or self._stop_requested():
                             break
                         result_queue.put(("item", item))
+                    else:
+                        # for/else: only natural exhaustion reaches here.
+                        exhausted = True
                 except Exception as exc:
+                    produce_exc = exc
                     result_queue.put(("error", exc))
+                except BaseException as exc:  # noqa: BLE001 - GreenletExit etc.
+                    produce_exc = exc
+                    raise
                 finally:
                     with contextlib.suppress(Exception):
                         stream_result.close()
+                    if not exhausted or produce_exc is not None:
+                        # The close above (or the interruption itself) may
+                        # have landed mid-DB-exchange in this thread's own
+                        # session; discard its connection rather than letting
+                        # remove() roll back on a possibly desynced stream.
+                        # NOTE: consumer_stopped is deliberately NOT part of
+                        # this predicate - the consumer's finally sets it
+                        # unconditionally, and a natural completion racing
+                        # that set must not discard a healthy connection
+                        # (exhausted stays True in that case).
+                        invalidate_session(source="mdflow stream producer abort")
                     with contextlib.suppress(Exception):
                         db.session.remove()
                     result_queue.put(("done", None))

--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -6,7 +6,7 @@ import select as select_module
 import socket as socket_module
 
 from flask import current_app
-from flaskr.dao import db
+from flaskr.dao import db, invalidate_session
 from sqlalchemy import bindparam, text
 from sqlalchemy.exc import ResourceClosedError
 
@@ -225,8 +225,12 @@ class ListenElementRunPersistenceMixin:
                     "Listen element SELECT hit a desynced connection; forensics: %s",
                     _describe_desynced_connection(result, connection),
                 )
-            with contextlib.suppress(Exception):
-                connection.invalidate()
+            # Session-level invalidate: this connection IS the session's
+            # transaction connection, so Session.invalidate() discards it AND
+            # resets the session state without emitting SQL - even a caller
+            # that swallows this exception can no longer commit/rollback on
+            # the desynced stream.
+            invalidate_session(source="listen element select desync")
             raise
         finally:
             with contextlib.suppress(Exception):

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Optional
 
 from flask import Flask
 
-from flaskr.dao import db
+from flaskr.dao import cleanup_session_after, db, invalidate_session
 from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.util.uuid import generate_id
 
@@ -53,23 +53,32 @@ def _resolve_billable(app: Flask, *, context: UsageContext, usage_scene: int) ->
 
 def _persist_usage_record(app: Flask, record: BillUsageRecord) -> bool:
     """Persist raw usage only; async settlement owns later credit mutations."""
-    try:
-        with app.app_context():
+    with app.app_context():
+        try:
             db.session.add(record)
             db.session.commit()
-        return True
-    except Exception as exc:
-        try:
-            app.logger.error("Usage metering persist failed: %s", exc, exc_info=True)
-        except Exception:
-            # Ignore logging failures to avoid masking the original persistence error.
-            pass
-        try:
-            db.session.rollback()
-        except Exception:
-            # Ignore rollback failures; session may already be invalidated.
-            pass
-        return False
+            return True
+        except Exception as exc:
+            try:
+                app.logger.error(
+                    "Usage metering persist failed: %s", exc, exc_info=True
+                )
+            except Exception:
+                # Never mask the persistence failure with a logging failure.
+                pass
+            # Clean up INSIDE the pushed context so it targets the session
+            # that actually failed - the previous cleanup ran after the
+            # context pop and rolled back the CALLER's session instead.
+            # Classified: stream-interrupting failures discard the
+            # connection, ordinary errors roll back as before.
+            cleanup_session_after(exc, source="usage metering persist")
+            return False
+        except BaseException:
+            # A GreenletExit landing inside commit's network IO leaves an
+            # unread response owed on the wire; discard the connection
+            # before the context teardown would roll back on it.
+            invalidate_session(source="usage metering persist interrupt")
+            raise
 
 
 def _should_enqueue_usage_settlement(

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from flask import Response, current_app, stream_with_context
 
+from flaskr.dao import cleanup_session_after, invalidate_session
+
 from flaskr.api.tts import (
     get_default_audio_settings,
     get_default_voice_settings,
@@ -200,9 +202,14 @@ def build_tts_preview_response(
             yield "data: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
         except GeneratorExit:
             current_app.logger.info("client closed tts preview stream early")
+            # The close may have interrupted a DB write (usage metering runs
+            # on this stream); discard the connection so the request teardown
+            # does not roll back on a possibly desynced stream.
+            invalidate_session(source="tts preview stream close")
             raise
-        except Exception:
+        except Exception as exc:
             current_app.logger.error("TTS preview stream failed", exc_info=True)
+            cleanup_session_after(exc, source="tts preview stream error")
             raise
 
     return Response(

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -136,3 +136,50 @@ def test_cleanup_escalates_to_invalidate_when_rollback_fails():
     outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
     assert outcome == "invalidated"
     assert events == ["rollback", "invalidate"]
+
+
+def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
+    """The global teardown guard must fire on abnormal context exits and run
+    BEFORE Flask-SQLAlchemy's remove (reverse registration order)."""
+    import flaskr.dao as dao
+
+    order = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: order.append(f"invalidate:{source}") or True,
+    )
+    original_remove = db.session.remove
+
+    def _tracking_remove():
+        order.append("remove")
+        return original_remove()
+
+    monkeypatch.setattr(db.session, "remove", _tracking_remove)
+
+    class _Interrupt(BaseException):
+        pass
+
+    with pytest.raises(_Interrupt):
+        with app.app_context():
+            raise _Interrupt()
+
+    assert order[0] == "invalidate:appcontext teardown interrupt"
+    assert "remove" in order
+
+
+def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
+    import flaskr.dao as dao
+
+    invalidations = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    with pytest.raises(ValueError):
+        with app.app_context():
+            raise ValueError("business")
+
+    assert invalidations == []

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -131,6 +131,18 @@ def app():
             raise
     app.extensions.pop("sqlalchemy", None)
     dao.db.init_app(app)
+    # The second init_app above registered another Flask-SQLAlchemy teardown
+    # AFTER dao's interrupt guard; teardowns run LIFO, so move the guard back
+    # to the end to preserve guard-before-session-removal ordering. This
+    # matches production, where init_app runs exactly once inside init_db.
+    _teardown_funcs = app.teardown_appcontext_funcs
+    for _func in list(_teardown_funcs):
+        if (
+            getattr(_func, "__name__", "")
+            == "_invalidate_session_on_interrupted_teardown"
+        ):
+            _teardown_funcs.remove(_func)
+            _teardown_funcs.append(_func)
 
     with app.app_context():
         # Allow skipping DB migrations in CI/unit-only runs

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -43,3 +43,66 @@ def test_stream_producer_stops_when_consumer_exits_early(app):
         thread.name == _PRODUCER_THREAD_NAME and thread.is_alive()
         for thread in threading.enumerate()
     )
+
+
+def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch):
+    from flaskr.service.learn import context_v2
+
+    invalidations = []
+    monkeypatch.setattr(
+        context_v2,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    stop_streaming = threading.Event()
+
+    def endless_stream():
+        index = 0
+        while not stop_streaming.is_set():
+            yield index
+            index += 1
+            time.sleep(0.01)
+
+    stub = _make_context_stub(app)
+    iterator = RunScriptContextV2._iter_stream_result_with_idle_callback(
+        stub,
+        endless_stream(),
+        idle_callback=None,
+    )
+    try:
+        assert next(iterator) == ("item", 0)
+    finally:
+        iterator.close()
+        stop_streaming.set()
+
+    assert invalidations == ["mdflow stream producer abort"]
+
+
+def test_natural_exhaustion_does_not_invalidate_producer_session(app, monkeypatch):
+    from flaskr.service.learn import context_v2
+
+    invalidations = []
+    monkeypatch.setattr(
+        context_v2,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    def short_stream():
+        yield "a"
+        yield "b"
+
+    stub = _make_context_stub(app)
+    items = [
+        payload
+        for kind, payload in RunScriptContextV2._iter_stream_result_with_idle_callback(
+            stub,
+            short_stream(),
+            idle_callback=None,
+        )
+        if kind == "item"
+    ]
+
+    assert items == ["a", "b"]
+    assert invalidations == []

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -144,13 +144,24 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
             run_session_bid="run-a",
         )
 
+        invalidations = []
+        monkeypatch.setattr(
+            listen_element_run_persistence,
+            "invalidate_session",
+            lambda *, source, session=None: invalidations.append(source) or True,
+        )
+
         with pytest.raises(ResourceClosedError):
             adapter._find_active_element_row_ids(
                 generated_block_bid="block-a",
                 element_bids=["element-a"],
             )
 
-    assert fake_connection.invalidated == 1
+    # Session-level invalidate replaces the old connection-level call: it
+    # discards the same transaction connection AND resets session state
+    # without emitting SQL.
+    assert invalidations == ["listen element select desync"]
+    assert fake_connection.invalidated == 0
 
 
 def test_deactivate_active_element_rows_retires_rows_without_touching_others(app):

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -334,3 +334,68 @@ def test_record_tts_usage_marks_builtin_demo_course_non_billable(
     assert record is not None
     assert record.billable == 0
     assert captured == []
+
+
+def test_persist_cleanup_targets_failed_session_inside_context(app, monkeypatch):
+    """Cleanup must run inside the pushed context (targeting the session that
+    failed) and classify the failure: ordinary errors roll back, protocol
+    interrupts invalidate."""
+    from flask import current_app
+    from sqlalchemy.exc import ResourceClosedError
+
+    from flaskr.service.metering import recorder as recorder_module
+
+    events = []
+
+    def _fake_cleanup(exc, *, source, session=None):
+        # Must be called while the pushed app context is active.
+        events.append((type(exc).__name__, current_app._get_current_object() is app))
+        return "cleaned"
+
+    monkeypatch.setattr(recorder_module, "cleanup_session_after", _fake_cleanup)
+
+    class _FailingSession:
+        def add(self, _record):
+            pass
+
+        def commit(self):
+            raise ResourceClosedError("desynced")
+
+    monkeypatch.setattr(
+        recorder_module, "db", type("D", (), {"session": _FailingSession()})
+    )
+
+    ok = recorder_module._persist_usage_record(app, object())
+
+    assert ok is False
+    assert events == [("ResourceClosedError", True)]
+
+
+def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch):
+    from flaskr.service.metering import recorder as recorder_module
+
+    invalidations = []
+    monkeypatch.setattr(
+        recorder_module,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    class _Interrupt(BaseException):
+        pass
+
+    class _InterruptedSession:
+        def add(self, _record):
+            pass
+
+        def commit(self):
+            raise _Interrupt()
+
+    monkeypatch.setattr(
+        recorder_module, "db", type("D", (), {"session": _InterruptedSession()})
+    )
+
+    with pytest.raises(_Interrupt):
+        recorder_module._persist_usage_record(app, object())
+
+    assert invalidations == ["usage metering persist interrupt"]

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -268,3 +268,91 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
             "owner_user_bid": "creator-debug-tts-1",
         }
     ]
+
+
+def _stub_preview_pipeline(monkeypatch):
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.validate_tts_settings_strict",
+        lambda **_kwargs: SimpleNamespace(
+            provider="fake",
+            model="tts-model-1",
+            voice_id="voice-1",
+            speed=1.0,
+            pitch=0,
+            emotion="",
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.is_tts_configured",
+        lambda _provider: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.get_default_voice_settings",
+        lambda _provider: SimpleNamespace(
+            voice_id="", speed=0.0, pitch=0, emotion="", volume=1.0
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.get_default_audio_settings",
+        lambda _provider: _FakeAudioSettings(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.split_text_for_tts",
+        lambda _text, provider_name="": ["hello", "world"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.preprocess_for_tts",
+        lambda text: text,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.generate_id",
+        lambda _app: "usage-parent-1",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.synthesize_text",
+        lambda **_kwargs: SimpleNamespace(
+            duration_ms=123,
+            audio_data=b"abc",
+            word_count=5,
+            usage_characters=8,
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.record_tts_usage",
+        lambda *_args, **kwargs: kwargs.get("usage_bid") or "segment-usage",
+        raising=False,
+    )
+
+
+def test_preview_stream_close_invalidates_session(monkeypatch) -> None:
+    """A client walking away mid-preview may interrupt the usage-metering DB
+    write; the GeneratorExit handler must discard the session connection."""
+    app = Flask(__name__)
+    _stub_preview_pipeline(monkeypatch)
+
+    invalidations: list[str] = []
+    monkeypatch.setattr(
+        "flaskr.service.shifu.tts_preview.invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+        raising=False,
+    )
+
+    with app.test_request_context("/api/shifu/tts/preview", method="POST"):
+        response = build_tts_preview_response(
+            {"provider": "fake", "voice_id": "voice-1", "text": "hello world"},
+            request_user_id="creator-1",
+            request_user_is_creator=True,
+        )
+        stream = iter(response.response)
+        next(stream)
+        stream.close()
+
+    assert invalidations == ["tts preview stream close"]


### PR DESCRIPTION
## PR-2 of the termination-principle rollout

#2263 (merged) established the principle — a session whose exchange may have been interrupted has its connection discarded, never rolled back and re-trusted — and applied it to the main listen chain (dao classification layer, run-script producer/cancellation/probe, learn SSE helpers). This PR closes the remaining side paths identified in the same audit.

## Changes

1. **mdflow stream producer** (`context_v2._iter_stream_result_with_idle_callback`): the producer thread tracks natural exhaustion via `for/else`, captures BaseException (GreenletExit), and invalidates its own session on any non-exhausted or exceptional exit before `remove()`. `consumer_stopped` is deliberately NOT part of the predicate: the consumer's finally sets it unconditionally, and a natural completion racing that set must not discard a healthy connection.
2. **Usage metering persist** (`metering/recorder._persist_usage_record`): cleanup now runs INSIDE the pushed app context — the previous code rolled back after the context pop, targeting the CALLER's session instead of the one that failed — with classified handling (`cleanup_session_after`) replacing two silent excepts, and a BaseException branch that invalidates before the interrupt propagates (this helper runs on TTS finalize/preview streams).
3. **TTS preview stream** (`tts_preview`): GeneratorExit invalidates (usage metering writes happen on this stream); other errors get classified cleanup.
4. **Listen element desync handler**: upgraded from connection-level `connection.invalidate()` to session-level `invalidate_session` — same connection discarded, but the session state is also reset without emitting SQL, so even a caller that swallows the exception cannot commit/rollback on the desynced stream.
5. **Global teardown guard** (`dao.init_db`): registered after `db.init_app`, so Flask's LIFO teardown order runs it BEFORE Flask-SQLAlchemy's session removal; any future interrupted path without an explicit handler still gets its connection discarded instead of rolled back. The test conftest performs a second `init_app` (to apply test binds), which re-ordered the teardowns — the conftest now restores guard-last ordering to match production, and an ordering test pins the contract.

## Testing

- Producer: early consumer exit invalidates; natural exhaustion does not.
- Metering: cleanup runs inside the pushed context and targets the failed session; BaseException invalidates then propagates.
- TTS preview: mid-stream close invalidates.
- Listen persistence: desync now asserts session-level invalidation (connection-level counter stays zero).
- Teardown guard: interrupt-classified context exits invalidate before removal; ordinary exceptions do not.
- **Full backend suite: 2,518 passed, 15 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)