### PR TITLE
fix: minimize unnecessary LLM reasoning

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -569,6 +569,47 @@ DEEPSEEK_FALLBACK_MODELS = [
 
 
 def _reload_openai_params(model_id: str, temperature: float) -> Dict[str, Any]:
+    if model_id.startswith("gpt-5"):
+        try:
+            model_info = litellm.get_model_info(
+                model=model_id,
+                custom_llm_provider="openai",
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Keep the existing prefix-based behavior for model aliases that
+            # have not reached LiteLLM's bundled model map yet.
+            logger.debug(
+                "LiteLLM model info unavailable for %s: %s",
+                model_id,
+                exc,
+            )
+        else:
+            if model_info.get("supports_none_reasoning_effort") is True:
+                return {
+                    "reasoning_effort": "none",
+                    "temperature": temperature,
+                }
+            if model_info.get("supports_minimal_reasoning_effort") is True:
+                reasoning_effort = "minimal"
+            elif model_info.get("supports_low_reasoning_effort") is True:
+                reasoning_effort = "low"
+            elif all(
+                model_info.get(key) is False
+                for key in (
+                    "supports_none_reasoning_effort",
+                    "supports_minimal_reasoning_effort",
+                    "supports_low_reasoning_effort",
+                )
+            ):
+                reasoning_effort = "medium"
+            else:
+                reasoning_effort = None
+            if reasoning_effort is not None:
+                return {
+                    "reasoning_effort": reasoning_effort,
+                    "temperature": 1,
+                }
+
     if model_id.startswith("gpt-5.2"):
         return {
             "reasoning_effort": "none",
@@ -603,13 +644,13 @@ def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
         "allowed_openai_params": ["reasoning_effort"],
     }
     if model_id.startswith("gemini-3"):
-        # Gemini 3 Flash-family supports minimal thinking; LiteLLM falls back to
-        # low for Gemini 3 models that do not support minimal.
-        params["reasoning_effort"] = "minimal"
+        # Gemini 3 cannot fully disable thinking. LiteLLM maps none to the
+        # model's lowest supported level and suppresses thought output.
+        params["reasoning_effort"] = "none"
     elif model_id.startswith("gemini-2.5-pro"):
-        # Gemini 2.5 Pro cannot disable thinking, so use the lowest supported
-        # reasoning level.
-        params["reasoning_effort"] = "low"
+        # Gemini 2.5 Pro cannot disable thinking; LiteLLM maps minimal to its
+        # minimum supported 128-token thinking budget.
+        params["reasoning_effort"] = "minimal"
     elif model_id.startswith("gemini"):
         # Older Gemini models can use the cost-optimized no-thinking mapping.
         params["reasoning_effort"] = "none"
@@ -617,10 +658,9 @@ def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
 
 
 def _reload_ark_params(model_id: str, temperature: float) -> Dict[str, Any]:
-    # doubao-seed models support thinking parameter, pass via extra_body for LiteLLM
     return {
         "temperature": temperature,
-        "extra_body": {"thinking": {"type": "disabled"}},
+        "thinking": {"type": "disabled"},
     }
 
 
@@ -641,8 +681,56 @@ def _reload_qwen_params(model_id: str, temperature: float) -> Dict[str, Any]:
 def _reload_deepseek_params(model_id: str, temperature: float) -> Dict[str, Any]:
     return {
         "temperature": temperature,
-        "extra_body": {"thinking": {"type": "disabled"}},
+        "reasoning_effort": "none",
     }
+
+
+_GLM_THINKING_MODEL_PREFIXES = ("glm-4.5", "glm-4.6", "glm-4.7", "glm-5")
+_THINKING_CONTROL_KEYS = ("reasoning_effort", "thinking", "enable_thinking")
+
+
+def _reload_glm_params(model_id: str, temperature: float) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "temperature": temperature,
+        # LiteLLM's ZAI adapter currently gates thinking on model metadata and
+        # omits response_format from its supported list. Keep JSON output
+        # compatible without allowing thinking on legacy GLM models.
+        "allowed_openai_params": ["response_format"],
+    }
+    if model_id.lower().startswith(_GLM_THINKING_MODEL_PREFIXES):
+        params["allowed_openai_params"].append("thinking")
+        # ZAI still sends chat completions through the OpenAI SDK in LiteLLM
+        # 1.95.0. Keep thinking in extra_body so the SDK forwards it instead
+        # of rejecting the vendor-specific argument before the request is sent.
+        params["extra_body"] = {"thinking": {"type": "disabled"}}
+    return params
+
+
+def _apply_provider_params(
+    kwargs: dict[str, Any], provider_params: dict[str, Any]
+) -> None:
+    provider_extra_body = provider_params.get("extra_body")
+    has_thinking_policy = any(
+        key in provider_params for key in _THINKING_CONTROL_KEYS
+    ) or (
+        isinstance(provider_extra_body, dict)
+        and any(key in provider_extra_body for key in _THINKING_CONTROL_KEYS)
+    )
+    if has_thinking_policy:
+        for key in _THINKING_CONTROL_KEYS:
+            kwargs.pop(key, None)
+        caller_extra_body = kwargs.get("extra_body")
+        if isinstance(caller_extra_body, dict):
+            sanitized_extra_body = {
+                key: value
+                for key, value in caller_extra_body.items()
+                if key not in _THINKING_CONTROL_KEYS
+            }
+            if sanitized_extra_body:
+                kwargs["extra_body"] = sanitized_extra_body
+            else:
+                kwargs.pop("extra_body", None)
+    kwargs.update(provider_params)
 
 
 LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
@@ -666,7 +754,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         extra_models=["deepseek-r1", "deepseek-v3"],
         wildcard_prefixes=(QWEN_PREFIX,),
         config_hint="QWEN_API_KEY,QWEN_API_URL",
-        custom_llm_provider="openai",
+        custom_llm_provider="dashscope",
         reload_params=_reload_qwen_params,
     ),
     ProviderConfig(
@@ -683,7 +771,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         base_url_env="DEEPSEEK_API_URL",
         default_base_url="https://api.deepseek.com",
         config_hint="DEEPSEEK_API_KEY,DEEPSEEK_API_URL",
-        custom_llm_provider="openai",
+        custom_llm_provider="deepseek",
         model_loader=_load_deepseek_models,
         reload_params=_reload_deepseek_params,
     ),
@@ -706,7 +794,8 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         default_base_url="https://open.bigmodel.cn/api/paas/v4",
         prefix=GLM_PREFIX,
         config_hint="BIGMODEL_API_KEY",
-        custom_llm_provider="openai",
+        custom_llm_provider="zai",
+        reload_params=_reload_glm_params,
     ),
     ProviderConfig(
         key="silicon",
@@ -723,7 +812,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
         default_base_url="https://ark.cn-beijing.volces.com/api/v3",
         prefix="ark/",
         config_hint="ARK_API_KEY",
-        custom_llm_provider="openai",
+        custom_llm_provider="volcengine",
         reload_params=_reload_ark_params,
     ),
 ]
@@ -842,7 +931,10 @@ def invoke_llm(
             kwargs["response_format"] = {"type": "json_object"}
         kwargs["stream_options"] = {"include_usage": True}
         if reload_params:
-            kwargs.update(reload_params(model, float(kwargs.get("temperature", 0.3))))
+            _apply_provider_params(
+                kwargs,
+                reload_params(invoke_model, float(kwargs.get("temperature", 0.3))),
+            )
         else:
             kwargs.update(
                 {
@@ -1010,7 +1102,10 @@ def chat_llm(
         provider_key, _normalized = _resolve_provider_for_model(model)
         provider_name = provider_key or ""
         if reload_params:
-            kwargs.update(reload_params(model, float(kwargs.get("temperature", 0.3))))
+            _apply_provider_params(
+                kwargs,
+                reload_params(invoke_model, float(kwargs.get("temperature", 0.3))),
+            )
         else:
             kwargs.update(
                 {

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -686,7 +686,15 @@ def _reload_deepseek_params(model_id: str, temperature: float) -> Dict[str, Any]
 
 
 _GLM_THINKING_MODEL_PREFIXES = ("glm-4.5", "glm-4.6", "glm-4.7", "glm-5")
-_THINKING_CONTROL_KEYS = ("reasoning_effort", "thinking", "enable_thinking")
+_THINKING_CONTROL_KEYS = (
+    "reasoning_effort",
+    "thinking",
+    "enable_thinking",
+    "thinkingConfig",
+    "thinking_config",
+)
+_GEMINI_GENERATION_CONFIG_KEYS = ("generation_config", "generationConfig")
+_GEMINI_THINKING_CONFIG_KEYS = ("thinkingConfig", "thinking_config")
 
 
 def _reload_glm_params(model_id: str, temperature: float) -> dict[str, Any]:
@@ -726,11 +734,38 @@ def _apply_provider_params(
                 for key, value in caller_extra_body.items()
                 if key not in _THINKING_CONTROL_KEYS
             }
+            # Gemini merges these native blocks after mapping reasoning_effort,
+            # so a caller-supplied thinking config would otherwise win.
+            normalized_generation_config: dict[str, Any] = {}
+            for generation_config_key in _GEMINI_GENERATION_CONFIG_KEYS:
+                generation_config = sanitized_extra_body.pop(
+                    generation_config_key,
+                    None,
+                )
+                if not isinstance(generation_config, dict):
+                    continue
+                normalized_generation_config.update(
+                    {
+                        key: value
+                        for key, value in generation_config.items()
+                        if key not in _GEMINI_THINKING_CONFIG_KEYS
+                    }
+                )
+            if normalized_generation_config:
+                sanitized_extra_body["generationConfig"] = normalized_generation_config
             if sanitized_extra_body:
                 kwargs["extra_body"] = sanitized_extra_body
             else:
                 kwargs.pop("extra_body", None)
-    kwargs.update(provider_params)
+
+    applied_params = dict(provider_params)
+    if isinstance(provider_extra_body, dict):
+        caller_extra_body = kwargs.get("extra_body")
+        applied_params["extra_body"] = {
+            **(caller_extra_body if isinstance(caller_extra_body, dict) else {}),
+            **provider_extra_body,
+        }
+    kwargs.update(applied_params)
 
 
 LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -661,6 +661,9 @@ def _reload_ark_params(model_id: str, temperature: float) -> Dict[str, Any]:
     return {
         "temperature": temperature,
         "thinking": {"type": "disabled"},
+        # The follow-up flow relies on JSON mode, but LiteLLM 1.95 omits this
+        # supported Volcengine parameter from its adapter metadata.
+        "allowed_openai_params": ["response_format"],
     }
 
 

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -66,7 +66,7 @@ mistune==3.2.1
 mpmath==1.3.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
-litellm==1.84.8
+litellm==1.95.0
 openpyxl==3.1.5
 opentelemetry-api==1.36.0
 opentelemetry-exporter-otlp-proto-http==1.36.0

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -823,6 +823,9 @@ def test_provider_specific_thinking_params_remain_compatible():
     assert llm._reload_ark_params("doubao-seed", 0.4)["thinking"] == {
         "type": "disabled"
     }
+    assert llm._reload_ark_params("doubao-seed", 0.4)["allowed_openai_params"] == [
+        "response_format"
+    ]
 
 
 def test_provider_thinking_policy_removes_caller_conflicts():
@@ -1098,7 +1101,11 @@ def test_litellm_195_native_adapter_contracts():
                 "volcengine",
                 "doubao-seed-2-0-lite-260428",
                 "https://ark.cn-beijing.volces.com/api/v3",
-                {"thinking": {"type": "disabled"}},
+                {
+                    "thinking": {"type": "disabled"},
+                    "allowed_openai_params": ["response_format"],
+                    "response_format": {"type": "json_object"},
+                },
             ),
             "zai": adapter_contract(
                 "zai",
@@ -1180,6 +1187,7 @@ def test_litellm_195_native_adapter_contracts():
     assert contracts["deepseek"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["dashscope"]["body"]["enable_thinking"] is False
     assert contracts["volcengine"]["body"]["thinking"] == {"type": "disabled"}
+    assert contracts["volcengine"]["body"]["response_format"] == {"type": "json_object"}
     assert contracts["zai"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["zai"]["body"]["response_format"] == {"type": "json_object"}
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1,5 +1,9 @@
 # ruff: noqa: E402
+import json
+import os
+import subprocess
 import sys
+import textwrap
 import types
 from datetime import datetime
 from decimal import Decimal
@@ -18,8 +22,13 @@ def _install_litellm_stub() -> None:
     def register_model(model_map):
         litellm_stub.model_cost.update(model_map)
 
+    def get_model_info(*args, **kwargs):
+        _ = args, kwargs
+        raise ValueError("unknown model")
+
     litellm_stub.register_model = register_model
     litellm_stub.get_max_tokens = lambda _model: 4096
+    litellm_stub.get_model_info = get_model_info
     litellm_stub.completion = lambda *args, **kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
@@ -480,13 +489,18 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
         return iter([FakeResponse("chunk-1", content="ok", finish_reason="stop")])
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+
+    def reload_qwen_params(model_id, temperature):
+        captured["reload_model"] = model_id
+        return llm._reload_qwen_params(model_id, temperature)
+
     provider_state = llm.ProviderState(
         enabled=True,
         params={"api_key": "test-key", "api_base": "https://example.com"},
         models=[],
         prefix=llm.QWEN_PREFIX,
         wildcard_prefixes=(llm.QWEN_PREFIX,),
-        reload_params=llm._reload_qwen_params,
+        reload_params=reload_qwen_params,
     )
     monkeypatch.setattr(llm, "PROVIDER_STATES", {"qwen": provider_state})
     monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {})
@@ -515,6 +529,7 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
 
     assert [resp.result for resp in responses] == ["ok"]
     assert captured["model"] == "deepseek-v4-flash"
+    assert captured["reload_model"] == "deepseek-v4-flash"
     assert captured["kwargs"]["temperature"] == 0.7
     assert captured["kwargs"]["extra_body"] == {"enable_thinking": False}
     assert captured["kwargs"]["max_tokens"] == 393216
@@ -665,6 +680,421 @@ def test_qwen_provider_config_keeps_prefix_fallback():
     )
 
     assert qwen_config.wildcard_prefixes == (llm.QWEN_PREFIX,)
+    assert qwen_config.custom_llm_provider == "dashscope"
+
+
+@pytest.mark.parametrize(
+    ("provider_key", "expected_litellm_provider"),
+    [
+        ("deepseek", "deepseek"),
+        ("qwen", "dashscope"),
+        ("ark", "volcengine"),
+        ("glm", "zai"),
+        ("silicon", "openai"),
+        ("ernie_v2", "openai"),
+    ],
+)
+def test_provider_configs_use_expected_litellm_adapters(
+    provider_key,
+    expected_litellm_provider,
+):
+    provider_config = next(
+        config for config in llm.LITELLM_PROVIDER_CONFIGS if config.key == provider_key
+    )
+
+    assert provider_config.custom_llm_provider == expected_litellm_provider
+
+
+@pytest.mark.parametrize(
+    ("model_info", "expected_effort", "expected_temperature"),
+    [
+        ({"supports_none_reasoning_effort": True}, "none", 0.4),
+        (
+            {
+                "supports_none_reasoning_effort": False,
+                "supports_minimal_reasoning_effort": True,
+            },
+            "minimal",
+            1,
+        ),
+        (
+            {
+                "supports_none_reasoning_effort": False,
+                "supports_minimal_reasoning_effort": False,
+                "supports_low_reasoning_effort": True,
+            },
+            "low",
+            1,
+        ),
+        (
+            {
+                "supports_none_reasoning_effort": False,
+                "supports_minimal_reasoning_effort": False,
+                "supports_low_reasoning_effort": False,
+            },
+            "medium",
+            1,
+        ),
+    ],
+)
+def test_openai_params_use_litellm_reasoning_capabilities(
+    monkeypatch,
+    model_info,
+    expected_effort,
+    expected_temperature,
+):
+    captured = {}
+
+    def fake_get_model_info(*, model, custom_llm_provider):
+        captured["model"] = model
+        captured["custom_llm_provider"] = custom_llm_provider
+        return model_info
+
+    monkeypatch.setattr(llm.litellm, "get_model_info", fake_get_model_info)
+
+    params = llm._reload_openai_params("gpt-5.6-luna", 0.4)
+
+    assert params == {
+        "reasoning_effort": expected_effort,
+        "temperature": expected_temperature,
+    }
+    assert captured == {
+        "model": "gpt-5.6-luna",
+        "custom_llm_provider": "openai",
+    }
+
+
+def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatch):
+    def raise_unknown(*args, **kwargs):
+        _ = args, kwargs
+        raise ValueError("unknown model")
+
+    monkeypatch.setattr(llm.litellm, "get_model_info", raise_unknown)
+
+    assert llm._reload_openai_params("gpt-5-custom", 0.4) == {
+        "reasoning_effort": "minimal",
+        "temperature": 1,
+    }
+
+
+def test_openai_params_fall_back_when_capability_metadata_is_partial(monkeypatch):
+    monkeypatch.setattr(
+        llm.litellm,
+        "get_model_info",
+        lambda *args, **kwargs: {"supports_none_reasoning_effort": False},
+    )
+
+    assert llm._reload_openai_params("gpt-5.2-custom", 0.4) == {
+        "reasoning_effort": "none",
+        "temperature": 0.4,
+    }
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    ["glm-4.5", "glm-4.6-air", "glm-4.7-flash", "glm-5.2"],
+)
+def test_glm_params_disable_thinking_for_supported_models(model_id):
+    params = llm._reload_glm_params(model_id, 0.4)
+
+    assert params == {
+        "temperature": 0.4,
+        "allowed_openai_params": ["response_format", "thinking"],
+        "extra_body": {"thinking": {"type": "disabled"}},
+    }
+
+
+def test_glm_params_leave_legacy_models_unchanged():
+    params = llm._reload_glm_params("glm-4-plus", 0.4)
+
+    assert params == {
+        "temperature": 0.4,
+        "allowed_openai_params": ["response_format"],
+    }
+
+
+def test_provider_specific_thinking_params_remain_compatible():
+    assert llm._reload_qwen_params("qwen-max", 0.4)["extra_body"] == {
+        "enable_thinking": False
+    }
+    assert llm._reload_silicon_params("deepseek-ai/DeepSeek-V3", 0.4)["extra_body"] == {
+        "enable_thinking": False
+    }
+    assert llm._reload_ark_params("doubao-seed", 0.4)["thinking"] == {
+        "type": "disabled"
+    }
+
+
+def test_provider_thinking_policy_removes_caller_conflicts():
+    kwargs = {
+        "reasoning_effort": "high",
+        "thinking": {"type": "enabled"},
+        "enable_thinking": True,
+        "extra_body": {
+            "thinking": {"type": "enabled"},
+            "enable_thinking": True,
+            "custom_field": "keep",
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        {"reasoning_effort": "none", "temperature": 0.4},
+    )
+
+    assert kwargs == {
+        "reasoning_effort": "none",
+        "temperature": 0.4,
+        "extra_body": {"custom_field": "keep"},
+    }
+
+
+def test_litellm_195_native_adapter_contracts():
+    script = textwrap.dedent(
+        """
+        import importlib.metadata
+        import json
+
+        import httpx
+        import litellm
+        from openai import OpenAI
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+        messages = [{"role": "user", "content": "hello"}]
+        sse_events = [
+            {
+                "id": "chatcmpl-contract",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "contract-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "Hello"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-contract",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "contract-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": " world"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-contract",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "contract-model",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 2,
+                    "total_tokens": 5,
+                },
+            },
+        ]
+        sse_payload = (
+            "".join(f"data: {json.dumps(event)}\\n\\n" for event in sse_events)
+            + "data: [DONE]\\n\\n"
+        ).encode()
+
+        def adapter_contract(provider, model, api_base, provider_kwargs):
+            captured = []
+
+            def respond(request):
+                captured.append(
+                    {
+                        "url": str(request.url),
+                        "body": json.loads(request.content.decode()),
+                    }
+                )
+                return httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=sse_payload,
+                    request=request,
+                )
+
+            http_client = httpx.Client(
+                transport=httpx.MockTransport(respond),
+                trust_env=False,
+            )
+            # DeepSeek uses LiteLLM's native HTTP handler. The other adapters
+            # currently route their transformed request through the OpenAI SDK.
+            client = (
+                HTTPHandler(client=http_client)
+                if provider == "deepseek"
+                else OpenAI(
+                    api_key="test-key",
+                    base_url=api_base,
+                    http_client=http_client,
+                )
+            )
+            chunks = list(
+                litellm.completion(
+                    model=model,
+                    custom_llm_provider=provider,
+                    api_base=api_base,
+                    api_key="test-key",
+                    client=client,
+                    messages=messages,
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    temperature=0.4,
+                    **provider_kwargs,
+                )
+            )
+            content = "".join(
+                chunk.choices[0].delta.content or ""
+                for chunk in chunks
+                if chunk.choices
+            )
+            usage_chunks = [
+                chunk.usage
+                for chunk in chunks
+                if getattr(chunk, "usage", None) is not None
+            ]
+            assert len(captured) == 1
+            assert len(usage_chunks) == 1
+            return {
+                **captured[0],
+                "content": content,
+                "usage": {
+                    "prompt_tokens": usage_chunks[0].prompt_tokens,
+                    "completion_tokens": usage_chunks[0].completion_tokens,
+                    "total_tokens": usage_chunks[0].total_tokens,
+                },
+            }
+
+        contracts = {
+            "version": importlib.metadata.version("litellm"),
+            "deepseek": adapter_contract(
+                "deepseek",
+                "deepseek-v4-pro",
+                "https://api.deepseek.com",
+                {"reasoning_effort": "none"},
+            ),
+            "dashscope": adapter_contract(
+                "dashscope",
+                "deepseek-v3",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                {"extra_body": {"enable_thinking": False}},
+            ),
+            "volcengine": adapter_contract(
+                "volcengine",
+                "doubao-seed-2-0-lite-260428",
+                "https://ark.cn-beijing.volces.com/api/v3",
+                {"thinking": {"type": "disabled"}},
+            ),
+            "zai": adapter_contract(
+                "zai",
+                "glm-5.2",
+                "https://open.bigmodel.cn/api/paas/v4",
+                {
+                    "extra_body": {"thinking": {"type": "disabled"}},
+                    "allowed_openai_params": ["thinking", "response_format"],
+                    "response_format": {"type": "json_object"},
+                },
+            ),
+            "gemini_3": litellm.get_optional_params(
+                model="gemini-3.6-flash",
+                custom_llm_provider="gemini",
+                reasoning_effort="none",
+                allowed_openai_params=["reasoning_effort"],
+            ),
+            "gemini_25_pro": litellm.get_optional_params(
+                model="gemini-2.5-pro",
+                custom_llm_provider="gemini",
+                reasoning_effort="minimal",
+                allowed_openai_params=["reasoning_effort"],
+            ),
+            "gemini_25_flash": litellm.get_optional_params(
+                model="gemini-2.5-flash",
+                custom_llm_provider="gemini",
+                reasoning_effort="none",
+                allowed_openai_params=["reasoning_effort"],
+            ),
+            "max_tokens": {
+                model: litellm.get_max_tokens(model)
+                for model in (
+                    "gpt-5.6-luna",
+                    "gemini-3.6-flash",
+                    "deepseek-v4-pro",
+                    "deepseek-v4-flash",
+                )
+            },
+        }
+        print(json.dumps(contracts, sort_keys=True))
+        """
+    )
+    env = os.environ.copy()
+    env["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    contracts = json.loads(completed.stdout.strip().splitlines()[-1])
+    assert contracts["version"] == "1.95.0"
+
+    expected_urls = {
+        "deepseek": "https://api.deepseek.com/chat/completions",
+        "dashscope": (
+            "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+        ),
+        "volcengine": ("https://ark.cn-beijing.volces.com/api/v3/chat/completions"),
+        "zai": "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+    }
+    for provider, expected_url in expected_urls.items():
+        body = contracts[provider]["body"]
+        assert contracts[provider]["url"] == expected_url
+        assert body["messages"] == [{"role": "user", "content": "hello"}]
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+        assert contracts[provider]["content"] == "Hello world"
+        assert contracts[provider]["usage"] == {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        }
+
+    assert contracts["deepseek"]["body"]["thinking"] == {"type": "disabled"}
+    assert contracts["dashscope"]["body"]["enable_thinking"] is False
+    assert contracts["volcengine"]["body"]["thinking"] == {"type": "disabled"}
+    assert contracts["zai"]["body"]["thinking"] == {"type": "disabled"}
+    assert contracts["zai"]["body"]["response_format"] == {"type": "json_object"}
+
+    assert contracts["gemini_3"]["thinkingConfig"] == {
+        "thinkingLevel": "minimal",
+        "includeThoughts": False,
+    }
+    assert contracts["gemini_25_pro"]["thinkingConfig"] == {
+        "thinkingBudget": 128,
+        "includeThoughts": True,
+    }
+    assert contracts["gemini_25_flash"]["thinkingConfig"] == {
+        "thinkingBudget": 0,
+        "includeThoughts": False,
+    }
+    assert contracts["max_tokens"] == {
+        "gpt-5.6-luna": 128000,
+        "gemini-3.6-flash": 65536,
+        "deepseek-v4-pro": 8192,
+        "deepseek-v4-flash": 8192,
+    }
 
 
 def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
@@ -703,21 +1133,29 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
             model="deepseek-v4-pro",
             messages=[{"role": "user", "content": "hello"}],
             temperature="0.7",
+            reasoning_effort="high",
+            thinking={"type": "enabled"},
+            extra_body={
+                "thinking": {"type": "enabled"},
+                "custom_field": "keep",
+            },
             generation_name="deepseek-test",
         )
     )
 
     assert captured_kwargs["kwargs"]["temperature"] == 0.7
-    assert captured_kwargs["kwargs"]["extra_body"] == {"thinking": {"type": "disabled"}}
+    assert captured_kwargs["kwargs"]["reasoning_effort"] == "none"
+    assert "thinking" not in captured_kwargs["kwargs"]
+    assert captured_kwargs["kwargs"]["extra_body"] == {"custom_field": "keep"}
 
 
-def test_gemini_params_use_minimal_reasoning_with_explicit_allowlist():
+def test_gemini_3_params_use_none_with_explicit_allowlist():
     params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
 
     assert params == {
         "temperature": 0.3,
         "allowed_openai_params": ["reasoning_effort"],
-        "reasoning_effort": "minimal",
+        "reasoning_effort": "none",
     }
 
 
@@ -725,7 +1163,59 @@ def test_gemini_25_pro_params_use_lowest_supported_reasoning():
     params = llm._reload_gemini_params("gemini-2.5-pro", 0.3)
 
     assert params["allowed_openai_params"] == ["reasoning_effort"]
-    assert params["reasoning_effort"] == "low"
+    assert params["reasoning_effort"] == "minimal"
+
+
+def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
+    captured = {}
+
+    def reload_params(model_id, temperature):
+        captured["reload_model"] = model_id
+        return {"temperature": temperature}
+
+    def fake_completion(model, *args, **kwargs):
+        _ = args
+        captured["completion_model"] = model
+        captured["completion_kwargs"] = kwargs
+        return iter([FakeResponse("chunk-1", content="ok", finish_reason="stop")])
+
+    monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        llm,
+        "PROVIDER_STATES",
+        {
+            "test": llm.ProviderState(
+                enabled=True,
+                params={"api_key": "test-key"},
+                models=["display-model"],
+                reload_params=reload_params,
+            )
+        },
+    )
+    monkeypatch.setattr(
+        llm,
+        "MODEL_ALIAS_MAP",
+        {"display-model": ("test", "actual-model")},
+    )
+    monkeypatch.setattr(llm, "PROVIDER_CONFIG_HINTS", {"test": "TEST_API_KEY"})
+
+    responses = list(
+        llm.invoke_llm(
+            app=app,
+            user_id="user-1",
+            span=DummySpan(),
+            model="display-model",
+            message="hello",
+            temperature="0.4",
+            generation_name="invoke-model-test",
+        )
+    )
+
+    assert [response.result for response in responses] == ["ok"]
+    assert captured["reload_model"] == "actual-model"
+    assert captured["completion_model"] == "actual-model"
+    assert captured["completion_kwargs"]["temperature"] == 0.4
 
 
 def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, app):
@@ -772,6 +1262,15 @@ def test_chat_llm_streams(monkeypatch, app):
         chunks = [
             FakeResponse("chunk-1", content="Hi "),
             FakeResponse("chunk-2", content="there", finish_reason="stop"),
+            SimpleNamespace(
+                id="usage",
+                choices=[],
+                usage=SimpleNamespace(
+                    prompt_tokens=3,
+                    completion_tokens=2,
+                    total_tokens=5,
+                ),
+            ),
         ]
         return iter(chunks)
 
@@ -812,9 +1311,13 @@ def test_chat_llm_streams(monkeypatch, app):
     assert [resp.result for resp in responses] == ["Hi ", "there"]
     assert captured_kwargs["kwargs"]["temperature"] == 0.7
     assert captured_kwargs["kwargs"]["stream"] is True
+    assert captured_kwargs["kwargs"]["stream_options"] == {"include_usage": True}
     assert span.generation_args["name"] == "chat-test"
     assert span.generation_args["trace_id"] == "trace-1"
     assert span.generation_args["parent_observation_id"] == "span-1"
+    assert captured_usage["input"] == 3
+    assert captured_usage["output"] == 2
+    assert captured_usage["total"] == 5
     assert captured_usage["extra"]["output_text"] == "Hi there"
 
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -849,6 +849,112 @@ def test_provider_thinking_policy_removes_caller_conflicts():
     }
 
 
+@pytest.mark.parametrize(
+    ("generation_config_key", "thinking_config_key", "top_k_key"),
+    [
+        ("generationConfig", "thinkingConfig", "topK"),
+        ("generation_config", "thinking_config", "top_k"),
+    ],
+)
+def test_gemini_thinking_policy_removes_nested_caller_override(
+    generation_config_key,
+    thinking_config_key,
+    top_k_key,
+):
+    kwargs = {
+        "extra_body": {
+            generation_config_key: {
+                thinking_config_key: {"thinkingLevel": "high"},
+                top_k_key: 8,
+            },
+            "custom_field": "keep",
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    )
+
+    assert kwargs == {
+        "temperature": 0.4,
+        "reasoning_effort": "none",
+        "allowed_openai_params": ["reasoning_effort"],
+        "extra_body": {
+            "generationConfig": {top_k_key: 8},
+            "custom_field": "keep",
+        },
+    }
+
+
+@pytest.mark.parametrize("generation_config_key", llm._GEMINI_GENERATION_CONFIG_KEYS)
+def test_gemini_thinking_policy_removes_invalid_native_config(
+    generation_config_key,
+):
+    kwargs = {
+        "extra_body": {
+            generation_config_key: None,
+            "custom_field": "keep",
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    )
+
+    assert kwargs["extra_body"] == {"custom_field": "keep"}
+
+
+def test_gemini_thinking_policy_normalizes_generation_config_aliases():
+    kwargs = {
+        "extra_body": {
+            "generation_config": {
+                "thinking_config": {"thinking_level": "high"},
+                "top_k": 4,
+            },
+            "generationConfig": {
+                "thinkingConfig": {"thinkingLevel": "high"},
+                "topK": 8,
+            },
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    )
+
+    assert kwargs["extra_body"] == {
+        "generationConfig": {
+            "top_k": 4,
+            "topK": 8,
+        },
+    }
+
+
+def test_provider_thinking_policy_preserves_caller_extra_body_fields():
+    kwargs = {
+        "extra_body": {
+            "enable_thinking": True,
+            "custom_field": "keep",
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        llm._reload_qwen_params("qwen-max", 0.4),
+    )
+
+    assert kwargs == {
+        "temperature": 0.4,
+        "extra_body": {
+            "enable_thinking": False,
+            "custom_field": "keep",
+        },
+    }
+
+
 def test_litellm_195_native_adapter_contracts():
     script = textwrap.dedent(
         """


### PR DESCRIPTION
## Summary

- upgrade LiteLLM from 1.84.8 to 1.95.0
- use native DeepSeek, DashScope, Volcengine, and ZAI adapters without changing public model names or configuration
- select the lowest supported OpenAI reasoning effort from LiteLLM model metadata and let Gemini map `none` to each model's lowest supported level
- keep provider-specific thinking controls for Qwen and SiliconFlow, preserve JSON responses for GLM and Ark, retain unrelated caller `extra_body` options, and ensure system reasoning policy overrides nested Gemini conflicts
- pass the resolved provider model ID into parameter selection while preserving configured output-token precedence and streaming usage tails

## Why

The wrapper previously used mostly OpenAI-compatible routing and provider-specific request bodies. That prevented LiteLLM from consistently translating a single no-reasoning policy into each provider's native request contract and made future model aliases less reliable.

## Impact

Existing environment variables, API URLs, public model names, route prefixes, allowlists, billing provider names, and calling interfaces remain unchanged. Models that can disable reasoning now do so; models that cannot are reduced to the lowest level supported by their provider.

## Validation

- `tests/test_llm.py`: 54 passed with LiteLLM 1.95.0
- complete backend suite: 2556 passed, 15 skipped
- architecture boundary validation: passed with zero new violations
- repository harness validation: passed
- clean Python 3.11 dependency installation: passed
- real provider calls through the modified ai-shifu wrapper using every deploy-config model entry: all 11 active CN/US routes completed successfully and accepted their configured or LiteLLM-derived output-token ceilings
- live Gemini checks covered 3.1 Pro mapping to hidden `low` reasoning and 3.6 Flash mapping to hidden `minimal` reasoning
- review follow-up used real LiteLLM 1.95 MockTransport requests to verify caller options are preserved and camel/snake Gemini native overrides cannot replace the system `thinkingConfig`
- Ark review follow-up verified the native Volcengine wire preserves existing `response_format` JSON mode while disabling thinking

The pre-commit Ruff step reports 106 existing violations in the two touched Python files. The branch and `origin/main` have the same violation count and identical rule-code distribution, so this change adds no Ruff debt. All other executed pre-commit checks passed. The API image build was not run because Docker is unavailable in the local environment.

## Known provider limitation

The Qwen-hosted `MiniMax/MiniMax-M2.5` route accepted `enable_thinking=false` but still returned reasoning content during the live test. This PR preserves the native disable request and does not claim that this provider/model combination fully honors it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for GPT-5, Gemini, Ark, DeepSeek, GLM, and Qwen models.
  - Added provider-specific controls for reasoning and thinking behavior.
  - Improved model routing, parameter handling, and reload behavior.
  - Added more accurate token usage reporting for streamed responses.

- **Bug Fixes**
  - Improved fallback handling for model metadata and request traces.
  - Resolved conflicting provider parameters during requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
