### PR TITLE
fix: prevent course footer from overlapping lesson content

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -229,9 +229,17 @@
   .chatComponents {
     width: 100%;
 
-    height: 100%;
+    // The footer is a fixed/absolute overlay pinned to the bottom. Reserving
+    // the footer height at the container level (shrinking this box) keeps all
+    // scrollable content above the overlay — not just the last item — so lesson
+    // text is never hidden behind the footer while scrolling. Inner
+    // padding-bottom cannot achieve this because the overlay still sits on top
+    // of the scroll area regardless of inner padding.
+    height: calc(100% - var(--chat-footer-height));
     min-width: 0;
-    min-height: calc(var(--app-viewport-block-unit, 1dvh) * 100);
+    min-height: calc(
+      var(--app-viewport-block-unit, 1dvh) * 100 - var(--chat-footer-height)
+    );
     background: #fff;
     flex: 1 1 auto;
     justify-content: center;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -285,6 +285,11 @@
   .footer {
     display: none;
   }
+  // Footer is hidden, so the chat area must not keep reserving space for it.
+  .chatComponents {
+    height: 100%;
+    min-height: calc(var(--app-viewport-block-unit, 1dvh) * 100);
+  }
 }
 
 .previewMode {


### PR DESCRIPTION
## Problem
On the course learning page (`/c/[id]`), the bottom footer (\"Content generated by AI under human guidance | Powered by MarkdownFlow\") overlaps lesson content. While scrolling — especially on mobile and tablet in portrait — the footer sits on top of the last lines of text and the follow-up buttons, partially hiding them.

## Root cause
The footer is a `position: fixed` (mobile) / `position: absolute` (desktop) overlay pinned to the bottom (`bottom: 0`, `height: var(--chat-footer-height)` = 40px, opaque background, `z-index: 10`). The chat scroll container `.chatComponents` was `height: 100%`, so it extended underneath the footer. Because the footer overlays the scroll area, the bottom 40px of content was always covered **while scrolling** — not just at the very end of the lesson.

## Fix
Shrink the scroll container by the footer height so the scrollable area ends above the footer overlay:

- `height: calc(100% - var(--chat-footer-height))`
- `min-height: calc(var(--app-viewport-block-unit, 1dvh) * 100 - var(--chat-footer-height))`

This mirrors how the header is already handled (the absolute header is cleared via `padding-top`). An inner `padding-bottom` was deliberately **not** used: it only reserves space at the very end of scroll and cannot stop the overlay from covering content mid-scroll.

Listen and classroom modes keep their own overrides (`padding: 0 !important` / separate min-height), so they are unaffected.

## Verification
- `sass` compiles the module cleanly.
- `jest` `ChatUi.test` — 8/8 pass.
- Verified on a real iPad in portrait: the lesson content (including the last section and follow-up buttons) is fully readable and no longer hidden behind the footer while scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted chat layout sizing to account for the footer.
  * Ensured scrollable chat content remains visible above the footer overlay.
  * Prevented hidden mobile footers from leaving unnecessary empty space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->