### PR TITLE
fix: prevent stale outline positions during content saves

### DIFF
--- a/src/api/flaskr/service/shifu/outline_write_lock.py
+++ b/src/api/flaskr/service/shifu/outline_write_lock.py
@@ -1,0 +1,13 @@
+"""Shared locking helpers for draft outline structural state."""
+
+from .models import DraftShifu
+
+
+def lock_shifu_for_outline_write(shifu_bid: str) -> None:
+    """Serialize concurrent structural/content writes for one draft course."""
+    (
+        DraftShifu.query.filter(DraftShifu.shifu_bid == shifu_bid)
+        .order_by(DraftShifu.id.desc())
+        .with_for_update()
+        .first()
+    )

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -154,36 +154,13 @@ def save_shifu_mdflow(
     """
     content = content or ""
     with app.app_context():
-        # The risk check commits its own RiskControlResult row and calls an
-        # external moderation API, so it must run at most once per save. This
-        # guard lives outside the retried transaction below, so a deadlock retry
-        # of the DB write does not repeat that side effect.
-        risk_checked = False
+        lock_latest = isinstance(base_revision, int) and base_revision >= 0
 
-        @retry_on_deadlock()
-        def _save_txn() -> DraftSaveResponse:
-            nonlocal risk_checked
-            lock_shifu_for_outline_write(shifu_bid)
-            lock_latest = isinstance(base_revision, int) and base_revision >= 0
-            outline_query = DraftOutlineItem.query.filter(
-                DraftOutlineItem.shifu_bid == shifu_bid,
-                DraftOutlineItem.outline_item_bid == outline_bid,
-            ).order_by(DraftOutlineItem.id.desc())
+        def _current_conflict() -> DraftConflictResult | None:
+            latest_meta = get_shifu_draft_meta(app, shifu_bid, outline_bid)
+            if int(latest_meta.get("deleted", 0) or 0) == 1:
+                return {"conflict": True, "meta": latest_meta}
             if lock_latest:
-                outline_query = outline_query.with_for_update()
-            outline_item: DraftOutlineItem = outline_query.first()
-            if not outline_item:
-                raise_error("server.shifu.outlineItemNotFound")
-            if outline_item.deleted == 1:
-                return {
-                    "conflict": True,
-                    "meta": get_shifu_draft_meta(app, shifu_bid, outline_bid),
-                }
-
-            if lock_latest:
-                latest_meta = get_shifu_draft_meta(app, shifu_bid, outline_bid)
-                if int(latest_meta.get("deleted", 0) or 0) == 1:
-                    return {"conflict": True, "meta": latest_meta}
                 latest_revision = int(latest_meta.get("revision", 0) or 0)
                 updated_user_bid = (latest_meta.get("updated_user") or {}).get(
                     "user_bid"
@@ -192,19 +169,57 @@ def save_shifu_mdflow(
                     not updated_user_bid or updated_user_bid != user_id
                 ):
                     return {"conflict": True, "meta": latest_meta}
-            # create new version
-            new_outline: DraftOutlineItem = outline_item.clone()
-            new_outline.content = content
+            return None
 
-            # risk check
-            # save to database
+        preflight_outline = (
+            DraftOutlineItem.query.filter(
+                DraftOutlineItem.shifu_bid == shifu_bid,
+                DraftOutlineItem.outline_item_bid == outline_bid,
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+        if not preflight_outline:
+            raise_error("server.shifu.outlineItemNotFound")
+        conflict = _current_conflict()
+        if conflict:
+            return conflict
+
+        # Risk control writes and commits its own audit row, so it must run before
+        # the outline write lock is acquired. The locked transaction below always
+        # re-reads the latest outline version after this possible commit.
+        if (preflight_outline.content or "") != content:
+            check_text_with_risk_control(
+                app, preflight_outline.outline_item_bid, user_id, content
+            )
+
+        @retry_on_deadlock()
+        def _save_txn() -> DraftSaveResponse:
+            lock_shifu_for_outline_write(shifu_bid)
+            conflict = _current_conflict()
+            if conflict:
+                return conflict
+
+            outline_item: DraftOutlineItem = (
+                DraftOutlineItem.query.filter(
+                    DraftOutlineItem.shifu_bid == shifu_bid,
+                    DraftOutlineItem.outline_item_bid == outline_bid,
+                )
+                .order_by(DraftOutlineItem.id.desc())
+                .first()
+            )
+            if not outline_item:
+                raise_error("server.shifu.outlineItemNotFound")
+            if outline_item.deleted == 1:
+                return {
+                    "conflict": True,
+                    "meta": get_shifu_draft_meta(app, shifu_bid, outline_bid),
+                }
+
             new_revision = None
-            if not outline_item.content == new_outline.content:
-                if not risk_checked:
-                    check_text_with_risk_control(
-                        app, outline_item.outline_item_bid, user_id, content
-                    )
-                    risk_checked = True
+            if (outline_item.content or "") != content:
+                new_outline: DraftOutlineItem = outline_item.clone()
+                new_outline.content = content
                 new_outline.updated_user_bid = user_id
                 new_outline.updated_at = now_utc()
                 db.session.add(new_outline)

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -2,6 +2,7 @@ from markdown_flow import MarkdownFlow
 from flask import Flask
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.service.shifu.models import DraftOutlineItem
+from flaskr.service.shifu.outline_write_lock import lock_shifu_for_outline_write
 from flaskr.service.common import raise_error
 from flaskr.dao import db, retry_on_deadlock
 from flaskr.service.shifu.dtos import MdflowDTOParseResult
@@ -162,6 +163,7 @@ def save_shifu_mdflow(
         @retry_on_deadlock()
         def _save_txn() -> DraftSaveResponse:
             nonlocal risk_checked
+            lock_shifu_for_outline_write(shifu_bid)
             lock_latest = isinstance(base_revision, int) and base_revision >= 0
             outline_query = DraftOutlineItem.query.filter(
                 DraftOutlineItem.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -20,7 +20,8 @@ from .consts import (
     UNIT_TYPE_TRIAL,
     UNIT_TYPE_GUEST,
 )
-from .models import DraftOutlineItem, DraftShifu
+from .models import DraftOutlineItem
+from .outline_write_lock import lock_shifu_for_outline_write
 from ...dao import db
 from ...util import generate_id
 from ..common.models import raise_error, raise_param_error
@@ -276,9 +277,11 @@ def __lock_shifu_for_outline_write(shifu_id: str) -> None:
     """Serialize concurrent outline structural writes for a single shifu.
 
     A new outline's ``position`` is allocated by reading the current siblings and
-    taking ``max(position) + 1``. Without a lock, concurrent create requests read
-    the same snapshot and allocate the *same* position, producing colliding
-    positions that later block publishing (``assert_outline_tree_publishable``).
+    taking ``max(position) + 1``. Content saves also clone the latest outline row
+    and must not race with structural reorders. Without a shared lock, concurrent
+    writes can publish a stale position as the latest version, producing
+    colliding positions that later block publishing
+    (``assert_outline_tree_publishable``).
 
     Take a row lock on the shifu's latest draft row so position allocation is
     serialized per shifu. ``DraftShifu`` rows are not written by outline creation,
@@ -287,12 +290,7 @@ def __lock_shifu_for_outline_write(shifu_id: str) -> None:
     shifts per write). ``FOR UPDATE`` is a no-op on SQLite (unit tests) and
     effective on MySQL (production).
     """
-    (
-        DraftShifu.query.filter(DraftShifu.shifu_bid == shifu_id)
-        .order_by(DraftShifu.id.desc())
-        .with_for_update()
-        .first()
-    )
+    lock_shifu_for_outline_write(shifu_id)
 
 
 def __normalize_outline_name(outline_name: str) -> str:

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 import pytest
 
@@ -47,13 +48,28 @@ def _add_outline_version(
     content: str,
     updated_user_bid: str,
     minutes_offset: int,
+    *,
+    title: str = "outline",
+    parent_bid: str = "",
+    position: str = "01",
 ) -> int:
     with app.app_context():
         item = DraftOutlineItem(
             shifu_bid=shifu_bid,
             outline_item_bid=outline_bid,
-            title="outline",
+            title=title,
             content=content,
+            parent_bid=parent_bid,
+            position=position,
+            prerequisite_item_bids="",
+            llm="",
+            llm_temperature=Decimal("0.3"),
+            llm_system_prompt="",
+            ask_enabled_status=5101,
+            ask_llm="",
+            ask_llm_temperature=Decimal("0.3"),
+            ask_llm_system_prompt="",
+            deleted=0,
             updated_user_bid=updated_user_bid,
             updated_at=datetime.now() + timedelta(minutes=minutes_offset),
             created_user_bid=updated_user_bid,
@@ -331,6 +347,88 @@ def test_save_shifu_mdflow_returns_outline_revision_not_history_log(app, monkeyp
     assert result["conflict"] is False
     assert result["new_revision"] == current_revision
     assert result["new_revision"] != 999999
+
+
+def test_save_shifu_mdflow_serializes_with_outline_structure_writes(app, monkeypatch):
+    shifu_bid = "shifu-mdflow-structure-lock-1"
+    outline_bid = "outline-mdflow-structure-lock-1"
+    lock_calls = []
+
+    _add_outline_version(
+        app,
+        shifu_bid,
+        outline_bid,
+        "Original",
+        "user-structure-lock-1",
+        0,
+        parent_bid="parent-old",
+        position="0105",
+    )
+    with app.app_context():
+        latest = (
+            DraftOutlineItem.query.filter_by(
+                shifu_bid=shifu_bid,
+                outline_item_bid=outline_bid,
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+        reordered = latest.clone()
+        reordered.parent_bid = "parent-new"
+        reordered.position = "0101"
+        reordered.updated_user_bid = "user-structure-lock-1"
+        reordered.updated_at = datetime.now() + timedelta(minutes=1)
+        db.session.add(reordered)
+        db.session.commit()
+
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.lock_shifu_for_outline_write",
+        lambda bid: lock_calls.append(bid),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.check_text_with_risk_control",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.get_profile_item_definition_list",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.add_profile_item_quick_internal",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.save_outline_history",
+        lambda *_args, **_kwargs: 999999,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.cleanup_outline_history_versions",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = save_shifu_mdflow(
+        app,
+        "user-structure-lock-2",
+        shifu_bid,
+        outline_bid,
+        "Updated content",
+    )
+
+    with app.app_context():
+        latest = (
+            DraftOutlineItem.query.filter_by(
+                shifu_bid=shifu_bid,
+                outline_item_bid=outline_bid,
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+
+    assert result["conflict"] is False
+    assert lock_calls == [shifu_bid]
+    assert latest.content == "Updated content"
+    assert latest.parent_bid == "parent-new"
+    assert latest.position == "0101"
 
 
 def test_cleanup_outline_history_preserves_content_anchor_revision(app):

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -431,6 +431,84 @@ def test_save_shifu_mdflow_serializes_with_outline_structure_writes(app, monkeyp
     assert latest.position == "0101"
 
 
+def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(app, monkeypatch):
+    shifu_bid = "shifu-mdflow-risk-commit-1"
+    outline_bid = "outline-mdflow-risk-commit-1"
+
+    _add_outline_version(
+        app,
+        shifu_bid,
+        outline_bid,
+        "Original",
+        "user-risk-commit-1",
+        0,
+        parent_bid="parent-old",
+        position="0105",
+    )
+
+    def _risk_check_and_reorder(_app, _check_id, _user_id, _content):
+        with app.app_context():
+            latest = (
+                DraftOutlineItem.query.filter_by(
+                    shifu_bid=shifu_bid,
+                    outline_item_bid=outline_bid,
+                )
+                .order_by(DraftOutlineItem.id.desc())
+                .first()
+            )
+            reordered = latest.clone()
+            reordered.parent_bid = "parent-new"
+            reordered.position = "0101"
+            reordered.updated_user_bid = "user-risk-commit-1"
+            reordered.updated_at = datetime.now() + timedelta(minutes=1)
+            db.session.add(reordered)
+            db.session.commit()
+
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.check_text_with_risk_control",
+        _risk_check_and_reorder,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.get_profile_item_definition_list",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.add_profile_item_quick_internal",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.save_outline_history",
+        lambda *_args, **_kwargs: 999999,
+    )
+    monkeypatch.setattr(
+        "flaskr.service.shifu.shifu_mdflow_funcs.cleanup_outline_history_versions",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = save_shifu_mdflow(
+        app,
+        "user-risk-commit-2",
+        shifu_bid,
+        outline_bid,
+        "Updated content",
+    )
+
+    with app.app_context():
+        latest = (
+            DraftOutlineItem.query.filter_by(
+                shifu_bid=shifu_bid,
+                outline_item_bid=outline_bid,
+            )
+            .order_by(DraftOutlineItem.id.desc())
+            .first()
+        )
+
+    assert result["conflict"] is False
+    assert latest.content == "Updated content"
+    assert latest.parent_bid == "parent-new"
+    assert latest.position == "0101"
+
+
 def test_cleanup_outline_history_preserves_content_anchor_revision(app):
     shifu_bid = "shifu-mdflow-cleanup-1"
     outline_bid = "outline-mdflow-cleanup-1"


### PR DESCRIPTION
Changed:
- Added a shared draft outline write lock helper and reused it in MarkdownFlow content saves.
- Moved MarkdownFlow risk checks before acquiring the outline write lock because risk audit persistence commits the active session.
- Re-read the latest outline version after risk control and inside the locked transaction before creating a content version.
- Added regression coverage for preserving the latest parent and position, including a risk-control commit that inserts a reorder before the content save continues.

Benefit:
- Prevents publish failures caused by overlapping content saves and outline reorders leaving duplicate latest outline positions.
- Keeps the existing publish validation intact so broken outline structures are still blocked instead of silently dropping lessons.

Validation:
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- `cd src/api && pytest tests/test_mdflow_adapter.py tests/service/shifu/test_reorder_outline_tree.py -q`
- pre-commit hooks passed during commit.
