### PR TITLE
fix: truncate billing seed rate bids to the column length

### DIFF
--- a/src/api/flaskr/service/billing/consts.py
+++ b/src/api/flaskr/service/billing/consts.py
@@ -426,6 +426,18 @@ class CreditUsageRateSeed:
         return getattr(self, key)
 
 
+_CREDIT_USAGE_RATE_BID_MAX_LENGTH = 36
+
+
+def _seed_rate_bid(name: str) -> str:
+    # CreditUsageRate.rate_bid is String(36). Legacy non-strict MySQL silently
+    # truncated longer seed bids on insert, so existing production rows store
+    # the 36-char prefixes. Truncating here keeps the seed command working on
+    # strict-mode MySQL and keeps upserts keyed on rate_bid hitting those
+    # existing rows instead of inserting duplicate wildcard rates.
+    return name[:_CREDIT_USAGE_RATE_BID_MAX_LENGTH]
+
+
 def _build_credit_usage_rate_seeds() -> tuple[CreditUsageRateSeed, ...]:
     seeds: list[CreditUsageRateSeed] = []
     effective_from = datetime(2026, 1, 1, 0, 0, 0)
@@ -443,7 +455,9 @@ def _build_credit_usage_rate_seeds() -> tuple[CreditUsageRateSeed, ...]:
         for metric_name, billing_metric in llm_metrics:
             seeds.append(
                 CreditUsageRateSeed(
-                    rate_bid=f"credit-rate-llm-{scene_name}-{metric_name}-default",
+                    rate_bid=_seed_rate_bid(
+                        f"credit-rate-llm-{scene_name}-{metric_name}-default"
+                    ),
                     usage_type=BILL_USAGE_TYPE_LLM,
                     provider="*",
                     model="*",
@@ -459,7 +473,9 @@ def _build_credit_usage_rate_seeds() -> tuple[CreditUsageRateSeed, ...]:
             )
         seeds.append(
             CreditUsageRateSeed(
-                rate_bid=f"credit-rate-tts-{scene_name}-request-default",
+                rate_bid=_seed_rate_bid(
+                    f"credit-rate-tts-{scene_name}-request-default"
+                ),
                 usage_type=BILL_USAGE_TYPE_TTS,
                 provider="*",
                 model="*",

--- a/src/api/tests/service/billing/test_billing_models.py
+++ b/src/api/tests/service/billing/test_billing_models.py
@@ -98,6 +98,18 @@ def test_credit_usage_rate_seeds_cover_all_scenes_with_bootstrap_defaults() -> N
     assert all(row["credits_per_unit"] == 0 for row in CREDIT_USAGE_RATE_SEEDS)
 
 
+def test_credit_usage_rate_seed_bids_fit_column_and_stay_unique() -> None:
+    rate_bid_column_length = CreditUsageRate.rate_bid.type.length
+    bids = [row["rate_bid"] for row in CREDIT_USAGE_RATE_SEEDS]
+
+    assert all(len(bid) <= rate_bid_column_length for bid in bids)
+    assert len(set(bids)) == len(bids)
+    # Legacy non-strict MySQL truncated the original longer bids on insert, so
+    # existing rows store 36-char prefixes; seeds must keep matching them.
+    assert "credit-rate-llm-production-output-de" in bids
+    assert "credit-rate-tts-production-request-d" in bids
+
+
 def test_billing_product_model_uses_catalog_table_name() -> None:
     assert BillingProduct.__tablename__ == "bill_products"
 


### PR DESCRIPTION
## Summary

`flask console billing seed-bootstrap-data` fails on strict-mode MySQL with:

```
pymysql.err.DataError: (1406, "Data too long for column 'rate_bid' at row 1")
```

`_build_credit_usage_rate_seeds()` generates rate bids such as `credit-rate-llm-production-output-default` (41 chars) and `credit-rate-tts-debug-request-default` (37 chars), while `CreditUsageRate.rate_bid` is `String(36)`. On legacy non-strict MySQL the values were silently truncated on insert, which is why existing production rows store 36-char prefixes like `credit-rate-llm-production-output-de`; on strict-mode MySQL (e.g. a fresh RDS instance) the seed command aborts entirely. Found while bootstrapping billing for the US region.

## Changes

- Truncate generated seed rate bids to the 36-char column length in `_build_credit_usage_rate_seeds()` via a `_seed_rate_bid()` helper.
- Truncation (rather than renaming to shorter bids) is deliberate: the seed upsert is keyed on `rate_bid`, so keeping the historical truncated prefixes makes re-runs update the existing wildcard rows instead of inserting zero-credit duplicates that could shadow operator-configured rates.
- Regression test asserting seed bids fit the column, stay unique, and keep matching the truncated prefixes stored by existing production rows.

## Testing

- `python -m pytest tests/service/billing/test_billing_models.py -q` — 12 passed
- `python -m pytest tests/service/billing/test_billing_cli.py -q -k seed` — 3 passed
- `lefthook run pre-commit --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credit usage rate identifiers exceeding the database’s 36-character limit.
  * Updated LLM and TTS credit usage rate generation to preserve unique, valid identifiers.
  * Prevented billing-related errors caused by oversized rate identifiers.

* **Quality Improvements**
  * Added validation to ensure generated identifiers fit storage limits and retain expected legacy prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->