### PR TITLE
feat: remove the expired discount tag from the premium voice option

### DIFF
--- a/src/cook-web/src/components/model-list/ModelList.test.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.test.tsx
@@ -169,56 +169,6 @@ describe('ModelList', () => {
     ).toBeNull();
   });
 
-  test('renders promo badge only for options that carry a promoLabel', () => {
-    render(
-      <ModelList
-        value='minimax/speech-2.8-turbo'
-        onChange={() => undefined}
-        showDefaultOption={false}
-        options={[
-          {
-            value: 'minimax/speech-2.8-turbo',
-            label: 'Premium Voice',
-            creditMultiplierLabel: '2x',
-            promoLabel: 'Limited-time 95% off',
-            promoOriginalLabel: '44x',
-          },
-          {
-            value: 'tencent_texttovoice/premium',
-            label: 'Basic Voice',
-            creditMultiplierLabel: '3x',
-          },
-        ]}
-      />,
-    );
-
-    // Promo badge shows in both the trigger and the dropdown option; the
-    // struck-through pre-promo rate sits inside the multiplier badge, right
-    // before the current rate.
-    expect(screen.getAllByText('Limited-time 95% off')).toHaveLength(2);
-    expect(screen.getAllByText('2x')).toHaveLength(2);
-    const originalRates = screen.getAllByText('44x');
-    expect(originalRates).toHaveLength(2);
-    originalRates.forEach(node => {
-      expect(node).toHaveClass('line-through');
-      // Exact textContent locks both co-location and order: the struck-through
-      // pre-promo rate first, the current rate right after.
-      expect(node.parentElement?.textContent).toBe('44x2x');
-    });
-
-    const basicOption = screen
-      .getByText('Basic Voice')
-      .closest('[role="option"]');
-    expect(basicOption).toBeTruthy();
-    expect(
-      within(basicOption as HTMLElement).queryByText('Limited-time 95% off'),
-    ).toBeNull();
-    expect(within(basicOption as HTMLElement).queryByText('44x')).toBeNull();
-    expect(
-      within(basicOption as HTMLElement).getByText('3x'),
-    ).toBeInTheDocument();
-  });
-
   test('refreshes model options on open with a short ttl', () => {
     const initialNow = Date.now() + 1_000_000;
     const nowSpy = jest.spyOn(Date, 'now');

--- a/src/cook-web/src/components/model-list/ModelList.tsx
+++ b/src/cook-web/src/components/model-list/ModelList.tsx
@@ -19,32 +19,18 @@ function ModelOptionLabel({
   label,
   creditMultiplier,
   creditMultiplierLabel,
-  promoLabel,
-  promoOriginalLabel,
 }: {
   label: string;
   creditMultiplier?: number | null;
   creditMultiplierLabel?: string;
-  promoLabel?: string;
-  promoOriginalLabel?: string;
 }) {
   const multiplierLabel =
     creditMultiplierLabel || (creditMultiplier ? `${creditMultiplier}x` : '');
   return (
     <span className='flex w-full min-w-0 items-center'>
       <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
-      {promoLabel ? (
-        <span className='ml-2 shrink-0 rounded-full border border-destructive/20 bg-destructive/10 px-2 py-0.5 text-xs font-medium leading-none text-destructive'>
-          {promoLabel}
-        </span>
-      ) : null}
       {multiplierLabel ? (
         <span className='ml-2 shrink-0 rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-xs font-medium leading-none text-primary'>
-          {promoOriginalLabel ? (
-            <span className='mr-1 line-through opacity-60'>
-              {promoOriginalLabel}
-            </span>
-          ) : null}
           {multiplierLabel}
         </span>
       ) : null}
@@ -142,8 +128,6 @@ export default function ModelList({
                 label={selectedOption.label}
                 creditMultiplier={selectedOption.creditMultiplier}
                 creditMultiplierLabel={selectedOption.creditMultiplierLabel}
-                promoLabel={selectedOption.promoLabel}
-                promoOriginalLabel={selectedOption.promoOriginalLabel}
               />
             ) : (
               t('common.core.selectModel')
@@ -179,8 +163,6 @@ export default function ModelList({
                 label={item.label}
                 creditMultiplier={item.creditMultiplier}
                 creditMultiplierLabel={item.creditMultiplierLabel}
-                promoLabel={item.promoLabel}
-                promoOriginalLabel={item.promoOriginalLabel}
               />
             </SelectItem>
           );

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -113,15 +113,6 @@ import {
   ONBOARDING_TARGET_IDS,
 } from '@/lib/onboardingTargets';
 
-// Temporary display-only promo tag on TTS model options; remove when the
-// campaign ends. Credit multipliers stay admin-configured and untouched.
-// originalMultiplierLabel is the struck-through pre-promo rate, shown so the
-// promo reads as "44x discounted to the current rate" rather than "current
-// rate with a further discount".
-const TTS_PROMO_MODELS: Record<string, { originalMultiplierLabel: string }> = {
-  'minimax/speech-2.8-turbo': { originalMultiplierLabel: '44x' },
-};
-
 interface Shifu {
   description: string;
   bid: string;
@@ -533,18 +524,8 @@ export default function ShifuSettingDialog({
     ttsConfig?.providers[0];
 
   const ttsModelOptions = useMemo(
-    () =>
-      (ttsConfig?.model_options || []).map(option => {
-        const promo = TTS_PROMO_MODELS[option.value];
-        return promo
-          ? {
-              ...option,
-              promoLabel: t('module.shifuSetting.ttsPromoBadge'),
-              promoOriginalLabel: promo.originalMultiplierLabel,
-            }
-          : option;
-      }),
-    [t, ttsConfig?.model_options],
+    () => ttsConfig?.model_options || [],
+    [ttsConfig?.model_options],
   );
   const ttsModelSelectValue = buildTtsModelOptionValue(
     resolvedProvider,

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -3408,7 +3408,6 @@ export type I18nKey =
   | 'module.shifuSetting.ttsPreview'
   | 'module.shifuSetting.ttsPreviewLoading'
   | 'module.shifuSetting.ttsPreviewStop'
-  | 'module.shifuSetting.ttsPromoBadge'
   | 'module.shifuSetting.ttsProvider'
   | 'module.shifuSetting.ttsProviderHint'
   | 'module.shifuSetting.ttsProviderRequiredDesc'

--- a/src/cook-web/src/types/shifu.ts
+++ b/src/cook-web/src/types/shifu.ts
@@ -15,8 +15,6 @@ export interface ModelOption {
   label: string;
   creditMultiplier?: number | null;
   creditMultiplierLabel?: string;
-  promoLabel?: string;
-  promoOriginalLabel?: string;
   isDefault?: boolean;
 }
 

--- a/src/i18n/en-US/modules/shifu-setting.json
+++ b/src/i18n/en-US/modules/shifu-setting.json
@@ -248,7 +248,6 @@
   "ttsPreview": "Preview current voice",
   "ttsPreviewLoading": "Generating preview...",
   "ttsPreviewStop": "Stop",
-  "ttsPromoBadge": "Limited-time 95% off",
   "ttsProvider": "Provider",
   "ttsProviderHint": "Choose the provider used to generate lesson narration",
   "ttsProviderRequiredDesc": "Please choose a voice provider before enabling listen mode.",

--- a/src/i18n/fr-FR/modules/shifu-setting.json
+++ b/src/i18n/fr-FR/modules/shifu-setting.json
@@ -248,7 +248,6 @@
   "ttsPreview": "Prévisualiser la voix actuelle",
   "ttsPreviewLoading": "Génération de l’aperçu…",
   "ttsPreviewStop": "Arrêter",
-  "ttsPromoBadge": "Offre limitée : -95 %",
   "ttsProvider": "Fournisseur",
   "ttsProviderHint": "Choisir le fournisseur utilisé pour générer la narration",
   "ttsProviderRequiredDesc": "Veuillez choisir un fournisseur vocal avant d’activer le mode écoute.",

--- a/src/i18n/zh-CN/modules/shifu-setting.json
+++ b/src/i18n/zh-CN/modules/shifu-setting.json
@@ -248,7 +248,6 @@
   "ttsPreview": "试听当前选择",
   "ttsPreviewLoading": "正在生成试听...",
   "ttsPreviewStop": "停止",
-  "ttsPromoBadge": "限时0.5折",
   "ttsProvider": "服务商",
   "ttsProviderHint": "选择用来生成讲课语音的服务商",
   "ttsProviderRequiredDesc": "开启听课模式后，请先选择语音服务商。",


### PR DESCRIPTION
## Changed

The limited-time discount campaign on the premium voice (`minimax/speech-2.8-turbo`) has ended, so this removes the whole display-only promo layer that was added in #2234 and refined in #2246:

- **Data source** — dropped the hardcoded `TTS_PROMO_MODELS` table in `ShifuSetting.tsx`; `ttsModelOptions` is back to passing `ttsConfig.model_options` straight through.
- **Type contract** — removed `promoLabel` / `promoOriginalLabel` from `ModelOption`.
- **Rendering** — removed the red promo badge and the struck-through pre-promo rate (`44x`) from `ModelList`, in both the dropdown list and the selected trigger.
- **Copy** — deleted the `ttsPromoBadge` entry from the zh-CN / en-US / fr-FR bundles and regenerated `i18n-keys.d.ts`.
- **Tests** — removed the promo-badge case; the existing multiplier-badge coverage is untouched.

The premium voice option now renders with the same name-and-rate layout as every other voice.

Credit multipliers were always admin-configured and are untouched here — the promo was display-only, so if the campaign rate is still configured in the admin console it needs to be adjusted there separately.

## Benefit

Teachers no longer see a discount that has already ended when they pick a voice for their course, and the shared `ModelList` component no longer carries unreachable promo branches.

## Verification

- `npx jest src/components/model-list src/components/shifu-setting` — 35 tests pass
- `npm run type-check` — passes (confirms no remaining references to the removed optional fields)
- `npx eslint` on the touched files — 0 errors
- `python scripts/check_repo_harness.py` — passes
- `lefthook` pre-commit suite — all checks pass, including `check-translation-usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed promotional badges and original-price labels from model selection options.
  * Text-to-speech model choices now display standard model information without temporary promotional metadata.
  * Removed related promotional translation text across supported languages.
* **Tests**
  * Updated model list coverage to reflect the removal of promotional labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->