### PR TITLE
fix: preserve unavoidable reasoning in Langfuse

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -720,15 +720,16 @@ def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
         "allowed_openai_params": ["reasoning_effort"],
     }
     if model_id.startswith("gemini-3"):
-        # Gemini 3 cannot fully disable thinking. LiteLLM maps none to the
-        # model's lowest supported level and suppresses thought output.
-        params["reasoning_effort"] = "none"
+        # Gemini 3 cannot fully disable thinking. LiteLLM maps minimal to the
+        # model's lowest supported level and includeThoughts=true, so any
+        # unavoidable thought summary remains available to Langfuse.
+        params["reasoning_effort"] = "minimal"
     elif model_id.startswith("gemini-2.5-pro"):
         # Gemini 2.5 Pro cannot disable thinking; LiteLLM maps minimal to its
-        # minimum supported 128-token thinking budget.
+        # minimum supported 128-token budget with includeThoughts=true.
         params["reasoning_effort"] = "minimal"
     elif model_id.startswith("gemini"):
-        # Older Gemini models can use the cost-optimized no-thinking mapping.
+        # Gemini models that support a zero thinking budget remain disabled.
         params["reasoning_effort"] = "none"
     return params
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -719,15 +719,16 @@ def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
         "allowed_openai_params": ["reasoning_effort"],
     }
     if model_id.startswith("gemini-3"):
-        # Gemini 3 cannot fully disable thinking. LiteLLM maps none to the
-        # model's lowest supported level and suppresses thought output.
-        params["reasoning_effort"] = "none"
+        # Gemini 3 cannot fully disable thinking. LiteLLM maps minimal to the
+        # model's lowest supported level and includeThoughts=true, so any
+        # unavoidable thought summary remains available to Langfuse.
+        params["reasoning_effort"] = "minimal"
     elif model_id.startswith("gemini-2.5-pro"):
         # Gemini 2.5 Pro cannot disable thinking; LiteLLM maps minimal to its
-        # minimum supported 128-token thinking budget.
+        # minimum supported 128-token budget with includeThoughts=true.
         params["reasoning_effort"] = "minimal"
     elif model_id.startswith("gemini"):
-        # Older Gemini models can use the cost-optimized no-thinking mapping.
+        # Gemini models that support a zero thinking budget remain disabled.
         params["reasoning_effort"] = "none"
     return params
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -892,7 +892,7 @@ def test_gemini_thinking_policy_removes_nested_caller_override(
 
     assert kwargs == {
         "temperature": 0.4,
-        "reasoning_effort": "none",
+        "reasoning_effort": "minimal",
         "allowed_openai_params": ["reasoning_effort"],
         "extra_body": {
             "generationConfig": {top_k_key: 8},
@@ -1150,7 +1150,7 @@ def test_litellm_195_native_adapter_contracts():
             "gemini_3": litellm.get_optional_params(
                 model="gemini-3.6-flash",
                 custom_llm_provider="gemini",
-                reasoning_effort="none",
+                reasoning_effort="minimal",
                 allowed_openai_params=["reasoning_effort"],
             ),
             "gemini_25_pro": litellm.get_optional_params(
@@ -1223,7 +1223,7 @@ def test_litellm_195_native_adapter_contracts():
 
     assert contracts["gemini_3"]["thinkingConfig"] == {
         "thinkingLevel": "minimal",
-        "includeThoughts": False,
+        "includeThoughts": True,
     }
     assert contracts["gemini_25_pro"]["thinkingConfig"] == {
         "thinkingBudget": 128,
@@ -1293,13 +1293,13 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     assert captured_kwargs["kwargs"]["extra_body"] == {"custom_field": "keep"}
 
 
-def test_gemini_3_params_use_none_with_explicit_allowlist():
+def test_gemini_3_params_use_minimal_with_explicit_allowlist():
     params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
 
     assert params == {
         "temperature": 0.3,
         "allowed_openai_params": ["reasoning_effort"],
-        "reasoning_effort": "none",
+        "reasoning_effort": "minimal",
     }
 
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -880,7 +880,7 @@ def test_gemini_thinking_policy_removes_nested_caller_override(
 
     assert kwargs == {
         "temperature": 0.4,
-        "reasoning_effort": "none",
+        "reasoning_effort": "minimal",
         "allowed_openai_params": ["reasoning_effort"],
         "extra_body": {
             "generationConfig": {top_k_key: 8},
@@ -1138,7 +1138,7 @@ def test_litellm_195_native_adapter_contracts():
             "gemini_3": litellm.get_optional_params(
                 model="gemini-3.6-flash",
                 custom_llm_provider="gemini",
-                reasoning_effort="none",
+                reasoning_effort="minimal",
                 allowed_openai_params=["reasoning_effort"],
             ),
             "gemini_25_pro": litellm.get_optional_params(
@@ -1211,7 +1211,7 @@ def test_litellm_195_native_adapter_contracts():
 
     assert contracts["gemini_3"]["thinkingConfig"] == {
         "thinkingLevel": "minimal",
-        "includeThoughts": False,
+        "includeThoughts": True,
     }
     assert contracts["gemini_25_pro"]["thinkingConfig"] == {
         "thinkingBudget": 128,
@@ -1281,13 +1281,13 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     assert captured_kwargs["kwargs"]["extra_body"] == {"custom_field": "keep"}
 
 
-def test_gemini_3_params_use_none_with_explicit_allowlist():
+def test_gemini_3_params_use_minimal_with_explicit_allowlist():
     params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
 
     assert params == {
         "temperature": 0.3,
         "allowed_openai_params": ["reasoning_effort"],
-        "reasoning_effort": "none",
+        "reasoning_effort": "minimal",
     }
 
 


### PR DESCRIPTION
## What changed

- Keep thinking disabled for providers that support disabling it.
- Keep Gemini 3 at its lowest supported reasoning level while requesting returned thought summaries.
- Preserve unavoidable reasoning in the existing Langfuse output path without streaming it to learners.
- Update the pinned LiteLLM 1.95 adapter contract coverage for Gemini 3.

## Why

Gemini 3 cannot fully disable thinking. The previous `none` mapping selected the lowest thinking level but also set `includeThoughts: false`, which hid unavoidable reasoning from Langfuse. Using `minimal` keeps the same lowest level while returning the thought summary for observability.

## Impact

Reasoning remains disabled or minimized across providers. When a provider still produces reasoning, operators can inspect it in Langfuse; learner-visible content remains unchanged.

## Validation

- `PYTHONPATH=/private/tmp/litellm195/litellm-1.95.0:/private/tmp/litellm195:. /Users/sunner/src/ai-shifu/.venv/bin/python -m pytest -q tests/test_llm.py` — 61 passed
- `ruff format --check flaskr/api/llm/__init__.py tests/test_llm.py`
- `ruff check --select F flaskr/api/llm/__init__.py tests/test_llm.py`
- `git diff --check`

The repository pre-commit hook was also run. Its architecture, translation, harness, and related checks passed, but the aggregate Ruff step failed on pre-existing lint debt in these large files and attempted broad unrelated auto-fixes; those auto-fixes were reverted before this scoped commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gemini 3 response handling by using minimal reasoning and preserving available thought summaries for improved visibility in supported monitoring views.
  - Preserved the established reasoning behavior for Gemini 2.5 Pro and other Gemini models, ensuring consistent model-specific processing.

- **Tests**
  - Updated Gemini 3 validation to confirm the revised reasoning configuration and inclusion of thought summaries in contract output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Gemini 3 provider param mapping and test expectations; no auth, billing, or learner-facing response changes.
> 
> **Overview**
> **Gemini 3** requests now use LiteLLM `reasoning_effort: "minimal"` instead of `"none"`. Under LiteLLM 1.95 that keeps the lowest thinking level but sets `includeThoughts: true`, so unavoidable model thoughts can flow into the existing Langfuse `reasoning_content` path. Learner-visible streamed content is unchanged.
> 
> Comments for **Gemini 2.5 Pro** and other Gemini variants are clarified; behavior for those models is unchanged. **Tests** and the pinned LiteLLM 1.95 contract assertions are updated for Gemini 3 (`thinkingLevel: minimal`, `includeThoughts: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fab8d1f9f5da489176dc7ee02f8ea2014f06308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->