### PR TITLE
chore: bump ruff to 0.16.3 and pin the lint rule set

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install "ruff==0.15.13" "pre-commit-hooks==6.0.0"
+          pip install "ruff==0.16.3" "pre-commit-hooks==6.0.0"
           (cd src/cook-web && npm ci)
 
       - name: Collect files changed in this PR

--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -181,7 +181,7 @@ checks are silently skipped on commit.**
 ```bash
 # From the repository root
 brew install lefthook   # or see https://lefthook.dev for non-macOS installs
-pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0
+pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
 (cd src/cook-web && npm ci)   # provides prettier + eslint
 lefthook install
 

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -42,7 +42,7 @@ tools that must already be on `PATH`. One-time setup:
 
 ```bash
 brew install lefthook
-pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0
+pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
 (cd src/cook-web && npm ci)   # provides prettier + eslint
 lefthook install
 ```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@
 #
 # One-time setup (see AGENTS.md / docs/engineering-baseline.md):
 #   brew install lefthook
-#   pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0
+#   pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
 #   (cd src/cook-web && npm ci)   # provides prettier + eslint
 #   lefthook install
 #

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,10 @@
+# Repo-wide Ruff configuration (used by lefthook.yml and .github/workflows/lint.yml).
+#
+# The lint rule set is pinned explicitly to E4/E7/E9/F. Ruff 0.16 broadened its
+# built-in default rule selection, which would surface thousands of new
+# violations across this repo; pinning keeps the enforced rule set stable and
+# independent of the installed Ruff version. Widening the rule set is a
+# deliberate follow-up decision, not a side effect of a version bump.
+
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -35,7 +35,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 # Install hints. Versions mirror lefthook.yml's header comment (lines 10-13).
 BREW_INSTALL = "brew install lefthook"
-PIP_INSTALL = "pip install ruff==0.15.13 commitizen==4.16.2 pre-commit-hooks==6.0.0"
+PIP_INSTALL = "pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0"
 NPM_INSTALL = "cd src/cook-web && npm ci"
 LEFTHOOK_INSTALL = "lefthook install"
 NODE_INSTALL = "install Node.js (see INSTALL_MANUAL.md for the supported version)"


### PR DESCRIPTION
## Summary

Bumps the pinned ruff version from **0.15.13** (carried over unchanged from the old `.pre-commit-config.yaml` when #1992 migrated to lefthook) to the current release **0.16.3**, in all places that state it:

- `lefthook.yml` (setup comment)
- `.github/workflows/lint.yml` (the actual CI pin)
- `scripts/check_dev_tools.py` (doctor install hint)
- `INSTALL_MANUAL.md` / `docs/engineering-baseline.md`

## Why a new `ruff.toml`

The repo had **no ruff config file**, so the enforced lint rule set was whatever the installed ruff version's built-in default happened to be. Ruff 0.16 broadened its default rule selection substantially — a bare `ruff check .` with 0.16.3 surfaces **6,180 violations** (DTZ, SIM, BLE, S, UP, …) that 0.15.13 never enforced.

The new root `ruff.toml` pins `lint.select = ["E4", "E7", "E9", "F"]` — exactly the rule set the repo has been enforcing so far. This makes the version bump behavior-preserving and decouples the enforced rules from any future ruff default changes. Widening the rule set (e.g. adopting DTZ, which aligns with the repo's UTC contract) can then be a deliberate follow-up, not a side effect of a version bump.

## Verification

- `ruff check .` with 0.16.3 + the pinned rule set: **All checks passed** (952 files)
- `ruff format .` with 0.16.3: **0 files reformatted** — formatter output is byte-identical to 0.15.13 for this repo, so no format churn
- `lefthook run pre-commit --all-files`: all hooks pass except `eslint`, which fails identically on a clean `main` checkout (pre-existing frontend warnings; no JS/TS files are touched here)
- `python scripts/check_dev_tools.py`: all tools present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Ruff code-quality tool to version 0.16.3.
  * Added consistent linting rule selections to keep code checks stable across environments.

* **Documentation**
  * Updated contributor setup and engineering guidance with the latest Ruff version.
  * Refreshed developer-tool installation instructions to match the current tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->