### PR TITLE
fix: improve learner AI error toast

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
@@ -9,7 +9,7 @@ import {
 import AskBlock from './AskBlock';
 import { AppContext } from '../AppContext';
 import { SSE_OUTPUT_TYPE } from '@/c-api/studyV2';
-import { toast } from '@/hooks/useToast';
+import { toast, toastOnce } from '@/hooks/useToast';
 import { useAskStateStore } from './useAskStateStore';
 
 jest.mock('react-i18next', () => ({
@@ -20,6 +20,10 @@ jest.mock('react-i18next', () => ({
       resolvedLanguage: 'zh-CN',
     },
   }),
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
 }));
 
 jest.mock('@/c-utils/markdownUtils', () => ({
@@ -63,6 +67,7 @@ jest.mock('markdown-flow-ui/renderer', () => ({
 
 jest.mock('@/hooks/useToast', () => ({
   toast: jest.fn(),
+  toastOnce: jest.fn(),
 }));
 
 jest.mock('next/image', () => {
@@ -949,6 +954,38 @@ describe('AskBlock', () => {
       expect(
         (screen.getByLabelText('ask-input') as HTMLTextAreaElement).value,
       ).toBe('another question');
+    });
+
+    it('shows a deduped friendly toast for technical AI service errors', async () => {
+      renderAskBlock();
+
+      fireEvent.change(screen.getByLabelText('ask-input'), {
+        target: { value: 'technical question' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+      await waitFor(() => expect(activeRun).toBeDefined());
+
+      await act(async () => {
+        await activeRun?.onMessage({
+          type: SSE_OUTPUT_TYPE.ERROR,
+          content: '模型 deepseek 调用失败：provider unavailable',
+        });
+      });
+
+      expect(toast).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining('deepseek'),
+        }),
+      );
+      expect(toastOnce).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dedupeKey: 'ai-service-unavailable',
+          title: 'module.chat.contentGenerationUnavailable',
+          variant: 'destructive',
+          duration: 8000,
+        }),
+      );
     });
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -19,7 +19,7 @@ import { fixMarkdownStream } from '@/c-utils/markdownUtils';
 import LoadingBar from './LoadingBar';
 import StreamingLoadingDotsBar from './StreamingLoadingDotsBar';
 import styles from './AskBlock.module.scss';
-import { toast } from '@/hooks/useToast';
+import { toast, toastOnce } from '@/hooks/useToast';
 import { AppContext } from '../AppContext';
 import { BLOCK_TYPE } from '@/c-api/studyV2';
 import { Avatar, AvatarImage } from '@/components/ui/Avatar';
@@ -32,6 +32,12 @@ import {
 import { useAskStateStore } from './useAskStateStore';
 import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 import { resolveMarkdownFlowLocale } from '@/lib/markdown-flow-locale';
+import {
+  AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+  AI_SERVICE_ERROR_TOAST_DURATION_MS,
+  AI_SERVICE_ERROR_TOAST_KEY,
+  resolveAiServiceErrorToast,
+} from '@/lib/aiServiceError';
 export type { AskMessage } from './askState';
 
 export interface AskBlockProps {
@@ -312,9 +318,24 @@ export default function AskBlock({
 
             const backendMessage =
               typeof response.content === 'string' ? response.content : '';
-            toast({
-              title: backendMessage || t('module.chat.outputInProgress'),
+            const displayErrorToast = resolveAiServiceErrorToast({
+              message: backendMessage,
+              fallbackMessage: t('module.chat.outputInProgress'),
+              includeUnknown: true,
             });
+            if (displayErrorToast.isAiServiceUnavailable) {
+              toastOnce({
+                dedupeKey: AI_SERVICE_ERROR_TOAST_KEY,
+                dedupeWindowMs: AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+                title: displayErrorToast.message,
+                variant: 'destructive',
+                duration: AI_SERVICE_ERROR_TOAST_DURATION_MS,
+              });
+            } else {
+              toast({
+                title: displayErrorToast.message,
+              });
+            }
 
             sseRef.current?.close();
             return;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1625,7 +1625,7 @@ describe('useChatLogicHook stream cleanup', () => {
     );
   });
 
-  it('uses the deduped friendly toast for preview AI service transport errors', async () => {
+  it('uses the deduped friendly toast for preview credit errors with AI-service details', async () => {
     renderHook(
       () =>
         useChatLogicHook({
@@ -1643,7 +1643,7 @@ describe('useChatLogicHook stream cleanup', () => {
       activeRun?.onError({
         detail: {
           code: 7101,
-          message: 'Model deepseek is not supported',
+          message: '模型 deepseek 调用失败：provider unavailable',
         },
       });
     });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { toast } from '@/hooks/useToast';
+import { toast, toastOnce } from '@/hooks/useToast';
 import useChatLogicHook, { ChatContentItemType } from './useChatLogicHook';
 import { AppContext } from '../AppContext';
 import { SSE_INPUT_TYPE, SSE_OUTPUT_TYPE } from '@/c-api/studyV2';
@@ -13,6 +13,10 @@ jest.mock('react-i18next', () => ({
     i18n: { language: 'en-US', changeLanguage: jest.fn() },
     ready: true,
   }),
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
 }));
 
 jest.mock('@/i18n', () => ({
@@ -34,6 +38,7 @@ jest.mock('remark-flow', () => ({
 jest.mock('@/hooks/useToast', () => ({
   show: jest.fn(),
   toast: jest.fn(),
+  toastOnce: jest.fn(),
   fail: jest.fn(),
 }));
 
@@ -1582,6 +1587,42 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(activeRun?.source.close).toHaveBeenCalled();
 
     jest.useRealTimers();
+  });
+
+  it('shows a deduped friendly toast for technical AI service stream errors', async () => {
+    renderHook(
+      () =>
+        useChatLogicHook({
+          ...buildBaseParams(),
+          isListenMode: false,
+        }),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        type: SSE_OUTPUT_TYPE.ERROR,
+        content: '模型 deepseek 调用失败：provider unavailable',
+      });
+    });
+
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('deepseek'),
+      }),
+    );
+    expect(toastOnce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: 'ai-service-unavailable',
+        title: 'module.chat.contentGenerationUnavailable',
+        variant: 'destructive',
+        duration: 8000,
+      }),
+    );
   });
 
   it('uses the longer run stream idle timeout on mobile', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1625,6 +1625,44 @@ describe('useChatLogicHook stream cleanup', () => {
     );
   });
 
+  it('uses the deduped friendly toast for preview AI service transport errors', async () => {
+    renderHook(
+      () =>
+        useChatLogicHook({
+          ...buildBaseParams(),
+          previewMode: true,
+        }),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    act(() => {
+      activeRun?.onError({
+        detail: {
+          code: 7101,
+          message: 'Model deepseek is not supported',
+        },
+      });
+    });
+
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('deepseek'),
+      }),
+    );
+    expect(toastOnce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: 'ai-service-unavailable',
+        title: 'module.chat.contentGenerationUnavailable',
+        variant: 'destructive',
+        duration: 8000,
+      }),
+    );
+  });
+
   it('uses the longer run stream idle timeout on mobile', async () => {
     jest.useFakeTimers();
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -60,7 +60,7 @@ import {
 import { OnSendContentParams } from 'markdown-flow-ui/renderer';
 import LoadingBar from './LoadingBar';
 import { useTranslation } from 'react-i18next';
-import { show as showToast, toast } from '@/hooks/useToast';
+import { show as showToast, toast, toastOnce } from '@/hooks/useToast';
 import { AppContext } from '../AppContext';
 import { stripCustomButtonAfterContent } from './chatUiUtils';
 import {
@@ -71,6 +71,12 @@ import {
 } from '@/c-store/useLessonRunContentStore';
 import { parseLessonHistoryDate } from '@/lib/lesson-history-time';
 import { resolveLearnerErrorToast } from '@/lib/learnerError';
+import {
+  AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+  AI_SERVICE_ERROR_TOAST_DURATION_MS,
+  AI_SERVICE_ERROR_TOAST_KEY,
+  resolveAiServiceErrorToast,
+} from '@/lib/aiServiceError';
 import { debugWarn } from '@/c-utils/debugConsole';
 import {
   buildElementContentItem as buildChatElementContentItem,
@@ -1409,11 +1415,26 @@ function useChatLogicHook({
                 message: errorContent,
                 fallbackMessage: t('module.chat.requestFailed'),
               });
-
-              toast({
-                title: resolvedErrorToast.message,
-                variant: resolvedErrorToast.variant,
+              const displayErrorToast = resolveAiServiceErrorToast({
+                message: resolvedErrorToast.message,
+                fallbackMessage: t('module.chat.requestFailed'),
+                includeUnknown: true,
               });
+
+              if (displayErrorToast.isAiServiceUnavailable) {
+                toastOnce({
+                  dedupeKey: AI_SERVICE_ERROR_TOAST_KEY,
+                  dedupeWindowMs: AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+                  title: displayErrorToast.message,
+                  variant: resolvedErrorToast.variant,
+                  duration: AI_SERVICE_ERROR_TOAST_DURATION_MS,
+                });
+              } else {
+                toast({
+                  title: displayErrorToast.message,
+                  variant: resolvedErrorToast.variant,
+                });
+              }
               if (
                 effectivePreviewMode &&
                 businessCode === CREDIT_INSUFFICIENT_ERROR_CODE &&
@@ -1970,8 +1991,13 @@ function useChatLogicHook({
               message: businessError.message.trim(),
               fallbackMessage: t('module.chat.requestFailed'),
             });
+            const displayErrorToast = resolveAiServiceErrorToast({
+              message: resolvedErrorToast.message,
+              fallbackMessage: t('module.chat.requestFailed'),
+              includeUnknown: true,
+            });
             toast({
-              title: resolvedErrorToast.message,
+              title: displayErrorToast.message,
               variant: resolvedErrorToast.variant,
             });
             cleanupRunStreamState();

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -1996,10 +1996,20 @@ function useChatLogicHook({
               fallbackMessage: t('module.chat.requestFailed'),
               includeUnknown: true,
             });
-            toast({
-              title: displayErrorToast.message,
-              variant: resolvedErrorToast.variant,
-            });
+            if (displayErrorToast.isAiServiceUnavailable) {
+              toastOnce({
+                dedupeKey: AI_SERVICE_ERROR_TOAST_KEY,
+                dedupeWindowMs: AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+                title: displayErrorToast.message,
+                variant: resolvedErrorToast.variant,
+                duration: AI_SERVICE_ERROR_TOAST_DURATION_MS,
+              });
+            } else {
+              toast({
+                title: displayErrorToast.message,
+                variant: resolvedErrorToast.variant,
+              });
+            }
             cleanupRunStreamState();
             setHasRunFailed(true);
             appendRunBusinessError(

--- a/src/cook-web/src/hooks/useToast.test.tsx
+++ b/src/cook-web/src/hooks/useToast.test.tsx
@@ -1,0 +1,63 @@
+import { act } from '@testing-library/react';
+import { toast, toastOnce } from './useToast';
+
+describe('toastOnce', () => {
+  afterEach(() => {
+    act(() => {
+      toast({ title: 'cleanup', duration: 0 }).dismiss();
+    });
+  });
+
+  it('suppresses duplicates while the previous toast is still visible', () => {
+    const first = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'first',
+      duration: 0,
+    });
+    const second = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'second',
+      duration: 0,
+    });
+
+    expect(second.id).toBe(first.id);
+  });
+
+  it('re-shows a deduped toast after the previous toast is dismissed', () => {
+    const first = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'first',
+      duration: 0,
+    });
+
+    act(() => {
+      first.dismiss();
+    });
+
+    const second = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'second',
+      duration: 0,
+    });
+
+    expect(second.id).not.toBe(first.id);
+  });
+
+  it('re-shows a deduped toast after another toast replaces the previous one', () => {
+    const first = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'first',
+      duration: 0,
+    });
+
+    toast({ title: 'replacement', duration: 0 });
+
+    const second = toastOnce({
+      dedupeKey: 'ai-service-unavailable',
+      title: 'second',
+      duration: 0,
+    });
+
+    expect(second.id).not.toBe(first.id);
+  });
+});

--- a/src/cook-web/src/hooks/useToast.tsx
+++ b/src/cook-web/src/hooks/useToast.tsx
@@ -142,6 +142,12 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, 'id'>;
 type ToastDisplayOptions = Omit<Toast, 'description' | 'variant'>;
+type ToastOnceOptions = Toast & {
+  dedupeKey: string;
+  dedupeWindowMs?: number;
+};
+
+const toastDedupeState = new Map<string, { id: string; shownAt: number }>();
 
 function toast({ duration = 2000, ...props }: Toast) {
   const id = genId();
@@ -174,6 +180,30 @@ function toast({ duration = 2000, ...props }: Toast) {
     dismiss,
     update,
   };
+}
+
+function toastOnce({
+  dedupeKey,
+  dedupeWindowMs = 5000,
+  ...props
+}: ToastOnceOptions) {
+  const now = Date.now();
+  const previous = toastDedupeState.get(dedupeKey);
+  if (previous && now - previous.shownAt < dedupeWindowMs) {
+    return {
+      id: previous.id,
+      dismiss: () => dispatch({ type: 'DISMISS_TOAST', toastId: previous.id }),
+      update: (toast: ToasterToast) =>
+        dispatch({
+          type: 'UPDATE_TOAST',
+          toast: { ...toast, id: previous.id },
+        }),
+    };
+  }
+
+  const result = toast(props);
+  toastDedupeState.set(dedupeKey, { id: result.id, shownAt: now });
+  return result;
 }
 
 function useToast() {
@@ -247,12 +277,21 @@ function show(description: string, duration = 20000) {
 const toastApi = {
   useToast,
   toast,
+  toastOnce,
   showDefaultToast,
   showErrorToast,
   fail,
   show,
 };
 
-export { useToast, toast, showDefaultToast, showErrorToast, fail, show };
+export {
+  useToast,
+  toast,
+  toastOnce,
+  showDefaultToast,
+  showErrorToast,
+  fail,
+  show,
+};
 
 export default toastApi;

--- a/src/cook-web/src/hooks/useToast.tsx
+++ b/src/cook-web/src/hooks/useToast.tsx
@@ -149,6 +149,11 @@ type ToastOnceOptions = Toast & {
 
 const toastDedupeState = new Map<string, { id: string; shownAt: number }>();
 
+const isToastVisible = (toastId: string) =>
+  memoryState.toasts.some(
+    toast => toast.id === toastId && toast.open !== false,
+  );
+
 function toast({ duration = 2000, ...props }: Toast) {
   const id = genId();
 
@@ -189,7 +194,11 @@ function toastOnce({
 }: ToastOnceOptions) {
   const now = Date.now();
   const previous = toastDedupeState.get(dedupeKey);
-  if (previous && now - previous.shownAt < dedupeWindowMs) {
+  if (
+    previous &&
+    now - previous.shownAt < dedupeWindowMs &&
+    isToastVisible(previous.id)
+  ) {
     return {
       id: previous.id,
       dismiss: () => dispatch({ type: 'DISMISS_TOAST', toastId: previous.id }),

--- a/src/cook-web/src/lib/aiServiceError.test.ts
+++ b/src/cook-web/src/lib/aiServiceError.test.ts
@@ -1,0 +1,55 @@
+import {
+  isAiServiceUnavailableMessage,
+  resolveAiServiceErrorToast,
+} from './aiServiceError';
+
+jest.mock('i18next', () => ({
+  t: (key: string) => `i18n:${key}`,
+}));
+
+describe('aiServiceError', () => {
+  it('maps technical LLM failures to learner-friendly copy', () => {
+    expect(
+      resolveAiServiceErrorToast({
+        message: '模型 deepseek 调用失败：provider returned 500',
+        fallbackMessage: 'fallback',
+      }),
+    ).toEqual({
+      message: 'i18n:module.chat.contentGenerationUnavailable',
+      isAiServiceUnavailable: true,
+    });
+  });
+
+  it('can treat unknown run-stream failures as AI service unavailable', () => {
+    expect(
+      resolveAiServiceErrorToast({
+        message: '未知错误',
+        fallbackMessage: 'fallback',
+        includeUnknown: true,
+      }),
+    ).toEqual({
+      message: 'i18n:module.chat.contentGenerationUnavailable',
+      isAiServiceUnavailable: true,
+    });
+  });
+
+  it('does not hide unrelated learner-facing errors', () => {
+    expect(
+      resolveAiServiceErrorToast({
+        message: '积分不足，请先购买积分',
+        fallbackMessage: 'fallback',
+        includeUnknown: true,
+      }),
+    ).toEqual({
+      message: '积分不足，请先购买积分',
+      isAiServiceUnavailable: false,
+    });
+  });
+
+  it('detects common English LLM failure markers', () => {
+    expect(isAiServiceUnavailableMessage('LiteLLM APIConnectionError')).toBe(
+      true,
+    );
+    expect(isAiServiceUnavailableMessage('payment canceled')).toBe(false);
+  });
+});

--- a/src/cook-web/src/lib/aiServiceError.test.ts
+++ b/src/cook-web/src/lib/aiServiceError.test.ts
@@ -52,4 +52,25 @@ describe('aiServiceError', () => {
     );
     expect(isAiServiceUnavailableMessage('payment canceled')).toBe(false);
   });
+
+  it('does not classify generic unsupported business errors', () => {
+    expect(isAiServiceUnavailableMessage('This action is not supported')).toBe(
+      false,
+    );
+    expect(
+      resolveAiServiceErrorToast({
+        message: 'This action is not supported',
+        fallbackMessage: 'fallback',
+      }),
+    ).toEqual({
+      message: 'This action is not supported',
+      isAiServiceUnavailable: false,
+    });
+  });
+
+  it('keeps model unsupported errors classified when AI evidence is present', () => {
+    expect(
+      isAiServiceUnavailableMessage('Model deepseek is not supported'),
+    ).toBe(true);
+  });
 });

--- a/src/cook-web/src/lib/aiServiceError.ts
+++ b/src/cook-web/src/lib/aiServiceError.ts
@@ -4,19 +4,27 @@ export const AI_SERVICE_ERROR_TOAST_KEY = 'ai-service-unavailable';
 export const AI_SERVICE_ERROR_TOAST_DURATION_MS = 8000;
 export const AI_SERVICE_ERROR_TOAST_DEDUPE_MS = 10000;
 
-const AI_SERVICE_ERROR_MARKERS = [
+const AI_SERVICE_IDENTITY_MARKERS = [
   'llm',
   'litellm',
   'model',
   'api key',
   'base_url',
+  'provider',
+  '模型',
+] as const;
+
+const AI_SERVICE_ERROR_STATE_MARKERS = [
+  'missing',
+  'failed',
+  'failure',
+  'error',
+  'unavailable',
   'not configured',
   'not supported',
-  'provider',
   'badrequesterror',
   'apiconnectionerror',
   'internalservererror',
-  '模型',
   '调用失败',
   '没有配置',
   '不支持',
@@ -40,11 +48,21 @@ export const isAiServiceUnavailableMessage = (
     return false;
   }
 
-  const markers = includeUnknown
-    ? [...AI_SERVICE_ERROR_MARKERS, ...UNKNOWN_ERROR_MARKERS]
-    : AI_SERVICE_ERROR_MARKERS;
+  const hasUnknownMarker =
+    includeUnknown &&
+    UNKNOWN_ERROR_MARKERS.some(marker => normalizedMessage.includes(marker));
+  if (hasUnknownMarker) {
+    return true;
+  }
 
-  return markers.some(marker => normalizedMessage.includes(marker));
+  const hasAiIdentity = AI_SERVICE_IDENTITY_MARKERS.some(marker =>
+    normalizedMessage.includes(marker),
+  );
+  const hasErrorState = AI_SERVICE_ERROR_STATE_MARKERS.some(marker =>
+    normalizedMessage.includes(marker),
+  );
+
+  return hasAiIdentity && hasErrorState;
 };
 
 export const resolveAiServiceErrorToast = ({

--- a/src/cook-web/src/lib/aiServiceError.ts
+++ b/src/cook-web/src/lib/aiServiceError.ts
@@ -1,0 +1,71 @@
+import i18n from 'i18next';
+
+export const AI_SERVICE_ERROR_TOAST_KEY = 'ai-service-unavailable';
+export const AI_SERVICE_ERROR_TOAST_DURATION_MS = 8000;
+export const AI_SERVICE_ERROR_TOAST_DEDUPE_MS = 10000;
+
+const AI_SERVICE_ERROR_MARKERS = [
+  'llm',
+  'litellm',
+  'model',
+  'api key',
+  'base_url',
+  'not configured',
+  'not supported',
+  'provider',
+  'badrequesterror',
+  'apiconnectionerror',
+  'internalservererror',
+  '模型',
+  '调用失败',
+  '没有配置',
+  '不支持',
+] as const;
+
+const UNKNOWN_ERROR_MARKERS = [
+  '未知错误',
+  'unknown error',
+  'erreur inconnue',
+] as const;
+
+const normalizeErrorMessage = (message?: string | null) =>
+  String(message || '').trim();
+
+export const isAiServiceUnavailableMessage = (
+  message?: string | null,
+  { includeUnknown = false }: { includeUnknown?: boolean } = {},
+) => {
+  const normalizedMessage = normalizeErrorMessage(message).toLowerCase();
+  if (!normalizedMessage) {
+    return false;
+  }
+
+  const markers = includeUnknown
+    ? [...AI_SERVICE_ERROR_MARKERS, ...UNKNOWN_ERROR_MARKERS]
+    : AI_SERVICE_ERROR_MARKERS;
+
+  return markers.some(marker => normalizedMessage.includes(marker));
+};
+
+export const resolveAiServiceErrorToast = ({
+  message,
+  fallbackMessage,
+  includeUnknown = false,
+}: {
+  message?: string | null;
+  fallbackMessage: string;
+  includeUnknown?: boolean;
+}) => {
+  const normalizedMessage = normalizeErrorMessage(message);
+  if (isAiServiceUnavailableMessage(normalizedMessage, { includeUnknown })) {
+    return {
+      message: i18n.t('module.chat.contentGenerationUnavailable'),
+      isAiServiceUnavailable: true,
+    };
+  }
+
+  return {
+    message: normalizedMessage || fallbackMessage,
+    isAiServiceUnavailable: false,
+  };
+};

--- a/src/i18n/en-US/modules/chat.json
+++ b/src/i18n/en-US/modules/chat.json
@@ -7,6 +7,7 @@
   "classroomEnterFullscreen": "Fullscreen",
   "classroomTitlePlaceholderTips": "Classroom mode only shows slides; press F to toggle fullscreen, and use arrow keys or Space to change slides.",
   "closeCatalog": "Close catalog",
+  "contentGenerationUnavailable": "Content generation is temporarily unavailable. Please try again later.",
   "generating": "Generating diagram...",
   "learningModeClassroom": "Classroom",
   "learningModeClassroomShort": "Classroom",

--- a/src/i18n/fr-FR/modules/chat.json
+++ b/src/i18n/fr-FR/modules/chat.json
@@ -7,6 +7,7 @@
   "classroomEnterFullscreen": "Plein écran",
   "classroomTitlePlaceholderTips": "Le mode classe affiche uniquement les diapositives ; appuyez sur F pour passer en plein écran, puis utilisez les touches fléchées ou Espace pour changer de diapositive.",
   "closeCatalog": "Fermer le catalogue",
+  "contentGenerationUnavailable": "La génération de contenu est temporairement indisponible. Veuillez réessayer plus tard.",
   "generating": "Génération du diagramme…",
   "learningModeClassroom": "Classe",
   "learningModeClassroomShort": "Classe",

--- a/src/i18n/zh-CN/modules/chat.json
+++ b/src/i18n/zh-CN/modules/chat.json
@@ -7,6 +7,7 @@
   "classroomEnterFullscreen": "全屏",
   "classroomTitlePlaceholderTips": "课堂模式只展示幻灯片；按 F 切换全屏，按方向键或空格翻页。",
   "closeCatalog": "关闭目录",
+  "contentGenerationUnavailable": "内容生成暂时不可用，请稍后再试",
   "generating": "插图生成中...",
   "learningModeClassroom": "课堂模式",
   "learningModeClassroomShort": "课堂",


### PR DESCRIPTION
## Summary
- Map technical learner LLM/model/provider failures to localized chat copy instead of exposing backend details.
- Deduplicate repeated AI content-generation error toasts and keep the message visible longer.
- Add focused coverage for learner run and follow-up SSE error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat error handling by replacing technical AI-service errors with clear, localized availability messages.
  * Prevented repeated error notifications from appearing while the same issue is active.
  * Preserved learner-facing messages for unrelated errors and preview credit issues.

* **Localization**
  * Added temporary content-generation failure messages in English, French, and Simplified Chinese.

* **Tests**
  * Added coverage for error classification, localized notifications, deduplication, dismissal, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->