### PR TITLE
chore: update markdown flow ui release

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -53,7 +53,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.8",
+        "markdown-flow-ui": "0.2.9",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13535,9 +13535,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.8.tgz",
-      "integrity": "sha512-AJ2wYuoLtMk4bKrzYDrNBVuB6uC8SGFnuJlJ+MWWGuA9OyXSF5kfe/KMnJqeEHM05Yv4gupBP29AbOmK/sIC6Q==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.9.tgz",
+      "integrity": "sha512-/6XSCgB0bOtJsJ1k82sppEWAyBkiXpoY/V1467O7ZE1OKSLDYqnxyPDY/zRpvNjyes1KIxnIJAK9o/Af6dYa/A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -70,7 +70,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.8",
+    "markdown-flow-ui": "0.2.9",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Changed
- Updated Cook Web to use the released `markdown-flow-ui@0.2.9` package.
- Refreshed the lockfile entry for the published release tarball.

## Benefit
- Learner pages use the released mobile slide overlay stability fix instead of a temporary development package.

## Verification
- `npm view markdown-flow-ui@0.2.9 version dist-tags --json`
- `cd src/cook-web && PATH="/Users/iris/.nvm/versions/node/v22.16.0/bin:/Users/iris/.codex/tmp/arg0/codex-arg0mYW93t:/Users/iris/.bun/bin:/Users/iris/.bun/bin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/iris/Library/Application Support/Code/User/globalStorage/github.copilot-chat/copilotCli:/Users/iris/.bun/bin:/opt/anaconda3/bin:/opt/anaconda3/condabin:/Users/iris/.nvm/versions/node/v24.8.0/bin:/Library/Frameworks/Python.framework/Versions/3.11/bin:/usr/local/mysql/bin:/Users/iris/.vscode/extensions/ms-python.debugpy-2026.6.0-darwin-arm64/bundled/scripts/noConfigScripts:/usr/local/mysql/bin" npm run type-check`
- `python scripts/check_dev_tools.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Markdown rendering component to the latest patch version, improving reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->