### PR TITLE
fix: dispose the DB pool inherited by forked celery workers

### DIFF
--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from celery import Celery, Task
 from celery.schedules import crontab
+from celery.signals import worker_process_init
 from flask import Flask
 
 from flaskr.common.config import get_explicit_env_override
@@ -24,10 +25,39 @@ _DEFAULT_BILLING_DAILY_LEDGER_SUMMARY_CRON = "30 1 * * *"
 __CELERY_APP__: Celery | None = None
 
 
+def dispose_inherited_db_pools(flask_app: Flask) -> None:
+    """Drop DB pool state inherited across a process fork.
+
+    The celery parent builds the Flask app (validating a DB connection on
+    the way), then billiard forks the worker children, which inherit the
+    pool WITH the parent's open sockets. Concurrent children then
+    interleave the MySQL protocol on one shared connection - production
+    journals showed '-- pool checkout -- pid=1' followed by checkouts from
+    two different worker pids on the same server thread id (off-by-one
+    desync). dispose(close=False) discards the inherited pool without
+    closing the parent's file descriptors, mirroring the gunicorn
+    post_fork handling.
+    """
+    from flaskr.dao import db
+
+    with flask_app.app_context():
+        for engine in db.engines.values():
+            engine.dispose(close=False)
+
+
 def create_celery_app(flask_app: Flask | None = None) -> Celery:
     """Build a Celery app bound to the Flask app context."""
 
     resolved_flask_app = flask_app or _load_flask_app()
+
+    @worker_process_init.connect(weak=False)
+    def _dispose_db_pools_after_fork(**_kwargs: Any) -> None:
+        try:
+            dispose_inherited_db_pools(resolved_flask_app)
+        except Exception:  # pragma: no cover - never kill a booting worker
+            resolved_flask_app.logger.exception(
+                "celery worker fork pool dispose failed"
+            )
 
     class FlaskTask(Task):
         abstract = True

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -41,8 +41,15 @@ def dispose_inherited_db_pools(flask_app: Flask) -> None:
     from flaskr.dao import db
 
     with flask_app.app_context():
-        for engine in db.engines.values():
-            engine.dispose(close=False)
+        for bind_key, engine in db.engines.items():
+            try:
+                engine.dispose(close=False)
+            except Exception:
+                # One failing bind must not leave the remaining binds with
+                # their inherited pools.
+                flask_app.logger.exception(
+                    "fork pool dispose failed for bind %r", bind_key
+                )
 
 
 def create_celery_app(flask_app: Flask | None = None) -> Celery:

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -1,0 +1,44 @@
+"""Celery worker children must not reuse the parent's pooled connections.
+
+The celery parent builds the Flask app (validating a DB connection on the
+way); billiard then forks worker children which inherit the pool with the
+parent's open sockets. Production journals showed one connection checked
+out by pid=1 and then by two different worker pids on the same MySQL
+server thread id - concurrent children interleaving one socket is the
+off-by-one protocol desync. The worker_process_init hook must discard the
+inherited pool without touching the parent's file descriptors.
+"""
+
+from celery.signals import worker_process_init
+from sqlalchemy import text
+
+from flaskr.common.celery_app import dispose_inherited_db_pools, get_celery_app
+from flaskr.dao import db
+
+
+def test_dispose_replaces_the_inherited_pool(app):
+    with app.app_context():
+        db.session.execute(text("SELECT 1"))
+        db.session.remove()
+        inherited_pool = db.engine.pool
+
+    dispose_inherited_db_pools(app)
+
+    with app.app_context():
+        assert db.engine.pool is not inherited_pool
+        # The replacement pool must be immediately usable.
+        db.session.execute(text("SELECT 1"))
+        db.session.remove()
+
+
+def test_worker_process_init_signal_disposes_pools(app):
+    get_celery_app(app)
+    with app.app_context():
+        db.session.execute(text("SELECT 1"))
+        db.session.remove()
+        inherited_pool = db.engine.pool
+
+    worker_process_init.send(sender=None)
+
+    with app.app_context():
+        assert db.engine.pool is not inherited_pool

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -42,3 +42,26 @@ def test_worker_process_init_signal_disposes_pools(app):
 
     with app.app_context():
         assert db.engine.pool is not inherited_pool
+
+
+def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
+    import flaskr.dao as dao
+
+    disposed = []
+
+    class _BrokenEngine:
+        def dispose(self, close):
+            raise RuntimeError("bind gone")
+
+    class _GoodEngine:
+        def dispose(self, close):
+            disposed.append(close)
+
+    class _FakeDB:
+        engines = {"broken": _BrokenEngine(), None: _GoodEngine()}
+
+    monkeypatch.setattr(dao, "db", _FakeDB())
+
+    dispose_inherited_db_pools(app)
+
+    assert disposed == [False]


### PR DESCRIPTION
## Problem

On 2026-08-10 the desync interceptor fired three times on `new-shifu-celery-worker` (plus one checkin-probe catch), and the journal's checkout boundary markers (added in #2274) captured the mechanism directly:

```
('-- pool checkout -- pid=1',  None, None),   <- celery PARENT used the connection
('SELECT sys_configs...',      0,    None),
('-- pool checkout -- pid=17', None, None),   <- forked worker child reused it
...
```

Two simultaneous alerts showed pids 17 and 21 intercepting on the **same `server_thread_id=485482`** - two forked worker children concurrently driving one inherited MySQL socket. The celery parent builds the Flask app (which validates a DB connection, the `sys_configs` SELECT above), billiard forks the prefork children, and every child inherits the engine pool with the parent's open sockets. Concurrent children interleave the wire protocol → off-by-one desync. The API side has had this exact handling in gunicorn's `post_fork` since preload landed; celery had no equivalent.

## Changes

- `flaskr/common/celery_app.py`: `create_celery_app` registers a `worker_process_init` handler that calls the new `dispose_inherited_db_pools(flask_app)` helper - `engine.dispose(close=False)` for every bound engine, discarding the inherited pool without closing the parent's file descriptors (mirroring `gunicorn.conf.py post_fork`). Failures are logged, never fatal to a booting worker.

## Verification

- New `tests/common/test_celery_fork_pool_dispose.py`: the helper replaces the pool and the replacement is immediately usable; the `worker_process_init` signal wired by `create_celery_app` disposes pools end-to-end.
- Full backend suite: 2624 passed, 15 skipped.

## Rollout observation

After deploy, celery-worker desync interceptions and checkin catches should drop to zero; journals should no longer show a `pid=1` checkout followed by worker-pid checkouts on one connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting background workers by preventing reuse of inherited database connections.
  * Ensured replacement database connection pools remain available for worker operations.
  * Worker startup now continues even if connection-pool cleanup encounters an error.

* **Tests**
  * Added coverage for worker initialization and database connection-pool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->