### PR TITLE
fix: log the yidun error code and msg field on check failures

### DIFF
--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -137,7 +137,14 @@ def yidun_check(
                 raw_data=response_json,
             )
         else:
-            app.logger.error(f"yidun check error: {response_json.get('message', '')}")
+            # Yidun's error payload uses "msg" (v5 API); "message" kept as a
+            # fallback. Include the code so auth/quota failures (e.g. 401
+            # trial expiry) are identifiable from the log alone.
+            app.logger.error(
+                "yidun check error: code=%s msg=%s",
+                response_json.get("code"),
+                response_json.get("msg") or response_json.get("message", ""),
+            )
             return CheckResultDTO(
                 check_result=CHECK_RESULT_UNKNOWN,
                 risk_labels=[],
@@ -146,7 +153,7 @@ def yidun_check(
                 raw_data=response_json,
             )
     except Exception as ex:
-        app.logger.error(f"yidun check error: {str(ex)}")
+        app.logger.error("yidun check error: %r", ex)
         return CheckResultDTO(
             check_result=CHECK_RESULT_UNKNOWN,
             risk_labels=[],


### PR DESCRIPTION
## Problem

Production alerts on 2026-08-12 showed three `yidun check error:` lines with an **empty reason**. The non-200 branch logs `response_json.get("message", "")`, but Yidun's v5 API reports errors in the `msg` field - so the actual failure was never logged. An in-pod probe revealed the real error:

```
code=401 msg=未经授权，请检查secretId或者businessId是否正确，若试用到期请联系商务
```

i.e. the Yidun credentials/trial have expired (an ops matter, handled separately). Every failure falls back to `CHECK_RESULT_UNKNOWN`, which the callers treat as pass - moderation is silently disabled while the account stays unauthorized.

## Changes

- `flaskr/api/check/yidun.py`: the non-200 log line now includes the response `code` and reads `msg` (falling back to `message`); the exception path logs `repr(ex)` so empty exception strings remain identifiable.

## Verification

- `tests/test_edun.py` and the full backend suite pass (2631 passed, 15 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for Yidun API responses by recording response codes and using the most relevant error message.
  * Enhanced exception logging to preserve structured error details.
  * No changes to API return behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->