### PR TITLE
fix: fit promotion filter controls

### DIFF
--- a/src/cook-web/src/app/admin/operations/promotions/PromotionCampaignsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/PromotionCampaignsTab.tsx
@@ -26,6 +26,7 @@ import {
   renderTimeRange,
   renderTooltipText,
   resolveCampaignApplyTypeLabel,
+  PROMOTION_FILTER_COLLAPSED_GRID_CLASS,
   SectionCard,
   shouldShowCampaignStatusToggle,
   TABLE_ACTION_CELL_CLASS,
@@ -116,8 +117,8 @@ export default function PromotionCampaignsTab({
           className='bg-transparent'
           contentClassName='min-w-0'
           labelClassName='w-24 text-right'
-          collapsedGridClassName='gap-x-5 xl:grid-cols-4'
-          expandedGridClassName='gap-x-5 xl:grid-cols-3'
+          collapsedGridClassName={PROMOTION_FILTER_COLLAPSED_GRID_CLASS}
+          expandedGridClassName='gap-x-5 xl:grid-cols-4'
           labelColon
         />
       </SectionCard>

--- a/src/cook-web/src/app/admin/operations/promotions/PromotionCouponsTab.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/PromotionCouponsTab.tsx
@@ -29,6 +29,7 @@ import {
   renderTooltipText,
   resolveCouponScopeLabel,
   resolveCouponUsageTypeLabel,
+  PROMOTION_FILTER_COLLAPSED_GRID_CLASS,
   SectionCard,
   shouldShowCouponStatusToggle,
   TABLE_ACTION_CELL_CLASS,
@@ -122,8 +123,8 @@ export default function PromotionCouponsTab({
           className='bg-transparent'
           contentClassName='min-w-0'
           labelClassName='w-24 text-right'
-          collapsedGridClassName='gap-x-5 xl:grid-cols-4'
-          expandedGridClassName='gap-x-5 xl:grid-cols-3'
+          collapsedGridClassName={PROMOTION_FILTER_COLLAPSED_GRID_CLASS}
+          expandedGridClassName='gap-x-5 xl:grid-cols-4'
           labelColon
         />
       </SectionCard>

--- a/src/cook-web/src/app/admin/operations/promotions/page.list.test.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.list.test.tsx
@@ -6,8 +6,14 @@ import {
   mockUpdateCouponStatus,
 } from './promotionsTestUtils.test-support';
 import AdminOperationPromotionsPage from './page';
+import { PROMOTION_FILTER_COLLAPSED_GRID_CLASS } from './promotionPageShared';
 
 describe('AdminOperationPromotionsPage list and pagination', () => {
+  test('keeps collapsed coupon filters shrinkable beside actions', () => {
+    expect(PROMOTION_FILTER_COLLAPSED_GRID_CLASS).toContain('minmax(0,180px)');
+    expect(PROMOTION_FILTER_COLLAPSED_GRID_CLASS).not.toContain('flex-none');
+  });
+
   test('loads coupon tab by default', async () => {
     render(<AdminOperationPromotionsPage />);
 

--- a/src/cook-web/src/app/admin/operations/promotions/page.list.test.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/page.list.test.tsx
@@ -6,12 +6,21 @@ import {
   mockUpdateCouponStatus,
 } from './promotionsTestUtils.test-support';
 import AdminOperationPromotionsPage from './page';
-import { PROMOTION_FILTER_COLLAPSED_GRID_CLASS } from './promotionPageShared';
 
 describe('AdminOperationPromotionsPage list and pagination', () => {
-  test('keeps collapsed coupon filters shrinkable beside actions', () => {
-    expect(PROMOTION_FILTER_COLLAPSED_GRID_CLASS).toContain('minmax(0,180px)');
-    expect(PROMOTION_FILTER_COLLAPSED_GRID_CLASS).not.toContain('flex-none');
+  test('renders collapsed coupon filters shrinkable beside actions', async () => {
+    const { container } = render(<AdminOperationPromotionsPage />);
+
+    const collapsedGrid = Array.from(container.querySelectorAll('.grid')).find(
+      element => element.className.includes('minmax(0,180px)'),
+    );
+
+    expect(collapsedGrid).toBeInTheDocument();
+    expect(collapsedGrid).toHaveClass(
+      'xl:grid-cols-[minmax(0,180px)_minmax(0,210px)_minmax(0,190px)_minmax(0,250px)]',
+    );
+    expect(collapsedGrid).not.toHaveClass('xl:flex-none');
+    await waitFor(() => expect(mockGetCoupons).toHaveBeenCalled());
   });
 
   test('loads coupon tab by default', async () => {

--- a/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
@@ -30,6 +30,9 @@ export type PromotionTab =
   | 'packageCampaigns'
   | 'referralCampaigns';
 
+export const PROMOTION_FILTER_COLLAPSED_GRID_CLASS =
+  'gap-x-2 xl:flex-none xl:grid-cols-[180px_210px_190px_250px]';
+
 export type CouponFilters = {
   keyword: string;
   name: string;

--- a/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
+++ b/src/cook-web/src/app/admin/operations/promotions/promotionPageShared.tsx
@@ -31,7 +31,7 @@ export type PromotionTab =
   | 'referralCampaigns';
 
 export const PROMOTION_FILTER_COLLAPSED_GRID_CLASS =
-  'gap-x-2 xl:flex-none xl:grid-cols-[180px_210px_190px_250px]';
+  'gap-x-2 xl:grid-cols-[minmax(0,180px)_minmax(0,210px)_minmax(0,190px)_minmax(0,250px)]';
 
 export type CouponFilters = {
   keyword: string;


### PR DESCRIPTION
Summary:
- Adjust promotion coupon and campaign collapsed filter columns to use non-uniform, shrinkable widths that keep all controls on one line without clipping the action buttons.
- Change expanded promotion filters to four columns per row, leaving the action row right-aligned below the filters.
- Add a regression assertion that the shared collapsed promotion filter grid stays shrinkable and does not reintroduce `flex-none`.

Validation:
- `cd src/cook-web && npm run test -- --runTestsByPath src/app/admin/operations/promotions/page.coupons.test.tsx`
- `cd src/cook-web && npm run test -- --runTestsByPath src/app/admin/operations/promotions/page.list.test.tsx`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint -- --file src/app/admin/operations/promotions/page.list.test.tsx --file src/app/admin/operations/promotions/promotionPageShared.tsx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of promotion campaign and coupon filters.
  * Expanded filters now display four columns on extra-large screens.
  * Collapsed filters use a consistent, space-efficient grid layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->