### PR TITLE
fix: open draft previews at the lesson being edited

### DIFF
--- a/src/cook-web/src/__tests__/url-utils.test.ts
+++ b/src/cook-web/src/__tests__/url-utils.test.ts
@@ -108,6 +108,14 @@ describe('buildAbsoluteUrlWithLessonId', () => {
       'https://learn.example.com/c/course-1?preview=true&lessonid=lesson-2',
     );
   });
+
+  it('resolves a relative preview url against the browser origin by default', () => {
+    expect(
+      buildAbsoluteUrlWithLessonId('/c/course-1?preview=true', 'lesson-2'),
+    ).toBe(
+      `${window.location.origin}/c/course-1?preview=true&lessonid=lesson-2`,
+    );
+  });
 });
 
 describe('replaceCurrentUrlWithLessonId', () => {

--- a/src/cook-web/src/__tests__/url-utils.test.ts
+++ b/src/cook-web/src/__tests__/url-utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildAbsoluteUrlWithLessonId,
   buildCoursePageUrl,
   buildLoginRedirectPath,
   buildUrlWithLessonId,
@@ -81,6 +82,31 @@ describe('buildUrlWithLessonId', () => {
   it('removes lessonid when the provided value is empty', () => {
     const url = 'https://example.com/c/123?lessonid=lesson-1&listen=1';
     expect(buildUrlWithLessonId(url, '')).toBe('/c/123?listen=1');
+  });
+});
+
+describe('buildAbsoluteUrlWithLessonId', () => {
+  it('adds lessonid while preserving an absolute preview url', () => {
+    expect(
+      buildAbsoluteUrlWithLessonId(
+        'https://preview.example.com/c/course-1?preview=true#outline',
+        'lesson-2',
+      ),
+    ).toBe(
+      'https://preview.example.com/c/course-1?preview=true&lessonid=lesson-2#outline',
+    );
+  });
+
+  it('resolves a relative preview url against the supplied origin', () => {
+    expect(
+      buildAbsoluteUrlWithLessonId(
+        '/c/course-1?preview=true',
+        'lesson-2',
+        'https://learn.example.com',
+      ),
+    ).toBe(
+      'https://learn.example.com/c/course-1?preview=true&lessonid=lesson-2',
+    );
   });
 });
 

--- a/src/cook-web/src/c-utils/urlUtils.ts
+++ b/src/cook-web/src/c-utils/urlUtils.ts
@@ -72,6 +72,25 @@ export const buildUrlWithLessonId = (
   return buildUrlWithQueryParam(url, LESSON_ID_QUERY_KEY, lessonId);
 };
 
+export const buildAbsoluteUrlWithLessonId = (
+  url: string,
+  lessonId: string | null | undefined,
+  origin = typeof window !== 'undefined'
+    ? window.location.origin
+    : FALLBACK_URL_ORIGIN,
+) => {
+  const urlObj = new URL(url, origin);
+  const trimmedLessonId = lessonId?.trim() || '';
+
+  if (trimmedLessonId) {
+    urlObj.searchParams.set(LESSON_ID_QUERY_KEY, trimmedLessonId);
+  } else {
+    urlObj.searchParams.delete(LESSON_ID_QUERY_KEY);
+  }
+
+  return urlObj.toString();
+};
+
 export const replaceCurrentUrlWithLessonId = (
   lessonId: string | null | undefined,
 ) => {

--- a/src/cook-web/src/c-utils/urlUtils.ts
+++ b/src/cook-web/src/c-utils/urlUtils.ts
@@ -31,6 +31,22 @@ const toRelativeUrl = (urlObj: URL) => {
   return `${urlObj.pathname}${urlObj.search}${urlObj.hash}`;
 };
 
+const updateQueryParam = (
+  urlObj: URL,
+  key: string,
+  value: string | null | undefined,
+) => {
+  const trimmedValue = value?.trim() || '';
+
+  if (trimmedValue) {
+    urlObj.searchParams.set(key, trimmedValue);
+  } else {
+    urlObj.searchParams.delete(key);
+  }
+
+  return urlObj;
+};
+
 export const buildCoursePageUrl = (currentUrl: string) => {
   try {
     const url = new URL(currentUrl);
@@ -54,15 +70,7 @@ export const buildUrlWithQueryParam = (
   value: string | null | undefined,
 ) => {
   const urlObj = createUrl(url);
-  const trimmedValue = value?.trim() || '';
-
-  if (trimmedValue) {
-    urlObj.searchParams.set(key, trimmedValue);
-  } else {
-    urlObj.searchParams.delete(key);
-  }
-
-  return toRelativeUrl(urlObj);
+  return toRelativeUrl(updateQueryParam(urlObj, key, value));
 };
 
 export const buildUrlWithLessonId = (
@@ -80,15 +88,7 @@ export const buildAbsoluteUrlWithLessonId = (
     : FALLBACK_URL_ORIGIN,
 ) => {
   const urlObj = new URL(url, origin);
-  const trimmedLessonId = lessonId?.trim() || '';
-
-  if (trimmedLessonId) {
-    urlObj.searchParams.set(LESSON_ID_QUERY_KEY, trimmedLessonId);
-  } else {
-    urlObj.searchParams.delete(LESSON_ID_QUERY_KEY);
-  }
-
-  return urlObj.toString();
+  return updateQueryParam(urlObj, LESSON_ID_QUERY_KEY, lessonId).toString();
 };
 
 export const replaceCurrentUrlWithLessonId = (

--- a/src/cook-web/src/components/preview/Preview.test.tsx
+++ b/src/cook-web/src/components/preview/Preview.test.tsx
@@ -119,6 +119,7 @@ describe('PreviewSettingsModal', () => {
       expect(openSpy).toHaveBeenCalledWith(
         'https://example.com/c/shifu-1?preview=true&lessonid=lesson-1',
         '_blank',
+        'noopener,noreferrer',
       );
     });
 

--- a/src/cook-web/src/components/preview/Preview.test.tsx
+++ b/src/cook-web/src/components/preview/Preview.test.tsx
@@ -26,6 +26,10 @@ jest.mock('@/c-store', () => ({
 
 jest.mock('@/store', () => ({
   useShifu: () => ({
+    currentNode: {
+      bid: 'lesson-1',
+      depth: 1,
+    },
     currentShifu: {
       bid: 'shifu-1',
       readonly: false,
@@ -96,7 +100,7 @@ describe('PreviewSettingsModal', () => {
       },
     });
     (api.previewShifu as jest.Mock).mockResolvedValue(
-      'https://example.com/preview',
+      'https://example.com/c/shifu-1?preview=true',
     );
     const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
 
@@ -112,6 +116,10 @@ describe('PreviewSettingsModal', () => {
     await waitFor(() => {
       expect(mockSaveMdflow).toHaveBeenCalled();
       expect(api.previewShifu).toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com/c/shifu-1?preview=true&lessonid=lesson-1',
+        '_blank',
+      );
     });
 
     openSpy.mockRestore();

--- a/src/cook-web/src/components/preview/Preview.test.tsx
+++ b/src/cook-web/src/components/preview/Preview.test.tsx
@@ -6,6 +6,10 @@ import PreviewSettingsModal from './Preview';
 
 const mockSaveMdflow = jest.fn();
 const mockUseBillingOverview = useBillingOverview as jest.Mock;
+const mockCurrentNode = {
+  bid: 'lesson-1',
+  depth: 1,
+};
 
 jest.mock('@/api', () => ({
   __esModule: true,
@@ -26,10 +30,7 @@ jest.mock('@/c-store', () => ({
 
 jest.mock('@/store', () => ({
   useShifu: () => ({
-    currentNode: {
-      bid: 'lesson-1',
-      depth: 1,
-    },
+    currentNode: mockCurrentNode,
     currentShifu: {
       bid: 'shifu-1',
       readonly: false,
@@ -57,6 +58,7 @@ describe('PreviewSettingsModal', () => {
     mockSaveMdflow.mockReset();
     (api.previewShifu as jest.Mock).mockReset();
     mockUseBillingOverview.mockReset();
+    mockCurrentNode.depth = 1;
   });
 
   it('disables preview when billing softlimit blocks debug', () => {
@@ -118,6 +120,36 @@ describe('PreviewSettingsModal', () => {
       expect(api.previewShifu).toHaveBeenCalled();
       expect(openSpy).toHaveBeenCalledWith(
         'https://example.com/c/shifu-1?preview=true&lessonid=lesson-1',
+        '_blank',
+        'noopener,noreferrer',
+      );
+    });
+
+    openSpy.mockRestore();
+  });
+
+  it('removes a stale lessonid when previewing from a root node', async () => {
+    mockCurrentNode.depth = 0;
+    mockUseBillingOverview.mockReturnValue({
+      data: {
+        debug_allowed: true,
+      },
+    });
+    (api.previewShifu as jest.Mock).mockResolvedValue(
+      'https://example.com/c/shifu-1?preview=true&lessonid=stale-lesson',
+    );
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<PreviewSettingsModal />);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /module.preview.previewAll/,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com/c/shifu-1?preview=true',
         '_blank',
         'noopener,noreferrer',
       );

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -48,6 +48,7 @@ const PreviewSettingsModal = ({ targetId }: PreviewSettingsModalProps) => {
         window.open(
           buildAbsoluteUrlWithLessonId(result, currentLessonId),
           '_blank',
+          'noopener,noreferrer',
         );
       }
     } catch (error) {

--- a/src/cook-web/src/components/preview/Preview.tsx
+++ b/src/cook-web/src/components/preview/Preview.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useTracking } from '@/c-common/hooks/useTracking';
 import { useBillingOverview } from '@/hooks/useBillingData';
 import { buildOnboardingTargetProps } from '@/lib/onboardingTargets';
+import { buildAbsoluteUrlWithLessonId } from '@/c-utils/urlUtils';
 
 type PreviewSettingsModalProps = {
   targetId?: string;
@@ -15,7 +16,7 @@ type PreviewSettingsModalProps = {
 
 const PreviewSettingsModal = ({ targetId }: PreviewSettingsModalProps) => {
   const { t } = useTranslation();
-  const { currentShifu, actions } = useShifu();
+  const { currentNode, currentShifu, actions } = useShifu();
   const { trackEvent } = useTracking();
   const [loading, setLoading] = useState(false);
   const billingEnabled = useEnvStore(state => state.billingEnabled === 'true');
@@ -42,7 +43,12 @@ const PreviewSettingsModal = ({ targetId }: PreviewSettingsModalProps) => {
         variables: {},
       });
       if (result) {
-        window.open(result, '_blank');
+        const currentLessonId =
+          (currentNode?.depth ?? 0) > 0 ? currentNode?.bid : undefined;
+        window.open(
+          buildAbsoluteUrlWithLessonId(result, currentLessonId),
+          '_blank',
+        );
       }
     } catch (error) {
       console.error('Preview failed:', error);


### PR DESCRIPTION
## What changed

- add the current editor lesson as the `lessonid` parameter when opening a draft preview
- preserve the preview host, existing query parameters, and URL hash
- cover absolute and relative preview URLs with focused regression tests

## Why

The draft preview API returns a course-level URL, so the preview page previously chose its default lesson instead of the lesson the teacher was actively editing.

## Impact

Teachers now land directly on the lesson they are editing when they click **Preview draft**.

## Verification

- `npm run test -- --runTestsByPath src/components/preview/Preview.test.tsx src/__tests__/url-utils.test.ts`
- `npm run type-check`
- repository pre-commit and commit-message hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview links now include the current lesson ID when opening nested lesson content.
  * Relative preview links are resolved into absolute URLs while preserving query parameters and fragments.
  * Lesson IDs are added, trimmed, or removed as needed when building preview URLs.

* **Bug Fixes**
  * Improved preview navigation reliability with secure new-window behavior.
  * Prevented stale lesson IDs from appearing when previewing content from a root node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->