### PR TITLE
fix: retry provider-throttled TTS segments with staggered backoff

### DIFF
--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -105,6 +105,19 @@ def _get_tts_executor() -> ThreadPoolExecutor:
 _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"
 _EMPTY_AUDIO_RETRY_PROVIDERS = {"", "tencent", "tencent_texttovoice", "volcengine"}
 _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
+# Provider throttling (e.g. Tencent LimitExceeded.AccessLimit) hits whole
+# bursts of concurrent segments at once; retries back off longer than the
+# empty-audio case and are staggered by segment index so the retrying
+# threads do not re-collide on the provider's quota window.
+_RATE_LIMIT_RETRY_MAX_ATTEMPTS = 3
+_RATE_LIMIT_RETRY_BASE_DELAY_SECONDS = 1.0
+_RATE_LIMIT_RETRY_STAGGER_SECONDS = 0.4
+_RATE_LIMIT_ERROR_MARKERS = (
+    "LimitExceeded",
+    "Too many requests",
+    "too frequently",
+    "rate limit",
+)
 _TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}
 _NON_SPEAKABLE_TTS_SKIP_PROVIDERS = {
@@ -134,6 +147,15 @@ def _is_retryable_empty_audio_error(error: Exception, provider_name: str) -> boo
     return (
         normalized_provider in _EMPTY_AUDIO_RETRY_PROVIDERS
         and _EMPTY_AUDIO_ERROR_MESSAGE in str(error)
+    )
+
+
+def _is_retryable_rate_limit_error(error: Exception) -> bool:
+    message = str(error)
+    lowered = message.lower()
+    return any(
+        marker in message or marker.lower() in lowered
+        for marker in _RATE_LIMIT_ERROR_MARKERS
     )
 
 
@@ -510,7 +532,9 @@ class StreamingTTSProcessor:
     ):
         result = None
         max_attempts = 2
-        for attempt in range(1, max_attempts + 1):
+        attempt = 0
+        while True:
+            attempt += 1
             try:
                 result = synthesize_text(
                     text=text,
@@ -534,6 +558,28 @@ class StreamingTTSProcessor:
                         _tts_error_text_preview(text or ""),
                     )
                     time.sleep(_EMPTY_AUDIO_RETRY_DELAY_SECONDS)
+                    continue
+                if (
+                    attempt < _RATE_LIMIT_RETRY_MAX_ATTEMPTS
+                    and _is_retryable_rate_limit_error(e)
+                ):
+                    delay = (
+                        _RATE_LIMIT_RETRY_BASE_DELAY_SECONDS * attempt
+                        + (segment_index or 0)
+                        % _RATE_LIMIT_RETRY_MAX_ATTEMPTS
+                        * _RATE_LIMIT_RETRY_STAGGER_SECONDS
+                    )
+                    logger.warning(
+                        "TTS segment %s throttled by provider; retrying in "
+                        "%.1fs (attempt %s/%s): provider=%s model=%s",
+                        segment_index if segment_index is not None else "request",
+                        delay,
+                        attempt,
+                        _RATE_LIMIT_RETRY_MAX_ATTEMPTS,
+                        tts_provider or "(auto)",
+                        tts_model or "(unset)",
+                    )
+                    time.sleep(delay)
                     continue
                 raise
         if result is None:

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -112,6 +112,12 @@ _EMPTY_AUDIO_RETRY_DELAY_SECONDS = 0.2
 _RATE_LIMIT_RETRY_MAX_ATTEMPTS = 3
 _RATE_LIMIT_RETRY_BASE_DELAY_SECONDS = 1.0
 _RATE_LIMIT_RETRY_STAGGER_SECONDS = 0.4
+# Stagger slot count matches the TTS executor width (4 workers): at most 4
+# segments synthesize concurrently and their indexes are close to
+# consecutive, so 4 slots give every in-flight segment a distinct delay
+# while keeping the delay bounded (a plain index multiplier would make
+# late segments wait tens of seconds).
+_RATE_LIMIT_RETRY_STAGGER_SLOTS = 4
 _RATE_LIMIT_ERROR_MARKERS = (
     "LimitExceeded",
     "Too many requests",
@@ -566,7 +572,7 @@ class StreamingTTSProcessor:
                     delay = (
                         _RATE_LIMIT_RETRY_BASE_DELAY_SECONDS * attempt
                         + (segment_index or 0)
-                        % _RATE_LIMIT_RETRY_MAX_ATTEMPTS
+                        % _RATE_LIMIT_RETRY_STAGGER_SLOTS
                         * _RATE_LIMIT_RETRY_STAGGER_SECONDS
                     )
                     logger.warning(

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -1,0 +1,104 @@
+"""Provider throttling must be retried with backoff, not fail the segment.
+
+Tencent large-model TTS returns ``LimitExceeded.AccessLimit`` for whole
+bursts of concurrent segments; a burst previously lost every throttled
+segment's audio. Throttled calls now retry with a staggered backoff.
+"""
+
+import types
+
+import pytest
+
+from flaskr.service.tts import streaming_tts
+from flaskr.service.tts.streaming_tts import (
+    _RATE_LIMIT_RETRY_MAX_ATTEMPTS,
+    _is_retryable_rate_limit_error,
+)
+
+_TENCENT_MESSAGE = (
+    "Tencent TextToVoice error LimitExceeded.AccessLimit: Your request is "
+    "too frequently. Please try again later"
+)
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        (_TENCENT_MESSAGE, True),
+        ("HTTP 429 Too many requests", True),
+        ("provider rate limit reached", True),
+        ("Tencent TextToVoice error AuthFailure: bad secret", False),
+        ("No audio data received", False),
+    ],
+)
+def test_rate_limit_detector(message, expected):
+    assert _is_retryable_rate_limit_error(ValueError(message)) is expected
+
+
+def _run_retry(monkeypatch, outcomes, segment_index=0):
+    calls = []
+    sleeps = []
+
+    def _fake_synthesize_text(**kwargs):
+        calls.append(kwargs)
+        outcome = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(streaming_tts, "synthesize_text", _fake_synthesize_text)
+    monkeypatch.setattr(streaming_tts.time, "sleep", sleeps.append)
+
+    generator = object.__new__(streaming_tts.StreamingTTSProcessor)
+    result = streaming_tts.StreamingTTSProcessor._synthesize_text_with_retry(
+        generator,
+        text="hello",
+        voice_settings=None,
+        audio_settings=None,
+        tts_provider="tencent_texttovoice",
+        tts_model="large-model",
+        segment_index=segment_index,
+    )
+    return result, calls, sleeps
+
+
+def test_throttled_segment_retries_until_success(monkeypatch):
+    success = types.SimpleNamespace(audio_data=b"ok")
+    result, calls, sleeps = _run_retry(
+        monkeypatch,
+        [ValueError(_TENCENT_MESSAGE), ValueError(_TENCENT_MESSAGE), success],
+    )
+
+    assert result is success
+    assert len(calls) == 3
+    # Backoff grows per attempt so retrying threads spread out.
+    assert len(sleeps) == 2
+    assert sleeps[1] > sleeps[0] > 0
+
+
+def test_throttled_segment_gives_up_after_max_attempts(monkeypatch):
+    with pytest.raises(ValueError, match="LimitExceeded"):
+        _run_retry(
+            monkeypatch,
+            [ValueError(_TENCENT_MESSAGE)] * (_RATE_LIMIT_RETRY_MAX_ATTEMPTS + 1),
+        )
+
+
+def test_stagger_depends_on_segment_index(monkeypatch):
+    success = types.SimpleNamespace(audio_data=b"ok")
+    _, _, sleeps_a = _run_retry(
+        monkeypatch, [ValueError(_TENCENT_MESSAGE), success], segment_index=0
+    )
+    _, _, sleeps_b = _run_retry(
+        monkeypatch, [ValueError(_TENCENT_MESSAGE), success], segment_index=1
+    )
+
+    assert sleeps_a[0] != sleeps_b[0]
+
+
+def test_non_retryable_error_still_raises_immediately(monkeypatch):
+    with pytest.raises(ValueError, match="AuthFailure"):
+        _run_retry(
+            monkeypatch,
+            [ValueError("Tencent TextToVoice error AuthFailure: bad secret")],
+        )

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -84,16 +84,23 @@ def test_throttled_segment_gives_up_after_max_attempts(monkeypatch):
         )
 
 
-def test_stagger_depends_on_segment_index(monkeypatch):
-    success = types.SimpleNamespace(audio_data=b"ok")
-    _, _, sleeps_a = _run_retry(
-        monkeypatch, [ValueError(_TENCENT_MESSAGE), success], segment_index=0
-    )
-    _, _, sleeps_b = _run_retry(
-        monkeypatch, [ValueError(_TENCENT_MESSAGE), success], segment_index=1
-    )
+def test_stagger_gives_concurrent_segments_distinct_delays(monkeypatch):
+    from flaskr.service.tts.streaming_tts import _RATE_LIMIT_RETRY_STAGGER_SLOTS
 
-    assert sleeps_a[0] != sleeps_b[0]
+    success = types.SimpleNamespace(audio_data=b"ok")
+    # The executor runs _RATE_LIMIT_RETRY_STAGGER_SLOTS segments at a time
+    # with near-consecutive indexes; every one of them must land in its own
+    # delay slot (index 0 vs 3 shared a slot under the old modulo-3 math).
+    delays = []
+    for index in range(_RATE_LIMIT_RETRY_STAGGER_SLOTS):
+        _, _, sleeps = _run_retry(
+            monkeypatch,
+            [ValueError(_TENCENT_MESSAGE), success],
+            segment_index=index,
+        )
+        delays.append(sleeps[0])
+
+    assert len(set(delays)) == _RATE_LIMIT_RETRY_STAGGER_SLOTS
 
 
 def test_non_retryable_error_still_raises_immediately(monkeypatch):


### PR DESCRIPTION
## Problem

On 2026-08-10 17:13 a burst of concurrent TTS segments (multiple pods, same second) all failed with:

```
Tencent TextToVoice error LimitExceeded.AccessLimit: Your request is too frequently. Please try again later
```

`tencent_texttovoice` (large-model) has a low provider-side quota, and unlike MiniMax (which goes through `acquire_tts_rpm_slot`) it has no request smoothing. A throttled segment failed immediately and permanently - every segment in the burst lost its audio.

## Changes

- `flaskr/service/tts/streaming_tts.py`: `_synthesize_text_with_retry` now detects provider throttling (`LimitExceeded`, `Too many requests`, `too frequently`, `rate limit`) and retries up to 3 attempts. The backoff grows per attempt (1s, 2s) and adds a per-segment stagger (index-based, 0.4s steps) so the burst's retrying threads spread out instead of re-colliding on the provider's quota window. The existing empty-audio retry path is unchanged; non-retryable errors still raise immediately.

## Verification

- New `tests/service/tts/test_streaming_tts_rate_limit_retry.py`: detector matrix, retry-until-success with growing backoff, bounded give-up, index-dependent stagger, non-retryable passthrough.
- Full TTS suite (170) and full backend suite: 2629 passed, 15 skipped.

## Notes

If throttling keeps recurring under normal load, the durable fix is quota-side (raise the Tencent large-model concurrency/QPS quota) or wiring `tencent_texttovoice` into the shared `acquire_tts_rpm_slot` gate like MiniMax; this PR makes bursts survivable either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech reliability when the provider temporarily enforces rate limits.
  * Automatically retries eligible synthesis requests up to three times with increasing delays.
  * Preserves retries for empty audio responses and immediately reports authentication failures.
  * Added segment-based retry staggering to reduce repeated throttling.

* **Tests**
  * Added coverage for retry detection, backoff behavior, maximum attempts, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->