### PR TITLE
refactor: type learner navigation components

### DIFF
--- a/src/cook-web/src/app/admin/SidebarContent.tsx
+++ b/src/cook-web/src/app/admin/SidebarContent.tsx
@@ -262,11 +262,9 @@ export const SidebarContent = ({
       </div>
       <NavFooter
         ref={footerRef}
-        // @ts-expect-error EXPECT
         onClick={onFooterClick}
         isMenuOpen={userMenuOpen}
       />
-      {/* @ts-expect-error EXPECT */}
       <MainMenuModal
         open={userMenuOpen}
         onClose={onUserMenuClose}

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseCatalog.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseCatalog.tsx
@@ -1,4 +1,5 @@
 import { memo, useContext, useCallback } from 'react';
+import type { LessonTreeLesson } from '../../hooks/useLessonTree';
 
 import { AppContext } from '../AppContext';
 import CourseSection from './CourseSection';
@@ -14,19 +15,30 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
+type CourseCatalogProps = {
+  id?: string;
+  name?: string;
+  status?: string;
+  lessons?: LessonTreeLesson[];
+  collapse?: boolean;
+  selectedLessonId?: string;
+  onCollapse?: (id: string) => void;
+  onLessonSelect?: (params: { id: string }) => void;
+  onTrySelect?: (params: { chapterId: string; lessonId: string }) => void;
+};
+
 export const CourseCatalog = ({
-  id = 0,
+  id = '',
   name = '',
-  status,
   lessons = [],
   collapse = false,
   selectedLessonId = '',
   onCollapse,
   onLessonSelect = () => {},
   onTrySelect,
-}) => {
+}: CourseCatalogProps) => {
   const _onTrySelect = useCallback(
-    ({ id: lessonId }) => {
+    ({ id: lessonId }: { id: string }) => {
       onTrySelect?.({ chapterId: id, lessonId });
     },
     [id, onTrySelect],
@@ -76,23 +88,13 @@ export const CourseCatalog = ({
         {lessons.map(e => {
           return (
             <CourseSection
-              // @ts-expect-error EXPECT
               key={e.id}
-              // @ts-expect-error EXPECT
               id={e.id}
-              // @ts-expect-error EXPECT
               name={e.name}
-              // @ts-expect-error EXPECT
-              status={e.status}
-              // @ts-expect-error EXPECT
               status_value={e.status_value}
-              // @ts-expect-error EXPECT
               selected={e.id === selectedLessonId}
-              // @ts-expect-error EXPECT
               type={e.type}
-              // @ts-expect-error EXPECT
               is_paid={e.is_paid}
-              // @ts-expect-error EXPECT
               canLearning={e.canLearning}
               chapterId={id}
               onSelect={onLessonSelect}

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseCatalogList.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseCatalogList.tsx
@@ -1,12 +1,31 @@
 // Course catalog
 import { memo, useState, useEffect } from 'react';
+import type { LessonTreeCatalog } from '../../hooks/useLessonTree';
 import styles from './CourseCatalogList.module.scss';
 import { cn } from '@/lib/utils';
 import TrialNodeBottomArea from './TrialNodeBottomArea';
 import CourseCatalog from './CourseCatalog';
-import { TRAIL_NODE_POSITION } from './TrialNodeBottomArea';
+import {
+  TRAIL_NODE_POSITION,
+  type TrialNodePosition,
+} from './TrialNodeBottomArea';
 import TrialNodeOuter from './TrialNodeOuter';
 import CourseHeaderSummary from '../CourseHeaderSummary';
+type CourseCatalogListCatalog = LessonTreeCatalog & { bannerInfo?: unknown };
+
+type CourseCatalogListProps = {
+  courseName?: string;
+  courseAvatar?: string;
+  catalogs?: CourseCatalogListCatalog[];
+  containerScrollTop?: number;
+  containerHeight?: number;
+  onChapterCollapse?: (id: string) => void;
+  onLessonSelect?: (params: { id: string }) => void;
+  onTryLessonSelect?: (params: { chapterId: string; lessonId: string }) => void;
+  selectedLessonId?: string;
+  hideCourseHeader?: boolean;
+};
+
 export const CourseCatalogList = ({
   courseName = '',
   courseAvatar = '',
@@ -18,20 +37,17 @@ export const CourseCatalogList = ({
   onTryLessonSelect,
   selectedLessonId = '',
   hideCourseHeader = false,
-}) => {
-  const [trialNodePosition, setTrialNodePosition] = useState(
+}: CourseCatalogListProps) => {
+  const [trialNodePosition, setTrialNodePosition] = useState<TrialNodePosition>(
     TRAIL_NODE_POSITION.NORMAL,
   );
-  const [trialNodePayload, setTrialNodePayload] = useState(null);
+  const [trialNodePayload, setTrialNodePayload] = useState<unknown>(null);
 
   useEffect(() => {
-    setTrialNodePayload(
-      // @ts-expect-error EXPECT
-      catalogs.find(c => !!c.bannerInfo)?.bannerInfo || null,
-    );
+    setTrialNodePayload(catalogs.find(c => !!c.bannerInfo)?.bannerInfo || null);
   }, [catalogs]);
 
-  const onNodePositionChange = position => {
+  const onNodePositionChange = (position: TrialNodePosition) => {
     setTrialNodePosition(position);
   };
 
@@ -55,32 +71,23 @@ export const CourseCatalogList = ({
         >
           {catalogs.map(catalog => {
             return (
-              // @ts-expect-error EXPECT
               <div key={catalog.id}>
                 <CourseCatalog
-                  // @ts-expect-error EXPECT
                   key={catalog.id}
-                  // @ts-expect-error EXPECT
                   id={catalog.id}
-                  // @ts-expect-error EXPECT
                   name={catalog.name}
-                  // @ts-expect-error EXPECT
                   status={catalog.status_value}
                   selectedLessonId={selectedLessonId}
-                  // @ts-expect-error EXPECT
                   lessons={catalog.lessons}
-                  // @ts-expect-error EXPECT
                   collapse={catalog.collapse}
                   onCollapse={onChapterCollapse}
                   onLessonSelect={onLessonSelect}
                   onTrySelect={onTryLessonSelect}
                 />
-                {/* @ts-expect-error EXPECT */}
-                {catalog.bannerInfo && (
+                {Boolean(catalog.bannerInfo) && (
                   <TrialNodeBottomArea
                     containerHeight={containerHeight}
                     containerScrollTop={containerScrollTop}
-                    // @ts-expect-error EXPECT
                     payload={catalog.bannerInfo}
                     onNodePositionChange={onNodePositionChange}
                   />
@@ -94,8 +101,6 @@ export const CourseCatalogList = ({
         <TrialNodeOuter
           nodePosition={trialNodePosition}
           payload={trialNodePayload}
-          // @ts-expect-error EXPECT
-          containerScrollTop={containerScrollTop}
         />
       )}
     </>

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseSection.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseSection.tsx
@@ -1,17 +1,12 @@
 import classNames from 'classnames';
 import styles from './CourseSection.module.scss';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, type MouseEvent } from 'react';
 import { memo } from 'react';
 import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import ResetChapterButton from './ResetChapterButton';
 import { AppContext } from '../AppContext';
-import Image from 'next/image';
-import imgLearningSelected from '@/c-assets/newchat/light/icon16-learning-selected.png';
-import imgLearning from '@/c-assets/newchat/light/icon16-learning.png';
 import { CircleCheck, CircleDotDashed } from 'lucide-react';
-import imgLearningCompletedSelected from '@/c-assets/newchat/light/icon16-learning-completed-selected.png';
-import imgLearningCompleted from '@/c-assets/newchat/light/icon16-learning-completed.png';
-import { LEARNING_PERMISSION } from '@/c-api/studyV2';
+import { LEARNING_PERMISSION, type LearningPermission } from '@/c-api/studyV2';
 import { useUserStore } from '@/store';
 import { useCourseStore } from '@/c-store/useCourseStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -24,6 +19,19 @@ import {
 } from '@/components/ui/tooltip';
 import { useTranslation } from 'react-i18next';
 import { useSystemStore } from '@/c-store/useSystemStore';
+
+type CourseSectionProps = {
+  id: string;
+  name?: string;
+  type?: LearningPermission | string;
+  is_paid?: boolean;
+  status_value?: string;
+  selected?: boolean;
+  canLearning?: boolean;
+  chapterId: string;
+  onSelect?: (params: { id: string }) => void;
+  onTrySelect?: (params: { id: string }) => void;
+};
 
 const getCourseTitleLang = (title: string) => {
   const trimmed = title.trim();
@@ -46,7 +54,7 @@ export const CourseSection = ({
   chapterId,
   onSelect,
   onTrySelect,
-}) => {
+}: CourseSectionProps) => {
   const { t } = useTranslation();
   const courseTitleLang = getCourseTitleLang(name);
   const { mobileStyle } = useContext(AppContext);
@@ -59,8 +67,6 @@ export const CourseSection = ({
   );
   const genIconClassName = () => {
     switch (status_value) {
-      // @ts-expect-error EXPECT
-      case LESSON_STATUS_VALUE.NOT_START:
       case LESSON_STATUS_VALUE.LOCKED:
         return styles.small;
       case LESSON_STATUS_VALUE.PREPARE_LEARNING:
@@ -113,7 +119,7 @@ export const CourseSection = ({
     chapterId,
   ]);
 
-  const onResetButtonClick = useCallback(e => {
+  const onResetButtonClick = useCallback((e: MouseEvent) => {
     e.stopPropagation();
   }, []);
 
@@ -189,7 +195,6 @@ export const CourseSection = ({
         <div className={styles.rightSection}>
           {(status_value === LESSON_STATUS_VALUE.LEARNING ||
             status_value === LESSON_STATUS_VALUE.COMPLETED) && (
-            // @ts-expect-error EXPECT
             <ResetChapterButton
               onClick={onResetButtonClick}
               chapterId={chapterId}

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/ResetChapterButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/ResetChapterButton.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useRef, useState, type MouseEvent } from 'react';
 import { Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,15 @@ import {
 import { useSingleFlight } from '@/hooks/useSingleFlight';
 import { stopActiveLessonStream } from '@/app/c/[[...id]]/events';
 
+type ResetChapterButtonProps = {
+  className?: string;
+  chapterId: string;
+  chapterName?: string;
+  lessonId?: string;
+  onClick?: (event: MouseEvent) => void;
+  onConfirm?: () => void;
+};
+
 export const ResetChapterButton = ({
   className,
   chapterId,
@@ -29,7 +38,7 @@ export const ResetChapterButton = ({
   lessonId,
   onClick,
   onConfirm,
-}) => {
+}: ResetChapterButtonProps) => {
   const { t } = useTranslation();
   const { trackEvent } = useTracking();
 
@@ -47,7 +56,7 @@ export const ResetChapterButton = ({
     Boolean(lessonId) && resettingLessonId === lessonId;
 
   const onButtonClick = useCallback(
-    e => {
+    (e: MouseEvent) => {
       onClick?.(e);
 
       const now = Date.now();

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeBottomArea.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeBottomArea.tsx
@@ -1,8 +1,7 @@
 import styles from './TrialNodeBottomArea.module.scss';
 import { memo, useEffect, useRef, useCallback, useState } from 'react';
 import { shifu } from '@/c-service/Shifu';
-
-const EMPTY_TRIAL_NODE_FALLBACK = 'non';
+import { useTranslation } from 'react-i18next';
 
 export const TRAIL_NODE_POSITION = {
   NORMAL: 'normal',
@@ -26,6 +25,7 @@ const TrialNodeBottomArea = ({
   payload,
   onNodePositionChange,
 }: TrialNodeBottomAreaProps) => {
+  const { t } = useTranslation();
   const [offsetToScroller, setOffsetToScroller] = useState(0);
   const normalAreaRef = useRef<HTMLDivElement | null>(null);
   const [currHeight, setCurrHeight] = useState(0);
@@ -39,9 +39,9 @@ const TrialNodeBottomArea = ({
     return Control ? (
       <Control payload={payload} />
     ) : (
-      <>{EMPTY_TRIAL_NODE_FALLBACK}</>
+      <>{t('common.core.none')}</>
     );
-  }, [payload]);
+  }, [payload, t]);
 
   const isStickTop = useCallback(() => {
     return containerHeight > 0 && containerScrollTop > offsetToScroller;

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeBottomArea.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeBottomArea.tsx
@@ -2,10 +2,22 @@ import styles from './TrialNodeBottomArea.module.scss';
 import { memo, useEffect, useRef, useCallback, useState } from 'react';
 import { shifu } from '@/c-service/Shifu';
 
+const EMPTY_TRIAL_NODE_FALLBACK = 'non';
+
 export const TRAIL_NODE_POSITION = {
   NORMAL: 'normal',
   STICK_TOP: 'stickTop',
   STICK_BOTTOM: 'stickBottom',
+} as const;
+
+export type TrialNodePosition =
+  (typeof TRAIL_NODE_POSITION)[keyof typeof TRAIL_NODE_POSITION];
+
+type TrialNodeBottomAreaProps = {
+  containerScrollTop?: number;
+  containerHeight?: number;
+  payload: unknown;
+  onNodePositionChange?: (position: TrialNodePosition) => void;
 };
 
 const TrialNodeBottomArea = ({
@@ -13,16 +25,22 @@ const TrialNodeBottomArea = ({
   containerHeight = 0,
   payload,
   onNodePositionChange,
-}) => {
+}: TrialNodeBottomAreaProps) => {
   const [offsetToScroller, setOffsetToScroller] = useState(0);
-  const normalAreaRef = useRef(null);
+  const normalAreaRef = useRef<HTMLDivElement | null>(null);
   const [currHeight, setCurrHeight] = useState(0);
-  const [nodePosition, setNodePosition] = useState(TRAIL_NODE_POSITION.NORMAL);
+  const [nodePosition, setNodePosition] = useState<TrialNodePosition>(
+    TRAIL_NODE_POSITION.NORMAL,
+  );
 
   const getTrialNodeAreaControl = useCallback(() => {
     const Control = shifu.getControl(shifu.ControlTypes.TRIAL_NODE_BOTTOM_AREA);
 
-    return Control ? <Control payload={payload} /> : <>non</>;
+    return Control ? (
+      <Control payload={payload} />
+    ) : (
+      <>{EMPTY_TRIAL_NODE_FALLBACK}</>
+    );
   }, [payload]);
 
   const isStickTop = useCallback(() => {
@@ -45,10 +63,8 @@ const TrialNodeBottomArea = ({
 
   useEffect(() => {
     if (normalAreaRef.current) {
-      let position = TRAIL_NODE_POSITION.NORMAL;
-      // @ts-expect-error EXPECT
+      let position: TrialNodePosition = TRAIL_NODE_POSITION.NORMAL;
       setOffsetToScroller(normalAreaRef.current.offsetTop);
-      // @ts-expect-error EXPECT
       setCurrHeight(normalAreaRef.current.clientHeight);
 
       if (isStickTop()) {

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeOuter.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeOuter.tsx
@@ -1,8 +1,7 @@
 import { memo, useCallback } from 'react';
 import { shifu } from '@/c-service/Shifu';
 import styles from './TrialNodeOuter.module.scss';
-
-const EMPTY_TRIAL_NODE_FALLBACK = 'non';
+import { useTranslation } from 'react-i18next';
 import {
   TRAIL_NODE_POSITION,
   type TrialNodePosition,
@@ -14,15 +13,16 @@ type TrialNodeOuterProps = {
 };
 
 const TrialNodeOuter = ({ nodePosition, payload }: TrialNodeOuterProps) => {
+  const { t } = useTranslation();
   const getTrialNodeAreaControl = useCallback(() => {
     const Control = shifu.getControl(shifu.ControlTypes.TRIAL_NODE_BOTTOM_AREA);
 
     return Control ? (
       <Control payload={payload} />
     ) : (
-      <>{EMPTY_TRIAL_NODE_FALLBACK}</>
+      <>{t('common.core.none')}</>
     );
-  }, [payload]);
+  }, [payload, t]);
 
   const getClassName = useCallback(() => {
     let className = '';

--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeOuter.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/TrialNodeOuter.tsx
@@ -1,13 +1,27 @@
 import { memo, useCallback } from 'react';
 import { shifu } from '@/c-service/Shifu';
 import styles from './TrialNodeOuter.module.scss';
-import { TRAIL_NODE_POSITION } from './TrialNodeBottomArea';
 
-const TrialNodeOuter = ({ nodePosition, payload }) => {
+const EMPTY_TRIAL_NODE_FALLBACK = 'non';
+import {
+  TRAIL_NODE_POSITION,
+  type TrialNodePosition,
+} from './TrialNodeBottomArea';
+
+type TrialNodeOuterProps = {
+  nodePosition: TrialNodePosition;
+  payload: unknown;
+};
+
+const TrialNodeOuter = ({ nodePosition, payload }: TrialNodeOuterProps) => {
   const getTrialNodeAreaControl = useCallback(() => {
     const Control = shifu.getControl(shifu.ControlTypes.TRIAL_NODE_BOTTOM_AREA);
 
-    return Control ? <Control payload={payload} /> : <>non</>;
+    return Control ? (
+      <Control payload={payload} />
+    ) : (
+      <>{EMPTY_TRIAL_NODE_FALLBACK}</>
+    );
   }, [payload]);
 
   const getClassName = useCallback(() => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/FilingModal.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/FilingModal.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/Button';
 import Image from 'next/image';
 import imgBeian from '@/c-assets/newchat/light/beian.png';
 
+const ACTION_SEPARATOR = '|';
+
 export const FillingModal = ({
   open,
   onClose,
@@ -19,7 +21,6 @@ export const FillingModal = ({
   const { t } = useTranslation();
 
   return (
-    // @ts-expect-error EXPECT
     <PopupModal
       open={open}
       onClose={onClose}
@@ -55,7 +56,7 @@ export const FillingModal = ({
           >
             {t('component.navigation.feedbackTitle')}
           </Button>
-          <div>|</div>
+          <div>{ACTION_SEPARATOR}</div>
           <Button
             variant='link'
             className={styles.actionBtn}
@@ -65,7 +66,7 @@ export const FillingModal = ({
           >
             {t('component.navigation.userAgreement')}
           </Button>
-          <div>|</div>
+          <div>{ACTION_SEPARATOR}</div>
           <Button
             variant='link'
             className={styles.actionBtn}

--- a/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/NavDrawer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/NavDrawer.tsx
@@ -9,13 +9,15 @@ import {
   memo,
   useCallback,
   useEffect,
+  type UIEvent,
+  type MouseEvent as ReactMouseEvent,
 } from 'react';
 import clsx from 'clsx';
 
 import { AppContext } from '../AppContext';
 import NavHeader from './NavHeader';
 import NavBody from './NavBody';
-import NavFooter from './NavFooter';
+import NavFooter, { type NavFooterHandle } from './NavFooter';
 import CourseCatalogList from '../CourseCatalog/CourseCatalogList';
 
 import FeedbackModal from '../FeedbackModal/FeedbackModal';
@@ -30,6 +32,7 @@ import MainMenuModal from './MainMenuModal';
 
 import { useUserStore } from '@/store';
 import { useUiLayoutStore } from '@/c-store/useUiLayoutStore';
+import type { LessonTree } from '../../hooks/useLessonTree';
 /**
  * Navigation display modes
  * 0: Default, rendered in-flow
@@ -49,7 +52,7 @@ export const POPUP_WINDOW_STATE_FILING = 1;
 const NAV_DRAWER_MAX_WIDTH = '280px';
 const NAV_DRAWER_COLLAPSE_WIDTH = '64px';
 
-const calcNavWidth = frameLayout => {
+const calcNavWidth = (frameLayout: number) => {
   if (frameLayout === FRAME_LAYOUT_MOBILE) {
     return '100%';
   }
@@ -64,6 +67,19 @@ const calcNavWidth = frameLayout => {
 
 const COLLAPSE_WIDTH = NAV_DRAWER_COLLAPSE_WIDTH;
 
+type NavDrawerProps = {
+  courseName?: string;
+  courseAvatar?: string;
+  onLoginClick?: () => void;
+  lessonTree?: LessonTree;
+  selectedLessonId?: string;
+  onChapterCollapse?: (id: string) => void;
+  onLessonSelect?: (params: { id: string }) => void;
+  onTryLessonSelect?: (params: { chapterId: string; lessonId: string }) => void;
+  onBasicInfoClick?: () => void;
+  onPersonalInfoClick?: () => void;
+};
+
 const NavDrawer = ({
   // showType = NAV_SHOW_TYPE_NORMAL,
   courseName = '',
@@ -76,7 +92,7 @@ const NavDrawer = ({
   onTryLessonSelect,
   onBasicInfoClick,
   onPersonalInfoClick,
-}) => {
+}: NavDrawerProps) => {
   const isLoggedIn = useUserStore(state => state.isLoggedIn);
   const [delayedIsLoggedIn, setDelayedIsLoggedIn] = useState(isLoggedIn);
 
@@ -91,8 +107,8 @@ const NavDrawer = ({
 
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   // const alwaysShowLessonTree = getBoolEnv('alwaysShowLessonTree');
-  const footerRef = useRef(null);
-  const bodyRef = useRef(null);
+  const footerRef = useRef<NavFooterHandle | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
 
   const {
     open: mainModalOpen,
@@ -100,22 +116,24 @@ const NavDrawer = ({
     onClose: onMainModalClose,
   } = useDisclosure();
 
-  const onBodyScroll = e => {
-    setBodyScrollTop(e.target.scrollTop);
+  const onBodyScroll = (e: UIEvent<HTMLDivElement>) => {
+    setBodyScrollTop(e.currentTarget.scrollTop);
   };
 
-  const onHeaderToggleClick = useCallback(({ isCollapse }) => {
-    setIsCollapse(isCollapse);
-  }, []);
+  const onHeaderToggleClick = useCallback(
+    ({ isCollapse }: { isCollapse: boolean }) => {
+      setIsCollapse(isCollapse);
+    },
+    [],
+  );
 
   const popupWindowClassname = useCallback(() => {
     return isCollapse ? styles.popUpWindowCollapse : styles.popUpWindowExpand;
   }, [isCollapse]);
 
   const mainModalCloseHandler = useCallback(
-    e => {
-      // @ts-expect-error EXPECT
-      if (footerRef.current && footerRef.current.containElement(e.target)) {
+    (e: MouseEvent | ReactMouseEvent) => {
+      if (footerRef.current?.containElement(e.target)) {
         return;
       }
       onMainModalClose();
@@ -173,15 +191,11 @@ const NavDrawer = ({
                   hideCourseHeader
                   selectedLessonId={selectedLessonId}
                   catalogs={lessonTree?.catalogs || []}
-                  // @ts-expect-error EXPECT
-                  catalogCount={lessonTree?.catalogCount || 0}
                   onChapterCollapse={onChapterCollapse}
                   onLessonSelect={onLessonSelect}
                   onTryLessonSelect={onTryLessonSelect}
                   containerScrollTop={bodyScrollTop}
-                  // @ts-expect-error EXPECT
                   containerHeight={bodyRef.current?.clientHeight || 0}
-                  bannerInfo={lessonTree?.bannerInfo}
                 />
               ) : (
                 <NavBody onLoginClick={onLoginClick} />
@@ -190,14 +204,12 @@ const NavDrawer = ({
         </div>
         <NavFooter
           ref={footerRef}
-          // @ts-expect-error EXPECT
           isCollapse={isCollapse}
           onClick={onFooterClick}
           isMenuOpen={mainModalOpen}
         />
         <MainMenuModal
           open={mainModalOpen}
-          // @ts-expect-error EXPECT
           onClose={mainModalCloseHandler}
           className={popupWindowClassname()}
           mobileStyle={frameLayout === FRAME_LAYOUT_MOBILE}

--- a/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/NavFooter.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/NavFooter.tsx
@@ -1,1 +1,5 @@
-export { default, NavFooter } from '@/c-components/NavDrawer/NavFooter';
+export {
+  default,
+  NavFooter,
+  type NavFooterHandle,
+} from '@/c-components/NavDrawer/NavFooter';

--- a/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/ThemeWindow.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/NavDrawer/ThemeWindow.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 export const ThemeWindow = ({ open, onClose, style, className }) => {
   const { t } = useTranslation();
   return (
-    // @ts-expect-error EXPECT
     <PopupModal
       open={open}
       onClose={onClose}

--- a/src/cook-web/src/app/c/[[...id]]/hooks/useLessonTree.ts
+++ b/src/cook-web/src/app/c/[[...id]]/hooks/useLessonTree.ts
@@ -57,12 +57,12 @@ export type LessonTreeCatalog = {
   collapse: boolean;
 };
 
-type LessonTreeData = {
+export type LessonTreeData = {
   bannerInfo?: unknown;
   catalogs: LessonTreeCatalog[];
 };
 
-type LessonTree = LessonTreeData | null;
+export type LessonTree = LessonTreeData | null;
 
 type LessonStatusLike = {
   status_value: string;

--- a/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/MainMenuModal.tsx
@@ -1,6 +1,12 @@
 import styles from './MainMenuModal.module.scss';
 
-import { memo, useRef, useState } from 'react';
+import {
+  memo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { cn } from '@/lib/utils';
 import { useShallow } from 'zustand/react/shallow';
 import { normalizeLanguage } from '@/i18n';
@@ -32,6 +38,17 @@ import { Monitor, BookPlus, KeyRound, Compass } from 'lucide-react';
 
 import LanguageSelect from '@/components/language-select';
 
+type MainMenuModalProps = {
+  open: boolean;
+  onClose?: (event: MouseEvent | ReactMouseEvent) => void;
+  style?: CSSProperties;
+  mobileStyle?: boolean;
+  className?: string;
+  onBasicInfoClick?: () => void;
+  onPersonalInfoClick?: () => void;
+  isAdmin?: boolean;
+};
+
 const MainMenuModal = ({
   open,
   onClose = () => {},
@@ -41,10 +58,10 @@ const MainMenuModal = ({
   onBasicInfoClick,
   onPersonalInfoClick,
   isAdmin = false,
-}) => {
+}: MainMenuModalProps) => {
   const { t } = useTranslation();
 
-  const htmlRef = useRef(null);
+  const htmlRef = useRef<HTMLDivElement | null>(null);
   const { isLoggedIn, logout, userInfo, refreshUserInfo } = useUserStore(
     useShallow(state => ({
       logout: state.logout,
@@ -105,7 +122,6 @@ const MainMenuModal = ({
     }
 
     setSetPasswordModalOpen(true);
-    // @ts-expect-error EXPECT
     onClose?.(evt);
   };
   const setPasswordRow = canSetPassword ? (
@@ -126,7 +142,6 @@ const MainMenuModal = ({
     evt.preventDefault();
     evt.stopPropagation();
     requestReplayAll();
-    // @ts-expect-error EXPECT
     onClose?.(evt);
   };
   const replayOnboardingRow = (
@@ -149,7 +164,6 @@ const MainMenuModal = ({
     evt.preventDefault();
     evt.stopPropagation();
     window.open('/admin', '_blank');
-    // @ts-expect-error EXPECT
     onClose?.(evt);
   };
 
@@ -157,11 +171,10 @@ const MainMenuModal = ({
     shifu.loginTools.openLogin();
   };
 
-  const onLogoutClick = evt => {
+  const onLogoutClick = (evt: ReactMouseEvent) => {
     evt.preventDefault();
     evt.stopPropagation();
     setLogoutConfirmOpen(true);
-    // @ts-expect-error EXPECT
     onClose?.(evt);
   };
 
@@ -171,6 +184,7 @@ const MainMenuModal = ({
       await logout();
       setLogoutConfirmOpen(false);
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error('❌ Logout failed:', error);
       setLogoutConfirmOpen(false);
     }
@@ -181,6 +195,7 @@ const MainMenuModal = ({
     try {
       await api.updateUserInfo({ language: normalized });
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.warn('Failed to persist language preference', e);
     }
     useUserStore.getState().updateUserInfo({ language: normalized });
@@ -212,7 +227,6 @@ const MainMenuModal = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {/* @ts-expect-error EXPECT */}
       <PopupModal
         open={open}
         onClose={onClose}

--- a/src/cook-web/src/c-components/NavDrawer/NavFooter.tsx
+++ b/src/cook-web/src/c-components/NavDrawer/NavFooter.tsx
@@ -1,23 +1,37 @@
 import styles from './NavFooter.module.scss';
 
 import clsx from 'clsx';
-import { memo, forwardRef, useImperativeHandle, useRef } from 'react';
+import {
+  memo,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  type MouseEventHandler,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUserStore } from '@/store';
 import { ChevronsUpDown, ChevronsDownUp } from 'lucide-react';
 
-export const NavFooter = forwardRef(
-  // @ts-expect-error EXPECT
+export type NavFooterHandle = {
+  containElement: (elem: EventTarget | null) => boolean;
+};
+
+type NavFooterProps = {
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  isCollapse?: boolean;
+  isMenuOpen?: boolean;
+};
+
+export const NavFooter = forwardRef<NavFooterHandle, NavFooterProps>(
   ({ onClick, isCollapse = false, isMenuOpen = false }, ref) => {
     const { t } = useTranslation();
 
     const userInfo = useUserStore(state => state.userInfo);
     const isLoggedIn = useUserStore(state => state.isLoggedIn);
-    const htmlRef = useRef(null);
+    const htmlRef = useRef<HTMLDivElement | null>(null);
 
-    const containElement = elem => {
-      // @ts-expect-error EXPECT
-      return htmlRef.current && htmlRef.current.contains(elem);
+    const containElement = (elem: EventTarget | null) => {
+      return Boolean(elem instanceof Node && htmlRef.current?.contains(elem));
     };
     useImperativeHandle(ref, () => ({
       containElement,

--- a/src/cook-web/src/c-components/PopupModal.tsx
+++ b/src/cook-web/src/c-components/PopupModal.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type CSSProperties, type ReactNode } from 'react';
 
 import clsx from 'clsx';
 import styles from './PopupModal.module.scss';
 
 import { useCallback } from 'react';
+
+export type PopupModalProps = {
+  open?: boolean;
+  onClose?: (event: MouseEvent) => void;
+  children?: ReactNode;
+  style?: CSSProperties;
+  wrapStyle?: CSSProperties;
+  className?: string;
+};
 
 export const PopupModal = ({
   open = false,
@@ -12,14 +21,16 @@ export const PopupModal = ({
   style,
   wrapStyle,
   className,
-}) => {
-  const popupRef = useRef(null);
+}: PopupModalProps) => {
+  const popupRef = useRef<HTMLDivElement | null>(null);
 
   // Close the popup when clicking outside the modal
   const handleClickOutside = useCallback(
-    event => {
-      // @ts-expect-error EXPECT
-      if (popupRef.current && !popupRef.current.contains(event.target)) {
+    (event: MouseEvent) => {
+      if (
+        popupRef.current &&
+        !popupRef.current.contains(event.target as Node)
+      ) {
         // `data-scroll-locked` indicates that another overlay is active, so the menu cannot be closed directly.
         // TODO: Migrate to `shadcn/ui`
         if (!document.body.getAttribute('data-scroll-locked')) {

--- a/src/i18n/en-US/common/core.json
+++ b/src/i18n/en-US/common/core.json
@@ -33,6 +33,7 @@
   "networkError": "Network error, please try again later",
   "noMoreShifus": "No more Courses",
   "noShifus": "No Courses available",
+  "none": "None",
   "ok": "OK",
   "operations": "Operations",
   "orderManagement": "Order Management",

--- a/src/i18n/fr-FR/common/core.json
+++ b/src/i18n/fr-FR/common/core.json
@@ -33,6 +33,7 @@
   "networkError": "Erreur réseau, veuillez réessayer plus tard",
   "noMoreShifus": "Plus aucun cours",
   "noShifus": "Aucun cours disponible",
+  "none": "Aucun",
   "ok": "OK",
   "operations": "Opérations",
   "orderManagement": "Gestion des commandes",

--- a/src/i18n/zh-CN/common/core.json
+++ b/src/i18n/zh-CN/common/core.json
@@ -33,6 +33,7 @@
   "networkError": "网络错误,请稍后重试",
   "noMoreShifus": "没有更多课程了",
   "noShifus": "暂无课程",
+  "none": "无",
   "ok": "确定",
   "operations": "运营",
   "orderManagement": "订单管理",


### PR DESCRIPTION
## Summary
- Added explicit props and ref types for learner course catalog and navigation components.
- Removed stale TypeScript suppression comments from the catalog, nav drawer, and directly related shared menu components.
- Preserved existing learner navigation behavior while keeping focused tests and type-check green.

## Changed
- Typed the learner course catalog, trial node, nav drawer, popup, footer, and main menu component boundaries.
- Removed now-unnecessary `@ts-expect-error` suppressions and invalid pass-through props.
- Kept rendering branches, navigation handlers, and menu actions unchanged.

## Benefit
- Learner navigation contracts are checked by TypeScript instead of broad suppression comments.
- Future course catalog and nav drawer changes are easier to review without hidden prop/ref drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added translated “None” labels in English, French, and Chinese.
  * Updated empty-state text to use localized wording.

* **Accessibility & Reliability**
  * Improved navigation drawer scrolling and interaction handling.
  * Added safer behavior for modal, footer, and course catalog interactions.

* **Maintenance**
  * Strengthened type safety across course catalog, navigation, and modal components.
  * Removed obsolete type-suppression workarounds without changing core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->