### PR TITLE
fix: avoid learner route state updates during render

### DIFF
--- a/src/cook-web/src/__tests__/c-preview-layout.test.tsx
+++ b/src/cook-web/src/__tests__/c-preview-layout.test.tsx
@@ -57,6 +57,7 @@ describe('C preview layout', () => {
   const mockedGetCourseInfo = getCourseInfo as jest.MockedFunction<
     typeof getCourseInfo
   >;
+  const contentLabel = 'content';
 
   afterEach(() => {
     window.location.href = originalHref;
@@ -84,7 +85,7 @@ describe('C preview layout', () => {
       const previewMode = useSystemStore(state => state.previewMode);
       useEffect(() => {
         observedPreviewMode = previewMode;
-      }, []);
+      }, [previewMode]);
       return null;
     }
 
@@ -96,6 +97,48 @@ describe('C preview layout', () => {
 
     await act(async () => {});
     expect(observedPreviewMode).toBe(true);
+  });
+
+  test('waits for query state before rendering children', async () => {
+    window.location.href =
+      'http://localhost:3000/c/123?preview=true&skip=true&channel=wechat';
+    act(() => {
+      useSystemStore.setState({
+        channel: '',
+        previewMode: false,
+        skip: false,
+      });
+    });
+
+    const observedQueryState: Array<{
+      channel: string;
+      previewMode: boolean;
+      skip: boolean;
+    }> = [];
+
+    function Probe() {
+      const channel = useSystemStore(state => state.channel);
+      const previewMode = useSystemStore(state => state.previewMode);
+      const skip = useSystemStore(state => state.skip);
+      observedQueryState.push({ channel, previewMode, skip });
+      return null;
+    }
+
+    render(
+      <ChatLayout>
+        <Probe />
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(observedQueryState).toEqual([
+        {
+          channel: 'wechat',
+          previewMode: true,
+          skip: true,
+        },
+      ]);
+    });
   });
 
   test('redirects to /404 when course is not found', async () => {
@@ -113,7 +156,7 @@ describe('C preview layout', () => {
 
     render(
       <ChatLayout>
-        <div>content</div>
+        <div>{contentLabel}</div>
       </ChatLayout>,
     );
 
@@ -138,7 +181,7 @@ describe('C preview layout', () => {
 
     render(
       <ChatLayout>
-        <div>content</div>
+        <div>{contentLabel}</div>
       </ChatLayout>,
     );
 

--- a/src/cook-web/src/__tests__/c-preview-layout.test.tsx
+++ b/src/cook-web/src/__tests__/c-preview-layout.test.tsx
@@ -6,6 +6,13 @@ import { getCourseInfo } from '@/c-api/course';
 import { useEnvStore } from '@/c-store';
 import { useSystemStore } from '@/c-store/useSystemStore';
 
+let mockSearchParamsValue = '';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: ['123'] }),
+  useSearchParams: () => new URLSearchParams(mockSearchParamsValue),
+}));
+
 jest.mock('@/c-api/course', () => ({
   getCourseInfo: jest.fn(),
 }));
@@ -60,6 +67,7 @@ describe('C preview layout', () => {
   const contentLabel = 'content';
 
   afterEach(() => {
+    mockSearchParamsValue = '';
     window.location.href = originalHref;
     mockedGetCourseInfo.mockReset();
     act(() => {
@@ -74,7 +82,8 @@ describe('C preview layout', () => {
   });
 
   test('applies preview mode before child effects run', async () => {
-    window.location.href = 'http://localhost:3000/c/123?preview=true';
+    mockSearchParamsValue = 'preview=true';
+    window.history.replaceState({}, '', '/c/123?preview=true');
     act(() => {
       useSystemStore.setState({ previewMode: false, skip: false });
     });
@@ -100,8 +109,12 @@ describe('C preview layout', () => {
   });
 
   test('waits for query state before rendering children', async () => {
-    window.location.href =
-      'http://localhost:3000/c/123?preview=true&skip=true&channel=wechat';
+    mockSearchParamsValue = 'preview=true&skip=true&channel=wechat';
+    window.history.replaceState(
+      {},
+      '',
+      '/c/123?preview=true&skip=true&channel=wechat',
+    );
     act(() => {
       useSystemStore.setState({
         channel: '',
@@ -138,6 +151,57 @@ describe('C preview layout', () => {
           skip: true,
         },
       ]);
+    });
+  });
+
+  test('updates query state after search params change', async () => {
+    mockSearchParamsValue = 'preview=true&skip=false&channel=wechat';
+    window.history.replaceState(
+      {},
+      '',
+      '/c/123?preview=true&skip=false&channel=wechat',
+    );
+    act(() => {
+      useSystemStore.setState({
+        channel: '',
+        previewMode: false,
+        skip: false,
+      });
+    });
+
+    const { rerender } = render(
+      <ChatLayout>
+        <div>{contentLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(useSystemStore.getState()).toMatchObject({
+        channel: 'wechat',
+        previewMode: true,
+        skip: false,
+      });
+    });
+
+    mockSearchParamsValue = 'preview=false&skip=true&channel=app';
+    window.history.replaceState(
+      {},
+      '',
+      '/c/123?preview=false&skip=true&channel=app',
+    );
+
+    rerender(
+      <ChatLayout>
+        <div>{contentLabel}</div>
+      </ChatLayout>,
+    );
+
+    await waitFor(() => {
+      expect(useSystemStore.getState()).toMatchObject({
+        channel: 'app',
+        previewMode: false,
+        skip: true,
+      });
     });
   });
 

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { parseUrlParams } from '@/c-utils/urlUtils';
 // import routes from './Router/index';
 // import { useRoutes } from 'react-router-dom';
 // import { ConfigProvider } from 'antd';
@@ -10,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { debugError, debugInfo, debugWarn } from '@/c-utils/debugConsole';
 
 import { useShallow } from 'zustand/react/shallow';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 
 import {
   inWechat,
@@ -91,6 +90,7 @@ export default function ChatLayout({
   const { i18n, t } = useTranslation();
   const { trackEvent } = useTracking();
   const routeParams = useParams<{ id?: string[] }>();
+  const searchParams = useSearchParams();
 
   const [checkWxcode, setCheckWxcode] = useState<boolean>(false);
   const envDataInitialized = useEnvStore(
@@ -157,15 +157,22 @@ export default function ChatLayout({
   }, [browserLanguage, updateLanguage, envDataInitialized, userInfo]);
 
   // const [loading, setLoading] = useState<boolean>(true);
-  const params = parseUrlParams() as Record<string, string>;
+  const queryCode = searchParams?.get('code') || '';
+  const queryCourseId = searchParams?.get('courseId') || '';
+  const queryLessonId = searchParams?.get('lessonid') || '';
+  const queryChannel = searchParams?.get('channel') || '';
+  const queryPreview = searchParams?.get('preview') || '';
+  const querySkip = searchParams?.get('skip') || '';
+  const queryListen = searchParams?.get('listen') || '';
+  const queryMode = searchParams?.get('mode') || '';
   const routeCourseId = Array.isArray(routeParams?.id) ? routeParams.id[0] : '';
-  const storageCourseId = routeCourseId || params.courseId || courseId;
-  const outlineBid = params.lessonid || '';
-  const currChannel = params.channel || '';
-  const isPreviewMode = parseBooleanQueryParam(params.preview) ?? false;
-  const isSkipMode = parseBooleanQueryParam(params.skip) ?? false;
-  const listenModeParam = parseBooleanQueryParam(params.listen);
-  const urlModeParam = parseLearningModeQueryParam(params.mode);
+  const storageCourseId = routeCourseId || queryCourseId || courseId;
+  const outlineBid = queryLessonId;
+  const currChannel = queryChannel;
+  const isPreviewMode = parseBooleanQueryParam(queryPreview) ?? false;
+  const isSkipMode = parseBooleanQueryParam(querySkip) ?? false;
+  const listenModeParam = parseBooleanQueryParam(queryListen);
+  const urlModeParam = parseLearningModeQueryParam(queryMode);
   const hasListenModeOverride = listenModeParam !== null;
   const hasClassroomModeOverride = urlModeParam === 'classroom';
   const canUseClassroomModeForCourse =
@@ -223,7 +230,7 @@ export default function ChatLayout({
     }
 
     const { appId } = useEnvStore.getState() as EnvStoreState;
-    const currCode = params.code;
+    const currCode = queryCode;
 
     if (!appId) {
       debugWarn('[lesson-layout] WeChat appId missing, skip OAuth redirect');
@@ -243,7 +250,7 @@ export default function ChatLayout({
     }
     setCheckWxcode(true);
   }, [
-    params.code,
+    queryCode,
     updateWechatCode,
     wechatCode,
     envDataInitialized,
@@ -253,12 +260,12 @@ export default function ChatLayout({
   useEffect(() => {
     const fetchCourseInfo = async () => {
       if (!envDataInitialized) return;
-      if (params.courseId) {
-        await updateCourseId(params.courseId);
+      if (queryCourseId) {
+        await updateCourseId(queryCourseId);
       }
     };
     fetchCourseInfo();
-  }, [envDataInitialized, updateCourseId, courseId, params.courseId]);
+  }, [envDataInitialized, updateCourseId, courseId, queryCourseId]);
 
   useEffect(() => {
     updateShowLearningModeToggle(showLearningModeToggle);

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -184,19 +184,34 @@ export default function ChatLayout({
         hasClassroomModeUrlOverride ||
         canUseClassroomModeForCourse === true;
 
-  if (channel !== currChannel) {
-    updateChannel(currChannel);
-  }
+  const queryStateReady =
+    channel === currChannel &&
+    previewMode === isPreviewMode &&
+    skip === isSkipMode;
 
-  // Apply preview/skip flags eagerly so child components (and their effects) see
-  // the correct mode on the first render.
-  if (previewMode !== isPreviewMode) {
-    updatePreviewMode(isPreviewMode);
-  }
+  useEffect(() => {
+    if (channel !== currChannel) {
+      updateChannel(currChannel);
+    }
 
-  if (skip !== isSkipMode) {
-    updateSkip(isSkipMode);
-  }
+    if (previewMode !== isPreviewMode) {
+      updatePreviewMode(isPreviewMode);
+    }
+
+    if (skip !== isSkipMode) {
+      updateSkip(isSkipMode);
+    }
+  }, [
+    channel,
+    currChannel,
+    isPreviewMode,
+    isSkipMode,
+    previewMode,
+    skip,
+    updateChannel,
+    updatePreviewMode,
+    updateSkip,
+  ]);
 
   useEffect(() => {
     if (!envDataInitialized) return;
@@ -246,17 +261,8 @@ export default function ChatLayout({
   }, [envDataInitialized, updateCourseId, courseId, params.courseId]);
 
   useEffect(() => {
-    updatePreviewMode(isPreviewMode);
-    updateSkip(isSkipMode);
     updateShowLearningModeToggle(showLearningModeToggle);
-  }, [
-    isPreviewMode,
-    isSkipMode,
-    showLearningModeToggle,
-    updatePreviewMode,
-    updateSkip,
-    updateShowLearningModeToggle,
-  ]);
+  }, [showLearningModeToggle, updateShowLearningModeToggle]);
 
   useEffect(() => {
     normalizeLegacyListenModeInUrl({
@@ -597,6 +603,10 @@ export default function ChatLayout({
     if (!checkWxcode) return;
     initUser();
   }, [envDataInitialized, checkWxcode, initUser]);
+
+  if (!queryStateReady) {
+    return null;
+  }
 
   return <UserProvider>{children}</UserProvider>;
 }


### PR DESCRIPTION
Summary:
- Move learner route URL state synchronization for channel, preview, and skip out of render and into an effect.
- Gate learner route children until query state is applied, so first child render still sees the correct URL-derived state.
- Add a regression test for query-state gating before child render.

Validation:
- cd src/cook-web && npm test -- --runTestsByPath src/__tests__/c-preview-layout.test.tsx src/app/c/layout.test.tsx 'src/app/c/[[...id]]/page.test.tsx'
- cd src/cook-web && npm run lint -- --file 'src/app/c/[[...id]]/layout.tsx' --file src/__tests__/c-preview-layout.test.tsx
- cd src/cook-web && npm run type-check
- python scripts/check_dev_tools.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview-mode page loading so channel, preview, and skip settings are applied from the URL before content appears.
  * Prevented inconsistent rendering while query-based settings are being synchronized.
  * Updated learning mode behavior to avoid unintentionally changing preview and skip settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->