### PR TITLE
fix: surface gevent hub errors and isolate the TTS executor per process

### DIFF
--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -1,0 +1,73 @@
+"""Surface gevent hub-level errors in the application log.
+
+A callback that dies inside the gevent hub (e.g. the AssertionError seen in
+``AbstractLinkable._notify_links``) is printed to stderr by the hub and never
+reaches any application-level ``except``. Such a crash can corrupt a greenlet
+wakeup chain and silently interrupt an in-flight DB exchange, leaving the
+MySQL connection with an unread response (off-by-one protocol desync).
+
+This observer wraps ``hub.handle_error`` so every hub error is ALSO logged
+through the application logger with the failing context object named, which
+turns the anonymous stderr traceback into an attributable event.
+"""
+
+from __future__ import annotations
+
+import os
+
+_OBSERVER_FLAG = "_ai_shifu_hub_error_observer"
+
+
+def _describe_context(context) -> str:
+    # repr() of an arbitrary hub context (Semaphore, Event, watcher, callback)
+    # can be large or can itself raise; keep it short and never fail.
+    try:
+        text = repr(context)
+    except Exception:
+        text = "<repr failed>"
+    if len(text) > 300:
+        text = text[:300] + "...(truncated)"
+    return f"{type(context).__name__}: {text}"
+
+
+def install_hub_error_observer(logger, hub=None) -> bool:
+    """Wrap the hub's ``handle_error`` to log hub-level failures.
+
+    Returns True when the observer is active (installed now or previously).
+    Safe to call multiple times; the wrapper is installed at most once per
+    hub. When ``hub`` is None the calling thread's gevent hub is used.
+    """
+    if hub is None:
+        try:
+            from gevent import get_hub
+        except ImportError:
+            return False
+        hub = get_hub()
+
+    if getattr(hub, _OBSERVER_FLAG, False):
+        return True
+
+    original_handle_error = hub.handle_error
+
+    def handle_error(context, exc_type, value, tb):
+        # Log BEFORE delegating: the original handler may re-raise for
+        # system errors. Nothing in here may raise or block - a failure in
+        # the error path would take down the hub itself.
+        try:
+            logger.error(
+                "gevent hub error (pid=%s): context=%s exc=%s: %s. "
+                "A crashed hub callback can break a greenlet wakeup and "
+                "silently interrupt an in-flight DB exchange.",
+                os.getpid(),
+                _describe_context(context),
+                getattr(exc_type, "__name__", exc_type),
+                value,
+                exc_info=(exc_type, value, tb) if exc_type is not None else None,
+            )
+        except Exception:
+            pass
+        return original_handle_error(context, exc_type, value, tb)
+
+    hub.handle_error = handle_error
+    setattr(hub, _OBSERVER_FLAG, True)
+    return True

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -167,6 +167,7 @@ def _reject_desynced_connection_on_checkout(
     # sees an already-invalidated record and never touches the wire.
     ping = getattr(dbapi_connection, "ping", None)
     if ping is None:
+        _mark_checkout_boundary(connection_record)
         return
     try:
         ping(False)
@@ -182,6 +183,17 @@ def _reject_desynced_connection_on_checkout(
         # GreenletExit and friends propagate; the record is already
         # invalidated so nothing dirty can reach the pool.
         raise
+    _mark_checkout_boundary(connection_record)
+
+
+def _mark_checkout_boundary(connection_record) -> None:
+    # The journal lives in connection_record.info and therefore survives
+    # checkin/checkout: without a boundary marker a dump can silently mix
+    # statements from different requests that shared this pooled connection.
+    with contextlib.suppress(Exception):
+        _journal_from_info(connection_record.info).append(
+            (f"{_CHECKOUT_BOUNDARY_MARKER} pid={os.getpid()}", None, None)
+        )
 
 
 # Ring buffer of recent statements per DBAPI connection, plus a pre-execute
@@ -199,12 +211,19 @@ _STATEMENT_JOURNAL_SIZE = 25
 _STATEMENT_SNIPPET_CHARS = 90
 
 
-def _statement_journal(connection) -> collections.deque:
-    journal = connection.info.get(_STATEMENT_JOURNAL_KEY)
+_CHECKOUT_BOUNDARY_MARKER = "-- pool checkout --"
+
+
+def _journal_from_info(info) -> collections.deque:
+    journal = info.get(_STATEMENT_JOURNAL_KEY)
     if journal is None:
         journal = collections.deque(maxlen=_STATEMENT_JOURNAL_SIZE)
-        connection.info[_STATEMENT_JOURNAL_KEY] = journal
+        info[_STATEMENT_JOURNAL_KEY] = journal
     return journal
+
+
+def _statement_journal(connection) -> collections.deque:
+    return _journal_from_info(connection.info)
 
 
 @event.listens_for(Engine, "before_cursor_execute")
@@ -219,10 +238,13 @@ def _intercept_desync_before_execute(
         _pool_diagnostics_logger().error(
             "DB connection has an unread response before executing a new "
             "statement (off-by-one protocol desync, pid=%s "
-            "server_thread_id=%s). The LAST journal entry is the statement "
-            "whose exchange was interrupted. journal=%s next_statement=%r",
+            "server_thread_id=%s). The journal lists this connection's "
+            "recent COMPLETED statements ('%s' rows mark pool checkout "
+            "boundaries); the interrupted statement itself may be absent "
+            "because it never finished. journal=%s next_statement=%r",
             os.getpid(),
             _server_thread_id(dbapi_connection),
+            _CHECKOUT_BOUNDARY_MARKER,
             journal,
             statement[:_STATEMENT_SNIPPET_CHARS],
         )

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -90,7 +90,13 @@ _tts_executor_pid: int | None = None
 def _get_tts_executor() -> ThreadPoolExecutor:
     global _tts_executor, _tts_executor_pid
     current_pid = os.getpid()
-    if _tts_executor is None or _tts_executor_pid != current_pid:
+    # Rebuild only when there is no executor or the recorded pid is STALE.
+    # An executor with no recorded pid was injected directly (tests patch
+    # `_tts_executor` with a mock) and must be honored as-is; production
+    # code always records the pid alongside the instance it creates.
+    if _tts_executor is None or (
+        _tts_executor_pid is not None and _tts_executor_pid != current_pid
+    ):
         _tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
         _tts_executor_pid = current_pid
     return _tts_executor

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -9,6 +9,7 @@ This module provides real-time TTS synthesis during content streaming.
 
 import base64
 import logging
+import os
 import traceback
 import uuid
 import threading
@@ -75,8 +76,25 @@ from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
-# Global thread pool for TTS synthesis
-_tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
+# Global thread pool for TTS synthesis, created lazily per process. A
+# module-level instance would be created during the gunicorn master's
+# preload import and inherited by every forked worker; its gevent-patched
+# internals then carry wakeup links bound to the parent's hub, which can
+# crash in AbstractLinkable._notify_links and silently interrupt unrelated
+# greenlets (observed as DB protocol desync). The pid guard hands each
+# process its own executor.
+_tts_executor: ThreadPoolExecutor | None = None
+_tts_executor_pid: int | None = None
+
+
+def _get_tts_executor() -> ThreadPoolExecutor:
+    global _tts_executor, _tts_executor_pid
+    current_pid = os.getpid()
+    if _tts_executor is None or _tts_executor_pid != current_pid:
+        _tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
+        _tts_executor_pid = current_pid
+    return _tts_executor
+
 
 _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"
 _EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "tencent_texttovoice", "volcengine"}
@@ -420,7 +438,7 @@ class StreamingTTSProcessor:
             f"Submitting TTS task {segment_index}: {len(text)} chars, provider={self.tts_provider or '(unset)'}"
         )
 
-        future = _tts_executor.submit(
+        future = _get_tts_executor().submit(
             self._synthesize_in_thread,
             segment,
             self.voice_settings,

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -45,6 +45,19 @@ def post_fork(server, worker):
     # flushing (a flush would write to the shared connection, which is the
     # exact failure being prevented), reset the OTel global so a fresh
     # provider can be registered, then rebuild the client in this worker.
+    # Hub-level callback crashes (e.g. AssertionError in
+    # AbstractLinkable._notify_links) are printed to stderr by gevent and
+    # bypass every application except-block, yet they can break a greenlet
+    # wakeup and silently interrupt an in-flight DB exchange (observed as
+    # off-by-one protocol desync). Mirror them into the app logger with the
+    # failing context object named so the culprit primitive is attributable.
+    try:
+        from flaskr.common.gevent_hub_observer import install_hub_error_observer
+
+        install_hub_error_observer(flask_app.logger)
+    except Exception:  # pragma: no cover - defensive: never kill a booting worker
+        worker.log.exception("post_fork hub observer install failed")
+
     try:
         from langfuse._client.resource_manager import LangfuseResourceManager
         from opentelemetry import trace as otel_trace_api

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -1,0 +1,93 @@
+"""The hub error observer must mirror gevent hub failures into the app log.
+
+A callback crashing inside the gevent hub (e.g. AssertionError in
+AbstractLinkable._notify_links) bypasses every application except-block; the
+observer wraps hub.handle_error so the failing context object is named in
+the application log while the hub's original behavior is preserved.
+"""
+
+import logging
+
+from flaskr.common.gevent_hub_observer import install_hub_error_observer
+
+
+class _StubHub:
+    def __init__(self):
+        self.calls = []
+
+        def _original(context, exc_type, value, tb):
+            self.calls.append((context, exc_type, value, tb))
+            return "original-result"
+
+        self.handle_error = _original
+
+
+def _fire(hub, context=None, exc=None):
+    exc = exc if exc is not None else AssertionError("(None, <callback>)")
+    return hub.handle_error(context, type(exc), exc, None)
+
+
+def test_observer_logs_and_delegates(caplog):
+    hub = _StubHub()
+    logger = logging.getLogger("test-hub-observer")
+    assert install_hub_error_observer(logger, hub=hub) is True
+
+    class _FakeSemaphore:
+        def __repr__(self):
+            return "<FakeSemaphore links=3>"
+
+    context = _FakeSemaphore()
+    with caplog.at_level(logging.ERROR, logger="test-hub-observer"):
+        result = _fire(hub, context=context)
+
+    assert result == "original-result"
+    assert len(hub.calls) == 1
+    assert "gevent hub error" in caplog.text
+    # The culprit primitive must be attributable: class name AND repr.
+    assert "_FakeSemaphore" in caplog.text
+    assert "<FakeSemaphore links=3>" in caplog.text
+    assert "AssertionError" in caplog.text
+
+
+def test_observer_installs_once(caplog):
+    hub = _StubHub()
+    logger = logging.getLogger("test-hub-observer-once")
+    assert install_hub_error_observer(logger, hub=hub) is True
+    assert install_hub_error_observer(logger, hub=hub) is True
+
+    with caplog.at_level(logging.ERROR, logger="test-hub-observer-once"):
+        _fire(hub)
+
+    # Double install must not double-wrap: one delegate call, one log line.
+    assert len(hub.calls) == 1
+    assert caplog.text.count("gevent hub error") == 1
+
+
+def test_logger_failure_never_blocks_the_original_handler():
+    hub = _StubHub()
+
+    class _BrokenLogger:
+        def error(self, *args, **kwargs):
+            raise RuntimeError("logging backend down")
+
+    install_hub_error_observer(_BrokenLogger(), hub=hub)
+    result = _fire(hub)
+
+    assert result == "original-result"
+    assert len(hub.calls) == 1
+
+
+def test_unreprable_context_is_still_logged(caplog):
+    hub = _StubHub()
+    logger = logging.getLogger("test-hub-observer-badrepr")
+    install_hub_error_observer(logger, hub=hub)
+
+    class _BadRepr:
+        def __repr__(self):
+            raise ValueError("no repr for you")
+
+    with caplog.at_level(logging.ERROR, logger="test-hub-observer-badrepr"):
+        _fire(hub, context=_BadRepr())
+
+    assert "_BadRepr" in caplog.text
+    assert "<repr failed>" in caplog.text

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -166,3 +166,32 @@ def test_checkin_grace_window_is_a_short_positive_interval():
     # enlarging the window must be an explicit two-place change backed by a
     # latency budget, not a silent constant bump.
     assert 0 < dao._CHECKIN_PROBE_GRACE_SECONDS <= 0.002
+
+
+def test_checkout_appends_a_journal_boundary_marker():
+    clean_a, clean_b = socket.socketpair()
+    conn = _FakePyMySQLConnection(clean_a)
+
+    pool = QueuePool(lambda: conn, pool_size=1, max_overflow=0, reset_on_return=None)
+    try:
+        fairy = pool.connect()
+        journal = list(fairy.info.get(dao._STATEMENT_JOURNAL_KEY, ()))
+        # The journal survives checkin/checkout, so without boundary markers
+        # one dump can silently mix statements from different requests.
+        assert any(
+            str(entry[0]).startswith(dao._CHECKOUT_BOUNDARY_MARKER) for entry in journal
+        ), journal
+        fairy.close()
+
+        fairy2 = pool.connect()
+        journal2 = list(fairy2.info.get(dao._STATEMENT_JOURNAL_KEY, ()))
+        markers = [
+            entry
+            for entry in journal2
+            if str(entry[0]).startswith(dao._CHECKOUT_BOUNDARY_MARKER)
+        ]
+        assert len(markers) == 2
+        fairy2.close()
+    finally:
+        pool.dispose()
+        clean_b.close()

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -27,6 +27,7 @@ class _FakePyMySQLConnection:
 
     def close(self):
         self.closed = True
+        self._sock.close()
 
 
 @pytest.fixture()
@@ -168,9 +169,20 @@ def test_checkin_grace_window_is_a_short_positive_interval():
     assert 0 < dao._CHECKIN_PROBE_GRACE_SECONDS <= 0.002
 
 
+class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
+    """Fake with a healthy ping - the pymysql-shaped checkout path."""
+
+    def __init__(self, sock):
+        super().__init__(sock)
+        self.pings = 0
+
+    def ping(self, reconnect):
+        self.pings += 1
+
+
 def test_checkout_appends_a_journal_boundary_marker():
     clean_a, clean_b = socket.socketpair()
-    conn = _FakePyMySQLConnection(clean_a)
+    conn = _FakePingablePyMySQLConnection(clean_a)
 
     pool = QueuePool(lambda: conn, pool_size=1, max_overflow=0, reset_on_return=None)
     try:
@@ -191,6 +203,8 @@ def test_checkout_appends_a_journal_boundary_marker():
             if str(entry[0]).startswith(dao._CHECKOUT_BOUNDARY_MARKER)
         ]
         assert len(markers) == 2
+        # The pymysql-shaped path reaches the marker AFTER a healthy ping.
+        assert conn.pings == 2
         fairy2.close()
     finally:
         pool.dispose()

--- a/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
+++ b/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
@@ -1,0 +1,58 @@
+"""The TTS thread pool must never be shared across a process fork.
+
+An executor created at import time in the gunicorn master (preload) is
+inherited by every forked worker; its gevent-patched internals then carry
+wakeup links bound to the parent's hub, which can crash in
+AbstractLinkable._notify_links and interrupt unrelated greenlets. The lazy
+accessor with a pid guard gives each process its own executor.
+"""
+
+import ast
+import inspect
+
+from flaskr.service.tts import streaming_tts
+
+
+def test_module_does_not_create_an_executor_at_import_time():
+    # The import-time instance is the fork-inheritance hazard; only the
+    # lazy accessor may create one.
+    module_ast = ast.parse(inspect.getsource(streaming_tts))
+    for node in module_ast.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = node.value
+            if (
+                isinstance(value, ast.Call)
+                and getattr(value.func, "id", None) == "ThreadPoolExecutor"
+            ):
+                raise AssertionError(
+                    "module-level ThreadPoolExecutor recreates the "
+                    "fork-inheritance hazard; use _get_tts_executor()"
+                )
+
+
+def test_executor_is_cached_within_one_process(monkeypatch):
+    monkeypatch.setattr(streaming_tts, "_tts_executor", None)
+    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+
+    first = streaming_tts._get_tts_executor()
+    second = streaming_tts._get_tts_executor()
+
+    assert first is second
+    first.shutdown(wait=False)
+
+
+def test_executor_is_rebuilt_after_fork(monkeypatch):
+    monkeypatch.setattr(streaming_tts, "_tts_executor", None)
+    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+
+    parent_executor = streaming_tts._get_tts_executor()
+
+    # Simulate the child process: same module state, different pid.
+    monkeypatch.setattr(
+        streaming_tts.os, "getpid", lambda: streaming_tts._tts_executor_pid + 1
+    )
+    child_executor = streaming_tts._get_tts_executor()
+
+    assert child_executor is not parent_executor
+    parent_executor.shutdown(wait=False)
+    child_executor.shutdown(wait=False)

--- a/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
+++ b/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
@@ -41,6 +41,17 @@ def test_executor_is_cached_within_one_process(monkeypatch):
     first.shutdown(wait=False)
 
 
+def test_directly_injected_executor_is_honored(monkeypatch):
+    # Existing tests patch `_tts_executor` with a mock and leave the pid
+    # unset; the accessor must return the injection instead of clobbering
+    # it with a real executor.
+    sentinel = object()
+    monkeypatch.setattr(streaming_tts, "_tts_executor", sentinel)
+    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+
+    assert streaming_tts._get_tts_executor() is sentinel
+
+
 def test_executor_is_rebuilt_after_fork(monkeypatch):
     monkeypatch.setattr(streaming_tts, "_tts_executor", None)
     monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)


### PR DESCRIPTION
## Problem

After #2267 (~90% drop) and #2272, listen-mode runs still hit sporadic off-by-one MySQL protocol desync interceptions. New production evidence changed the diagnosis:

- The poisoning happens **within a single pool checkout**: since the #2272 rollout, the checkin probe, checkout probe, and checkout liveness ping all recorded **zero** hits across all pods, while the pre-execute probe still intercepted mid-run. Pool-path fixes structurally cannot reach this source.
- 200ms before today's interception, the same pod (and only that pod) emitted two raw gevent hub tracebacks on stderr:

  ```
  File "src/gevent/_abstract_linkable.py", line 333, in AbstractLinkable._notify_links
  AssertionError: (None, <callback at 0x... args=([],)>)
  <callback ...> failed with AssertionError
  ```

  A callback crashing inside the hub bypasses every application `except`, can break a greenlet wakeup chain, and silently interrupts an in-flight DB exchange - which explains every anomaly: no exception ever reaches termination classification, the interrupted statement never appears in the journal (it never completes), and retries of the same run on other pods fail the same way (load-correlated, not connection-correlated).
- Environment: gunicorn `preload_app` (since 2026-07-14) means module-level objects are created in the master and inherited by every forked worker - the same family as the langfuse/OTel fork issue fixed in #2244. The module-level `_tts_executor = ThreadPoolExecutor(4)` in `streaming_tts.py` was created during master preload and is not covered by the `post_fork` reset list.

## Changes

1. **Hub error observer** (`flaskr/common/gevent_hub_observer.py`, installed in `gunicorn.conf.py post_fork`): wraps `hub.handle_error` so every hub-level failure is also logged through the app logger with the failing context object named (`type` + truncated `repr`) and full traceback. The next occurrence names the culprit primitive instead of dying anonymously on stderr. The wrapper never raises, installs at most once per hub, and always delegates to the original handler.
2. **Per-process TTS executor** (`streaming_tts.py`): the module-level executor is now a lazy singleton guarded by pid (`_get_tts_executor()`), so each process builds its own and the master's preload instance is never used across fork. An AST-based test forbids reintroducing a module-level instance.
3. **Journal checkout boundary markers** (`flaskr/dao/__init__.py`): the per-connection statement journal survives checkin/checkout, so one dump could silently mix statements from different requests. Checkout now appends a `-- pool checkout --` marker, and the interception log wording no longer claims the last entry is the interrupted statement (it may be absent because it never finished).
4. Audit note: remaining module-level threading primitives (`pingxx.py`, `rpm_gate.py`, `creator_analytics/engine.py`) are bare locks with no waiters at fork time and were left as is.

## Verification

- New tests: `tests/common/test_gevent_hub_observer.py` (log + delegate, idempotent install, broken logger, unreprable context), `tests/service/tts/test_tts_executor_fork_isolation.py` (no import-time executor, per-process cache, rebuild after fork), checkout boundary marker assertions in `tests/common/test_pool_desync_detection.py`.
- Full backend suite: 2578 passed, 15 skipped.

## Rollout observation

After deploy, correlate `gevent hub error` log lines (now structured, with the context object named) against pre-execute interception counts; if the named primitive is not in our own code, the fix targets it next (or a gevent 25.x upgrade validated on dev01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of text-to-speech processing across worker processes.
  * Enhanced database connection-pool recovery and diagnostics, including clearer identification of interrupted operations.
  * Improved handling and logging of background server errors without disrupting worker startup.

* **Tests**
  * Added coverage for error reporting, connection-pool boundary tracking, and text-to-speech process isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->