### PR TITLE
chore: regenerate the harness health report

### DIFF
--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -10,7 +10,7 @@ This generated report summarizes the repository harness control plane.
 - Product specs: `10`
 - References: `3`
 - Active ExecPlans: `17`
-- Completed ExecPlans: `9`
+- Completed ExecPlans: `10`
 
 ## Boundary Baseline
 


### PR DESCRIPTION
## Problem

`repo-harness` has been failing on main since e7f3e45 (and therefore on every open PR): a merged change completed an ExecPlan without regenerating `docs/generated/harness-health.md`, leaving the completed-ExecPlan count stale (9 vs 10).

## Changes

Ran `python scripts/build_repo_knowledge_index.py`; the only diff is the regenerated count. `python scripts/check_repo_harness.py` passes.

After this merges, re-running the failed `repo-harness` checks on open PRs (#2317, #2318) will pass without touching their branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)