### PR TITLE
fix: show anonymous user for empty nicknames

### DIFF
--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -31,6 +31,7 @@ type FollowUpDetailSheetProps = {
   error: ErrorState | null;
   emptyValue: string;
   contactMode: ContactMode;
+  defaultUserName: string;
   resolveLessonDisplay: (values: {
     lessonTitle?: string;
     chapterTitle?: string;
@@ -162,6 +163,7 @@ export default function FollowUpDetailSheet({
   error,
   emptyValue,
   contactMode,
+  defaultUserName,
   resolveLessonDisplay,
   onRetry,
   onOpenChange,
@@ -191,8 +193,8 @@ export default function FollowUpDetailSheet({
   );
   const nickname = useMemo(() => {
     const normalizedNickname = basicInfo?.nickname?.trim() || '';
-    return normalizedNickname || emptyValue;
-  }, [basicInfo?.nickname, emptyValue]);
+    return normalizedNickname || defaultUserName;
+  }, [basicInfo?.nickname, defaultUserName]);
   const turnIndexLabel = useMemo(() => {
     if (basicInfo?.turn_index == null) {
       return emptyValue;

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -31,7 +31,6 @@ type FollowUpDetailSheetProps = {
   error: ErrorState | null;
   emptyValue: string;
   contactMode: ContactMode;
-  defaultUserName: string;
   resolveLessonDisplay: (values: {
     lessonTitle?: string;
     chapterTitle?: string;
@@ -163,7 +162,6 @@ export default function FollowUpDetailSheet({
   error,
   emptyValue,
   contactMode,
-  defaultUserName,
   resolveLessonDisplay,
   onRetry,
   onOpenChange,
@@ -193,11 +191,8 @@ export default function FollowUpDetailSheet({
   );
   const nickname = useMemo(() => {
     const normalizedNickname = basicInfo?.nickname?.trim() || '';
-    if (!normalizedNickname || normalizedNickname === defaultUserName) {
-      return emptyValue;
-    }
-    return normalizedNickname;
-  }, [basicInfo?.nickname, defaultUserName, emptyValue]);
+    return normalizedNickname || emptyValue;
+  }, [basicInfo?.nickname, emptyValue]);
   const turnIndexLabel = useMemo(() => {
     if (basicInfo?.turn_index == null) {
       return emptyValue;

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.test.tsx
@@ -84,7 +84,11 @@ jest.mock('react-i18next', () => ({
           if (typeof options?.count === 'number') {
             return `${key}:${options.count}`;
           }
-          return ns && ns !== 'translation' ? `${ns}.${key}` : key;
+          const translatedKey =
+            ns && ns !== 'translation' ? `${ns}.${key}` : key;
+          return translatedKey === 'module.user.defaultUserName'
+            ? 'Anonymous User'
+            : translatedKey;
         },
       });
     }
@@ -388,6 +392,45 @@ describe('AdminDashboardCourseFollowUpsPage', () => {
         'module.dashboard.detail.followUps.table.sourceResolved',
       ),
     ).toBeInTheDocument();
+  });
+
+  test('uses the shared anonymous user label in the list and detail drawer', async () => {
+    const followUps = await mockGetDashboardCourseFollowUps();
+    const detail = await mockGetDashboardCourseFollowUpDetail({
+      generated_block_bid: 'ask-2',
+    });
+    mockGetDashboardCourseFollowUps.mockClear();
+    mockGetDashboardCourseFollowUpDetail.mockClear();
+    mockGetDashboardCourseFollowUps.mockResolvedValueOnce({
+      ...followUps,
+      items: followUps.items.map(
+        (item: { generated_block_bid: string; nickname: string }) =>
+          item.generated_block_bid === 'ask-2'
+            ? { ...item, nickname: '   ' }
+            : item,
+      ),
+    });
+    mockGetDashboardCourseFollowUpDetail.mockResolvedValueOnce({
+      ...detail,
+      basic_info: {
+        ...detail.basic_info,
+        nickname: '   ',
+      },
+    });
+
+    render(<AdminDashboardCourseFollowUpsPage />);
+
+    expect(await screen.findByText('Anonymous User')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.dashboard.detail.followUps.table.detailAction',
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Anonymous User')).toHaveLength(2);
+    });
   });
 
   test('submits filters and opens the detail drawer', async () => {

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
@@ -207,7 +207,6 @@ export default function AdminDashboardCourseFollowUpsPage() {
   const followUpDetailLoadErrorMessage = t(
     'module.dashboard.messages.loadFollowUpDetailFailed',
   );
-  const defaultUserName = t('module.user.defaultUserName');
   const contactMode = useMemo<ContactMode>(
     () => resolveContactMode(loginMethodsEnabled, defaultLoginMethod),
     [defaultLoginMethod, loginMethodsEnabled],
@@ -472,14 +471,8 @@ export default function AdminDashboardCourseFollowUpsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: DashboardCourseFollowUpItem) => {
-      const nickname = item.nickname?.trim() || '';
-      if (!nickname || nickname === defaultUserName) {
-        return '';
-      }
-      return nickname;
-    },
-    [defaultUserName],
+    (item: DashboardCourseFollowUpItem) => item.nickname?.trim() || '',
+    [],
   );
 
   const handleSearch = useCallback(() => {
@@ -980,7 +973,6 @@ export default function AdminDashboardCourseFollowUpsPage() {
         error={detailError}
         emptyValue={emptyValue}
         contactMode={contactMode}
-        defaultUserName={defaultUserName}
         resolveLessonDisplay={resolvePrimaryLessonDisplay}
         onRetry={() => fetchFollowUpDetail({ forceRefresh: true })}
         onOpenChange={handleDetailOpenChange}

--- a/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/dashboard/[shifu_bid]/follow-ups/page.tsx
@@ -207,6 +207,7 @@ export default function AdminDashboardCourseFollowUpsPage() {
   const followUpDetailLoadErrorMessage = t(
     'module.dashboard.messages.loadFollowUpDetailFailed',
   );
+  const defaultUserName = t('module.user.defaultUserName');
   const contactMode = useMemo<ContactMode>(
     () => resolveContactMode(loginMethodsEnabled, defaultLoginMethod),
     [defaultLoginMethod, loginMethodsEnabled],
@@ -471,8 +472,9 @@ export default function AdminDashboardCourseFollowUpsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: DashboardCourseFollowUpItem) => item.nickname?.trim() || '',
-    [],
+    (item: DashboardCourseFollowUpItem) =>
+      item.nickname?.trim() || defaultUserName,
+    [defaultUserName],
   );
 
   const handleSearch = useCallback(() => {
@@ -973,6 +975,7 @@ export default function AdminDashboardCourseFollowUpsPage() {
         error={detailError}
         emptyValue={emptyValue}
         contactMode={contactMode}
+        defaultUserName={defaultUserName}
         resolveLessonDisplay={resolvePrimaryLessonDisplay}
         onRetry={() => fetchFollowUpDetail({ forceRefresh: true })}
         onOpenChange={handleDetailOpenChange}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -32,6 +32,7 @@ type FollowUpDetailSheetProps = {
   error: ErrorState | null;
   emptyValue: string;
   contactMode: ContactMode;
+  defaultUserName: string;
   resolveLessonDisplay: (values: {
     lessonTitle?: string;
     chapterTitle?: string;
@@ -199,6 +200,7 @@ export default function FollowUpDetailSheet({
   error,
   emptyValue,
   contactMode,
+  defaultUserName,
   resolveLessonDisplay,
   resolveOutlineFieldLabel,
   onRetry,
@@ -229,8 +231,8 @@ export default function FollowUpDetailSheet({
   );
   const nickname = useMemo(() => {
     const normalizedNickname = basicInfo?.nickname?.trim() || '';
-    return normalizedNickname || emptyValue;
-  }, [basicInfo?.nickname, emptyValue]);
+    return normalizedNickname || defaultUserName;
+  }, [basicInfo?.nickname, defaultUserName]);
   const turnIndexLabel = useMemo(() => {
     if (!basicInfo?.turn_index) {
       return emptyValue;

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/FollowUpDetailSheet.tsx
@@ -32,7 +32,6 @@ type FollowUpDetailSheetProps = {
   error: ErrorState | null;
   emptyValue: string;
   contactMode: ContactMode;
-  defaultUserName: string;
   resolveLessonDisplay: (values: {
     lessonTitle?: string;
     chapterTitle?: string;
@@ -200,7 +199,6 @@ export default function FollowUpDetailSheet({
   error,
   emptyValue,
   contactMode,
-  defaultUserName,
   resolveLessonDisplay,
   resolveOutlineFieldLabel,
   onRetry,
@@ -231,11 +229,8 @@ export default function FollowUpDetailSheet({
   );
   const nickname = useMemo(() => {
     const normalizedNickname = basicInfo?.nickname?.trim() || '';
-    if (!normalizedNickname || normalizedNickname === defaultUserName) {
-      return emptyValue;
-    }
-    return normalizedNickname;
-  }, [basicInfo?.nickname, defaultUserName, emptyValue]);
+    return normalizedNickname || emptyValue;
+  }, [basicInfo?.nickname, emptyValue]);
   const turnIndexLabel = useMemo(() => {
     if (!basicInfo?.turn_index) {
       return emptyValue;

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.test.tsx
@@ -90,7 +90,13 @@ jest.mock('react-i18next', () => ({
     const cacheKey = ns || 'translation';
     if (!mockTranslationCache.has(cacheKey)) {
       mockTranslationCache.set(cacheKey, {
-        t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
+        t: (key: string) => {
+          const translatedKey =
+            ns && ns !== 'translation' ? `${ns}.${key}` : key;
+          return translatedKey === 'module.user.defaultUserName'
+            ? 'Anonymous User'
+            : translatedKey;
+        },
       });
     }
     return {
@@ -391,6 +397,43 @@ describe('AdminOperationCourseFollowUpsPage', () => {
         name: 'module.operationsCourse.detail.title',
       }),
     ).toHaveAttribute('href', '/admin/operations/course-1');
+  });
+
+  test('uses the shared anonymous user label in the list and detail drawer', async () => {
+    const followUps = await mockGetAdminOperationCourseFollowUps();
+    const detail = await mockGetAdminOperationCourseFollowUpDetail();
+    mockGetAdminOperationCourseFollowUps.mockClear();
+    mockGetAdminOperationCourseFollowUpDetail.mockClear();
+    mockGetAdminOperationCourseFollowUps.mockResolvedValueOnce({
+      ...followUps,
+      items: followUps.items.map(
+        (item: { generated_block_bid: string; nickname: string }) =>
+          item.generated_block_bid === 'ask-2'
+            ? { ...item, nickname: '   ' }
+            : item,
+      ),
+    });
+    mockGetAdminOperationCourseFollowUpDetail.mockResolvedValueOnce({
+      ...detail,
+      basic_info: {
+        ...detail.basic_info,
+        nickname: '   ',
+      },
+    });
+
+    render(<AdminOperationCourseFollowUpsPage />);
+
+    expect(await screen.findByText('Anonymous User')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: 'module.operationsCourse.detail.followUps.table.detailAction',
+      })[0],
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Anonymous User')).toHaveLength(2);
+    });
   });
 
   test('formats follow-up summary counts without grouping in Chinese locale', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -294,6 +294,7 @@ const resolvePrimaryAccount = ({
  * t('module.operationsCourse.detail.followUps.emptyValue')
  * t('module.operationsCourse.detail.followUps.turnIndex')
  * t('module.operationsCourse.detail.followUps.turnIndexHelp')
+ * t('module.user.defaultUserName')
  */
 export default function AdminOperationCourseFollowUpsPage() {
   const router = useRouter();
@@ -315,6 +316,7 @@ export default function AdminOperationCourseFollowUpsPage() {
   const followUpDetailLoadErrorMessage = t(
     'module.operationsCourse.messages.loadFollowUpDetailFailed',
   );
+  const defaultUserName = t('module.user.defaultUserName');
   const contactMode = useMemo<ContactMode>(
     () => resolveContactMode(loginMethodsEnabled, defaultLoginMethod),
     [defaultLoginMethod, loginMethodsEnabled],
@@ -568,8 +570,9 @@ export default function AdminOperationCourseFollowUpsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: AdminOperationCourseFollowUpItem) => item.nickname?.trim() || '',
-    [],
+    (item: AdminOperationCourseFollowUpItem) =>
+      item.nickname?.trim() || defaultUserName,
+    [defaultUserName],
   );
 
   const handleSearch = useCallback(() => {
@@ -1161,6 +1164,7 @@ export default function AdminOperationCourseFollowUpsPage() {
         error={detailError}
         emptyValue={emptyValue}
         contactMode={contactMode}
+        defaultUserName={defaultUserName}
         resolveLessonDisplay={resolveDetailLessonDisplay}
         resolveOutlineFieldLabel={resolveDetailOutlineFieldLabel}
         onRetry={fetchFollowUpDetail}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/follow-ups/page.tsx
@@ -294,7 +294,6 @@ const resolvePrimaryAccount = ({
  * t('module.operationsCourse.detail.followUps.emptyValue')
  * t('module.operationsCourse.detail.followUps.turnIndex')
  * t('module.operationsCourse.detail.followUps.turnIndexHelp')
- * t('module.user.defaultUserName')
  */
 export default function AdminOperationCourseFollowUpsPage() {
   const router = useRouter();
@@ -316,7 +315,6 @@ export default function AdminOperationCourseFollowUpsPage() {
   const followUpDetailLoadErrorMessage = t(
     'module.operationsCourse.messages.loadFollowUpDetailFailed',
   );
-  const defaultUserName = t('module.user.defaultUserName');
   const contactMode = useMemo<ContactMode>(
     () => resolveContactMode(loginMethodsEnabled, defaultLoginMethod),
     [defaultLoginMethod, loginMethodsEnabled],
@@ -570,14 +568,8 @@ export default function AdminOperationCourseFollowUpsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: AdminOperationCourseFollowUpItem) => {
-      const nickname = item.nickname?.trim() || '';
-      if (!nickname || nickname === defaultUserName) {
-        return '';
-      }
-      return nickname;
-    },
-    [defaultUserName],
+    (item: AdminOperationCourseFollowUpItem) => item.nickname?.trim() || '',
+    [],
   );
 
   const handleSearch = useCallback(() => {
@@ -1169,7 +1161,6 @@ export default function AdminOperationCourseFollowUpsPage() {
         error={detailError}
         emptyValue={emptyValue}
         contactMode={contactMode}
-        defaultUserName={defaultUserName}
         resolveLessonDisplay={resolveDetailLessonDisplay}
         resolveOutlineFieldLabel={resolveDetailOutlineFieldLabel}
         onRetry={fetchFollowUpDetail}

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.test.tsx
@@ -120,7 +120,13 @@ jest.mock('react-i18next', () => ({
     const cacheKey = ns || 'translation';
     if (!mockTranslationCache.has(cacheKey)) {
       mockTranslationCache.set(cacheKey, {
-        t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
+        t: (key: string) => {
+          const translatedKey =
+            ns && ns !== 'translation' ? `${ns}.${key}` : key;
+          return translatedKey === 'module.user.defaultUserName'
+            ? 'Anonymous User'
+            : translatedKey;
+        },
       });
     }
     return {
@@ -667,6 +673,21 @@ describe('AdminOperationCourseDetailPage', () => {
         name: 'module.operationsCourse.title',
       }),
     ).toHaveAttribute('href', '/admin/operations');
+  });
+
+  test('preserves a real nickname that matches the localized fallback', async () => {
+    const detail = await mockGetAdminOperationCourseDetail();
+    mockGetAdminOperationCourseDetail.mockResolvedValueOnce({
+      ...detail,
+      basic_info: {
+        ...detail.basic_info,
+        creator_nickname: 'Anonymous User',
+      },
+    });
+
+    render(<AdminOperationCourseDetailPage />);
+
+    expect(await screen.findByText('Anonymous User')).toBeInTheDocument();
   });
 
   test('converts course detail metadata timestamps to the browser timezone', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/page.tsx
@@ -751,17 +751,13 @@ export default function AdminOperationCourseDetailPage() {
         chapter.modifier_email ||
         chapter.modifier_user_bid ||
         emptyValue;
-      const secondary =
-        chapter.modifier_nickname &&
-        chapter.modifier_nickname !== t('module.user.defaultUserName')
-          ? chapter.modifier_nickname
-          : '';
+      const secondary = chapter.modifier_nickname?.trim() || '';
       return {
         primary,
         secondary,
       };
     },
-    [emptyValue, t],
+    [emptyValue],
   );
 
   const creatorDisplay = useMemo(() => {
@@ -770,13 +766,10 @@ export default function AdminOperationCourseDetailPage() {
       detail.basic_info.creator_email ||
       detail.basic_info.creator_user_bid ||
       emptyValue;
-    const secondary = detail.basic_info.creator_nickname || '';
+    const secondary = detail.basic_info.creator_nickname?.trim() || '';
     return {
       primary,
-      secondary:
-        secondary && secondary !== t('module.user.defaultUserName')
-          ? secondary
-          : '',
+      secondary,
     };
   }, [
     detail.basic_info.creator_email,
@@ -784,7 +777,6 @@ export default function AdminOperationCourseDetailPage() {
     detail.basic_info.creator_nickname,
     detail.basic_info.creator_user_bid,
     emptyValue,
-    t,
   ]);
 
   const metricCards = useMemo(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -80,7 +80,13 @@ jest.mock('react-i18next', () => ({
     const cacheKey = ns || 'translation';
     if (!mockTranslationCache.has(cacheKey)) {
       mockTranslationCache.set(cacheKey, {
-        t: (key: string) => (ns && ns !== 'translation' ? `${ns}.${key}` : key),
+        t: (key: string) => {
+          const translatedKey =
+            ns && ns !== 'translation' ? `${ns}.${key}` : key;
+          return translatedKey === 'module.user.defaultUserName'
+            ? 'Anonymous User'
+            : translatedKey;
+        },
       });
     }
     return {
@@ -293,6 +299,25 @@ describe('AdminOperationCourseRatingsPage', () => {
         name: 'module.operationsCourse.detail.title',
       }),
     ).toHaveAttribute('href', '/admin/operations/course-1');
+  });
+
+  test('uses the shared anonymous user label for an empty nickname', async () => {
+    const ratings = await mockGetAdminOperationCourseRatings();
+    mockGetAdminOperationCourseRatings.mockClear();
+    mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
+      ...ratings,
+      items: ratings.items.map(
+        (item: { lesson_feedback_bid: string; nickname: string }) =>
+          item.lesson_feedback_bid === 'feedback-2'
+            ? { ...item, nickname: '   ' }
+            : item,
+      ),
+    });
+
+    render(<AdminOperationCourseRatingsPage />);
+
+    await screen.findByText('Very helpful lesson');
+    expect(screen.getByText('Anonymous User')).toBeInTheDocument();
   });
 
   test('converts rating timestamps to the browser timezone', async () => {

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -730,6 +730,7 @@ describe('AdminOperationCourseRatingsPage', () => {
         'module.operationsCourse.detail.ratings.table.guestUser',
       ),
     ).toBeInTheDocument();
+    expect(screen.queryByText('Anonymous User')).not.toBeInTheDocument();
     expect(screen.queryByText('--')).not.toBeInTheDocument();
   });
 

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.test.tsx
@@ -734,6 +734,33 @@ describe('AdminOperationCourseRatingsPage', () => {
     expect(screen.queryByText('--')).not.toBeInTheDocument();
   });
 
+  test('preserves a real nickname when the rating user has no contact info', async () => {
+    const ratings = await mockGetAdminOperationCourseRatings();
+    mockGetAdminOperationCourseRatings.mockClear();
+    mockGetAdminOperationCourseRatings.mockResolvedValueOnce({
+      ...ratings,
+      items: [
+        {
+          ...ratings.items[0],
+          mobile: '',
+          email: '',
+          nickname: 'Nickname Only',
+        },
+      ],
+      total: 1,
+    });
+
+    render(<AdminOperationCourseRatingsPage />);
+
+    await screen.findByText('Very helpful lesson');
+    expect(
+      screen.getByText(
+        'module.operationsCourse.detail.ratings.table.guestUser',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Nickname Only')).toBeInTheDocument();
+  });
+
   test('does not show guest label when alternate contact exists', async () => {
     mockEnvState.loginMethodsEnabled = ['email'];
     mockEnvState.defaultLoginMethod = 'email';

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -267,6 +267,7 @@ export default function AdminOperationCourseRatingsPage() {
   );
   const emptyValue = tOperations('detail.ratings.emptyValue');
   const clearLabel = t('common.core.close');
+  const defaultUserName = t('module.user.defaultUserName');
   const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
   const defaultLoginMethod = useEnvStore(state => state.defaultLoginMethod);
   const contactMode = useMemo<ContactMode>(
@@ -449,8 +450,9 @@ export default function AdminOperationCourseRatingsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: AdminOperationCourseRatingItem) => item.nickname?.trim() || '',
-    [],
+    (item: AdminOperationCourseRatingItem) =>
+      item.nickname?.trim() || defaultUserName,
+    [defaultUserName],
   );
 
   const resolveRatingModeLabel = useCallback(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -966,9 +966,13 @@ export default function AdminOperationCourseRatingsPage() {
                                 });
                                 const isGuestAccount =
                                   !item.mobile?.trim() && !item.email?.trim();
-                                const secondaryAccount = isGuestAccount
-                                  ? ''
-                                  : resolveUserSecondary(item);
+                                const hasNickname = Boolean(
+                                  item.nickname?.trim(),
+                                );
+                                const secondaryAccount =
+                                  isGuestAccount && !hasNickname
+                                    ? ''
+                                    : resolveUserSecondary(item);
                                 const primaryLessonDisplay =
                                   resolvePrimaryLessonDisplay({
                                     lessonTitle: item.lesson_title,

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -267,7 +267,6 @@ export default function AdminOperationCourseRatingsPage() {
   );
   const emptyValue = tOperations('detail.ratings.emptyValue');
   const clearLabel = t('common.core.close');
-  const defaultUserName = t('module.user.defaultUserName');
   const loginMethodsEnabled = useEnvStore(state => state.loginMethodsEnabled);
   const defaultLoginMethod = useEnvStore(state => state.defaultLoginMethod);
   const contactMode = useMemo<ContactMode>(
@@ -450,14 +449,8 @@ export default function AdminOperationCourseRatingsPage() {
   );
 
   const resolveUserSecondary = useCallback(
-    (item: AdminOperationCourseRatingItem) => {
-      const nickname = item.nickname?.trim() || '';
-      if (!nickname || nickname === defaultUserName) {
-        return '';
-      }
-      return nickname;
-    },
-    [defaultUserName],
+    (item: AdminOperationCourseRatingItem) => item.nickname?.trim() || '',
+    [],
   );
 
   const resolveRatingModeLabel = useCallback(

--- a/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
+++ b/src/cook-web/src/app/admin/operations/[shifu_bid]/ratings/page.tsx
@@ -964,10 +964,11 @@ export default function AdminOperationCourseRatingsPage() {
                                   contactMode,
                                   emptyValue,
                                 });
-                                const secondaryAccount =
-                                  resolveUserSecondary(item);
                                 const isGuestAccount =
                                   !item.mobile?.trim() && !item.email?.trim();
+                                const secondaryAccount = isGuestAccount
+                                  ? ''
+                                  : resolveUserSecondary(item);
                                 const primaryLessonDisplay =
                                   resolvePrimaryLessonDisplay({
                                     lessonTitle: item.lesson_title,

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationManagedListDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationManagedListDialog.tsx
@@ -92,7 +92,8 @@ export function CreditNotificationManagedListDialog({
                         {contactValue}
                       </p>
                       <p className='mt-0.5 truncate text-xs text-muted-foreground'>
-                        {item.nickname || t('module.user.defaultUserName')}
+                        {item.nickname?.trim() ||
+                          t('module.user.defaultUserName')}
                       </p>
                     </div>
                     {canDelete ? (

--- a/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationManagedListDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/CreditNotificationManagedListDialog.tsx
@@ -92,10 +92,7 @@ export function CreditNotificationManagedListDialog({
                         {contactValue}
                       </p>
                       <p className='mt-0.5 truncate text-xs text-muted-foreground'>
-                        {item.nickname ||
-                          t(
-                            'module.operationsCreditNotifications.config.listDialog.emptyNickname',
-                          )}
+                        {item.nickname || t('module.user.defaultUserName')}
                       </p>
                     </div>
                     {canDelete ? (

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -16,6 +16,7 @@ let mockDefaultLoginMethod = 'phone';
 const mockBrowserTimeZone = jest.fn(() => 'America/Los_Angeles');
 
 const mockTranslations: Record<string, string> = {
+  'module.user.defaultUserName': 'Anonymous User',
   'module.operationsCreditNotifications.errorReason.policy_disabled':
     'Notification policy is disabled, not sent.',
   'module.operationsCreditNotifications.errorReason.provider_failed':
@@ -1081,7 +1082,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
         'module.operationsCreditNotifications.config.fields.blockedCreatorList',
       ).length,
     ).toBeGreaterThan(1);
-    expect(screen.getByText('module.user.defaultUserName')).toBeInTheDocument();
+    expect(screen.getByText('Anonymous User')).toBeInTheDocument();
 
     fireEvent.change(
       screen.getByPlaceholderText(

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -1044,7 +1044,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
     });
   });
 
-  it('opens blocked creators dialog and removes an item from the draft list', async () => {
+  it('uses the shared anonymous user label and removes an item from the draft list', async () => {
     mockGetConfig.mockResolvedValueOnce({
       enabled: false,
       blacklist: {
@@ -1059,7 +1059,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
               creator_bid: 'creator-1',
               mobile: '13800000000',
               email: '',
-              nickname: 'Creator One',
+              nickname: '',
             },
           ],
         },
@@ -1081,7 +1081,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
         'module.operationsCreditNotifications.config.fields.blockedCreatorList',
       ).length,
     ).toBeGreaterThan(1);
-    expect(screen.getByText('Creator One')).toBeInTheDocument();
+    expect(screen.getByText('module.user.defaultUserName')).toBeInTheDocument();
 
     fireEvent.change(
       screen.getByPlaceholderText(

--- a/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
+++ b/src/cook-web/src/app/admin/operations/credit-notifications/page.test.tsx
@@ -1059,7 +1059,7 @@ describe('AdminOperationCreditNotificationsPage', () => {
               creator_bid: 'creator-1',
               mobile: '13800000000',
               email: '',
-              nickname: '',
+              nickname: '   ',
             },
           ],
         },

--- a/src/cook-web/src/types/i18n-keys.d.ts
+++ b/src/cook-web/src/types/i18n-keys.d.ts
@@ -1673,7 +1673,6 @@ export type I18nKey =
   | 'module.operationsCreditNotifications.config.listDialog.blockedSummary'
   | 'module.operationsCreditNotifications.config.listDialog.delete'
   | 'module.operationsCreditNotifications.config.listDialog.duplicateBlockedCreators'
-  | 'module.operationsCreditNotifications.config.listDialog.emptyNickname'
   | 'module.operationsCreditNotifications.config.listDialog.emptyPreview'
   | 'module.operationsCreditNotifications.config.listDialog.emptyResult'
   | 'module.operationsCreditNotifications.config.listDialog.invalidBlockedCreators'

--- a/src/i18n/en-US/modules/operations-credit-notifications.json
+++ b/src/i18n/en-US/modules/operations-credit-notifications.json
@@ -91,7 +91,6 @@
       "blockedSummary": "{count} blocked teachers",
       "delete": "Delete",
       "duplicateBlockedCreators": "The input is already in the blocked list.",
-      "emptyNickname": "No nickname",
       "emptyPreview": "No details yet",
       "emptyResult": "No matching results.",
       "invalidBlockedCreators": "Unrecognized content: {values}",

--- a/src/i18n/en-US/modules/user.json
+++ b/src/i18n/en-US/modules/user.json
@@ -2,7 +2,7 @@
   "__namespace__": "module.user",
   "confirmLogoutContent": "Are you sure you want to logout?",
   "confirmLogoutTitle": "Confirm Logout",
-  "defaultUserName": "Default Name",
+  "defaultUserName": "Anonymous User",
   "gender": {
     "female": "Female",
     "male": "Male",

--- a/src/i18n/fr-FR/modules/operations-credit-notifications.json
+++ b/src/i18n/fr-FR/modules/operations-credit-notifications.json
@@ -91,7 +91,6 @@
       "blockedSummary": "{count} enseignants bloqués",
       "delete": "Supprimer",
       "duplicateBlockedCreators": "La saisie existe déjà dans la liste de blocage.",
-      "emptyNickname": "Aucun pseudo",
       "emptyPreview": "Aucun détail",
       "emptyResult": "Aucun résultat.",
       "invalidBlockedCreators": "Contenu non reconnu : {values}",

--- a/src/i18n/fr-FR/modules/user.json
+++ b/src/i18n/fr-FR/modules/user.json
@@ -2,7 +2,7 @@
   "__namespace__": "module.user",
   "confirmLogoutContent": "Êtes-vous sûr de vouloir vous déconnecter ?",
   "confirmLogoutTitle": "Confirmer la déconnexion",
-  "defaultUserName": "Nom par défaut",
+  "defaultUserName": "Utilisateur anonyme",
   "gender": {
     "female": "Femme",
     "male": "Homme",

--- a/src/i18n/zh-CN/modules/operations-credit-notifications.json
+++ b/src/i18n/zh-CN/modules/operations-credit-notifications.json
@@ -91,7 +91,6 @@
       "blockedSummary": "已屏蔽 {count} 位老师",
       "delete": "删除",
       "duplicateBlockedCreators": "输入内容已在屏蔽名单中。",
-      "emptyNickname": "暂无昵称",
       "emptyPreview": "暂无明细",
       "emptyResult": "暂无匹配结果。",
       "invalidBlockedCreators": "以下内容未识别：{values}",

--- a/src/i18n/zh-CN/modules/user.json
+++ b/src/i18n/zh-CN/modules/user.json
@@ -2,7 +2,7 @@
   "__namespace__": "module.user",
   "confirmLogoutContent": "确认退出登录吗？",
   "confirmLogoutTitle": "确认退出登录？",
-  "defaultUserName": "默认名称",
+  "defaultUserName": "匿名用户",
   "gender": {
     "female": "女性",
     "male": "男性",


### PR DESCRIPTION
## Summary

- change the shared empty-nickname label to `Anonymous User` and align the Chinese and French translations
- make the credit-notification managed list reuse the shared user label instead of its local `No nickname` copy
- trim managed-list nicknames so whitespace-only values also use the shared fallback
- show the same shared fallback in admin and teacher follow-up lists, follow-up detail drawers, and the admin rating list
- keep guest rating rows on their dedicated `Guest` label instead of adding a second anonymous-user label
- preserve real nicknames on rating rows that have no phone or email
- preserve stored nicknames that happen to match a localized fallback label instead of treating display text as a data sentinel
- remove the obsolete locale key, regenerate i18n types, and assert the rendered `Anonymous User` label in the regression test

## Why

Empty nicknames used inconsistent placeholder copy across the product. The shared label also read like a state description instead of a display name, and whitespace-only values could still render as blank.

This change gives the relevant admin nickname fields a consistent, name-like fallback while removing the remaining local exceptions. Missing names are determined from the source nickname, so a real nickname such as `Anonymous User` remains visible in every locale.

## Validation

- `npm run test -- --runInBand src/app/admin/operations/credit-notifications/page.test.tsx` (25 tests passed)
- focused course detail, follow-up, and rating suites (52 tests passed)
- exact-path follow-up and rating regression suites (30 tests passed)
- exact-path rating regression suite after the guest edge-case fixes (11 tests passed)
- `npm run type-check`
- `npm run lint`
- `python3 scripts/check_translations.py`
- `python3 scripts/check_translation_usage.py --fail-on-unused`
- repository pre-commit and commit-message hooks
