### PR TITLE
fix: reset mobile slide overlays on orientation changes

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -1309,7 +1309,7 @@ describe('ListenModeSlideRenderer', () => {
     });
   });
 
-  it('does not remount the slide for manual mobile view mode changes', () => {
+  it('refreshes mobile interaction elements without remounting the slide for manual view mode changes', async () => {
     render(
       <ListenModeSlideRenderer
         items={[
@@ -1334,6 +1334,14 @@ describe('ListenModeSlideRenderer', () => {
     const initialMountId = screen
       .getByTestId('mock-slide')
       .getAttribute('data-mount-id');
+    const initialSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | {
+          elementList?: Array<{ type?: string; content?: unknown }>;
+        }
+      | undefined;
+    const initialInteractionElement = initialSlideProps?.elementList?.find(
+      element => element.type === 'interaction',
+    );
     const slideProps = getMockSlide().mock.calls.at(-1)?.[0] as
       | {
           onMobileViewModeChange?: (viewMode: 'fullscreen') => void;
@@ -1344,10 +1352,23 @@ describe('ListenModeSlideRenderer', () => {
       slideProps?.onMobileViewModeChange?.('fullscreen');
     });
 
-    expect(screen.getByTestId('mock-slide')).toHaveAttribute(
-      'data-mount-id',
-      initialMountId ?? '',
-    );
+    await waitFor(() => {
+      const nextSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            elementList?: Array<{ type?: string; content?: unknown }>;
+          }
+        | undefined;
+      const nextInteractionElement = nextSlideProps?.elementList?.find(
+        element => element.type === 'interaction',
+      );
+
+      expect(screen.getByTestId('mock-slide')).toHaveAttribute(
+        'data-mount-id',
+        initialMountId ?? '',
+      );
+      expect(nextInteractionElement).not.toBe(initialInteractionElement);
+      expect(nextInteractionElement?.content).toBe('?[A | B]');
+    });
   });
 
   it('keeps lesson feedback pending until the trailing visible interaction settles', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -1168,7 +1168,7 @@ describe('ListenModeSlideRenderer', () => {
     });
   });
 
-  it('remounts the slide on mobile viewport orientation changes to clear drag offsets', async () => {
+  it('refreshes mobile interaction elements on viewport orientation changes without remounting the slide', async () => {
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       value: 390,
@@ -1199,7 +1199,15 @@ describe('ListenModeSlideRenderer', () => {
       />,
     );
 
-    const firstMountId = screen
+    const initialSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | {
+          elementList?: Array<{ type?: string; content?: unknown }>;
+        }
+      | undefined;
+    const initialInteractionElement = initialSlideProps?.elementList?.find(
+      element => element.type === 'interaction',
+    );
+    const initialMountId = screen
       .getByTestId('mock-slide')
       .getAttribute('data-mount-id');
 
@@ -1217,14 +1225,25 @@ describe('ListenModeSlideRenderer', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('mock-slide')).not.toHaveAttribute(
-        'data-mount-id',
-        firstMountId,
+      const nextSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            elementList?: Array<{ type?: string; content?: unknown }>;
+          }
+        | undefined;
+      const nextInteractionElement = nextSlideProps?.elementList?.find(
+        element => element.type === 'interaction',
       );
+
+      expect(screen.getByTestId('mock-slide')).toHaveAttribute(
+        'data-mount-id',
+        initialMountId ?? '',
+      );
+      expect(nextInteractionElement).not.toBe(initialInteractionElement);
+      expect(nextInteractionElement?.content).toBe('?[A | B]');
     });
   });
 
-  it('remounts the slide when mobile orientation events fire before viewport dimensions settle', async () => {
+  it('refreshes mobile interaction elements when orientation events fire before viewport dimensions settle', async () => {
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
       value: 390,
@@ -1255,7 +1274,15 @@ describe('ListenModeSlideRenderer', () => {
       />,
     );
 
-    const firstMountId = screen
+    const initialSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | {
+          elementList?: Array<{ type?: string; content?: unknown }>;
+        }
+      | undefined;
+    const initialInteractionElement = initialSlideProps?.elementList?.find(
+      element => element.type === 'interaction',
+    );
+    const initialMountId = screen
       .getByTestId('mock-slide')
       .getAttribute('data-mount-id');
 
@@ -1264,11 +1291,63 @@ describe('ListenModeSlideRenderer', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('mock-slide')).not.toHaveAttribute(
-        'data-mount-id',
-        firstMountId,
+      const nextSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            elementList?: Array<{ type?: string; content?: unknown }>;
+          }
+        | undefined;
+      const nextInteractionElement = nextSlideProps?.elementList?.find(
+        element => element.type === 'interaction',
       );
+
+      expect(screen.getByTestId('mock-slide')).toHaveAttribute(
+        'data-mount-id',
+        initialMountId ?? '',
+      );
+      expect(nextInteractionElement).not.toBe(initialInteractionElement);
+      expect(nextInteractionElement?.content).toBe('?[A | B]');
     });
+  });
+
+  it('does not remount the slide for manual mobile view mode changes', () => {
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Slide',
+            element_bid: 'content-1',
+            element_type: 'html',
+          },
+          {
+            type: 'interaction',
+            content: '?[A | B]',
+            element_bid: 'interaction-1',
+          },
+        ]}
+        mobileStyle={true}
+        chatRef={createChatRef()}
+        lessonId='lesson-1'
+      />,
+    );
+
+    const initialMountId = screen
+      .getByTestId('mock-slide')
+      .getAttribute('data-mount-id');
+    const slideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | {
+          onMobileViewModeChange?: (viewMode: 'fullscreen') => void;
+        }
+      | undefined;
+
+    act(() => {
+      slideProps?.onMobileViewModeChange?.('fullscreen');
+    });
+
+    expect(screen.getByTestId('mock-slide')).toHaveAttribute(
+      'data-mount-id',
+      initialMountId ?? '',
+    );
   });
 
   it('keeps lesson feedback pending until the trailing visible interaction settles', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -35,6 +35,7 @@ const mockAskBlock = jest.fn(
     />
   ),
 );
+let mockSlideMountId = 0;
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -58,6 +59,7 @@ jest.mock('next/image', () => ({
 }));
 
 jest.mock('markdown-flow-ui/slide', () => {
+  const ReactRuntime = jest.requireActual('react') as typeof React;
   const slideCustomActionContext = {
     currentElement: {
       blockBid: 'content-1',
@@ -76,16 +78,26 @@ jest.mock('markdown-flow-ui/slide', () => {
         playerCustomActions?:
           | React.ReactNode
           | ((context: typeof slideCustomActionContext) => React.ReactNode);
-      }) => (
-        <div data-testid='mock-slide'>
-          <audio data-testid='slide-audio' />
-          <div data-testid='slide-custom-actions'>
-            {typeof props.playerCustomActions === 'function'
-              ? props.playerCustomActions(slideCustomActionContext)
-              : props.playerCustomActions}
+      }) => {
+        const mountId = ReactRuntime.useMemo(() => {
+          mockSlideMountId += 1;
+          return mockSlideMountId;
+        }, []);
+
+        return (
+          <div
+            data-testid='mock-slide'
+            data-mount-id={mountId}
+          >
+            <audio data-testid='slide-audio' />
+            <div data-testid='slide-custom-actions'>
+              {typeof props.playerCustomActions === 'function'
+                ? props.playerCustomActions(slideCustomActionContext)
+                : props.playerCustomActions}
+            </div>
           </div>
-        </div>
-      ),
+        );
+      },
     ),
   };
 });
@@ -148,6 +160,7 @@ const originalRequestFullscreen = HTMLElement.prototype.requestFullscreen;
 describe('ListenModeSlideRenderer', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mockSlideMountId = 0;
     getMockSlide().mockClear();
     mockAskBlock.mockClear();
     mockIsLessonFeedbackInteractionContent.mockClear();
@@ -1152,6 +1165,109 @@ describe('ListenModeSlideRenderer', () => {
     await waitFor(() => {
       expect(newAudioElement.defaultPlaybackRate).toBe(1.25);
       expect(newAudioElement.playbackRate).toBe(1.25);
+    });
+  });
+
+  it('remounts the slide on mobile viewport orientation changes to clear drag offsets', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 844,
+    });
+
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Slide',
+            element_bid: 'content-1',
+            element_type: 'html',
+          },
+          {
+            type: 'interaction',
+            content: '?[A | B]',
+            element_bid: 'interaction-1',
+          },
+        ]}
+        mobileStyle={true}
+        chatRef={createChatRef()}
+        lessonId='lesson-1'
+      />,
+    );
+
+    const firstMountId = screen
+      .getByTestId('mock-slide')
+      .getAttribute('data-mount-id');
+
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 844,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 390,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('orientationchange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-slide')).not.toHaveAttribute(
+        'data-mount-id',
+        firstMountId,
+      );
+    });
+  });
+
+  it('remounts the slide when mobile orientation events fire before viewport dimensions settle', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 390,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 844,
+    });
+
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Slide',
+            element_bid: 'content-1',
+            element_type: 'html',
+          },
+          {
+            type: 'interaction',
+            content: '?[A | B]',
+            element_bid: 'interaction-1',
+          },
+        ]}
+        mobileStyle={true}
+        chatRef={createChatRef()}
+        lessonId='lesson-1'
+      />,
+    );
+
+    const firstMountId = screen
+      .getByTestId('mock-slide')
+      .getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(new Event('orientationchange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-slide')).not.toHaveAttribute(
+        'data-mount-id',
+        firstMountId,
+      );
     });
   });
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -727,7 +727,7 @@ const ListenModeSlideRenderer = ({
   const [mobileViewMode, setMobileViewMode] = useState<MobileViewMode>(
     DEFAULT_LISTEN_MOBILE_VIEW_MODE,
   );
-  const [slideViewportResetKey, setSlideViewportResetKey] = useState(0);
+  const [slideInteractionResetKey, setSlideInteractionResetKey] = useState(0);
   const [fullscreenPortalContainer, setFullscreenPortalContainer] =
     useState<HTMLElement | null>(null);
   const [currentStepBlockBid, setCurrentStepBlockBid] = useState('');
@@ -916,25 +916,35 @@ const ListenModeSlideRenderer = ({
   );
   const renderedElementList = useMemo(
     () =>
-      !disableInteractionEdits
-        ? elementList
-        : elementList.map(element => {
-            if (element.type !== 'interaction') {
-              return element;
-            }
-
-            const interactionContent =
-              typeof element.content === 'string' ? element.content : '';
-            if (isSystemInteractionContent(interactionContent)) {
-              return element;
-            }
-
-            return {
+      elementList.map(element => {
+        let nextElement = element;
+        if (disableInteractionEdits && element.type === 'interaction') {
+          const interactionContent =
+            typeof element.content === 'string' ? element.content : '';
+          if (!isSystemInteractionContent(interactionContent)) {
+            nextElement = {
               ...element,
               readonly: true,
             };
-          }),
-    [disableInteractionEdits, elementList],
+          }
+        }
+
+        if (
+          !mobileStyle ||
+          slideInteractionResetKey === 0 ||
+          element.type !== 'interaction'
+        ) {
+          return nextElement;
+        }
+
+        return nextElement === element ? { ...element } : nextElement;
+      }),
+    [
+      disableInteractionEdits,
+      elementList,
+      mobileStyle,
+      slideInteractionResetKey,
+    ],
   );
   const markerStepList = useMemo(
     () => renderedElementList.filter(element => Boolean(element.is_marker)),
@@ -1169,7 +1179,7 @@ const ListenModeSlideRenderer = ({
     setIsMobileAskOpen(false);
     setIsMobileAskPanelMounted(false);
     handlePlayerCustomActionClose();
-    setSlideViewportResetKey(prevKey => prevKey + 1);
+    setSlideInteractionResetKey(prevKey => prevKey + 1);
   }, [handlePlayerCustomActionClose]);
 
   useEffect(() => {
@@ -1876,20 +1886,14 @@ const ListenModeSlideRenderer = ({
     }),
     [fullscreenHeaderContent],
   );
-  const handleMobileViewModeChange = useCallback(
-    (viewMode: MobileViewMode) => {
-      if (mobileViewModeRef.current === viewMode) {
-        return;
-      }
+  const handleMobileViewModeChange = useCallback((viewMode: MobileViewMode) => {
+    if (mobileViewModeRef.current === viewMode) {
+      return;
+    }
 
-      mobileViewModeRef.current = viewMode;
-      setMobileViewMode(viewMode);
-      if (mobileStyle) {
-        resetMobileSlideViewport();
-      }
-    },
-    [mobileStyle, resetMobileSlideViewport],
-  );
+    mobileViewModeRef.current = viewMode;
+    setMobileViewMode(viewMode);
+  }, []);
 
   useEffect(() => {
     mobileViewModeRef.current = mobileViewMode;
@@ -2086,7 +2090,6 @@ const ListenModeSlideRenderer = ({
             : desktopAskOverlay
           : null}
         <Slide
-          key={`${lessonId || 'lesson'}:${slideViewportResetKey}`}
           className={cn(
             'h-full w-full listen-slide-root',
             isMobileFullscreen && 'listen-slide-root--landscape',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1886,14 +1886,18 @@ const ListenModeSlideRenderer = ({
     }),
     [fullscreenHeaderContent],
   );
-  const handleMobileViewModeChange = useCallback((viewMode: MobileViewMode) => {
-    if (mobileViewModeRef.current === viewMode) {
-      return;
-    }
+  const handleMobileViewModeChange = useCallback(
+    (viewMode: MobileViewMode) => {
+      if (mobileViewModeRef.current === viewMode) {
+        return;
+      }
 
-    mobileViewModeRef.current = viewMode;
-    setMobileViewMode(viewMode);
-  }, []);
+      mobileViewModeRef.current = viewMode;
+      setMobileViewMode(viewMode);
+      resetMobileSlideViewport();
+    },
+    [resetMobileSlideViewport],
+  );
 
   useEffect(() => {
     mobileViewModeRef.current = mobileViewMode;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -727,6 +727,7 @@ const ListenModeSlideRenderer = ({
   const [mobileViewMode, setMobileViewMode] = useState<MobileViewMode>(
     DEFAULT_LISTEN_MOBILE_VIEW_MODE,
   );
+  const [slideViewportResetKey, setSlideViewportResetKey] = useState(0);
   const [fullscreenPortalContainer, setFullscreenPortalContainer] =
     useState<HTMLElement | null>(null);
   const [currentStepBlockBid, setCurrentStepBlockBid] = useState('');
@@ -741,6 +742,8 @@ const ListenModeSlideRenderer = ({
     useState('');
   const mobileAskActionRef = useRef<HTMLButtonElement | null>(null);
   const desktopAskActionRef = useRef<HTMLButtonElement | null>(null);
+  const mobileViewModeRef = useRef<MobileViewMode>(mobileViewMode);
+  const mobileViewportOrientationRef = useRef('');
   const playerCustomActionSetActiveRef = useRef<(active: boolean) => void>(
     () => {},
   );
@@ -1162,6 +1165,13 @@ const ListenModeSlideRenderer = ({
     playerCustomActionSetActiveRef.current(false);
   }, []);
 
+  const resetMobileSlideViewport = useCallback(() => {
+    setIsMobileAskOpen(false);
+    setIsMobileAskPanelMounted(false);
+    handlePlayerCustomActionClose();
+    setSlideViewportResetKey(prevKey => prevKey + 1);
+  }, [handlePlayerCustomActionClose]);
+
   useEffect(() => {
     if (!isAskActionDisabled) {
       return;
@@ -1502,11 +1512,74 @@ const ListenModeSlideRenderer = ({
 
   useEffect(() => {
     if (!mobileStyle) {
+      mobileViewportOrientationRef.current = '';
       return;
     }
     setIsMobileAskOpen(false);
     setIsMobileAskPanelMounted(false);
   }, [mobileStyle]);
+
+  useEffect(() => {
+    if (!mobileStyle || typeof window === 'undefined') {
+      mobileViewportOrientationRef.current = '';
+      return;
+    }
+
+    const getViewportOrientation = () =>
+      window.innerWidth > window.innerHeight ? 'landscape' : 'portrait';
+
+    mobileViewportOrientationRef.current = getViewportOrientation();
+    let animationFrameId = 0;
+
+    let shouldForceReset = false;
+
+    const handleViewportChange = (forceReset = false) => {
+      shouldForceReset = shouldForceReset || forceReset;
+      if (animationFrameId) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+
+      animationFrameId = window.requestAnimationFrame(() => {
+        animationFrameId = 0;
+        const forceNextReset = shouldForceReset;
+        shouldForceReset = false;
+        const nextOrientation = getViewportOrientation();
+        if (
+          !forceNextReset &&
+          mobileViewportOrientationRef.current === nextOrientation
+        ) {
+          return;
+        }
+
+        mobileViewportOrientationRef.current = nextOrientation;
+        resetMobileSlideViewport();
+      });
+    };
+
+    const handleOrientationChange = () => {
+      handleViewportChange(true);
+    };
+    const handleResize = () => {
+      handleViewportChange(false);
+    };
+    const screenOrientation = window.screen.orientation;
+
+    window.addEventListener('orientationchange', handleOrientationChange);
+    window.addEventListener('resize', handleResize);
+    screenOrientation?.addEventListener?.('change', handleOrientationChange);
+
+    return () => {
+      if (animationFrameId) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      window.removeEventListener('orientationchange', handleOrientationChange);
+      window.removeEventListener('resize', handleResize);
+      screenOrientation?.removeEventListener?.(
+        'change',
+        handleOrientationChange,
+      );
+    };
+  }, [mobileStyle, resetMobileSlideViewport]);
 
   useEffect(() => {
     if (!mobileStyle) {
@@ -1803,9 +1876,24 @@ const ListenModeSlideRenderer = ({
     }),
     [fullscreenHeaderContent],
   );
-  const handleMobileViewModeChange = useCallback((viewMode: MobileViewMode) => {
-    setMobileViewMode(viewMode);
-  }, []);
+  const handleMobileViewModeChange = useCallback(
+    (viewMode: MobileViewMode) => {
+      if (mobileViewModeRef.current === viewMode) {
+        return;
+      }
+
+      mobileViewModeRef.current = viewMode;
+      setMobileViewMode(viewMode);
+      if (mobileStyle) {
+        resetMobileSlideViewport();
+      }
+    },
+    [mobileStyle, resetMobileSlideViewport],
+  );
+
+  useEffect(() => {
+    mobileViewModeRef.current = mobileViewMode;
+  }, [mobileViewMode]);
 
   useEffect(() => {
     onMobileViewModeChange?.(mobileViewMode);
@@ -1998,6 +2086,7 @@ const ListenModeSlideRenderer = ({
             : desktopAskOverlay
           : null}
         <Slide
+          key={`${lessonId || 'lesson'}:${slideViewportResetKey}`}
           className={cn(
             'h-full w-full listen-slide-root',
             isMobileFullscreen && 'listen-slide-root--landscape',


### PR DESCRIPTION
## Changed
- Remount the mobile listen-mode slide renderer when the viewport orientation changes, including embedded-browser orientation events that can fire before dimensions settle.
- Clear mobile ask/custom-action overlay state during that slide viewport reset so stale slide overlay drag state is not reused.
- Add regression coverage for regular orientation changes and stale-dimension orientation events.

## Benefit
Learners can repeatedly rotate the device and drag slide interaction blocks without carrying old MarkdownFlow overlay drag offsets into a React maximum update-depth loop.

## Root Cause
The previous production fix preserved the MarkdownFlow drag transform, but the slide library still keeps drag offset and overlay rect cache internally. In embedded mobile browsers, orientation events can arrive before `innerWidth` / `innerHeight` update; if the learner then drags the interaction overlay again, stale offset/rect state can re-enter the library layout correction loop and surface as React error #185.

## Verification
- `cd src/cook-web && npm run test -- --runTestsByPath 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx' 'src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts'`
- `cd src/cook-web && npm run lint -- --file 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx' --file 'src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx' --file 'src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts'`
- `cd src/cook-web && npm run type-check`
- `git diff --check`
- `PATH="$HOME/.local/bin:$PATH" python scripts/check_dev_tools.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile interaction behavior when device orientation or viewport dimensions change.
  * Mobile ask panels, custom actions, and interaction states now refresh reliably, including when changes occur before viewport dimensions settle.
  * Manual mobile view-mode changes are handled more smoothly and consistently.
  * Slides remain mounted during supported view-mode updates, reducing unnecessary interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->