### PR TITLE
test: organize learner chat hook helpers

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1,9 +1,16 @@
-import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { toast, toastOnce } from '@/hooks/useToast';
 import useChatLogicHook, { ChatContentItemType } from './useChatLogicHook';
-import { AppContext } from '../AppContext';
 import { SSE_INPUT_TYPE, SSE_OUTPUT_TYPE } from '@/c-api/studyV2';
+import {
+  buildBaseParams,
+  createDeferred,
+  mobileWrapper,
+  MockRunSource,
+  wrapper,
+  type ActiveRun,
+  type RunRequestBody,
+} from './useChatLogicHook.testUtils';
 import { stopAllActiveLessonStreams } from '@/app/c/[[...id]]/events';
 import { useLessonRunContentStore } from '@/c-store/useLessonRunContentStore';
 
@@ -171,39 +178,8 @@ jest.mock('@/c-api/studyV2', () => {
   };
 });
 
-type Listener = (event?: Event) => void;
-
-class MockRunSource {
-  readyState = 0;
-
-  private listeners = new Map<string, Listener[]>();
-
-  addEventListener = jest.fn((type: string, listener: Listener) => {
-    const existing = this.listeners.get(type) ?? [];
-    existing.push(listener);
-    this.listeners.set(type, existing);
-  });
-
-  close = jest.fn(() => {
-    this.readyState = 2;
-    this.emit('readystatechange');
-  });
-
-  emit(type: string, event?: Event) {
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
-
 describe('useChatLogicHook stream cleanup', () => {
-  let activeRun:
-    | {
-        source: MockRunSource;
-        onMessage: (response: any) => Promise<void> | void;
-        onError: (error: unknown) => void;
-      }
-    | undefined;
+  let activeRun: ActiveRun | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -232,10 +208,7 @@ describe('useChatLogicHook stream cleanup', () => {
         _shifuBid: string,
         _outlineBid: string,
         _previewMode: boolean,
-        _body: {
-          input: string | Record<string, any>;
-          input_type: SSE_INPUT_TYPE;
-        },
+        _body: RunRequestBody,
         onMessage: (response: any) => Promise<void> | void,
         onError: (error: unknown) => void,
       ) => {
@@ -248,59 +221,6 @@ describe('useChatLogicHook stream cleanup', () => {
         return source;
       },
     );
-  });
-
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <AppContext.Provider
-      value={{
-        isLoggedIn: false,
-        mobileStyle: false,
-        userInfo: null,
-        theme: 'light',
-        frameLayout: 0,
-      }}
-    >
-      {children}
-    </AppContext.Provider>
-  );
-
-  const mobileWrapper = ({ children }: { children: React.ReactNode }) => (
-    <AppContext.Provider
-      value={{
-        isLoggedIn: false,
-        mobileStyle: true,
-        userInfo: null,
-        theme: 'light',
-        frameLayout: 0,
-      }}
-    >
-      {children}
-    </AppContext.Provider>
-  );
-
-  const createDeferred = <T,>() => {
-    let resolve!: (value: T) => void;
-    const promise = new Promise<T>(next => {
-      resolve = next;
-    });
-    return { promise, resolve };
-  };
-
-  const buildBaseParams = () => ({
-    shifuBid: 'shifu-1',
-    outlineBid: 'lesson-1',
-    lessonId: 'lesson-1',
-    lessonHasContentUpdate: false,
-    trackEvent: jest.fn(),
-    trackTrailProgress: jest.fn(),
-    lessonUpdate: jest.fn(),
-    chapterUpdate: jest.fn(),
-    updateSelectedLesson: jest.fn(),
-    getNextLessonId: jest.fn(() => null),
-    scrollToLesson: jest.fn(),
-    showOutputInProgressToast: jest.fn(),
-    onPayModalOpen: jest.fn(),
-    onGoChapter: jest.fn(),
   });
 
   it('sends listen=false in the run body when listen requests are disabled', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.testUtils.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.testUtils.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { AppContext } from '../AppContext';
+import type { SSE_INPUT_TYPE } from '@/c-api/studyV2';
+import type { UseChatSessionParams } from './useChatLogicHook.types';
+
+type Listener = (event?: Event) => void;
+
+export class MockRunSource {
+  readyState = 0;
+
+  private listeners = new Map<string, Listener[]>();
+
+  addEventListener = jest.fn((type: string, listener: Listener) => {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  });
+
+  close = jest.fn(() => {
+    this.readyState = 2;
+    this.emit('readystatechange');
+  });
+
+  emit(type: string, event?: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+export type ActiveRun = {
+  source: MockRunSource;
+  onMessage: (response: unknown) => Promise<void> | void;
+  onError: (error: unknown) => void;
+};
+
+const buildAppContextWrapper = (mobileStyle: boolean) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <AppContext.Provider
+      value={{
+        isLoggedIn: false,
+        mobileStyle,
+        userInfo: null,
+        theme: 'light',
+        frameLayout: 0,
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+  Wrapper.displayName = mobileStyle
+    ? 'MobileChatHookWrapper'
+    : 'ChatHookWrapper';
+  return Wrapper;
+};
+
+export const wrapper = buildAppContextWrapper(false);
+export const mobileWrapper = buildAppContextWrapper(true);
+
+export const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(next => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
+export const buildBaseParams = (): UseChatSessionParams => ({
+  shifuBid: 'shifu-1',
+  outlineBid: 'lesson-1',
+  lessonId: 'lesson-1',
+  lessonHasContentUpdate: false,
+  trackEvent: jest.fn(),
+  trackTrailProgress: jest.fn(),
+  lessonUpdate: jest.fn(),
+  chapterUpdate: jest.fn(),
+  updateSelectedLesson: jest.fn(),
+  getNextLessonId: jest.fn(() => null),
+  scrollToLesson: jest.fn(),
+  showOutputInProgressToast: jest.fn(),
+  onPayModalOpen: jest.fn(),
+  onGoChapter: jest.fn(),
+});
+
+export type RunRequestBody = {
+  input: string | Record<string, unknown>;
+  input_type: SSE_INPUT_TYPE;
+};

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.testUtils.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.testUtils.tsx
@@ -35,7 +35,7 @@ export type ActiveRun = {
 };
 
 const buildAppContextWrapper = (mobileStyle: boolean) => {
-  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <AppContext.Provider
       value={{
         isLoggedIn: false,


### PR DESCRIPTION
## Summary
- Move shared `useChatLogicHook` test wrappers, base params, deferred helper, and mock run-source helper into `useChatLogicHook.testUtils.tsx`.
- Keep existing `useChatLogicHook` assertions and runtime code unchanged.
- Validate with focused learner chat hook tests, related ChatUi tests, lint-file, and type-check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared test utilities for chat logic scenarios.
  * Simplified chat logic test setup by reusing common wrappers, mocks, and helper types.
  * Improved support for testing desktop and mobile chat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->