### PR TITLE
chore: preserve environment files in worktrees

### DIFF
--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -33,6 +33,11 @@ alwaysApply: true
 - For complex design work, create an ExecPlan under `docs/exec-plans/active/`
   and maintain it according to `PLANS.md`.
 
+- When creating a Git worktree, copy existing local `.env` files from the
+  source checkout into matching paths in the new worktree before starting
+  services. Preserve permissions, never commit the copies, and do not
+  overwrite worktree-specific environment files.
+
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,11 @@
 - For complex design work, create an ExecPlan in `docs/exec-plans/active/` and
   maintain it according to `PLANS.md`.
 
+- When creating a Git worktree, copy existing local `.env` files from the
+  source checkout into matching paths in the new worktree before starting
+  services. Preserve permissions, never commit the copies, and do not
+  overwrite worktree-specific environment files.
+
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ to.
   before creating new abstractions.
 - Use ExecPlans for complex work. `PLANS.md` defines the format, and active
   plans live under `docs/exec-plans/active/`.
+- Whenever creating a Git worktree for this repository, copy existing local
+  `.env` files from the source checkout into the matching paths in the new
+  worktree before starting services, including the repository-root `.env` and
+  `src/cook-web/.env` when present. Preserve file permissions, never commit
+  these copies, and do not overwrite an environment file already customized
+  in the new worktree.
 - Before committing, run `python scripts/check_dev_tools.py` to confirm
   lefthook and its underlying tools are installed; the local checks are
   silently skipped if lefthook was never installed.

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import re
 import textwrap
 
-
 ROOT = Path(__file__).resolve().parents[1]
 WIDTH = 78
 MIN_AGENT_LINES = 60
@@ -119,6 +118,12 @@ ROOT_SPEC = DocSpec(
         "the current complex topic and keep its progress and decisions current.",
         "Move completed ExecPlans to `docs/exec-plans/completed/` only after "
         "implementation and verification are complete.",
+        "Whenever creating a Git worktree for this repository, copy existing "
+        "local `.env` files from the source checkout into matching paths in the "
+        "new worktree before starting services, including the repository-root "
+        "`.env` and `src/cook-web/.env` when present. Preserve permissions, "
+        "never commit the copies, and do not overwrite an environment file "
+        "already customized in the new worktree.",
         "Run the smallest relevant verification first, then widen to shared "
         "checks when a change crosses API boundaries, shared DTOs, i18n files, "
         "or common frontend libraries.",
@@ -1611,6 +1616,11 @@ def build_documents() -> dict[Path, str]:
                 "For complex design work, create an ExecPlan under "
                 "`docs/exec-plans/active/` and maintain it according to "
                 "`PLANS.md`.",
+                "When creating a Git worktree, copy existing local `.env` files "
+                "from the source checkout into matching paths in the new "
+                "worktree before starting services. Preserve permissions, never "
+                "commit the copies, and do not overwrite worktree-specific "
+                "environment files.",
                 "When a branch already has an open PR, keep the PR title and "
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
@@ -1788,6 +1798,11 @@ def build_documents() -> dict[Path, str]:
                 "For complex design work, create an ExecPlan in "
                 "`docs/exec-plans/active/` and maintain it according to "
                 "`PLANS.md`.",
+                "When creating a Git worktree, copy existing local `.env` files "
+                "from the source checkout into matching paths in the new "
+                "worktree before starting services. Preserve permissions, never "
+                "commit the copies, and do not overwrite worktree-specific "
+                "environment files.",
                 "When a branch already has an open PR, keep the PR title and "
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "


### PR DESCRIPTION
## What changed

- Added a repository-wide rule requiring new Git worktrees to copy existing local `.env` files into matching paths before services start.
- Explicitly covers the repository-root `.env` and `src/cook-web/.env` when present.
- Preserves permissions, avoids overwriting worktree-specific configuration, and keeps copied environment files out of Git.
- Regenerated the shared Cursor and Copilot instruction mirrors from the repository generator.

## Why

Untracked environment files are not carried into Git worktrees automatically. This caused local frontend services to silently fall back to default API configuration when a task ran from an isolated worktree.

## Impact

Future worktree setup should retain required local configuration without copying secrets into version control or replacing deliberate per-worktree settings.

## Verification

- `python3 scripts/generate_ai_collab_docs.py`
- `python3 scripts/check_repo_harness.py`
- repository-pinned Ruff check and format-check for `scripts/generate_ai_collab_docs.py`
- `python3 scripts/check_dev_tools.py`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Git worktree setup guidance for carrying over local environment files.
  - Clarified that file permissions should be preserved, customized worktree files should not be overwritten, and local environment files must not be committed.
  - Updated collaboration guidance consistently across supported development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->