### PR TITLE
fix: prevent mobile slide overlay update loops

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -581,7 +581,10 @@
   left: 0;
   right: 0;
   margin: 0 12px;
-  transform: none;
+  transform: translate(
+    var(--slide-interaction-drag-x, 0px),
+    var(--slide-interaction-drag-y, 0px)
+  );
 }
 
 .slide-ask-overlay--with-player {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+describe('ListenModeRenderer styles', () => {
+  it('keeps mobile landscape interaction overlays compatible with slide drag offsets', () => {
+    const stylesheet = readFileSync(
+      path.join(__dirname, 'ListenModeRenderer.scss'),
+      'utf8',
+    );
+    const ruleMatch = stylesheet.match(
+      /\.listen-reveal-wrapper\.mobile\s+\.listen-slide-root--landscape\.slide--mobile-landscape\s+\.slide-interaction-overlay\s*\{([^}]+)\}/,
+    );
+    const ruleBody = ruleMatch?.[1];
+
+    expect(ruleBody).toBeDefined();
+    expect(ruleBody).toContain('var(--slide-interaction-drag-x, 0px)');
+    expect(ruleBody).toContain('var(--slide-interaction-drag-y, 0px)');
+    expect(ruleBody).not.toContain('transform: none');
+  });
+});


### PR DESCRIPTION
Changed:
- Preserved `markdown-flow-ui` drag-offset transforms for mobile landscape slide interaction overlays instead of overriding them with `transform: none`.
- Added a focused style regression test to keep the mobile landscape interaction overlay compatible with the slide drag offset variables.

Benefit:
- Learners opening slide interactions in mobile WeChat avoid React update-depth crashes while the existing mobile overlay layout is preserved.

Root cause:
- The learner app overrode the slide interaction overlay transform in mobile landscape mode. `markdown-flow-ui` relies on that transform to apply `--slide-interaction-drag-x/y` offsets during overlay position correction; removing it can keep the correction loop from converging in WeChat mobile browsers.

Verification:
- `cd src/cook-web && npm run test -- --runTestsByPath 'src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts' 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx'`
- `cd src/cook-web && npm run lint -- --file 'src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts' --file 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx'`
- `cd src/cook-web && npm run type-check`
- `git diff --check`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`
- Branch context `pre-pr-review` and `pre-push-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile landscape interaction overlay so horizontal and vertical drag offsets are applied correctly.
  * Preserved overlay movement during drag interactions instead of disabling transforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->