### PR TITLE
feat: guide teachers from draft preview to course editing

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.module.scss
@@ -22,6 +22,12 @@
     box-sizing: border-box;
   }
 
+  .previewHeaderBanner {
+    flex: 0 0 var(--mobile-chat-preview-banner-height, 76px);
+    min-height: var(--mobile-chat-preview-banner-height, 76px);
+    height: var(--mobile-chat-preview-banner-height, 76px);
+  }
+
   .actionGroup {
     display: inline-flex;
     align-items: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatMobileHeader.tsx
@@ -20,6 +20,7 @@ export const ChatMobileHeader = ({
   navOpen,
   iconPopoverPayload,
   lessonUpdateNoticeVisible = false,
+  courseId,
   chapterId,
   lessonId,
   lessonTitle,
@@ -54,7 +55,13 @@ export const ChatMobileHeader = ({
           />
         </div>
       ) : null}
-      {previewMode ? <PreviewHeaderBanner /> : null}
+      {previewMode ? (
+        <PreviewHeaderBanner
+          courseId={courseId}
+          lessonId={lessonId}
+          className={styles.previewHeaderBanner}
+        />
+      ) : null}
       <div className={styles.headerRow}>
         <CourseHeaderSummary />
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/c-constants/uiConstants';
 
 let mockFrameLayout = FRAME_LAYOUT_PC;
+let mockPreviewMode = false;
 let mockShowLearningModeToggle = false;
 let mockChatComponentProps: Record<string, any> = {};
 
@@ -44,7 +45,7 @@ jest.mock('@/c-store/useSystemStore', () => ({
   useSystemStore: (selector: (state: any) => unknown) =>
     selector({
       learningMode: 'read',
-      previewMode: false,
+      previewMode: mockPreviewMode,
       showLearningModeToggle: mockShowLearningModeToggle,
       skip: false,
       updateSkip: jest.fn(),
@@ -80,8 +81,14 @@ jest.mock(
 jest.mock(
   '../PreviewHeaderBanner',
   () =>
-    function MockPreviewHeaderBanner() {
-      return <div />;
+    function MockPreviewHeaderBanner({ courseId, lessonId }: any) {
+      return (
+        <div
+          data-testid='preview-header-banner'
+          data-course-id={courseId}
+          data-lesson-id={lessonId}
+        />
+      );
     },
 );
 jest.mock(
@@ -108,6 +115,7 @@ const pdfAction = {
 
 const createChatUi = (lessonId = 'lesson-1') => (
   <ChatUi
+    courseId='course-1'
     chapterId='chapter-1'
     chapterUpdate={jest.fn()}
     getNextLessonId={jest.fn()}
@@ -128,6 +136,7 @@ describe('ChatUi lesson PDF action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFrameLayout = FRAME_LAYOUT_PC;
+    mockPreviewMode = false;
     mockShowLearningModeToggle = false;
     mockChatComponentProps = {};
   });
@@ -228,6 +237,39 @@ describe('ChatUi lesson PDF action', () => {
     expect(screen.getByTestId('learning-mode-switch')).toHaveAttribute(
       'data-size',
       'mobile',
+    );
+  });
+});
+
+describe('ChatUi preview banner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFrameLayout = FRAME_LAYOUT_PC;
+    mockPreviewMode = false;
+    mockShowLearningModeToggle = false;
+    mockChatComponentProps = {};
+  });
+
+  it('does not render outside preview mode', () => {
+    renderChatUi();
+
+    expect(
+      screen.queryByTestId('preview-header-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes the current course and lesson to the preview banner', () => {
+    mockPreviewMode = true;
+
+    renderChatUi('lesson-2');
+
+    expect(screen.getByTestId('preview-header-banner')).toHaveAttribute(
+      'data-course-id',
+      'course-1',
+    );
+    expect(screen.getByTestId('preview-header-banner')).toHaveAttribute(
+      'data-lesson-id',
+      'lesson-2',
     );
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -30,6 +30,7 @@ const ChatComponents = dynamic(() => import('./NewChatComp'), {
 });
 
 interface ChatUiProps {
+  courseId: string;
   chapterId: string;
   lessonId?: string;
   lessonUpdate: (val: any) => void;
@@ -55,6 +56,7 @@ interface ChatUiProps {
  * Overall canvas for the chat area
  */
 export const ChatUi = ({
+  courseId,
   chapterId,
   lessonId,
   lessonUpdate,
@@ -164,7 +166,11 @@ export const ChatUi = ({
             )}
           >
             {previewMode ? (
-              <PreviewHeaderBanner className={styles.previewHeaderBanner} />
+              <PreviewHeaderBanner
+                courseId={courseId}
+                lessonId={lessonId}
+                className={styles.previewHeaderBanner}
+              />
             ) : null}
             <div className={styles.headerMain}>
               <div className={styles.headerContent}>

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
@@ -3,11 +3,13 @@ import { render, screen } from '@testing-library/react';
 import PreviewHeaderBanner from './PreviewHeaderBanner';
 
 jest.mock('react-i18next', () => {
+  const draftNotice = 'Draft notice.';
+
   return {
     Trans: ({ components }: any) => {
       return (
         <>
-          Draft notice.
+          {draftNotice}
           {React.cloneElement(components.editLink, {}, 'Edit course')}
         </>
       );

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PreviewHeaderBanner from './PreviewHeaderBanner';
+
+jest.mock('react-i18next', () => {
+  const translation =
+    '正在预览课程草稿，发布后学生才能看到更新。<editLink>编辑课程</editLink>';
+
+  return {
+    Trans: ({ components }: any) => {
+      const match = translation.match(/^(.*)<editLink>(.*)<\/editLink>(.*)$/);
+
+      if (!match) {
+        return <>{translation}</>;
+      }
+
+      return (
+        <>
+          {match[1]}
+          {React.cloneElement(components.editLink, {}, match[2])}
+          {match[3]}
+        </>
+      );
+    },
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+describe('PreviewHeaderBanner', () => {
+  it('links the draft notice to the current lesson editor in the same tab', () => {
+    render(
+      <PreviewHeaderBanner
+        courseId='course-1'
+        lessonId='lesson-2'
+      />,
+    );
+
+    expect(
+      screen.getByText('正在预览课程草稿，发布后学生才能看到更新。'),
+    ).toBeInTheDocument();
+
+    const editLink = screen.getByRole('link', { name: '编辑课程' });
+    expect(editLink).toHaveAttribute(
+      'href',
+      '/shifu/course-1?lessonid=lesson-2',
+    );
+    expect(editLink).not.toHaveAttribute('target');
+  });
+
+  it('omits the lesson query when no current lesson is available', () => {
+    render(<PreviewHeaderBanner courseId='course-1' />);
+
+    expect(screen.getByRole('link', { name: '编辑课程' })).toHaveAttribute(
+      'href',
+      '/shifu/course-1',
+    );
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx
@@ -3,22 +3,12 @@ import { render, screen } from '@testing-library/react';
 import PreviewHeaderBanner from './PreviewHeaderBanner';
 
 jest.mock('react-i18next', () => {
-  const translation =
-    '正在预览课程草稿，发布后学生才能看到更新。<editLink>编辑课程</editLink>';
-
   return {
     Trans: ({ components }: any) => {
-      const match = translation.match(/^(.*)<editLink>(.*)<\/editLink>(.*)$/);
-
-      if (!match) {
-        return <>{translation}</>;
-      }
-
       return (
         <>
-          {match[1]}
-          {React.cloneElement(components.editLink, {}, match[2])}
-          {match[3]}
+          Draft notice.
+          {React.cloneElement(components.editLink, {}, 'Edit course')}
         </>
       );
     },
@@ -37,11 +27,13 @@ describe('PreviewHeaderBanner', () => {
       />,
     );
 
-    expect(
-      screen.getByText('正在预览课程草稿，发布后学生才能看到更新。'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Draft notice.')).toBeInTheDocument();
 
-    const editLink = screen.getByRole('link', { name: '编辑课程' });
+    const editLinks = screen.getAllByRole('link');
+    expect(editLinks).toHaveLength(1);
+
+    const [editLink] = editLinks;
+    expect(editLink).toHaveAccessibleName('Edit course');
     expect(editLink).toHaveAttribute(
       'href',
       '/shifu/course-1?lessonid=lesson-2',
@@ -52,7 +44,7 @@ describe('PreviewHeaderBanner', () => {
   it('omits the lesson query when no current lesson is available', () => {
     render(<PreviewHeaderBanner courseId='course-1' />);
 
-    expect(screen.getByRole('link', { name: '编辑课程' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Edit course' })).toHaveAttribute(
       'href',
       '/shifu/course-1',
     );

--- a/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/PreviewHeaderBanner.tsx
@@ -1,20 +1,39 @@
 import { memo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { buildUrlWithLessonId } from '@/c-utils/urlUtils';
 
 interface PreviewHeaderBannerProps {
+  courseId: string;
+  lessonId?: string;
   className?: string;
 }
 
 export const PreviewHeaderBanner = ({
+  courseId,
+  lessonId,
   className,
 }: PreviewHeaderBannerProps) => {
   const { t } = useTranslation();
+  const editCourseUrl = buildUrlWithLessonId(`/shifu/${courseId}`, lessonId);
 
   return (
     <div className={cn('w-full bg-sky-100 text-sky-800', className)}>
-      <div className='flex min-h-10 w-full items-center justify-center px-4 py-2 text-center text-[14px] font-medium leading-5 md:text-[15px]'>
-        {t('module.preview.previewModeBanner')}
+      <div className='flex h-full min-h-10 w-full items-center justify-center px-4 py-2 text-center text-[14px] font-medium leading-5 md:text-[15px]'>
+        <span className='inline max-w-full'>
+          <Trans
+            t={t}
+            i18nKey='module.preview.previewModeBanner'
+            components={{
+              editLink: (
+                <a
+                  href={editCourseUrl}
+                  className='ml-1 rounded-sm font-semibold underline decoration-sky-700/40 underline-offset-[3px] transition-colors hover:text-sky-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600 focus-visible:ring-offset-2 focus-visible:ring-offset-sky-100'
+                />
+              ),
+            }}
+          />
+        </span>
       </div>
     </div>
   );

--- a/src/cook-web/src/app/c/[[...id]]/page.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/page.module.scss
@@ -1,7 +1,7 @@
 .newChatPage {
   --mobile-chat-header-base-height: 44px;
   --mobile-chat-header-notice-height: 32px;
-  --mobile-chat-preview-banner-height: 40px;
+  --mobile-chat-preview-banner-height: 76px;
   --mobile-chat-header-height: var(--mobile-chat-header-base-height);
   width: 100%;
   min-height: calc(var(--app-viewport-block-unit, 1dvh) * 100);

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -949,6 +949,7 @@ export default function ChatPage() {
             iconPopoverPayload={tree?.bannerInfo}
             onSettingClick={onNavToggle}
             lessonUpdateNoticeVisible={lessonUpdateNoticeVisible}
+            courseId={courseId}
             chapterId={chapterId}
             lessonId={resolvedLessonId}
             lessonTitle={currentLessonTitle}
@@ -990,6 +991,7 @@ export default function ChatPage() {
 
         {initialized && profileOnboardingRuntimeReady ? (
           <ChatUi
+            courseId={courseId}
             lessonId={resolvedLessonId}
             chapterId={chapterId}
             lessonTitle={currentLessonTitle}

--- a/src/i18n/en-US/modules/preview.json
+++ b/src/i18n/en-US/modules/preview.json
@@ -5,7 +5,7 @@
   "llmError": "LLM Invocation Error",
   "missingApiBaseUrl": "The current environment is misconfigured. Please try again later.",
   "previewAll": "Preview Draft",
-  "previewModeBanner": "Previewing a course draft. Students will see updates only after publication. <editLink>Edit course</editLink>",
+  "previewModeBanner": "Previewing a course draft. Students will see updates only after publication.<editLink>Edit course</editLink>",
   "requestFailed": "Preview failed. Please try again later.",
   "streamError": "The preview connection was interrupted. Please try again."
 }

--- a/src/i18n/en-US/modules/preview.json
+++ b/src/i18n/en-US/modules/preview.json
@@ -5,7 +5,7 @@
   "llmError": "LLM Invocation Error",
   "missingApiBaseUrl": "The current environment is misconfigured. Please try again later.",
   "previewAll": "Preview Draft",
-  "previewModeBanner": "This link is a preview link and is only visible to the course publisher",
+  "previewModeBanner": "Previewing a course draft. Students will see updates only after publication. <editLink>Edit course</editLink>",
   "requestFailed": "Preview failed. Please try again later.",
   "streamError": "The preview connection was interrupted. Please try again."
 }

--- a/src/i18n/fr-FR/modules/preview.json
+++ b/src/i18n/fr-FR/modules/preview.json
@@ -5,7 +5,7 @@
   "llmError": "Erreur d’appel LLM",
   "missingApiBaseUrl": "L’environnement actuel est mal configuré. Veuillez réessayer plus tard.",
   "previewAll": "Prévisualiser le brouillon",
-  "previewModeBanner": "Ce lien est un lien de prévisualisation visible uniquement par l’éditeur du cours",
+  "previewModeBanner": "Aperçu du brouillon du cours. Les élèves ne verront les mises à jour qu’après publication. <editLink>Modifier le cours</editLink>",
   "requestFailed": "La prévisualisation a échoué. Veuillez réessayer plus tard.",
   "streamError": "La connexion de prévisualisation a été interrompue. Veuillez réessayer."
 }

--- a/src/i18n/fr-FR/modules/preview.json
+++ b/src/i18n/fr-FR/modules/preview.json
@@ -5,7 +5,7 @@
   "llmError": "Erreur d’appel LLM",
   "missingApiBaseUrl": "L’environnement actuel est mal configuré. Veuillez réessayer plus tard.",
   "previewAll": "Prévisualiser le brouillon",
-  "previewModeBanner": "Aperçu du brouillon du cours. Les élèves ne verront les mises à jour qu’après publication. <editLink>Modifier le cours</editLink>",
+  "previewModeBanner": "Aperçu du brouillon du cours. Les élèves ne verront les mises à jour qu’après publication.<editLink>Modifier le cours</editLink>",
   "requestFailed": "La prévisualisation a échoué. Veuillez réessayer plus tard.",
   "streamError": "La connexion de prévisualisation a été interrompue. Veuillez réessayer."
 }

--- a/src/i18n/zh-CN/modules/preview.json
+++ b/src/i18n/zh-CN/modules/preview.json
@@ -5,7 +5,7 @@
   "llmError": "LLM 调用错误",
   "missingApiBaseUrl": "当前环境配置异常，请稍后重试。",
   "previewAll": "预览草稿",
-  "previewModeBanner": "当前链接为预览链接，仅课程发布者可查看",
+  "previewModeBanner": "正在预览课程草稿，发布后学生才能看到更新。<editLink>编辑课程</editLink>",
   "requestFailed": "预览失败，请稍后重试。",
   "streamError": "预览连接已中断，请重试。"
 }


### PR DESCRIPTION
## Summary

- clarify that course preview shows draft content and students see updates only after publication
- add a same-tab editing link that returns teachers to the current lesson when available
- keep the banner readable on mobile and synchronize Chinese, English, and French copy

## Validation

- `npm test -- --runInBand --runTestsByPath 'src/app/c/[[...id]]/Components/PreviewHeaderBanner.test.tsx' 'src/app/c/[[...id]]/Components/ChatUi/ChatUi.test.tsx'`
- `npm run type-check`
- `npm run lint`
- `python3 scripts/check_translations.py`
- `python3 scripts/check_translation_usage.py`
- `lefthook run pre-commit`
- verified desktop and 320px mobile layouts with Playwright


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview mode now clearly explains that draft changes remain hidden until publication.
  - Added a direct “Edit course” link, including lesson-specific navigation when applicable.
  - Improved preview banner sizing and consistency in mobile chat views.

- **Documentation**
  - Updated preview messaging in English, French, and Chinese.

- **Tests**
  - Added coverage for preview visibility, messaging, links, and lesson navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->