### PR TITLE
fix: match credit notification teacher search hint

### DIFF
--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import AdminClearableInput from '@/app/admin/components/AdminClearableInput';
 import AdminDateRangeFilter from '@/app/admin/components/AdminDateRangeFilter';
 import AdminFilter from '@/app/admin/components/AdminFilter';
+import { useEnvStore } from '@/c-store';
 import {
   Select,
   SelectContent,
@@ -19,6 +20,7 @@ import {
   NOTIFICATION_SKIP_REASONS,
   NOTIFICATION_TYPES,
 } from './creditNotificationUtils';
+import { resolveContactMode } from '@/lib/resolve-contact-mode';
 
 const SELECT_ITEM_CLASS = 'pl-3 pr-8';
 
@@ -48,8 +50,14 @@ export function CreditNotificationRecordsFilter({
   resolveSourceTypeLabel: (value: string) => string;
 }) {
   const { t } = useTranslation();
+  const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
+  const defaultLoginMethod = useEnvStore(state => state.defaultLoginMethod);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const clearLabel = t('common.core.close');
+  const creatorPlaceholderKey =
+    resolveContactMode(loginMethodsEnabled, defaultLoginMethod) === 'email'
+      ? 'module.operationsCreditNotifications.filters.creatorPlaceholderEmail'
+      : 'module.operationsCreditNotifications.filters.creatorPlaceholderPhone';
 
   const filterItems = useMemo(() => {
     const renderTypeSelect = () => (
@@ -220,9 +228,7 @@ export function CreditNotificationRecordsFilter({
     const renderCreatorInput = () => (
       <AdminClearableInput
         value={draftFilters.creator_keyword}
-        placeholder={t(
-          'module.operationsCreditNotifications.filters.creatorPlaceholder',
-        )}
+        placeholder={t(creatorPlaceholderKey)}
         clearLabel={clearLabel}
         onChange={value => updateDraftFilter('creator_keyword', value)}
       />
@@ -270,6 +276,7 @@ export function CreditNotificationRecordsFilter({
     ];
   }, [
     clearLabel,
+    creatorPlaceholderKey,
     draftFilters,
     resolveDeliveryStatusLabel,
     resolveSkipReasonLabel,

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -651,7 +651,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
 
     fireEvent.change(
       screen.getByPlaceholderText(
-        'module.operationsCreditNotifications.filters.creatorPlaceholder',
+        'module.operationsCreditNotifications.filters.creatorPlaceholderPhone',
       ),
       { target: { value: '13800138000' } },
     );
@@ -695,6 +695,22 @@ describe('AdminOperationCreditNotificationsPage', () => {
         page_index: 1,
       }),
     );
+  });
+
+  it('uses email teacher search placeholder when email login is enabled', async () => {
+    mockLoginMethodsEnabled = ['email'];
+    mockDefaultLoginMethod = 'email';
+    render(<AdminOperationCreditNotificationsPage />);
+
+    await waitFor(() => {
+      expect(mockGetRecords).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByPlaceholderText(
+        'module.operationsCreditNotifications.filters.creatorPlaceholderEmail',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('applies overview card filters to the search results', async () => {

--- a/src/i18n/en-US/modules/operations-credit-notifications.json
+++ b/src/i18n/en-US/modules/operations-credit-notifications.json
@@ -306,6 +306,8 @@
     "creator": "Teacher",
     "creatorBid": "Teacher ID",
     "creatorPlaceholder": "Email / nickname",
+    "creatorPlaceholderEmail": "Email / nickname",
+    "creatorPlaceholderPhone": "Mobile / nickname",
     "mobile": "Mobile",
     "notificationType": "Notification type",
     "skipReason": "Not-sent reason",

--- a/src/i18n/fr-FR/modules/operations-credit-notifications.json
+++ b/src/i18n/fr-FR/modules/operations-credit-notifications.json
@@ -306,6 +306,8 @@
     "creator": "Créateur",
     "creatorBid": "ID de créateur",
     "creatorPlaceholder": "E-mail / pseudonyme",
+    "creatorPlaceholderEmail": "E-mail / pseudonyme",
+    "creatorPlaceholderPhone": "Mobile / pseudonyme",
     "mobile": "Mobile",
     "notificationType": "Type de notification",
     "skipReason": "Raison de non-envoi",

--- a/src/i18n/zh-CN/modules/operations-credit-notifications.json
+++ b/src/i18n/zh-CN/modules/operations-credit-notifications.json
@@ -306,6 +306,8 @@
     "creator": "老师",
     "creatorBid": "老师ID",
     "creatorPlaceholder": "手机号/昵称",
+    "creatorPlaceholderEmail": "邮箱/昵称",
+    "creatorPlaceholderPhone": "手机号/昵称",
     "mobile": "手机号",
     "notificationType": "通知类型",
     "skipReason": "未发送原因",


### PR DESCRIPTION
Summary:
- Make the Operations credit notification teacher search placeholder follow the site's preferred contact mode.
- Add explicit email and phone placeholder translations for zh-CN, en-US, and fr-FR.
- Cover email-mode placeholder behavior in the credit notification page test.

Validation:
- cd src/cook-web && npm test -- --runTestsByPath src/app/admin/operations/credit-notifications/page.test.tsx
- cd src/cook-web && npm run lint -- --file src/app/admin/operations/credit-notifications/CreditNotificationRecordsFilter.tsx --file src/app/admin/operations/credit-notifications/page.test.tsx
- cd src/cook-web && npm run type-check
- PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improved Search**
  - Creator search fields in credit notification records now display the appropriate placeholder for email- or mobile-based login configurations.
  - Search guidance adapts automatically to the configured login method.

- **Localization**
  - Added email- and mobile-specific search placeholders in English, French, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->