### PR TITLE
fix: prevent admin menu text showing through settings popup

### DIFF
--- a/src/cook-web/src/app/admin/SidebarContent.tsx
+++ b/src/cook-web/src/app/admin/SidebarContent.tsx
@@ -221,7 +221,7 @@ export const SidebarContent = ({
   return (
     <div
       className={cn(
-        'relative flex h-full min-h-0 flex-col',
+        'relative isolate flex h-full min-h-0 flex-col',
         styles.adminLayout,
       )}
     >
@@ -231,7 +231,7 @@ export const SidebarContent = ({
           size={32}
         />
       </h1>
-      <div className='flex min-h-0 flex-1 flex-col p-2'>
+      <div className='relative z-0 flex min-h-0 flex-1 flex-col p-2'>
         {loading ? (
           <div
             className='space-y-3 px-2 pt-2 animate-pulse'
@@ -246,7 +246,7 @@ export const SidebarContent = ({
           <>
             {/* Keep the menu list flexible so the billing card stays pinned to the bottom. */}
             <nav
-              className='min-h-0 flex-1 space-y-1 overflow-y-auto'
+              className='relative z-0 min-h-0 flex-1 space-y-1 overflow-y-auto'
               data-testid='admin-sidebar-nav'
             >
               {renderMenuItems(menuItems)}
@@ -260,17 +260,19 @@ export const SidebarContent = ({
           </>
         )}
       </div>
-      <NavFooter
-        ref={footerRef}
-        onClick={onFooterClick}
-        isMenuOpen={userMenuOpen}
-      />
-      <MainMenuModal
-        open={userMenuOpen}
-        onClose={onUserMenuClose}
-        className={userMenuClassName || adminSidebarStyles.navMenuPopup}
-        isAdmin
-      />
+      <div className='relative z-50 shrink-0'>
+        <NavFooter
+          ref={footerRef}
+          onClick={onFooterClick}
+          isMenuOpen={userMenuOpen}
+        />
+        <MainMenuModal
+          open={userMenuOpen}
+          onClose={onUserMenuClose}
+          className={userMenuClassName || adminSidebarStyles.navMenuPopup}
+          isAdmin
+        />
+      </div>
     </div>
   );
 };

--- a/src/cook-web/src/c-components/PopupModal.module.scss
+++ b/src/cook-web/src/c-components/PopupModal.module.scss
@@ -8,6 +8,6 @@
   min-width: 100px;
   padding: 10px;
   border-radius: 20px;
-  background: var(--color-5);
+  background: var(--color-5, #fff);
   box-shadow: 0px 0px 8px 0px rgba(15, 99, 238, 0.1);
 }


### PR DESCRIPTION
Changed:
- Added explicit stacking contexts in the admin sidebar so the footer user menu renders above the operations navigation.
- Added a white fallback for the shared popup modal background when `--color-5` is not defined.

Benefit:
- The admin user settings popup no longer shows underlying operations menu text through the panel.

Root cause:
- Admin pages do not define the legacy `--color-5` CSS variable used by `PopupModal`, so its background could become transparent.

Validation:
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/layout.test.tsx src/c-components/NavDrawer/MainMenuModal.test.tsx`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layering and stacking behavior in the admin sidebar, footer, and menu modal.
  * Ensured popup modals retain a white background when the configured color is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->