### PR TITLE
refactor: centralize ask provider config

### DIFF
--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -81,6 +81,15 @@ import {
   AskProviderSchemaValidationError,
   buildAskProviderConfigForSubmit as buildAskProviderConfigBySchema,
 } from '@/components/shifu-setting/ask-provider-schema';
+import {
+  ASK_PROVIDER_LLM,
+  buildAskProviderSubmitConfig,
+  getAskProviderDefaultConfig as getAskProviderDefaultConfigFromMeta,
+  getAskProviderMeta,
+  normalizeStoredAskProviderConfig,
+  resolveAskProvider,
+  resolveAskProviderSelection,
+} from '@/components/shifu-setting/ask-provider-config';
 import AskSettingsSection from '@/components/shifu-setting/AskSettingsSection';
 import MiniMaxVoiceCloneDialog from '@/components/shifu-setting/MiniMaxVoiceCloneDialog';
 import {
@@ -163,8 +172,6 @@ const MIN_SHIFU_PRICE = 0.5;
 const TEMPERATURE_MIN = 0;
 const TEMPERATURE_MAX = 2;
 const ASK_MODE_ENABLE = 5103;
-const ASK_PROVIDER_LLM = 'llm';
-const ASK_PROVIDER_MODE_PROVIDER_ONLY = 'provider_only';
 const ASK_TEMPERATURE_MIN = 0;
 const ASK_TEMPERATURE_MAX = 2;
 const TTS_PREVIEW_CURRENT_TARGET = 'tts-current';
@@ -726,23 +733,11 @@ export default function ShifuSettingDialog({
       value: item.provider,
       label: item.title || item.provider,
     })) || [];
-  const resolvedAskProvider = (() => {
-    const provider = (askProvider || '').trim().toLowerCase();
-    if (!provider) {
-      return askConfigMeta?.providers?.[0]?.provider || ASK_PROVIDER_LLM;
-    }
-    if (askConfigMeta?.providers?.length) {
-      const exists = askConfigMeta.providers.some(p => p.provider === provider);
-      return exists
-        ? provider
-        : askConfigMeta.providers[0]?.provider || provider;
-    }
-    return provider;
-  })();
-  const currentAskProviderMeta =
-    askConfigMeta?.providers?.find(
-      item => item.provider === resolvedAskProvider,
-    ) || askConfigMeta?.providers?.[0];
+  const resolvedAskProvider = resolveAskProvider(askConfigMeta, askProvider);
+  const currentAskProviderMeta = getAskProviderMeta(
+    askConfigMeta,
+    resolvedAskProvider,
+  );
   const askProviderFieldEntries = useMemo(
     () => Object.entries(currentAskProviderMeta?.json_schema?.properties || {}),
     [currentAskProviderMeta],
@@ -752,14 +747,8 @@ export default function ShifuSettingDialog({
     [currentAskProviderMeta],
   );
   const getAskProviderDefaultConfig = useCallback(
-    (provider: string) => {
-      const config =
-        askConfigMeta?.providers?.find(item => item.provider === provider)
-          ?.default_config || {};
-      return config && typeof config === 'object' && !Array.isArray(config)
-        ? { ...config }
-        : {};
-    },
+    (provider: string) =>
+      getAskProviderDefaultConfigFromMeta(askConfigMeta, provider),
     [askConfigMeta],
   );
   const handleAskProviderChange = useCallback(
@@ -786,18 +775,14 @@ export default function ShifuSettingDialog({
 
   useEffect(() => {
     if (!askConfigMeta?.providers?.length) return;
-    const provider = (askProvider || '').trim().toLowerCase();
-    if (
-      provider &&
-      askConfigMeta.providers.some(item => item.provider === provider)
-    ) {
+    const selection = resolveAskProviderSelection(askConfigMeta, askProvider);
+    if (!selection.changed) {
       return;
     }
-    const fallbackProvider = askConfigMeta.providers[0].provider;
-    setAskProvider(fallbackProvider);
-    setAskProviderConfig(getAskProviderDefaultConfig(fallbackProvider));
+    setAskProvider(selection.provider);
+    setAskProviderConfig(selection.config);
     setAskProviderObjectInputs({});
-  }, [askConfigMeta, askProvider, getAskProviderDefaultConfig]);
+  }, [askConfigMeta, askProvider]);
 
   const normalizeAskTemperature = useCallback((value: number) => {
     const clamped = Math.min(
@@ -1061,15 +1046,15 @@ export default function ShifuSettingDialog({
           getDefaultTtsModelOption(ttsConfig?.model_options || [])?.provider ||
           ttsConfig?.providers?.[0]?.name ||
           '';
-        const askProviderForSubmit =
-          resolvedAskProvider ||
-          askConfigMeta?.default?.provider ||
-          ASK_PROVIDER_LLM;
-        const askModeForSubmit = ASK_PROVIDER_MODE_PROVIDER_ONLY;
         const askTemperatureForSubmit = normalizeAskTemperature(
           Number(askTemperatureInput || askTemperature || 0),
         );
         const askConfigForSubmit = buildAskProviderConfigForSubmit();
+        const askProviderConfigForSubmit = buildAskProviderSubmitConfig({
+          metadata: askConfigMeta,
+          provider: resolvedAskProvider,
+          config: askConfigForSubmit,
+        });
 
         if (ttsEnabled && !providerForSubmit) {
           if (!ttsProviderToastShownRef.current && saveType === 'manual') {
@@ -1097,11 +1082,7 @@ export default function ShifuSettingDialog({
           ask_model: askModel,
           ask_temperature: askTemperatureForSubmit,
           ask_system_prompt: '',
-          ask_provider_config: {
-            provider: askProviderForSubmit,
-            mode: askModeForSubmit,
-            config: askConfigForSubmit,
-          },
+          ask_provider_config: askProviderConfigForSubmit,
           // TTS Configuration
           tts_enabled: ttsEnabled,
           tts_provider: providerForSubmit,
@@ -1182,27 +1163,16 @@ export default function ShifuSettingDialog({
         temperature: result.temperature + '',
         systemPrompt: result.system_prompt || '',
       });
-      const rawAskProviderConfig =
-        result.ask_provider_config &&
-        typeof result.ask_provider_config === 'object' &&
-        !Array.isArray(result.ask_provider_config)
-          ? result.ask_provider_config
-          : {};
-      const rawAskProviderInnerConfig =
-        rawAskProviderConfig.config &&
-        typeof rawAskProviderConfig.config === 'object' &&
-        !Array.isArray(rawAskProviderConfig.config)
-          ? rawAskProviderConfig.config
-          : {};
+      const savedAskProviderConfig = normalizeStoredAskProviderConfig(
+        result.ask_provider_config,
+      );
       setAskModel(result.ask_model || '');
       setAskTemperature(result.ask_temperature ?? ASK_TEMPERATURE_MIN);
       setAskTemperatureInput(
         String(result.ask_temperature ?? ASK_TEMPERATURE_MIN),
       );
-      setAskProvider(
-        (rawAskProviderConfig.provider || ASK_PROVIDER_LLM).toLowerCase(),
-      );
-      setAskProviderConfig(rawAskProviderInnerConfig);
+      setAskProvider(savedAskProviderConfig.provider);
+      setAskProviderConfig(savedAskProviderConfig.config);
       setAskProviderObjectInputs({});
       setAskPreviewLoading(false);
       setAskPreviewQuery('');
@@ -1547,14 +1517,14 @@ export default function ShifuSettingDialog({
       return;
     }
 
-    const askProviderForSubmit =
-      resolvedAskProvider ||
-      askConfigMeta?.default?.provider ||
-      ASK_PROVIDER_LLM;
-    const askModeForSubmit = ASK_PROVIDER_MODE_PROVIDER_ONLY;
     const askTemperatureForSubmit = normalizeAskTemperature(
       Number(askTemperatureInput || askTemperature || 0),
     );
+    const askProviderConfigForSubmit = buildAskProviderSubmitConfig({
+      metadata: askConfigMeta,
+      provider: resolvedAskProvider,
+      config: askConfigForSubmit,
+    });
 
     setAskPreviewLoading(true);
     try {
@@ -1564,11 +1534,7 @@ export default function ShifuSettingDialog({
           ask_model: askModel,
           ask_temperature: askTemperatureForSubmit,
           ask_system_prompt: '',
-          ask_provider_config: {
-            provider: askProviderForSubmit,
-            mode: askModeForSubmit,
-            config: askConfigForSubmit,
-          },
+          ask_provider_config: askProviderConfigForSubmit,
         },
         { skipErrorToast: true },
       )) as {
@@ -1598,7 +1564,7 @@ export default function ShifuSettingDialog({
       setAskPreviewLoading(false);
     }
   }, [
-    askConfigMeta?.default?.provider,
+    askConfigMeta,
     askModel,
     askPreviewLoading,
     askPreviewQuery,

--- a/src/cook-web/src/components/shifu-setting/ask-provider-config.test.ts
+++ b/src/cook-web/src/components/shifu-setting/ask-provider-config.test.ts
@@ -1,0 +1,103 @@
+import {
+  ASK_PROVIDER_LLM,
+  ASK_PROVIDER_MODE_PROVIDER_ONLY,
+  buildAskProviderSubmitConfig,
+  getAskProviderDefaultConfig,
+  getAskProviderMeta,
+  normalizeAskProviderId,
+  normalizeStoredAskProviderConfig,
+  resolveAskProvider,
+  resolveAskProviderSelection,
+} from './ask-provider-config';
+import type { AskConfigMetadata } from './settings-config-options';
+
+const metadata: AskConfigMetadata = {
+  default: { provider: 'openai', mode: 'provider_only', config: {} },
+  providers: [
+    {
+      provider: 'openai',
+      title: 'OpenAI',
+      default_config: { model: 'gpt-test' },
+    },
+    {
+      provider: 'qwen',
+      title: 'Qwen',
+      default_config: { model: 'qwen-test', temperature: 0.4 },
+    },
+  ],
+};
+
+describe('ask provider config helpers', () => {
+  it('normalizes provider ids with trim and lowercase', () => {
+    expect(normalizeAskProviderId(' QWEN ')).toBe('qwen');
+  });
+
+  it('uses the first provider when selected provider is missing or unknown', () => {
+    expect(resolveAskProvider(metadata, '')).toBe('openai');
+    expect(resolveAskProvider(metadata, 'missing')).toBe('openai');
+  });
+
+  it('keeps selected providers that exist in metadata', () => {
+    expect(resolveAskProvider(metadata, 'QWEN')).toBe('qwen');
+    expect(getAskProviderMeta(metadata, 'qwen')?.title).toBe('Qwen');
+  });
+
+  it('falls back to llm when provider metadata is unavailable', () => {
+    expect(resolveAskProvider(null, '')).toBe(ASK_PROVIDER_LLM);
+    expect(resolveAskProvider(null, 'custom')).toBe('custom');
+  });
+
+  it('returns a copy of provider default config', () => {
+    const config = getAskProviderDefaultConfig(metadata, 'qwen');
+    config.model = 'changed';
+
+    expect(getAskProviderDefaultConfig(metadata, 'qwen')).toEqual({
+      model: 'qwen-test',
+      temperature: 0.4,
+    });
+  });
+
+  it('normalizes stored config while preserving provider inner config', () => {
+    expect(
+      normalizeStoredAskProviderConfig({
+        provider: ' QWEN ',
+        mode: 'custom_mode',
+        config: { model: 'qwen-test' },
+      }),
+    ).toEqual({
+      provider: 'qwen',
+      mode: 'custom_mode',
+      config: { model: 'qwen-test' },
+    });
+  });
+
+  it('falls back stored malformed config to existing defaults', () => {
+    expect(normalizeStoredAskProviderConfig(null)).toEqual({
+      provider: ASK_PROVIDER_LLM,
+      mode: ASK_PROVIDER_MODE_PROVIDER_ONLY,
+      config: {},
+    });
+  });
+
+  it('returns fallback selection with default config for unknown providers', () => {
+    expect(resolveAskProviderSelection(metadata, 'missing')).toEqual({
+      provider: 'openai',
+      config: { model: 'gpt-test' },
+      changed: true,
+    });
+  });
+
+  it('builds submit config with the fixed existing provider-only mode', () => {
+    expect(
+      buildAskProviderSubmitConfig({
+        metadata,
+        provider: 'qwen',
+        config: { model: 'qwen-test' },
+      }),
+    ).toEqual({
+      provider: 'qwen',
+      mode: ASK_PROVIDER_MODE_PROVIDER_ONLY,
+      config: { model: 'qwen-test' },
+    });
+  });
+});

--- a/src/cook-web/src/components/shifu-setting/ask-provider-config.ts
+++ b/src/cook-web/src/components/shifu-setting/ask-provider-config.ts
@@ -1,0 +1,133 @@
+import type {
+  AskConfigMetadata,
+  AskProviderConfigItem,
+} from './settings-config-options';
+
+export const ASK_PROVIDER_LLM = 'llm';
+export const ASK_PROVIDER_MODE_PROVIDER_ONLY = 'provider_only';
+
+export type StoredAskProviderConfig = {
+  provider?: string;
+  mode?: string;
+  config?: Record<string, unknown>;
+};
+
+export type AskProviderSubmitConfig = {
+  provider: string;
+  mode: string;
+  config: Record<string, unknown>;
+};
+
+export const normalizeAskProviderId = (provider?: string | null) =>
+  String(provider || '')
+    .trim()
+    .toLowerCase();
+
+const clonePlainConfig = (config: unknown): Record<string, unknown> =>
+  config && typeof config === 'object' && !Array.isArray(config)
+    ? { ...(config as Record<string, unknown>) }
+    : {};
+
+export const resolveAskProvider = (
+  metadata?: AskConfigMetadata | null,
+  provider?: string | null,
+  fallbackProvider = ASK_PROVIDER_LLM,
+): string => {
+  const normalizedProvider = normalizeAskProviderId(provider);
+  const providers = metadata?.providers || [];
+
+  if (!normalizedProvider) {
+    return providers[0]?.provider || fallbackProvider;
+  }
+
+  if (providers.length) {
+    const exists = providers.some(item => item.provider === normalizedProvider);
+    return exists
+      ? normalizedProvider
+      : providers[0]?.provider || normalizedProvider;
+  }
+
+  return normalizedProvider;
+};
+
+export const getAskProviderMeta = (
+  metadata?: AskConfigMetadata | null,
+  provider?: string | null,
+): AskProviderConfigItem | undefined => {
+  const resolvedProvider = resolveAskProvider(metadata, provider);
+  return (
+    metadata?.providers?.find(item => item.provider === resolvedProvider) ||
+    metadata?.providers?.[0]
+  );
+};
+
+export const getAskProviderDefaultConfig = (
+  metadata?: AskConfigMetadata | null,
+  provider?: string | null,
+): Record<string, unknown> => {
+  const resolvedProvider = normalizeAskProviderId(provider);
+  const providerMeta = metadata?.providers?.find(
+    item => item.provider === resolvedProvider,
+  );
+  return clonePlainConfig(providerMeta?.default_config);
+};
+
+export const normalizeStoredAskProviderConfig = (
+  rawConfig: unknown,
+): Required<StoredAskProviderConfig> => {
+  const configObject = clonePlainConfig(rawConfig);
+  return {
+    provider: normalizeAskProviderId(
+      typeof configObject.provider === 'string'
+        ? configObject.provider
+        : ASK_PROVIDER_LLM,
+    ),
+    mode:
+      typeof configObject.mode === 'string' && configObject.mode.trim()
+        ? configObject.mode.trim()
+        : ASK_PROVIDER_MODE_PROVIDER_ONLY,
+    config: clonePlainConfig(configObject.config),
+  };
+};
+
+export const resolveAskProviderSelection = (
+  metadata?: AskConfigMetadata | null,
+  provider?: string | null,
+): { provider: string; config: Record<string, unknown>; changed: boolean } => {
+  const normalizedProvider = normalizeAskProviderId(provider);
+  const providers = metadata?.providers || [];
+
+  if (!providers.length) {
+    return {
+      provider: normalizedProvider || ASK_PROVIDER_LLM,
+      config: {},
+      changed: false,
+    };
+  }
+
+  const matched = providers.some(item => item.provider === normalizedProvider);
+  const nextProvider = matched ? normalizedProvider : providers[0].provider;
+
+  return {
+    provider: nextProvider,
+    config: getAskProviderDefaultConfig(metadata, nextProvider),
+    changed: !matched,
+  };
+};
+
+export const buildAskProviderSubmitConfig = ({
+  metadata,
+  provider,
+  config,
+}: {
+  metadata?: AskConfigMetadata | null;
+  provider?: string | null;
+  config: Record<string, unknown>;
+}): AskProviderSubmitConfig => ({
+  provider:
+    resolveAskProvider(metadata, provider) ||
+    metadata?.default?.provider ||
+    ASK_PROVIDER_LLM,
+  mode: ASK_PROVIDER_MODE_PROVIDER_ONLY,
+  config,
+});


### PR DESCRIPTION
# Summary

- Centralize Ask provider id normalization, metadata fallback selection, stored config parsing, default config cloning, and submit payload construction in `ask-provider-config`.
- Reuse the shared helpers from Shifu settings save and Ask preview payloads.
- Add characterization tests for current fallback and provider-only submit behavior.

Business behavior preserved:
- Unknown or empty provider still falls back to the first configured provider when metadata exists.
- Missing metadata still falls back to `llm`.
- Save and preview still submit `mode: "provider_only"`.
- Saved provider config still restores the inner `config` object and lowercases provider ids.

Validation:
- `cd src/cook-web && npm test -- --runTestsByPath src/components/shifu-setting/ask-provider-config.test.ts src/components/shifu-setting/settings-config-options.test.ts`
- `cd src/cook-web && npm run type-check -- --pretty false`
- `cd src/cook-web && npm run lint-file -- src/components/shifu-setting/ask-provider-config.ts src/components/shifu-setting/ask-provider-config.test.ts src/components/shifu-setting/ShifuSetting.tsx`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- pre-commit via `PATH="$HOME/.local/bin:$PATH" git commit ...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ask provider selection and configuration handling.
  * Restored saved settings more reliably, including fallback handling for invalid or unknown configurations.
  * Ensured save and preview actions submit consistent provider settings.

* **Tests**
  * Added coverage for provider selection, defaults, saved configuration restoration, validation, and submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->