### PR TITLE
fix: keep profile input focus styles consistent

### DIFF
--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -591,7 +591,7 @@ export default function LearnerProfileDialog({
                 <div className='space-y-1'>
                   <Input
                     id='learner-profile-dialog-nickname'
-                    className='h-10 rounded-lg shadow-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                    className='h-10 rounded-lg shadow-none'
                     value={nickname}
                     disabled={!loaded || busy}
                     aria-invalid={nicknameOverLimit || undefined}
@@ -666,7 +666,7 @@ export default function LearnerProfileDialog({
                 <ProfileDraftEditor
                   inputId='learner-profile-dialog-draft'
                   textareaRef={textareaRef}
-                  textareaClassName='h-[clamp(7rem,16dvh,11rem)] min-h-[clamp(7rem,16dvh,11rem)] max-h-[clamp(7rem,16dvh,11rem)] resize-none overflow-y-auto rounded-xl border-border px-4 py-3 leading-6 shadow-none focus-visible:ring-primary/30'
+                  textareaClassName='h-[clamp(7rem,16dvh,11rem)] min-h-[clamp(7rem,16dvh,11rem)] max-h-[clamp(7rem,16dvh,11rem)] resize-none overflow-y-auto rounded-xl border-border px-4 py-3 leading-6 shadow-none'
                   minRows={4}
                   autoResize={false}
                   value={profile}


### PR DESCRIPTION
## Summary

- remove the dialog-specific focus ring from the learner nickname field
- remove the leftover focus ring color override from the learner profile textarea
- keep both fields aligned with the shared `Input` and `Textarea` styling

## Root cause

The learner profile dialog locally reintroduced `focus-visible:ring-2` after focus rings had been removed from the shared form controls, so the nickname field displayed an inconsistent blue halo.

## User impact

Learners now see the same focus styling across both profile fields without the extra blue outline.

## Validation

- `npm test -- src/components/profile-onboarding/LearnerProfileDialog.test.tsx --runInBand` (44 tests passed)
- `npm run type-check`
- `npm run lint` (passed with existing repository warnings)
- `python3 scripts/check_dev_tools.py`
- commit-time Lefthook checks

Browser screenshot comparison was not completed because the verification session was interrupted before the final capture.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified focus styling for the nickname input and profile draft textarea during learner profile onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->