### PR TITLE
fix: improve admin AI error toasts

### DIFF
--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -276,6 +276,49 @@ describe('usePreviewChat helpers and business error rendering', () => {
     });
   });
 
+  test('shows friendly content when preview SSE error exposes Langfuse details', async () => {
+    const source = buildMockSseSource();
+    (SSE as jest.Mock).mockImplementationOnce(() => source);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+      });
+    });
+
+    act(() => {
+      source.listeners.message?.({
+        data: JSON.stringify({
+          type: 'error',
+          content: "'Langfuse' object has no attribute 'start_span'",
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        'module.chat.contentGenerationUnavailable',
+      );
+    });
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('Langfuse'),
+      }),
+    );
+    expect(toastOnce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: 'ai-service-unavailable',
+        title: 'module.chat.contentGenerationUnavailable',
+        variant: 'destructive',
+        duration: 8000,
+      }),
+    );
+  });
+
   test('drops the loading placeholder without appending an empty error row', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -252,9 +252,7 @@ describe('usePreviewChat helpers and business error rendering', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.error).toBe(
-        'module.chat.contentGenerationUnavailable',
-      );
+      expect(result.current.error).toBe('module.preview.aiDebugUnavailable');
     });
     expect(toast).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -264,13 +262,13 @@ describe('usePreviewChat helpers and business error rendering', () => {
     expect(toastOnce).toHaveBeenCalledWith(
       expect.objectContaining({
         dedupeKey: 'ai-service-unavailable',
-        title: 'module.chat.contentGenerationUnavailable',
+        title: 'module.preview.aiDebugUnavailable',
         variant: 'destructive',
         duration: 8000,
       }),
     );
     expect(result.current.items.at(-1)).toMatchObject({
-      content: 'module.chat.contentGenerationUnavailable',
+      content: 'module.preview.aiDebugUnavailable',
       type: ChatContentItemType.ERROR,
       business_code: 500,
     });
@@ -300,9 +298,7 @@ describe('usePreviewChat helpers and business error rendering', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.error).toBe(
-        'module.chat.contentGenerationUnavailable',
-      );
+      expect(result.current.error).toBe('module.preview.aiDebugUnavailable');
     });
     expect(toast).not.toHaveBeenCalledWith(
       expect.objectContaining({
@@ -312,7 +308,7 @@ describe('usePreviewChat helpers and business error rendering', () => {
     expect(toastOnce).toHaveBeenCalledWith(
       expect.objectContaining({
         dedupeKey: 'ai-service-unavailable',
-        title: 'module.chat.contentGenerationUnavailable',
+        title: 'module.preview.aiDebugUnavailable',
         variant: 'destructive',
         duration: 8000,
       }),

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -400,6 +400,70 @@ describe('usePreviewChat helpers and business error rendering', () => {
     });
   });
 
+  test('keeps successful final content when preview closes before done', async () => {
+    const source = buildMockSseSource();
+    (SSE as jest.Mock).mockReturnValueOnce(source);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+        max_block_count: 1,
+      });
+    });
+
+    act(() => {
+      source.listeners.message?.({
+        data: JSON.stringify({
+          type: 'content',
+          generated_block_bid: 'final-block',
+          content: 'Final preview content.',
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            generated_block_bid: 'final-block',
+            content: 'Final preview content.',
+            type: ChatContentItemType.CONTENT,
+          }),
+        ]),
+      );
+    });
+
+    act(() => {
+      source.listeners.error?.({});
+    });
+
+    await waitFor(() => {
+      expect(result.current.items).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: ChatContentItemType.ERROR,
+          }),
+        ]),
+      );
+    });
+    expect(result.current.error).toBeNull();
+    expect(toast).not.toHaveBeenCalled();
+    expect(toastOnce).not.toHaveBeenCalled();
+    expect(result.current.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'final-block',
+          content: 'Final preview content.',
+          is_final: true,
+        }),
+      ]),
+    );
+  });
+
   test('drops the loading placeholder without appending an empty error row', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -272,6 +272,24 @@ describe('usePreviewChat helpers and business error rendering', () => {
       type: ChatContentItemType.ERROR,
       business_code: 500,
     });
+
+    act(() => {
+      source.listeners.message?.({
+        data: JSON.stringify({
+          type: 'content',
+          generated_block_bid: 'late-block',
+          content: 'late content should be ignored',
+        }),
+      });
+    });
+
+    expect(result.current.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'late-block',
+        }),
+      ]),
+    );
   });
 
   test('shows friendly content when preview SSE error exposes Langfuse details', async () => {
@@ -312,6 +330,24 @@ describe('usePreviewChat helpers and business error rendering', () => {
         variant: 'destructive',
         duration: 8000,
       }),
+    );
+
+    act(() => {
+      source.listeners.message?.({
+        data: JSON.stringify({
+          type: 'content',
+          generated_block_bid: 'late-langfuse-block',
+          content: 'late content should be ignored',
+        }),
+      });
+    });
+
+    expect(result.current.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'late-langfuse-block',
+        }),
+      ]),
     );
   });
 

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -217,7 +217,7 @@ describe('usePreviewChat helpers and business error rendering', () => {
 
   test('shows one friendly toast when preview business fallback reports an AI service error', async () => {
     const source = buildMockSseSource();
-    (SSE as jest.Mock).mockImplementationOnce(() => source);
+    (SSE as jest.Mock).mockReturnValueOnce(source);
     let handledError:
       | ((error: { message: string; code: number }) => void)
       | undefined;
@@ -294,7 +294,7 @@ describe('usePreviewChat helpers and business error rendering', () => {
 
   test('shows friendly content when preview SSE error exposes Langfuse details', async () => {
     const source = buildMockSseSource();
-    (SSE as jest.Mock).mockImplementationOnce(() => source);
+    (SSE as jest.Mock).mockReturnValueOnce(source);
 
     const { result } = renderHook(() => usePreviewChat());
 
@@ -331,6 +331,17 @@ describe('usePreviewChat helpers and business error rendering', () => {
         duration: 8000,
       }),
     );
+    expect(result.current.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'loading',
+        }),
+      ]),
+    );
+    expect(result.current.items.at(-1)).toMatchObject({
+      content: 'module.preview.aiDebugUnavailable',
+      type: ChatContentItemType.ERROR,
+    });
 
     act(() => {
       source.listeners.message?.({
@@ -349,6 +360,44 @@ describe('usePreviewChat helpers and business error rendering', () => {
         }),
       ]),
     );
+  });
+
+  test('replaces the loading placeholder when preview closes before content', async () => {
+    const source = buildMockSseSource();
+    (SSE as jest.Mock).mockReturnValueOnce(source);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+      });
+    });
+
+    expect(result.current.items.at(-1)).toMatchObject({
+      generated_block_bid: 'loading',
+    });
+
+    act(() => {
+      source.listeners.error?.({});
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('module.preview.streamError');
+    });
+    expect(result.current.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'loading',
+        }),
+      ]),
+    );
+    expect(result.current.items.at(-1)).toMatchObject({
+      content: 'module.preview.streamError',
+      type: ChatContentItemType.ERROR,
+    });
   });
 
   test('drops the loading placeholder without appending an empty error row', () => {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -1,8 +1,13 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { SSE } from 'sse.js';
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
+import { toast, toastOnce } from '@/hooks/useToast';
+import { attachSseBusinessResponseFallback } from '@/lib/request';
 import {
   buildInteractionContinuationPreviewParams,
   buildPreviewBusinessErrorItem,
   replacePreviewLoadingWithBusinessError,
+  usePreviewChat,
 } from './usePreviewChat';
 
 jest.mock('sse.js', () => ({
@@ -46,6 +51,7 @@ jest.mock('@/store', () => {
 
 jest.mock('@/hooks/useToast', () => ({
   toast: jest.fn(),
+  toastOnce: jest.fn(),
 }));
 
 jest.mock('@/lib/request', () => ({
@@ -68,6 +74,27 @@ jest.mock('@/c-utils/envUtils', () => ({
   getStringEnv: jest.fn(() => ''),
 }));
 
+type MockSseSource = {
+  addEventListener: jest.Mock;
+  stream: jest.Mock;
+  close: jest.Mock;
+  listeners: Record<string, (event: { data?: string }) => void>;
+};
+
+const buildMockSseSource = (): MockSseSource => {
+  const listeners: Record<string, (event: { data?: string }) => void> = {};
+  return {
+    listeners,
+    addEventListener: jest.fn(
+      (type: string, listener: (event: { data?: string }) => void) => {
+        listeners[type] = listener;
+      },
+    ),
+    stream: jest.fn(),
+    close: jest.fn(),
+  };
+};
+
 jest.mock('@/c-utils/markdownUtils', () => ({
   mergeStreamingMarkdownText: jest.fn((_prev: string, next: string) => next),
   maskIncompleteMermaidBlock: jest.fn((content: string) => content),
@@ -80,6 +107,9 @@ jest.mock('react-i18next', () => ({
 }));
 
 describe('usePreviewChat helpers and business error rendering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   test('builds interaction continuation preview params with latest mdflow', () => {
     expect(
       buildInteractionContinuationPreviewParams({
@@ -182,6 +212,67 @@ describe('usePreviewChat helpers and business error rendering', () => {
       content: '积分不足，请稍后重试',
       type: ChatContentItemType.ERROR,
       business_code: 7101,
+    });
+  });
+
+  test('shows one friendly toast when preview business fallback reports an AI service error', async () => {
+    const source = buildMockSseSource();
+    (SSE as jest.Mock).mockImplementationOnce(() => source);
+    let handledError:
+      | ((error: { message: string; code: number }) => void)
+      | undefined;
+    (attachSseBusinessResponseFallback as jest.Mock).mockImplementationOnce(
+      (_source, options) => {
+        handledError = options.onHandled;
+      },
+    );
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+      });
+    });
+
+    expect(attachSseBusinessResponseFallback).toHaveBeenCalledWith(
+      source,
+      expect.objectContaining({
+        meta: expect.objectContaining({ skipErrorToast: true }),
+      }),
+    );
+
+    act(() => {
+      handledError?.({
+        code: 500,
+        message: '模型 deepseek 调用失败：provider unavailable',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        'module.chat.contentGenerationUnavailable',
+      );
+    });
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('deepseek'),
+      }),
+    );
+    expect(toastOnce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: 'ai-service-unavailable',
+        title: 'module.chat.contentGenerationUnavailable',
+        variant: 'destructive',
+        duration: 8000,
+      }),
+    );
+    expect(result.current.items.at(-1)).toMatchObject({
+      content: 'module.chat.contentGenerationUnavailable',
+      type: ChatContentItemType.ERROR,
+      business_code: 500,
     });
   });
 

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.test.ts
@@ -10,13 +10,15 @@ import {
   usePreviewChat,
 } from './usePreviewChat';
 
+const mockParseToRemarkFormat = jest.fn();
+
 jest.mock('sse.js', () => ({
   SSE: jest.fn(),
 }));
 
 jest.mock('remark-flow', () => ({
   createInteractionParser: () => ({
-    parseToRemarkFormat: jest.fn(),
+    parseToRemarkFormat: mockParseToRemarkFormat,
   }),
 }));
 
@@ -109,6 +111,10 @@ jest.mock('react-i18next', () => ({
 describe('usePreviewChat helpers and business error rendering', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
   test('builds interaction continuation preview params with latest mdflow', () => {
     expect(
@@ -462,6 +468,159 @@ describe('usePreviewChat helpers and business error rendering', () => {
         }),
       ]),
     );
+  });
+
+  test('ignores stale interaction auto-submit after preview reset', async () => {
+    jest.useFakeTimers();
+    mockParseToRemarkFormat.mockReturnValue({
+      variableName: 'answer',
+      placeholder: 'Type your answer',
+    });
+    const source = buildMockSseSource();
+    (SSE as jest.Mock).mockReturnValueOnce(source);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+        variables: { answer: 'saved answer' },
+      });
+    });
+
+    act(() => {
+      source.listeners.message?.({
+        data: JSON.stringify({
+          type: 'interaction',
+          generated_block_bid: 'old-interaction',
+          content: '?[answer]',
+        }),
+      });
+    });
+
+    act(() => {
+      result.current.resetPreview();
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(SSE).toHaveBeenCalledTimes(1);
+    expect(result.current.items).toEqual([]);
+  });
+
+  test('ignores stale interaction auto-submit after a new preview starts', async () => {
+    jest.useFakeTimers();
+    mockParseToRemarkFormat.mockReturnValue({
+      variableName: 'answer',
+      placeholder: 'Type your answer',
+    });
+    const oldSource = buildMockSseSource();
+    const newSource = buildMockSseSource();
+    (SSE as jest.Mock)
+      .mockReturnValueOnce(oldSource)
+      .mockReturnValueOnce(newSource);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'old prompt',
+        variables: { answer: 'saved answer' },
+      });
+    });
+
+    act(() => {
+      oldSource.listeners.message?.({
+        data: JSON.stringify({
+          type: 'interaction',
+          generated_block_bid: 'old-interaction',
+          content: '?[answer]',
+        }),
+      });
+    });
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'new prompt',
+        variables: {},
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(SSE).toHaveBeenCalledTimes(2);
+    expect(newSource.stream).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores stale preview audio callbacks after preview reset', async () => {
+    const previewSource = buildMockSseSource();
+    const ttsSource = buildMockSseSource();
+    (SSE as jest.Mock)
+      .mockReturnValueOnce(previewSource)
+      .mockReturnValueOnce(ttsSource);
+
+    const { result } = renderHook(() => usePreviewChat());
+
+    await act(async () => {
+      await result.current.startPreview({
+        shifuBid: 'shifu-1',
+        outlineBid: 'lesson-1',
+        mdflow: 'prompt',
+      });
+    });
+
+    act(() => {
+      previewSource.listeners.message?.({
+        data: JSON.stringify({
+          type: 'content',
+          generated_block_bid: 'audio-block',
+          content: 'Audio text.',
+        }),
+      });
+    });
+
+    act(() => {
+      void result.current.requestAudioForBlock({
+        shifuBid: 'shifu-1',
+        blockId: 'audio-block',
+        text: 'Audio text.',
+      });
+    });
+
+    await waitFor(() => {
+      expect(ttsSource.stream).toHaveBeenCalled();
+    });
+    expect(result.current.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generated_block_bid: 'audio-block',
+          isAudioStreaming: true,
+        }),
+      ]),
+    );
+
+    act(() => {
+      result.current.resetPreview();
+      ttsSource.listeners.message?.({
+        data: JSON.stringify({
+          type: 'audio_complete',
+          content: {
+            audio_url: 'https://example.com/stale.mp3',
+            duration_ms: 1000,
+          },
+        }),
+      });
+      ttsSource.listeners.error?.({});
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.error).toBeNull();
   });
 
   test('drops the loading placeholder without appending an empty error row', () => {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -1252,16 +1252,10 @@ export function usePreviewChat() {
           currentStreamingElementBidRef.current = null;
           stopPreviewAndContinueIfNeeded(latestActionableItem);
         } else if (responseType === PREVIEW_SSE_OUTPUT_TYPE.ERROR) {
-          previewFailedRef.current = true;
           const errorMessage =
             resolveResponseStringPayload(response) ||
             t('module.preview.llmError');
-          const displayMessage = showPreviewErrorToast(
-            errorMessage,
-            t('module.preview.llmError'),
-          );
-          setError(displayMessage);
-          stopPreview();
+          handlePreviewBusinessError(errorMessage);
         } else if (responseType === PREVIEW_SSE_OUTPUT_TYPE.AUDIO_SEGMENT) {
           const audioSegment = normalizeAudioSegmentPayload(
             resolveResponsePayload(response),
@@ -1305,6 +1299,7 @@ export function usePreviewChat() {
       ensureContentItem,
       finalizePreviewElementOutputInList,
       finalizePreviewItems,
+      handlePreviewBusinessError,
       parseInteractionBlock,
       stopPreviewAndContinueIfNeeded,
       setTrackedContentList,
@@ -1478,6 +1473,7 @@ export function usePreviewChat() {
           // Interaction submissions must receive the block-level done marker first.
           const shouldContinuePreviewOnAbruptClose =
             doneTerminalStateRef.current === null &&
+            Boolean(latestActionableItem) &&
             latestActionableItem?.type !== ChatContentItemType.INTERACTION;
           if (shouldContinuePreviewOnAbruptClose) {
             const didContinue =
@@ -1485,12 +1481,8 @@ export function usePreviewChat() {
             if (didContinue) {
               return;
             }
-            stopPreview();
-            return;
           }
-          previewFailedRef.current = true;
-          setError(t('module.preview.streamError'));
-          stopPreview();
+          handlePreviewBusinessError(t('module.preview.streamError'));
         });
         source.stream();
       } catch (err) {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -37,6 +37,7 @@ import {
   resolveLearnerErrorMessage,
   resolveLearnerErrorToast,
 } from '@/lib/learnerError';
+import { showAiServiceErrorToast } from '@/lib/aiServiceToast';
 import { attachSseBusinessResponseFallback } from '@/lib/request';
 import type { ErrorWithCode } from '@/lib/request';
 import { buildTraceHeaders } from '@/lib/request-trace';
@@ -494,6 +495,17 @@ export function usePreviewChat() {
     });
   }, [t]);
 
+  const showPreviewErrorToast = useCallback(
+    (message: string, fallbackMessage: string) => {
+      return showAiServiceErrorToast({
+        message,
+        fallbackMessage,
+        includeUnknown: true,
+      }).message;
+    },
+    [],
+  );
+
   const removeAutoSubmittedBlocks = useCallback((blockIds: string[]) => {
     if (!blockIds?.length) {
       return;
@@ -723,17 +735,21 @@ export function usePreviewChat() {
         typeof errorOrMessage === 'string'
           ? fallbackCode
           : (errorOrMessage?.code ?? fallbackCode);
+      const displayMessage = showPreviewErrorToast(
+        resolvedToast.message,
+        t('module.preview.llmError'),
+      );
       setTrackedContentList(prev =>
         replacePreviewLoadingWithBusinessError(
           prev,
-          resolvedToast.message,
+          displayMessage,
           resolvedCode,
         ),
       );
-      setError(resolvedToast.message);
+      setError(displayMessage);
       stopPreview();
     },
-    [setTrackedContentList, stopPreview, t],
+    [setTrackedContentList, showPreviewErrorToast, stopPreview, t],
   );
 
   const resetPreview = useCallback(() => {
@@ -1235,12 +1251,11 @@ export function usePreviewChat() {
           const errorMessage =
             resolveResponseStringPayload(response) ||
             t('module.preview.llmError');
-          toast({
-            title: t('module.preview.llmError'),
-            description: errorMessage,
-            variant: 'destructive',
-          });
-          setError(errorMessage);
+          const displayMessage = showPreviewErrorToast(
+            errorMessage,
+            t('module.preview.llmError'),
+          );
+          setError(displayMessage);
           stopPreview();
         } else if (responseType === PREVIEW_SSE_OUTPUT_TYPE.AUDIO_SEGMENT) {
           const audioSegment = normalizeAudioSegmentPayload(
@@ -1289,6 +1304,7 @@ export function usePreviewChat() {
       stopPreviewAndContinueIfNeeded,
       setTrackedContentList,
       stopPreview,
+      showPreviewErrorToast,
       t,
       upsertElementPreviewItem,
     ],
@@ -1419,6 +1435,7 @@ export function usePreviewChat() {
             requestToken: tokenValue || '',
             requestId: traceHeaders.requestId,
             harnessRunId: traceHeaders.harnessRunId,
+            skipErrorToast: true,
           },
           onHandled: error => {
             if (sseRef.current !== source) {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -482,6 +482,10 @@ export function usePreviewChat() {
   const sseParams = useRef<StartPreviewParams>({});
   const sseRef = useRef<PreviewSseSource | null>(null);
   const ttsSseRef = useRef<Record<string, PreviewSseSource>>({});
+  const previewRunIdRef = useRef(0);
+  const autoSubmitTimeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(
+    new Set(),
+  );
   const isStreamingRef = useRef(false);
   const previewFailedRef = useRef(false);
   const doneTerminalStateRef = useRef<boolean | null>(null);
@@ -732,7 +736,26 @@ export function usePreviewChat() {
     ttsSseRef.current = {};
   }, []);
 
+  const invalidatePreviewRun = useCallback(() => {
+    previewRunIdRef.current += 1;
+    return previewRunIdRef.current;
+  }, []);
+
+  const isCurrentPreviewRun = useCallback(
+    (runId: number) => previewRunIdRef.current === runId,
+    [],
+  );
+
+  const clearAutoSubmitTimers = useCallback(() => {
+    autoSubmitTimeoutsRef.current.forEach(timeoutId => {
+      clearTimeout(timeoutId);
+    });
+    autoSubmitTimeoutsRef.current.clear();
+  }, []);
+
   const stopPreview = useCallback(() => {
+    invalidatePreviewRun();
+    clearAutoSubmitTimers();
     if (sseRef.current) {
       sseRef.current.close();
       sseRef.current = null;
@@ -741,7 +764,7 @@ export function usePreviewChat() {
     isStreamingRef.current = false;
     currentStreamingElementBidRef.current = null;
     setIsLoading(false);
-  }, [closeAllTtsStreams]);
+  }, [clearAutoSubmitTimers, closeAllTtsStreams, invalidatePreviewRun]);
 
   const handlePreviewBusinessError = useCallback(
     (errorOrMessage?: string | ErrorWithCode | null, fallbackCode?: number) => {
@@ -1395,6 +1418,7 @@ export function usePreviewChat() {
       }
 
       stopPreview();
+      const previewRunId = invalidatePreviewRun();
       doneTerminalStateRef.current = null;
       const resolvedBaseUrl = await resolveBaseUrl();
       if (!resolvedBaseUrl) {
@@ -1462,7 +1486,11 @@ export function usePreviewChat() {
           },
         });
         source.addEventListener('message', event => {
-          if (previewFailedRef.current || sseRef.current !== source) {
+          if (
+            !isCurrentPreviewRun(previewRunId) ||
+            previewFailedRef.current ||
+            sseRef.current !== source
+          ) {
             return;
           }
           const raw = event?.data;
@@ -1474,7 +1502,7 @@ export function usePreviewChat() {
           }
         });
         source.addEventListener('error', err => {
-          if (sseRef.current !== source) {
+          if (!isCurrentPreviewRun(previewRunId) || sseRef.current !== source) {
             return;
           }
           debugError('[preview-chat] preview SSE error', err);
@@ -1527,6 +1555,8 @@ export function usePreviewChat() {
       finalizePreviewItems,
       handlePreviewBusinessError,
       handlePayload,
+      invalidatePreviewRun,
+      isCurrentPreviewRun,
       resolveBaseUrl,
       setTrackedContentList,
       stopPreview,
@@ -1857,10 +1887,12 @@ export function usePreviewChat() {
       if (!sendParams) {
         return;
       }
+      const previewRunId = previewRunIdRef.current;
       autoSubmittedBlocksRef.current.add(blockId);
       const delay = parsedInfo?.isMultiSelect ? 1000 : 600;
-      setTimeout(() => {
-        if (previewFailedRef.current) {
+      const timeoutId = setTimeout(() => {
+        autoSubmitTimeoutsRef.current.delete(timeoutId);
+        if (!isCurrentPreviewRun(previewRunId) || previewFailedRef.current) {
           return;
         }
         performSend(sendParams, blockId, {
@@ -1868,8 +1900,14 @@ export function usePreviewChat() {
           skipConfirm: true,
         });
       }, delay);
+      autoSubmitTimeoutsRef.current.add(timeoutId);
     },
-    [buildAutoSendParams, parseInteractionBlock, performSend],
+    [
+      buildAutoSendParams,
+      isCurrentPreviewRun,
+      parseInteractionBlock,
+      performSend,
+    ],
   );
 
   useEffect(() => {
@@ -1917,6 +1955,7 @@ export function usePreviewChat() {
       if (!shifuBid || !blockId) {
         return null;
       }
+      const previewRunId = previewRunIdRef.current;
 
       const existingItem = contentListRef.current.find(item =>
         matchPreviewItemBid(item, blockId),
@@ -1961,6 +2000,9 @@ export function usePreviewChat() {
       );
 
       const resolvedBaseUrl = await resolveBaseUrl();
+      if (!isCurrentPreviewRun(previewRunId)) {
+        return null;
+      }
       const tokenValue = useUserStore.getState().getToken();
       const traceHeaders = buildTraceHeaders({
         'Content-Type': 'application/json',
@@ -1990,6 +2032,12 @@ export function usePreviewChat() {
             harnessRunId: traceHeaders.harnessRunId,
           },
           onHandled: error => {
+            if (
+              !isCurrentPreviewRun(previewRunId) ||
+              ttsSseRef.current[blockId] !== source
+            ) {
+              return;
+            }
             setTrackedContentList(prevState =>
               ensureAudioItem(
                 prevState.map(item => {
@@ -2011,6 +2059,7 @@ export function usePreviewChat() {
 
         source.addEventListener('message', event => {
           if (
+            !isCurrentPreviewRun(previewRunId) ||
             previewFailedRef.current ||
             ttsSseRef.current[blockId] !== source
           ) {
@@ -2063,6 +2112,12 @@ export function usePreviewChat() {
         });
 
         source.addEventListener('error', err => {
+          if (
+            !isCurrentPreviewRun(previewRunId) ||
+            ttsSseRef.current[blockId] !== source
+          ) {
+            return;
+          }
           debugError('[preview-chat] preview audio SSE error', err);
           setTrackedContentList(prevState =>
             ensureAudioItem(
@@ -2085,7 +2140,13 @@ export function usePreviewChat() {
         source.stream();
       });
     },
-    [closeTtsStream, ensureAudioItem, resolveBaseUrl, setTrackedContentList],
+    [
+      closeTtsStream,
+      ensureAudioItem,
+      isCurrentPreviewRun,
+      resolveBaseUrl,
+      setTrackedContentList,
+    ],
   );
 
   return {

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -328,6 +328,24 @@ const getPreviewItemGeneratedBlockBid = (
   return item.generated_block_bid || item.element_bid || '';
 };
 
+const hasRemainingPreviewBlocks = (params: StartPreviewParams) => {
+  const nextIndex = (params?.block_index || 0) + 1;
+  const totalBlocks = params?.max_block_count;
+  return !(
+    typeof totalBlocks === 'number' &&
+    totalBlocks >= 0 &&
+    nextIndex >= totalBlocks
+  );
+};
+
+const isCompletedFinalPreviewContentAfterAbruptClose = (
+  item?: ChatContentItem,
+  params: StartPreviewParams = {},
+) =>
+  item?.type === ChatContentItemType.CONTENT &&
+  Boolean(item.content?.trim()) &&
+  !hasRemainingPreviewBlocks(params);
+
 const isPreviewActionableItem = (
   item?: Pick<
     ChatContentItem,
@@ -1303,8 +1321,6 @@ export function usePreviewChat() {
       parseInteractionBlock,
       stopPreviewAndContinueIfNeeded,
       setTrackedContentList,
-      stopPreview,
-      showPreviewErrorToast,
       t,
       upsertElementPreviewItem,
     ],
@@ -1481,6 +1497,15 @@ export function usePreviewChat() {
             if (didContinue) {
               return;
             }
+            if (
+              isCompletedFinalPreviewContentAfterAbruptClose(
+                latestActionableItem,
+                sseParams.current,
+              )
+            ) {
+              stopPreview();
+              return;
+            }
           }
           handlePreviewBusinessError(t('module.preview.streamError'));
         });
@@ -1519,12 +1544,7 @@ export function usePreviewChat() {
         return false;
       }
       const nextIndex = (sseParams.current?.block_index || 0) + 1;
-      const totalBlocks = sseParams.current?.max_block_count;
-      if (
-        typeof totalBlocks === 'number' &&
-        totalBlocks >= 0 &&
-        nextIndex >= totalBlocks
-      ) {
+      if (!hasRemainingPreviewBlocks(sseParams.current)) {
         return false;
       }
       startPreview({

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -465,6 +465,7 @@ export function usePreviewChat() {
   const sseRef = useRef<PreviewSseSource | null>(null);
   const ttsSseRef = useRef<Record<string, PreviewSseSource>>({});
   const isStreamingRef = useRef(false);
+  const previewFailedRef = useRef(false);
   const doneTerminalStateRef = useRef<boolean | null>(null);
   const [variablesSnapshot, setVariablesSnapshot] =
     useState<PreviewVariablesMap>({});
@@ -726,6 +727,7 @@ export function usePreviewChat() {
 
   const handlePreviewBusinessError = useCallback(
     (errorOrMessage?: string | ErrorWithCode | null, fallbackCode?: number) => {
+      previewFailedRef.current = true;
       const resolvedToast = resolveLearnerErrorToast({
         error: typeof errorOrMessage === 'string' ? undefined : errorOrMessage,
         message:
@@ -754,6 +756,7 @@ export function usePreviewChat() {
   );
 
   const resetPreview = useCallback(() => {
+    previewFailedRef.current = false;
     stopPreview();
     setTrackedContentList([]);
     setError(null);
@@ -1249,6 +1252,7 @@ export function usePreviewChat() {
           currentStreamingElementBidRef.current = null;
           stopPreviewAndContinueIfNeeded(latestActionableItem);
         } else if (responseType === PREVIEW_SSE_OUTPUT_TYPE.ERROR) {
+          previewFailedRef.current = true;
           const errorMessage =
             resolveResponseStringPayload(response) ||
             t('module.preview.llmError');
@@ -1358,6 +1362,7 @@ export function usePreviewChat() {
         max_block_count: finalMaxBlockCount,
         visual_mode: finalVisualMode = false,
       } = mergedParams;
+      previewFailedRef.current = false;
       sseParams.current = mergedParams;
       setVariablesSnapshot(buildVariablesSnapshot(finalVariables));
       if (!normalizedUserInput) {
@@ -1446,6 +1451,9 @@ export function usePreviewChat() {
           },
         });
         source.addEventListener('message', event => {
+          if (previewFailedRef.current || sseRef.current !== source) {
+            return;
+          }
           const raw = event?.data;
           if (!raw) return;
           const payload = String(raw).trim();
@@ -1480,11 +1488,13 @@ export function usePreviewChat() {
             stopPreview();
             return;
           }
+          previewFailedRef.current = true;
           setError(t('module.preview.streamError'));
           stopPreview();
         });
         source.stream();
       } catch (err) {
+        previewFailedRef.current = true;
         debugError('[preview-chat] preview stream error', err);
         handlePreviewBusinessError(
           resolveLearnerErrorMessage({
@@ -1510,6 +1520,9 @@ export function usePreviewChat() {
 
   const continuePreviewFromLatestState = useCallback(
     (latestActionableItem?: ChatContentItem) => {
+      if (previewFailedRef.current) {
+        return false;
+      }
       if (!shouldContinueFromLatestActionableItem(latestActionableItem)) {
         return false;
       }
@@ -1811,6 +1824,9 @@ export function usePreviewChat() {
 
   const tryAutoSubmitInteraction = useCallback(
     (blockId: string, content?: string | null) => {
+      if (previewFailedRef.current) {
+        return;
+      }
       if (!content || autoSubmittedBlocksRef.current.has(blockId)) {
         return;
       }
@@ -1832,6 +1848,9 @@ export function usePreviewChat() {
       autoSubmittedBlocksRef.current.add(blockId);
       const delay = parsedInfo?.isMultiSelect ? 1000 : 600;
       setTimeout(() => {
+        if (previewFailedRef.current) {
+          return;
+        }
         performSend(sendParams, blockId, {
           skipStreamCheck: true,
           skipConfirm: true,
@@ -1979,6 +1998,12 @@ export function usePreviewChat() {
         });
 
         source.addEventListener('message', event => {
+          if (
+            previewFailedRef.current ||
+            ttsSseRef.current[blockId] !== source
+          ) {
+            return;
+          }
           const raw = event?.data;
           if (!raw) return;
           const payload = String(raw).trim();

--- a/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
+++ b/src/cook-web/src/components/lesson-preview/usePreviewChat.tsx
@@ -501,9 +501,10 @@ export function usePreviewChat() {
         message,
         fallbackMessage,
         includeUnknown: true,
+        unavailableMessage: t('module.preview.aiDebugUnavailable'),
       }).message;
     },
-    [],
+    [t],
   );
 
   const removeAutoSubmittedBlocks = useCallback((blockIds: string[]) => {

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -1632,6 +1632,7 @@ export default function ShifuSettingDialog({
         message: error instanceof Error ? error.message : '',
         fallbackMessage: t('common.core.unknownError'),
         includeUnknown: true,
+        unavailableMessage: t('module.preview.aiDebugUnavailable'),
       });
       setAskPreviewResult('');
       setAskPreviewMeta(null);

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -22,6 +22,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { uploadFile } from '@/lib/file';
 import { buildTraceHeaders } from '@/lib/request-trace';
+import { showAiServiceErrorToast } from '@/lib/aiServiceToast';
 import { getResolvedBaseURL } from '@/c-utils/envUtils';
 import { normalizeShifuDetail } from '@/lib/shifu-normalize';
 import {
@@ -1599,17 +1600,20 @@ export default function ShifuSettingDialog({
 
     setAskPreviewLoading(true);
     try {
-      const response = (await api.askPreview({
-        query,
-        ask_model: askModel,
-        ask_temperature: askTemperatureForSubmit,
-        ask_system_prompt: '',
-        ask_provider_config: {
-          provider: askProviderForSubmit,
-          mode: askModeForSubmit,
-          config: askConfigForSubmit,
+      const response = (await api.askPreview(
+        {
+          query,
+          ask_model: askModel,
+          ask_temperature: askTemperatureForSubmit,
+          ask_system_prompt: '',
+          ask_provider_config: {
+            provider: askProviderForSubmit,
+            mode: askModeForSubmit,
+            config: askConfigForSubmit,
+          },
         },
-      })) as {
+        { skipErrorToast: true },
+      )) as {
         answer?: string;
         provider?: string;
         requested_provider?: string;
@@ -1623,7 +1627,12 @@ export default function ShifuSettingDialog({
         requestedProvider: String(response?.requested_provider || ''),
         fallbackUsed: Boolean(response?.fallback_used),
       });
-    } catch {
+    } catch (error) {
+      showAiServiceErrorToast({
+        message: error instanceof Error ? error.message : '',
+        fallbackMessage: t('common.core.unknownError'),
+        includeUnknown: true,
+      });
       setAskPreviewResult('');
       setAskPreviewMeta(null);
     } finally {

--- a/src/cook-web/src/lib/aiServiceError.test.ts
+++ b/src/cook-web/src/lib/aiServiceError.test.ts
@@ -53,6 +53,18 @@ describe('aiServiceError', () => {
     expect(isAiServiceUnavailableMessage('payment canceled')).toBe(false);
   });
 
+  it('maps Langfuse instrumentation failures to the friendly copy', () => {
+    expect(
+      resolveAiServiceErrorToast({
+        message: "'Langfuse' object has no attribute 'start_span'",
+        fallbackMessage: 'fallback',
+      }),
+    ).toEqual({
+      message: 'i18n:module.chat.contentGenerationUnavailable',
+      isAiServiceUnavailable: true,
+    });
+  });
+
   it('does not classify generic unsupported business errors', () => {
     expect(isAiServiceUnavailableMessage('This action is not supported')).toBe(
       false,

--- a/src/cook-web/src/lib/aiServiceError.ts
+++ b/src/cook-web/src/lib/aiServiceError.ts
@@ -72,15 +72,19 @@ export const resolveAiServiceErrorToast = ({
   message,
   fallbackMessage,
   includeUnknown = false,
+  unavailableMessage,
 }: {
   message?: string | null;
   fallbackMessage: string;
   includeUnknown?: boolean;
+  unavailableMessage?: string;
 }) => {
   const normalizedMessage = normalizeErrorMessage(message);
   if (isAiServiceUnavailableMessage(normalizedMessage, { includeUnknown })) {
     return {
-      message: i18n.t('module.chat.contentGenerationUnavailable'),
+      message:
+        unavailableMessage ||
+        i18n.t('module.chat.contentGenerationUnavailable'),
       isAiServiceUnavailable: true,
     };
   }

--- a/src/cook-web/src/lib/aiServiceError.ts
+++ b/src/cook-web/src/lib/aiServiceError.ts
@@ -7,6 +7,7 @@ export const AI_SERVICE_ERROR_TOAST_DEDUPE_MS = 10000;
 const AI_SERVICE_IDENTITY_MARKERS = [
   'llm',
   'litellm',
+  'langfuse',
   'model',
   'api key',
   'base_url',
@@ -25,6 +26,8 @@ const AI_SERVICE_ERROR_STATE_MARKERS = [
   'badrequesterror',
   'apiconnectionerror',
   'internalservererror',
+  'object has no attribute',
+  'attributeerror',
   '调用失败',
   '没有配置',
   '不支持',

--- a/src/cook-web/src/lib/aiServiceToast.test.ts
+++ b/src/cook-web/src/lib/aiServiceToast.test.ts
@@ -1,0 +1,58 @@
+import { toast, toastOnce } from '@/hooks/useToast';
+import { showAiServiceErrorToast } from './aiServiceToast';
+
+jest.mock('@/hooks/useToast', () => ({
+  toast: jest.fn(),
+  toastOnce: jest.fn(),
+}));
+
+jest.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+describe('aiServiceToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dedupes AI service unavailable toasts with the friendly copy', () => {
+    expect(
+      showAiServiceErrorToast({
+        message: '模型 deepseek 调用失败：provider unavailable',
+        fallbackMessage: 'fallback',
+      }),
+    ).toEqual({
+      message: 'module.chat.contentGenerationUnavailable',
+      isAiServiceUnavailable: true,
+    });
+
+    expect(toastOnce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupeKey: 'ai-service-unavailable',
+        title: 'module.chat.contentGenerationUnavailable',
+        variant: 'destructive',
+        duration: 8000,
+      }),
+    );
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it('keeps non-AI business errors on the regular toast path', () => {
+    expect(
+      showAiServiceErrorToast({
+        message: '积分不足，请先购买积分',
+        fallbackMessage: 'fallback',
+        includeUnknown: true,
+      }),
+    ).toEqual({
+      message: '积分不足，请先购买积分',
+      isAiServiceUnavailable: false,
+    });
+
+    expect(toast).toHaveBeenCalledWith({
+      title: '积分不足，请先购买积分',
+      variant: 'destructive',
+    });
+    expect(toastOnce).not.toHaveBeenCalled();
+  });
+});

--- a/src/cook-web/src/lib/aiServiceToast.ts
+++ b/src/cook-web/src/lib/aiServiceToast.ts
@@ -10,15 +10,18 @@ export const showAiServiceErrorToast = ({
   message,
   fallbackMessage,
   includeUnknown = false,
+  unavailableMessage,
 }: {
   message?: string | null;
   fallbackMessage: string;
   includeUnknown?: boolean;
+  unavailableMessage?: string;
 }) => {
   const displayErrorToast = resolveAiServiceErrorToast({
     message,
     fallbackMessage,
     includeUnknown,
+    unavailableMessage,
   });
 
   if (displayErrorToast.isAiServiceUnavailable) {

--- a/src/cook-web/src/lib/aiServiceToast.ts
+++ b/src/cook-web/src/lib/aiServiceToast.ts
@@ -1,0 +1,40 @@
+import { toast, toastOnce } from '@/hooks/useToast';
+import {
+  AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+  AI_SERVICE_ERROR_TOAST_DURATION_MS,
+  AI_SERVICE_ERROR_TOAST_KEY,
+  resolveAiServiceErrorToast,
+} from './aiServiceError';
+
+export const showAiServiceErrorToast = ({
+  message,
+  fallbackMessage,
+  includeUnknown = false,
+}: {
+  message?: string | null;
+  fallbackMessage: string;
+  includeUnknown?: boolean;
+}) => {
+  const displayErrorToast = resolveAiServiceErrorToast({
+    message,
+    fallbackMessage,
+    includeUnknown,
+  });
+
+  if (displayErrorToast.isAiServiceUnavailable) {
+    toastOnce({
+      dedupeKey: AI_SERVICE_ERROR_TOAST_KEY,
+      dedupeWindowMs: AI_SERVICE_ERROR_TOAST_DEDUPE_MS,
+      title: displayErrorToast.message,
+      variant: 'destructive',
+      duration: AI_SERVICE_ERROR_TOAST_DURATION_MS,
+    });
+  } else {
+    toast({
+      title: displayErrorToast.message,
+      variant: 'destructive',
+    });
+  }
+
+  return displayErrorToast;
+};

--- a/src/i18n/en-US/modules/preview.json
+++ b/src/i18n/en-US/modules/preview.json
@@ -1,5 +1,6 @@
 {
   "__namespace__": "module.preview",
+  "aiDebugUnavailable": "AI debugging is temporarily unavailable. Please try again later; if it keeps failing, check the model configuration.",
   "debugDisabledBySoftLimit": "Credit balance is below the reminder threshold. Preview debugging is disabled.",
   "invalidParams": "Preview parameters are incomplete. Please refresh and try again.",
   "llmError": "LLM Invocation Error",

--- a/src/i18n/fr-FR/modules/preview.json
+++ b/src/i18n/fr-FR/modules/preview.json
@@ -1,5 +1,6 @@
 {
   "__namespace__": "module.preview",
+  "aiDebugUnavailable": "Le débogage IA est temporairement indisponible. Veuillez réessayer plus tard ; si le problème persiste, vérifiez la configuration du modèle.",
   "debugDisabledBySoftLimit": "Le solde de crédits est sous le seuil d’alerte. La prévisualisation de débogage est désactivée.",
   "invalidParams": "Les paramètres de prévisualisation sont incomplets. Actualisez puis réessayez.",
   "llmError": "Erreur d’appel LLM",

--- a/src/i18n/zh-CN/modules/preview.json
+++ b/src/i18n/zh-CN/modules/preview.json
@@ -1,5 +1,6 @@
 {
   "__namespace__": "module.preview",
+  "aiDebugUnavailable": "调试暂时不可用，请稍后重试；如持续失败，请检查模型配置",
   "debugDisabledBySoftLimit": "积分余额已低于提醒阈值，暂不能预览调试。",
   "invalidParams": "预览参数不完整，请刷新后重试。",
   "llmError": "LLM 调用错误",


### PR DESCRIPTION
Summary:
- Route admin lesson preview and ask-preview AI failures through the shared friendly deduped toast path.
- Suppress lower-level duplicate raw request toasts for those handled preview paths.
- Keep successful final preview content when the SSE closes after content but before the final done marker.
- Ignore stale preview auto-submit timers and late TTS callbacks after reset or a new preview run starts.
- Add focused coverage for the shared toast helper, preview fallback handling, and stale callback guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for AI-powered lesson previews and Ask requests.
  * Added clearer, localized fallback messages when AI services are unavailable or return unexpected errors.
  * Prevented duplicate error notifications during streaming responses.
  * Stopped failed previews from triggering additional requests, interactions, or audio updates.
  * Ensured business errors display consistently while preserving relevant error details.
  * Added retry and model-configuration guidance in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
