### PR TITLE
refactor: organize shifu setting config helpers

### DIFF
--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -103,6 +103,12 @@ import {
   type TtsModelOption,
 } from '@/components/shifu-setting/tts-model-options';
 import {
+  normalizeAskProviders,
+  normalizeTtsProviders,
+  type AskConfigMetadata,
+  type TTSProviderConfig,
+} from '@/components/shifu-setting/settings-config-options';
+import {
   buildOnboardingTargetProps,
   ONBOARDING_TARGET_IDS,
 } from '@/lib/onboardingTargets';
@@ -422,60 +428,12 @@ export default function ShifuSettingDialog({
   );
 
   // TTS Config from backend
-  interface AskProviderConfigItem {
-    provider: string;
-    title: string;
-    description?: string;
-    default_config?: Record<string, any>;
-    json_schema?: {
-      properties?: Record<string, any>;
-      required?: string[];
-    };
-  }
-  interface AskConfigMetadata {
-    feature_enabled?: boolean;
-    default?: {
-      provider?: string;
-      mode?: string;
-      config?: Record<string, any>;
-    };
-    modes?: Array<{ value: string; title: string }>;
-    providers?: AskProviderConfigItem[];
-  }
-  interface TTSProviderConfig {
-    name: string;
-    label: string;
-    speed: { min: number; max: number; step: number; default: number };
-    pitch: { min: number; max: number; step: number; default: number };
-    supports_emotion: boolean;
-    supports_custom_voice_id?: boolean;
-    supports_voice_cloning?: boolean;
-    models: { value: string; label: string }[];
-    voices: { value: string; label: string; resource_id?: string }[];
-    emotions: { value: string; label: string }[];
-  }
   const [ttsConfig, setTtsConfig] = useState<{
     providers: TTSProviderConfig[];
     model_options: TtsModelOption[];
   } | null>(null);
   const [askConfigMeta, setAskConfigMeta] = useState<AskConfigMetadata | null>(
     null,
-  );
-  const normalizeTtsProviders = useCallback(
-    (providers?: TTSProviderConfig[] | null): TTSProviderConfig[] =>
-      (providers ?? []).map(provider => ({
-        ...provider,
-        name: (provider.name || '').toLowerCase(),
-      })),
-    [],
-  );
-  const normalizeAskProviders = useCallback(
-    (providers?: AskProviderConfigItem[] | null): AskProviderConfigItem[] =>
-      (providers ?? []).map(provider => ({
-        ...provider,
-        provider: (provider.provider || '').toLowerCase(),
-      })),
-    [],
   );
 
   // Fetch TTS config from backend
@@ -511,7 +469,7 @@ export default function ShifuSettingDialog({
     return () => {
       cancelled = true;
     };
-  }, [currentLanguage, normalizeAskProviders, normalizeTtsProviders]);
+  }, [currentLanguage]);
 
   const refreshMinimaxVoiceData = useCallback(async () => {
     if (!shifuId) return;

--- a/src/cook-web/src/components/shifu-setting/settings-config-options.test.ts
+++ b/src/cook-web/src/components/shifu-setting/settings-config-options.test.ts
@@ -1,0 +1,68 @@
+import {
+  normalizeAskProviders,
+  normalizeTtsProviders,
+} from './settings-config-options';
+
+describe('settings-config-options', () => {
+  it('normalizes TTS provider names while preserving provider config', () => {
+    expect(
+      normalizeTtsProviders([
+        {
+          name: 'MiniMax',
+          label: 'MiniMax',
+          speed: { min: 0.5, max: 2, step: 0.1, default: 1 },
+          pitch: { min: -12, max: 12, step: 1, default: 0 },
+          supports_emotion: true,
+          supports_voice_cloning: true,
+          models: [{ value: 'speech-2.8-turbo', label: 'Speech' }],
+          voices: [{ value: 'voice-1', label: 'Voice 1' }],
+          emotions: [{ value: 'happy', label: 'Happy' }],
+        },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        name: 'minimax',
+        label: 'MiniMax',
+        supports_voice_cloning: true,
+        models: [{ value: 'speech-2.8-turbo', label: 'Speech' }],
+      }),
+    ]);
+  });
+
+  it('normalizes ask provider ids while preserving schema metadata', () => {
+    expect(
+      normalizeAskProviders([
+        {
+          provider: 'OpenAI',
+          title: 'OpenAI',
+          description: 'Provider description',
+          default_config: { model: 'gpt-test' },
+          json_schema: {
+            properties: {
+              model: { type: 'string', title: 'Model' },
+            },
+            required: ['model'],
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        provider: 'openai',
+        title: 'OpenAI',
+        description: 'Provider description',
+        default_config: { model: 'gpt-test' },
+        json_schema: {
+          properties: {
+            model: { type: 'string', title: 'Model' },
+          },
+          required: ['model'],
+        },
+      },
+    ]);
+  });
+
+  it('handles missing provider lists', () => {
+    expect(normalizeTtsProviders(null)).toEqual([]);
+    expect(normalizeAskProviders(undefined)).toEqual([]);
+  });
+});

--- a/src/cook-web/src/components/shifu-setting/settings-config-options.ts
+++ b/src/cook-web/src/components/shifu-setting/settings-config-options.ts
@@ -1,0 +1,49 @@
+import type { AskProviderJsonSchema } from './ask-provider-schema';
+
+export interface AskProviderConfigItem {
+  provider: string;
+  title: string;
+  description?: string;
+  default_config?: Record<string, unknown>;
+  json_schema?: AskProviderJsonSchema;
+}
+
+export interface AskConfigMetadata {
+  feature_enabled?: boolean;
+  default?: {
+    provider?: string;
+    mode?: string;
+    config?: Record<string, unknown>;
+  };
+  modes?: Array<{ value: string; title: string }>;
+  providers?: AskProviderConfigItem[];
+}
+
+export interface TTSProviderConfig {
+  name: string;
+  label: string;
+  speed: { min: number; max: number; step: number; default: number };
+  pitch: { min: number; max: number; step: number; default: number };
+  supports_emotion: boolean;
+  supports_custom_voice_id?: boolean;
+  supports_voice_cloning?: boolean;
+  models: { value: string; label: string }[];
+  voices: { value: string; label: string; resource_id?: string }[];
+  emotions: { value: string; label: string }[];
+}
+
+export const normalizeTtsProviders = (
+  providers?: TTSProviderConfig[] | null,
+): TTSProviderConfig[] =>
+  (providers ?? []).map(provider => ({
+    ...provider,
+    name: (provider.name || '').toLowerCase(),
+  }));
+
+export const normalizeAskProviders = (
+  providers?: AskProviderConfigItem[] | null,
+): AskProviderConfigItem[] =>
+  (providers ?? []).map(provider => ({
+    ...provider,
+    provider: (provider.provider || '').toLowerCase(),
+  }));


### PR DESCRIPTION
## Summary
- Move TTS and ask provider config normalization helpers out of `ShifuSetting.tsx` into `settings-config-options.ts`.
- Keep `ShifuSetting` state, UI, and fetch behavior unchanged.
- Add focused regression coverage for provider id normalization and empty config handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved settings configuration handling for Ask and text-to-speech providers.
  - Provider identifiers are now normalized consistently, helping settings display and operate reliably across configurations.
  - Configurations with unavailable provider lists are handled gracefully without disrupting the settings experience.
  - Existing provider metadata and schema details are preserved during normalization.

- **Tests**
  - Added coverage for provider name normalization, metadata preservation, and missing provider lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->