### PR TITLE
fix: let dashboard course table fit content height

### DIFF
--- a/src/cook-web/src/app/admin/dashboard/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/page.tsx
@@ -296,14 +296,14 @@ export default function AdminDashboardEntryPage() {
           </div>
         ) : null}
 
-        <div className='flex min-h-0 flex-1 flex-col'>
+        <div className='shrink-0'>
           <AdminTableShell
             loading={loading}
             isEmpty={items.length === 0}
             emptyContent={t('module.dashboard.entry.table.empty')}
             emptyColSpan={6}
-            containerClassName='min-h-0 flex-1'
-            tableWrapperClassName='flex min-h-0 flex-1 flex-col overflow-hidden'
+            containerClassName='shrink-0'
+            tableWrapperClassName='overflow-hidden'
             tableWrapperTestId='dashboard-course-list-scroll-region'
             loadingClassName='h-auto min-h-40 flex-1'
             footerTestId='dashboard-course-list-footer'
@@ -328,7 +328,7 @@ export default function AdminDashboardEntryPage() {
             }}
             table={emptyRow => (
               <Table
-                containerClassName='min-h-0 flex-1'
+                containerClassName='max-h-[calc(100vh-360px)]'
                 className='min-w-[980px]'
               >
                 <TableHeader>

--- a/src/cook-web/src/app/admin/dashboard/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/page.tsx
@@ -296,14 +296,14 @@ export default function AdminDashboardEntryPage() {
           </div>
         ) : null}
 
-        <div className='shrink-0'>
+        <div className='flex min-h-0 flex-1 flex-col'>
           <AdminTableShell
             loading={loading}
             isEmpty={items.length === 0}
             emptyContent={t('module.dashboard.entry.table.empty')}
             emptyColSpan={6}
-            containerClassName='shrink-0'
-            tableWrapperClassName='overflow-hidden'
+            containerClassName='min-h-0 flex-1'
+            tableWrapperClassName='min-h-0 overflow-hidden'
             tableWrapperTestId='dashboard-course-list-scroll-region'
             loadingClassName='h-auto min-h-40 flex-1'
             footerTestId='dashboard-course-list-footer'
@@ -328,7 +328,7 @@ export default function AdminDashboardEntryPage() {
             }}
             table={emptyRow => (
               <Table
-                containerClassName='max-h-[calc(100vh-360px)]'
+                containerClassName='max-h-full'
                 className='min-w-[980px]'
               >
                 <TableHeader>


### PR DESCRIPTION
Summary:
- Let the admin dashboard course table fit its content height for short lists.
- Keep long course lists bounded by the parent layout's remaining height instead of a fixed viewport offset.
- Preserve the footer and pagination outside the table scroll region so they stay reachable.

Validation:
- `cd src/cook-web && npm test -- --runTestsByPath src/app/admin/dashboard/page.test.tsx`
- `cd src/cook-web && npm run lint -- --file src/app/admin/dashboard/page.tsx`
- `cd src/cook-web && npm run type-check`
- `git diff --check`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- Commit hook: lefthook pre-commit and commit-msg
