### PR TITLE
fix: restore listen mode narration after answering an interaction

### DIFF
--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -502,6 +502,9 @@ def run_script_inner(
         except BreakException:
             _finalize_langfuse_if_available(run_script_context)
             db.session.commit()
+            yield from _iter_audio_backfill_ready_events(
+                ready_element_bids_by_block_bid
+            )
             app.logger.info("BreakException")
         except GeneratorExit:
             # The close lands at an arbitrary yield point (client disconnect),

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -991,6 +991,120 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
     assert ready_event.content.element_bids == ["element-1"]
 
 
+def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypatch):
+    app = Flask(__name__)
+    sequence = []
+
+    monkeypatch.setattr(
+        runscript_v2,
+        "db",
+        SimpleNamespace(
+            session=SimpleNamespace(
+                commit=lambda: sequence.append("commit"),
+                rollback=lambda: None,
+                remove=lambda: None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "load_user_aggregate",
+        lambda _user_bid: SimpleNamespace(user_id="user-1"),
+    )
+
+    outline_item_info = SimpleNamespace(
+        bid="outline-1",
+        shifu_bid="shifu-1",
+        title="Lesson",
+        __json__=lambda: {"bid": "outline-1"},
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_outline_item_dto",
+        lambda *_args, **_kwargs: outline_item_info,
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_shifu_dto",
+        lambda *_args, **_kwargs: SimpleNamespace(bid="shifu-1", price=0),
+    )
+    monkeypatch.setattr(
+        runscript_v2,
+        "get_shifu_struct",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    class FakeRunScriptContext:
+        def __init__(self, **_kwargs):
+            self._has_next = True
+
+        def set_input(self, *_args, **_kwargs):
+            return None
+
+        def reload(self, *_args, **_kwargs):
+            return []
+
+        def has_next(self):
+            if self._has_next:
+                self._has_next = False
+                return True
+            return False
+
+        def run(self, _app):
+            yield RunMarkdownFlowDTO(
+                outline_bid="outline-1",
+                generated_block_bid="generated-1",
+                type=GeneratedType.CONTENT,
+                content="hello",
+            )
+            raise runscript_v2.BreakException()
+
+    monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
+
+    class ElementAdapter:
+        def process(self, events):
+            for event in events:
+                if event.type == GeneratedType.CONTENT:
+                    yield RunElementSSEMessageDTO(
+                        type="element",
+                        event_type="element",
+                        generated_block_bid="generated-1",
+                        content=ElementDTO(
+                            element_bid="element-1",
+                            generated_block_bid="generated-1",
+                            element_index=0,
+                            role="assistant",
+                            element_type=ElementType.TEXT,
+                            element_type_code=1,
+                            is_final=True,
+                            is_speakable=True,
+                            content="hello",
+                        ),
+                    )
+
+    emitted = list(
+        runscript_v2.run_script_inner(
+            app=app,
+            user_bid="user-1",
+            shifu_bid="shifu-1",
+            outline_bid="outline-1",
+            input="hello",
+            input_type="text",
+            element_adapter=ElementAdapter(),
+        )
+    )
+
+    for event in emitted:
+        if getattr(event, "type", "") == GeneratedType.AUDIO_BACKFILL_READY.value:
+            sequence.append("ready")
+
+    assert sequence == ["commit", "ready"]
+    ready_event = emitted[-1]
+    assert ready_event.type == GeneratedType.AUDIO_BACKFILL_READY.value
+    assert ready_event.generated_block_bid == "generated-1"
+    assert ready_event.content.element_bids == ["element-1"]
+
+
 def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch):
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -968,19 +968,20 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
                         is_terminal=False,
                     )
 
-    emitted = list(
-        runscript_v2.run_script_inner(
-            app=app,
-            user_bid="user-1",
-            shifu_bid="shifu-1",
-            outline_bid="outline-1",
-            input="hello",
-            input_type="text",
-            element_adapter=ElementAdapter(),
-        )
-    )
-
-    for event in emitted:
+    # Record the marker while iterating. Consuming the generator first would
+    # make the ordering assertion pass even if the ready event were yielded
+    # before the commit, which is exactly what this test needs to rule out.
+    emitted = []
+    for event in runscript_v2.run_script_inner(
+        app=app,
+        user_bid="user-1",
+        shifu_bid="shifu-1",
+        outline_bid="outline-1",
+        input="hello",
+        input_type="text",
+        element_adapter=ElementAdapter(),
+    ):
+        emitted.append(event)
         if getattr(event, "type", "") == GeneratedType.AUDIO_BACKFILL_READY.value:
             sequence.append("ready")
 
@@ -1082,19 +1083,20 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
                         ),
                     )
 
-    emitted = list(
-        runscript_v2.run_script_inner(
-            app=app,
-            user_bid="user-1",
-            shifu_bid="shifu-1",
-            outline_bid="outline-1",
-            input="hello",
-            input_type="text",
-            element_adapter=ElementAdapter(),
-        )
-    )
-
-    for event in emitted:
+    # Record the marker while iterating. Consuming the generator first would
+    # make the ordering assertion pass even if the ready event were yielded
+    # before the commit, which is exactly what this test needs to rule out.
+    emitted = []
+    for event in runscript_v2.run_script_inner(
+        app=app,
+        user_bid="user-1",
+        shifu_bid="shifu-1",
+        outline_bid="outline-1",
+        input="hello",
+        input_type="text",
+        element_adapter=ElementAdapter(),
+    ):
+        emitted.append(event)
         if getattr(event, "type", "") == GeneratedType.AUDIO_BACKFILL_READY.value:
             sequence.append("ready")
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -683,6 +683,41 @@ describe('ListenModeSlideRenderer', () => {
     expect(pauseSpy).toHaveBeenCalled();
   });
 
+  it('refreshes the empty title placeholder when the section title changes', () => {
+    // The placeholder renders its title inside a React node and always carries
+    // the same blockBid, so the slide reuse cache used to hand back the previous
+    // lesson's placeholder after switching lessons.
+    const { rerender } = render(
+      <ListenModeSlideRenderer
+        items={[]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        sectionTitle='First lesson'
+      />,
+    );
+
+    rerender(
+      <ListenModeSlideRenderer
+        items={[]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        sectionTitle='Second lesson'
+      />,
+    );
+
+    const slideCalls = getMockSlide().mock.calls;
+    const latestSlideProps = slideCalls[slideCalls.length - 1]?.[0] as
+      | { elementList?: Array<Record<string, unknown>> }
+      | undefined;
+
+    const { unmount } = render(
+      latestSlideProps?.elementList?.[0]?.content as React.ReactElement,
+    );
+    expect(screen.getByText('Second lesson')).toBeInTheDocument();
+    expect(screen.queryByText('First lesson')).not.toBeInTheDocument();
+    unmount();
+  });
+
   it('shows classroom paging tips on the empty title placeholder', () => {
     render(
       <ListenModeSlideRenderer

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -331,6 +331,93 @@ describe('ListenModeSlideRenderer', () => {
     );
   });
 
+  it('keeps a resolved interaction stable when feedback narration is appended', () => {
+    const chatRef = createChatRef();
+    const baseItems: ChatContentItem[] = [
+      {
+        type: 'content',
+        content: 'Hello',
+        element_bid: 'content-1',
+        is_speakable: true,
+      },
+      {
+        type: 'interaction',
+        content: '?[1945 年 | 1946 年 | 1947 年]',
+        element_bid: 'interaction-1',
+        is_renderable: false,
+      },
+    ];
+
+    const { rerender } = render(
+      <ListenModeSlideRenderer
+        items={baseItems}
+        mobileStyle={false}
+        chatRef={chatRef}
+      />,
+    );
+
+    rerender(
+      <ListenModeSlideRenderer
+        items={[
+          baseItems[0],
+          {
+            ...baseItems[1],
+            user_input: '1946 年',
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={chatRef}
+      />,
+    );
+
+    const resolvedSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | { elementList?: Array<Record<string, unknown>> }
+      | undefined;
+    const resolvedInteraction = resolvedSlideProps?.elementList?.find(
+      element => element.blockBid === 'interaction-1',
+    );
+
+    rerender(
+      <ListenModeSlideRenderer
+        items={[
+          baseItems[0],
+          {
+            ...baseItems[1],
+            user_input: '1946 年',
+          },
+          {
+            type: 'content',
+            content: '答对了，继续看下一个坑。',
+            element_bid: 'feedback-answer-1',
+            generated_block_bid: 'feedback-generated-1',
+            is_speakable: true,
+            audioUrl: '/feedback.mp3',
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={chatRef}
+      />,
+    );
+
+    const appendedSlideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+      | { elementList?: Array<Record<string, unknown>> }
+      | undefined;
+    const appendedInteraction = appendedSlideProps?.elementList?.find(
+      element => element.blockBid === 'interaction-1',
+    );
+    const feedbackElement = appendedSlideProps?.elementList?.find(
+      element => element.blockBid === 'feedback-answer-1',
+    );
+
+    expect(appendedInteraction).toBe(resolvedInteraction);
+    expect(feedbackElement).toEqual(
+      expect.objectContaining({
+        type: 'text',
+        audio_url: '/feedback.mp3',
+      }),
+    );
+  });
+
   it('keeps resolved button-and-input interactions editable and forwards reselection', () => {
     const onSend = jest.fn();
     render(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -82,6 +82,11 @@ type ListenSlideElement = SlideElement & {
   subtitle_cues?: ElementSubtitleCue[];
 };
 
+type ListenSlideElementCacheEntry = {
+  element: ListenSlideElement;
+  fingerprint: string;
+};
+
 const CLASSROOM_PAGE_SHORTCUT_KEY_MAP: Record<
   string,
   'ArrowLeft' | 'ArrowRight'
@@ -461,6 +466,69 @@ const hasBlockingListenInteraction = (element?: SlideElement) => {
   );
 };
 
+const buildListenSlideElementCacheKey = (
+  element: ListenSlideElement,
+  index: number,
+) =>
+  getListenMarkerIdentityKey(
+    element,
+    typeof element.content === 'string' && element.content
+      ? `${index}:${element.content}`
+      : index,
+  );
+
+const buildListenSlideElementFingerprint = (element: ListenSlideElement) =>
+  JSON.stringify({
+    type: element.type,
+    sequence_number: element.sequence_number,
+    content:
+      typeof element.content === 'string' ? element.content : element.blockBid,
+    is_marker: element.is_marker,
+    is_renderable: element.is_renderable,
+    is_speakable: element.is_speakable,
+    blockBid: element.blockBid,
+    page: element.page,
+    user_input: element.user_input,
+    readonly: element.readonly,
+    audio_url: element.audio_url,
+    audio_segments: element.audio_segments,
+    is_audio_streaming: element.is_audio_streaming,
+    isAudioStreaming: element.isAudioStreaming,
+    subtitle_cues: element.subtitle_cues,
+  });
+
+const stabilizeListenSlideElements = (
+  elements: ListenSlideElement[],
+  cache: Map<string, ListenSlideElementCacheEntry>,
+) => {
+  const activeKeys = new Set<string>();
+
+  const stableElements = elements.map((element, index) => {
+    const cacheKey = buildListenSlideElementCacheKey(element, index);
+    const fingerprint = buildListenSlideElementFingerprint(element);
+    activeKeys.add(cacheKey);
+
+    const cachedEntry = cache.get(cacheKey);
+    if (cachedEntry?.fingerprint === fingerprint) {
+      return cachedEntry.element;
+    }
+
+    cache.set(cacheKey, {
+      element,
+      fingerprint,
+    });
+    return element;
+  });
+
+  for (const cacheKey of Array.from(cache.keys())) {
+    if (!activeKeys.has(cacheKey)) {
+      cache.delete(cacheKey);
+    }
+  }
+
+  return stableElements;
+};
+
 const getListenPlaybackSequenceActive = ({
   currentStepIndex,
   totalStepCount,
@@ -744,6 +812,9 @@ const ListenModeSlideRenderer = ({
   const playerCustomActionSetActiveRef = useRef<(active: boolean) => void>(
     () => {},
   );
+  const listenSlideElementCacheRef = useRef<
+    Map<string, ListenSlideElementCacheEntry>
+  >(new Map());
   const customAskOverlayRef = useRef<HTMLDivElement | null>(null);
   const slideShellRef = useRef<HTMLDivElement | null>(null);
   const ensureLessonScope = useAskStateStore(state => state.ensureLessonScope);
@@ -894,7 +965,10 @@ const ListenModeSlideRenderer = ({
       sequenceMap.delete(streamKey);
     }
 
-    return nextElementList;
+    return stabilizeListenSlideElements(
+      nextElementList,
+      listenSlideElementCacheRef.current,
+    );
   }, [
     askListByAnchorElementBid,
     includeAudio,
@@ -1011,10 +1085,15 @@ const ListenModeSlideRenderer = ({
         return [];
       }
 
+      const latestAskList = askListByAnchorElementBid.get(elementBid);
+      if (latestAskList) {
+        return latestAskList;
+      }
+
       return (elementList.find(element => element.blockBid === elementBid)
         ?.ask_list ?? []) as AskMessage[];
     },
-    [elementList],
+    [askListByAnchorElementBid, elementList],
   );
   const playerCustomAskList = useMemo<AskMessage[]>(() => {
     return resolveAskListByElementBid(renderedPlayerCustomAskElementBid);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -80,6 +80,10 @@ type ListenSlideElement = SlideElement & {
   isAudioStreaming?: boolean;
   ask_list?: AskMessage[];
   subtitle_cues?: ElementSubtitleCue[];
+  // Identity seed for elements whose `content` is a React node rather than a
+  // string. The reuse fingerprint cannot inspect a node, so such elements must
+  // declare what makes them distinct or they all collapse into one cache entry.
+  fingerprintSeed?: string;
 };
 
 type ListenSlideElementCacheEntry = {
@@ -482,7 +486,12 @@ const buildListenSlideElementFingerprint = (element: ListenSlideElement) =>
     type: element.type,
     sequence_number: element.sequence_number,
     content:
-      typeof element.content === 'string' ? element.content : element.blockBid,
+      typeof element.content === 'string'
+        ? element.content
+        : // A React node cannot be fingerprinted, and `blockBid` is a constant
+          // for the placeholder slide, so without the seed every lesson would
+          // reuse the first lesson's rendered title.
+          (element.fingerprintSeed ?? element.blockBid),
     is_marker: element.is_marker,
     is_renderable: element.is_renderable,
     is_speakable: element.is_speakable,
@@ -577,6 +586,7 @@ const createEmptyStateElement = (
   is_new: true,
   blockBid: 'empty-ppt',
   page: 0,
+  fingerprintSeed: JSON.stringify([sectionTitle, sectionPlaceholderTips]),
 });
 
 const buildSlideElementList = ({

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -554,6 +554,15 @@ export const NewChatComponents = ({
       }),
     [askButtonMarkup, items, mobileStyle, scopedAskListByAnchorElementBid],
   );
+  const slideModeItems = useMemo(
+    () =>
+      projectListenModeItems({
+        items,
+        askButtonMarkup,
+        variant: isClassroomMode ? 'classroom' : 'listen',
+      }),
+    [askButtonMarkup, isClassroomMode, items],
+  );
   const visibleReadModeItems = useMemo(
     () => buildVisibleReadModeItems(readModeItems, readModeTypewriterCache),
     [readModeItems, readModeTypewriterCache],
@@ -765,7 +774,7 @@ export const NewChatComponents = ({
       return;
     }
 
-    const contentItems = items.filter(isContentItemWithElementBid);
+    const contentItems = slideModeItems.filter(isContentItemWithElementBid);
 
     if (!contentItems.length) {
       return;
@@ -871,10 +880,10 @@ export const NewChatComponents = ({
     isListenModeActive,
     isListenModeAvailable,
     isOutputInProgress,
-    items,
     previewMode,
     requestListenAudioBackfillForBlock,
     resolvedLessonId,
+    slideModeItems,
     t,
     updateLearningMode,
   ]);
@@ -932,16 +941,6 @@ export const NewChatComponents = ({
     promptContextKey,
     resolveScrollPresentation,
   ]);
-
-  const slideModeItems = useMemo(
-    () =>
-      projectListenModeItems({
-        items,
-        askButtonMarkup,
-        variant: isClassroomMode ? 'classroom' : 'listen',
-      }),
-    [askButtonMarkup, isClassroomMode, items],
-  );
 
   const itemByGeneratedBid = useMemo(() => {
     const mapping = new Map<string, ChatContentItem>();

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -43,6 +43,7 @@ import { AudioPlayer } from '@/components/audio/AudioPlayer';
 import {
   getAudioTrackByPosition,
   hasAudioContentInTrack,
+  upsertAudioComplete,
 } from '@/c-utils/audio-utils';
 import {
   Dialog,
@@ -356,6 +357,7 @@ export const NewChatComponents = ({
   const isPromptContextSettled = settledPromptContextKey === promptContextKey;
   const ensureLessonScope = useAskStateStore(state => state.ensureLessonScope);
   const hydrateAskListMap = useAskStateStore(state => state.hydrateAskListMap);
+  const setAskList = useAskStateStore(state => state.setAskList);
   const lessonScopeKey = useAskStateStore(state => state.lessonScopeKey);
   const storedAskListByAnchorElementBid = useAskStateStore(
     state => state.askListByAnchorElementBid,
@@ -516,6 +518,33 @@ export const NewChatComponents = ({
       }).then(result => {
         if (result) {
           listenAudioBackfillFailedBlockBidsRef.current.delete(blockBid);
+          const askEntry = Object.entries(
+            useAskStateStore.getState().askListByAnchorElementBid,
+          ).find(([, askList]) =>
+            askList.some(
+              message =>
+                message.element_bid === blockBid ||
+                message.generated_block_bid === blockBid,
+            ),
+          );
+          if (askEntry) {
+            const [anchorElementBid, askList] = askEntry;
+            const targetMessage = askList.find(
+              message =>
+                message.element_bid === blockBid ||
+                message.generated_block_bid === blockBid,
+            );
+            const targetElementBid = targetMessage?.element_bid || blockBid;
+            setAskList(
+              anchorElementBid,
+              previousAskList =>
+                upsertAudioComplete(
+                  previousAskList as ChatContentItem[],
+                  targetElementBid,
+                  result,
+                ) as typeof previousAskList,
+            );
+          }
         }
         return result;
       });
@@ -526,7 +555,7 @@ export const NewChatComponents = ({
       }
       return trackedPromise;
     },
-    [requestAudioForBlock],
+    [requestAudioForBlock, setAskList],
   );
 
   const baseAskListByAnchorElementBid = useMemo(
@@ -559,9 +588,10 @@ export const NewChatComponents = ({
       projectListenModeItems({
         items,
         askButtonMarkup,
+        askListByAnchorElementBid: scopedAskListByAnchorElementBid,
         variant: isClassroomMode ? 'classroom' : 'listen',
       }),
-    [askButtonMarkup, isClassroomMode, items],
+    [askButtonMarkup, isClassroomMode, items, scopedAskListByAnchorElementBid],
   );
   const visibleReadModeItems = useMemo(
     () => buildVisibleReadModeItems(readModeItems, readModeTypewriterCache),

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -941,7 +941,8 @@ export const NewChatComponents = ({
         })
           .then(result => {
             if (listenAudioBackfillLessonIdRef.current !== lessonIdAtRequest) {
-              return null;
+              // Superseded by a lesson switch, not a synthesis failure.
+              return undefined;
             }
 
             return result;
@@ -953,8 +954,13 @@ export const NewChatComponents = ({
       }
 
       const hasGeneratedAudio = results.some(Boolean);
+      // Only a `null` result means synthesis was attempted and failed.
+      // `undefined` means it was never attempted (cancelled, superseded, or
+      // de-duplicated), and must stay retryable — otherwise answering an
+      // interaction, which cancels every in-flight stream, would permanently
+      // blacklist the blocks whose narration follows the answer.
       const failedBlockBids = prioritizedBlockBids.filter(
-        (_, index) => !results[index],
+        (_, index) => results[index] === null,
       );
       failedBlockBids.forEach(blockBid => {
         listenAudioBackfillFailedBlockBidsRef.current.add(blockBid);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -990,6 +990,15 @@ export const NewChatComponents = ({
         return;
       }
 
+      // Narration still being produced is not a failure. Answering an interaction
+      // cancels every in-flight request, so a round can legitimately come back
+      // empty while the next run is already streaming. The failure branch above
+      // guards on this; without the same guard here, cancelled requests would
+      // surface a spurious "audio generation failed" toast.
+      if (isOutputInProgress) {
+        return;
+      }
+
       fail(t('module.chat.listenAudioBackfillFailed'));
     });
   }, [

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -492,7 +492,11 @@ export const NewChatComponents = ({
   );
 
   const requestListenAudioBackfillForBlock = useCallback(
-    (blockBid: string, lessonIdAtRequest: string) => {
+    (
+      blockBid: string,
+      lessonIdAtRequest: string,
+      options: { listen?: boolean } = {},
+    ) => {
       const existingPromise = listenAudioBackfillInFlightRef.current[blockBid];
       if (existingPromise) {
         return existingPromise;
@@ -511,7 +515,7 @@ export const NewChatComponents = ({
       };
 
       trackedPromise = requestAudioForBlock(blockBid, {
-        listen: true,
+        listen: options.listen ?? true,
         shouldApplyResult: () =>
           listenAudioBackfillLessonIdRef.current === lessonIdAtRequest,
         onStreamSettled: clearTrackedRequest,
@@ -858,7 +862,16 @@ export const NewChatComponents = ({
       prioritizedBlockBids,
       LISTEN_AUDIO_BACKFILL_CONCURRENCY,
       blockBid =>
-        requestListenAudioBackfillForBlock(blockBid, lessonIdAtRequest)
+        requestListenAudioBackfillForBlock(blockBid, lessonIdAtRequest, {
+          listen:
+            readyBackfillCandidateItems.find(
+              item =>
+                item.generated_block_bid === blockBid ||
+                item.element_bid === blockBid,
+            )?.listenAudioBackfillMode === 'block'
+              ? false
+              : true,
+        })
           .then(result => {
             if (listenAudioBackfillLessonIdRef.current !== lessonIdAtRequest) {
               return null;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/askState.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/askState.ts
@@ -1,11 +1,18 @@
 import { BLOCK_TYPE } from '@/c-api/studyV2';
+import type { AudioTrack } from '@/c-utils/audio-utils';
 
 export interface AskMessage {
   type: typeof BLOCK_TYPE.ASK | typeof BLOCK_TYPE.ANSWER;
   content: string;
   isStreaming?: boolean;
   element_bid?: string;
+  generated_block_bid?: string;
   shouldUseTypewriter?: boolean;
+  audioUrl?: string;
+  audioTracks?: AudioTrack[];
+  audioDurationMs?: number;
+  isAudioStreaming?: boolean;
+  isAudioBackfillReady?: boolean;
 }
 
 interface AskAnchorLike {
@@ -42,8 +49,14 @@ export const areAskMessageListsEqual = (
       item.type === nextItem?.type &&
       item.content === nextItem?.content &&
       item.element_bid === nextItem?.element_bid &&
+      item.generated_block_bid === nextItem?.generated_block_bid &&
       item.isStreaming === nextItem?.isStreaming &&
-      item.shouldUseTypewriter === nextItem?.shouldUseTypewriter
+      item.shouldUseTypewriter === nextItem?.shouldUseTypewriter &&
+      item.audioUrl === nextItem?.audioUrl &&
+      item.audioTracks === nextItem?.audioTracks &&
+      item.audioDurationMs === nextItem?.audioDurationMs &&
+      item.isAudioStreaming === nextItem?.isAudioStreaming &&
+      item.isAudioBackfillReady === nextItem?.isAudioBackfillReady
     );
   });
 };

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/askState.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/askState.ts
@@ -13,6 +13,7 @@ export interface AskMessage {
   audioDurationMs?: number;
   isAudioStreaming?: boolean;
   isAudioBackfillReady?: boolean;
+  listenAudioBackfillMode?: 'listen' | 'block';
 }
 
 interface AskAnchorLike {
@@ -56,7 +57,8 @@ export const areAskMessageListsEqual = (
       item.audioTracks === nextItem?.audioTracks &&
       item.audioDurationMs === nextItem?.audioDurationMs &&
       item.isAudioStreaming === nextItem?.isAudioStreaming &&
-      item.isAudioBackfillReady === nextItem?.isAudioBackfillReady
+      item.isAudioBackfillReady === nextItem?.isAudioBackfillReady &&
+      item.listenAudioBackfillMode === nextItem?.listenAudioBackfillMode
     );
   });
 };

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
@@ -191,6 +191,7 @@ describe('chatUiModeProjection', () => {
         generated_block_bid: 'feedback-generated-1',
         content: '答对了，继续看下一个坑。',
         is_speakable: true,
+        listenAudioBackfillMode: 'block',
       }),
     );
   });
@@ -238,6 +239,11 @@ describe('chatUiModeProjection', () => {
       '',
       'feedback-answer-1',
     ]);
+    expect(projectedItems[2]).toEqual(
+      expect.objectContaining({
+        listenAudioBackfillMode: 'block',
+      }),
+    );
   });
 
   it('does not project regular follow-up answers as listen-mode narration', () => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
@@ -144,6 +144,102 @@ describe('chatUiModeProjection', () => {
     expect(slideItem.payload?.audio).toBeDefined();
   });
 
+  it('projects answer feedback as listen-mode narration without reading the learner input', () => {
+    const items: ChatContentItem[] = [
+      {
+        type: ChatContentItemType.INTERACTION,
+        element_bid: 'interaction-1',
+        content: '?[%{{choice}} A | B]',
+        is_renderable: false,
+      },
+      {
+        type: ChatContentItemType.ASK,
+        element_bid: '',
+        parent_element_bid: 'interaction-1',
+        content: '',
+        ask_list: [
+          {
+            type: ChatContentItemType.ASK,
+            element_bid: 'learner-answer-1',
+            generated_block_bid: 'learner-answer-generated-1',
+            content: 'A',
+          },
+          {
+            type: 'answer',
+            element_bid: 'feedback-answer-1',
+            generated_block_bid: 'feedback-generated-1',
+            content: '答对了，继续看下一个坑。',
+          },
+        ],
+      },
+    ];
+
+    const projectedItems = projectListenModeItems({
+      items,
+      askButtonMarkup,
+    });
+
+    expect(projectedItems.map(item => item.element_bid)).toEqual([
+      'interaction-1',
+      '',
+      'feedback-answer-1',
+    ]);
+    expect(projectedItems[2]).toEqual(
+      expect.objectContaining({
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        generated_block_bid: 'feedback-generated-1',
+        content: '答对了，继续看下一个坑。',
+        is_speakable: true,
+      }),
+    );
+  });
+
+  it('does not project regular follow-up answers as listen-mode narration', () => {
+    const items: ChatContentItem[] = [
+      {
+        type: ChatContentItemType.CONTENT,
+        element_bid: 'content-1',
+        element_type: 'text',
+        content: 'Main lesson content',
+        is_renderable: true,
+      },
+      {
+        type: ChatContentItemType.ASK,
+        element_bid: '',
+        parent_element_bid: 'content-1',
+        content: '',
+        ask_list: [
+          {
+            type: ChatContentItemType.ASK,
+            element_bid: 'follow-up-ask-1',
+            generated_block_bid: 'follow-up-ask-generated-1',
+            content: 'Can you explain this again?',
+          },
+          {
+            type: 'answer',
+            element_bid: 'follow-up-answer-1',
+            generated_block_bid: 'follow-up-answer-generated-1',
+            content: 'Sure, here is a follow-up explanation.',
+          },
+        ],
+      },
+    ];
+
+    const projectedItems = projectListenModeItems({
+      items,
+      askButtonMarkup,
+    });
+
+    expect(projectedItems.map(item => item.element_bid)).toEqual([
+      'content-1',
+      '',
+    ]);
+    expect(
+      projectedItems.some(item => item.element_bid === 'follow-up-answer-1'),
+    ).toBe(false);
+  });
+
   it('filters classroom projection to visual content and interactions', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
@@ -246,6 +246,58 @@ describe('chatUiModeProjection', () => {
     );
   });
 
+  it('prefers hydrated interaction feedback when embedded ask list is stale', () => {
+    const items: ChatContentItem[] = [
+      {
+        type: ChatContentItemType.INTERACTION,
+        element_bid: 'interaction-1',
+        content: '?[%{{choice}} A | B]',
+        is_renderable: false,
+      },
+      {
+        type: ChatContentItemType.ASK,
+        element_bid: '',
+        parent_element_bid: 'interaction-1',
+        content: '',
+        ask_list: [
+          {
+            type: 'answer',
+            element_bid: 'feedback-answer-1',
+            generated_block_bid: 'feedback-generated-1',
+            content: '答对了，继续看下一个坑。',
+          },
+        ],
+      },
+    ];
+
+    const projectedItems = projectListenModeItems({
+      items,
+      askButtonMarkup,
+      askListByAnchorElementBid: {
+        'interaction-1': [
+          {
+            type: 'answer',
+            element_bid: 'feedback-answer-1',
+            generated_block_bid: 'feedback-generated-1',
+            content: '答对了，继续看下一个坑。',
+            audioUrl: '/feedback.mp3',
+            isAudioBackfillReady: false,
+            listenAudioBackfillMode: 'block',
+          },
+        ],
+      },
+    });
+
+    expect(projectedItems[2]).toEqual(
+      expect.objectContaining({
+        element_bid: 'feedback-answer-1',
+        audioUrl: '/feedback.mp3',
+        isAudioBackfillReady: false,
+        listenAudioBackfillMode: 'block',
+      }),
+    );
+  });
+
   it('does not project regular follow-up answers as listen-mode narration', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.test.ts
@@ -195,6 +195,51 @@ describe('chatUiModeProjection', () => {
     );
   });
 
+  it('projects stored live interaction answer feedback as listen-mode narration', () => {
+    const items: ChatContentItem[] = [
+      {
+        type: ChatContentItemType.INTERACTION,
+        element_bid: 'interaction-1',
+        content: '?[%{{choice}} A | B]',
+        is_renderable: false,
+      },
+      {
+        type: ChatContentItemType.ASK,
+        element_bid: '',
+        parent_element_bid: 'interaction-1',
+        content: '',
+        ask_list: [],
+      },
+    ];
+
+    const projectedItems = projectListenModeItems({
+      items,
+      askButtonMarkup,
+      askListByAnchorElementBid: {
+        'interaction-1': [
+          {
+            type: ChatContentItemType.ASK,
+            element_bid: 'learner-answer-1',
+            generated_block_bid: 'learner-answer-generated-1',
+            content: 'A',
+          },
+          {
+            type: 'answer',
+            element_bid: 'feedback-answer-1',
+            generated_block_bid: 'feedback-generated-1',
+            content: '答对了，继续看下一个坑。',
+          },
+        ],
+      },
+    });
+
+    expect(projectedItems.map(item => item.element_bid)).toEqual([
+      'interaction-1',
+      '',
+      'feedback-answer-1',
+    ]);
+  });
+
   it('does not project regular follow-up answers as listen-mode narration', () => {
     const items: ChatContentItem[] = [
       {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
@@ -204,9 +204,7 @@ const projectListenAnswerFeedbackItems = (
   }
 
   const askList =
-    Array.isArray(item.ask_list) && item.ask_list.length
-      ? item.ask_list
-      : askListByAnchorElementBid[item.parent_element_bid || ''];
+    askListByAnchorElementBid[item.parent_element_bid || ''] ?? item.ask_list;
 
   if (!Array.isArray(askList)) {
     return [];

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
@@ -188,6 +188,49 @@ const stripClassroomContentAudio = (item: ChatContentItem) => {
   return nextItem;
 };
 
+const projectListenAnswerFeedbackItems = (
+  item: ChatContentItem,
+  itemByElementBid: Map<string, ChatContentItem>,
+) => {
+  if (item.type !== ChatContentItemType.ASK || !Array.isArray(item.ask_list)) {
+    return [];
+  }
+
+  const parentItem = itemByElementBid.get(item.parent_element_bid || '');
+  if (parentItem?.type !== ChatContentItemType.INTERACTION) {
+    return [];
+  }
+
+  return item.ask_list
+    .filter(
+      message => message?.type === 'answer' && Boolean(message.content?.trim()),
+    )
+    .map((message, index) => {
+      const fallbackElementBid = `answer-${item.parent_element_bid || 'feedback'}-${index}`;
+      const elementBid =
+        message.element_bid ||
+        message.generated_block_bid ||
+        fallbackElementBid;
+
+      return {
+        ...message,
+        element_bid: elementBid,
+        generated_block_bid: message.generated_block_bid || elementBid,
+        parent_element_bid: item.parent_element_bid,
+        type: ChatContentItemType.CONTENT,
+        element_type: 'text',
+        is_speakable: true,
+        is_renderable: true,
+        is_marker: true,
+        isAudioBackfillReady:
+          message.isAudioBackfillReady ?? item.isAudioBackfillReady ?? true,
+        readonly: true,
+        customRenderBar: () => null,
+        user_input: '',
+      } satisfies ChatContentItem;
+    });
+};
+
 export const projectReadModeItems = ({
   items,
   askListByAnchorElementBid,
@@ -306,19 +349,31 @@ export const projectListenModeItems = ({
   variant = 'listen',
 }: ProjectListenModeItemsParams) => {
   const hiddenContentElementBids = getHiddenContentElementBids(items);
+  const itemByElementBid = new Map(
+    items
+      .filter(item => item.element_bid)
+      .map(item => [item.element_bid, item] as const),
+  );
   const projectableItems = items.filter(item =>
     variant === 'classroom'
       ? shouldProjectClassroomModeItem(item, hiddenContentElementBids)
       : shouldProjectModeItem(item, hiddenContentElementBids),
   );
   let hasChanges = projectableItems.length !== items.length;
-  const nextItems = projectableItems.map(item => {
+  const nextItems = projectableItems.flatMap(item => {
     if (item.type !== ChatContentItemType.CONTENT) {
-      return item;
+      const answerFeedbackItems =
+        variant === 'listen'
+          ? projectListenAnswerFeedbackItems(item, itemByElementBid)
+          : [];
+      if (answerFeedbackItems.length > 0) {
+        hasChanges = true;
+      }
+      return [item, ...answerFeedbackItems];
     }
     if (variant === 'classroom') {
       hasChanges = true;
-      return stripClassroomContentAudio(item);
+      return [stripClassroomContentAudio(item)];
     }
     const sanitizedContent = syncCustomButtonAfterContent({
       content: item.content,
@@ -326,13 +381,15 @@ export const projectListenModeItems = ({
       shouldShowButton: false,
     });
     if (sanitizedContent === (item.content ?? '')) {
-      return item;
+      return [item];
     }
     hasChanges = true;
-    return {
-      ...item,
-      content: sanitizedContent,
-    };
+    return [
+      {
+        ...item,
+        content: sanitizedContent,
+      },
+    ];
   });
 
   return hasChanges ? nextItems : items;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
@@ -16,6 +16,7 @@ interface ProjectReadModeItemsParams {
 interface ProjectListenModeItemsParams {
   items: ChatContentItem[];
   askButtonMarkup: string;
+  askListByAnchorElementBid?: Record<string, ProjectAskMessage[]>;
   variant?: 'listen' | 'classroom';
 }
 
@@ -191,8 +192,9 @@ const stripClassroomContentAudio = (item: ChatContentItem) => {
 const projectListenAnswerFeedbackItems = (
   item: ChatContentItem,
   itemByElementBid: Map<string, ChatContentItem>,
+  askListByAnchorElementBid: Record<string, ProjectAskMessage[]> = {},
 ) => {
-  if (item.type !== ChatContentItemType.ASK || !Array.isArray(item.ask_list)) {
+  if (item.type !== ChatContentItemType.ASK) {
     return [];
   }
 
@@ -201,7 +203,16 @@ const projectListenAnswerFeedbackItems = (
     return [];
   }
 
-  return item.ask_list
+  const askList =
+    Array.isArray(item.ask_list) && item.ask_list.length
+      ? item.ask_list
+      : askListByAnchorElementBid[item.parent_element_bid || ''];
+
+  if (!Array.isArray(askList)) {
+    return [];
+  }
+
+  return askList
     .filter(
       message => message?.type === 'answer' && Boolean(message.content?.trim()),
     )
@@ -346,6 +357,7 @@ export const projectReadModeItems = ({
 export const projectListenModeItems = ({
   items,
   askButtonMarkup,
+  askListByAnchorElementBid,
   variant = 'listen',
 }: ProjectListenModeItemsParams) => {
   const hiddenContentElementBids = getHiddenContentElementBids(items);
@@ -364,7 +376,11 @@ export const projectListenModeItems = ({
     if (item.type !== ChatContentItemType.CONTENT) {
       const answerFeedbackItems =
         variant === 'listen'
-          ? projectListenAnswerFeedbackItems(item, itemByElementBid)
+          ? projectListenAnswerFeedbackItems(
+              item,
+              itemByElementBid,
+              askListByAnchorElementBid,
+            )
           : [];
       if (answerFeedbackItems.length > 0) {
         hasChanges = true;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/chatUiModeProjection.ts
@@ -235,6 +235,7 @@ const projectListenAnswerFeedbackItems = (
         is_marker: true,
         isAudioBackfillReady:
           message.isAudioBackfillReady ?? item.isAudioBackfillReady ?? true,
+        listenAudioBackfillMode: 'block',
         readonly: true,
         customRenderBar: () => null,
         user_input: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -267,6 +267,35 @@ describe('listenModeUtils', () => {
     ).toBe(false);
   });
 
+  it('allows html slides with visible text to use generated-block tts fallback', () => {
+    expect(
+      isListenModeAudioBackfillCandidate(
+        createContentItem({
+          element_bid: 'html-slide-1',
+          generated_block_bid: 'generated-block-1',
+          element_type: 'html',
+          content:
+            '<section><h1>计算机的定义</h1><p>存储程序，自动高速。</p></section>',
+          is_speakable: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not use html tts fallback for visual markup without visible text', () => {
+    expect(
+      isListenModeAudioBackfillCandidate(
+        createContentItem({
+          element_bid: 'html-slide-1',
+          generated_block_bid: 'generated-block-1',
+          element_type: 'html',
+          content: '<section><img src="/cover.png" /></section>',
+          is_speakable: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it('does not make very short content a listen-mode backfill candidate', () => {
     expect(
       isListenModeAudioBackfillCandidate(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -355,6 +355,9 @@ describe('listenModeUtils', () => {
       'template',
       '<section><template>Hidden fallback text</template></section>',
     ],
+    ['unclosed script', '<section><script>const visible = "read this";'],
+    ['unclosed style', '<section><style>.hero { display: flex; }'],
+    ['unclosed template', '<section><template>Hidden fallback text'],
   ])(
     'does not use html tts fallback for %s-only hidden content',
     (_caseName, content) => {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -133,6 +133,55 @@ describe('listenModeUtils', () => {
     expect(missingBids).toEqual(['generated-block-1', 'generated-block-2']);
   });
 
+  it('does not re-request a generated block when a sibling already has audio', () => {
+    const missingBids = getMissingListenModeAudioBlockBids([
+      createContentItem({
+        element_bid: 'narration-1',
+        generated_block_bid: 'generated-block-1',
+        is_speakable: true,
+        audioTracks: [
+          {
+            position: 0,
+            audioUrl: 'https://example.com/audio.mp3',
+          },
+        ],
+      }),
+      createContentItem({
+        element_bid: 'html-slide-1',
+        generated_block_bid: 'generated-block-1',
+        element_type: 'html',
+        content: '<section><h1>计算机的定义</h1></section>',
+        is_speakable: false,
+      }),
+    ]);
+
+    expect(missingBids).toEqual([]);
+  });
+
+  it('keeps requesting missing speakable siblings during listen-mode backfill', () => {
+    const missingBids = getMissingListenModeAudioBlockBids([
+      createContentItem({
+        element_bid: 'narration-1',
+        generated_block_bid: 'generated-block-1',
+        is_speakable: true,
+        audioTracks: [
+          {
+            position: 0,
+            audioUrl: 'https://example.com/audio.mp3',
+          },
+        ],
+      }),
+      createContentItem({
+        element_bid: 'narration-2',
+        generated_block_bid: 'generated-block-1',
+        is_speakable: true,
+        audioTracks: [],
+      }),
+    ]);
+
+    expect(missingBids).toEqual(['generated-block-1']);
+  });
+
   it('treats streaming audio tracks as playable during listen-mode backfill', () => {
     const item = createContentItem({
       audioTracks: [
@@ -295,6 +344,32 @@ describe('listenModeUtils', () => {
       ),
     ).toBe(false);
   });
+
+  it.each([
+    [
+      'script',
+      '<section><script>const visible = "read this";</script></section>',
+    ],
+    ['style', '<section><style>.hero { display: flex; }</style></section>'],
+    [
+      'template',
+      '<section><template>Hidden fallback text</template></section>',
+    ],
+  ])(
+    'does not use html tts fallback for %s-only hidden content',
+    (_caseName, content) => {
+      const item = createContentItem({
+        element_bid: 'html-slide-1',
+        generated_block_bid: 'generated-block-1',
+        element_type: 'html',
+        content,
+        is_speakable: false,
+      });
+
+      expect(canRequestListenModeTtsForItem(item)).toBe(false);
+      expect(isListenModeAudioBackfillCandidate(item)).toBe(false);
+    },
+  );
 
   it('does not make very short content a listen-mode backfill candidate', () => {
     expect(

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -20,7 +20,7 @@ const MIN_LISTEN_MODE_TTS_TEXT_LENGTH = 2;
 const CUSTOM_BUTTON_RE =
   /<custom-button-after-content\b[\s\S]*?<\/custom-button-after-content>/gi;
 const HTML_NON_VISIBLE_CONTENT_RE =
-  /<(script|style|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+  /<(script|style|template)\b[^>]*>(?:[\s\S]*?<\/\1\s*>|[\s\S]*$)/gi;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 const HTML_TAG_RE = /<\/?\s*[a-zA-Z][a-zA-Z0-9:_-]*\b[^>]*>/g;
 const HTML_SPACE_ENTITY_RE = /&(?:nbsp|ensp|emsp|thinsp|zwnj|zwj);/gi;

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -40,6 +40,13 @@ const hasListenModeSpeakableText = (content?: string) => {
   );
 };
 
+const isHtmlSlideFallbackTtsCandidate = (item?: ChatContentItem | null) =>
+  Boolean(
+    item?.element_type === 'html' &&
+    item.generated_block_bid?.trim() &&
+    hasListenModeSpeakableText(item.content),
+  );
+
 export const sortByPosition = <T extends { position?: number }>(
   list: T[] = [],
 ) =>
@@ -291,6 +298,7 @@ export const canRequestListenModeTtsForItem = (
 
   return Boolean(
     (item.is_speakable === true && hasListenModeSpeakableText(item.content)) ||
+    isHtmlSlideFallbackTtsCandidate(item) ||
     item.audio_url ||
     item.audioUrl ||
     item.isAudioStreaming ||
@@ -321,7 +329,8 @@ export const isListenModeAudioBackfillCandidate = (
   }
 
   return (
-    item.is_speakable !== false && hasListenModeSpeakableText(item.content)
+    (item.is_speakable !== false && hasListenModeSpeakableText(item.content)) ||
+    isHtmlSlideFallbackTtsCandidate(item)
   );
 };
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -19,6 +19,8 @@ const MARKDOWN_VIDEO_IFRAME_PATTERN =
 const MIN_LISTEN_MODE_TTS_TEXT_LENGTH = 2;
 const CUSTOM_BUTTON_RE =
   /<custom-button-after-content\b[\s\S]*?<\/custom-button-after-content>/gi;
+const HTML_NON_VISIBLE_CONTENT_RE =
+  /<(script|style|template)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 const HTML_TAG_RE = /<\/?\s*[a-zA-Z][a-zA-Z0-9:_-]*\b[^>]*>/g;
 const HTML_SPACE_ENTITY_RE = /&(?:nbsp|ensp|emsp|thinsp|zwnj|zwj);/gi;
@@ -27,6 +29,7 @@ const SPEAKABLE_TEXT_RE = /[\p{L}\p{N}]/u;
 const normalizeListenModeSpeakableText = (content?: string) =>
   String(content ?? '')
     .replace(CUSTOM_BUTTON_RE, ' ')
+    .replace(HTML_NON_VISIBLE_CONTENT_RE, ' ')
     .replace(HTML_COMMENT_RE, ' ')
     .replace(HTML_TAG_RE, ' ')
     .replace(HTML_SPACE_ENTITY_RE, ' ')
@@ -341,14 +344,46 @@ export const isListenModeAudioBackfillReady = (item?: ChatContentItem | null) =>
     hasPlayableListenAudioForItem(item),
   );
 
+const resolveListenModeAudioBackfillRequestBid = (
+  item?: ChatContentItem | null,
+) => item?.generated_block_bid?.trim() || item?.element_bid?.trim() || '';
+
 export const getMissingListenModeAudioBlockBids = (
   items: ChatContentItem[],
 ) => {
   const seen = new Set<string>();
   const missingBids: string[] = [];
+  const playableRequestBids = new Set<string>();
 
   items.forEach(item => {
     if (!isListenModeAudioBackfillCandidate(item)) {
+      return;
+    }
+
+    if (!hasPlayableListenAudioForItem(item)) {
+      return;
+    }
+
+    const requestBid = resolveListenModeAudioBackfillRequestBid(item);
+    if (requestBid) {
+      playableRequestBids.add(requestBid);
+    }
+  });
+
+  items.forEach(item => {
+    if (!isListenModeAudioBackfillCandidate(item)) {
+      return;
+    }
+
+    const requestBid = resolveListenModeAudioBackfillRequestBid(item);
+    if (!requestBid) {
+      return;
+    }
+
+    if (
+      isHtmlSlideFallbackTtsCandidate(item) &&
+      playableRequestBids.has(requestBid)
+    ) {
       return;
     }
 
@@ -356,9 +391,7 @@ export const getMissingListenModeAudioBlockBids = (
       return;
     }
 
-    const requestBid =
-      item.generated_block_bid?.trim() || item.element_bid?.trim();
-    if (!requestBid || seen.has(requestBid)) {
+    if (seen.has(requestBid)) {
       return;
     }
 

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -3263,6 +3263,70 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(result.current.reGenerateConfirm.open).toBe(false);
   });
 
+  it('updates the submitted variable-free interaction by block id', async () => {
+    mockGetLessonStudyRecord.mockResolvedValueOnce({
+      mdflow: '',
+      elements: [
+        {
+          block_type: 'content',
+          element_type: 'content',
+          content: 'intro',
+          generated_block_bid: 'content-1',
+          element_bid: 'content-1',
+          like_status: 'none',
+          user_input: '',
+        },
+        {
+          block_type: 'interaction',
+          element_type: 'interaction',
+          content: '?[概念还含糊 | 会算但老错 | 几乎空白]',
+          generated_block_bid: 'interaction-1',
+          element_bid: 'interaction-1',
+          like_status: 'none',
+          user_input: '',
+        },
+        {
+          block_type: 'interaction',
+          element_type: 'interaction',
+          content: '?[1945 年 | 1946 年 | 1947 年]',
+          generated_block_bid: 'interaction-2',
+          element_bid: 'interaction-2',
+          like_status: 'none',
+          user_input: '',
+        },
+      ],
+      slides: [],
+      records: [],
+    });
+
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.onSend(
+        {
+          variableName: '',
+          selectedValues: ['1946 年'],
+        },
+        'interaction-2',
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(item => item.element_bid === 'interaction-2')
+          ?.user_input,
+      ).toBe('1946 年'),
+    );
+    expect(
+      result.current.items.find(item => item.element_bid === 'interaction-1')
+        ?.user_input,
+    ).toBe('');
+  });
+
   it('drops orphan history follow-ups whose anchor element is absent from records', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -3327,6 +3327,80 @@ describe('useChatLogicHook stream cleanup', () => {
     ).toBe('');
   });
 
+  it('attaches live answer feedback without payload to the submitted interaction', async () => {
+    mockGetLessonStudyRecord.mockResolvedValueOnce({
+      mdflow: '',
+      elements: [
+        {
+          block_type: 'content',
+          element_type: 'content',
+          content: 'intro',
+          generated_block_bid: 'content-1',
+          element_bid: 'content-1',
+          like_status: 'none',
+          user_input: '',
+        },
+        {
+          block_type: 'interaction',
+          element_type: 'interaction',
+          content: '?[1945 年 | 1946 年 | 1947 年]',
+          generated_block_bid: 'interaction-1',
+          element_bid: 'interaction-1',
+          like_status: 'none',
+          user_input: '',
+        },
+      ],
+      slides: [],
+      records: [],
+    });
+
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.onSend(
+        {
+          variableName: '',
+          selectedValues: ['1946 年'],
+        },
+        'interaction-1',
+      );
+    });
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    await act(async () => {
+      await activeRun?.onMessage({
+        generated_block_bid: 'feedback-generated-1',
+        type: SSE_OUTPUT_TYPE.ELEMENT,
+        content: {
+          element_bid: 'feedback-answer-1',
+          generated_block_bid: 'feedback-generated-1',
+          element_type: 'answer',
+          content: '答对了，继续看下一个坑。',
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        result.current.items.find(
+          item =>
+            item.type === ChatContentItemType.ASK &&
+            item.parent_element_bid === 'interaction-1',
+        )?.ask_list,
+      ).toEqual([
+        expect.objectContaining({
+          element_bid: 'feedback-answer-1',
+          type: 'answer',
+          content: '答对了，继续看下一个坑。',
+        }),
+      ]),
+    );
+  });
+
   it('drops orphan history follow-ups whose anchor element is absent from records', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -1250,6 +1250,70 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(stoppedItem?.audioTracks?.[0]?.isAudioStreaming).toBe(false);
   });
 
+  it('resolves cancelled and de-duplicated audio requests as undefined rather than a failure', async () => {
+    mockGetLessonStudyRecord.mockResolvedValueOnce({
+      mdflow: '',
+      elements: [
+        {
+          element_type: 'text',
+          content: 'History content without audio',
+          generated_block_bid: 'generated-block-skip-1',
+          element_bid: 'element-skip-1',
+          element_index: 0,
+          like_status: 'none',
+          user_input: '',
+          is_speakable: true,
+          is_renderable: true,
+          is_marker: false,
+          is_new: false,
+        },
+      ],
+      slides: [],
+      records: [],
+    });
+
+    const closeTtsSource = jest.fn();
+    mockStreamGeneratedBlockAudio.mockImplementation(() => ({
+      close: closeTtsSource,
+    }));
+
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let firstRequest: Promise<unknown> | undefined;
+    act(() => {
+      firstRequest = result.current.requestAudioForBlock('element-skip-1', {
+        listen: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockStreamGeneratedBlockAudio).toHaveBeenCalled(),
+    );
+
+    // A second request while the first stream is still in flight is de-duplicated.
+    // That is not a failure, so it must stay retryable.
+    let duplicateRequest: Promise<unknown> | undefined;
+    act(() => {
+      duplicateRequest = result.current.requestAudioForBlock('element-skip-1', {
+        listen: true,
+      });
+    });
+    await expect(duplicateRequest).resolves.toBeUndefined();
+
+    // Answering an interaction tears down every in-flight TTS stream. The
+    // cancelled request must not be reported as a synthesis failure, otherwise
+    // the block is blacklisted and its narration is silenced for good.
+    await act(async () => {
+      stopAllActiveLessonStreams();
+      await firstRequest;
+    });
+    await expect(firstRequest).resolves.toBeUndefined();
+  });
+
   it('keeps an active read run open when presentation mode changes', async () => {
     const { result, rerender } = renderHook(
       ({ isListenMode }) =>

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.test.tsx
@@ -755,6 +755,101 @@ describe('useChatLogicHook stream cleanup', () => {
     expect(onStreamSettled).toHaveBeenCalledTimes(1);
   });
 
+  it('writes listen backfill audio to nested interaction answer feedback', async () => {
+    mockGetLessonStudyRecord.mockResolvedValueOnce({
+      mdflow: '',
+      elements: [
+        {
+          element_type: 'interaction',
+          content: '?[A | B]',
+          generated_block_bid: 'interaction-block-1',
+          element_bid: 'interaction-1',
+          like_status: 'none',
+          user_input: '',
+          is_renderable: false,
+        },
+        {
+          element_type: 'ask',
+          content: 'A',
+          generated_block_bid: 'learner-answer-generated-1',
+          element_bid: 'learner-answer-1',
+          payload: {
+            anchor_element_bid: 'interaction-1',
+          },
+        },
+        {
+          element_type: 'answer',
+          content: '答对了，继续看下一个坑。',
+          generated_block_bid: 'feedback-generated-1',
+          element_bid: 'feedback-answer-1',
+          payload: {
+            anchor_element_bid: 'interaction-1',
+            ask_element_bid: 'learner-answer-1',
+          },
+        },
+      ],
+      slides: [],
+      records: [],
+    });
+
+    let ttsRequest:
+      | {
+          onMessage: (response: unknown) => void;
+        }
+      | undefined;
+    mockStreamGeneratedBlockAudio.mockImplementation(params => {
+      ttsRequest = params;
+      return {
+        close: jest.fn(),
+      };
+    });
+
+    const { result } = renderHook(() => useChatLogicHook(buildBaseParams()), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      void result.current.requestAudioForBlock('feedback-generated-1', {
+        listen: true,
+      });
+    });
+
+    expect(mockStreamGeneratedBlockAudio).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generated_block_bid: 'feedback-generated-1',
+        listen: true,
+      }),
+    );
+
+    await act(async () => {
+      ttsRequest?.onMessage({
+        type: SSE_OUTPUT_TYPE.AUDIO_COMPLETE,
+        content: {
+          audio_url: 'https://example.com/feedback.mp3',
+          audio_bid: 'feedback-audio-1',
+          duration_ms: 1234,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const askBlock = result.current.items.find(
+        item =>
+          item.type === ChatContentItemType.ASK &&
+          item.parent_element_bid === 'interaction-1',
+      );
+      const feedbackMessage = askBlock?.ask_list?.find(
+        message => message.element_bid === 'feedback-answer-1',
+      );
+
+      expect(feedbackMessage?.audioUrl).toBe(
+        'https://example.com/feedback.mp3',
+      );
+    });
+  });
+
   it('closes non-listen generated-block audio after the first complete event', async () => {
     mockGetLessonStudyRecord.mockResolvedValueOnce({
       mdflow: '',

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -20,6 +20,7 @@ import {
   StudyRecordItem,
   LikeStatus,
   AudioCompleteData,
+  AudioSegmentData,
   type ListenSlideData,
   type ElementType,
   getRunMessage,
@@ -103,6 +104,122 @@ const CREDIT_INSUFFICIENT_ERROR_CODE = 7101;
 
 export { ChatContentItemType };
 export type { ChatContentItem };
+
+const findAudioTargetItem = (items: ChatContentItem[], bid: string) => {
+  if (!bid) {
+    return undefined;
+  }
+
+  for (const item of items) {
+    if (item.element_bid === bid || item.generated_block_bid === bid) {
+      return item;
+    }
+
+    const askMessage = item.ask_list?.find(
+      message =>
+        message.element_bid === bid || message.generated_block_bid === bid,
+    );
+    if (askMessage) {
+      return askMessage;
+    }
+  }
+
+  return undefined;
+};
+
+const mapNestedAskMessages = (
+  items: ChatContentItem[],
+  shouldUpdate: (message: ChatContentItem) => boolean,
+  updateMessage: (message: ChatContentItem) => ChatContentItem,
+) =>
+  items.map(item => {
+    if (!Array.isArray(item.ask_list)) {
+      return item;
+    }
+
+    let hasChanges = false;
+    const nextAskList = item.ask_list.map(message => {
+      if (!shouldUpdate(message)) {
+        return message;
+      }
+      hasChanges = true;
+      return updateMessage(message);
+    });
+
+    if (!hasChanges) {
+      return item;
+    }
+
+    return {
+      ...item,
+      ask_list: nextAskList,
+    };
+  });
+
+const updateNestedAskMessageAudioStreaming = (
+  items: ChatContentItem[],
+  targetElementBid: string,
+  sourceBlockBid: string,
+  isAudioStreaming: boolean,
+) =>
+  mapNestedAskMessages(
+    items,
+    message =>
+      Boolean(targetElementBid && message.element_bid === targetElementBid) ||
+      Boolean(sourceBlockBid && message.generated_block_bid === sourceBlockBid),
+    message => ({
+      ...message,
+      ...(isAudioStreaming
+        ? {
+            audioTracks: [],
+            audioUrl: undefined,
+            audioDurationMs: undefined,
+          }
+        : {
+            audioTracks: (message.audioTracks ?? []).map(track => ({
+              ...track,
+              isAudioStreaming: false,
+            })),
+          }),
+      isAudioStreaming,
+    }),
+  );
+
+const upsertNestedAskAudioSegment = (
+  items: ChatContentItem[],
+  elementBid: string,
+  segment: AudioSegmentData,
+) =>
+  mapNestedAskMessages(
+    items,
+    message =>
+      message.element_bid === elementBid ||
+      message.generated_block_bid === elementBid,
+    message =>
+      upsertAudioSegment(
+        [message],
+        message.element_bid || elementBid,
+        segment,
+      )[0] ?? message,
+  );
+
+const upsertNestedAskAudioComplete = (
+  items: ChatContentItem[],
+  elementBid: string,
+  complete: Partial<AudioCompleteData>,
+) =>
+  mapNestedAskMessages(
+    items,
+    message =>
+      message.element_bid === elementBid ||
+      message.generated_block_bid === elementBid,
+    message =>
+      upsertAudioComplete(
+        [message],
+        message.element_bid || elementBid,
+        complete,
+      )[0] ?? message,
+  );
 
 /**
  * useChatLogicHook orchestrates the streaming chat lifecycle for lesson content.
@@ -265,11 +382,7 @@ function useChatLogicHook({
   }, []);
 
   const resolveAudioBlockTarget = useCallback((bid: string) => {
-    const item = contentListRef.current.find(
-      contentItem =>
-        contentItem.element_bid === bid ||
-        contentItem.generated_block_bid === bid,
-    );
+    const item = findAudioTargetItem(contentListRef.current, bid);
 
     return {
       elementBid: item?.element_bid || bid,
@@ -3117,10 +3230,9 @@ function useChatLogicHook({
         return null;
       }
 
-      const existingItem = contentListRef.current.find(
-        item =>
-          item.element_bid === targetElementBid ||
-          item.generated_block_bid === sourceBlockBid,
+      const existingItem = findAudioTargetItem(
+        contentListRef.current,
+        targetElementBid,
       );
       const cachedTrack = getAudioTrackByPosition(
         existingItem?.audioTracks ?? [],
@@ -3144,19 +3256,24 @@ function useChatLogicHook({
       }
 
       setTrackedContentList(prev =>
-        prev.map(item => {
-          if (!matchItemBid(item, targetElementBid)) {
-            return item;
-          }
+        updateNestedAskMessageAudioStreaming(
+          prev.map(item => {
+            if (!matchItemBid(item, targetElementBid)) {
+              return item;
+            }
 
-          return {
-            ...item,
-            audioTracks: [],
-            audioUrl: undefined,
-            audioDurationMs: undefined,
-            isAudioStreaming: true,
-          };
-        }),
+            return {
+              ...item,
+              audioTracks: [],
+              audioUrl: undefined,
+              audioDurationMs: undefined,
+              isAudioStreaming: true,
+            };
+          }),
+          targetElementBid,
+          sourceBlockBid,
+          true,
+        ),
       );
 
       return new Promise((resolve, reject) => {
@@ -3189,23 +3306,31 @@ function useChatLogicHook({
             return;
           }
           setTrackedContentList(prev =>
-            prev.map(item => {
-              const isSourceBlockItem =
-                Boolean(sourceBlockBid) &&
-                item.type === ChatContentItemType.CONTENT &&
-                item.generated_block_bid === sourceBlockBid;
-              if (!matchItemBid(item, targetElementBid) && !isSourceBlockItem) {
-                return item;
-              }
-              return {
-                ...item,
-                isAudioStreaming: false,
-                audioTracks: (item.audioTracks ?? []).map(track => ({
-                  ...track,
+            updateNestedAskMessageAudioStreaming(
+              prev.map(item => {
+                const isSourceBlockItem =
+                  Boolean(sourceBlockBid) &&
+                  item.type === ChatContentItemType.CONTENT &&
+                  item.generated_block_bid === sourceBlockBid;
+                if (
+                  !matchItemBid(item, targetElementBid) &&
+                  !isSourceBlockItem
+                ) {
+                  return item;
+                }
+                return {
+                  ...item,
                   isAudioStreaming: false,
-                })),
-              };
-            }),
+                  audioTracks: (item.audioTracks ?? []).map(track => ({
+                    ...track,
+                    isAudioStreaming: false,
+                  })),
+                };
+              }),
+              targetElementBid,
+              sourceBlockBid,
+              false,
+            ),
           );
         };
 
@@ -3298,11 +3423,16 @@ function useChatLogicHook({
               }
               const audioTargetElementBid =
                 resolveAudioEventTargetElementBid(audioSegment);
+              const audioSegmentData = toAudioSegmentData(audioSegment);
               setTrackedContentList(prevState =>
-                upsertAudioSegment(
-                  prevState,
+                upsertNestedAskAudioSegment(
+                  upsertAudioSegment(
+                    prevState,
+                    audioTargetElementBid,
+                    audioSegmentData,
+                  ),
                   audioTargetElementBid,
-                  toAudioSegmentData(audioSegment),
+                  audioSegmentData,
                 ),
               );
               return;
@@ -3323,8 +3453,12 @@ function useChatLogicHook({
               const audioTargetElementBid =
                 resolveAudioEventTargetElementBid(audioComplete);
               setTrackedContentList(prevState =>
-                upsertAudioComplete(
-                  prevState,
+                upsertNestedAskAudioComplete(
+                  upsertAudioComplete(
+                    prevState,
+                    audioTargetElementBid,
+                    audioComplete,
+                  ),
                   audioTargetElementBid,
                   audioComplete,
                 ),

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -2590,19 +2590,24 @@ function useChatLogicHook({
       options?: { truncateFollowingItems?: boolean },
     ): { newList: ChatContentItem[]; needChangeItemIndex: number } => {
       const newList = [...contentListRef.current];
-      // first find the item with the same variable value
-      let needChangeItemIndex = newList.findIndex(item =>
-        item.content?.includes(params.variableName || ''),
+      let needChangeItemIndex = newList.findIndex(
+        item => item.element_bid === blockBid,
       );
-      // if has multiple items with the same variable value, we need to find the item with the same blockBid
-      const sameVariableValueItems =
-        newList.filter(item =>
-          item.content?.includes(params.variableName || ''),
-        ) || [];
-      if (sameVariableValueItems.length > 1) {
-        needChangeItemIndex = newList.findIndex(
-          item => item.element_bid === blockBid,
+      const variableName = params.variableName;
+      if (variableName) {
+        // first find the item with the same variable value
+        const variableMatchIndex = newList.findIndex(item =>
+          item.content?.includes(variableName),
         );
+        // if has multiple items with the same variable value, we need to find the item with the same blockBid
+        const sameVariableValueItems =
+          newList.filter(item => item.content?.includes(variableName)) || [];
+        needChangeItemIndex =
+          sameVariableValueItems.length > 1
+            ? needChangeItemIndex
+            : variableMatchIndex >= 0
+              ? variableMatchIndex
+              : needChangeItemIndex;
       }
       if (needChangeItemIndex !== -1) {
         newList[needChangeItemIndex] = {

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -3220,9 +3220,11 @@ function useChatLogicHook({
     async (
       elementBid: string,
       options: RequestAudioForBlockOptions = {},
-    ): Promise<AudioCompleteData | null> => {
+    ): Promise<AudioCompleteData | null | undefined> => {
+      // `undefined` marks "never attempted" so callers can tell a cancelled or
+      // de-duplicated request apart from a real synthesis failure.
       if (!elementBid) {
-        return null;
+        return undefined;
       }
 
       const {
@@ -3245,12 +3247,12 @@ function useChatLogicHook({
 
       if (!allowTtsStreaming) {
         notifyStreamSettled();
-        return null;
+        return undefined;
       }
 
       if (!shouldApplyResult()) {
         notifyStreamSettled();
-        return null;
+        return undefined;
       }
 
       const existingItem = findAudioTargetItem(
@@ -3274,8 +3276,10 @@ function useChatLogicHook({
       }
 
       if (ttsSseRef.current[sourceBlockBid]) {
+        // Another stream for this block is already in flight; de-duplicating is
+        // not a failure, so the caller must be able to retry later.
         notifyStreamSettled();
-        return null;
+        return undefined;
       }
 
       setTrackedContentList(prev =>
@@ -3316,7 +3320,7 @@ function useChatLogicHook({
           }
         };
 
-        const resolveOnce = (value: AudioCompleteData | null) => {
+        const resolveOnce = (value: AudioCompleteData | null | undefined) => {
           if (hasResolved) {
             return;
           }
@@ -3370,7 +3374,11 @@ function useChatLogicHook({
           if (updateState) {
             markAudioStreamSettled();
           }
-          resolveOnce(null);
+          // Cancellation is not a synthesis failure. Submitting an interaction
+          // tears down every in-flight TTS stream, so resolving as `null` here
+          // would permanently blacklist those blocks and silence all narration
+          // generated after the answer.
+          resolveOnce(undefined);
           closeTtsStream(sourceBlockBid);
           notifyStreamSettled();
         };

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.tsx
@@ -311,6 +311,7 @@ function useChatLogicHook({
   const contentListRef = useRef<ChatContentItem[]>([]);
   const currentContentRef = useRef<string>('');
   const currentBlockIdRef = useRef<string | null>(null);
+  const pendingInteractionAnchorBidRef = useRef('');
   const runRef = useRef<((params: SSEParams) => void) | null>(null);
   const sseRef = useRef<any>(null);
   const sseRunSerialRef = useRef(0);
@@ -611,19 +612,32 @@ function useChatLogicHook({
         typeof payload.ask_element_bid === 'string'
           ? payload.ask_element_bid
           : '';
-      if (!payloadAskElementBid) {
+      if (payloadAskElementBid) {
+        const matchedAskBlock = items.find(
+          item =>
+            item.type === ChatContentItemType.ASK &&
+            Array.isArray(item.ask_list) &&
+            item.ask_list.some(
+              askMessage => askMessage.element_bid === payloadAskElementBid,
+            ),
+        );
+        if (matchedAskBlock?.parent_element_bid) {
+          return matchedAskBlock.parent_element_bid;
+        }
+      }
+
+      const pendingInteractionAnchorBid =
+        pendingInteractionAnchorBidRef.current;
+      if (!pendingInteractionAnchorBid) {
         return '';
       }
 
-      const matchedAskBlock = items.find(
+      const pendingInteraction = items.find(
         item =>
-          item.type === ChatContentItemType.ASK &&
-          Array.isArray(item.ask_list) &&
-          item.ask_list.some(
-            askMessage => askMessage.element_bid === payloadAskElementBid,
-          ),
+          item.element_bid === pendingInteractionAnchorBid &&
+          item.type === ChatContentItemType.INTERACTION,
       );
-      return matchedAskBlock?.parent_element_bid || '';
+      return pendingInteraction?.element_bid || '';
     },
     [],
   );
@@ -2930,6 +2944,10 @@ function useChatLogicHook({
         setTrackedContentList(newList);
       }
 
+      pendingInteractionAnchorBidRef.current =
+        currentInteractionItem?.type === ChatContentItemType.INTERACTION
+          ? blockBid
+          : '';
       isTypeFinishedRef.current = false;
 
       const { values } = resolveInteractionSubmission(content);

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/useChatLogicHook.types.ts
@@ -88,10 +88,14 @@ export interface UseChatSessionResult {
       expand?: boolean;
     },
   ) => void;
+  // Resolves to the audio payload on success, `null` when synthesis genuinely
+  // failed, and `undefined` when the request was never attempted (cancelled,
+  // superseded, or de-duplicated against an in-flight stream). Callers must not
+  // treat `undefined` as a failure.
   requestAudioForBlock: (
     elementBid: string,
     options?: RequestAudioForBlockOptions,
-  ) => Promise<AudioCompleteData | null>;
+  ) => Promise<AudioCompleteData | null | undefined>;
   reGenerateConfirm: {
     open: boolean;
     onConfirm: () => void;

--- a/src/cook-web/src/c-types/chatUi.ts
+++ b/src/cook-web/src/c-types/chatUi.ts
@@ -43,6 +43,7 @@ export interface ChatContentItem {
   audioTracks?: AudioTrack[];
   isAudioStreaming?: boolean;
   isAudioBackfillReady?: boolean;
+  listenAudioBackfillMode?: 'listen' | 'block';
   audioDurationMs?: number;
   listenSlides?: ListenSlideData[];
   element_type?: ElementType;


### PR DESCRIPTION
## Summary

Listen mode goes silent for the narration generated after a learner answers an interaction. This PR restores it.

It revives the work from #2280 (closed by its author without a replacement PR, no review objections) rebased onto current `main`, and adds one fix that branch did not cover.

### Revived from #2280

- Emit `audio_backfill_ready` after interrupted lesson runs so live listen mode can request audio before a history refresh.
- Project interaction answer feedback into listen narration; feedback arrives nested inside `ask_list` and was structurally unable to carry audio.
- Fall back to the submitted interaction as the live ask/answer anchor when SSE feedback elements omit an explicit anchor payload, so live feedback is no longer silently discarded.
- Scan the projected listen list, not the raw items, when looking for blocks missing audio.
- Keep resolved interaction slide elements stable when feedback narration is appended, so playback continues instead of remounting.
- Mark the answered question resolved by block id. For a variable-free interaction `variableName` is `undefined`, so the previous `content.includes(variableName || '')` matched indiscriminately.

### New in this PR

`requestAudioForBlock` conflated "never attempted" with "failed": de-duplication against an in-flight stream, supersession by a lesson switch, and cancellation all resolved to `null`, and the caller blacklisted every `null` permanently. The blacklist was only cleared on a lesson change, so a single cancellation silenced a block for the rest of the lesson.

It now resolves to `undefined` for never-attempted requests and reserves `null` for genuine synthesis failures; only `null` is blacklisted.

## Conflict resolution

One hunk in `NewChatComp.tsx`. `main` added read-mode typewriter suppression on `visibilitychange`; the branch hoisted the `slideModeItems` projection above `visibleReadModeItems` because the audio backfill path consumes it. The two are semantically disjoint, so both sides are kept. Verified there is exactly one `slideModeItems` definition after the merge.

## Verification

- `npx jest src/app/c/` — 28 suites, 335 tests pass
- `npx tsc --noEmit` — clean
- `lefthook run pre-commit --all-files` — all checks pass
- Added a test pinning the skipped-vs-failed contract: a de-duplicated request and a cancelled stream both resolve to `undefined`

## Scope

This addresses the playback and backfill side. Two related issues are tracked separately:

1. MarkdownFlow interaction syntax is never stripped from TTS input, so `?[A | B | C]` fragments get synthesized and read aloud. Confirmed in production: 204 of 48332 recent final text elements contain `?[`, 26 of them already have synthesized audio. Backend fix to follow.
2. `markdown-flow-ui` resets `hasCompletedCurrentStepAudio` only when the step index or interaction content changes, so audio arriving late within one step never starts. The mechanism is present in the pinned 0.2.9. Note this needs two or more speakable text elements in a single step to trigger, which the reported lesson does not produce — tracked as a separate hardening item rather than a fix for this report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved listen mode with more reliable audio backfill for generated content and interaction feedback.
  * Added narration support for eligible answer feedback and visible HTML slide content.
  * Preserved audio playback state across updates and prevented duplicate or superseded audio requests.

* **Bug Fixes**
  * Fixed transaction timing for pending audio notifications.
  * Improved handling of cancellations, nested interactions, regenerated content, and missing audio.

* **Tests**
  * Added regression coverage for audio backfill, feedback narration, caching, cancellation, and HTML content filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->