### PR TITLE
fix: monkey-patch gevent only when the gevent worker class is selected

### DIFF
--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -39,8 +39,13 @@ def install_hub_error_observer(logger, hub=None) -> bool:
     """
     if hub is None:
         try:
-            from gevent import get_hub
+            from gevent import get_hub, monkey
         except ImportError:
+            return False
+        if not monkey.is_module_patched("socket"):
+            # Without monkey-patching there is no gevent scheduling to
+            # observe, and get_hub() would needlessly CREATE a hub in a
+            # plain-threaded process (e.g. gthread workers).
             return False
         hub = get_hub()
 

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -2,15 +2,38 @@
 # gunicorn from /app (this file's directory); command-line flags from the
 # deployment entrypoint (e.g. -w) still take precedence over values here.
 
-# With preload_app the master imports the application BEFORE forking workers,
-# so gevent's monkey-patching must happen here, in the master, before any of
-# the app's imports touch socket/ssl. The gevent worker class re-patches in
-# the child, which is a no-op.
 import os
+import sys
 
-from gevent import monkey
 
-monkey.patch_all()
+def _gevent_worker_requested(argv) -> bool:
+    """True when the command line selects the gevent worker class.
+
+    Monkey-patching must match the worker class. The production deployment
+    runs ``-k gthread``; patching gevent onto gthread workers turns their
+    request threads into hub-scheduled greenlets and swaps subprocess for
+    gevent's fork implementation - a hybrid that produced hub crashes
+    (AbstractLinkable._notify_links) which silently interrupted in-flight
+    DB exchanges (MySQL off-by-one protocol desync) and corrupted shared
+    TLS records. Only a real gevent worker gets patched, and it must be
+    patched HERE (the preload master) because with preload_app the app is
+    imported before the worker's own patching would run.
+    """
+    for index, arg in enumerate(argv):
+        if arg in ("-k", "--worker-class"):
+            if index + 1 < len(argv):
+                return argv[index + 1] == "gevent"
+        elif arg.startswith("--worker-class="):
+            return arg.split("=", 1)[1] == "gevent"
+        elif arg.startswith("-k") and len(arg) > 2:
+            return arg[2:] == "gevent"
+    return False
+
+
+if _gevent_worker_requested(sys.argv):
+    from gevent import monkey
+
+    monkey.patch_all()
 
 # Mark the preload master so import-time initializers skip anything that
 # would start background threads here (e.g. the Langfuse/OTel batch

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -19,14 +19,22 @@ def _gevent_worker_requested(argv) -> bool:
     patched HERE (the preload master) because with preload_app the app is
     imported before the worker's own patching would run.
     """
+
+    def _is_gevent(value: str) -> bool:
+        # Accept every gunicorn spelling of the bundled gevent worker: the
+        # alias, the import path (module gunicorn.workers.ggevent), and the
+        # legacy egg form.
+        value = value.strip()
+        return value == "gevent" or value.endswith("#gevent") or "ggevent" in value
+
     for index, arg in enumerate(argv):
         if arg in ("-k", "--worker-class"):
             if index + 1 < len(argv):
-                return argv[index + 1] == "gevent"
+                return _is_gevent(argv[index + 1])
         elif arg.startswith("--worker-class="):
-            return arg.split("=", 1)[1] == "gevent"
+            return _is_gevent(arg.split("=", 1)[1])
         elif arg.startswith("-k") and len(arg) > 2:
-            return arg[2:] == "gevent"
+            return _is_gevent(arg[2:])
     return False
 
 

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -1,0 +1,65 @@
+"""Monkey-patching must match the gunicorn worker class.
+
+The production deployment runs ``-k gthread``; the config file used to call
+``monkey.patch_all()`` unconditionally (written for a gevent worker),
+producing a gthread/gevent hybrid whose hub crashes silently interrupted
+in-flight DB exchanges. The guard patches only when the command line
+actually selects the gevent worker.
+"""
+
+import pathlib
+
+
+def _load_detector():
+    conf_path = pathlib.Path(__file__).resolve().parents[1] / "gunicorn.conf.py"
+    source = conf_path.read_text()
+    # Execute only the detector function, not the module (which would
+    # monkey-patch or set env flags as a side effect).
+    namespace = {}
+    marker = "def _gevent_worker_requested"
+    start = source.index(marker)
+    end = source.index("\nif _gevent_worker_requested", start)
+    exec(source[start:end], namespace)  # noqa: S102 - own config source
+    return namespace["_gevent_worker_requested"]
+
+
+def test_worker_class_detection():
+    detect = _load_detector()
+
+    assert detect(["gunicorn", "-k", "gevent", "app:app"]) is True
+    assert detect(["gunicorn", "--worker-class", "gevent"]) is True
+    assert detect(["gunicorn", "--worker-class=gevent"]) is True
+    assert detect(["gunicorn", "-kgevent"]) is True
+
+    # The production command line - MUST NOT patch.
+    assert (
+        detect(
+            [
+                "gunicorn",
+                "-k",
+                "gthread",
+                "--threads",
+                "8",
+                "-w",
+                "4",
+                "app:app",
+            ]
+        )
+        is False
+    )
+    assert detect(["gunicorn", "--worker-class=gthread"]) is False
+    assert detect(["gunicorn", "app:app"]) is False
+
+
+def test_observer_skips_unpatched_processes(monkeypatch):
+    from gevent import monkey
+
+    from flaskr.common.gevent_hub_observer import install_hub_error_observer
+
+    monkeypatch.setattr(monkey, "is_module_patched", lambda name: False)
+
+    class _Logger:
+        def error(self, *args, **kwargs):
+            raise AssertionError("must not log during a skipped install")
+
+    assert install_hub_error_observer(_Logger()) is False

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -30,6 +30,12 @@ def test_worker_class_detection():
     assert detect(["gunicorn", "--worker-class", "gevent"]) is True
     assert detect(["gunicorn", "--worker-class=gevent"]) is True
     assert detect(["gunicorn", "-kgevent"]) is True
+    assert detect(["gunicorn", "-k", "gunicorn.workers.ggevent.GeventWorker"]) is True
+    assert (
+        detect(["gunicorn", "--worker-class=gunicorn.workers.ggevent.GeventWorker"])
+        is True
+    )
+    assert detect(["gunicorn", "-k", "egg:gunicorn#gevent"]) is True
 
     # The production command line - MUST NOT patch.
     assert (

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -18,14 +18,19 @@ class _RecordingLangfuse:
         _RecordingLangfuse.instances.append(kwargs)
 
 
-def _configure(app):
+def _configure(app, monkeypatch):
     app.config["LANGFUSE_PUBLIC_KEY"] = "pk"
     app.config["LANGFUSE_SECRET_KEY"] = "sk"
     app.config["LANGFUSE_HOST"] = "https://langfuse.example"
+    # init_langfuse rebinds the module-global client; snapshot the current
+    # value so monkeypatch restores it and later tests keep the real mock.
+    monkeypatch.setattr(
+        langfuse_module, "langfuse_client", langfuse_module.langfuse_client
+    )
 
 
 def test_preload_master_defers_real_client(app, monkeypatch):
-    _configure(app)
+    _configure(app, monkeypatch)
     monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
     monkeypatch.setattr(_RecordingLangfuse, "instances", [])
     monkeypatch.setenv(langfuse_module.PRELOAD_MASTER_ENV, "1")
@@ -37,7 +42,7 @@ def test_preload_master_defers_real_client(app, monkeypatch):
 
 
 def test_worker_builds_real_client_after_flag_cleared(app, monkeypatch):
-    _configure(app)
+    _configure(app, monkeypatch)
     monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
     monkeypatch.setattr(_RecordingLangfuse, "instances", [])
     monkeypatch.delenv(langfuse_module.PRELOAD_MASTER_ENV, raising=False)


### PR DESCRIPTION
## Problem

Investigation of the desync errors that survived #2276 uncovered the deepest layer of the incident: **production does not run the gevent worker at all**. The k8s deployment overrides the image CMD with:

```
gunicorn -k gthread --threads 8 -w 4 ...
```

(set in deploy-config on 2026-05-18, "fix: use gthread for shifu api"), while `gunicorn.conf.py` - added on 2026-07-14 and written for a gevent worker ("The gevent worker class re-patches in the child, which is a no-op") - calls `monkey.patch_all()` **unconditionally** in the master.

Since 07-14 production has therefore been running a gthread/gevent hybrid:

- the gthread worker's 8 request "threads" become hub-scheduled greenlets;
- `subprocess` (pydub/ffmpeg audio processing) is replaced by gevent's fork-based implementation, which runs `os.register_at_fork` hooks - re-igniting OTel batch-processor threads inside short-lived children that inherit the parent's open MySQL/TLS sockets (the mystery pids 31/47/1117 logging hub errors at exit);
- gevent hub crashes (`AbstractLinkable._notify_links` AssertionError / `KeyError` on stopped `OtelBatchSpanRecordProcessor` threads) break greenlet wakeups and silently interrupt in-flight DB exchanges.

This hybrid is the substrate of the entire 08-02 → 08-05 incident family: MySQL off-by-one protocol desync, `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` on LLM/Langfuse connections, and the hub crash storm. It stayed quiet from 07-14 until the listen/TTS feature ramped up cross-thread load in August. The pure-gthread configuration ran stably from 05-18 to 07-14.

## Changes

1. `gunicorn.conf.py`: `monkey.patch_all()` now runs only when the command line actually selects the gevent worker (`-k gevent` / `--worker-class gevent`, all argument spellings handled). The production gthread deployment runs unpatched - plain OS threads, no hub, no gevent subprocess. A real gevent worker (e.g. the image's default CMD used by dev environments) still gets patched in the preload master, where it must happen for `preload_app` correctness.
2. `flaskr/common/gevent_hub_observer.py`: the observer installs only in processes whose modules are actually monkey-patched, instead of needlessly creating a gevent hub inside a plain-threaded worker.
3. Everything else stays: the preload-master Langfuse deferral (#2276), desync probes/journal, and termination classification remain as defense-in-depth and for genuinely-gevent environments.

## Verification

- New `tests/test_gunicorn_worker_patch_guard.py`: worker-class detection matrix (including the exact production command line, which must NOT patch) and the observer's unpatched-process guard.
- Full backend suite: 2592 passed, 15 skipped.

## Rollout observation

After deploy: `gevent hub error` lines and bare `_notify_links` tracebacks must disappear entirely (there is no hub anymore), and with them the desync family (pre-execute interceptions, checkin catches, NULL-identity FlushErrors) and the SSL bad-record-mac errors. Watch thread-pool saturation under listen streaming load (8 threads x 4 workers per pod); if long SSE streams exhaust slots, raising `--threads` in the deployment is the lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup reliability by applying gevent support only when the gevent worker is explicitly selected.
  - Prevented unnecessary gevent setup for other worker types, including gthread.
  - Avoided hub observer activity in processes that are not gevent-patched, reducing unwanted startup logging and overhead.

- **Tests**
  - Added coverage for supported and unsupported worker configuration formats.
  - Verified observer setup is skipped in unpatched processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->