### PR TITLE
feat: send LLM reasoning to Langfuse

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -201,11 +201,16 @@ def _extract_reasoning_delta(delta: Any) -> str:
     ]
     thinking_blocks = _get(delta, "thinking_blocks")
     if isinstance(thinking_blocks, list):
-        block_reasoning = [
-            normalized
-            for block in thinking_blocks
-            if (normalized := _normalize(_get(block, "thinking")))
-        ]
+        block_reasoning = []
+        for block in thinking_blocks:
+            # Anthropic emits the full accumulated thinking again alongside
+            # the signature. Incremental reasoning was already delivered in
+            # earlier chunks, so recording the signed snapshot duplicates it.
+            if _normalize(_get(block, "signature")):
+                continue
+            normalized = _normalize(_get(block, "thinking"))
+            if normalized:
+                block_reasoning.append(normalized)
         if block_reasoning:
             candidates.append("\n".join(block_reasoning))
     provider_fields = _get(delta, "provider_specific_fields")
@@ -511,8 +516,10 @@ def _iter_stream_with_precontent_retry(
     established stream that dies mid-read (transient network corruption,
     provider LB reset) surfaces as an exception from the chunk iterator and
     kills the whole run. Re-issuing is only safe while no content has been
-    seen: nothing user-visible can be duplicated. Once content flowed, the
-    error is re-raised unchanged.
+    seen: nothing user-visible can be duplicated. Hidden reasoning chunks are
+    buffered until the attempt produces content or completes, so reasoning
+    from an abandoned attempt does not leak into Langfuse. Once content
+    flowed, the error is re-raised unchanged.
     """
     attempts = 0
     while True:
@@ -525,11 +532,24 @@ def _iter_stream_with_precontent_retry(
             kwargs,
         )
         saw_content = False
+        pending_reasoning_chunks = []
         try:
             for res in response:
-                if len(res.choices) and res.choices[0].delta.content:
+                has_choices = bool(len(res.choices))
+                has_content = bool(has_choices and res.choices[0].delta.content)
+                has_reasoning = bool(
+                    has_choices and _extract_reasoning_delta(res.choices[0].delta)
+                )
+                if has_content:
                     saw_content = True
-                yield res
+                    yield from pending_reasoning_chunks
+                    pending_reasoning_chunks.clear()
+                    yield res
+                elif not saw_content and has_reasoning:
+                    pending_reasoning_chunks.append(res)
+                else:
+                    yield res
+            yield from pending_reasoning_chunks
             return
         except Exception as exc:
             attempts += 1

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -190,13 +190,24 @@ def _extract_reasoning_delta(delta: Any) -> str:
             return value.get(key)
         return getattr(value, key, None)
 
+    def _normalize(value: Any) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value
+        return normalize_langfuse_output_value(value)
+
     candidates: list[Any] = [
         _get(delta, "reasoning_content"),
         _get(delta, "reasoning"),
     ]
     thinking_blocks = _get(delta, "thinking_blocks")
     if isinstance(thinking_blocks, list):
-        candidates.extend(_get(block, "thinking") for block in thinking_blocks)
+        block_reasoning = [
+            normalized
+            for block in thinking_blocks
+            if (normalized := _normalize(_get(block, "thinking")))
+        ]
+        if block_reasoning:
+            candidates.append("\n".join(block_reasoning))
     provider_fields = _get(delta, "provider_specific_fields")
     if provider_fields:
         candidates.extend(
@@ -207,11 +218,7 @@ def _extract_reasoning_delta(delta: Any) -> str:
         )
 
     for candidate in candidates:
-        normalized = (
-            candidate
-            if isinstance(candidate, str) and candidate.strip()
-            else normalize_langfuse_output_value(candidate)
-        )
+        normalized = _normalize(candidate)
         if normalized:
             return normalized
     return ""
@@ -223,11 +230,10 @@ def _build_langfuse_llm_output(
 ) -> str | dict[str, str]:
     if not reasoning_text:
         return response_text
-    output: dict[str, str] = {}
-    if response_text:
-        output["content"] = response_text
-    output["reasoning_content"] = reasoning_text
-    return output
+    return {
+        "content": response_text,
+        "reasoning_content": reasoning_text,
+    }
 
 
 def _normalize_model_config(value: Any) -> list[str]:

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -20,6 +20,7 @@ from flaskr.api.langfuse import (
     LangfuseObservationHandle,
     build_langfuse_observation_link,
     get_request_id,
+    normalize_langfuse_output_value,
     resolve_langfuse_trace_id,
 )
 from flaskr.common.config import (
@@ -179,6 +180,54 @@ def _attach_usage_output_text(
         :_USAGE_OUTPUT_TEXT_MAX_LENGTH
     ]
     return next_metadata
+
+
+def _extract_reasoning_delta(delta: Any) -> str:
+    """Return provider reasoning from a normalized LiteLLM stream delta."""
+
+    def _get(value: Any, key: str) -> Any:
+        if isinstance(value, dict):
+            return value.get(key)
+        return getattr(value, key, None)
+
+    candidates: list[Any] = [
+        _get(delta, "reasoning_content"),
+        _get(delta, "reasoning"),
+    ]
+    thinking_blocks = _get(delta, "thinking_blocks")
+    if isinstance(thinking_blocks, list):
+        candidates.extend(_get(block, "thinking") for block in thinking_blocks)
+    provider_fields = _get(delta, "provider_specific_fields")
+    if provider_fields:
+        candidates.extend(
+            [
+                _get(provider_fields, "reasoning_content"),
+                _get(provider_fields, "reasoning"),
+            ]
+        )
+
+    for candidate in candidates:
+        normalized = (
+            candidate
+            if isinstance(candidate, str) and candidate.strip()
+            else normalize_langfuse_output_value(candidate)
+        )
+        if normalized:
+            return normalized
+    return ""
+
+
+def _build_langfuse_llm_output(
+    response_text: str,
+    reasoning_text: str,
+) -> str | dict[str, str]:
+    if not reasoning_text:
+        return response_text
+    output: dict[str, str] = {}
+    if response_text:
+        output["content"] = response_text
+    output["reasoning_content"] = reasoning_text
+    return output
 
 
 def _normalize_model_config(value: Any) -> list[str]:
@@ -952,6 +1001,7 @@ def invoke_llm(
         model,
     )
     response_text = ""
+    reasoning_text = ""
     usage = None
     input_cache_tokens = 0
     provider_name = ""
@@ -991,6 +1041,8 @@ def invoke_llm(
         for res in response:
             if start_completion_time is None:
                 start_completion_time = datetime.now()
+            if len(res.choices):
+                reasoning_text += _extract_reasoning_delta(res.choices[0].delta)
             if len(res.choices) and res.choices[0].delta.content:
                 response_text += res.choices[0].delta.content
                 yield LLMStreamResponse(
@@ -1078,7 +1130,7 @@ def invoke_llm(
         )
     generation.end(
         input=generation_input,
-        output=response_text,
+        output=_build_langfuse_llm_output(response_text, reasoning_text),
         usage=usage,
         metadata=kwargs,
         completion_start_time=start_completion_time,
@@ -1130,6 +1182,7 @@ def chat_llm(
         model,
     )
     response_text = ""
+    reasoning_text = ""
     usage = None
     input_cache_tokens = 0
     provider_name = ""
@@ -1163,6 +1216,8 @@ def chat_llm(
             for res in response:
                 if start_completion_time is None:
                     start_completion_time = datetime.now()
+                if len(res.choices):
+                    reasoning_text += _extract_reasoning_delta(res.choices[0].delta)
                 if len(res.choices) and res.choices[0].delta.content:
                     response_text += res.choices[0].delta.content
                     yield LLMStreamResponse(
@@ -1259,7 +1314,7 @@ def chat_llm(
         )
     generation.end(
         input=generation_input,
-        output=response_text,
+        output=_build_langfuse_llm_output(response_text, reasoning_text),
         usage=usage,
         metadata=kwargs,
         completion_start_time=start_completion_time,

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1550,6 +1550,19 @@ def test_langfuse_reasoning_output_keeps_empty_content_key():
             ),
             "provider",
         ),
+        (
+            SimpleNamespace(
+                reasoning_content=None,
+                thinking_blocks=[
+                    {
+                        "type": "thinking",
+                        "thinking": "accumulated snapshot",
+                        "signature": "signed",
+                    }
+                ],
+            ),
+            "",
+        ),
     ],
 )
 def test_extract_reasoning_delta_supports_litellm_fallback_fields(delta, expected):
@@ -1604,6 +1617,20 @@ def _stream_chunk(content):
     return SimpleNamespace(
         choices=[
             SimpleNamespace(delta=SimpleNamespace(content=content), finish_reason=None)
+        ],
+        usage=None,
+    )
+
+
+def _reasoning_stream_chunk(reasoning_content):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None, reasoning_content=reasoning_content
+                ),
+                finish_reason=None,
+            )
         ],
         usage=None,
     )
@@ -1671,6 +1698,33 @@ def test_stream_retries_connection_error_before_first_content(
     chunks = _collect_retry_stream(app)
 
     assert [c.choices[0].delta.content for c in chunks] == ["hello", " world"]
+    assert calls["count"] == 2
+
+
+def test_stream_retry_discards_reasoning_from_failed_attempt(monkeypatch, app):
+    _patch_retryable_stream_errors(monkeypatch)
+    calls = _patch_scripted_streams(
+        monkeypatch,
+        [
+            [
+                _reasoning_stream_chunk("stale reasoning"),
+                _FakeAPIConnectionError("bad record mac"),
+            ],
+            [
+                _reasoning_stream_chunk("fresh reasoning"),
+                _stream_chunk("answer"),
+            ],
+        ],
+    )
+
+    chunks = _collect_retry_stream(app)
+
+    assert [
+        llm._extract_reasoning_delta(chunk.choices[0].delta)
+        for chunk in chunks
+        if llm._extract_reasoning_delta(chunk.choices[0].delta)
+    ] == ["fresh reasoning"]
+    assert [chunk.choices[0].delta.content for chunk in chunks] == [None, "answer"]
     assert calls["count"] == 2
 
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -140,9 +140,19 @@ class DummySpan:
 
 
 class FakeResponse:
-    def __init__(self, chunk_id, content=None, finish_reason=None, usage=None):
+    def __init__(
+        self,
+        chunk_id,
+        content=None,
+        finish_reason=None,
+        usage=None,
+        reasoning_content=None,
+    ):
         self.id = chunk_id
-        delta = SimpleNamespace(content=content)
+        delta = SimpleNamespace(
+            content=content,
+            reasoning_content=reasoning_content,
+        )
         self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
         self.usage = usage
 
@@ -1452,7 +1462,88 @@ def test_chat_llm_streams(monkeypatch, app):
     assert captured_usage["input"] == 3
     assert captured_usage["output"] == 2
     assert captured_usage["total"] == 5
+    assert span.end_args["output"] == "Hi there"
     assert captured_usage["extra"]["output_text"] == "Hi there"
+
+
+@pytest.mark.parametrize("llm_method", ["invoke_llm", "chat_llm"])
+def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
+    monkeypatch, app, llm_method
+):
+    def fake_completion(*args, **kwargs):
+        _ = args, kwargs
+        return iter(
+            [
+                FakeResponse("chunk-1", reasoning_content="Think "),
+                FakeResponse(
+                    "chunk-2",
+                    content="The answer",
+                    reasoning_content="carefully.",
+                    finish_reason="stop",
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    provider_state = llm.ProviderState(
+        enabled=True,
+        params={"api_key": "test-key", "api_base": "https://example.com"},
+        models=["gpt-test"],
+        prefix="",
+        wildcard_prefixes=("gpt",),
+    )
+    monkeypatch.setattr(llm, "PROVIDER_STATES", {"openai": provider_state})
+    monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {"gpt-test": ("openai", "gpt-test")})
+    monkeypatch.setattr(llm, "PROVIDER_CONFIG_HINTS", {"openai": "OPENAI_API_KEY"})
+
+    span = DummySpan()
+    common_kwargs = {
+        "app": app,
+        "user_id": "user-1",
+        "span": span,
+        "model": "gpt-test",
+        "generation_name": "reasoning-test",
+    }
+    if llm_method == "invoke_llm":
+        responses = list(llm.invoke_llm(message="hello", **common_kwargs))
+    else:
+        responses = list(
+            llm.chat_llm(
+                messages=[{"role": "user", "content": "hello"}],
+                **common_kwargs,
+            )
+        )
+
+    assert [response.result for response in responses] == ["The answer"]
+    assert span.end_args["output"] == {
+        "content": "The answer",
+        "reasoning_content": "Think carefully.",
+    }
+
+
+@pytest.mark.parametrize(
+    ("delta", "expected"),
+    [
+        (
+            SimpleNamespace(
+                reasoning_content=None,
+                thinking_blocks=[{"type": "thinking", "thinking": "block"}],
+            ),
+            "block",
+        ),
+        (
+            SimpleNamespace(
+                reasoning_content=None,
+                thinking_blocks=None,
+                provider_specific_fields={"reasoning": "provider"},
+            ),
+            "provider",
+        ),
+    ],
+)
+def test_extract_reasoning_delta_supports_litellm_fallback_fields(delta, expected):
+    assert llm._extract_reasoning_delta(delta) == expected
 
 
 def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1522,15 +1522,25 @@ def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     }
 
 
+def test_langfuse_reasoning_output_keeps_empty_content_key():
+    assert llm._build_langfuse_llm_output("", "Think carefully.") == {
+        "content": "",
+        "reasoning_content": "Think carefully.",
+    }
+
+
 @pytest.mark.parametrize(
     ("delta", "expected"),
     [
         (
             SimpleNamespace(
                 reasoning_content=None,
-                thinking_blocks=[{"type": "thinking", "thinking": "block"}],
+                thinking_blocks=[
+                    {"type": "thinking", "thinking": "first block"},
+                    {"type": "thinking", "thinking": "second block"},
+                ],
             ),
-            "block",
+            "first block\nsecond block",
         ),
         (
             SimpleNamespace(


### PR DESCRIPTION
## Summary

- Capture reasoning returned by LiteLLM stream chunks through `reasoning_content`, unsigned `thinking_blocks`, and provider-specific fallback fields.
- Preserve every unsigned thinking block in order and include a stable `content` plus `reasoning_content` schema in Langfuse generation output whenever reasoning exists, including reasoning-only responses with empty content.
- Keep retries attempt-safe by discarding buffered reasoning from an abandoned pre-content stream attempt, and skip Anthropic signed cumulative thinking snapshots to prevent duplicate reasoning.
- Preserve the existing string output shape when reasoning is absent and keep reasoning out of the learner response stream.

## Why

Reasoning-capable models can return useful diagnostic output separately from their final answer. The shared LLM wrapper previously discarded that output before finalizing its Langfuse generation, so operators could not inspect it. Retry and signature edge cases also need to preserve only the successful, non-duplicated reasoning sequence.

## Validation

- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/test_llm.py tests/test_langfuse.py -q` — 70 passed, 1 skipped (the existing LiteLLM 1.95 contract test skips because the shared environment still has LiteLLM 1.80.11)
- `python3 scripts/check_architecture_boundaries.py` — passed with no new violations
- `python3 scripts/check_dev_tools.py` — core tooling passed
- `ruff format --check flaskr/api/llm/__init__.py tests/test_llm.py` and `git diff --check` — passed
- Ruff baseline comparison — unchanged: 98 existing findings in the LLM module and 8 in its test file on both `origin/main` and this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed reasoning content across supported providers.
  * Prevented reasoning text from appearing in the visible response while preserving it in generated output records.
  * Fixed retry handling to discard reasoning from failed streaming attempts.
  * Improved output tracking for reasoning-only and empty-content streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->