### PR TITLE
fix: keep the Langfuse OTel exporter out of the gunicorn preload master

### DIFF
--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -1,3 +1,4 @@
+import os
 import ast
 import json
 import re
@@ -128,8 +129,23 @@ def build_langfuse_observation_link(
     return observation_link
 
 
+PRELOAD_MASTER_ENV = "AI_SHIFU_PRELOAD_MASTER"
+
+
 def init_langfuse(app: Flask):
     global langfuse_client
+    if os.environ.get(PRELOAD_MASTER_ENV):
+        # Running inside the gunicorn preload master. Creating a real client
+        # here starts the Langfuse/OTel BatchProcessor worker thread in the
+        # master and registers an os.register_at_fork hook; after fork every
+        # worker restarts that orphaned processor's thread, whose gevent
+        # threading bookkeeping then crashes the hub (KeyError on the stopped
+        # Thread in AbstractLinkable._notify_links) and can interrupt
+        # unrelated in-flight DB exchanges. post_fork clears the flag and
+        # calls init_langfuse again to build the real client per worker.
+        app.logger.info("Deferring Langfuse init out of the preload master")
+        langfuse_client = MockClient()
+        return
     app.logger.info("Initializing Langfuse client")
     if (
         app.config.get("LANGFUSE_PUBLIC_KEY")

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -9,6 +9,7 @@ from redis import Redis
 from sqlalchemy import event
 from sqlalchemy import pool as sa_pool
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm.exc import FlushError
 from sqlalchemy.exc import (
     DisconnectionError,
     InterfaceError,
@@ -129,12 +130,15 @@ def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_reco
         return
     if _socket_has_unread_data(dbapi_connection, timeout=_CHECKIN_PROBE_GRACE_SECONDS):
         # stack_info identifies the code path that returned the poisoned
-        # connection - i.e. the request that interrupted a protocol exchange.
+        # connection. That path is not necessarily the origin: a poisoned
+        # connection that slipped past earlier gates can be checked out and
+        # returned by an innocent request, which is then merely the carrier.
         _pool_diagnostics_logger().error(
             "DB connection returned to pool with unread protocol data; "
             "invalidating it (pid=%s server_thread_id=%s). The stack below "
-            "is the checkin path of the request that desynced this "
-            "connection.",
+            "is the checkin path that RETURNED this connection - either the "
+            "request that desynced it or a carrier that checked out an "
+            "already-poisoned connection.",
             os.getpid(),
             _server_thread_id(dbapi_connection),
             stack_info=True,
@@ -306,6 +310,10 @@ def is_protocol_interrupt_error(exc: BaseException) -> bool:
     off-by-one.
     """
     if isinstance(exc, (ResourceClosedError, DisconnectionError)):
+        return True
+    if isinstance(exc, FlushError) and "NULL identity key" in str(exc):
+        # An INSERT that flushed "successfully" but yielded no autoincrement
+        # id read some other statement's response: the stream is off by one.
         return True
     # gevent interruptions frequently surface as driver interface or raw
     # socket errors rather than clean MySQL errnos; all of them mean the

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -6,9 +6,20 @@
 # so gevent's monkey-patching must happen here, in the master, before any of
 # the app's imports touch socket/ssl. The gevent worker class re-patches in
 # the child, which is a no-op.
+import os
+
 from gevent import monkey
 
 monkey.patch_all()
+
+# Mark the preload master so import-time initializers skip anything that
+# would start background threads here (e.g. the Langfuse/OTel batch
+# exporter). A thread started in the master registers an at-fork restart
+# hook; after fork each worker revives the orphaned processor's thread,
+# whose gevent threading bookkeeping crashes the hub (KeyError in
+# AbstractLinkable._notify_links) and can interrupt unrelated in-flight DB
+# exchanges. post_fork clears the flag and re-runs the deferred inits.
+os.environ["AI_SHIFU_PRELOAD_MASTER"] = "1"
 
 # Import the app once in the master and share its read-only memory (imports,
 # model tables, litellm's cost map, ...) with every worker via copy-on-write.
@@ -25,6 +36,8 @@ def post_fork(server, worker):
     pool without closing the parent's file descriptors. redis-py connection
     pools are fork-safe already (pid check on checkout) and need no handling.
     """
+    os.environ.pop("AI_SHIFU_PRELOAD_MASTER", None)
+
     try:
         from app import app as flask_app
         from flaskr.dao import db

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import (
     OperationalError,
     ResourceClosedError,
 )
+from sqlalchemy.orm.exc import FlushError
 
 from flaskr.dao import (
     cleanup_session_after,
@@ -47,6 +48,10 @@ def _operational(errno: int) -> OperationalError:
         (DisconnectionError("desynced"), True),
         (_operational(2013), True),
         (_operational(2014), True),
+        # An INSERT that "succeeds" without an autoincrement id read some
+        # other statement's response: off-by-one evidence, must invalidate.
+        (FlushError("Instance <X> has a NULL identity key."), True),
+        (FlushError("New instance with identity key already present"), False),
         (Exception(2014, "raw pymysql Command Out of Sync"), True),
         (None, False),
         (ValueError("business"), False),

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -1,0 +1,48 @@
+"""Langfuse init must not create a real client in the gunicorn preload master.
+
+A real client starts the Langfuse/OTel BatchProcessor worker thread in the
+master and registers an at-fork restart hook; after fork every worker
+revives the orphaned processor's thread, whose gevent threading bookkeeping
+crashes the hub (KeyError in AbstractLinkable._notify_links) and can
+interrupt unrelated in-flight DB exchanges.
+"""
+
+import flaskr.api.langfuse as langfuse_module
+from flaskr.api.langfuse import MockClient, init_langfuse
+
+
+class _RecordingLangfuse:
+    instances = []
+
+    def __init__(self, **kwargs):
+        _RecordingLangfuse.instances.append(kwargs)
+
+
+def _configure(app):
+    app.config["LANGFUSE_PUBLIC_KEY"] = "pk"
+    app.config["LANGFUSE_SECRET_KEY"] = "sk"
+    app.config["LANGFUSE_HOST"] = "https://langfuse.example"
+
+
+def test_preload_master_defers_real_client(app, monkeypatch):
+    _configure(app)
+    monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
+    monkeypatch.setattr(_RecordingLangfuse, "instances", [])
+    monkeypatch.setenv(langfuse_module.PRELOAD_MASTER_ENV, "1")
+
+    init_langfuse(app)
+
+    assert _RecordingLangfuse.instances == []
+    assert isinstance(langfuse_module.langfuse_client, MockClient)
+
+
+def test_worker_builds_real_client_after_flag_cleared(app, monkeypatch):
+    _configure(app)
+    monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
+    monkeypatch.setattr(_RecordingLangfuse, "instances", [])
+    monkeypatch.delenv(langfuse_module.PRELOAD_MASTER_ENV, raising=False)
+
+    init_langfuse(app)
+
+    assert len(_RecordingLangfuse.instances) == 1
+    assert _RecordingLangfuse.instances[0]["host"] == "https://langfuse.example"


### PR DESCRIPTION
## Problem

The hub error observer from #2274 did its job on its first day in production: every gevent hub crash is now attributable, and it **named the culprit**:

```
context=Greenlet: <bound method Thread._bootstrap of <Thread(OtelBatchSpanRecordProcessor, stopped daemon ...)>>
exc=KeyError: <Thread(OtelBatchSpanRecordProcessor, stopped daemon ...)>
```

64 hub errors since rollout, all pointing at **OTel `BatchProcessor` worker threads** (Langfuse v3 is OTel-based; the standalone `OBSERVABILITY_TRACES_ENABLED` tracing is off in production, so these are all Langfuse's).

Mechanism (`opentelemetry/sdk/_shared_internal/__init__.py`):

1. With `preload_app`, `create_app` → `init_langfuse` runs in the **gunicorn master**, creating the Langfuse client → OTel `BatchProcessor.__init__` **starts its worker thread in the master** and registers an `os.register_at_fork(after_in_child=...)` hook.
2. Every forked worker runs that hook and **revives the orphaned master processor's thread** - in addition to the fresh per-worker client that the `post_fork` re-init from #2244 builds. #2244 cleared the singletons but could not undo the at-fork restart of objects that should never have existed in the master.
3. These zombie threads' gevent threading bookkeeping is inconsistent (`KeyError` on the stopped `Thread`), and the crash lands inside the hub (`AbstractLinkable._notify_links`), where it can corrupt an unrelated greenlet's wakeup and silently interrupt an in-flight DB exchange - the residual off-by-one protocol desync source (today: 2 checkin-probe catches, 1 pre-execute interception, 4 NULL-identity FlushErrors).

## Changes

1. **Defer Langfuse init out of the preload master** (`flaskr/api/langfuse.py`, `gunicorn.conf.py`): the config file sets `AI_SHIFU_PRELOAD_MASTER=1` before the app is preloaded; `init_langfuse` sees the flag and installs a `MockClient` placeholder without touching the Langfuse/OTel SDK. `post_fork` clears the flag before its existing per-worker `init_langfuse`, so every worker builds its real client post-fork - nothing OTel exists in the master, so there is nothing to orphan or revive.
2. **Classify NULL-identity-key `FlushError` as an abnormal termination** (`flaskr/dao/__init__.py`): an INSERT that flushes "successfully" without an autoincrement id read some other statement's response; the session now invalidates (discards) the connection instead of rolling back on the desynced stream - today's FlushError victims returned their poisoned connection to the pool via rollback.
3. **Checkin log wording**: the captured stack is the path that *returned* the connection, which may be an innocent carrier rather than the origin (observed today: the TTS usage-record commit checkin was flagged while the desync predated its checkout).

## Verification

- New: `tests/test_langfuse_preload_deferral.py` (flag → MockClient, no SDK construction; flag cleared → real client built), FlushError rows in the `test_dao_session_termination.py` classification matrix (NULL-identity → abnormal, other FlushErrors unchanged).
- Full backend suite: 2590 passed, 15 skipped.

## Rollout observation

`gevent hub error` lines should drop to zero (no more `OtelBatchSpanRecordProcessor` contexts), and with them the residual desync family (checkin catches, pre-execute interceptions, NULL-identity FlushErrors). Langfuse tracing keeps working - clients are simply built per worker after fork, which is what #2244 already intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup reliability when running with preloaded worker processes by safely deferring telemetry client initialization until workers are ready.
  - Enhanced handling of database connection interruptions and invalid session states, reducing the risk of cascading request failures.
  - Added clearer diagnostics to help identify requests associated with problematic database connections.

- **Tests**
  - Added coverage for deferred telemetry initialization and abnormal database termination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->