### PR TITLE
refactor: centralize learner access rules

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseSection.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/CourseCatalog/CourseSection.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useTranslation } from 'react-i18next';
 import { useSystemStore } from '@/c-store/useSystemStore';
+import { resolveLearnerLessonAccess } from '../../learnerAccessRules';
 
 type CourseSectionProps = {
   id: string;
@@ -85,22 +86,25 @@ export const CourseSection = ({
       return;
     }
 
-    const needsLogin =
-      (type === LEARNING_PERMISSION.TRIAL ||
-        type === LEARNING_PERMISSION.NORMAL) &&
-      !isLoggedIn;
-    if (!previewMode && needsLogin) {
-      window.location.href = `/login?redirect=${encodeURIComponent(location.pathname + location.search)}`;
+    const access = resolveLearnerLessonAccess({
+      type,
+      isPaid: is_paid,
+      isLoggedIn,
+      previewMode,
+      chapterId,
+      lessonId: id,
+      currentPathAndSearch: location.pathname + location.search,
+    });
+
+    if (access.type === 'login') {
+      window.location.href = access.redirectUrl;
       return;
     }
 
-    if (!previewMode && type === LEARNING_PERMISSION.NORMAL && !is_paid) {
+    if (access.type === 'pay') {
       openPayModal({
-        type,
-        payload: {
-          chapterId,
-          lessonId: id,
-        },
+        type: access.modalType,
+        payload: access.payload,
       });
       return;
     }

--- a/src/cook-web/src/app/c/[[...id]]/hooks/useLessonTree.ts
+++ b/src/cook-web/src/app/c/[[...id]]/hooks/useLessonTree.ts
@@ -5,11 +5,11 @@ import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import { useTracking, EVENT_NAMES } from '@/c-common/hooks/useTracking';
 import { useEnvStore } from '@/c-store/envStore';
 import { useSystemStore } from '@/c-store/useSystemStore';
-import { LEARNING_PERMISSION } from '@/c-api/studyV2';
 import { useUserStore } from '@/store';
 import { useCourseStore } from '@/c-store/useCourseStore';
 import { useShallow } from 'zustand/react/shallow';
 import { debugError, debugInfo, debugWarn } from '@/c-utils/debugConsole';
+import { resolveLearnerLessonAccess } from '../learnerAccessRules';
 
 type LessonTreeApiLesson = {
   bid: string;
@@ -130,26 +130,25 @@ export const useLessonTree = () => {
 
   const ensureLessonAccessible = useCallback(
     (lesson: LessonTreeLesson, chapterId: string) => {
-      const needsLogin =
-        (lesson.type === LEARNING_PERMISSION.TRIAL ||
-          lesson.type === LEARNING_PERMISSION.NORMAL) &&
-        !isLoggedIn;
-      if (!previewMode && needsLogin) {
-        window.location.href = `/login?redirect=${encodeURIComponent(location.pathname + location.search)}`;
+      const access = resolveLearnerLessonAccess({
+        type: lesson.type,
+        isPaid: lesson.is_paid,
+        isLoggedIn,
+        previewMode,
+        chapterId,
+        lessonId: lesson.id,
+        currentPathAndSearch: location.pathname + location.search,
+      });
+
+      if (access.type === 'login') {
+        window.location.href = access.redirectUrl;
         return false;
       }
 
-      if (
-        !previewMode &&
-        lesson.type === LEARNING_PERMISSION.NORMAL &&
-        !lesson.is_paid
-      ) {
+      if (access.type === 'pay') {
         openPayModal({
-          type: lesson.type,
-          payload: {
-            chapterId,
-            lessonId: lesson.id,
-          },
+          type: access.modalType,
+          payload: access.payload,
         });
         return false;
       }

--- a/src/cook-web/src/app/c/[[...id]]/learnerAccessRules.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/learnerAccessRules.test.ts
@@ -1,0 +1,100 @@
+import {
+  buildLearnerLoginRedirectUrl,
+  resolveLearnerLessonAccess,
+} from './learnerAccessRules';
+
+const LEARNING_PERMISSION = {
+  NORMAL: 'normal',
+  TRIAL: 'trial',
+  GUEST: 'guest',
+} as const;
+
+const baseInput = {
+  type: LEARNING_PERMISSION.NORMAL,
+  isPaid: false,
+  isLoggedIn: true,
+  previewMode: false,
+  chapterId: 'chapter-1',
+  lessonId: 'lesson-1',
+  currentPathAndSearch: '/c/course-1?lessonid=lesson-1',
+};
+
+describe('resolveLearnerLessonAccess', () => {
+  it('sends guests to login for trial lessons outside preview mode', () => {
+    expect(
+      resolveLearnerLessonAccess({
+        ...baseInput,
+        type: LEARNING_PERMISSION.TRIAL,
+        isLoggedIn: false,
+        isPaid: true,
+      }),
+    ).toEqual({
+      type: 'login',
+      redirectUrl: '/login?redirect=%2Fc%2Fcourse-1%3Flessonid%3Dlesson-1',
+    });
+  });
+
+  it('sends guests to login before payment for normal unpaid lessons', () => {
+    expect(
+      resolveLearnerLessonAccess({
+        ...baseInput,
+        type: LEARNING_PERMISSION.NORMAL,
+        isLoggedIn: false,
+        isPaid: false,
+      }),
+    ).toMatchObject({ type: 'login' });
+  });
+
+  it('opens payment for logged-in learners on normal unpaid lessons', () => {
+    expect(resolveLearnerLessonAccess(baseInput)).toEqual({
+      type: 'pay',
+      modalType: LEARNING_PERMISSION.NORMAL,
+      payload: {
+        chapterId: 'chapter-1',
+        lessonId: 'lesson-1',
+      },
+    });
+  });
+
+  it('allows guest lessons without login or payment', () => {
+    expect(
+      resolveLearnerLessonAccess({
+        ...baseInput,
+        type: LEARNING_PERMISSION.GUEST,
+        isLoggedIn: false,
+        isPaid: false,
+      }),
+    ).toEqual({ type: 'allow' });
+  });
+
+  it('allows every permission check in preview mode', () => {
+    expect(
+      resolveLearnerLessonAccess({
+        ...baseInput,
+        type: LEARNING_PERMISSION.NORMAL,
+        isLoggedIn: false,
+        isPaid: false,
+        previewMode: true,
+      }),
+    ).toEqual({ type: 'allow' });
+  });
+
+  it('allows logged-in learners on paid normal lessons', () => {
+    expect(
+      resolveLearnerLessonAccess({
+        ...baseInput,
+        type: LEARNING_PERMISSION.NORMAL,
+        isLoggedIn: true,
+        isPaid: true,
+      }),
+    ).toEqual({ type: 'allow' });
+  });
+});
+
+describe('buildLearnerLoginRedirectUrl', () => {
+  it('keeps the current path and query in the redirect parameter', () => {
+    expect(buildLearnerLoginRedirectUrl('/c/course-1?mode=listen')).toBe(
+      '/login?redirect=%2Fc%2Fcourse-1%3Fmode%3Dlisten',
+    );
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/learnerAccessRules.ts
+++ b/src/cook-web/src/app/c/[[...id]]/learnerAccessRules.ts
@@ -1,0 +1,59 @@
+import type { LearningPermission } from '@/c-api/studyV2';
+
+const TRIAL_PERMISSION: LearningPermission = 'trial';
+const NORMAL_PERMISSION: LearningPermission = 'normal';
+
+export type LearnerLessonAccessAction =
+  | { type: 'allow' }
+  | { type: 'login'; redirectUrl: string }
+  | {
+      type: 'pay';
+      modalType: LearningPermission | string;
+      payload: { chapterId: string; lessonId: string };
+    };
+
+export type LearnerLessonAccessInput = {
+  type?: LearningPermission | string;
+  isPaid?: boolean;
+  isLoggedIn: boolean;
+  previewMode: boolean;
+  chapterId: string;
+  lessonId: string;
+  currentPathAndSearch: string;
+};
+
+export const buildLearnerLoginRedirectUrl = (currentPathAndSearch: string) =>
+  `/login?redirect=${encodeURIComponent(currentPathAndSearch)}`;
+
+export const resolveLearnerLessonAccess = ({
+  type,
+  isPaid,
+  isLoggedIn,
+  previewMode,
+  chapterId,
+  lessonId,
+  currentPathAndSearch,
+}: LearnerLessonAccessInput): LearnerLessonAccessAction => {
+  const needsLogin =
+    (type === TRIAL_PERMISSION || type === NORMAL_PERMISSION) && !isLoggedIn;
+
+  if (!previewMode && needsLogin) {
+    return {
+      type: 'login',
+      redirectUrl: buildLearnerLoginRedirectUrl(currentPathAndSearch),
+    };
+  }
+
+  if (!previewMode && type === NORMAL_PERMISSION && !isPaid) {
+    return {
+      type: 'pay',
+      modalType: type,
+      payload: {
+        chapterId,
+        lessonId,
+      },
+    };
+  }
+
+  return { type: 'allow' };
+};


### PR DESCRIPTION
# Summary

- Centralize the existing learner lesson access decision for login and payment into `learnerAccessRules`.
- Reuse the shared decision from both lesson tree selection and course catalog clicks.
- Add characterization tests for the current matrix: guest trial, guest normal unpaid, logged-in normal unpaid, guest lessons, preview mode, and paid normal lessons.

Business behavior preserved:
- Preview mode still bypasses login and payment gates.
- Guest trial and normal lessons still redirect to login.
- Logged-in normal unpaid lessons still open the pay modal with the same payload shape.
- Guest lessons still remain selectable without login or payment.

Validation:
- `cd src/cook-web && npm test -- --runTestsByPath 'src/app/c/[[...id]]/learnerAccessRules.test.ts'`
- `cd src/cook-web && npm run type-check -- --pretty false`
- `cd src/cook-web && npm run lint-file -- 'src/app/c/[[...id]]/learnerAccessRules.ts' 'src/app/c/[[...id]]/learnerAccessRules.test.ts' 'src/app/c/[[...id]]/hooks/useLessonTree.ts' 'src/app/c/[[...id]]/Components/CourseCatalog/CourseSection.tsx'`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- pre-commit via `PATH="$HOME/.local/bin:$PATH" git commit ...`
