### PR TITLE
refactor: centralize admin filter params

### DIFF
--- a/src/cook-web/src/app/admin/operations/adminFilterParams.test.ts
+++ b/src/cook-web/src/app/admin/operations/adminFilterParams.test.ts
@@ -1,0 +1,175 @@
+import {
+  buildAdminCourseListParams,
+  buildAdminCreditOrderListParams,
+  buildAdminDateRangeParams,
+  buildAdminLearnOrderListParams,
+  buildAdminPaginationParams,
+  buildAdminUserListParams,
+} from './adminFilterParams';
+
+describe('admin filter params', () => {
+  it('builds pagination params without renaming the existing API fields', () => {
+    expect(buildAdminPaginationParams(3, 20)).toEqual({
+      page_index: 3,
+      page_size: 20,
+    });
+  });
+
+  it('converts date ranges to UTC params and keeps empty date filters empty', () => {
+    expect(buildAdminDateRangeParams('', '')).toEqual({
+      start_time: '',
+      end_time: '',
+    });
+    expect(buildAdminDateRangeParams('2026-08-06', '2026-08-07')).toEqual({
+      start_time: expect.stringMatching(/^2026-08-0[5-6]T/),
+      end_time: expect.stringMatching(/^2026-08-0[7-8]T/),
+    });
+  });
+
+  it('builds course list params with trimmed text filters and update date keys', () => {
+    expect(
+      buildAdminCourseListParams({
+        pageIndex: 2,
+        pageSize: 20,
+        quickFilter: 'published',
+        filters: {
+          shifu_bid: ' course-1 ',
+          course_name: ' Course ',
+          creator_keyword: ' teacher@example.com ',
+          course_status: 'published',
+          start_time: '',
+          end_time: '',
+          updated_start_time: '',
+          updated_end_time: '',
+        },
+      }),
+    ).toEqual({
+      page_index: 2,
+      page_size: 20,
+      shifu_bid: 'course-1',
+      course_name: 'Course',
+      creator_keyword: 'teacher@example.com',
+      course_status: 'published',
+      quick_filter: 'published',
+      start_time: '',
+      end_time: '',
+      updated_start_time: '',
+      updated_end_time: '',
+    });
+  });
+
+  it('builds user list params with status, role, quick filter, and trimmed text filters', () => {
+    expect(
+      buildAdminUserListParams({
+        pageIndex: 1,
+        pageSize: 20,
+        quickFilter: 'paid',
+        filters: {
+          identifier: ' user@example.com ',
+          nickname: ' Alice ',
+          user_status: 'paid',
+          user_role: 'learner',
+          start_time: '',
+          end_time: '',
+        },
+      }),
+    ).toEqual({
+      page_index: 1,
+      page_size: 20,
+      identifier: 'user@example.com',
+      nickname: 'Alice',
+      user_status: 'paid',
+      user_role: 'learner',
+      quick_filter: 'paid',
+      start_time: '',
+      end_time: '',
+    });
+  });
+
+  it('builds learn order params while preserving all status-like filter fields', () => {
+    expect(
+      buildAdminLearnOrderListParams({
+        pageIndex: 4,
+        pageSize: 20,
+        filters: {
+          user_keyword: ' learner ',
+          order_bid: ' order-1 ',
+          shifu_bid: ' course-1 ',
+          course_name: ' Course ',
+          status: '502',
+          order_source: 'direct',
+          payment_channel: 'wechatpay',
+          start_time: '',
+          end_time: '',
+        },
+      }),
+    ).toEqual({
+      page_index: 4,
+      page_size: 20,
+      user_keyword: 'learner',
+      order_bid: 'order-1',
+      shifu_bid: 'course-1',
+      course_name: 'Course',
+      status: '502',
+      order_source: 'direct',
+      payment_channel: 'wechatpay',
+      start_time: '',
+      end_time: '',
+    });
+  });
+
+  it('omits optional credit order flags when they are not active', () => {
+    expect(
+      buildAdminCreditOrderListParams({
+        pageIndex: 1,
+        pageSize: 20,
+        filters: {
+          creator_keyword: ' creator ',
+          product_keyword: ' package ',
+          bill_order_bid: ' ',
+          credit_order_kind: '',
+          status: 'paid',
+          has_available_credits: false,
+          payment_provider: '',
+          start_time: '',
+          end_time: '',
+        },
+      }),
+    ).toEqual({
+      page_index: 1,
+      page_size: 20,
+      creator_keyword: 'creator',
+      product_keyword: 'package',
+      credit_order_kind: '',
+      status: 'paid',
+      payment_provider: '',
+      start_time: '',
+      end_time: '',
+    });
+  });
+
+  it('includes optional credit order flags when active', () => {
+    expect(
+      buildAdminCreditOrderListParams({
+        pageIndex: 1,
+        pageSize: 20,
+        filters: {
+          creator_keyword: '',
+          product_keyword: '',
+          bill_order_bid: ' bill-1 ',
+          credit_order_kind: 'package',
+          status: '',
+          has_available_credits: true,
+          payment_provider: 'stripe',
+          start_time: '',
+          end_time: '',
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        bill_order_bid: 'bill-1',
+        has_available_credits: true,
+      }),
+    );
+  });
+});

--- a/src/cook-web/src/app/admin/operations/adminFilterParams.ts
+++ b/src/cook-web/src/app/admin/operations/adminFilterParams.ts
@@ -1,0 +1,162 @@
+import {
+  formatAdminDateRangeEndUtc,
+  formatAdminDateRangeStartUtc,
+} from '@/app/admin/lib/dateTime';
+
+export type AdminPaginationParams = {
+  page_index: number;
+  page_size: number;
+};
+
+const trimValue = (value: string | undefined | null) =>
+  String(value || '').trim();
+
+export const buildAdminPaginationParams = (
+  pageIndex: number,
+  pageSize: number,
+): AdminPaginationParams => ({
+  page_index: pageIndex,
+  page_size: pageSize,
+});
+
+export const buildAdminDateRangeParams = (
+  startTime?: string,
+  endTime?: string,
+  startKey = 'start_time',
+  endKey = 'end_time',
+): Record<string, string> => ({
+  [startKey]: formatAdminDateRangeStartUtc(startTime || ''),
+  [endKey]: formatAdminDateRangeEndUtc(endTime || ''),
+});
+
+export type AdminCourseListFilters = {
+  shifu_bid: string;
+  course_name: string;
+  creator_keyword: string;
+  course_status: string;
+  start_time: string;
+  end_time: string;
+  updated_start_time: string;
+  updated_end_time: string;
+};
+
+export const buildAdminCourseListParams = ({
+  pageIndex,
+  pageSize,
+  filters,
+  quickFilter,
+}: {
+  pageIndex: number;
+  pageSize: number;
+  filters: AdminCourseListFilters;
+  quickFilter: string;
+}) => ({
+  ...buildAdminPaginationParams(pageIndex, pageSize),
+  shifu_bid: trimValue(filters.shifu_bid),
+  course_name: trimValue(filters.course_name),
+  creator_keyword: trimValue(filters.creator_keyword),
+  course_status: filters.course_status,
+  quick_filter: quickFilter,
+  ...buildAdminDateRangeParams(filters.start_time, filters.end_time),
+  ...buildAdminDateRangeParams(
+    filters.updated_start_time,
+    filters.updated_end_time,
+    'updated_start_time',
+    'updated_end_time',
+  ),
+});
+
+export type AdminUserListFilters = {
+  identifier: string;
+  nickname: string;
+  user_status: string;
+  user_role: string;
+  start_time: string;
+  end_time: string;
+};
+
+export const buildAdminUserListParams = ({
+  pageIndex,
+  pageSize,
+  filters,
+  quickFilter,
+}: {
+  pageIndex: number;
+  pageSize: number;
+  filters: AdminUserListFilters;
+  quickFilter: string;
+}) => ({
+  ...buildAdminPaginationParams(pageIndex, pageSize),
+  identifier: trimValue(filters.identifier),
+  nickname: trimValue(filters.nickname),
+  user_status: filters.user_status,
+  user_role: filters.user_role,
+  quick_filter: quickFilter,
+  ...buildAdminDateRangeParams(filters.start_time, filters.end_time),
+});
+
+export type AdminLearnOrderListFilters = {
+  user_keyword: string;
+  order_bid: string;
+  shifu_bid: string;
+  course_name: string;
+  status: string;
+  order_source: string;
+  payment_channel: string;
+  start_time: string;
+  end_time: string;
+};
+
+export const buildAdminLearnOrderListParams = ({
+  pageIndex,
+  pageSize,
+  filters,
+}: {
+  pageIndex: number;
+  pageSize: number;
+  filters: AdminLearnOrderListFilters;
+}) => ({
+  ...buildAdminPaginationParams(pageIndex, pageSize),
+  user_keyword: trimValue(filters.user_keyword),
+  order_bid: trimValue(filters.order_bid),
+  shifu_bid: trimValue(filters.shifu_bid),
+  course_name: trimValue(filters.course_name),
+  status: filters.status,
+  order_source: filters.order_source,
+  payment_channel: filters.payment_channel,
+  ...buildAdminDateRangeParams(filters.start_time, filters.end_time),
+});
+
+export type AdminCreditOrderListFilters = {
+  creator_keyword: string;
+  product_keyword: string;
+  bill_order_bid: string;
+  credit_order_kind: string;
+  status: string;
+  has_available_credits: boolean;
+  payment_provider: string;
+  start_time: string;
+  end_time: string;
+};
+
+export const buildAdminCreditOrderListParams = ({
+  pageIndex,
+  pageSize,
+  filters,
+}: {
+  pageIndex: number;
+  pageSize: number;
+  filters: AdminCreditOrderListFilters;
+}) => ({
+  ...buildAdminPaginationParams(pageIndex, pageSize),
+  creator_keyword: trimValue(filters.creator_keyword),
+  product_keyword: trimValue(filters.product_keyword),
+  ...(trimValue(filters.bill_order_bid)
+    ? { bill_order_bid: trimValue(filters.bill_order_bid) }
+    : {}),
+  credit_order_kind: filters.credit_order_kind,
+  status: filters.status,
+  ...(filters.has_available_credits ? { has_available_credits: true } : {}),
+  payment_provider: filters.payment_provider,
+  ...buildAdminDateRangeParams(filters.start_time, filters.end_time),
+});

--- a/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/CreditOrdersTab.tsx
@@ -11,10 +11,6 @@ import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
-  formatAdminDateRangeEndUtc,
-  formatAdminDateRangeStartUtc,
-} from '@/app/admin/lib/dateTime';
-import {
   ADMIN_TABLE_HEADER_CELL_CENTER_CLASS,
   ADMIN_TABLE_RESIZE_HANDLE_CLASS,
   getAdminStickyRightCellClass,
@@ -58,6 +54,7 @@ import {
   resolveOperationCreditOrderValidityLabel,
   resolveOperationCreditOrderProviderLabel,
 } from '../operation-credit-order-helpers';
+import { buildAdminCreditOrderListParams } from '../adminFilterParams';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
 import type {
   AdminOperationCreditOrderItem,
@@ -290,21 +287,11 @@ export default function CreditOrdersTab() {
 
       try {
         const response = (await api.getAdminOperationCreditOrders({
-          page_index: targetPage,
-          page_size: PAGE_SIZE,
-          creator_keyword: filters.creator_keyword.trim(),
-          product_keyword: filters.product_keyword.trim(),
-          ...(filters.bill_order_bid.trim()
-            ? { bill_order_bid: filters.bill_order_bid.trim() }
-            : {}),
-          credit_order_kind: filters.credit_order_kind,
-          status: filters.status,
-          ...(filters.has_available_credits
-            ? { has_available_credits: true }
-            : {}),
-          payment_provider: filters.payment_provider,
-          start_time: formatAdminDateRangeStartUtc(filters.start_time),
-          end_time: formatAdminDateRangeEndUtc(filters.end_time),
+          ...buildAdminCreditOrderListParams({
+            pageIndex: targetPage,
+            pageSize: PAGE_SIZE,
+            filters,
+          }),
         })) as AdminOperationCreditOrderListResponse;
 
         if (requestId !== requestIdRef.current) {

--- a/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
+++ b/src/cook-web/src/app/admin/operations/orders/LearnOrdersTab.tsx
@@ -11,10 +11,6 @@ import AdminFilter from '@/app/admin/components/AdminFilter';
 import AdminTableShell from '@/app/admin/components/AdminTableShell';
 import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import {
-  formatAdminDateRangeEndUtc,
-  formatAdminDateRangeStartUtc,
-} from '@/app/admin/lib/dateTime';
-import {
   formatAdminCount,
   formatAdminNumber,
 } from '@/app/admin/lib/numberFormat';
@@ -51,6 +47,7 @@ import { cn } from '@/lib/utils';
 import { getOperationOrderSourceLabel } from '../operation-order-source';
 import { buildAdminOperationsCourseDetailUrl } from '../operation-course-routes';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
+import { buildAdminLearnOrderListParams } from '../adminFilterParams';
 import type {
   AdminOperationOrderItem,
   AdminOperationOrderListResponse,
@@ -291,17 +288,11 @@ export default function LearnOrdersTab() {
       setError(null);
       try {
         const response = (await api.getAdminOperationOrders({
-          page_index: targetPage,
-          page_size: PAGE_SIZE,
-          user_keyword: filters.user_keyword.trim(),
-          order_bid: filters.order_bid.trim(),
-          shifu_bid: filters.shifu_bid.trim(),
-          course_name: filters.course_name.trim(),
-          status: filters.status,
-          order_source: filters.order_source,
-          payment_channel: filters.payment_channel,
-          start_time: formatAdminDateRangeStartUtc(filters.start_time),
-          end_time: formatAdminDateRangeEndUtc(filters.end_time),
+          ...buildAdminLearnOrderListParams({
+            pageIndex: targetPage,
+            pageSize: PAGE_SIZE,
+            filters,
+          }),
         })) as AdminOperationOrderListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/page.tsx
+++ b/src/cook-web/src/app/admin/operations/page.tsx
@@ -15,11 +15,7 @@ import AdminBreadcrumb from '@/app/admin/components/AdminBreadcrumb';
 import AdminTitle from '@/app/admin/components/AdminTitle';
 import { ADMIN_TABLE_RESIZE_HANDLE_CLASS } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import {
-  formatAdminDateRangeEndUtc,
-  formatAdminDateRangeStartUtc,
-  formatAdminUtcDateTime,
-} from '@/app/admin/lib/dateTime';
+import { formatAdminUtcDateTime } from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -52,6 +48,7 @@ import type {
   AdminOperationCourseOverview,
   AdminOperationCoursePromptResponse,
 } from './operation-course-types';
+import { buildAdminCourseListParams } from './adminFilterParams';
 import useOperatorGuard from './useOperatorGuard';
 import {
   ALL_OPTION_VALUE,
@@ -454,21 +451,12 @@ const OperationsPage = () => {
       setError(null);
       try {
         const response = (await api.getAdminOperationCourses({
-          page_index: targetPage,
-          page_size: PAGE_SIZE,
-          shifu_bid: resolvedFilters.shifu_bid.trim(),
-          course_name: resolvedFilters.course_name.trim(),
-          creator_keyword: resolvedFilters.creator_keyword.trim(),
-          course_status: resolvedFilters.course_status,
-          quick_filter: resolvedQuickFilter,
-          start_time: formatAdminDateRangeStartUtc(resolvedFilters.start_time),
-          end_time: formatAdminDateRangeEndUtc(resolvedFilters.end_time),
-          updated_start_time: formatAdminDateRangeStartUtc(
-            resolvedFilters.updated_start_time,
-          ),
-          updated_end_time: formatAdminDateRangeEndUtc(
-            resolvedFilters.updated_end_time,
-          ),
+          ...buildAdminCourseListParams({
+            pageIndex: targetPage,
+            pageSize: PAGE_SIZE,
+            filters: resolvedFilters,
+            quickFilter: resolvedQuickFilter,
+          }),
         })) as AdminOperationCourseListResponse;
         if (requestId !== requestIdRef.current) {
           return;

--- a/src/cook-web/src/app/admin/operations/users/page.tsx
+++ b/src/cook-web/src/app/admin/operations/users/page.tsx
@@ -25,10 +25,6 @@ import {
   getAdminStickyRightHeaderClass,
 } from '@/app/admin/components/adminTableStyles';
 import { useAdminResizableColumns } from '@/app/admin/hooks/useAdminResizableColumns';
-import {
-  formatAdminDateRangeEndUtc,
-  formatAdminDateRangeStartUtc,
-} from '@/app/admin/lib/dateTime';
 import ErrorDisplay from '@/components/ErrorDisplay';
 import Loading from '@/components/loading';
 import {
@@ -63,6 +59,7 @@ import { resolveContactMode } from '@/lib/resolve-contact-mode';
 import { ErrorWithCode } from '@/lib/request';
 import { buildAdminOperationsCourseDetailUrl } from '../operation-course-routes';
 import { buildAdminOperationsUserDetailUrl } from '../operation-user-routes';
+import { buildAdminUserListParams } from '../adminFilterParams';
 import { formatOperatorUtcDateTime } from './dateTime';
 import { normalizeLoginMethodLabelKey } from './loginMethodUtils';
 import UserCreditGrantDialog from './UserCreditGrantDialog';
@@ -527,15 +524,12 @@ export default function AdminOperationUsersPage() {
       setError(null);
       try {
         const response = (await api.getAdminOperationUsers({
-          page_index: targetPage,
-          page_size: PAGE_SIZE,
-          identifier: filters.identifier.trim(),
-          nickname: filters.nickname.trim(),
-          user_status: filters.user_status,
-          user_role: filters.user_role,
-          quick_filter: resolvedQuickFilter,
-          start_time: formatAdminDateRangeStartUtc(filters.start_time),
-          end_time: formatAdminDateRangeEndUtc(filters.end_time),
+          ...buildAdminUserListParams({
+            pageIndex: targetPage,
+            pageSize: PAGE_SIZE,
+            filters,
+            quickFilter: resolvedQuickFilter,
+          }),
         })) as AdminOperationUserListResponse;
         if (requestId !== requestIdRef.current) {
           return;


### PR DESCRIPTION
# Summary

- Centralize operations admin filter-to-request parameter mapping in `adminFilterParams`.
- Reuse the builders from course list, user list, learn orders, and credit orders.
- Add characterization tests for pagination, trimmed text filters, status/quick filters, date keys, and optional credit order flags.

Business behavior preserved:
- Existing API parameter names are unchanged.
- Empty/all-like filters continue to use the existing empty-string behavior.
- Credit order `bill_order_bid` and `has_available_credits` remain conditionally omitted unless active.
- Date range filters still use the existing admin UTC conversion helpers.

Validation:
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/adminFilterParams.test.ts src/app/admin/operations/page.test.tsx src/app/admin/operations/users/page.test.tsx src/app/admin/operations/orders/LearnOrdersTab.test.tsx src/app/admin/operations/orders/CreditOrdersTab.test.tsx`
- `cd src/cook-web && npm run type-check -- --pretty false`
- `cd src/cook-web && npm run lint-file -- src/app/admin/operations/adminFilterParams.ts src/app/admin/operations/adminFilterParams.test.ts src/app/admin/operations/page.tsx src/app/admin/operations/users/page.tsx src/app/admin/operations/orders/LearnOrdersTab.tsx src/app/admin/operations/orders/CreditOrdersTab.tsx`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- pre-commit via `PATH="$HOME/.local/bin:$PATH" git commit ...`

Note:
- Existing React `act(...)` warnings still appear in `users/page.test.tsx`; tests pass and this PR does not introduce those warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin operations filtering with consistent pagination, date-range handling, trimmed text filters, status, role, and order criteria.
  - Ensured date filters are consistently converted to UTC across course, user, learning-order, and credit-order lists.
  - Improved conditional filtering for credit orders and availability options.

- **Tests**
  - Added comprehensive coverage for admin filter behavior, including pagination, dates, text fields, statuses, roles, and order-specific flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->