### PR TITLE
refactor: tighten learner chat prop types

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -24,6 +24,13 @@ import LessonUpdateNotice from '../LessonUpdateNotice';
 import LessonPdfDownloadButton, {
   type LessonPdfDownloadAction,
 } from './LessonPdfDownloadButton';
+import type {
+  ChapterNavigationHandler,
+  ChapterUpdateHandler,
+  LessonSelectionUpdater,
+  LessonUpdateHandler,
+  NextLessonIdGetter,
+} from './useChatLogicHook.types';
 
 const ChatComponents = dynamic(() => import('./NewChatComp'), {
   ssr: false,
@@ -33,8 +40,8 @@ interface ChatUiProps {
   courseId: string;
   chapterId: string;
   lessonId?: string;
-  lessonUpdate: (val: any) => void;
-  onGoChapter: (id: any) => void;
+  lessonUpdate: LessonUpdateHandler;
+  onGoChapter: ChapterNavigationHandler;
   onPurchased: () => void;
   lessonTitle?: string;
   lessonStatus?: string;
@@ -43,9 +50,9 @@ interface ChatUiProps {
   userSettingBasicInfo?: boolean;
   onUserSettingsClose?: () => void;
   onMobileSettingClick?: () => void;
-  chapterUpdate: any;
-  updateSelectedLesson: any;
-  getNextLessonId: any;
+  chapterUpdate: ChapterUpdateHandler;
+  updateSelectedLesson: LessonSelectionUpdater;
+  getNextLessonId: NextLessonIdGetter;
   isNavOpen?: boolean;
   onListenMobileViewModeChange?: ListenMobileViewModeChangeHandler;
   showGenerateBtn?: boolean;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -92,6 +92,13 @@ import {
 import { useLessonPdfPrint } from './useLessonPdfPrint';
 import LessonPdfPreparingOverlay from './LessonPdfPreparingOverlay';
 import { buildCoursePageUrl } from '@/c-utils/urlUtils';
+import type {
+  ChapterNavigationHandler,
+  ChapterUpdateHandler,
+  LessonSelectionUpdater,
+  LessonUpdateHandler,
+  NextLessonIdGetter,
+} from './useChatLogicHook.types';
 
 const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
 
@@ -103,17 +110,17 @@ const LISTEN_AUDIO_BACKFILL_CONCURRENCY = 3;
 
 interface NewChatComponentsProps {
   className?: string;
-  lessonUpdate: (val: any) => void;
-  onGoChapter: (id: any) => void;
+  lessonUpdate: LessonUpdateHandler;
+  onGoChapter: ChapterNavigationHandler;
   chapterId: string;
   lessonId?: string;
   lessonTitle?: string;
   lessonStatus?: string;
   lessonHasContentUpdate?: boolean;
   onPurchased: () => void;
-  chapterUpdate: any;
-  updateSelectedLesson: any;
-  getNextLessonId: any;
+  chapterUpdate: ChapterUpdateHandler;
+  updateSelectedLesson: LessonSelectionUpdater;
+  getNextLessonId: NextLessonIdGetter;
   previewMode?: boolean;
   isNavOpen?: boolean;
   onListenPlayerVisibilityChange?: (visible: boolean) => void;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
@@ -27,6 +27,28 @@ export interface RequestAudioForBlockOptions {
 
 export type TtsStreamCancel = (options?: { updateState?: boolean }) => void;
 
+export interface LessonUpdatePayload {
+  id: string;
+  name?: string;
+  status?: string;
+  status_value?: string;
+}
+
+export interface ChapterUpdatePayload {
+  id: string;
+  status: string;
+  status_value: string;
+}
+
+export type LessonUpdateHandler = (params: LessonUpdatePayload) => void;
+export type ChapterUpdateHandler = (params: ChapterUpdatePayload) => void;
+export type LessonSelectionUpdater = (
+  lessonId: string,
+  forceExpand?: boolean,
+) => void | Promise<void>;
+export type NextLessonIdGetter = (lessonId?: string | null) => string | null;
+export type ChapterNavigationHandler = (lessonId: string) => void;
+
 export interface UseChatSessionParams {
   shifuBid: string;
   outlineBid: string;
@@ -39,14 +61,14 @@ export interface UseChatSessionParams {
   shouldPromptLessonFeedback?: boolean;
   trackEvent: (name: string, payload?: Record<string, any>) => void;
   trackTrailProgress: (courseId: string, elementBid: string) => void;
-  lessonUpdate?: (params: Record<string, any>) => void;
-  chapterUpdate?: (params: Record<string, any>) => void;
-  updateSelectedLesson: (lessonId: string, forceExpand?: boolean) => void;
-  getNextLessonId: (lessonId?: string | null) => string | null;
+  lessonUpdate?: LessonUpdateHandler;
+  chapterUpdate?: ChapterUpdateHandler;
+  updateSelectedLesson: LessonSelectionUpdater;
+  getNextLessonId: NextLessonIdGetter;
   scrollToLesson: (lessonId: string) => void;
   showOutputInProgressToast: () => void;
   onPayModalOpen: () => void;
-  onGoChapter: (lessonId: string) => void;
+  onGoChapter: ChapterNavigationHandler;
 }
 
 export interface UseChatSessionResult {


### PR DESCRIPTION
## Summary
- Replace broad `any` callback props in `ChatUi` and `NewChatComp` with shared learner chat handler types.
- Add explicit lesson update, chapter update, lesson selection, next-lesson lookup, and chapter navigation type aliases.
- Validate with focused ChatUi/NewChatComp tests and `npm run type-check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for chat interactions, including lesson updates, chapter navigation, lesson selection, and next-lesson retrieval.
  * Standardized callback data and handler definitions across chat components for more reliable behavior and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->