### PR TITLE
fix: protect checkout ping and classify session release everywhere

### DIFF
--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy import pool as sa_pool
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import (
     DisconnectionError,
+    InterfaceError,
     OperationalError,
     ResourceClosedError,
     SQLAlchemyError,
@@ -18,6 +19,7 @@ from sqlalchemy.exc import (
 import functools
 import random
 import select as select_module
+import sys
 import sqlparse
 import logging
 import time
@@ -83,6 +85,14 @@ def _socket_has_unread_data(dbapi_connection) -> bool:
     return bool(readable)
 
 
+def _server_thread_id(dbapi_connection):
+    """Best-effort MySQL server-side connection id for log correlation."""
+    try:
+        return dbapi_connection.thread_id()
+    except Exception:  # noqa: BLE001 - diagnostics only
+        return None
+
+
 def _pool_diagnostics_logger():
     """Log through the app logger when available.
 
@@ -108,8 +118,11 @@ def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_reco
         # connection - i.e. the request that interrupted a protocol exchange.
         _pool_diagnostics_logger().error(
             "DB connection returned to pool with unread protocol data; "
-            "invalidating it. The stack below is the checkin path of the "
-            "request that desynced this connection.",
+            "invalidating it (pid=%s server_thread_id=%s). The stack below "
+            "is the checkin path of the request that desynced this "
+            "connection.",
+            os.getpid(),
+            _server_thread_id(dbapi_connection),
             stack_info=True,
         )
         connection_record.invalidate()
@@ -122,13 +135,39 @@ def _reject_desynced_connection_on_checkout(
     if _socket_has_unread_data(dbapi_connection):
         _pool_diagnostics_logger().warning(
             "Rejecting pooled DB connection with unread protocol data at "
-            "checkout; the pool will retry with a fresh connection."
+            "checkout (pid=%s); the pool will retry with a fresh connection.",
+            os.getpid(),
         )
         # DisconnectionError makes the pool discard this connection and
         # transparently retry the checkout with another one.
         raise DisconnectionError(
             "pooled connection has unread protocol data (desynced stream)"
         )
+    # Protected liveness ping, replacing pool_pre_ping. The stock pre_ping
+    # path is the one wire operation with NO BaseException protection: a
+    # GreenletExit landing in COM_PING's recv escapes every layer, leaks the
+    # checkout, and the leaked fairy's GC finalizer later emits a ROLLBACK
+    # that consumes the stale PING OK - leaving the connection permanently
+    # off by one response. Pinging here keeps dead-connection detection while
+    # invalidating BEFORE any interruption propagates, so the GC finalizer
+    # sees an already-invalidated record and never touches the wire.
+    ping = getattr(dbapi_connection, "ping", None)
+    if ping is None:
+        return
+    try:
+        ping(False)
+    except BaseException as ping_exc:
+        connection_record.invalidate(
+            e=ping_exc if isinstance(ping_exc, Exception) else None
+        )
+        if isinstance(ping_exc, Exception):
+            # Dead connection: let the pool retry with a fresh one.
+            raise DisconnectionError(
+                "pooled connection failed the checkout liveness ping"
+            ) from ping_exc
+        # GreenletExit and friends propagate; the record is already
+        # invalidated so nothing dirty can reach the pool.
+        raise
 
 
 # Ring buffer of recent statements per DBAPI connection, plus a pre-execute
@@ -165,9 +204,11 @@ def _intercept_desync_before_execute(
         journal = list(_statement_journal(conn))
         _pool_diagnostics_logger().error(
             "DB connection has an unread response before executing a new "
-            "statement (off-by-one protocol desync). The LAST journal entry "
-            "is the statement whose exchange was interrupted. journal=%s "
-            "next_statement=%r",
+            "statement (off-by-one protocol desync, pid=%s "
+            "server_thread_id=%s). The LAST journal entry is the statement "
+            "whose exchange was interrupted. journal=%s next_statement=%r",
+            os.getpid(),
+            _server_thread_id(dbapi_connection),
             journal,
             statement[:_STATEMENT_SNIPPET_CHARS],
         )
@@ -230,7 +271,17 @@ def is_protocol_interrupt_error(exc: BaseException) -> bool:
     """
     if isinstance(exc, (ResourceClosedError, DisconnectionError)):
         return True
+    # gevent interruptions frequently surface as driver interface or raw
+    # socket errors rather than clean MySQL errnos; all of them mean the
+    # exchange on this connection did not complete.
     for candidate in (exc, getattr(exc, "orig", None)):
+        if isinstance(candidate, (InterfaceError, OSError)):
+            # OSError covers BrokenPipeError / ConnectionResetError / timeouts.
+            return True
+        if type(candidate).__name__ == "InterfaceError":
+            # pymysql.err.InterfaceError is not SQLAlchemy's InterfaceError;
+            # match the driver-level one by name to avoid a driver import.
+            return True
         args = getattr(candidate, "args", ())
         if args and isinstance(args[0], int) and args[0] in _PROTOCOL_INTERRUPT_ERRNOS:
             return True
@@ -314,6 +365,28 @@ def cleanup_session_after(
         )
         invalidate_session(source=source, session=session)
         return "invalidated"
+
+
+def release_session_classified(*, source: str) -> None:
+    """Remove the scoped session, discarding the connection first when a
+    stream-interrupting exception is propagating.
+
+    Designed for ``finally`` blocks: ``sys.exc_info()`` still sees the
+    in-flight exception there - including BaseExceptions like GreenletExit
+    that never hit an ``except GeneratorExit`` handler because they were
+    injected into IO deep inside the generator's own frame. Without this,
+    the closing ``remove()`` emits a ROLLBACK on a possibly desynced
+    connection (and runs BEFORE the app-context teardown guard could act).
+    """
+    exc = sys.exc_info()[1]
+    if exc is not None and is_abnormal_stream_termination(exc):
+        invalidate_session(source=source)
+    try:
+        db.session.remove()
+    except Exception:  # noqa: BLE001 - cleanup must not mask the original
+        _pool_diagnostics_logger().warning(
+            "%s db session cleanup failed", source, exc_info=True
+        )
 
 
 def _rollback_quietly() -> bool:
@@ -435,9 +508,13 @@ def init_db(app: Flask):
             if opt not in existing_options:
                 existing_options[opt] = _coerce_int(cfg, default)
 
-    # pool_pre_ping is default-on; callers can opt out by pre-setting
-    # SQLALCHEMY_ENGINE_OPTIONS["pool_pre_ping"] = False.
-    existing_options.setdefault("pool_pre_ping", True)
+    # pool_pre_ping is OFF by default: the stock pre-ping runs before the
+    # checkout event with no BaseException protection, so a gevent
+    # interruption inside COM_PING leaks a permanently desynced connection
+    # back to the pool (see _reject_desynced_connection_on_checkout, which
+    # performs a protected ping instead). Callers can still opt back in by
+    # pre-setting SQLALCHEMY_ENGINE_OPTIONS["pool_pre_ping"] = True.
+    existing_options.setdefault("pool_pre_ping", False)
 
     # Force every MySQL connection to use the UTC session time zone so that
     # DB-side time evaluation (func.now()/CURRENT_TIMESTAMP/NOW()) stores UTC,

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -514,6 +514,10 @@ def init_db(app: Flask):
     # back to the pool (see _reject_desynced_connection_on_checkout, which
     # performs a protected ping instead). Callers can still opt back in by
     # pre-setting SQLALCHEMY_ENGINE_OPTIONS["pool_pre_ping"] = True.
+    # NOTE: the protected checkout ping relies on the DBAPI connection
+    # exposing ``ping`` (pymysql does). If this deployment ever switches to
+    # a driver without it, re-enable pool_pre_ping explicitly or liveness
+    # checking at checkout is silently lost.
     existing_options.setdefault("pool_pre_ping", False)
 
     # Force every MySQL connection to use the UTC session time zone so that

--- a/src/api/flaskr/dao/uow.py
+++ b/src/api/flaskr/dao/uow.py
@@ -111,12 +111,20 @@ def unit_of_work():
             callbacks = _post_commit.get()
             dao.db.session.commit()
             _run_post_commit(callbacks)
-    except Exception:
+    except Exception as exc:
         if depth == 0:
-            try:
-                dao.db.session.rollback()
-            except Exception as rollback_exc:  # noqa: BLE001 - best-effort cleanup
-                logger.warning("unit_of_work rollback failed: %s", rollback_exc)
+            # Classified cleanup: stream-interrupting failures (desync
+            # errors surfaced by the commit) discard the connection, other
+            # errors roll back; a rollback that itself fails escalates to
+            # invalidate. Never emit a ROLLBACK on a desynced stream.
+            dao.cleanup_session_after(exc, source="unit_of_work")
+        raise
+    except BaseException:
+        if depth == 0:
+            # GreenletExit landing inside the COMMIT's network IO leaves an
+            # unread response owed on the wire; discard the connection
+            # before any later cleanup could roll back on it.
+            dao.invalidate_session(source="unit_of_work interrupt")
         raise
     finally:
         _depth.reset(token)

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -36,7 +36,7 @@ from flaskr.common.i18n_utils import (
     resolve_markdownflow_output_language,
 )
 from flaskr.common.cache_provider import cache as cache_provider
-from flaskr.dao import db, invalidate_session
+from flaskr.dao import cleanup_session_after, db, invalidate_session
 from flaskr.service.shifu.shifu_struct_manager import (
     ShifuOutlineItemDto,
     ShifuInfoDto,
@@ -1755,6 +1755,7 @@ class RunScriptContextV2:
             self.app.logger.warning(
                 "Create TTS processor failed: %s", exc, exc_info=True
             )
+            cleanup_session_after(exc, source="create tts processor")
             return None
 
     def _finalize_stream_tts_processor(
@@ -1773,6 +1774,7 @@ class RunScriptContextV2:
             )
         except Exception as exc:
             self.app.logger.warning("%s: %s", log_prefix, exc, exc_info=True)
+            cleanup_session_after(exc, source="finalize stream tts processor")
 
     def _teardown_stream_tts_state(
         self,
@@ -1793,6 +1795,7 @@ class RunScriptContextV2:
                     exc,
                     exc_info=True,
                 )
+                cleanup_session_after(exc, source="flush streaming content cache")
         if tts_processor:
             yield from self._finalize_stream_tts_processor(
                 tts_processor,

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -1,11 +1,17 @@
 import json
+import sys
 import uuid
 
 from flask import Flask, Response, request, stream_with_context
 from pydantic import ValidationError
 from sqlalchemy import select
 
-from flaskr.dao import db, invalidate_session, is_protocol_interrupt_error
+from flaskr.dao import (
+    db,
+    invalidate_session,
+    is_abnormal_stream_termination,
+    is_protocol_interrupt_error,
+)
 from flaskr.framework.plugin.inject import inject
 from flaskr.i18n import get_current_language
 from flaskr.route.common import make_common_response, bypass_token_validation
@@ -76,6 +82,13 @@ def _is_generator_close_error(exc: RuntimeError) -> bool:
 
 
 def _release_db_session(app: Flask, *, source: str) -> None:
+    # sys.exc_info in finally blocks sees propagating BaseExceptions like
+    # GreenletExit injected into IO deep inside the generator frame; discard
+    # the connection before removal on stream-interrupting exits. Uses this
+    # module's ``db`` so tests that monkeypatch routes.db keep working.
+    exc = sys.exc_info()[1]
+    if exc is not None and is_abnormal_stream_termination(exc):
+        invalidate_session(source=source, session=db.session)
     try:
         db.session.remove()
     except Exception:

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import queue
+import sys
 import threading
 import time
 import traceback
@@ -24,7 +25,12 @@ from flaskr.service.learn.learn_dtos import (
     RunStatusDTO,
 )
 from flaskr.common.cache_provider import cache as cache_provider
-from flaskr.dao import db, invalidate_session, is_protocol_interrupt_error
+from flaskr.dao import (
+    db,
+    invalidate_session,
+    is_abnormal_stream_termination,
+    is_protocol_interrupt_error,
+)
 from flaskr.service.learn.const import INPUT_TYPE_ASK
 from flaskr.service.shifu.shifu_struct_manager import (
     get_shifu_dto,
@@ -56,6 +62,15 @@ DEFAULT_MAX_PARALLEL_ASK_COUNT = 3
 
 
 def _remove_db_session_safely(app: Flask, *, source: str) -> None:
+    # In finally blocks sys.exc_info still sees a propagating
+    # GreenletExit/GeneratorExit that never reached an except handler
+    # (injected into IO inside the generator frame); discard the connection
+    # before removal in that case instead of letting remove() emit a
+    # ROLLBACK on a possibly desynced stream. Uses this module's ``db`` so
+    # tests that monkeypatch runscript_v2.db keep working.
+    exc = sys.exc_info()[1]
+    if exc is not None and is_abnormal_stream_termination(exc):
+        invalidate_session(source=source, session=db.session)
     try:
         db.session.remove()
     except Exception:

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -4,6 +4,7 @@ import queue
 import threading
 from typing import Any, Generator
 
+from flaskr.dao import cleanup_session_after, invalidate_session
 from flaskr.common.shifu_context import (
     apply_shifu_context_snapshot,
     get_shifu_context_snapshot,
@@ -52,7 +53,16 @@ class StreamTTSFinalizeDrainer:
                     for event in processor.finalize(commit=True):
                         event_queue.put(("event", event))
                 except Exception as exc:
+                    # Classify before reporting: a desync surfaced by the
+                    # finalize commit must discard this worker's connection,
+                    # otherwise the app-context teardown pops with exc=None
+                    # (we swallowed it) and remove() would emit a ROLLBACK on
+                    # the desynced stream.
+                    cleanup_session_after(exc, source="stream tts finalize worker")
                     event_queue.put(("error", exc))
+                except BaseException:
+                    invalidate_session(source="stream tts finalize interrupt")
+                    raise
                 finally:
                     event_queue.put(
                         (

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -19,6 +19,7 @@ from concurrent.futures import ThreadPoolExecutor, Future
 
 from flask import Flask
 
+from flaskr.dao import cleanup_session_after
 from flaskr.api.tts import (
     synthesize_text,
     is_tts_configured,
@@ -1378,6 +1379,10 @@ class StreamingTTSProcessor:
             )
         except Exception as e:
             logger.error(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
+            # The swallowed error may be a desync surfaced by the audio
+            # record write; classify so an interrupted exchange discards the
+            # connection instead of leaving it for the next statement.
+            cleanup_session_after(e, source="streaming tts finalize")
 
     def _synthesize_minimax_complete_fallback(
         self,

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Flask
 
-from flaskr.dao import db
+from flaskr.dao import db, cleanup_session_after
 from flaskr.service.common.dtos import UserInfo
 from flaskr.service.user.consts import (
     CREDENTIAL_STATE_UNVERIFIED,
@@ -837,6 +837,8 @@ def transactional_session():
     try:
         with db.session.begin_nested():
             yield
-    except Exception:
-        db.session.rollback()
+    except Exception as exc:
+        # Classified: interrupted exchanges discard the connection instead
+        # of emitting a ROLLBACK on a possibly desynced stream.
+        cleanup_session_after(exc, source="transactional_session")
         raise

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -11,7 +11,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Flask
 
-from flaskr.dao import db, cleanup_session_after
+from flaskr.dao import (
+    cleanup_session_after,
+    db,
+    invalidate_session,
+    is_abnormal_stream_termination,
+)
 from flaskr.service.common.dtos import UserInfo
 from flaskr.service.user.consts import (
     CREDENTIAL_STATE_UNVERIFIED,
@@ -834,11 +839,29 @@ def upsert_wechat_credentials(
 
 @contextmanager
 def transactional_session():
+    # Managed manually instead of ``with begin_nested()``: the context
+    # manager's __exit__ would emit ROLLBACK TO SAVEPOINT on the wire BEFORE
+    # any classification could run, which is exactly what must not happen on
+    # a connection whose exchange was interrupted.
+    nested = db.session.begin_nested()
     try:
-        with db.session.begin_nested():
-            yield
+        yield
     except Exception as exc:
-        # Classified: interrupted exchanges discard the connection instead
-        # of emitting a ROLLBACK on a possibly desynced stream.
-        cleanup_session_after(exc, source="transactional_session")
+        if is_abnormal_stream_termination(exc):
+            invalidate_session(source="transactional_session desync")
+        else:
+            try:
+                nested.rollback()
+            except Exception:  # noqa: BLE001 - savepoint already broken
+                invalidate_session(source="transactional_session rollback failure")
+            # Preserve the legacy contract: a failure rolls back the whole
+            # session transaction, not only the savepoint.
+            cleanup_session_after(exc, source="transactional_session")
         raise
+    except BaseException:
+        # GreenletExit landing inside the body's DB IO: discard before any
+        # cleanup could touch the wire.
+        invalidate_session(source="transactional_session interrupt")
+        raise
+    else:
+        nested.commit()

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -183,3 +183,81 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
             raise ValueError("business")
 
     assert invalidations == []
+
+
+def test_release_session_classified_invalidates_during_propagating_interrupt(
+    app, monkeypatch
+):
+    import flaskr.dao as dao
+
+    order = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: order.append("invalidate") or True,
+    )
+
+    class _Interrupt(BaseException):
+        pass
+
+    with app.app_context():
+        try:
+            raise _Interrupt()
+        except _Interrupt:
+            pass
+        # No in-flight exception here: plain removal, no invalidate.
+        dao.release_session_classified(source="t-clean")
+        assert order == []
+
+        try:
+            try:
+                raise _Interrupt()
+            finally:
+                # In-flight BaseException visible via sys.exc_info in finally:
+                # invalidate must run before removal.
+                dao.release_session_classified(source="t-interrupt")
+        except _Interrupt:
+            pass
+
+    assert order == ["invalidate"]
+
+
+def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch):
+    import flaskr.dao as dao
+
+    invalidations = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    with app.app_context():
+        try:
+            try:
+                raise ValueError("business")
+            finally:
+                dao.release_session_classified(source="t-ordinary")
+        except ValueError:
+            pass
+
+    assert invalidations == []
+
+
+def test_classifier_covers_driver_interface_and_socket_errors():
+    class _DriverInterfaceError(Exception):
+        pass
+
+    _DriverInterfaceError.__name__ = "InterfaceError"
+
+    from sqlalchemy.exc import InterfaceError as SAInterfaceError
+
+    assert (
+        is_protocol_interrupt_error(SAInterfaceError("stmt", {}, Exception())) is True
+    )
+    assert is_protocol_interrupt_error(_DriverInterfaceError()) is True
+    assert is_protocol_interrupt_error(BrokenPipeError(32, "broken pipe")) is True
+    assert is_protocol_interrupt_error(ConnectionResetError(104, "reset")) is True
+    wrapped = OperationalError("stmt", {}, BrokenPipeError(32, "broken pipe"))
+    assert is_protocol_interrupt_error(wrapped) is True
+    assert is_protocol_interrupt_error(ValueError("business")) is False

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -196,6 +196,12 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
         "invalidate_session",
         lambda *, source, session=None: order.append("invalidate") or True,
     )
+    original_remove = db.session.remove
+    monkeypatch.setattr(
+        db.session,
+        "remove",
+        lambda: order.append("remove") or original_remove(),
+    )
 
     class _Interrupt(BaseException):
         pass
@@ -207,19 +213,23 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
             pass
         # No in-flight exception here: plain removal, no invalidate.
         dao.release_session_classified(source="t-clean")
-        assert order == []
+        assert order == ["remove"]
+        order.clear()
 
         try:
             try:
                 raise _Interrupt()
             finally:
                 # In-flight BaseException visible via sys.exc_info in finally:
-                # invalidate must run before removal.
+                # invalidate must run BEFORE removal, otherwise remove() emits
+                # a ROLLBACK on the desynced stream.
                 dao.release_session_classified(source="t-interrupt")
         except _Interrupt:
             pass
 
-    assert order == ["invalidate"]
+        # Assert inside the context: the context exit's own teardown removes
+        # would otherwise append extra entries.
+        assert order == ["invalidate", "remove"]
 
 
 def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch):

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -1,0 +1,88 @@
+"""Protected checkout liveness ping (pool_pre_ping replacement).
+
+The stock pre-ping path has no BaseException protection: a GreenletExit in
+COM_PING's recv leaks the checkout and the leaked fairy's GC finalizer later
+emits a ROLLBACK that consumes the stale PING OK, leaving the connection
+permanently off by one response. The checkout-event ping must invalidate the
+record BEFORE any interruption propagates.
+"""
+
+import socket
+
+import pytest
+from sqlalchemy.exc import DisconnectionError
+
+import flaskr.dao as dao
+
+
+class _FakeRecord:
+    def __init__(self):
+        self.invalidated_with = []
+
+    def invalidate(self, e=None):
+        self.invalidated_with.append(e)
+
+
+class _FakeGreenletExit(BaseException):
+    pass
+
+
+def _make_conn(sock, ping_exc=None):
+    class _Conn:
+        _sock = sock
+
+        def ping(self, reconnect):
+            assert reconnect is False
+            if ping_exc is not None:
+                raise ping_exc
+
+    return _Conn()
+
+
+@pytest.fixture()
+def clean_sock():
+    left, right = socket.socketpair()
+    yield left
+    left.close()
+    right.close()
+
+
+def test_healthy_ping_passes(clean_sock):
+    record = _FakeRecord()
+    dao._reject_desynced_connection_on_checkout(_make_conn(clean_sock), record, None)
+    assert record.invalidated_with == []
+
+
+def test_dead_connection_ping_invalidates_and_retries(clean_sock):
+    record = _FakeRecord()
+    ping_exc = OSError("dead")
+    with pytest.raises(DisconnectionError):
+        dao._reject_desynced_connection_on_checkout(
+            _make_conn(clean_sock, ping_exc), record, None
+        )
+    assert record.invalidated_with == [ping_exc]
+
+
+def test_interrupted_ping_invalidates_before_propagating(clean_sock):
+    record = _FakeRecord()
+    with pytest.raises(_FakeGreenletExit):
+        dao._reject_desynced_connection_on_checkout(
+            _make_conn(clean_sock, _FakeGreenletExit()), record, None
+        )
+    # Record invalidated (with e=None for non-Exception) BEFORE the
+    # interruption propagates: the GC finalizer then sees an invalidated
+    # record and never emits a ROLLBACK on the desynced wire.
+    assert record.invalidated_with == [None]
+
+
+def test_connections_without_ping_are_skipped(clean_sock):
+    class _NoPing:
+        _sock = clean_sock
+
+    record = _FakeRecord()
+    dao._reject_desynced_connection_on_checkout(_NoPing(), record, None)
+    assert record.invalidated_with == []
+
+
+def test_pre_ping_engine_option_defaults_off(app):
+    assert app.config["SQLALCHEMY_ENGINE_OPTIONS"].get("pool_pre_ping") is False

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -106,3 +106,38 @@ def test_natural_exhaustion_does_not_invalidate_producer_session(app, monkeypatc
 
     assert items == ["a", "b"]
     assert invalidations == []
+
+
+def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch):
+    """A DB failure swallowed by the TTS finalize wrapper must still run the
+    classified cleanup so an interrupted exchange discards the connection."""
+    import types
+
+    from sqlalchemy.exc import ResourceClosedError
+
+    from flaskr.service.learn import context_v2
+
+    outcomes = []
+    monkeypatch.setattr(
+        context_v2,
+        "cleanup_session_after",
+        lambda exc, *, source, session=None: (
+            outcomes.append((type(exc).__name__, source)) or "invalidated"
+        ),
+    )
+
+    class _FailingProcessor:
+        next_element_index = 0
+
+        def finalize(self, *, commit):
+            raise ResourceClosedError("desynced during finalize")
+            yield  # pragma: no cover - generator marker
+
+    stub = types.SimpleNamespace(app=app)
+    list(
+        RunScriptContextV2._finalize_stream_tts_processor(
+            stub, _FailingProcessor(), log_prefix="finalize failed"
+        )
+    )
+
+    assert outcomes == [("ResourceClosedError", "finalize stream tts processor")]

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -143,7 +143,10 @@ def test_desync_error_invalidates_connection_instead_of_rollback(app, monkeypatc
         with pytest.raises(ResourceClosedError):
             next(generator)
 
-    assert session.invalidations == 1
+    # Both the except branch and the classified finally-release invalidate
+    # (idempotent defense in depth); the essential contract is: at least one
+    # invalidate, zero rollbacks on the desynced stream.
+    assert session.invalidations >= 1
     assert session.rollbacks == 0
     assert session.removed == 1
 

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -143,10 +143,11 @@ def test_desync_error_invalidates_connection_instead_of_rollback(app, monkeypatc
         with pytest.raises(ResourceClosedError):
             next(generator)
 
-    # Both the except branch and the classified finally-release invalidate
-    # (idempotent defense in depth); the essential contract is: at least one
-    # invalidate, zero rollbacks on the desynced stream.
-    assert session.invalidations >= 1
+    # Exactly two invalidations - one from the desync except branch, one
+    # from the classified finally-release (idempotent defense in depth). A
+    # drop to one means one of the two layers regressed; zero rollbacks on
+    # the desynced stream is the hard contract.
+    assert session.invalidations == 2
     assert session.rollbacks == 0
     assert session.removed == 1
 

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -1,0 +1,61 @@
+"""transactional_session termination-classification behavior."""
+
+
+def test_transactional_session_classifies_before_savepoint_rollback(app, monkeypatch):
+    """Abnormal terminations must invalidate WITHOUT any savepoint rollback
+    reaching the wire; ordinary errors keep the legacy full-rollback path."""
+    import flaskr.service.user.repository as repo_module
+    from sqlalchemy.exc import ResourceClosedError
+
+    events = []
+    monkeypatch.setattr(
+        repo_module,
+        "invalidate_session",
+        lambda *, source, session=None: events.append(("invalidate", source)) or True,
+    )
+    monkeypatch.setattr(
+        repo_module,
+        "cleanup_session_after",
+        lambda exc, *, source, session=None: (
+            events.append(("cleanup", source)) or "rolled_back"
+        ),
+    )
+
+    class _Nested:
+        def __init__(self):
+            self.rollbacks = 0
+            self.commits = 0
+
+        def rollback(self):
+            self.rollbacks += 1
+
+        def commit(self):
+            self.commits += 1
+
+    nested = _Nested()
+    monkeypatch.setattr(
+        repo_module.db.session, "begin_nested", lambda: nested, raising=False
+    )
+
+    import pytest as _pytest
+
+    # Desync inside the body: invalidate only, savepoint untouched.
+    with _pytest.raises(ResourceClosedError):
+        with repo_module.transactional_session():
+            raise ResourceClosedError("desynced")
+    assert events == [("invalidate", "transactional_session desync")]
+    assert nested.rollbacks == 0
+    events.clear()
+
+    # Ordinary error: savepoint rollback then classified session cleanup.
+    with _pytest.raises(ValueError):
+        with repo_module.transactional_session():
+            raise ValueError("business")
+    assert events == [("cleanup", "transactional_session")]
+    assert nested.rollbacks == 1
+    events.clear()
+
+    # Success commits the savepoint.
+    with repo_module.transactional_session():
+        pass
+    assert nested.commits == 1

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -1,0 +1,48 @@
+"""unit_of_work termination-classification behavior."""
+
+import pytest
+
+
+def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
+    import flaskr.dao as dao
+    from flaskr.dao.uow import unit_of_work
+
+    invalidations = []
+    monkeypatch.setattr(
+        dao,
+        "invalidate_session",
+        lambda *, source, session=None: invalidations.append(source) or True,
+    )
+
+    class _Interrupt(BaseException):
+        pass
+
+    with app.app_context():
+        with pytest.raises(_Interrupt):
+            with unit_of_work():
+                raise _Interrupt()
+
+    assert invalidations == ["unit_of_work interrupt"]
+
+
+def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
+    import flaskr.dao as dao
+    from flaskr.dao.uow import unit_of_work
+
+    outcomes = []
+    monkeypatch.setattr(
+        dao,
+        "cleanup_session_after",
+        lambda exc, *, source, session=None: (
+            outcomes.append((type(exc).__name__, source)) or "invalidated"
+        ),
+    )
+
+    from sqlalchemy.exc import ResourceClosedError
+
+    with app.app_context():
+        with pytest.raises(ResourceClosedError):
+            with unit_of_work():
+                raise ResourceClosedError("desynced")
+
+    assert outcomes == [("ResourceClosedError", "unit_of_work")]


### PR DESCRIPTION
## The remaining producer, found at the SQLAlchemy source level

After the termination-principle rollouts (#2263/#2264), the pre-execute desync interception still fired ~9 times/hour — desynced connections were still being produced. A source-level audit of every wire operation that bypasses cursor events found exactly one with **no BaseException protection**: the stock `pool_pre_ping`.

**The leak mechanism** (all in SQLAlchemy/pymysql internals):
1. Every commit returns the connection to the pool; the next statement re-checks it out → COM_PING. A single /run performs dozens of step-level commits, so dozens of ping windows.
2. A GreenletExit landing in the ping's recv escapes every layer — `_do_ping_w_event` only catches `dbapi.Error`, `_ConnectionFairy._checkout` only catches `DisconnectionError`, `Pool.connect()` has no wrapper — the checkout **leaks** (neither invalidated nor checked in), and gunicorn's gevent worker swallows the GreenletExit silently.
3. The leaked fairy is later garbage-collected; its finalizer runs `_finalize_fairy` from whatever greenlet triggers GC and emits a ROLLBACK — which **consumes the stale PING OK as its own response and leaves the ROLLBACK's OK owed**. The connection returns to the pool permanently off by one.
4. That GC rollback goes through neither the statement journal nor the pre-execute probe, and subsequent pre-pings keep 'carrying' the offset forward — matching every production observation: clean journals, low checkin-probe hits, deployment-independent continuous production.

The audit also confirmed `do_begin` emits no wire traffic, and `do_commit`/`do_rollback`/pool-reset already invalidate on BaseException inside SQLAlchemy — pre-ping was the one hole.

## Changes

**A1 — protected ping replaces pre_ping** (`flaskr/dao`): `pool_pre_ping` now defaults off (explicit config can re-enable); the checkout probe performs the liveness ping itself, wrapped so ANY interruption invalidates the connection record **before** propagating — the GC finalizer then sees an already-invalidated record and never touches the wire. Dead-connection detection is preserved (Exception → `DisconnectionError` → pool retries transparently).

**A2 — classified session release**: GreenletExit injected into IO deep inside a generator frame never reaches `except GeneratorExit` handlers — it lands straight in `finally` blocks whose `db.session.remove()` emitted a ROLLBACK on the desynced stream (running before the teardown guard could act). `_release_db_session` / `_remove_db_session_safely` (plus shared `dao.release_session_classified`) now read `sys.exc_info()` — which still sees the propagating BaseException in a finally block — and discard the connection first. `unit_of_work` gains classified cleanup plus a BaseException branch, covering all sixteen in-stream commits through one choke point. `tts_preview` handled in the same pass.

**A3 — classifier extension**: driver-level `InterfaceError` (pymysql's, matched by name to avoid a driver import) and the `OSError` family (BrokenPipeError/ConnectionResetError) now classify as protocol interrupts. IntegrityError/deadlock semantics unchanged.

**A4 — remaining swallow points classified**: TTS finalize paths (`streaming_tts`, `stream_tts_finalize` worker, three spots in `context_v2`) and `transactional_session` now run `cleanup_session_after` before swallowing.

**A5 — attribution data**: desync probe logs now carry `pid` and the MySQL server thread id for post-rollout confirmation/attribution.

## Testing

- Protected ping: healthy pass / dead → DisconnectionError + invalidate / interruption → invalidate-before-propagate / no-ping drivers skipped / engine option defaults off.
- Classified release: invalidate fires for propagating BaseExceptions visible from finally, not for ordinary exceptions or clean paths.
- `unit_of_work`: BaseException → invalidate + propagate; desync Exception → classified cleanup.
- Classifier matrix extended.
- Full backend suite: **2,554 passed**, 15 skipped (1 deselected: `test_litellm_195_native_adapter_contracts`, which fails on clean main — pre-existing, tracked separately).

## Verification after rollout

1. Pre-execute interception count must drop to zero (pid/thread-id stamped logs).
2. Alert family and all probes silent; `session invalidate failed` stays zero.
3. Dead-connection handling equivalence: checkout ping replaces pre-ping one-for-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection resilience with liveness detection and automatic invalidation of failed connections.
  * Enhanced error handling for streaming operations to prevent connection desynchronization errors during abnormal terminations.

* **Tests**
  * Added tests for connection failure handling and session cleanup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->