### PR TITLE
fix: mask account-specific example identifiers

### DIFF
--- a/.github/workflows/repo-harness.yml
+++ b/.github/workflows/repo-harness.yml
@@ -6,14 +6,17 @@ on:
       - "AGENTS.md"
       - "ARCHITECTURE.md"
       - "PLANS.md"
+      - "README*"
       - "lefthook.yml"
       - ".github/**"
       - ".claude/**"
       - ".cursor/**"
       - "docs/**"
+      - "docker/**"
       - "scripts/**"
       - "src/api/**"
       - "src/cook-web/src/**"
+      - "src/i18n/**"
   push:
     branches:
       - main
@@ -21,14 +24,17 @@ on:
       - "AGENTS.md"
       - "ARCHITECTURE.md"
       - "PLANS.md"
+      - "README*"
       - "lefthook.yml"
       - ".github/**"
       - ".claude/**"
       - ".cursor/**"
       - "docs/**"
+      - "docker/**"
       - "scripts/**"
       - "src/api/**"
       - "src/cook-web/src/**"
+      - "src/i18n/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/repo-harness.yml
+++ b/.github/workflows/repo-harness.yml
@@ -2,39 +2,9 @@ name: Repo Harness
 
 on:
   pull_request:
-    paths:
-      - "AGENTS.md"
-      - "ARCHITECTURE.md"
-      - "PLANS.md"
-      - "README*"
-      - "lefthook.yml"
-      - ".github/**"
-      - ".claude/**"
-      - ".cursor/**"
-      - "docs/**"
-      - "docker/**"
-      - "scripts/**"
-      - "src/api/**"
-      - "src/cook-web/src/**"
-      - "src/i18n/**"
   push:
     branches:
       - main
-    paths:
-      - "AGENTS.md"
-      - "ARCHITECTURE.md"
-      - "PLANS.md"
-      - "README*"
-      - "lefthook.yml"
-      - ".github/**"
-      - ".claude/**"
-      - ".cursor/**"
-      - "docs/**"
-      - "docker/**"
-      - "scripts/**"
-      - "src/api/**"
-      - "src/cook-web/src/**"
-      - "src/i18n/**"
   workflow_dispatch:
 
 permissions:

--- a/docs/design-docs/minimax-voice-cloning.md
+++ b/docs/design-docs/minimax-voice-cloning.md
@@ -508,7 +508,7 @@ Return cloned voices using a small DTO:
 ```json
 {
   "voice_bid": "voice_8f4c2a6b91d4",
-  "voice_id": "AiShifu_abcd_20260618_x1",
+  "voice_id": "AiShifu_xxxxxxxxxx",
   "display_name": "Teacher Zhang",
   "provider": "minimax",
   "status": "ready",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -81,7 +81,7 @@ pre-commit:
       glob: "{AGENTS.md,CLAUDE.md,ARCHITECTURE.md,PLANS.md,docs/**,.claude/**,.cursor/**,.github/**,scripts/build_repo_knowledge_index.py,scripts/check_repo_harness.py,scripts/check_ai_collab_docs.py,scripts/generate_ai_collab_docs.py}"
       run: python3 scripts/check_repo_harness.py
     check-example-identifiers:
-      run: python3 scripts/check_example_identifiers.py
+      run: python3 scripts/check_example_identifiers.py --staged
     check-architecture-boundaries:
       glob: "{docs/generated/architecture-boundary-baseline.json,docs/references/architecture-boundaries.md,scripts/check_architecture_boundaries.py,scripts/testdata/architecture_boundaries/**,src/api/**,src/cook-web/src/**}"
       run: python3 scripts/check_architecture_boundaries.py

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -81,7 +81,6 @@ pre-commit:
       glob: "{AGENTS.md,CLAUDE.md,ARCHITECTURE.md,PLANS.md,docs/**,.claude/**,.cursor/**,.github/**,scripts/build_repo_knowledge_index.py,scripts/check_repo_harness.py,scripts/check_ai_collab_docs.py,scripts/generate_ai_collab_docs.py}"
       run: python3 scripts/check_repo_harness.py
     check-example-identifiers:
-      glob: "{README*,docs/**,docker/**,src/api/**,src/cook-web/src/**,src/i18n/**,scripts/check_example_identifiers.py}"
       run: python3 scripts/check_example_identifiers.py
     check-architecture-boundaries:
       glob: "{docs/generated/architecture-boundary-baseline.json,docs/references/architecture-boundaries.md,scripts/check_architecture_boundaries.py,scripts/testdata/architecture_boundaries/**,src/api/**,src/cook-web/src/**}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -80,6 +80,9 @@ pre-commit:
     check-repo-harness:
       glob: "{AGENTS.md,CLAUDE.md,ARCHITECTURE.md,PLANS.md,docs/**,.claude/**,.cursor/**,.github/**,scripts/build_repo_knowledge_index.py,scripts/check_repo_harness.py,scripts/check_ai_collab_docs.py,scripts/generate_ai_collab_docs.py}"
       run: python3 scripts/check_repo_harness.py
+    check-example-identifiers:
+      glob: "{README*,docs/**,docker/**,src/api/**,src/cook-web/src/**,src/i18n/**,scripts/check_example_identifiers.py}"
+      run: python3 scripts/check_example_identifiers.py
     check-architecture-boundaries:
       glob: "{docs/generated/architecture-boundary-baseline.json,docs/references/architecture-boundaries.md,scripts/check_architecture_boundaries.py,scripts/testdata/architecture_boundaries/**,src/api/**,src/cook-web/src/**}"
       run: python3 scripts/check_architecture_boundaries.py

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -76,7 +76,7 @@ HOME_COURSE_ID_RE = re.compile(
 )
 FEISHU_RESOURCE_RE = re.compile(
     r"(?P<value>https?://[A-Za-z0-9.-]+\.feishu\.cn/"
-    r"(?:docx|wiki|share/base/form)/[A-Za-z0-9]+)"
+    r"(?:base|docx|sheets|wiki|share/base/form)/[A-Za-z0-9]+)"
 )
 
 MASKED_MINIMAX_VOICE_ID = "AiShifu_xxxxxxxxxx"
@@ -443,6 +443,8 @@ def run_self_test() -> None:
     suspicious_course = "1234567890abcdef" * 2
     wrong_masked_course = "y" * 32
     suspicious_doc = "https://internal." + "feishu.cn/docx/" + "AbCdEfGhIjKlMnOp"
+    suspicious_base = "https://internal." + "feishu.cn/base/" + "AbCdEfGhIjKlMnOp"
+    suspicious_sheet = "https://internal." + "feishu.cn/sheets/" + "AbCdEfGhIjKlMnOp"
 
     assert find_violations_in_text(
         "fixture.py", f'voice_id = "{suspicious_volcengine}"'
@@ -560,6 +562,8 @@ def run_self_test() -> None:
     assert not find_violations_in_text("fixture.md", f"HOME_URL=/c/{MASKED_COURSE_ID}")
     assert find_violations_in_text("fixture.ts", suspicious_doc)
     assert find_violations_in_text("fixture.md", suspicious_doc)
+    assert find_violations_in_text("fixture.md", suspicious_base)
+    assert find_violations_in_text("fixture.md", suspicious_sheet)
     assert not find_violations_in_text(
         "fixture.ts", next(iter(INTENTIONAL_PUBLIC_FEISHU_RESOURCES))
     )

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -17,6 +17,14 @@ VOLCENGINE_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>S_[A-Za-z0-9_-]{4,64})"
     r"(?![A-Za-z0-9_-])"
 )
+VOLCENGINE_VOICE_CONTEXT_RE = re.compile(
+    r"(?:\b(?:tts[_ -]?)?voice[_ -]?id\b|"
+    r"\bspeaker[_ -]?(?:id|slot)\b|"
+    r"\bvoiceIdPlaceholderVolcengine\b|"
+    r"\bquery_volcengine_voice_status\b|"
+    r"\bverify_volcengine_voice_id\b)",
+    re.IGNORECASE,
+)
 MASKED_VOLCENGINE_VOICE_ID_RE = re.compile(r"^S_x{4,64}$")
 MINIMAX_OPAQUE_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>AiShifu_[0-9A-Fa-f]{12,64})"
@@ -76,6 +84,12 @@ def _line_number(text: str, offset: int) -> int:
     return text.count("\n", 0, offset) + 1
 
 
+def _line_containing(text: str, offset: int) -> str:
+    start = text.rfind("\n", 0, offset) + 1
+    end = text.find("\n", offset)
+    return text[start:] if end == -1 else text[start:end]
+
+
 def _append_match(
     violations: list[IdentifierViolation],
     *,
@@ -99,6 +113,10 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
     violations: list[IdentifierViolation] = []
 
     for match in VOLCENGINE_VOICE_ID_RE.finditer(text):
+        if not VOLCENGINE_VOICE_CONTEXT_RE.search(
+            _line_containing(text, match.start("value"))
+        ):
+            continue
         value = match.group("value")
         if MASKED_VOLCENGINE_VOICE_ID_RE.fullmatch(value):
             continue
@@ -275,6 +293,7 @@ def _run_self_test() -> None:
     suspicious_volcengine = "S_" + "a1b2c3d4"
     suspicious_volcengine_hyphen = "S_" + "-abcd"
     suspicious_volcengine_underscore = "S_" + "_abcd"
+    status_like_volcengine = "S_" + "READY"
     suspicious_minimax = "AiShifu_" + "0123456789ab"
     suspicious_wechat = "wx" + "1234567890abcdef"
     wrong_masked_wechat = "wx" + ("y" * 16)
@@ -291,8 +310,20 @@ def _run_self_test() -> None:
     assert not find_violations_in_text("fixture.py", 'voice_id = "S_xxxx"')
     assert not find_violations_in_text("fixture.py", 'voice_id = "S_xxxxxxxxxx"')
     assert not find_violations_in_text("fixture.py", f'voice_id = "S_{"x" * 64}"')
-    assert find_violations_in_text("fixture.py", suspicious_volcengine_hyphen)
-    assert find_violations_in_text("fixture.py", suspicious_volcengine_underscore)
+    assert find_violations_in_text(
+        "fixture.py", f'voice_id = "{suspicious_volcengine_hyphen}"'
+    )
+    assert find_violations_in_text(
+        "fixture.py", f'voice_id = "{suspicious_volcengine_underscore}"'
+    )
+    assert not find_violations_in_text("fixture.py", status_like_volcengine)
+    assert not find_violations_in_text("fixture.py", "S_ALPHA_1")
+    assert find_violations_in_text(
+        "fixture.py", f'voice_id = "{status_like_volcengine}"'
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"Volcengine speaker ID: {suspicious_volcengine}"
+    )
     assert find_violations_in_text("fixture.py", f'voice_id = "{suspicious_minimax}"')
     assert not find_violations_in_text(
         "fixture.py", f'voice_id = "{MASKED_MINIMAX_VOICE_ID}"'

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -44,14 +44,14 @@ WECHAT_APP_ID_EXAMPLE_RE = re.compile(
     r"(?P<value>wx[A-Za-z0-9_-]{16})(?![A-Za-z0-9_-])"
 )
 UMAMI_SITE_ID_RE = re.compile(
-    r"(?:umamiWebsiteId|NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID)"
+    r"(?:umamiWebsiteId|(?:NEXT_PUBLIC_)?ANALYTICS_UMAMI_SITE_ID)"
     r"[\"']?\s*[:=]\s*[\"']?"
     r"(?P<value>[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-"
     r"[A-Za-z0-9]{4}-[A-Za-z0-9]{12})",
     re.IGNORECASE,
 )
 UMAMI_SCRIPT_URL_RE = re.compile(
-    r"(?:umamiScriptSrc|NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT)"
+    r"(?:umamiScriptSrc|(?:NEXT_PUBLIC_)?ANALYTICS_UMAMI_SCRIPT)"
     r"[\"']?\s*[:=]\s*[\"']?(?P<value>https?://[^\s\"']+)",
     re.IGNORECASE,
 )
@@ -397,10 +397,23 @@ def _run_self_test() -> None:
         f"NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID={MASKED_UMAMI_SITE_ID}",
     )
     assert find_violations_in_text(
+        "fixture.env", f"ANALYTICS_UMAMI_SITE_ID={suspicious_umami}"
+    )
+    assert not find_violations_in_text(
+        "fixture.env", f"ANALYTICS_UMAMI_SITE_ID={MASKED_UMAMI_SITE_ID}"
+    )
+    assert find_violations_in_text(
         "fixture.md", f"umamiScriptSrc: {suspicious_umami_script}"
     )
     assert not find_violations_in_text(
         "fixture.md", "umamiScriptSrc: https://analytics.example.test/script.js"
+    )
+    assert find_violations_in_text(
+        "fixture.env", f"ANALYTICS_UMAMI_SCRIPT={suspicious_umami_script}"
+    )
+    assert not find_violations_in_text(
+        "fixture.env",
+        "ANALYTICS_UMAMI_SCRIPT=https://analytics.example.test/script.js",
     )
     assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{suspicious_course}")
     assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{wrong_masked_course}")

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -109,9 +109,6 @@ def _line_containing(text: str, offset: int) -> str:
 def _volcengine_context(text: str, match: re.Match[str]) -> str:
     value_offset = match.start("value")
     current_line = _line_containing(text, value_offset)
-    if VOLCENGINE_VOICE_CONTEXT_RE.search(current_line):
-        return current_line
-
     value_start = value_offset - (text.rfind("\n", 0, value_offset) + 1)
     value_end = value_start + len(match.group("value"))
     prefix = current_line[:value_start]
@@ -119,7 +116,9 @@ def _volcengine_context(text: str, match: re.Match[str]) -> str:
     is_standalone_value = re.fullmatch(
         r"\s*(?:[-*]\s*)?[`\"']?", prefix
     ) and re.fullmatch(r"[`\"']?\s*[,;]?\s*", suffix)
-    if not is_standalone_value:
+    has_voice_context = VOLCENGINE_VOICE_CONTEXT_RE.search(current_line)
+    needs_nearby_context = bool(is_standalone_value or has_voice_context)
+    if not needs_nearby_context:
         return current_line
 
     current_start = text.rfind("\n", 0, value_offset) + 1
@@ -460,6 +459,10 @@ def run_self_test() -> None:
     )
     assert find_violations_in_text(
         "fixture.env", f"VOLCENGINE_VOICE_ID={status_like_volcengine}"
+    )
+    assert find_violations_in_text(
+        "fixture.py",
+        f'provider = "volcengine"\nlast_voice_id = {status_like_volcengine}',
     )
     assert find_violations_in_text(
         "fixture.md", f"Volcengine speaker ID: {suspicious_volcengine}"

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -294,8 +294,12 @@ def find_violations(
     paths: list[Path] | None = None,
     *,
     staged: bool = False,
+    validate_fixtures: bool = True,
 ) -> list[IdentifierViolation]:
     """Scan repository text files, or the explicitly supplied paths."""
+
+    if validate_fixtures:
+        run_self_test()
 
     violations: list[IdentifierViolation] = []
     if paths is not None and staged:
@@ -326,7 +330,7 @@ def find_violations(
     return sorted(violations)
 
 
-def _run_self_test() -> None:
+def run_self_test() -> None:
     suspicious_volcengine = "S_" + "a1b2c3d4"
     suspicious_volcengine_hyphen = "S_" + "-abcd"
     suspicious_volcengine_underscore = "S_" + "_abcd"
@@ -440,10 +444,13 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.self_test:
-        _run_self_test()
+        run_self_test()
 
     try:
-        violations = find_violations(staged=args.staged)
+        violations = find_violations(
+            staged=args.staged,
+            validate_fixtures=not args.self_test,
+        )
     except (OSError, subprocess.CalledProcessError) as exc:
         print(f"Identifier example validation could not run: {exc}", file=sys.stderr)
         return 1

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -20,11 +20,17 @@ VOLCENGINE_VOICE_ID_RE = re.compile(
 VOLCENGINE_VOICE_CONTEXT_RE = re.compile(
     r"(?<![A-Za-z0-9])"
     r"(?:voice[_ -]?id|speaker[_ -]?(?:id|slots?)|"
+    r"(?:\u58f0\u97f3|\u97f3\u8272|\u8bf4\u8bdd\u4eba)\s*"
+    r"(?:id|\u7f16\u53f7|\u69fd\u4f4d)|"
     r"voiceIdPlaceholderVolcengine|query_volcengine_voice_status|"
     r"verify_volcengine_voice_id)"
     r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
+VOLCENGINE_PROVIDER_CONTEXT_RE = re.compile(
+    r"(?:volcengine|\u706b\u5c71\u5f15\u64ce)", re.IGNORECASE
+)
+GENERIC_S_CONSTANT_RE = re.compile(r"^S_[A-Z][A-Z0-9_]*$")
 MASKED_VOLCENGINE_VOICE_ID_RE = re.compile(r"^S_x{4,64}$")
 MINIMAX_OPAQUE_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>AiShifu_[0-9A-Fa-f]{12,64})"
@@ -117,9 +123,16 @@ def _volcengine_context(text: str, match: re.Match[str]) -> str:
         return current_line
 
     current_start = text.rfind("\n", 0, value_offset) + 1
-    previous_end = max(current_start - 1, 0)
-    previous_start = text.rfind("\n", 0, previous_end) + 1
-    return text[previous_start : current_start + len(current_line)]
+    previous_lines = text[:current_start].splitlines()
+    nearby_lines: list[str] = []
+    for line in reversed(previous_lines):
+        if not line.strip():
+            continue
+        nearby_lines.append(line)
+        if len(nearby_lines) == 3:
+            break
+    nearby_lines.reverse()
+    return "\n".join([*nearby_lines, current_line])
 
 
 def _is_test_fixture_path(path: str) -> bool:
@@ -157,10 +170,14 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
     violations: list[IdentifierViolation] = []
 
     for match in VOLCENGINE_VOICE_ID_RE.finditer(text):
-        if not VOLCENGINE_VOICE_CONTEXT_RE.search(_volcengine_context(text, match)):
+        context = _volcengine_context(text, match)
+        has_provider_context = VOLCENGINE_PROVIDER_CONTEXT_RE.search(context)
+        if not (has_provider_context or VOLCENGINE_VOICE_CONTEXT_RE.search(context)):
             continue
         value = match.group("value")
         if MASKED_VOLCENGINE_VOICE_ID_RE.fullmatch(value):
+            continue
+        if GENERIC_S_CONSTANT_RE.fullmatch(value) and not has_provider_context:
             continue
         _append_match(
             violations,
@@ -435,8 +452,14 @@ def run_self_test() -> None:
     )
     assert not find_violations_in_text("fixture.py", status_like_volcengine)
     assert not find_violations_in_text("fixture.py", "S_ALPHA_1")
-    assert find_violations_in_text(
+    assert not find_violations_in_text(
         "fixture.py", f'voice_id = "{status_like_volcengine}"'
+    )
+    assert not find_violations_in_text(
+        "fixture.py", f"last_voice_id = {status_like_volcengine}"
+    )
+    assert find_violations_in_text(
+        "fixture.env", f"VOLCENGINE_VOICE_ID={status_like_volcengine}"
     )
     assert find_violations_in_text(
         "fixture.md", f"Volcengine speaker ID: {suspicious_volcengine}"
@@ -450,6 +473,14 @@ def run_self_test() -> None:
     )
     assert find_violations_in_text(
         "fixture.md", f"Volcengine Voice ID:\n{suspicious_volcengine}"
+    )
+    assert find_violations_in_text(
+        "fixture.md",
+        f"\u706b\u5c71\u5f15\u64ce\u58f0\u97f3 ID\uff1a{suspicious_volcengine}",
+    )
+    assert find_violations_in_text(
+        "fixture.md",
+        f"Volcengine speaker ID:\n```text\n{suspicious_volcengine}\n```",
     )
     assert not find_violations_in_text(
         "fixture.py", f"{status_like_volcengine} = 'ready'\nvoice_id = 'other'"

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -266,28 +266,64 @@ def _repository_relative_paths() -> list[str]:
     ]
 
 
-def _staged_paths() -> set[str]:
+def _index_entries() -> list[tuple[str, str]]:
     result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+        ["git", "ls-files", "--stage", "-z"],
         cwd=ROOT,
         check=True,
         capture_output=True,
     )
-    return {
-        raw_path.decode("utf-8", errors="surrogateescape")
-        for raw_path in result.stdout.split(b"\0")
-        if raw_path
-    }
+    entries: list[tuple[str, str]] = []
+    for raw_entry in result.stdout.split(b"\0"):
+        if not raw_entry:
+            continue
+        metadata, raw_path = raw_entry.split(b"\t", 1)
+        mode, raw_object_id, stage = metadata.split(b" ", 2)
+        if stage != b"0" or mode == b"160000":
+            continue
+        entries.append(
+            (
+                raw_path.decode("utf-8", errors="surrogateescape"),
+                raw_object_id.decode("ascii"),
+            )
+        )
+    return entries
 
 
-def _read_staged_blob(relative_path: str) -> bytes:
+def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
+    unique_object_ids = list(dict.fromkeys(object_ids))
+    if not unique_object_ids:
+        return {}
     result = subprocess.run(
-        ["git", "show", f":{relative_path}"],
+        ["git", "cat-file", "--batch"],
         cwd=ROOT,
         check=True,
+        input="".join(f"{object_id}\n" for object_id in unique_object_ids).encode(),
         capture_output=True,
     )
-    return result.stdout
+    objects: dict[str, bytes] = {}
+    offset = 0
+    for object_id in unique_object_ids:
+        header_end = result.stdout.find(b"\n", offset)
+        if header_end == -1:
+            raise OSError("git cat-file returned a truncated header")
+        header = result.stdout[offset:header_end].split()
+        if len(header) != 3 or header[1] != b"blob":
+            raise OSError(f"git cat-file did not return blob {object_id}")
+        size = int(header[2])
+        content_start = header_end + 1
+        content_end = content_start + size
+        if result.stdout[content_end : content_end + 1] != b"\n":
+            raise OSError("git cat-file returned a truncated blob")
+        objects[object_id] = result.stdout[content_start:content_end]
+        offset = content_end + 1
+    return objects
+
+
+def _index_candidates() -> list[tuple[str, bytes]]:
+    entries = _index_entries()
+    objects = _read_index_objects([object_id for _, object_id in entries])
+    return [(path, objects[object_id]) for path, object_id in entries]
 
 
 def find_violations(
@@ -310,17 +346,14 @@ def find_violations(
             (path.as_posix(), path.read_bytes()) for path in paths if path.is_file()
         ]
     else:
-        staged_paths = _staged_paths() if staged else set()
-        candidates = []
-        for relative_path in _repository_relative_paths():
-            path = ROOT / relative_path
-            if relative_path in staged_paths:
-                raw = _read_staged_blob(relative_path)
-            elif path.is_file():
-                raw = path.read_bytes()
-            else:
-                continue
-            candidates.append((relative_path, raw))
+        if staged:
+            candidates = _index_candidates()
+        else:
+            candidates = []
+            for relative_path in _repository_relative_paths():
+                path = ROOT / relative_path
+                if path.is_file():
+                    candidates.append((relative_path, path.read_bytes()))
 
     for path_label, raw in candidates:
         if b"\0" in raw:
@@ -439,7 +472,7 @@ def main() -> int:
     parser.add_argument(
         "--staged",
         action="store_true",
-        help="Read staged tracked files from the Git index instead of the worktree.",
+        help="Scan the complete Git index snapshot instead of the worktree.",
     )
     args = parser.parse_args()
 

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -18,11 +18,11 @@ VOLCENGINE_VOICE_ID_RE = re.compile(
     r"(?![A-Za-z0-9_-])"
 )
 VOLCENGINE_VOICE_CONTEXT_RE = re.compile(
-    r"(?:\b(?:tts[_ -]?)?voice[_ -]?id\b|"
-    r"\bspeaker[_ -]?(?:id|slot)\b|"
-    r"\bvoiceIdPlaceholderVolcengine\b|"
-    r"\bquery_volcengine_voice_status\b|"
-    r"\bverify_volcengine_voice_id\b)",
+    r"(?<![A-Za-z0-9])"
+    r"(?:voice[_ -]?id|speaker[_ -]?(?:id|slots?)|"
+    r"voiceIdPlaceholderVolcengine|query_volcengine_voice_status|"
+    r"verify_volcengine_voice_id)"
+    r"(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 MASKED_VOLCENGINE_VOICE_ID_RE = re.compile(r"^S_x{4,64}$")
@@ -95,6 +95,28 @@ def _line_containing(text: str, offset: int) -> str:
     return text[start:] if end == -1 else text[start:end]
 
 
+def _volcengine_context(text: str, match: re.Match[str]) -> str:
+    value_offset = match.start("value")
+    current_line = _line_containing(text, value_offset)
+    if VOLCENGINE_VOICE_CONTEXT_RE.search(current_line):
+        return current_line
+
+    value_start = value_offset - (text.rfind("\n", 0, value_offset) + 1)
+    value_end = value_start + len(match.group("value"))
+    prefix = current_line[:value_start]
+    suffix = current_line[value_end:]
+    is_standalone_value = re.fullmatch(
+        r"\s*(?:[-*]\s*)?[`\"']?", prefix
+    ) and re.fullmatch(r"[`\"']?\s*[,;]?\s*", suffix)
+    if not is_standalone_value:
+        return current_line
+
+    current_start = text.rfind("\n", 0, value_offset) + 1
+    previous_end = max(current_start - 1, 0)
+    previous_start = text.rfind("\n", 0, previous_end) + 1
+    return text[previous_start : current_start + len(current_line)]
+
+
 def _is_test_fixture_path(path: str) -> bool:
     normalized = Path(path)
     parts = {part.lower() for part in normalized.parts}
@@ -130,9 +152,7 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
     violations: list[IdentifierViolation] = []
 
     for match in VOLCENGINE_VOICE_ID_RE.finditer(text):
-        if not VOLCENGINE_VOICE_CONTEXT_RE.search(
-            _line_containing(text, match.start("value"))
-        ):
+        if not VOLCENGINE_VOICE_CONTEXT_RE.search(_volcengine_context(text, match)):
             continue
         value = match.group("value")
         if MASKED_VOLCENGINE_VOICE_ID_RE.fullmatch(value):
@@ -399,6 +419,19 @@ def run_self_test() -> None:
     )
     assert find_violations_in_text(
         "fixture.md", f"Volcengine speaker ID: {suspicious_volcengine}"
+    )
+    assert find_violations_in_text(
+        "fixture.env", f"VOLCENGINE_VOICE_ID={suspicious_volcengine}"
+    )
+    assert find_violations_in_text(
+        "fixture.py",
+        f'is_volcengine_cloned_speaker_id("{suspicious_volcengine}")',
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"Volcengine Voice ID:\n{suspicious_volcengine}"
+    )
+    assert not find_violations_in_text(
+        "fixture.py", f"{status_like_volcengine} = 'ready'\nvoice_id = 'other'"
     )
     assert find_violations_in_text("fixture.py", f'voice_id = "{suspicious_minimax}"')
     assert find_violations_in_text(

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -30,6 +30,11 @@ MINIMAX_OPAQUE_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>AiShifu_[0-9A-Fa-f]{12,64})"
     r"(?![A-Za-z0-9_-])"
 )
+MINIMAX_GENERATED_VOICE_ID_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<value>AiShifu_[A-Za-z0-9_]{1,13}_[0-9A-Fa-f]{8})"
+    r"(?![A-Za-z0-9_-])"
+)
 MINIMAX_RUNTIME_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_-])"
     r"(?P<value>AiShifu_[A-Za-z0-9_-]{0,55}[A-Za-z0-9])"
@@ -178,6 +183,21 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
             match=match,
             message=(
                 f"MiniMax-style opaque Voice ID {match.group('value')!r} "
+                f"looks account-scoped; use {MASKED_MINIMAX_VOICE_ID}"
+            ),
+        )
+
+    for match in MINIMAX_GENERATED_VOICE_ID_RE.finditer(text):
+        if match.start("value") in reported_minimax_offsets:
+            continue
+        reported_minimax_offsets.add(match.start("value"))
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=(
+                f"Generated-format MiniMax Voice ID {match.group('value')!r} "
                 f"looks account-scoped; use {MASKED_MINIMAX_VOICE_ID}"
             ),
         )
@@ -390,6 +410,7 @@ def run_self_test() -> None:
     status_like_volcengine = "S_" + "READY"
     suspicious_minimax = "AiShifu_" + "0123456789ab"
     suspicious_minimax_non_hex = "AiShifu_" + "abcd_20260618_x1"
+    suspicious_minimax_generated = "AiShifu_" + "teacher_89abcdef"
     semantic_minimax_fixture = "AiShifu_" + "ready_voice"
     suspicious_wechat = "wx" + "1234567890abcdef"
     wrong_masked_wechat = "wx" + ("y" * 16)
@@ -442,6 +463,10 @@ def run_self_test() -> None:
     )
     assert find_violations_in_text(
         "src/api/tests/test_fixture.py", f'voice_id = "{suspicious_minimax}"'
+    )
+    assert find_violations_in_text(
+        "src/api/tests/test_fixture.py",
+        f'voice_id = "{suspicious_minimax_generated}"',
     )
     assert not find_violations_in_text(
         "fixture.py", f'voice_id = "{MASKED_MINIMAX_VOICE_ID}"'

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -46,6 +46,9 @@ MINIMAX_RUNTIME_VOICE_ID_RE = re.compile(
     r"(?P<value>AiShifu_[A-Za-z0-9_-]{0,55}[A-Za-z0-9])"
     r"(?![A-Za-z0-9_-])"
 )
+MINIMAX_SEMANTIC_TEST_VOICE_ID_RE = re.compile(
+    r"^AiShifu_[A-Za-z0-9_-]*[G-WYZg-wyz][A-Za-z0-9_-]*$"
+)
 WECHAT_APP_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>wx[0-9A-Fa-f]{16})(?![A-Za-z0-9_])"
 )
@@ -218,23 +221,27 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
             ),
         )
 
-    if not _is_test_fixture_path(path):
-        for match in MINIMAX_RUNTIME_VOICE_ID_RE.finditer(text):
-            if (
-                match.start("value") in reported_minimax_offsets
-                or match.group("value") == MASKED_MINIMAX_VOICE_ID
-            ):
-                continue
-            _append_match(
-                violations,
-                path=path,
-                text=text,
-                match=match,
-                message=(
-                    f"MiniMax Voice ID {match.group('value')!r} is not visibly "
-                    f"masked; use {MASKED_MINIMAX_VOICE_ID}"
-                ),
-            )
+    for match in MINIMAX_RUNTIME_VOICE_ID_RE.finditer(text):
+        value = match.group("value")
+        is_semantic_test_fixture = _is_test_fixture_path(
+            path
+        ) and MINIMAX_SEMANTIC_TEST_VOICE_ID_RE.fullmatch(value)
+        if (
+            match.start("value") in reported_minimax_offsets
+            or value == MASKED_MINIMAX_VOICE_ID
+            or is_semantic_test_fixture
+        ):
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=(
+                f"MiniMax Voice ID {value!r} is not visibly masked; "
+                f"use {MASKED_MINIMAX_VOICE_ID}"
+            ),
+        )
 
     for match in WECHAT_APP_ID_RE.finditer(text):
         _append_match(
@@ -491,6 +498,10 @@ def run_self_test() -> None:
     assert find_violations_in_text("fixture.py", f'voice_id = "{suspicious_minimax}"')
     assert find_violations_in_text(
         "docs/fixture.md", f'voice_id = "{suspicious_minimax_non_hex}"'
+    )
+    assert find_violations_in_text(
+        "src/api/tests/test_fixture.py",
+        f'voice_id = "{suspicious_minimax_non_hex}"',
     )
     assert not find_violations_in_text(
         "src/api/tests/test_fixture.py", f'voice_id = "{semantic_minimax_fixture}"'

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Reject account-scoped identifiers copied into repository examples."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+
+VOLCENGINE_VOICE_ID_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?P<value>S_[A-Za-z0-9_-]{4,64})"
+    r"(?![A-Za-z0-9_-])"
+)
+MASKED_VOLCENGINE_VOICE_ID_RE = re.compile(r"^S_x{4,64}$")
+MINIMAX_OPAQUE_VOICE_ID_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?P<value>AiShifu_[0-9A-Fa-f]{12,64})"
+    r"(?![A-Za-z0-9_-])"
+)
+WECHAT_APP_ID_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?P<value>wx[0-9A-Fa-f]{16})(?![A-Za-z0-9_])"
+)
+WECHAT_APP_ID_EXAMPLE_RE = re.compile(
+    r"(?:\bNEXT_PUBLIC_WECHAT_APP_ID\s*=\s*[\"']?|"
+    r"[\"']?wechatAppId[\"']?\s*:\s*[\"'])"
+    r"(?P<value>wx[A-Za-z0-9_-]{16})(?![A-Za-z0-9_-])"
+)
+UMAMI_SITE_ID_RE = re.compile(
+    r"(?:umamiWebsiteId|NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID)"
+    r"[\"']?\s*[:=]\s*[\"']?"
+    r"(?P<value>[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-"
+    r"[A-Za-z0-9]{4}-[A-Za-z0-9]{12})",
+    re.IGNORECASE,
+)
+UMAMI_SCRIPT_URL_RE = re.compile(
+    r"(?:umamiScriptSrc|NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT)"
+    r"[\"']?\s*[:=]\s*[\"']?(?P<value>https?://[^\s\"']+)",
+    re.IGNORECASE,
+)
+HOME_COURSE_ID_RE = re.compile(
+    r"(?:\bHOME_URL\s*=\s*[\"']?|[\"']?homeUrl[\"']?\s*:\s*[\"']?)"
+    r"/c/(?P<value>[A-Za-z0-9_-]{24,64})(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
+FEISHU_RESOURCE_RE = re.compile(
+    r"(?P<value>https?://[A-Za-z0-9.-]+\.feishu\.cn/"
+    r"(?:docx|wiki|share/base/form)/[A-Za-z0-9]+)"
+)
+
+MASKED_MINIMAX_VOICE_ID = "AiShifu_xxxxxxxxxx"
+MASKED_WECHAT_APP_ID = "wx" + ("x" * 16)
+MASKED_UMAMI_SITE_ID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+MASKED_COURSE_ID = "x" * 32
+INTENTIONAL_PUBLIC_FEISHU_RESOURCES = {
+    "https://zhentouai.feishu.cn/wiki/AUE5wpipJi5bL4k6GticmxddnPb",
+    "https://zhentouai.feishu.cn/share/base/form/shrcnwp8SRl1ghzia4fBG08VYkh",
+}
+
+
+@dataclass(frozen=True, order=True)
+class IdentifierViolation:
+    path: str
+    line: int
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line}: {self.message}"
+
+
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _append_match(
+    violations: list[IdentifierViolation],
+    *,
+    path: str,
+    text: str,
+    match: re.Match[str],
+    message: str,
+) -> None:
+    violations.append(
+        IdentifierViolation(
+            path=path,
+            line=_line_number(text, match.start("value")),
+            message=message,
+        )
+    )
+
+
+def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
+    """Return identifier-example violations for one UTF-8 text file."""
+
+    violations: list[IdentifierViolation] = []
+
+    for match in VOLCENGINE_VOICE_ID_RE.finditer(text):
+        value = match.group("value")
+        if MASKED_VOLCENGINE_VOICE_ID_RE.fullmatch(value):
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=(
+                f"Volcengine Voice ID {value!r} is not visibly masked; "
+                "use S_ followed only by x characters"
+            ),
+        )
+
+    for match in MINIMAX_OPAQUE_VOICE_ID_RE.finditer(text):
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=(
+                f"MiniMax-style opaque Voice ID {match.group('value')!r} "
+                f"looks account-scoped; use {MASKED_MINIMAX_VOICE_ID}"
+            ),
+        )
+
+    for match in WECHAT_APP_ID_RE.finditer(text):
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=f"WeChat App ID example must use {MASKED_WECHAT_APP_ID}",
+        )
+
+    for match in WECHAT_APP_ID_EXAMPLE_RE.finditer(text):
+        value = match.group("value")
+        if value == MASKED_WECHAT_APP_ID or WECHAT_APP_ID_RE.fullmatch(value):
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=f"WeChat App ID example must use {MASKED_WECHAT_APP_ID}",
+        )
+
+    for match in UMAMI_SITE_ID_RE.finditer(text):
+        if match.group("value") == MASKED_UMAMI_SITE_ID:
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=f"Umami website ID example must use {MASKED_UMAMI_SITE_ID}",
+        )
+
+    for match in UMAMI_SCRIPT_URL_RE.finditer(text):
+        hostname = (urlparse(match.group("value")).hostname or "").lower()
+        if hostname == "example.test" or hostname.endswith(".example.test"):
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message="Umami script example must use an example.test host",
+        )
+
+    for match in HOME_COURSE_ID_RE.finditer(text):
+        if match.group("value") == MASKED_COURSE_ID:
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=f"HOME_URL course ID example must use {MASKED_COURSE_ID}",
+        )
+
+    for match in FEISHU_RESOURCE_RE.finditer(text):
+        if match.group("value") in INTENTIONAL_PUBLIC_FEISHU_RESOURCES:
+            continue
+        _append_match(
+            violations,
+            path=path,
+            text=text,
+            match=match,
+            message=(
+                "Unreviewed Feishu resource locator; remove incidental links or "
+                "explicitly allowlist an intentional public product destination"
+            ),
+        )
+
+    return violations
+
+
+def _repository_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        ROOT / raw_path.decode("utf-8", errors="surrogateescape")
+        for raw_path in result.stdout.split(b"\0")
+        if raw_path
+    ]
+
+
+def find_violations(paths: list[Path] | None = None) -> list[IdentifierViolation]:
+    """Scan repository text files, or the explicitly supplied paths."""
+
+    violations: list[IdentifierViolation] = []
+    files = paths if paths is not None else _repository_files()
+    for path in files:
+        if not path.is_file():
+            continue
+        raw = path.read_bytes()
+        if b"\0" in raw:
+            continue
+        text = raw.decode("utf-8", errors="replace")
+        try:
+            relative_path = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            relative_path = path.as_posix()
+        violations.extend(find_violations_in_text(relative_path, text))
+    return sorted(violations)
+
+
+def _run_self_test() -> None:
+    suspicious_volcengine = "S_" + "a1b2c3d4"
+    suspicious_volcengine_hyphen = "S_" + "-abcd"
+    suspicious_volcengine_underscore = "S_" + "_abcd"
+    suspicious_minimax = "AiShifu_" + "0123456789ab"
+    suspicious_wechat = "wx" + "1234567890abcdef"
+    wrong_masked_wechat = "wx" + ("y" * 16)
+    suspicious_umami = "12345678-1234-4abc-8def-1234567890ab"
+    wrong_masked_umami = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+    suspicious_umami_script = "https://analytics." + "internal.test/script.js"
+    suspicious_course = "1234567890abcdef" * 2
+    wrong_masked_course = "y" * 32
+    suspicious_doc = "https://internal." + "feishu.cn/docx/" + "AbCdEfGhIjKlMnOp"
+
+    assert find_violations_in_text(
+        "fixture.py", f'voice_id = "{suspicious_volcengine}"'
+    )
+    assert not find_violations_in_text("fixture.py", 'voice_id = "S_xxxx"')
+    assert not find_violations_in_text("fixture.py", 'voice_id = "S_xxxxxxxxxx"')
+    assert not find_violations_in_text("fixture.py", f'voice_id = "S_{"x" * 64}"')
+    assert find_violations_in_text("fixture.py", suspicious_volcengine_hyphen)
+    assert find_violations_in_text("fixture.py", suspicious_volcengine_underscore)
+    assert find_violations_in_text("fixture.py", f'voice_id = "{suspicious_minimax}"')
+    assert not find_violations_in_text(
+        "fixture.py", f'voice_id = "{MASKED_MINIMAX_VOICE_ID}"'
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"NEXT_PUBLIC_WECHAT_APP_ID={suspicious_wechat}"
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"NEXT_PUBLIC_WECHAT_APP_ID={wrong_masked_wechat}"
+    )
+    assert not find_violations_in_text(
+        "fixture.md", f"NEXT_PUBLIC_WECHAT_APP_ID={MASKED_WECHAT_APP_ID}"
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID={suspicious_umami}"
+    )
+    assert find_violations_in_text(
+        "fixture.md",
+        f"NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID={wrong_masked_umami}",
+    )
+    assert not find_violations_in_text(
+        "fixture.md",
+        f"NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID={MASKED_UMAMI_SITE_ID}",
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"umamiScriptSrc: {suspicious_umami_script}"
+    )
+    assert not find_violations_in_text(
+        "fixture.md", "umamiScriptSrc: https://analytics.example.test/script.js"
+    )
+    assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{suspicious_course}")
+    assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{wrong_masked_course}")
+    assert not find_violations_in_text("fixture.md", f"HOME_URL=/c/{MASKED_COURSE_ID}")
+    assert find_violations_in_text("fixture.ts", suspicious_doc)
+    assert find_violations_in_text("fixture.md", suspicious_doc)
+    assert not find_violations_in_text(
+        "fixture.ts", next(iter(INTENTIONAL_PUBLIC_FEISHU_RESOURCES))
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run deterministic checker fixtures before scanning the repository.",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        _run_self_test()
+
+    try:
+        violations = find_violations()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"Identifier example validation could not run: {exc}", file=sys.stderr)
+        return 1
+
+    if violations:
+        print("Identifier example validation failed:", file=sys.stderr)
+        for violation in violations:
+            print(f" - {violation}", file=sys.stderr)
+        return 1
+
+    print("Identifier example validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -69,10 +69,18 @@ UMAMI_SCRIPT_URL_RE = re.compile(
     r"[\"']?\s*[:=]\s*[\"']?(?P<value>https?://[^\s\"']+)",
     re.IGNORECASE,
 )
-HOME_COURSE_ID_RE = re.compile(
-    r"(?:\bHOME_URL\s*=\s*[\"']?|[\"']?homeUrl[\"']?\s*:\s*[\"']?)"
-    r"/c/(?P<value>[A-Za-z0-9_-]{24,64})(?![A-Za-z0-9_-])",
+HOME_URL_ASSIGNMENT_RE = re.compile(
+    r"(?:\bHOME_URL|[\"']?homeUrl[\"']?)\s*[:=]\s*[\"']?"
+    r"(?P<url>[^\s\"',}]+)",
     re.IGNORECASE,
+)
+HOME_URL_COURSE_ID_RES = (
+    re.compile(r"/c/(?P<value>[A-Za-z0-9_-]{24,64})(?![A-Za-z0-9_-])"),
+    re.compile(
+        r"[?&]courseId=(?P<value>[A-Za-z0-9_-]{24,64})"
+        r"(?![A-Za-z0-9_-])",
+        re.IGNORECASE,
+    ),
 )
 FEISHU_RESOURCE_RE = re.compile(
     r"(?P<value>https?://[A-Za-z0-9.-]+\.feishu\.cn/"
@@ -287,16 +295,24 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
             message="Umami script example must use an example.test host",
         )
 
-    for match in HOME_COURSE_ID_RE.finditer(text):
-        if match.group("value") == MASKED_COURSE_ID:
-            continue
-        _append_match(
-            violations,
-            path=path,
-            text=text,
-            match=match,
-            message=f"HOME_URL course ID example must use {MASKED_COURSE_ID}",
-        )
+    for assignment in HOME_URL_ASSIGNMENT_RE.finditer(text):
+        url = assignment.group("url")
+        for course_id_re in HOME_URL_COURSE_ID_RES:
+            for match in course_id_re.finditer(url):
+                if match.group("value") == MASKED_COURSE_ID:
+                    continue
+                violations.append(
+                    IdentifierViolation(
+                        path=path,
+                        line=_line_number(
+                            text,
+                            assignment.start("url") + match.start("value"),
+                        ),
+                        message=(
+                            f"HOME_URL course ID example must use {MASKED_COURSE_ID}"
+                        ),
+                    )
+                )
 
     for match in FEISHU_RESOURCE_RE.finditer(text):
         if match.group("value") in INTENTIONAL_PUBLIC_FEISHU_RESOURCES:
@@ -560,6 +576,20 @@ def run_self_test() -> None:
     assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{suspicious_course}")
     assert find_violations_in_text("fixture.md", f"HOME_URL=/c/{wrong_masked_course}")
     assert not find_violations_in_text("fixture.md", f"HOME_URL=/c/{MASKED_COURSE_ID}")
+    assert find_violations_in_text(
+        "fixture.md",
+        f"HOME_URL=https://app.example.test/c/{suspicious_course}",
+    )
+    assert not find_violations_in_text(
+        "fixture.md",
+        f"HOME_URL=https://app.example.test/c/{MASKED_COURSE_ID}",
+    )
+    assert find_violations_in_text(
+        "fixture.md", f"HOME_URL=/c?courseId={suspicious_course}"
+    )
+    assert not find_violations_in_text(
+        "fixture.md", f"HOME_URL=/c?courseId={MASKED_COURSE_ID}"
+    )
     assert find_violations_in_text("fixture.ts", suspicious_doc)
     assert find_violations_in_text("fixture.md", suspicious_doc)
     assert find_violations_in_text("fixture.md", suspicious_base)

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -30,6 +30,11 @@ MINIMAX_OPAQUE_VOICE_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>AiShifu_[0-9A-Fa-f]{12,64})"
     r"(?![A-Za-z0-9_-])"
 )
+MINIMAX_RUNTIME_VOICE_ID_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])"
+    r"(?P<value>AiShifu_[A-Za-z0-9_-]{0,55}[A-Za-z0-9])"
+    r"(?![A-Za-z0-9_-])"
+)
 WECHAT_APP_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>wx[0-9A-Fa-f]{16})(?![A-Za-z0-9_])"
 )
@@ -90,6 +95,18 @@ def _line_containing(text: str, offset: int) -> str:
     return text[start:] if end == -1 else text[start:end]
 
 
+def _is_test_fixture_path(path: str) -> bool:
+    normalized = Path(path)
+    parts = {part.lower() for part in normalized.parts}
+    filename = normalized.name.lower()
+    return (
+        bool(parts & {"test", "tests"})
+        or filename.startswith("test_")
+        or ".test." in filename
+        or ".spec." in filename
+    )
+
+
 def _append_match(
     violations: list[IdentifierViolation],
     *,
@@ -131,7 +148,9 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
             ),
         )
 
+    reported_minimax_offsets: set[int] = set()
     for match in MINIMAX_OPAQUE_VOICE_ID_RE.finditer(text):
+        reported_minimax_offsets.add(match.start("value"))
         _append_match(
             violations,
             path=path,
@@ -142,6 +161,24 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
                 f"looks account-scoped; use {MASKED_MINIMAX_VOICE_ID}"
             ),
         )
+
+    if not _is_test_fixture_path(path):
+        for match in MINIMAX_RUNTIME_VOICE_ID_RE.finditer(text):
+            if (
+                match.start("value") in reported_minimax_offsets
+                or match.group("value") == MASKED_MINIMAX_VOICE_ID
+            ):
+                continue
+            _append_match(
+                violations,
+                path=path,
+                text=text,
+                match=match,
+                message=(
+                    f"MiniMax Voice ID {match.group('value')!r} is not visibly "
+                    f"masked; use {MASKED_MINIMAX_VOICE_ID}"
+                ),
+            )
 
     for match in WECHAT_APP_ID_RE.finditer(text):
         _append_match(
@@ -295,6 +332,8 @@ def _run_self_test() -> None:
     suspicious_volcengine_underscore = "S_" + "_abcd"
     status_like_volcengine = "S_" + "READY"
     suspicious_minimax = "AiShifu_" + "0123456789ab"
+    suspicious_minimax_non_hex = "AiShifu_" + "abcd_20260618_x1"
+    semantic_minimax_fixture = "AiShifu_" + "ready_voice"
     suspicious_wechat = "wx" + "1234567890abcdef"
     wrong_masked_wechat = "wx" + ("y" * 16)
     suspicious_umami = "12345678-1234-4abc-8def-1234567890ab"
@@ -325,6 +364,15 @@ def _run_self_test() -> None:
         "fixture.md", f"Volcengine speaker ID: {suspicious_volcengine}"
     )
     assert find_violations_in_text("fixture.py", f'voice_id = "{suspicious_minimax}"')
+    assert find_violations_in_text(
+        "docs/fixture.md", f'voice_id = "{suspicious_minimax_non_hex}"'
+    )
+    assert not find_violations_in_text(
+        "src/api/tests/test_fixture.py", f'voice_id = "{semantic_minimax_fixture}"'
+    )
+    assert find_violations_in_text(
+        "src/api/tests/test_fixture.py", f'voice_id = "{suspicious_minimax}"'
+    )
     assert not find_violations_in_text(
         "fixture.py", f'voice_id = "{MASKED_MINIMAX_VOICE_ID}"'
     )

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -197,7 +197,7 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
     return violations
 
 
-def _repository_files() -> list[Path]:
+def _repository_relative_paths() -> list[str]:
     result = subprocess.run(
         ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
         cwd=ROOT,
@@ -205,29 +205,69 @@ def _repository_files() -> list[Path]:
         capture_output=True,
     )
     return [
-        ROOT / raw_path.decode("utf-8", errors="surrogateescape")
+        raw_path.decode("utf-8", errors="surrogateescape")
         for raw_path in result.stdout.split(b"\0")
         if raw_path
     ]
 
 
-def find_violations(paths: list[Path] | None = None) -> list[IdentifierViolation]:
+def _staged_paths() -> set[str]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return {
+        raw_path.decode("utf-8", errors="surrogateescape")
+        for raw_path in result.stdout.split(b"\0")
+        if raw_path
+    }
+
+
+def _read_staged_blob(relative_path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f":{relative_path}"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def find_violations(
+    paths: list[Path] | None = None,
+    *,
+    staged: bool = False,
+) -> list[IdentifierViolation]:
     """Scan repository text files, or the explicitly supplied paths."""
 
     violations: list[IdentifierViolation] = []
-    files = paths if paths is not None else _repository_files()
-    for path in files:
-        if not path.is_file():
-            continue
-        raw = path.read_bytes()
+    if paths is not None and staged:
+        raise ValueError("explicit paths cannot be combined with staged content")
+
+    if paths is not None:
+        candidates = [
+            (path.as_posix(), path.read_bytes()) for path in paths if path.is_file()
+        ]
+    else:
+        staged_paths = _staged_paths() if staged else set()
+        candidates = []
+        for relative_path in _repository_relative_paths():
+            path = ROOT / relative_path
+            if relative_path in staged_paths:
+                raw = _read_staged_blob(relative_path)
+            elif path.is_file():
+                raw = path.read_bytes()
+            else:
+                continue
+            candidates.append((relative_path, raw))
+
+    for path_label, raw in candidates:
         if b"\0" in raw:
             continue
         text = raw.decode("utf-8", errors="replace")
-        try:
-            relative_path = path.relative_to(ROOT).as_posix()
-        except ValueError:
-            relative_path = path.as_posix()
-        violations.extend(find_violations_in_text(relative_path, text))
+        violations.extend(find_violations_in_text(path_label, text))
     return sorted(violations)
 
 
@@ -300,13 +340,18 @@ def main() -> int:
         action="store_true",
         help="Run deterministic checker fixtures before scanning the repository.",
     )
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="Read staged tracked files from the Git index instead of the worktree.",
+    )
     args = parser.parse_args()
 
     if args.self_test:
         _run_self_test()
 
     try:
-        violations = find_violations()
+        violations = find_violations(staged=args.staged)
     except (OSError, subprocess.CalledProcessError) as exc:
         print(f"Identifier example validation could not run: {exc}", file=sys.stderr)
         return 1

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -46,9 +46,44 @@ MINIMAX_RUNTIME_VOICE_ID_RE = re.compile(
     r"(?P<value>AiShifu_[A-Za-z0-9_-]{0,55}[A-Za-z0-9])"
     r"(?![A-Za-z0-9_-])"
 )
-MINIMAX_SEMANTIC_TEST_VOICE_ID_RE = re.compile(
-    r"^AiShifu_[A-Za-z0-9_-]*[G-WYZg-wyz][A-Za-z0-9_-]*$"
-)
+INTENTIONAL_MINIMAX_TEST_VOICE_IDS = {
+    "AiShifu_" + suffix
+    for suffix in (
+        "clone_1",
+        "deleted_1",
+        "detached_1",
+        "does_not_exist",
+        "failed_1",
+        "filter_mm",
+        "manual_voice",
+        "missing_voice",
+        "no_row_here",
+        "not_a_speaker",
+        "not_teacher",
+        "other_voice",
+        "owned_voice",
+        "processing_voice",
+        "ready_1",
+        "ready_2",
+        "ready_owned",
+        "ready_voice",
+        "reusable_1",
+        "route_1",
+        "route_low_balance",
+        "route_queued_1",
+        "saved_voice_1",
+        "shared_id",
+        "teacher_1",
+        "teacher_2",
+        "teacher_a",
+        "teacher_retry_1",
+        "teacher_storage_1",
+        "teacher_voice",
+        "unknown_voice",
+        "voice_1",
+        "voice_123",
+    )
+}
 WECHAT_APP_ID_RE = re.compile(
     r"(?<![A-Za-z0-9_])(?P<value>wx[0-9A-Fa-f]{16})(?![A-Za-z0-9_])"
 )
@@ -231,9 +266,9 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
 
     for match in MINIMAX_RUNTIME_VOICE_ID_RE.finditer(text):
         value = match.group("value")
-        is_semantic_test_fixture = _is_test_fixture_path(
-            path
-        ) and MINIMAX_SEMANTIC_TEST_VOICE_ID_RE.fullmatch(value)
+        is_semantic_test_fixture = (
+            _is_test_fixture_path(path) and value in INTENTIONAL_MINIMAX_TEST_VOICE_IDS
+        )
         if (
             match.start("value") in reported_minimax_offsets
             or value == MASKED_MINIMAX_VOICE_ID
@@ -520,6 +555,10 @@ def run_self_test() -> None:
     assert find_violations_in_text(
         "src/api/tests/test_fixture.py",
         f'voice_id = "{suspicious_minimax_non_hex}"',
+    )
+    assert find_violations_in_text(
+        "src/api/tests/test_fixture.py",
+        'voice_id = "AiShifu_' + 'sunner_89abcdeg"',
     )
     assert not find_violations_in_text(
         "src/api/tests/test_fixture.py", f'voice_id = "{semantic_minimax_fixture}"'

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -3,17 +3,20 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
 from build_repo_knowledge_index import (
     DOCS_ROOT,
     FRONTMATTER_FIELDS,
     GARDENING_SUMMARY_PATH,
-    GENERATED_COMMENT as KNOWLEDGE_GENERATED_COMMENT,
     build_knowledge_docs,
     parse_frontmatter,
 )
+from build_repo_knowledge_index import (
+    GENERATED_COMMENT as KNOWLEDGE_GENERATED_COMMENT,
+)
+from check_example_identifiers import find_violations as find_identifier_violations
 from generate_ai_collab_docs import (
     DOC_COMMENT,
     MAX_AGENT_LINES,
@@ -23,7 +26,6 @@ from generate_ai_collab_docs import (
     REQUIRED_HEADINGS,
     build_documents,
 )
-
 
 ROOT = Path(__file__).resolve().parents[1]
 BOUNDARY_BASELINE = DOCS_ROOT / "generated" / "architecture-boundary-baseline.json"
@@ -224,6 +226,11 @@ def check_frontmatter_docs(errors: list[str]) -> None:
                     errors.append(f"Missing frontmatter field '{field}' in {path}")
 
 
+def check_example_identifiers(errors: list[str]) -> None:
+    for violation in find_identifier_violations():
+        errors.append(str(violation))
+
+
 def main() -> int:
     errors: list[str] = []
     check_generated_ai_docs(errors)
@@ -232,6 +239,7 @@ def main() -> int:
     check_manual_rules(errors)
     check_root_docs(errors)
     check_frontmatter_docs(errors)
+    check_example_identifiers(errors)
 
     if errors:
         print("Repository harness validation failed:", file=sys.stderr)

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -178,7 +178,7 @@ VOLCENGINE_MODELS = [
 # synthesis time (see _infer_resource_id_for_voice).
 VOLCENGINE_ICL_RESOURCE_ID = "seed-icl-2.0"
 
-# Console-allocated cloned speaker slots look like S_v57vvPYM1.
+# Console-allocated cloned speaker slots look like S_xxxxxxxxxx.
 _VOLCENGINE_CLONED_SPEAKER_RE = re.compile(r"^S_[A-Za-z0-9_-]{4,64}$")
 
 
@@ -342,7 +342,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
             if voice.get("value") == voice_id:
                 return (voice.get("resource_id") or "").strip()
 
-        # Cloned speaker slots (S_xxx) are not in the static voice table but
+        # Cloned speaker slots (S_xxxxxxxxxx) are not in the static voice table but
         # always synthesize under the voice-clone resource, regardless of the
         # model the caller selected.
         if is_volcengine_cloned_speaker_id(voice_id):

--- a/src/api/flaskr/service/tts/cloned_voice_registry.py
+++ b/src/api/flaskr/service/tts/cloned_voice_registry.py
@@ -3,7 +3,7 @@
 Cloned-voice asset management grew up MiniMax-only. This module carries the
 per-provider facts (custom id format, synthesis model requirement, validation
 strictness) so validation / preview / runtime code can stay free of provider
-literals. Voice id shapes overlap across providers (an ``S_xxx`` id also
+literals. Voice id shapes overlap across providers (an ``S_xxxxxxxxxx`` id also
 matches MiniMax's rule), so callers must always dispatch on the provider
 name, never on the id format.
 

--- a/src/api/flaskr/service/tts/models.py
+++ b/src/api/flaskr/service/tts/models.py
@@ -267,7 +267,7 @@ class TTSMiniMaxClonedVoice(db.Model):
     shifu_bid = Column(String(36), nullable=False, default="", index=True)
     display_name = Column(String(128), nullable=False, default="")
     # TTS provider that owns this cloned voice. Voice id shapes overlap across
-    # providers (an S_xxx id also matches MiniMax's rule), so the provider must
+    # providers (an S_xxxxxxxxxx id also matches MiniMax's rule), so the provider must
     # be stored explicitly rather than inferred from the id format.
     provider = Column(
         String(32),

--- a/src/api/flaskr/service/tts/volcengine_voice_clone.py
+++ b/src/api/flaskr/service/tts/volcengine_voice_clone.py
@@ -1,7 +1,7 @@
 """Volcengine (豆包声音复刻 2.0) cloned-voice verification helpers.
 
 Unlike MiniMax, the cloning itself happens outside the platform: an operator
-trains a pre-purchased console slot (``S_xxx`` speaker id) with the standalone
+trains a pre-purchased console slot (``S_xxxxxxxxxx`` speaker id) with the standalone
 toolkit, then registers the resulting id here. The platform only needs to
 verify that a speaker id is trained and usable, which the free ``mega_tts``
 status API answers — no paid test synthesis is required (Volcengine also has

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -155,7 +155,7 @@ def test_minimax_untracked_custom_voice_falls_back(voice_app, monkeypatch):
         # fallback unless we can verify them through a READY local clone row.
         assert (
             learn_funcs._resolve_runtime_tts_voice_id(
-                voice_app, "minimax", "sunner-ai-shifu", shifu_bid="shifu-1"
+                voice_app, "minimax", "AiShifu_xxxxxxxxxx", shifu_bid="shifu-1"
             )
             == "default-voice"
         )
@@ -185,13 +185,13 @@ def test_volcengine_operator_registered_clone_is_kept(voice_app, monkeypatch):
         # Operator-registered rows carry an empty shifu_bid; the global ready
         # fallback is what makes them usable inside a course.
         _add_clone(
-            "", "S_v57vvPYM1", TTS_MINIMAX_CLONE_STATUS_READY, "vb-v1", "volcengine"
+            "", "S_xxxxxxxxxx", TTS_MINIMAX_CLONE_STATUS_READY, "vb-v1", "volcengine"
         )
         assert (
             learn_funcs._resolve_runtime_tts_voice_id(
-                voice_app, "volcengine", "S_v57vvPYM1", shifu_bid="shifu-1"
+                voice_app, "volcengine", "S_xxxxxxxxxx", shifu_bid="shifu-1"
             )
-            == "S_v57vvPYM1"
+            == "S_xxxxxxxxxx"
         )
 
 
@@ -202,7 +202,7 @@ def test_volcengine_unregistered_clone_falls_back(voice_app, monkeypatch):
     with voice_app.app_context():
         assert (
             learn_funcs._resolve_runtime_tts_voice_id(
-                voice_app, "volcengine", "S_unknown01", shifu_bid="shifu-1"
+                voice_app, "volcengine", "S_xxxxxxxxxxxxxxxx", shifu_bid="shifu-1"
             )
             == "default-voice"
         )
@@ -215,10 +215,10 @@ def test_volcengine_does_not_accept_minimax_clone_row(voice_app, monkeypatch):
     with voice_app.app_context():
         # A ready MiniMax row with the same id must not authorize the id under
         # volcengine — clone rows are provider-scoped.
-        _add_clone("", "S_v57vvPYM1", TTS_MINIMAX_CLONE_STATUS_READY, "vb-m1")
+        _add_clone("", "S_xxxxxxxxxx", TTS_MINIMAX_CLONE_STATUS_READY, "vb-m1")
         assert (
             learn_funcs._resolve_runtime_tts_voice_id(
-                voice_app, "volcengine", "S_v57vvPYM1", shifu_bid="shifu-1"
+                voice_app, "volcengine", "S_xxxxxxxxxx", shifu_bid="shifu-1"
             )
             == "default-voice"
         )

--- a/src/api/tests/service/shifu/test_admin_voice_clones.py
+++ b/src/api/tests/service/shifu/test_admin_voice_clones.py
@@ -202,7 +202,7 @@ def test_list_operator_voice_clones_filters_provider(app):
             shifu_bid="",
             display_name="Volc Voice",
             provider="volcengine",
-            voice_id="S_v57vvPYM1",
+            voice_id="S_xxxxxxxxxx",
             status="ready",
             billing_status="not_required",
             created_at=datetime(2026, 6, 22, 8, 0, 0),

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -210,7 +210,7 @@ def test_operator_voice_clone_register_volcengine_uses_free_status_check(
         json={
             "owner_user_bid": "teacher-volc",
             "display_name": "Volc Voice",
-            "voice_id": "S_v57vvPYM1",
+            "voice_id": "S_xxxxxxxxxx",
             "provider": "volcengine",
         },
         headers={"Token": "test-token"},
@@ -220,13 +220,13 @@ def test_operator_voice_clone_register_volcengine_uses_free_status_check(
     assert payload["code"] == 0
     data = payload["data"]
     assert data["provider"] == "volcengine"
-    assert data["voice_id"] == "S_v57vvPYM1"
+    assert data["voice_id"] == "S_xxxxxxxxxx"
     assert data["status"] == TTS_MINIMAX_CLONE_STATUS_READY
     assert data["billing_status"] == TTS_MINIMAX_CLONE_BILLING_NOT_REQUIRED
 
     with app.app_context():
         row = TTSMiniMaxClonedVoice.query.filter_by(
-            voice_id="S_v57vvPYM1", owner_user_bid="teacher-volc"
+            voice_id="S_xxxxxxxxxx", owner_user_bid="teacher-volc"
         ).one()
         assert row.provider == "volcengine"
         assert row.shifu_bid == ""
@@ -270,7 +270,7 @@ def test_operator_voice_clone_register_volcengine_rejects_untrained_voice(
         json={
             "owner_user_bid": "teacher-volc-3",
             "display_name": "Volc Voice",
-            "voice_id": "S_untrained01",
+            "voice_id": "S_xxxxxxxxxxxxx",
             "provider": "volcengine",
         },
         headers={"Token": "test-token"},
@@ -292,7 +292,7 @@ def test_operator_voice_clone_register_rejects_unknown_provider(
         json={
             "owner_user_bid": "teacher-volc-4",
             "display_name": "Voice",
-            "voice_id": "S_v57vvPYM1",
+            "voice_id": "S_xxxxxxxxxx",
             "provider": "tencent",
         },
         headers={"Token": "test-token"},
@@ -321,7 +321,7 @@ def test_operator_voice_clone_register_same_voice_id_across_providers(
             json={
                 "owner_user_bid": "teacher-cross",
                 "display_name": f"Voice {provider}",
-                "voice_id": "S_crossPYM1",
+                "voice_id": "S_xxxxxxxxxxxxxx",
                 "provider": provider,
             },
             headers={"Token": "test-token"},
@@ -333,7 +333,7 @@ def test_operator_voice_clone_register_same_voice_id_across_providers(
         json={
             "owner_user_bid": "teacher-cross",
             "display_name": "Voice again",
-            "voice_id": "S_crossPYM1",
+            "voice_id": "S_xxxxxxxxxxxxxx",
             "provider": "volcengine",
         },
         headers={"Token": "test-token"},
@@ -347,7 +347,7 @@ def test_operator_voice_clone_register_same_voice_id_across_providers(
         providers = {
             row.provider
             for row in TTSMiniMaxClonedVoice.query.filter_by(
-                voice_id="S_crossPYM1", deleted=0
+                voice_id="S_xxxxxxxxxxxxxx", deleted=0
             ).all()
         }
         assert providers == {"minimax", "volcengine"}
@@ -362,7 +362,7 @@ def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch):
 
     for provider, voice_id in (
         ("minimax", "AiShifu_filter_mm"),
-        ("volcengine", "S_filterPYM1"),
+        ("volcengine", "S_xxxxxxxxxxxxxxx"),
     ):
         resp = test_client.post(
             REGISTER_PATH,
@@ -383,7 +383,7 @@ def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch):
     volc_payload = volc_resp.get_json(force=True)
     assert volc_payload["code"] == 0
     assert [voice["voice_id"] for voice in volc_payload["data"]["voices"]] == [
-        "S_filterPYM1"
+        "S_xxxxxxxxxxxxxxx"
     ]
     assert volc_payload["data"]["voices"][0]["provider"] == "volcengine"
 
@@ -392,7 +392,7 @@ def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch):
     assert all_payload["code"] == 0
     assert {voice["voice_id"] for voice in all_payload["data"]["voices"]} == {
         "AiShifu_filter_mm",
-        "S_filterPYM1",
+        "S_xxxxxxxxxxxxxxx",
     }
 
 

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -232,7 +232,7 @@ def test_volcengine_ready_clone_owned_by_requester_is_allowed(app):
     _prepare_tables(app)
     _seed_clone(
         app,
-        voice_id="S_v57vvPYM1",
+        voice_id="S_xxxxxxxxxx",
         owner="creator-1",
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         provider="volcengine",
@@ -241,7 +241,7 @@ def test_volcengine_ready_clone_owned_by_requester_is_allowed(app):
         assert_preview_cloned_voice_available(
             app,
             provider="volcengine",
-            voice_id="S_v57vvPYM1",
+            voice_id="S_xxxxxxxxxx",
             owner_user_bid="creator-1",
         )
 
@@ -250,7 +250,7 @@ def test_volcengine_ready_clone_of_another_owner_is_rejected(app):
     _prepare_tables(app)
     _seed_clone(
         app,
-        voice_id="S_w57vvPYM1",
+        voice_id="S_xxxxxxxxx",
         owner="other-creator",
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         provider="volcengine",
@@ -260,7 +260,7 @@ def test_volcengine_ready_clone_of_another_owner_is_rejected(app):
             assert_preview_cloned_voice_available(
                 app,
                 provider="volcengine",
-                voice_id="S_w57vvPYM1",
+                voice_id="S_xxxxxxxxx",
                 owner_user_bid="creator-1",
             )
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
@@ -271,7 +271,7 @@ def test_volcengine_clone_row_does_not_leak_to_minimax_provider(app):
     _prepare_tables(app)
     _seed_clone(
         app,
-        voice_id="S_x57vvPYM1",
+        voice_id="S_xxxxxxxx",
         owner="creator-1",
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         provider="volcengine",
@@ -281,7 +281,7 @@ def test_volcengine_clone_row_does_not_leak_to_minimax_provider(app):
             assert_preview_cloned_voice_available(
                 app,
                 provider="minimax",
-                voice_id="S_x57vvPYM1",
+                voice_id="S_xxxxxxxx",
                 owner_user_bid="creator-1",
             )
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]

--- a/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
+++ b/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
@@ -84,19 +84,19 @@ def test_volcengine_registered_clone_keeps_teacher_selected_model(app):
     (e.g. seed-tts-2.0); the clone resource id is inferred inside the
     provider, never selected as a model."""
     _prepare_tables(app)
-    _seed_ready_clone(app, provider="volcengine", voice_id="S_v57vvPYM1")
+    _seed_ready_clone(app, provider="volcengine", voice_id="S_xxxxxxxxxx")
     with app.app_context():
-        validated = _validate("volcengine", "seed-tts-2.0", "S_v57vvPYM1")
-    assert validated.voice_id == "S_v57vvPYM1"
+        validated = _validate("volcengine", "seed-tts-2.0", "S_xxxxxxxxxx")
+    assert validated.voice_id == "S_xxxxxxxxxx"
     assert validated.model == "seed-tts-2.0"
 
 
 def test_volcengine_clone_with_unlisted_model_is_rejected(app):
     _prepare_tables(app)
-    _seed_ready_clone(app, provider="volcengine", voice_id="S_v57vvPYM1")
+    _seed_ready_clone(app, provider="volcengine", voice_id="S_xxxxxxxxxx")
     with app.app_context():
         with pytest.raises(AppException) as exc_info:
-            _validate("volcengine", "seed-tts-9.9", "S_v57vvPYM1")
+            _validate("volcengine", "seed-tts-9.9", "S_xxxxxxxxxx")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
@@ -104,7 +104,7 @@ def test_volcengine_unregistered_clone_is_rejected(app):
     _prepare_tables(app)
     with app.app_context():
         with pytest.raises(AppException) as exc_info:
-            _validate("volcengine", "seed-tts-2.0", "S_unregistered1")
+            _validate("volcengine", "seed-tts-2.0", "S_xxxxxxxxxxxx")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -40,14 +40,14 @@ class _FakeResponse:
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ("S_v57vvPYM1", True),
-        ("S_w57vvPYM1", True),
-        ("S_abcd", True),
-        ("  S_v57vvPYM1  ", True),
-        ("S_ab", False),  # too short
-        ("AiShifu_86d977e360a8", False),  # MiniMax-shaped id
-        ("s_v57vvPYM1", False),  # lowercase prefix
-        ("S_v57vv PYM1", False),  # whitespace inside
+        ("S_xxxxxxxxxx", True),
+        ("S_xxxxxxxxx", True),
+        ("S_xxxx", True),
+        ("  S_xxxxxxxxxx  ", True),
+        ("S_xx", False),  # too short
+        ("AiShifu_xxxxxxxxxx", False),  # MiniMax-shaped id
+        ("s_xxxxxxxxxx", False),  # lowercase prefix
+        ("S_xxxxx xxxxx", False),  # whitespace inside
         ("", False),
         (None, False),
     ],
@@ -63,14 +63,14 @@ def test_query_status_sends_expected_request(monkeypatch) -> None:
         assert url == VOLCENGINE_MEGA_TTS_STATUS_URL
         assert headers["Authorization"] == "Bearer;test-token"
         assert headers["Resource-Id"] == VOLCENGINE_ICL_RESOURCE_ID
-        assert json == {"appid": "test-appid", "speaker_id": "S_v57vvPYM1"}
+        assert json == {"appid": "test-appid", "speaker_id": "S_xxxxxxxxxx"}
         assert timeout == (10, 60)
         return _FakeResponse(
             {"BaseResp": {"StatusCode": 0, "StatusMessage": ""}, "status": 2}
         )
 
     monkeypatch.setattr(volcengine_voice_clone.requests, "post", fake_post)
-    assert query_volcengine_voice_status("S_v57vvPYM1") == 2
+    assert query_volcengine_voice_status("S_xxxxxxxxxx") == 2
 
 
 def test_query_status_raises_on_base_resp_error(monkeypatch) -> None:
@@ -83,13 +83,13 @@ def test_query_status_raises_on_base_resp_error(monkeypatch) -> None:
         ),
     )
     with pytest.raises(AppException):
-        query_volcengine_voice_status("S_v57vvPYM1")
+        query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
 def test_query_status_raises_without_credentials(monkeypatch) -> None:
     _patch_config(monkeypatch, config={})
     with pytest.raises(AppException):
-        query_volcengine_voice_status("S_v57vvPYM1")
+        query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
 def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> None:
@@ -104,7 +104,7 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
 
     monkeypatch.setattr(volcengine_voice_clone.requests, "post", _raise_transport_error)
     with pytest.raises(AppException):
-        query_volcengine_voice_status("S_v57vvPYM1")
+        query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
 def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
@@ -123,7 +123,7 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
         lambda *args, **kwargs: _BadJsonResponse(),
     )
     with pytest.raises(AppException):
-        query_volcengine_voice_status("S_v57vvPYM1")
+        query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
 def test_query_status_converts_http_error_to_param_error(monkeypatch) -> None:
@@ -138,7 +138,7 @@ def test_query_status_converts_http_error_to_param_error(monkeypatch) -> None:
         ),
     )
     with pytest.raises(AppException):
-        query_volcengine_voice_status("S_notexist99")
+        query_volcengine_voice_status("S_xxxxxxxxxxx")
 
 
 @pytest.mark.parametrize("status", [2, 4])
@@ -151,7 +151,7 @@ def test_verify_accepts_success_and_active(monkeypatch, status) -> None:
             {"BaseResp": {"StatusCode": 0}, "status": status}
         ),
     )
-    verify_volcengine_voice_id("S_v57vvPYM1")
+    verify_volcengine_voice_id("S_xxxxxxxxxx")
 
 
 @pytest.mark.parametrize("status", [0, 1, 3])
@@ -165,7 +165,7 @@ def test_verify_rejects_not_ready_statuses(monkeypatch, status) -> None:
         ),
     )
     with pytest.raises(AppException):
-        verify_volcengine_voice_id("S_v57vvPYM1")
+        verify_volcengine_voice_id("S_xxxxxxxxxx")
 
 
 def test_icl_resource_is_not_a_selectable_model() -> None:
@@ -183,7 +183,7 @@ def test_provider_infers_icl_resource_for_cloned_speakers() -> None:
 
     provider = VolcengineTTSProvider()
     assert (
-        provider._infer_resource_id_for_voice("S_v57vvPYM1")
+        provider._infer_resource_id_for_voice("S_xxxxxxxxxx")
         == VOLCENGINE_ICL_RESOURCE_ID
     )
     # Static voices keep their declared resource id.
@@ -192,7 +192,7 @@ def test_provider_infers_icl_resource_for_cloned_speakers() -> None:
         == "seed-tts-2.0"
     )
     # Unknown non-speaker ids leave the caller's model untouched.
-    assert provider._infer_resource_id_for_voice("AiShifu_86d977e360a8") == ""
+    assert provider._infer_resource_id_for_voice("AiShifu_xxxxxxxxxx") == ""
 
 
 def test_clone_provider_specs_dispatch_by_provider() -> None:
@@ -210,9 +210,9 @@ def test_clone_provider_specs_dispatch_by_provider() -> None:
 
     # Same S_ id: accepted by the volcengine spec, and (by design) also by the
     # MiniMax format rule — which is exactly why dispatch is by provider name.
-    assert volcengine_spec.is_valid_custom_voice_id("S_v57vvPYM1") is True
-    assert minimax_spec.is_valid_custom_voice_id("S_v57vvPYM1") is True
-    assert volcengine_spec.is_valid_custom_voice_id("AiShifu_86d977e360a8") is False
+    assert volcengine_spec.is_valid_custom_voice_id("S_xxxxxxxxxx") is True
+    assert minimax_spec.is_valid_custom_voice_id("S_xxxxxxxxxx") is True
+    assert volcengine_spec.is_valid_custom_voice_id("AiShifu_xxxxxxxxxx") is False
 
     assert supports_cloned_voices("volcengine") is True
     assert supports_cloned_voices("volcengine_http") is False

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from flaskr.service.common.models import AppException
 from flaskr.service.tts import volcengine_voice_clone
 from flaskr.service.tts.volcengine_voice_clone import (
@@ -43,6 +42,7 @@ class _FakeResponse:
         ("S_xxxxxxxxxx", True),
         ("S_xxxxxxxxx", True),
         ("S_xxxx", True),
+        ("S_" + "Ab9" + "-z_7", True),  # mixed allowed character classes
         ("  S_xxxxxxxxxx  ", True),
         ("S_xx", False),  # too short
         ("AiShifu_xxxxxxxxxx", False),  # MiniMax-shaped id

--- a/src/cook-web/src/c-api/user.ts
+++ b/src/cook-web/src/c-api/user.ts
@@ -26,8 +26,6 @@ export const updateUserInfo = name => {
  * Obtain a temporary token, also required when a user logs in normally
  * @param tmp_id Client-generated id, used to exchange for a token
  * @returns
- *
- * https://agiclass.feishu.cn/docx/WyXhdgeVzoKVqDx1D4wc0eMknmg
  */
 export const registerTmp = ({ temp_id }) => {
   const { channel, wechatCode: wxcode, language } = useSystemStore.getState();

--- a/src/cook-web/src/components/shifu-setting/minimax-voice-clone.test.ts
+++ b/src/cook-web/src/components/shifu-setting/minimax-voice-clone.test.ts
@@ -217,7 +217,7 @@ describe('minimax voice clone helpers', () => {
   });
 
   it('validates volcengine speaker ids and provider cloning support', () => {
-    expect(isValidVolcengineCustomVoiceId('S_v57vvPYM1')).toBe(true);
+    expect(isValidVolcengineCustomVoiceId('S_xxxxxxxxxx')).toBe(true);
     expect(isValidVolcengineCustomVoiceId('AiShifu_voice_123')).toBe(false);
     expect(isValidVolcengineCustomVoiceId('s_lowercase1')).toBe(false);
 
@@ -233,19 +233,21 @@ describe('minimax voice clone helpers', () => {
       clonedVoices: [
         {
           voice_bid: 'vb-volc-1',
-          voice_id: 'S_v57vvPYM1',
+          voice_id: 'S_xxxxxxxxxx',
           display_name: '何老师的声音',
           provider: 'volcengine',
           status: 'ready',
         },
       ],
-      currentVoiceId: 'S_manualPY1',
+      currentVoiceId: 'S_xxxxxxxxxxxxxxxxx',
       manualLabel: 'Manual',
       manualVoiceValidator: isValidVolcengineCustomVoiceId,
     });
 
-    const cloned = options.find(option => option.value === 'S_v57vvPYM1');
-    const manual = options.find(option => option.value === 'S_manualPY1');
+    const cloned = options.find(option => option.value === 'S_xxxxxxxxxx');
+    const manual = options.find(
+      option => option.value === 'S_xxxxxxxxxxxxxxxxx',
+    );
     expect(cloned?.source).toBe('cloned');
     // No resource_id annotation: cloned voices stay visible under the
     // teacher's normal model; the clone resource is inferred backend-side.

--- a/src/cook-web/src/components/shifu-setting/minimax-voice-clone.ts
+++ b/src/cook-web/src/components/shifu-setting/minimax-voice-clone.ts
@@ -65,7 +65,7 @@ export type MiniMaxCloneSubmitBlockReason =
 const MINIMAX_CUSTOM_VOICE_ID_PATTERN =
   /^[A-Za-z](?=.{7,63}$)[A-Za-z0-9_-]*[A-Za-z0-9]$/;
 
-// Volcengine speaker slots allocated in the console look like S_v57vvPYM1.
+// Volcengine speaker slots allocated in the console look like S_xxxxxxxxxx.
 const VOLCENGINE_CUSTOM_VOICE_ID_PATTERN = /^S_[A-Za-z0-9_-]{4,64}$/;
 
 export function isMiniMaxProvider(providerName: string): boolean {

--- a/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
+++ b/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
@@ -187,8 +187,8 @@ Docker 部署不受影响：
 ```bash
 # 使用新的环境变量名
 docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
-           -e HOME_URL=/c/your-course-id \
-           -e NEXT_PUBLIC_WECHAT_APP_ID=your-wechat-app-id \
+           -e HOME_URL=/c/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+           -e NEXT_PUBLIC_WECHAT_APP_ID=wxxxxxxxxxxxxxxxxx \
            your-image:tag
 ```
 
@@ -343,10 +343,10 @@ NEXT_PUBLIC_STRIPE_ENABLED=false
 NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com
 
 # ===== Entry Redirect Configuration =====
-HOME_URL=/c/your-course-id
+HOME_URL=/c/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ===== WeChat Integration =====
-NEXT_PUBLIC_WECHAT_APP_ID=your-wechat-app-id
+NEXT_PUBLIC_WECHAT_APP_ID=wxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_WECHAT_CODE_ENABLED=true
 
 # ===== User Interface Configuration =====
@@ -356,7 +356,7 @@ NEXT_PUBLIC_UI_LOGO_VERTICAL=
 
 # ===== Analytics & Tracking =====
 NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT=https://analytics.example.test/script.js
-NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID=your-umami-site-id
+NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 # ===== Development & Debugging Tools =====
 NEXT_PUBLIC_DEBUG_ERUDA_ENABLED=false

--- a/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
+++ b/src/cook-web/src/config/ENVIRONMENT_CONFIG.md
@@ -139,15 +139,15 @@ Cook Web 内置的 `/api/config` 只返回 `apiBaseUrl`。后端 `/api/runtime-c
 
 ```json
 {
-  "wechatAppId": "wx973eb6079c64d030",
+  "wechatAppId": "wxxxxxxxxxxxxxxxxx",
   "enableWechatCode": true,
   "billingEnabled": true,
   "alwaysShowLessonTree": "true",
   "logoWideUrl": "",
   "logoSquareUrl": "",
   "faviconUrl": "",
-  "umamiScriptSrc": "https://umami.ai-shifu.com/script.js",
-  "umamiWebsiteId": "f3108c8f-6898-4404-b6d7-fd076ad011db",
+  "umamiScriptSrc": "https://analytics.example.test/script.js",
+  "umamiWebsiteId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "enableEruda": "false",
   "loginMethodsEnabled": ["phone"],
   "defaultLoginMethod": "phone",
@@ -311,10 +311,10 @@ docker run -e NEXT_PUBLIC_API_BASE_URL=https://api.your-domain.com \
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:5800
 
 # ===== Entry Redirect Configuration =====
-HOME_URL=/c/ca3265b045e84774b8d845a4c3c5b0a3
+HOME_URL=/c/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ===== WeChat Integration =====
-NEXT_PUBLIC_WECHAT_APP_ID=wx973eb6079c64d030
+NEXT_PUBLIC_WECHAT_APP_ID=wxxxxxxxxxxxxxxxxx
 NEXT_PUBLIC_WECHAT_CODE_ENABLED=true
 
 # ===== User Interface Configuration =====
@@ -323,8 +323,8 @@ NEXT_PUBLIC_UI_LOGO_HORIZONTAL=
 NEXT_PUBLIC_UI_LOGO_VERTICAL=
 
 # ===== Analytics & Tracking =====
-NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT=https://umami.ai-shifu.com/script.js
-NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID=f3108c8f-6898-4404-b6d7-fd076ad011db
+NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT=https://analytics.example.test/script.js
+NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 # ===== Development & Debugging Tools =====
 NEXT_PUBLIC_DEBUG_ERUDA_ENABLED=false
@@ -355,7 +355,7 @@ NEXT_PUBLIC_UI_LOGO_HORIZONTAL=
 NEXT_PUBLIC_UI_LOGO_VERTICAL=
 
 # ===== Analytics & Tracking =====
-NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT=https://umami.your-domain.com/script.js
+NEXT_PUBLIC_ANALYTICS_UMAMI_SCRIPT=https://analytics.example.test/script.js
 NEXT_PUBLIC_ANALYTICS_UMAMI_SITE_ID=your-umami-site-id
 
 # ===== Development & Debugging Tools =====

--- a/src/i18n/en-US/modules/operations-voice-clone.json
+++ b/src/i18n/en-US/modules/operations-voice-clone.json
@@ -127,11 +127,11 @@
     "teacherSearchPlaceholder": "Mobile / Email",
     "title": "Register cloned voice",
     "voiceIdHint": "Enter the Voice ID cloned on the MiniMax console.",
-    "voiceIdHintVolcengine": "Enter the speaker ID trained on the Volcengine console (an S_-prefixed voice slot).",
+    "voiceIdHintVolcengine": "Enter the speaker ID trained on the Volcengine console (a voice slot beginning with S_).",
     "voiceIdInvalid": "Invalid Voice ID format",
     "voiceIdLabel": "Voice ID",
-    "voiceIdPlaceholder": "e.g. AiShifu_teacher_voice",
-    "voiceIdPlaceholderVolcengine": "e.g. S_v57vvPYM1",
+    "voiceIdPlaceholder": "e.g. AiShifu_xxxxxxxxxx",
+    "voiceIdPlaceholderVolcengine": "e.g. S_xxxxxxxxxx",
     "voiceIdRequired": "Please enter a Voice ID"
   },
   "status": {

--- a/src/i18n/fr-FR/modules/operations-voice-clone.json
+++ b/src/i18n/fr-FR/modules/operations-voice-clone.json
@@ -130,8 +130,8 @@
     "voiceIdHintVolcengine": "Saisissez l'identifiant de voix entraîné sur la console Volcengine (un emplacement commençant par S_).",
     "voiceIdInvalid": "Format de Voice ID invalide",
     "voiceIdLabel": "Voice ID",
-    "voiceIdPlaceholder": "ex. AiShifu_teacher_voice",
-    "voiceIdPlaceholderVolcengine": "ex. S_v57vvPYM1",
+    "voiceIdPlaceholder": "ex. AiShifu_xxxxxxxxxx",
+    "voiceIdPlaceholderVolcengine": "ex. S_xxxxxxxxxx",
     "voiceIdRequired": "Veuillez saisir un Voice ID"
   },
   "status": {

--- a/src/i18n/zh-CN/modules/operations-voice-clone.json
+++ b/src/i18n/zh-CN/modules/operations-voice-clone.json
@@ -130,8 +130,8 @@
     "voiceIdHintVolcengine": "填写在火山引擎控制台训练完成的声音 ID（S_ 开头的音色槽位）。",
     "voiceIdInvalid": "Voice ID 格式不正确",
     "voiceIdLabel": "Voice ID",
-    "voiceIdPlaceholder": "例如：AiShifu_teacher_voice",
-    "voiceIdPlaceholderVolcengine": "例如：S_v57vvPYM1",
+    "voiceIdPlaceholder": "例如：AiShifu_xxxxxxxxxx",
+    "voiceIdPlaceholderVolcengine": "例如：S_xxxxxxxxxx",
     "voiceIdRequired": "请填写 Voice ID"
   },
   "status": {


### PR DESCRIPTION
## Summary

- replace Volcengine and MiniMax Voice ID examples with format-preserving all-x masks
- mask WeChat, Umami, and course identifiers and remove an incidental Feishu document locator
- run the repository identifier checker for every pull request and local commit
- scan the exact staged Git snapshot locally and validate detector fixtures on every automated run
- preserve runtime validators, semantic test fixtures, and public provider voice/model catalogs

## Root cause

Account-scoped provider and deployment identifiers had been copied into UI placeholders, comments, tests, and configuration documentation without a repository-wide masking convention or prevention check.

## Impact

Examples now remain structurally recognizable without exposing tenant metadata or encouraging users to copy live account-bound values. Future production-shaped examples are rejected in local checks and CI without blocking unrelated `S_` constants or semantic test fixtures.

## Validation

- 68 focused backend tests passed
- 17 focused frontend tests passed
- identifier checker self-test, worktree scan, and complete staged-index scan passed
- staged-dangerous/worktree-safe and staged-safe/worktree-dangerous snapshot regressions behaved as expected, including a path containing spaces
- repo harness, translations, translation usage, architecture boundaries, YAML, Ruff, Prettier, and `git diff --check` passed
- original identifiers, semantic placeholders replaced by this change, and task-related `FAKE` values have zero hits
- public voice/model catalog entries have no diff

## Notes

The repository-wide `lefthook run pre-commit --all-files` gate still reports existing all-file Ruff debt. Its automatic rewrites were fully reverted; the scoped checks above passed on the exact committed diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated voice-cloning examples and guidance to use generic, masked identifiers.
  - Refreshed environment configuration examples, including API, course, and analytics settings.
  - Removed an obsolete registration documentation link.

- **Bug Fixes**
  - Improved validation coverage for example identifiers and resource URLs, helping prevent accidental exposure of account-specific values.

- **Chores**
  - Repository checks now run consistently for all pull requests and pushes to the main branch.
  - Added automated checks for staged content and repository validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->