### PR TITLE
fix: finish read mode typing when page is hidden

### DIFF
--- a/src/cook-web/skills/chat-element-streaming/SKILL.md
+++ b/src/cook-web/skills/chat-element-streaming/SKILL.md
@@ -56,6 +56,7 @@ description: 当 ai-shifu 聊天流从 block 粒度向 element 粒度演进，�
 41. 学习模式切换期间如果旧的 SSE stream 还在继续消费，凡是 `finalize/build item` 这类依赖当前模式的逻辑，都不能直接读取创建 stream 时 closure 里的 `isListenMode`；应改读实时 ref，否则“听课模式发起、阅读模式收尾”的交互链路会把新正文误标成 history-like，触发 typewriter 中途关闭后再重开，造成闪烁或整段重打。
 42. 追问 `AskBlock` 的 streaming answer 若在打字途中被收起/关闭，不能把这条 answer 的 `shouldUseTypewriter` 立即改成 `false`，也不要卸载承载它的 `ContentRender` 面板节点；应让流式会话在隐藏状态下继续保活，否则再次打开时同一条 answer 会因重挂载从错误进度重新打字，表现为速度异常、跳字或像被“叠速”一样。
 43. 上一条只适用于“流仍未结束”的窗口期；如果追问 answer 在面板隐藏期间已经收到终态 `done/text_end(is_terminal=true)` 并完成收尾，就应立即把该 answer 的 `shouldUseTypewriter` 置为 `false`。这样再次打开时直接展示静态最终文本，不要再重放一次打字机。
+44. 阅读模式页面进入 `document.visibilityState === 'hidden'` 时，应立即绕过 element 可见性 gate，并把所有已收到的实时 text element 标记为静态直出；这些 `element_bid` 回到前台后也要保持静态，避免 `ContentRender.enableTypewriter` 经历 `false -> true` 后从头重播。后台期间收到的同 bid 增量继续直出，回到前台后新出现的 text element 才重新使用打字机。
 
 ## 备注
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.lessonUpdateNotice.test.tsx
@@ -220,9 +220,23 @@ jest.mock(
 jest.mock(
   './ContentBlock',
   () =>
-    function MockContentBlock({ item }: { item: { element_bid?: string } }) {
+    function MockContentBlock({
+      item,
+      contentRenderKey,
+      enableStreamingTypewriter,
+    }: {
+      item: { content?: string; element_bid?: string };
+      contentRenderKey?: string;
+      enableStreamingTypewriter?: boolean;
+    }) {
       return (
-        <div data-testid={`content-block-${item.element_bid || 'item'}`} />
+        <div
+          data-testid={`content-block-${item.element_bid || 'item'}`}
+          data-content-render-key={contentRenderKey}
+          data-typewriter={String(Boolean(enableStreamingTypewriter))}
+        >
+          {item.content}
+        </div>
       );
     },
 );
@@ -281,11 +295,7 @@ jest.mock('@/components/audio/AudioPlayer', () => ({
   },
 }));
 
-const renderNewChatComponents = (
-  onLessonUpdateNoticeVisibilityChange = jest.fn(),
-  onLessonPdfActionChange = jest.fn(),
-  items: Array<Record<string, unknown>> = [],
-) => {
+const setMockChatLogicItems = (items: Array<Record<string, unknown>>) => {
   mockUseChatLogicHook.mockReturnValue({
     currentStreamingElementBid: '',
     currentTypewriterElementBid: '',
@@ -311,35 +321,59 @@ const renderNewChatComponents = (
     showLessonUpdateNotice: true,
     toggleAskExpanded: jest.fn(),
   });
+};
 
-  return render(
-    <AppContext.Provider
-      value={{
-        frameLayout: 1,
-        isLoggedIn: true,
-        mobileStyle: false,
-        theme: 'light',
-        userInfo: null,
-      }}
-    >
-      <NewChatComponents
-        chapterId='chapter-1'
-        chapterUpdate={jest.fn()}
-        getNextLessonId={jest.fn()}
-        lessonHasContentUpdate={true}
-        lessonId='lesson-1'
-        lessonTitle='第一课'
-        lessonUpdate={jest.fn()}
-        onGoChapter={jest.fn()}
-        onPurchased={jest.fn()}
-        updateSelectedLesson={jest.fn()}
-        onLessonUpdateNoticeVisibilityChange={
-          onLessonUpdateNoticeVisibilityChange
-        }
-        onLessonPdfActionChange={onLessonPdfActionChange}
-      />
-    </AppContext.Provider>,
-  );
+const createNewChatComponentsElement = (
+  onLessonUpdateNoticeVisibilityChange: jest.Mock,
+  onLessonPdfActionChange: jest.Mock,
+) => (
+  <AppContext.Provider
+    value={{
+      frameLayout: 1,
+      isLoggedIn: true,
+      mobileStyle: false,
+      theme: 'light',
+      userInfo: null,
+    }}
+  >
+    <NewChatComponents
+      chapterId='chapter-1'
+      chapterUpdate={jest.fn()}
+      getNextLessonId={jest.fn()}
+      lessonHasContentUpdate={true}
+      lessonId='lesson-1'
+      lessonTitle='第一课'
+      lessonUpdate={jest.fn()}
+      onGoChapter={jest.fn()}
+      onPurchased={jest.fn()}
+      updateSelectedLesson={jest.fn()}
+      onLessonUpdateNoticeVisibilityChange={
+        onLessonUpdateNoticeVisibilityChange
+      }
+      onLessonPdfActionChange={onLessonPdfActionChange}
+    />
+  </AppContext.Provider>
+);
+
+const renderNewChatComponents = (
+  onLessonUpdateNoticeVisibilityChange = jest.fn(),
+  onLessonPdfActionChange = jest.fn(),
+  items: Array<Record<string, unknown>> = [],
+) => {
+  setMockChatLogicItems(items);
+  const renderElement = () =>
+    createNewChatComponentsElement(
+      onLessonUpdateNoticeVisibilityChange,
+      onLessonPdfActionChange,
+    );
+  const renderResult = render(renderElement());
+
+  return Object.assign(renderResult, {
+    rerenderWithItems(nextItems: Array<Record<string, unknown>>) {
+      setMockChatLogicItems(nextItems);
+      renderResult.rerender(renderElement());
+    },
+  });
 };
 
 const renderTitlebarLessonUpdateNotice = () =>
@@ -353,6 +387,8 @@ const renderTitlebarLessonUpdateNotice = () =>
 
 describe('NewChatComponents', () => {
   let requestAnimationFrameSpy: jest.SpyInstance;
+  let visibilityStateSpy: jest.SpyInstance;
+  let documentVisibilityState: DocumentVisibilityState;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -369,6 +405,10 @@ describe('NewChatComponents', () => {
     mockOfficialSiteUrl = 'https://official.example.com';
     mockLessonPdfReady = false;
     mockLessonPdfPreparing = false;
+    documentVisibilityState = 'visible';
+    visibilityStateSpy = jest
+      .spyOn(document, 'visibilityState', 'get')
+      .mockImplementation(() => documentVisibilityState);
     requestAnimationFrameSpy = jest
       .spyOn(window, 'requestAnimationFrame')
       .mockImplementation(() => 0);
@@ -376,6 +416,7 @@ describe('NewChatComponents', () => {
 
   afterEach(() => {
     requestAnimationFrameSpy.mockRestore();
+    visibilityStateSpy.mockRestore();
   });
 
   it('renders the titlebar retake action and opens the existing confirm dialog', async () => {
@@ -418,6 +459,127 @@ describe('NewChatComponents', () => {
     expect(
       screen.queryByText('本节课程已更新，建议重修'),
     ).not.toBeInTheDocument();
+  });
+
+  it('finishes visible read content immediately when the page becomes hidden', async () => {
+    mockLearningMode = 'read';
+    const initialItems: Array<Record<string, unknown>> = [
+      {
+        content: '正在打字的正文',
+        element_bid: 'text-1',
+        element_type: 'text',
+        is_final: false,
+        shouldUseTypewriter: true,
+        type: 'content',
+      },
+      {
+        content: '<div>已经收到的后续内容</div>',
+        element_bid: 'html-1',
+        element_type: 'html',
+        type: 'content',
+      },
+    ];
+    const backgroundItems: Array<Record<string, unknown>> = [
+      {
+        ...initialItems[0],
+        content: '正在打字的正文，以及后台收到的增量',
+      },
+      {
+        content: '后台收到的新正文块',
+        element_bid: 'text-2',
+        element_type: 'text',
+        is_final: false,
+        shouldUseTypewriter: true,
+        type: 'content',
+      },
+      initialItems[1],
+    ];
+    const { rerenderWithItems } = renderNewChatComponents(
+      jest.fn(),
+      jest.fn(),
+      initialItems,
+    );
+
+    expect(screen.getByTestId('content-block-text-1')).toHaveAttribute(
+      'data-typewriter',
+      'true',
+    );
+    expect(
+      screen.queryByTestId('content-block-html-1'),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      documentVisibilityState = 'hidden';
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-block-text-1')).toHaveAttribute(
+        'data-typewriter',
+        'false',
+      );
+      expect(screen.getByTestId('content-block-text-1')).toHaveAttribute(
+        'data-content-render-key',
+        'text-1:hidden',
+      );
+      expect(screen.getByTestId('content-block-html-1')).toBeInTheDocument();
+    });
+
+    // Make a background SSE update available to the hook without committing a
+    // component render first. The foreground event must suppress this latest
+    // snapshot before typewriter mode can resume.
+    setMockChatLogicItems(backgroundItems);
+    act(() => {
+      documentVisibilityState = 'visible';
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-block-text-1')).toHaveTextContent(
+        '正在打字的正文，以及后台收到的增量',
+      );
+      expect(screen.getByTestId('content-block-text-1')).toHaveAttribute(
+        'data-typewriter',
+        'false',
+      );
+      expect(screen.getByTestId('content-block-text-1')).toHaveAttribute(
+        'data-content-render-key',
+        'text-1:suppressed',
+      );
+      expect(screen.getByTestId('content-block-text-2')).toHaveAttribute(
+        'data-typewriter',
+        'false',
+      );
+      expect(screen.getByTestId('content-block-text-2')).toHaveAttribute(
+        'data-content-render-key',
+        'text-2:suppressed',
+      );
+      expect(screen.getByTestId('content-block-html-1')).toBeInTheDocument();
+    });
+
+    act(() => {
+      rerenderWithItems([
+        ...backgroundItems,
+        {
+          content: '回到前台后收到的新正文块',
+          element_bid: 'text-3',
+          element_type: 'text',
+          is_final: false,
+          shouldUseTypewriter: true,
+          type: 'content',
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content-block-text-3')).toHaveAttribute(
+        'data-typewriter',
+        'true',
+      );
+      expect(screen.getByTestId('content-block-text-3')).not.toHaveAttribute(
+        'data-content-render-key',
+      );
+    });
   });
 
   it('exposes the PDF action while a desktop slide mode is active', async () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -339,6 +339,10 @@ export const NewChatComponents = ({
   const isSlideMode = isListenMode || isClassroomMode;
   const [readModeTypewriterCache, setReadModeTypewriterCache] =
     useState<ReadModeTypewriterCache>({});
+  const [isDocumentVisible, setIsDocumentVisible] = useState(true);
+  const [isVisibilityRestorePending, setIsVisibilityRestorePending] =
+    useState(false);
+  const isDocumentVisibleRef = useRef(true);
   const courseTtsEnabled = useCourseStore(state => state.courseTtsEnabled);
   const isListenModeAvailable = courseTtsEnabled !== false;
   const isListenModeActive = getIsListenModeActive({
@@ -561,9 +565,63 @@ export const NewChatComponents = ({
       }),
     [askButtonMarkup, items, mobileStyle, scopedAskListByAnchorElementBid],
   );
+  const readModeItemsRef = useRef(readModeItems);
+  readModeItemsRef.current = readModeItems;
+  const suppressCurrentReadModeTypewriters = useCallback(() => {
+    setReadModeTypewriterCache(prevCache =>
+      syncReadModeTypewriterCache(readModeItemsRef.current, prevCache, {
+        suppressTypewriter: true,
+      }),
+    );
+  }, []);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      const nextIsDocumentVisible = document.visibilityState === 'visible';
+
+      if (!nextIsDocumentVisible) {
+        suppressCurrentReadModeTypewriters();
+        isDocumentVisibleRef.current = false;
+        setIsVisibilityRestorePending(false);
+        setIsDocumentVisible(false);
+        return;
+      }
+
+      if (!isDocumentVisibleRef.current) {
+        // Keep rendering the complete static list for one foreground commit.
+        // This lets any background SSE update commit before it is suppressed.
+        setIsVisibilityRestorePending(true);
+        return;
+      }
+
+      setIsDocumentVisible(true);
+    };
+
+    handleVisibilityChange();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [suppressCurrentReadModeTypewriters]);
+
+  useEffect(() => {
+    if (!isVisibilityRestorePending) {
+      return;
+    }
+
+    suppressCurrentReadModeTypewriters();
+    isDocumentVisibleRef.current = true;
+    setIsDocumentVisible(true);
+    setIsVisibilityRestorePending(false);
+  }, [isVisibilityRestorePending, suppressCurrentReadModeTypewriters]);
+
   const visibleReadModeItems = useMemo(
-    () => buildVisibleReadModeItems(readModeItems, readModeTypewriterCache),
-    [readModeItems, readModeTypewriterCache],
+    () =>
+      isDocumentVisible
+        ? buildVisibleReadModeItems(readModeItems, readModeTypewriterCache)
+        : readModeItems,
+    [isDocumentVisible, readModeItems, readModeTypewriterCache],
   );
   const isFollowUpStreaming = useMemo(
     () =>
@@ -628,6 +686,7 @@ export const NewChatComponents = ({
         return {
           ...prevCache,
           [blockBid]: {
+            ...(existingEntry ?? {}),
             content: normalizedContent,
             isFinished: true,
           },
@@ -758,9 +817,10 @@ export const NewChatComponents = ({
     setReadModeTypewriterCache(prevCache =>
       syncReadModeTypewriterCache(readModeItems, prevCache, {
         markFinalTextItemsFinished: isClassroomMode,
+        suppressTypewriter: !isDocumentVisible,
       }),
     );
-  }, [isClassroomMode, readModeItems]);
+  }, [isClassroomMode, isDocumentVisible, readModeItems]);
 
   useEffect(() => {
     if (!isListenModeActive) {
@@ -1623,6 +1683,12 @@ export const NewChatComponents = ({
                   const isCourseInteraction =
                     item.type === ChatContentItemType.INTERACTION &&
                     !shouldExcludeLessonPdfInteraction(item.content);
+                  const typewriterCacheEntry =
+                    readModeTypewriterCache[item.element_bid || ''];
+                  const isReadModeTypewriterSuppressed =
+                    isReadModeTextContentItem(item) &&
+                    (!isDocumentVisible ||
+                      typewriterCacheEntry?.isSuppressed === true);
 
                   return (
                     <div
@@ -1658,18 +1724,28 @@ export const NewChatComponents = ({
                       ) : null}
                       {/*
                         Keep typewriter enabled when the current element content
-                        has already grown beyond the finished cache snapshot.
+                        has already grown beyond the finished cache snapshot. A
+                        backgrounded element stays static after foregrounding so
+                        markdown-flow-ui never restarts it from the beginning.
                       */}
                       <ContentBlock
                         item={item}
                         printMode={isPreparingLessonPdf && isCourseInteraction}
                         mobileStyle={mobileStyle}
                         blockBid={item.element_bid}
+                        contentRenderKey={
+                          isReadModeTypewriterSuppressed
+                            ? `${item.element_bid || baseKey}:${
+                                isDocumentVisible ? 'suppressed' : 'hidden'
+                              }`
+                            : undefined
+                        }
                         enableStreamingTypewriter={
+                          isDocumentVisible &&
                           !isPreparingLessonPdf &&
                           shouldEnableReadModeTypewriter(
                             item,
-                            readModeTypewriterCache[item.element_bid || ''],
+                            typewriterCacheEntry,
                             {
                               keepAliveWhileStreaming:
                                 isOutputInProgress &&

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/readModeTypewriterGate.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/readModeTypewriterGate.test.ts
@@ -111,6 +111,45 @@ describe('readModeTypewriterGate', () => {
     ).toStrictEqual({});
   });
 
+  it('preserves visibility suppression across a temporary history-like projection', () => {
+    const suppressedCache = syncReadModeTypewriterCache(
+      [createTextItem()],
+      {},
+      { suppressTypewriter: true },
+    );
+    const historyLikeText = createTextItem({
+      is_final: true,
+      isHistory: true,
+      shouldUseTypewriter: false,
+      shouldRenderAsHistoryInReadMode: true,
+    });
+
+    const historyCache = syncReadModeTypewriterCache(
+      [historyLikeText],
+      suppressedCache,
+    );
+    const resumedRealtimeText = createTextItem({
+      content: 'First text resumed',
+    });
+    const resumedCache = syncReadModeTypewriterCache(
+      [resumedRealtimeText],
+      historyCache,
+    );
+
+    expect(historyCache['text-1']?.isSuppressed).toBe(true);
+    expect(resumedCache['text-1']).toStrictEqual({
+      content: 'First text resumed',
+      isFinished: true,
+      isSuppressed: true,
+    });
+    expect(
+      shouldEnableReadModeTypewriter(
+        resumedRealtimeText,
+        resumedCache['text-1'],
+      ),
+    ).toBe(false);
+  });
+
   it('resets the cache entry when a tracked text item receives new content', () => {
     const initialCache: ReadModeTypewriterCache = {
       'text-1': {
@@ -151,6 +190,82 @@ describe('readModeTypewriterGate', () => {
     expect(
       buildVisibleReadModeItems([finalizedClassroomText, secondHtml], cache),
     ).toStrictEqual([finalizedClassroomText, secondHtml]);
+  });
+
+  it('reveals every received item and disables typewriter when the page is hidden', () => {
+    const firstText = createTextItem();
+    const secondText = createTextItem({
+      element_bid: 'text-2',
+      content: 'Second text',
+    });
+    const interaction = createInteractionItem();
+    const items = [firstText, secondText, interaction];
+
+    const cache = syncReadModeTypewriterCache(
+      items,
+      {},
+      {
+        suppressTypewriter: true,
+      },
+    );
+
+    expect(cache).toStrictEqual({
+      'text-1': {
+        content: 'First text',
+        isFinished: true,
+        isSuppressed: true,
+      },
+      'text-2': {
+        content: 'Second text',
+        isFinished: true,
+        isSuppressed: true,
+      },
+    });
+    expect(isReadModeTextContentItemReady(firstText, cache)).toBe(true);
+    expect(shouldEnableReadModeTypewriter(firstText, cache['text-1'])).toBe(
+      false,
+    );
+    expect(buildVisibleReadModeItems(items, cache)).toStrictEqual(items);
+  });
+
+  it('keeps a hidden text element static when the same element receives more content', () => {
+    const initialCache = syncReadModeTypewriterCache(
+      [createTextItem()],
+      {},
+      { suppressTypewriter: true },
+    );
+    const appendedText = createTextItem({
+      content: 'First text with more content',
+    });
+
+    const nextCache = syncReadModeTypewriterCache([appendedText], initialCache);
+
+    expect(nextCache).toStrictEqual({
+      'text-1': {
+        content: 'First text with more content',
+        isFinished: true,
+        isSuppressed: true,
+      },
+    });
+    expect(
+      shouldEnableReadModeTypewriter(appendedText, nextCache['text-1']),
+    ).toBe(false);
+  });
+
+  it('allows a new foreground text element to use typewriter after hidden items were suppressed', () => {
+    const suppressedCache = syncReadModeTypewriterCache(
+      [createTextItem()],
+      {},
+      { suppressTypewriter: true },
+    );
+    const foregroundText = createTextItem({
+      element_bid: 'text-2',
+      content: 'Foreground text',
+    });
+
+    expect(
+      shouldEnableReadModeTypewriter(foregroundText, suppressedCache['text-2']),
+    ).toBe(true);
   });
 
   it('keeps typewriter enabled when the current text content outgrows a finished cache entry', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/readModeTypewriterGate.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/readModeTypewriterGate.ts
@@ -4,6 +4,7 @@ import { stripCustomButtonAfterContent } from './chatUiUtils';
 export interface ReadModeTypewriterCacheEntry {
   content: string;
   isFinished: boolean;
+  isSuppressed?: boolean;
 }
 
 export interface ReadModeTypewriterKeepAliveOptions {
@@ -19,6 +20,7 @@ export type ReadModeTypewriterCache = Record<
 
 export interface SyncReadModeTypewriterCacheOptions {
   markFinalTextItemsFinished?: boolean;
+  suppressTypewriter?: boolean;
 }
 
 export const normalizeReadModeTypewriterContent = (content?: string | null) =>
@@ -50,6 +52,10 @@ export const shouldEnableReadModeTypewriter = (
     return true;
   }
 
+  if (cacheEntry.isSuppressed) {
+    return false;
+  }
+
   const currentContent = getItemContent(item);
   const hasAppendedContentBeyondCache =
     currentContent.length > cacheEntry.content.length &&
@@ -69,7 +75,10 @@ export const shouldTrackReadModeTypewriter = (
   cacheEntry?: ReadModeTypewriterCacheEntry,
 ) => {
   if (isReadModeHistoryLikeTextItem(item)) {
-    return false;
+    // A visibility-suppressed element must stay static across temporary
+    // history-like projections. Dropping it here would let the same bid replay
+    // from the beginning if it becomes realtime again.
+    return cacheEntry?.isSuppressed === true;
   }
 
   return (
@@ -111,22 +120,33 @@ export const syncReadModeTypewriterCache = (
     }
 
     const content = getItemContent(item);
+    const isSuppressed = Boolean(
+      previousEntry?.isSuppressed || options.suppressTypewriter,
+    );
+    const shouldMarkFinished = Boolean(
+      isSuppressed || (options.markFinalTextItemsFinished && item.is_final),
+    );
     if (previousEntry?.content === content) {
-      nextCache[itemBid] =
-        options.markFinalTextItemsFinished &&
-        item.is_final &&
-        !previousEntry.isFinished
-          ? {
-              ...previousEntry,
-              isFinished: true,
-            }
-          : previousEntry;
+      if (
+        (previousEntry.isFinished || !shouldMarkFinished) &&
+        (previousEntry.isSuppressed || !isSuppressed)
+      ) {
+        nextCache[itemBid] = previousEntry;
+        return;
+      }
+
+      nextCache[itemBid] = {
+        ...previousEntry,
+        isFinished: previousEntry.isFinished || shouldMarkFinished,
+        ...(isSuppressed ? { isSuppressed: true } : {}),
+      };
       return;
     }
 
     nextCache[itemBid] = {
       content,
-      isFinished: Boolean(options.markFinalTextItemsFinished && item.is_final),
+      isFinished: shouldMarkFinished,
+      ...(isSuppressed ? { isSuppressed: true } : {}),
     };
   });
 
@@ -149,6 +169,10 @@ export const isReadModeTextContentItemReady = (
   const cacheEntry = itemBid ? cache[itemBid] : undefined;
   if (!cacheEntry) {
     return item.shouldUseTypewriter !== true;
+  }
+
+  if (cacheEntry.isSuppressed) {
+    return true;
   }
 
   return (


### PR DESCRIPTION
## Summary

- finish active read-mode typewriters as soon as the page becomes hidden
- reveal queued and newly received background content without waiting for the learner to return
- prevent background content from replaying while keeping new foreground blocks eligible for typewriter rendering
- add visibility-race regression coverage and document the streaming invariant

## Root cause

Read-mode visibility gating was not connected to `document.visibilityState`, so hidden-tab timer throttling paused the typewriter and also blocked following content. Simply disabling and re-enabling the pinned renderer would restart the whole block, so the fix records background-flushed elements and restores foreground rendering in two phases.

## User impact

Learners who switch away from a lesson receive the complete background response immediately and return to fully rendered content instead of watching a paused typewriter resume.

## Validation

- 5 focused Jest suites, 76 tests passed
- `npm run type-check`
- `python3 scripts/check_repo_harness.py`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read mode now automatically switches streamed text to static rendering when the page is hidden.
  * Existing content remains static when returning to the page, while newly received content resumes typewriter animation.
  * Background updates remain visible without replaying suppressed animations.

* **Bug Fixes**
  * Improved rendering consistency for streamed content during visibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->