### PR TITLE
refactor: extract course detail header

### DIFF
--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseDetailHeader.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/CourseDetailHeader.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import AdminTitle from '@/app/admin/components/AdminTitle';
+import AdminOperationsBreadcrumb from '../AdminOperationsBreadcrumb';
+
+type CourseDetailHeaderProps = {
+  operationsLabel: string;
+  detailLabel: string;
+};
+
+export default function CourseDetailHeader({
+  operationsLabel,
+  detailLabel,
+}: CourseDetailHeaderProps) {
+  return (
+    <>
+      <AdminOperationsBreadcrumb
+        items={[
+          {
+            label: operationsLabel,
+            href: '/admin/operations',
+          },
+          { label: detailLabel },
+        ]}
+      />
+      <AdminTitle title={detailLabel} />
+    </>
+  );
+}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import api from '@/api';
-import AdminTitle from '@/app/admin/components/AdminTitle';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import { formatAdminCount } from '@/app/admin/lib/numberFormat';
@@ -16,7 +15,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { fail, show } from '@/hooks/useToast';
 import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
-import AdminOperationsBreadcrumb from '../AdminOperationsBreadcrumb';
 import {
   buildAdminOperationsCourseFollowUpsUrl,
   buildAdminOperationsOrdersUrl,
@@ -39,6 +37,7 @@ import CourseChaptersTab, {
   type FlattenedChapterRow,
 } from './CourseChaptersTab';
 import CourseBasicInfoCard from './CourseBasicInfoCard';
+import CourseDetailHeader from './CourseDetailHeader';
 import CourseCreditUsageTab from './CourseCreditUsageTab';
 import CourseMetricsCardGrid from './CourseMetricsCardGrid';
 import CourseUsersTab from './CourseUsersTab';
@@ -1505,16 +1504,10 @@ export default function AdminOperationCourseDetailPage() {
   return (
     <div className='h-full min-h-0 overflow-hidden bg-stone-50 p-0 overscroll-none'>
       <div className='mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col overflow-hidden'>
-        <AdminOperationsBreadcrumb
-          items={[
-            {
-              label: tOperations('title'),
-              href: '/admin/operations',
-            },
-            { label: tOperations('detail.title') },
-          ]}
+        <CourseDetailHeader
+          operationsLabel={tOperations('title')}
+          detailLabel={tOperations('detail.title')}
         />
-        <AdminTitle title={tOperations('detail.title')} />
 
         <div className='min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-y-contain pr-1'>
           <div className='space-y-5 pb-6'>


### PR DESCRIPTION
## Summary
- Extract the admin course detail breadcrumb/title block into `CourseDetailHeader`.
- Keep course detail page state, requests, tabs, metrics, and dialogs unchanged.
- Validate with the focused course detail page test, lint-file, and type-check.
