### PR TITLE
fix: update pinned alembic head in single-head migration test

### DIFF
--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -28,7 +28,7 @@ def test_alembic_migrations_have_single_head():
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
 
-    assert heads == ["b8d5f0a2c3e4"]
+    assert heads == ["e7b3c9d1f5a2"]
 
 
 def _get_base_mysql_uri() -> str:


### PR DESCRIPTION
## Summary

`tests/migrations/test_fresh_mysql_upgrade.py::test_alembic_migrations_have_single_head` pins the expected alembic head, but PR #2316 (`fef58815b`) added migration `e7b3c9d1f5a2_add_provider_to_tts_cloned_voices` (revises `b8d5f0a2c3e4`) without updating the pinned value. The `Backend Tests` workflow on `main` has been failing on this assertion since 2026-08-13 (runs 31654583689, 31679804758, 31775411548).

This PR updates the pinned head to `e7b3c9d1f5a2`.

## Verification

- Parsed all 47 files under `src/api/migrations/versions/` (handling tuple `down_revision` for merge revisions): the chain is a clean single head `e7b3c9d1f5a2` with no dangling parents.
- `python -m pytest tests/migrations/test_fresh_mysql_upgrade.py -q` → 1 passed, 1 skipped (the MySQL smoke test skips without `RUN_MYSQL_MIGRATION_SMOKE=1`, as designed).
- `lefthook run pre-commit` gates all passed.

## Why CI did not block the original PR

The PR-event `Backend Tests` job correctly escalated to a full run (`Selected targets: tests`) because migrations changed, but it executes `pytest --testmon`, and testmon deselected the single-head test (`469 collected / 180 deselected / 289 selected` in run 31654508281): the newly added migration file was not part of any test's recorded dependency fingerprint, so no test was considered affected by it. The push-to-main job runs `--testmon-noselect` (full suite) and caught the failure immediately — but only after merge. A follow-up could force `--testmon-noselect` for PRs that touch `src/api/migrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the fresh MySQL migration test to validate the current migration state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->