### PR TITLE
fix: strip markdownflow syntax from tts input

### DIFF
--- a/src/api/flaskr/service/tts/__init__.py
+++ b/src/api/flaskr/service/tts/__init__.py
@@ -20,6 +20,9 @@ from flaskr.service.tts.patterns import (
     IMAGE_MD,
     LINK,
     LIST_MARKER,
+    MDFLOW_INTERACTION,
+    MDFLOW_INTERACTION_INCOMPLETE,
+    MDFLOW_VARIABLE,
     MERMAID_BLOCK,
     MULTI_NEWLINE,
     MULTI_SPACE,
@@ -182,6 +185,14 @@ def _strip_incomplete_blocks(text: str) -> tuple[str, bool]:
     text, removed = _strip_incomplete_markdown_image(text)
     had_incomplete = had_incomplete or removed
 
+    # Strip a trailing unclosed MarkdownFlow interaction block (e.g. `?[A | B`).
+    # A streaming chunk can end mid-block, and speaking half an option list is
+    # worse than waiting for the closing bracket.
+    stripped_interaction = MDFLOW_INTERACTION_INCOMPLETE.sub("", text)
+    if stripped_interaction != text:
+        text = stripped_interaction
+        had_incomplete = True
+
     return text, had_incomplete
 
 
@@ -239,6 +250,16 @@ def preprocess_for_tts(text: str) -> str:
     # Remove any remaining angle bracket content that looks like tags
     # This catches malformed or partial SVG/HTML
     text = ANY_HTML_TAG.sub("", text)
+
+    # Remove MarkdownFlow authoring syntax. Interaction blocks carry the
+    # learner's answer options, not narration, so speaking them reads out
+    # choices such as "concept still fuzzy | often miscalculates" as if they
+    # were part of the lesson. Runs before the markdown rules below so that
+    # `LINK`/`BOLD_ITALIC` cannot rewrite a block into speakable-looking text.
+    text = MDFLOW_INTERACTION.sub("", text)
+
+    # Remove unresolved variable placeholders (`%{{var}}` / `{{var}}`).
+    text = MDFLOW_VARIABLE.sub("", text)
 
     # Remove markdown headers (keep the text)
     text = HEADER.sub("", text)

--- a/src/api/flaskr/service/tts/patterns.py
+++ b/src/api/flaskr/service/tts/patterns.py
@@ -31,7 +31,11 @@ ANY_HTML_TAG = re.compile(r"<[^>]*>")
 # `?[label//value]`, `?[]`. Option text is the learner's choice, not narration,
 # so the whole block is dropped rather than flattened into speech.
 # LINK above only matches `[text](url)`, so it never covers these.
-MDFLOW_INTERACTION = re.compile(r"\?\[[^\[\]]*\]")
+# The negative lookahead hands a markdown link that merely follows a question
+# mark (`?[label](url)`) over to LINK instead. Without it the label would be
+# dropped here and the orphaned `(url)` would survive every later rule and end
+# up being read aloud.
+MDFLOW_INTERACTION = re.compile(r"\?\[[^\[\]]*\](?!\()")
 # A trailing interaction block that has not been closed yet. Streaming chunks
 # can split mid-block, and half of one must not reach the synthesizer.
 MDFLOW_INTERACTION_INCOMPLETE = re.compile(r"\?\[[^\[\]]*\Z")

--- a/src/api/flaskr/service/tts/patterns.py
+++ b/src/api/flaskr/service/tts/patterns.py
@@ -24,6 +24,21 @@ MULTI_NEWLINE = re.compile(r"\n{3,}")
 MULTI_SPACE = re.compile(r"[ \t]+")
 ANY_HTML_TAG = re.compile(r"<[^>]*>")
 
+# ---------------------------------------------------------------------------
+# MarkdownFlow authoring syntax (never speak these aloud)
+# ---------------------------------------------------------------------------
+# Interaction blocks: `?[A | B | C]`, `?[%{{var}} A | B]`, `?[...prompt]`,
+# `?[label//value]`, `?[]`. Option text is the learner's choice, not narration,
+# so the whole block is dropped rather than flattened into speech.
+# LINK above only matches `[text](url)`, so it never covers these.
+MDFLOW_INTERACTION = re.compile(r"\?\[[^\[\]]*\]")
+# A trailing interaction block that has not been closed yet. Streaming chunks
+# can split mid-block, and half of one must not reach the synthesizer.
+MDFLOW_INTERACTION_INCOMPLETE = re.compile(r"\?\[[^\[\]]*\Z")
+# Variable placeholders: `%{{preserved}}` and `{{replaceable}}`. An unresolved
+# placeholder is authoring syntax, not something to read out.
+MDFLOW_VARIABLE = re.compile(r"%?\{\{[^{}]*\}\}")
+
 # Stray SVG text elements (malformed streaming fragments)
 SVG_TEXT_TAGS = [
     re.compile(rf"<{tag}\b[^>]*>[\s\S]*?</{tag}>", re.IGNORECASE)

--- a/src/api/tests/service/tts/test_tts_text_preprocess.py
+++ b/src/api/tests/service/tts/test_tts_text_preprocess.py
@@ -250,17 +250,20 @@ def test_preprocess_for_tts_removes_interaction_block_variants(app):
 
     from flaskr.service.tts import preprocess_for_tts
 
-    for block in (
-        "?[下一节//_sys_next_chapter]",
-        "?[...填写例子]",
-        "?[填写形式]",
-        "?[]",
+    # Assert each payload is gone, not just the `?[` marker: a regression could
+    # leave the option text behind and still satisfy a marker-only check.
+    for block, forbidden in (
+        ("?[下一节//_sys_next_chapter]", ("下一节", "_sys_next_chapter")),
+        ("?[...填写例子]", ("填写例子",)),
+        ("?[填写形式]", ("填写形式",)),
+        ("?[]", ()),
     ):
         cleaned = preprocess_for_tts(f"讲解正文。\n\n{block}")
 
         assert "讲解正文。" in cleaned
         assert "?[" not in cleaned
-        assert "_sys_next_chapter" not in cleaned
+        for fragment in forbidden:
+            assert fragment not in cleaned
 
 
 def test_preprocess_for_tts_strips_incomplete_interaction_tail(app):
@@ -302,3 +305,19 @@ def test_preprocess_for_tts_keeps_regular_markdown_links(app):
 
     assert "官方文档" in cleaned
     assert "example.com" not in cleaned
+
+
+def test_preprocess_for_tts_keeps_markdown_link_directly_after_question_mark(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    # `?[label](url)` is a markdown link preceded by a question mark, not an
+    # interaction block. Dropping just the label would strand the URL, and the
+    # synthesizer would spell the address out loud.
+    text = "想了解更多吗?[官方文档](https://example.com/docs)。"
+    cleaned = preprocess_for_tts(text)
+
+    assert "官方文档" in cleaned
+    assert "example.com" not in cleaned
+    assert "https" not in cleaned

--- a/src/api/tests/service/tts/test_tts_text_preprocess.py
+++ b/src/api/tests/service/tts/test_tts_text_preprocess.py
@@ -210,3 +210,95 @@ def test_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch):
     assert any("这是后续讲解。" in t for t in captured)
     assert all("picx.zhimg.com" not in t for t in captured)
     assert all("![" not in t for t in captured)
+
+
+def test_preprocess_for_tts_removes_interaction_block(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    # Real production content: the interaction block leaked into the narrated
+    # text element and its options were synthesized as if they were lesson text.
+    text = (
+        "好，咱们先不急着背，先看看你现在的底子在哪。你心里最没底的是哪一块？\n\n"
+        "?[概念还含糊 | 会算但老错 | 几乎空白]"
+    )
+    cleaned = preprocess_for_tts(text)
+
+    assert "你心里最没底的是哪一块？" in cleaned
+    assert "?[" not in cleaned
+    assert "概念还含糊" not in cleaned
+    assert "几乎空白" not in cleaned
+
+
+def test_preprocess_for_tts_removes_interaction_block_with_variable(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    text = "这节讲完了。\n\n?[%{{l04_check}} 概念清楚了 | 会做题了 | 还得再练]"
+    cleaned = preprocess_for_tts(text)
+
+    assert "这节讲完了。" in cleaned
+    assert "?[" not in cleaned
+    assert "l04_check" not in cleaned
+    assert "概念清楚了" not in cleaned
+
+
+def test_preprocess_for_tts_removes_interaction_block_variants(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    for block in (
+        "?[下一节//_sys_next_chapter]",
+        "?[...填写例子]",
+        "?[填写形式]",
+        "?[]",
+    ):
+        cleaned = preprocess_for_tts(f"讲解正文。\n\n{block}")
+
+        assert "讲解正文。" in cleaned
+        assert "?[" not in cleaned
+        assert "_sys_next_chapter" not in cleaned
+
+
+def test_preprocess_for_tts_strips_incomplete_interaction_tail(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    # A streaming chunk can end mid-block; half an option list must not be read.
+    text = "先摸个底。\n\n?[概念还含糊 | 会算但"
+    cleaned = preprocess_for_tts(text)
+
+    assert cleaned == "先摸个底。"
+    assert "?[" not in cleaned
+    assert "概念还含糊" not in cleaned
+
+
+def test_preprocess_for_tts_removes_unresolved_variable_placeholders(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    text = "同学 {{sys_user_nickname}} 你好，欢迎回来 %{{preserved}}。"
+    cleaned = preprocess_for_tts(text)
+
+    assert "你好" in cleaned
+    assert "{{" not in cleaned
+    assert "sys_user_nickname" not in cleaned
+    assert "preserved" not in cleaned
+
+
+def test_preprocess_for_tts_keeps_regular_markdown_links(app):
+    _require_app(app)
+
+    from flaskr.service.tts import preprocess_for_tts
+
+    # `?[` is MarkdownFlow syntax; a plain markdown link must keep its label.
+    text = "详见 [官方文档](https://example.com/docs)。"
+    cleaned = preprocess_for_tts(text)
+
+    assert "官方文档" in cleaned
+    assert "example.com" not in cleaned


### PR DESCRIPTION
## Problem

TTS reads MarkdownFlow authoring syntax aloud. When an interaction block reaches a narrated text element, the synthesizer speaks the answer options as if they were lesson content, so the audio does not match what is on screen.

Confirmed in production. Of the last 30 days of finalized text elements, 204 out of 48332 contain `?[`, and 26 of those already have synthesized audio. Two of the captured elements were narrated with nothing but an option label as their entire content:

- `专用计算机` — an option from `?[ATM 取款机、红绿灯控制器属于？ | 通用计算机 | 专用计算机 | 巨型机]`
- `概念清楚了` — an option from `?[%{{l04_check}} 概念清楚了 | 会做题了 | 还得再练]`

`preprocess_for_tts` strips code blocks, mermaid, SVG, XML, HTML tags, headers, images, links, emphasis, list markers and data URIs, but had no rule for MarkdownFlow syntax at all. `LINK` only matches `[text](url)`, so it never covered `?[A | B | C]`.

## Change

- Add `MDFLOW_INTERACTION`, `MDFLOW_INTERACTION_INCOMPLETE` and `MDFLOW_VARIABLE` to the TTS pattern module.
- Drop complete interaction blocks and unresolved `%{{var}}` / `{{var}}` placeholders in `preprocess_for_tts`, before the markdown rules so `LINK`/`BOLD_ITALIC` cannot rewrite a block into speakable-looking text.
- Strip a trailing unclosed interaction block in `_strip_incomplete_blocks`, next to the existing incomplete fence/SVG/image handling. A streaming chunk can end mid-block, and speaking half an option list is worse than waiting for the closing bracket.

Interaction blocks are dropped whole rather than flattened, because the option text is the learner's choice, not narration.

## Scope

This is the last line of defense, and it is deliberately independent of why the syntax leaks into a text element in the first place. The upstream question — whether `markdown_flow` classifies a trailing `?[...]` as `text` during streaming, and that the run path lacks the `transformed_to_interaction` check the preview path has in `_preview_events_from_result` — is worth a separate look. This change makes the audio correct regardless of how that is resolved.

Existing rows are not touched here; backfilling `is_speakable` on the 204 affected rows and invalidating the 26 synthesized clips belongs in a separate data script.

## Verification

- `pytest tests/service/tts/ tests/service/shifu/test_tts_preview_helper.py` — 213 pass
- `pytest tests/service/learn/` — 431 pass, 5 skipped
- `lefthook run pre-commit --all-files` — all checks pass
- Six new cases cover plain, variable-carrying, `//value`, ellipsis and empty interaction blocks, an unclosed streaming tail, placeholder removal, and a regression guard that plain markdown links keep their label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text-to-speech preprocessing for MarkdownFlow content.
  * Interaction blocks and unresolved variable placeholders are excluded from spoken output.
  * Incomplete interaction blocks are safely removed during streaming cleanup.
  * Markdown links retain their readable labels while excluding URLs from speech.

* **Bug Fixes**
  * Prevented authoring syntax, empty blocks, and unresolved placeholders from being read aloud.
  * Added coverage for variable-bearing, placeholder, empty, and incomplete interaction blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->