### PR TITLE
chore: put ruff to full use with zero-risk changes

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -108,15 +108,14 @@ select = [
     "DTZ",   # flake8-datetimez (DTZ001/DTZ007/DTZ901 ignored below)
 
     # --- Partially selected groups -----------------------------------------
-    # flake8-builtins -- off: A001, A002, A006
-    "A003", "A004", "A005",
+    # flake8-builtins -- off: A001, A002
+    "A003", "A004", "A005", "A006",
+    # flake8-unused-arguments -- off: ARG001, ARG002, ARG004
+    "ARG003", "ARG005",
     # flake8-async -- off: ASYNC230
     "ASYNC1", "ASYNC21", "ASYNC22", "ASYNC24", "ASYNC25",
-    # flake8-bugbear -- off: B006, B017, B023, B026, B035, B904
-    "B002", "B003", "B004", "B005", "B007", "B008", "B009", "B010", "B011",
-    "B012", "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021",
-    "B022", "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032",
-    "B033", "B034", "B039", "B905", "B91",
+    # flake8-bugbear -- off: B904
+    "B0", "B905", "B91",
     # flake8-comprehensions -- off: C901
     "C4",
     # flake8-commas -- off: COM812, COM819
@@ -139,15 +138,15 @@ select = [
     "ISC001", "ISC003",
     # flake8-logging -- off: LOG014
     "LOG00", "LOG015",
-    # pep8-naming -- off: N801, N802, N803, N806, N813, N815, N818
-    "N804", "N805", "N807", "N811", "N812", "N814", "N816", "N817", "N9",
+    # pep8-naming -- off: N802, N803, N806, N813, N815, N818
+    "N801", "N804", "N805", "N807", "N811", "N812", "N814", "N816", "N817",
+    "N9",
     # Perflint -- off: PERF203, PERF401
     "PERF1", "PERF402", "PERF403",
     # pygrep-hooks -- off: PGH003
     "PGH004", "PGH005",
-    # Pylint conventions -- off: PLC0206, PLC0415
-    "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC0414", "PLC1", "PLC2",
-    "PLC3",
+    # Pylint conventions -- off: PLC0415
+    "PLC01", "PLC02", "PLC0414", "PLC1", "PLC2", "PLC3",
     # Pylint refactors -- off: PLR0911, PLR0912, PLR0913, PLR0915, PLR0917,
     # PLR2004
     "PLR01", "PLR02", "PLR0402", "PLR17", "PLR204", "PLR5",
@@ -165,14 +164,14 @@ select = [
     # flake8-return -- off: RET503
     "RET501", "RET502", "RET504", "RET505", "RET506", "RET507", "RET508",
     # Ruff-specific rules -- off: RUF001, RUF002, RUF003, RUF006, RUF012,
-    # RUF013, RUF043, RUF100
+    # RUF013, RUF100
     "RUF005", "RUF007", "RUF008", "RUF009", "RUF010", "RUF015", "RUF016",
-    "RUF017", "RUF018", "RUF019", "RUF02", "RUF03", "RUF040", "RUF041",
-    "RUF046", "RUF048", "RUF049", "RUF05", "RUF06", "RUF101", "RUF102",
-    "RUF103", "RUF104", "RUF2",
-    # flake8-bandit -- off: S101, S104, S105, S106, S107, S108, S110, S112,
-    # S113, S310, S311, S324, S603, S605, S607, S608
-    "S102", "S103", "S2", "S30", "S312", "S313", "S314", "S315", "S316",
+    "RUF017", "RUF018", "RUF019", "RUF02", "RUF03", "RUF04", "RUF05", "RUF06",
+    "RUF101", "RUF102", "RUF103", "RUF104", "RUF2",
+    # flake8-bandit -- off: S104, S105, S108, S110, S112, S113, S310, S311,
+    # S324, S603, S605, S607, S608
+    "S101", "S102", "S103", "S106", "S107",
+    "S2", "S30", "S312", "S313", "S314", "S315", "S316",
     "S317", "S318", "S319", "S321", "S323", "S5", "S601", "S602", "S604",
     "S606", "S609", "S61", "S7",
     # flake8-simplify -- off: SIM102, SIM105, SIM108, SIM115, SIM117
@@ -202,4 +201,20 @@ ignore = [
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "DTZ901",  # datetime.min/max -- naive UTC is the house convention
     "E501",    # line length is owned by the formatter
+]
+
+# Rules that only ever fire in test or tooling code, carved out per directory so
+# they stay enforced for the served backend. Without these carve-outs the rules
+# could not be selected at all.
+[lint.per-file-ignores]
+"src/api/tests/**" = [
+    "A006",    # `id`/`type` lambda parameters in stubs mirror the API being faked
+    "ARG003",  # fake classes keep the signature of the class they stand in for
+    "ARG005",  # patch targets are replaced by lambdas that ignore their arguments
+    "S101",    # a pytest suite asserts by design
+    "S106",    # fixtures pass obvious dummy credentials
+    "S107",    # fixtures default to obvious dummy credentials
+]
+"scripts/**" = [
+    "S101",    # the repo-maintenance scripts assert their own invariants
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -79,8 +79,10 @@ select = [
     "INT",   # flake8-gettext
     "NPY",   # NumPy-specific rules
     "PD",    # pandas-vet
+    "PIE",   # flake8-pie
     "PLE",   # Pylint errors
     "PYI",   # flake8-pyi
+    "RSE",   # flake8-raise
     "SLOT",  # flake8-slots
     "YTT",   # flake8-2020
 
@@ -98,9 +100,8 @@ select = [
     "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021", "B022",
     "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032", "B033",
     "B034", "B039", "B905", "B91",
-    # flake8-comprehensions -- off: C401, C408, C414, C416, C901
-    "C400", "C402", "C403", "C404", "C405", "C406", "C409", "C410", "C411",
-    "C413", "C415", "C417", "C418", "C419", "C42",
+    # flake8-comprehensions -- off: C901
+    "C4",
     # flake8-commas -- off: COM812, COM819
     "COM818",
     # pydocstyle -- off: D100, D101, D102, D103, D104, D105, D107, D203, D205,
@@ -112,9 +113,9 @@ select = [
     "EM103",
     # flake8-fixme -- off: FIX002
     "FIX001", "FIX003", "FIX004",
-    # refurb -- off: FURB110, FURB157, FURB171, FURB187, FURB192
-    "FURB10", "FURB116", "FURB12", "FURB13", "FURB16", "FURB177", "FURB181",
-    "FURB188",
+    # refurb -- off: FURB157
+    "FURB10", "FURB11", "FURB12", "FURB13", "FURB16", "FURB17", "FURB18",
+    "FURB19",
     # flake8-logging-format -- off: G001, G003, G004
     "G002", "G01", "G1", "G2",
     # flake8-implicit-str-concat -- off: ISC002, ISC004
@@ -123,22 +124,19 @@ select = [
     "LOG00", "LOG015",
     # pep8-naming -- off: N801, N802, N803, N806, N813, N815, N818
     "N804", "N805", "N807", "N811", "N812", "N814", "N816", "N817", "N9",
-    # Perflint -- off: PERF102, PERF203, PERF401
-    "PERF101", "PERF402", "PERF403",
+    # Perflint -- off: PERF203, PERF401
+    "PERF1", "PERF402", "PERF403",
     # pygrep-hooks -- off: PGH003, PGH004
     "PGH005",
-    # flake8-pie -- off: PIE810
-    "PIE7", "PIE80",
     # Pylint conventions -- off: PLC0206, PLC0414, PLC0415
     "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC1", "PLC2", "PLC3",
     # Pylint refactors -- off: PLR0402, PLR0911, PLR0912, PLR0913, PLR0915,
-    # PLR0917, PLR1714, PLR2004
-    "PLR01", "PLR02", "PLR170", "PLR1711", "PLR1716", "PLR172", "PLR173",
-    "PLR204", "PLR5",
+    # PLR0917, PLR2004
+    "PLR01", "PLR02", "PLR17", "PLR204", "PLR5",
     # Pylint warnings -- off: PLW0108, PLW0127, PLW0602, PLW0603, PLW1641,
-    # PLW2901, PLW3301
+    # PLW2901
     "PLW0120", "PLW0128", "PLW0129", "PLW013", "PLW017", "PLW02", "PLW04",
-    "PLW0604", "PLW064", "PLW07", "PLW15", "PLW21",
+    "PLW0604", "PLW064", "PLW07", "PLW15", "PLW21", "PLW3",
     # flake8-pytest-style -- off: PT006, PT009, PT011, PT012, PT013, PT017,
     # PT018, PT022, PT027
     "PT001", "PT002", "PT003", "PT007", "PT008", "PT010", "PT014", "PT015",
@@ -161,10 +159,9 @@ select = [
     "S102", "S103", "S2", "S30", "S312", "S313", "S314", "S315", "S316",
     "S317", "S318", "S319", "S321", "S323", "S5", "S601", "S602", "S604",
     "S606", "S609", "S61", "S7",
-    # flake8-simplify -- off: SIM102, SIM103, SIM105, SIM108, SIM115, SIM117,
-    # SIM118, SIM210, SIM212, SIM401
-    "SIM101", "SIM107", "SIM109", "SIM110", "SIM112", "SIM113", "SIM114",
-    "SIM116", "SIM20", "SIM211", "SIM22", "SIM3", "SIM9",
+    # flake8-simplify -- off: SIM102, SIM105, SIM108, SIM115, SIM117
+    "SIM101", "SIM103", "SIM107", "SIM109", "SIM110", "SIM112", "SIM113",
+    "SIM114", "SIM116", "SIM118", "SIM2", "SIM3", "SIM4", "SIM9",
     # flake8-debugger -- off: T201
     "T1", "T203",
     # flake8-type-checking -- off: TC001, TC002, TC003

--- a/ruff.toml
+++ b/ruff.toml
@@ -143,8 +143,8 @@ select = [
     "N804", "N805", "N807", "N811", "N812", "N814", "N816", "N817", "N9",
     # Perflint -- off: PERF203, PERF401
     "PERF1", "PERF402", "PERF403",
-    # pygrep-hooks -- off: PGH003, PGH004
-    "PGH005",
+    # pygrep-hooks -- off: PGH003
+    "PGH004", "PGH005",
     # Pylint conventions -- off: PLC0206, PLC0415
     "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC0414", "PLC1", "PLC2",
     "PLC3",
@@ -154,11 +154,9 @@ select = [
     # Pylint warnings -- off: PLW0108, PLW0603, PLW1641, PLW2901
     "PLW012", "PLW013", "PLW017", "PLW02", "PLW04", "PLW0602", "PLW0604",
     "PLW064", "PLW07", "PLW15", "PLW21", "PLW3",
-    # flake8-pytest-style -- off: PT006, PT009, PT011, PT012, PT013, PT017,
-    # PT018, PT022, PT027
-    "PT001", "PT002", "PT003", "PT007", "PT008", "PT010", "PT014", "PT015",
-    "PT016", "PT019", "PT020", "PT021", "PT023", "PT024", "PT025", "PT026",
-    "PT028", "PT03",
+    # flake8-pytest-style -- off: PT009, PT011, PT012
+    "PT001", "PT002", "PT003", "PT006", "PT007", "PT008", "PT010", "PT013",
+    "PT014", "PT015", "PT016", "PT017", "PT018", "PT019", "PT02", "PT03",
     # flake8-use-pathlib -- off: PTH100, PTH103, PTH106, PTH107, PTH109,
     # PTH110, PTH112, PTH118, PTH119, PTH120, PTH123, PTH206, PTH208
     "PTH101", "PTH102", "PTH104", "PTH105", "PTH108", "PTH111", "PTH113",
@@ -191,11 +189,11 @@ select = [
     # tryceratops -- off: TRY002, TRY003, TRY004, TRY203, TRY300, TRY301,
     # TRY400, TRY401
     "TRY201",
-    # pyupgrade -- off: UP006, UP007, UP028, UP031, UP035, UP037, UP045
+    # pyupgrade -- off: UP006, UP007, UP031, UP035, UP045
     "UP001", "UP003", "UP004", "UP005", "UP008", "UP009", "UP01", "UP020",
-    "UP021", "UP022", "UP023", "UP024", "UP025", "UP026", "UP029", "UP030",
-    "UP032", "UP033", "UP034", "UP036", "UP039", "UP040", "UP041", "UP042",
-    "UP043", "UP044", "UP046", "UP047", "UP049", "UP05",
+    "UP021", "UP022", "UP023", "UP024", "UP025", "UP026", "UP028", "UP029",
+    "UP030", "UP032", "UP033", "UP034", "UP036", "UP037", "UP039", "UP040",
+    "UP041", "UP042", "UP043", "UP044", "UP046", "UP047", "UP049", "UP05",
     # pycodestyle warnings -- off: W191
     "W2", "W5", "W6",
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,6 +11,10 @@
 # have violations. Those `off` lists are the backlog for future clean-ups: fix
 # the code, then move the rule code into `select`.
 #
+# A few rules only ever fire in test or tooling code. Those are selected and
+# carved out per directory under `[lint.per-file-ignores]`, so the rule still
+# guards the served backend instead of being dropped entirely.
+#
 # Rules the repo already satisfies but that stay off on purpose:
 # - Formatter-owned rules, per Ruff's own "conflicting lint rules" list: W191,
 #   D206, D300, Q000-Q004, COM819, ISC002. Enforcing them would fight
@@ -58,8 +62,9 @@
 # - D100-D107, D400, D415, D205: the missing-docstring and docstring-wording
 #   rules would either require bulk new prose or rewrite the summary text that
 #   flasgger publishes as the API description.
-# - S101: the pytest suites assert by design, so the rule cannot be enforced
-#   repo-wide without per-directory carve-outs.
+# - UP031: the `%`-formatted strings it flags are raw SQL statements. Rewriting
+#   them with `.format()` makes the interpolation no safer and only pushes the
+#   statement past the line limit.
 # - RET503: the functions it flags end in `raise_error()` / `raise_param_error()`,
 #   which always raise. Ruff does not follow `NoReturn` across modules, so its
 #   fix would append an unreachable `return None` to each of them.
@@ -70,10 +75,13 @@
 # - FLY002: the `"\n".join([...])` calls it flags build provider signing
 #   payloads, where the list form documents the canonical layout line by line
 #   better than an f-string full of `\n` escapes.
-# - The remaining SIM / UP / PL / PTH / TRY members listed as `off` below:
-#   style or modernization churn with no bug-catching value for this codebase
-#   today. Members that are mechanical and behavior-preserving get folded in
-#   one commit at a time, after applying the fix repo-wide.
+# - SIM115 / PTH*: the remaining `open(...)` and `os.path` call sites are in the
+#   one-off inventory scripts under `src/api/scripts/`; moving them to pathlib
+#   and context managers is a rewrite of those scripts, not a local fix.
+# - The remaining SIM / UP / PL / TRY members listed as `off` below: style or
+#   modernization churn with no bug-catching value for this codebase today.
+#   Members that are mechanical and behavior-preserving get folded in one commit
+#   at a time, after applying the fix repo-wide.
 
 # `target-version` states the version Ruff already resolves to today, so a Ruff
 # release cannot move it. It gates the rules that rewrite code into newer syntax

--- a/ruff.toml
+++ b/ruff.toml
@@ -75,6 +75,13 @@
 #   today. Members that are mechanical and behavior-preserving get folded in
 #   one commit at a time, after applying the fix repo-wide.
 
+# `target-version` states the version Ruff already resolves to today, so a Ruff
+# release cannot move it. It gates the rules that rewrite code into newer syntax
+# (UP017 `datetime.UTC`, FURB162, UP042 `StrEnum`, UP040 `type X = ...`), and
+# pinning it keeps those rewrites from landing on their own and raising the
+# minimum interpreter the backend needs.
+target-version = "py310"
+
 [lint]
 select = [
     # --- Groups where every stable rule is already satisfied ---------------
@@ -159,11 +166,12 @@ select = [
     "PTH201", "PTH202", "PTH203", "PTH204", "PTH205", "PTH207", "PTH21",
     # flake8-return -- off: RET503
     "RET501", "RET502", "RET504", "RET505", "RET506", "RET507", "RET508",
-    # Ruff-specific rules -- off: RUF001, RUF002, RUF003, RUF005, RUF006,
-    # RUF007, RUF012, RUF013, RUF043, RUF046, RUF100
-    "RUF008", "RUF009", "RUF010", "RUF015", "RUF016", "RUF017", "RUF018",
-    "RUF019", "RUF02", "RUF03", "RUF040", "RUF041", "RUF048", "RUF049",
-    "RUF05", "RUF06", "RUF101", "RUF102", "RUF103", "RUF104", "RUF2",
+    # Ruff-specific rules -- off: RUF001, RUF002, RUF003, RUF006, RUF012,
+    # RUF013, RUF043, RUF100
+    "RUF005", "RUF007", "RUF008", "RUF009", "RUF010", "RUF015", "RUF016",
+    "RUF017", "RUF018", "RUF019", "RUF02", "RUF03", "RUF040", "RUF041",
+    "RUF046", "RUF048", "RUF049", "RUF05", "RUF06", "RUF101", "RUF102",
+    "RUF103", "RUF104", "RUF2",
     # flake8-bandit -- off: S101, S104, S105, S106, S107, S108, S110, S112,
     # S113, S310, S311, S324, S603, S605, S607, S608
     "S102", "S103", "S2", "S30", "S312", "S313", "S314", "S315", "S316",
@@ -183,11 +191,11 @@ select = [
     # tryceratops -- off: TRY002, TRY003, TRY004, TRY203, TRY300, TRY301,
     # TRY400, TRY401
     "TRY201",
-    # pyupgrade -- off: UP006, UP007, UP022, UP028, UP031, UP035, UP037, UP045
+    # pyupgrade -- off: UP006, UP007, UP028, UP031, UP035, UP037, UP045
     "UP001", "UP003", "UP004", "UP005", "UP008", "UP009", "UP01", "UP020",
-    "UP021", "UP023", "UP024", "UP025", "UP026", "UP029", "UP030", "UP032",
-    "UP033", "UP034", "UP036", "UP039", "UP040", "UP041", "UP042", "UP043",
-    "UP044", "UP046", "UP047", "UP049", "UP05",
+    "UP021", "UP022", "UP023", "UP024", "UP025", "UP026", "UP029", "UP030",
+    "UP032", "UP033", "UP034", "UP036", "UP039", "UP040", "UP041", "UP042",
+    "UP043", "UP044", "UP046", "UP047", "UP049", "UP05",
     # pycodestyle warnings -- off: W191
     "W2", "W5", "W6",
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -148,9 +148,9 @@ select = [
     # Pylint conventions -- off: PLC0206, PLC0415
     "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC0414", "PLC1", "PLC2",
     "PLC3",
-    # Pylint refactors -- off: PLR0402, PLR0911, PLR0912, PLR0913, PLR0915,
-    # PLR0917, PLR2004
-    "PLR01", "PLR02", "PLR17", "PLR204", "PLR5",
+    # Pylint refactors -- off: PLR0911, PLR0912, PLR0913, PLR0915, PLR0917,
+    # PLR2004
+    "PLR01", "PLR02", "PLR0402", "PLR17", "PLR204", "PLR5",
     # Pylint warnings -- off: PLW0108, PLW0603, PLW1641, PLW2901
     "PLW012", "PLW013", "PLW017", "PLW02", "PLW04", "PLW0602", "PLW0604",
     "PLW064", "PLW07", "PLW15", "PLW21", "PLW3",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,16 +1,40 @@
 # Repo-wide Ruff configuration (used by lefthook.yml and .github/workflows/lint.yml).
 #
-# The lint rule set is pinned explicitly. Ruff 0.16 broadened its built-in
-# default rule selection, which would surface thousands of new violations
-# across this repo; pinning keeps the enforced rule set stable and independent
-# of the installed Ruff version. Widening the rule set is a deliberate
-# decision, not a side effect of a version bump.
+# Policy: enforce every stable Ruff rule that the repository already satisfies,
+# and nothing else. The rule set is written out explicitly rather than inherited
+# from Ruff's built-in defaults, so a Ruff version bump can neither silently
+# widen nor narrow what is enforced; widening stays a deliberate change.
 #
-# Whole groups are selected only where every rule in the group is already
-# satisfied repo-wide; the individually listed rules below are the members of
-# groups that stay off as a whole (selecting their group would surface new
-# violations). The `ignore` block carves out the few members of an otherwise
-# fully selected group that conflict with house conventions.
+# A whole group is selected only where every stable rule in the group is already
+# satisfied repo-wide. Elsewhere the satisfied members are listed individually,
+# and the `-- off:` comment on each of those blocks names the members that still
+# have violations. Those `off` lists are the backlog for future clean-ups: fix
+# the code, then move the rule code into `select`.
+#
+# Rules the repo already satisfies but that stay off on purpose:
+# - Formatter-owned rules, per Ruff's own "conflicting lint rules" list: W191,
+#   D206, D300, Q000-Q004, COM819, ISC002. Enforcing them would fight
+#   `ruff format`, which owns quoting, indentation, and trailing commas.
+# - D203 and D213: Ruff reports both as incompatible with D211 / D212, which are
+#   the formatter-compatible members of those pairs and are selected instead.
+# - The numpydoc section rules D214, D215, D405-D410, D412, D414, D416. Route
+#   docstrings carry the flasgger/Swagger spec after a `---` line, and these
+#   rules read YAML keys such as `parameters:` as numpydoc section headers.
+#   Their fixes strip the colon or insert a dashed underline, which turns the
+#   embedded spec into invalid YAML and breaks the generated API docs. D209 /
+#   D211 / D212 / D403 / D411 / D413 are safe here because they never rewrite a
+#   line inside the YAML block, and D207 / D208 only ever dedent the docstring
+#   uniformly, which preserves the relative indentation YAML depends on.
+# - RUF100: the repo carries deliberate `# noqa: BLE001 / DTZ001 / SLF001`
+#   markers, and Ruff reports a `noqa` for a rule that is not enforced as
+#   unused, so enforcing RUF100 would delete documentation of intentional
+#   exceptions. Stale directives are pruned by hand instead.
+#
+# Some selected groups are inert today and guard future code instead: AIR, DJ,
+# FAST, NPY, and PD only fire in files that import the matching framework, ICN
+# and INT key off import conventions and gettext calls, and TID251 / TID253 /
+# W505 need a `banned-api`, `banned-module-level-imports`, or `max-doc-length`
+# setting before they can fire.
 #
 # DTZ selection is intentionally partial. The repo's UTC contract (AGENTS.md)
 # stores naive-UTC datetimes and provides `now_utc()` as the sanctioned naive
@@ -22,8 +46,8 @@
 # which are exactly the UTC-vs-local drifts the contract forbids; use
 # `now_utc()` instead.
 #
-# Other rule groups from ruff 0.16's broadened defaults were evaluated and
-# deliberately left off:
+# Notable rules that stay off because the code does not satisfy them, and where
+# conforming would be churn rather than a fix:
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
 #   tuples/lists, not a missed comma.
 # - BLE001 / S110 / S112: blind/except-pass handlers are deliberate fail-open
@@ -31,66 +55,134 @@
 # - G001 / G003 / G004: f-string logging is the established house style; the
 #   lazy-%-formatting argument does not outweigh the churn. G201 IS enabled --
 #   `.exception(...)` is strictly equivalent to `.error(..., exc_info=True)`.
-# - SIM* / RUF012 / RUF013 / RUF046 / UP* as whole groups: style or
-#   modernization churn with no bug-catching value for this codebase today.
-#   Individual members that are mechanical and behavior-preserving are listed
-#   in the select block below; the rest stay off.
-# - RUF100: with a narrow select list, ruff reports deliberate `# noqa:
-#   BLE001 / DTZ001 / SLF001 / S102` markers as unused simply because those
-#   rules are off here, so enforcing it would delete documentation of
-#   intentional exceptions. Stale directives are pruned by hand instead.
-# - D405 / D406 / D407: route docstrings carry the flasgger/Swagger spec after
-#   a `---` line, and these rules read YAML keys such as `parameters:` as
-#   numpydoc section headers. Their fixes strip the colon and insert a dashed
-#   underline, which turns the embedded spec into invalid YAML and breaks the
-#   generated API docs. D209 / D212 / D403 / D411 / D413 are safe here because
-#   they never rewrite a line inside the YAML block.
+# - D100-D107, D400, D415, D205: the missing-docstring and docstring-wording
+#   rules would either require bulk new prose or rewrite the summary text that
+#   flasgger publishes as the API description.
+# - S101: the pytest suites assert by design, so the rule cannot be enforced
+#   repo-wide without per-directory carve-outs.
+# - The remaining SIM / UP / PL / PTH / TRY members listed as `off` below:
+#   style or modernization churn with no bug-catching value for this codebase
+#   today. Members that are mechanical and behavior-preserving get folded in
+#   one commit at a time, after applying the fix repo-wide.
 
 [lint]
 select = [
-    "E",       # pycodestyle errors (E501 ignored below)
-    "F",       # pyflakes
-    "DTZ",     # process-time-zone-dependent datetime calls (see ignore below)
-    "EXE",     # shebang vs executable-bit consistency
-    "G2",      # .error(..., exc_info=True) -> .exception(...)
-    "I",       # import sorting and grouping
-    "RUF059",  # unused unpacked variable
-    # Mechanical, behavior-preserving cleanups; each was applied repo-wide
-    # with `ruff check --fix` in the commit that selected it here.
-    "B009",    # getattr with a constant attribute name
-    "B010",    # setattr with a constant attribute name
-    "C420",    # dict.fromkeys instead of a constant-value comprehension
-    "D202",    # blank line after a function docstring
-    "D209",    # closing quotes of a multi-line docstring not on their own line
-    "D212",    # multi-line docstring summary not on the first line
-    "D403",    # first word of a docstring not capitalized
-    "D411",    # missing blank line before section
-    "D413",    # missing blank line after the last docstring section
-    "FURB136", # if-expression that should be min()/max()
-    "FURB188", # manual prefix/suffix stripping
-    "PIE790",  # unnecessary pass / ... placeholder
-    "PIE80",   # unnecessary dict kwargs, builtin-reimplementing lambdas
-    "PLC0207", # str.split without maxsplit when one segment is used
-    "PLC0208", # iteration over a set literal
-    "PLR1711", # useless return at the end of a function
-    "PLR1730", # if-statement that should be min()/max()
-    "PLR5501", # else: if ... that should be elif
-    "PT001",   # pytest.fixture with empty parentheses
-    "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)
-    "RET501",  # unnecessary explicit return None
-    "RET502",  # implicit return value
-    "RET505",  # superfluous else after return
-    "RUF010",  # explicit str()/repr() call inside an f-string
-    "RUF02",   # unparenthesized and inside or, unsorted __all__/__slots__
-    "RUF036",  # None not at the end of a union
-    "RUF102",  # noqa directive naming an unknown rule
-    "SIM114",  # if branches with identical bodies
-    "SIM300",  # yoda condition
-    "SIM910",  # dict.get(key, None)
-    "UP01",    # redundant str.encode/open() arguments
-    "UP024",   # deprecated OSError alias
-    "UP032",   # str.format that should be an f-string
-    "UP034",   # extraneous parentheses
+    # --- Groups where every stable rule is already satisfied ---------------
+    "AIR",   # Airflow
+    "DJ",    # flake8-django
+    "EXE",   # flake8-executable
+    "F",     # Pyflakes
+    "FA",    # flake8-future-annotations
+    "FAST",  # FastAPI
+    "I",     # isort
+    "ICN",   # flake8-import-conventions
+    "INT",   # flake8-gettext
+    "NPY",   # NumPy-specific rules
+    "PD",    # pandas-vet
+    "PLE",   # Pylint errors
+    "PYI",   # flake8-pyi
+    "SLOT",  # flake8-slots
+    "YTT",   # flake8-2020
+
+    # --- Groups selected whole, with the unsatisfied members in `ignore` ---
+    "E",     # pycodestyle errors (E501 ignored below)
+    "DTZ",   # flake8-datetimez (DTZ001/DTZ007/DTZ901 ignored below)
+
+    # --- Partially selected groups -----------------------------------------
+    # flake8-builtins -- off: A001, A002, A006
+    "A003", "A004", "A005",
+    # flake8-async -- off: ASYNC230
+    "ASYNC1", "ASYNC21", "ASYNC22", "ASYNC24", "ASYNC25",
+    # flake8-bugbear -- off: B006, B007, B017, B023, B026, B035, B904, B905
+    "B002", "B003", "B004", "B005", "B008", "B009", "B010", "B011", "B012",
+    "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021", "B022",
+    "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032", "B033",
+    "B034", "B039", "B91",
+    # flake8-comprehensions -- off: C401, C408, C414, C416, C901
+    "C400", "C402", "C403", "C404", "C405", "C406", "C409", "C410", "C411",
+    "C413", "C415", "C417", "C418", "C419", "C42",
+    # flake8-commas -- off: COM812, COM819
+    "COM818",
+    # pydocstyle -- off: D100, D101, D102, D103, D104, D105, D107, D203, D205,
+    # D206, D213, D214, D215, D300, D301, D400, D401, D405, D406, D407, D408,
+    # D409, D410, D412, D414, D415, D416, D417
+    "D106", "D200", "D201", "D202", "D204", "D207", "D208", "D209", "D210",
+    "D211", "D212", "D402", "D403", "D404", "D411", "D413", "D418", "D419",
+    # flake8-errmsg -- off: EM101, EM102
+    "EM103",
+    # flake8-fixme -- off: FIX002
+    "FIX001", "FIX003", "FIX004",
+    # refurb -- off: FURB110, FURB157, FURB171, FURB187, FURB192
+    "FURB10", "FURB116", "FURB12", "FURB13", "FURB16", "FURB177", "FURB181",
+    "FURB188",
+    # flake8-logging-format -- off: G001, G003, G004
+    "G002", "G01", "G1", "G2",
+    # flake8-implicit-str-concat -- off: ISC002, ISC004
+    "ISC001", "ISC003",
+    # flake8-logging -- off: LOG014
+    "LOG00", "LOG015",
+    # pep8-naming -- off: N801, N802, N803, N806, N813, N815, N818
+    "N804", "N805", "N807", "N811", "N812", "N814", "N816", "N817", "N9",
+    # Perflint -- off: PERF102, PERF203, PERF401
+    "PERF101", "PERF402", "PERF403",
+    # pygrep-hooks -- off: PGH003, PGH004
+    "PGH005",
+    # flake8-pie -- off: PIE810
+    "PIE7", "PIE80",
+    # Pylint conventions -- off: PLC0206, PLC0414, PLC0415
+    "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC1", "PLC2", "PLC3",
+    # Pylint refactors -- off: PLR0402, PLR0911, PLR0912, PLR0913, PLR0915,
+    # PLR0917, PLR1714, PLR2004
+    "PLR01", "PLR02", "PLR170", "PLR1711", "PLR1716", "PLR172", "PLR173",
+    "PLR204", "PLR5",
+    # Pylint warnings -- off: PLW0108, PLW0127, PLW0602, PLW0603, PLW1510,
+    # PLW1641, PLW2901, PLW3301
+    "PLW0120", "PLW0128", "PLW0129", "PLW013", "PLW017", "PLW02", "PLW04",
+    "PLW0604", "PLW064", "PLW07", "PLW150", "PLW21",
+    # flake8-pytest-style -- off: PT006, PT009, PT011, PT012, PT013, PT017,
+    # PT018, PT022, PT027
+    "PT001", "PT002", "PT003", "PT007", "PT008", "PT010", "PT014", "PT015",
+    "PT016", "PT019", "PT020", "PT021", "PT023", "PT024", "PT025", "PT026",
+    "PT028", "PT03",
+    # flake8-use-pathlib -- off: PTH100, PTH103, PTH106, PTH107, PTH109,
+    # PTH110, PTH112, PTH118, PTH119, PTH120, PTH123, PTH206, PTH208
+    "PTH101", "PTH102", "PTH104", "PTH105", "PTH108", "PTH111", "PTH113",
+    "PTH114", "PTH115", "PTH116", "PTH117", "PTH121", "PTH122", "PTH124",
+    "PTH201", "PTH202", "PTH203", "PTH204", "PTH205", "PTH207", "PTH21",
+    # flake8-return -- off: RET503, RET504
+    "RET501", "RET502", "RET505", "RET506", "RET507", "RET508",
+    # Ruff-specific rules -- off: RUF001, RUF002, RUF003, RUF005, RUF006,
+    # RUF007, RUF012, RUF013, RUF043, RUF046, RUF100
+    "RUF008", "RUF009", "RUF010", "RUF015", "RUF016", "RUF017", "RUF018",
+    "RUF019", "RUF02", "RUF03", "RUF040", "RUF041", "RUF048", "RUF049",
+    "RUF05", "RUF06", "RUF101", "RUF102", "RUF103", "RUF104", "RUF2",
+    # flake8-bandit -- off: S101, S104, S105, S106, S107, S108, S110, S112,
+    # S113, S310, S311, S324, S603, S605, S607, S608
+    "S102", "S103", "S2", "S30", "S312", "S313", "S314", "S315", "S316",
+    "S317", "S318", "S319", "S321", "S323", "S5", "S601", "S602", "S604",
+    "S606", "S609", "S61", "S7",
+    # flake8-simplify -- off: SIM102, SIM103, SIM105, SIM108, SIM115, SIM117,
+    # SIM118, SIM210, SIM212, SIM401
+    "SIM101", "SIM107", "SIM109", "SIM110", "SIM112", "SIM113", "SIM114",
+    "SIM116", "SIM20", "SIM211", "SIM22", "SIM3", "SIM9",
+    # flake8-debugger -- off: T201
+    "T1", "T203",
+    # flake8-type-checking -- off: TC001, TC002, TC003
+    "TC004", "TC005", "TC006", "TC007", "TC01",
+    # flake8-todos -- off: TD002, TD003
+    "TD001", "TD004", "TD005", "TD006", "TD007",
+    # flake8-tidy-imports -- off: TID252
+    "TID251", "TID253",
+    # tryceratops -- off: TRY002, TRY003, TRY004, TRY203, TRY300, TRY301,
+    # TRY400, TRY401
+    "TRY201",
+    # pyupgrade -- off: UP006, UP007, UP022, UP028, UP031, UP035, UP037, UP045
+    "UP001", "UP003", "UP004", "UP005", "UP008", "UP009", "UP01", "UP020",
+    "UP021", "UP023", "UP024", "UP025", "UP026", "UP029", "UP030", "UP032",
+    "UP033", "UP034", "UP036", "UP039", "UP040", "UP041", "UP042", "UP043",
+    "UP044", "UP046", "UP047", "UP049", "UP05",
+    # pycodestyle warnings -- off: W191
+    "W2", "W5", "W6",
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/ruff.toml
+++ b/ruff.toml
@@ -60,6 +60,16 @@
 #   flasgger publishes as the API description.
 # - S101: the pytest suites assert by design, so the rule cannot be enforced
 #   repo-wide without per-directory carve-outs.
+# - RET503: the functions it flags end in `raise_error()` / `raise_param_error()`,
+#   which always raise. Ruff does not follow `NoReturn` across modules, so its
+#   fix would append an unreachable `return None` to each of them.
+# - D301: the docstrings it flags escape backslashes on purpose. One is the
+#   `description=__doc__` help text of `scripts/migrate_oss_domain.py`, where
+#   `\\` must render as a single backslash, and another is a doctest example.
+#   Adding the `r` prefix would change the text those docstrings render.
+# - FLY002: the `"\n".join([...])` calls it flags build provider signing
+#   payloads, where the list form documents the canonical layout line by line
+#   better than an f-string full of `\n` escapes.
 # - The remaining SIM / UP / PL / PTH / TRY members listed as `off` below:
 #   style or modernization churn with no bug-catching value for this codebase
 #   today. Members that are mechanical and behavior-preserving get folded in
@@ -147,8 +157,8 @@ select = [
     "PTH101", "PTH102", "PTH104", "PTH105", "PTH108", "PTH111", "PTH113",
     "PTH114", "PTH115", "PTH116", "PTH117", "PTH121", "PTH122", "PTH124",
     "PTH201", "PTH202", "PTH203", "PTH204", "PTH205", "PTH207", "PTH21",
-    # flake8-return -- off: RET503, RET504
-    "RET501", "RET502", "RET505", "RET506", "RET507", "RET508",
+    # flake8-return -- off: RET503
+    "RET501", "RET502", "RET504", "RET505", "RET506", "RET507", "RET508",
     # Ruff-specific rules -- off: RUF001, RUF002, RUF003, RUF005, RUF006,
     # RUF007, RUF012, RUF013, RUF043, RUF046, RUF100
     "RUF008", "RUF009", "RUF010", "RUF015", "RUF016", "RUF017", "RUF018",

--- a/ruff.toml
+++ b/ruff.toml
@@ -93,11 +93,11 @@ select = [
     "A003", "A004", "A005",
     # flake8-async -- off: ASYNC230
     "ASYNC1", "ASYNC21", "ASYNC22", "ASYNC24", "ASYNC25",
-    # flake8-bugbear -- off: B006, B007, B017, B023, B026, B035, B904, B905
+    # flake8-bugbear -- off: B006, B007, B017, B023, B026, B035, B904
     "B002", "B003", "B004", "B005", "B008", "B009", "B010", "B011", "B012",
     "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021", "B022",
     "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032", "B033",
-    "B034", "B039", "B91",
+    "B034", "B039", "B905", "B91",
     # flake8-comprehensions -- off: C401, C408, C414, C416, C901
     "C400", "C402", "C403", "C404", "C405", "C406", "C409", "C410", "C411",
     "C413", "C415", "C417", "C418", "C419", "C42",
@@ -135,10 +135,10 @@ select = [
     # PLR0917, PLR1714, PLR2004
     "PLR01", "PLR02", "PLR170", "PLR1711", "PLR1716", "PLR172", "PLR173",
     "PLR204", "PLR5",
-    # Pylint warnings -- off: PLW0108, PLW0127, PLW0602, PLW0603, PLW1510,
-    # PLW1641, PLW2901, PLW3301
+    # Pylint warnings -- off: PLW0108, PLW0127, PLW0602, PLW0603, PLW1641,
+    # PLW2901, PLW3301
     "PLW0120", "PLW0128", "PLW0129", "PLW013", "PLW017", "PLW02", "PLW04",
-    "PLW0604", "PLW064", "PLW07", "PLW150", "PLW21",
+    "PLW0604", "PLW064", "PLW07", "PLW15", "PLW21",
     # flake8-pytest-style -- off: PT006, PT009, PT011, PT012, PT013, PT017,
     # PT018, PT022, PT027
     "PT001", "PT002", "PT003", "PT007", "PT008", "PT010", "PT014", "PT015",

--- a/ruff.toml
+++ b/ruff.toml
@@ -105,11 +105,11 @@ select = [
     "A003", "A004", "A005",
     # flake8-async -- off: ASYNC230
     "ASYNC1", "ASYNC21", "ASYNC22", "ASYNC24", "ASYNC25",
-    # flake8-bugbear -- off: B006, B007, B017, B023, B026, B035, B904
-    "B002", "B003", "B004", "B005", "B008", "B009", "B010", "B011", "B012",
-    "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021", "B022",
-    "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032", "B033",
-    "B034", "B039", "B905", "B91",
+    # flake8-bugbear -- off: B006, B017, B023, B026, B035, B904
+    "B002", "B003", "B004", "B005", "B007", "B008", "B009", "B010", "B011",
+    "B012", "B013", "B014", "B015", "B016", "B018", "B019", "B020", "B021",
+    "B022", "B024", "B025", "B027", "B028", "B029", "B030", "B031", "B032",
+    "B033", "B034", "B039", "B905", "B91",
     # flake8-comprehensions -- off: C901
     "C4",
     # flake8-commas -- off: COM812, COM819
@@ -138,15 +138,15 @@ select = [
     "PERF1", "PERF402", "PERF403",
     # pygrep-hooks -- off: PGH003, PGH004
     "PGH005",
-    # Pylint conventions -- off: PLC0206, PLC0414, PLC0415
-    "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC1", "PLC2", "PLC3",
+    # Pylint conventions -- off: PLC0206, PLC0415
+    "PLC01", "PLC0205", "PLC0207", "PLC0208", "PLC0414", "PLC1", "PLC2",
+    "PLC3",
     # Pylint refactors -- off: PLR0402, PLR0911, PLR0912, PLR0913, PLR0915,
     # PLR0917, PLR2004
     "PLR01", "PLR02", "PLR17", "PLR204", "PLR5",
-    # Pylint warnings -- off: PLW0108, PLW0127, PLW0602, PLW0603, PLW1641,
-    # PLW2901
-    "PLW0120", "PLW0128", "PLW0129", "PLW013", "PLW017", "PLW02", "PLW04",
-    "PLW0604", "PLW064", "PLW07", "PLW15", "PLW21", "PLW3",
+    # Pylint warnings -- off: PLW0108, PLW0603, PLW1641, PLW2901
+    "PLW012", "PLW013", "PLW017", "PLW02", "PLW04", "PLW0602", "PLW0604",
+    "PLW064", "PLW07", "PLW15", "PLW21", "PLW3",
     # flake8-pytest-style -- off: PT006, PT009, PT011, PT012, PT013, PT017,
     # PT018, PT022, PT027
     "PT001", "PT002", "PT003", "PT007", "PT008", "PT010", "PT014", "PT015",

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -81,6 +81,7 @@ def _hooks_dir() -> Path | None:
             cwd=ROOT,
             capture_output=True,
             text=True,
+            check=False,
         )
         if configured.returncode == 0 and configured.stdout.strip():
             # git config values may use ~ / ~user; Path() does not expand it.

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -187,7 +187,7 @@ def collect_backend_keys() -> Set[str]:
                 if "." not in match:
                     continue
                 # Only consider backend namespaces we intentionally allow in Python.
-                if match.startswith("server.") or match.startswith("module."):
+                if match.startswith(("server.", "module.")):
                     used.add(match)
                     # Add alias (with domain remap where needed)
                     if match.startswith("server."):

--- a/scripts/generate_languages.py
+++ b/scripts/generate_languages.py
@@ -77,7 +77,7 @@ def main() -> int:
                 rel = str(file_path.relative_to(code_dir).with_suffix(""))
                 namespaces.add(rel.replace("/", "."))
 
-    locales_meta["namespaces"] = sorted(list(namespaces))
+    locales_meta["namespaces"] = sorted(namespaces)
 
     LOCALES_FILE.write_text(
         json.dumps(locales_meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"

--- a/scripts/test_prettier_check_changed.py
+++ b/scripts/test_prettier_check_changed.py
@@ -22,8 +22,7 @@ def run(
         env=env,
         check=False,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
 
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -79,7 +79,7 @@ def create_app() -> Flask:
 
     # Init LLM
     with app.app_context():
-        from flaskr.api import llm  # noqa
+        from flaskr.api import llm  # noqa: F401
     # init langfuse
     from flaskr import api
 

--- a/src/api/flaskr/api/__init__.py
+++ b/src/api/flaskr/api/__init__.py
@@ -1,1 +1,1 @@
-from .langfuse import init_langfuse  # noqa
+from .langfuse import init_langfuse  # noqa: F401

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -4,7 +4,7 @@
 import base64
 import hmac
 import json
-from hashlib import sha256 as sha256
+from hashlib import sha256
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -67,7 +67,7 @@ def gen_signature(params=None):
     for k in sorted(params.keys()):
         buff += str(k) + str(params[k])
     buff += YIDUN_SECRET_KEY
-    if "signatureMethod" in params.keys() and params["signatureMethod"] == "SM3":
+    if "signatureMethod" in params and params["signatureMethod"] == "SM3":
         return sm3.sm3_hash(func.bytes_to_list(bytes(buff, encoding="utf8")))
     return hashlib.md5(buff.encode("utf8")).hexdigest()
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -1074,7 +1074,7 @@ def invoke_llm(
                 response_text += res.choices[0].delta.content
                 yield LLMStreamResponse(
                     res.id,
-                    True if res.choices[0].finish_reason else False,
+                    bool(res.choices[0].finish_reason),
                     False,
                     res.choices[0].delta.content,
                     res.choices[0].finish_reason,
@@ -1249,7 +1249,7 @@ def chat_llm(
                     response_text += res.choices[0].delta.content
                     yield LLMStreamResponse(
                         res.id,
-                        True if res.choices[0].finish_reason else False,
+                        bool(res.choices[0].finish_reason),
                         False,
                         res.choices[0].delta.content,
                         res.choices[0].finish_reason,

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -1378,7 +1378,7 @@ def _build_model_options(
             "LLM_ALLOWED_MODELS"
         )
     display_map: dict[str, str] = (
-        dict(zip(allowed, display_names)) if display_names_enabled else {}
+        dict(zip(allowed, display_names, strict=False)) if display_names_enabled else {}
     )
 
     options = [

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -143,8 +143,6 @@ def get_tts_provider(provider_name: str = "") -> BaseTTSProvider:
         ValueError: If no configured provider is available
 
     """
-    global _provider_instances
-
     provider_name = _resolve_provider_name(provider_name)
 
     # Get or create provider instance

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1287,19 +1287,17 @@ class AliyunTTSProvider(BaseTTSProvider):
 
         # Use provider-native ranges for Aliyun
         aliyun_speed = (
-            int(round(voice_settings.speed)) if voice_settings.speed is not None else 0
+            round(voice_settings.speed) if voice_settings.speed is not None else 0
         )
         aliyun_speed = max(-500, min(500, aliyun_speed))
 
         aliyun_pitch = (
-            int(round(voice_settings.pitch)) if voice_settings.pitch is not None else 0
+            round(voice_settings.pitch) if voice_settings.pitch is not None else 0
         )
         aliyun_pitch = max(-500, min(500, aliyun_pitch))
 
         aliyun_volume = (
-            int(round(voice_settings.volume))
-            if voice_settings.volume is not None
-            else 50
+            round(voice_settings.volume) if voice_settings.volume is not None else 50
         )
         aliyun_volume = max(0, min(100, aliyun_volume))
 

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -837,19 +837,17 @@ class BaiduTTSProvider(BaseTTSProvider):
 
         # Use provider-native ranges (0-15) for speed, pitch, and volume
         baidu_speed = (
-            int(round(voice_settings.speed)) if voice_settings.speed is not None else 5
+            round(voice_settings.speed) if voice_settings.speed is not None else 5
         )
         baidu_speed = max(0, min(15, baidu_speed))
 
         baidu_pitch = (
-            int(round(voice_settings.pitch)) if voice_settings.pitch is not None else 5
+            round(voice_settings.pitch) if voice_settings.pitch is not None else 5
         )
         baidu_pitch = max(0, min(15, baidu_pitch))
 
         baidu_volume = (
-            int(round(voice_settings.volume))
-            if voice_settings.volume is not None
-            else 5
+            round(voice_settings.volume) if voice_settings.volume is not None else 5
         )
         baidu_volume = max(0, min(15, baidu_volume))
 

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -669,8 +669,6 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
 
     Token is cached and refreshed when expired.
     """
-    global _token_cache
-
     # Check cache
     current_time = time.time()
     if _token_cache["access_token"] and _token_cache["expires_at"] > current_time + 300:

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -1259,11 +1259,7 @@ class TencentTTSProvider(BaseTTSProvider):
                 if line.startswith(":"):
                     continue
                 lower_line = line.lower()
-                if (
-                    lower_line.startswith("event:")
-                    or lower_line.startswith("id:")
-                    or lower_line.startswith("retry:")
-                ):
+                if lower_line.startswith(("event:", "id:", "retry:")):
                     continue
                 if line.startswith("data:"):
                     line = line[5:].strip()

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -694,7 +694,9 @@ def _group_tencent_subtitle_cues_by_source_text(
         bounded_target = max(min(float(target_weight), float(total_cue_weight)), 0.0)
         consumed = 0.0
         last_end_ms = start_ms
-        for index, (cue, weight) in enumerate(zip(normalized_cues, cue_weights)):
+        for index, (cue, weight) in enumerate(
+            zip(normalized_cues, cue_weights, strict=False)
+        ):
             cue_start_ms = int(cue.get("start_ms", 0) or 0)
             cue_end_ms = int(cue.get("end_ms", cue_start_ms) or cue_start_ms)
             cue_end_ms = max(cue_end_ms, cue_start_ms)
@@ -712,6 +714,7 @@ def _group_tencent_subtitle_cues_by_source_text(
                     for next_cue, next_weight in zip(
                         normalized_cues[index + 1 :],
                         cue_weights[index + 1 :],
+                        strict=False,
                     ):
                         if next_weight > 0:
                             break

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -278,7 +278,7 @@ def _tencent_pcm_duration_ms(audio_data: bytes, *, sample_rate: int) -> int:
     if not audio_data:
         return 0
     bytes_per_second = max(int(sample_rate or TENCENT_DEFAULT_SAMPLE_RATE), 1) * 2
-    return int(round(len(audio_data) * 1000 / bytes_per_second))
+    return round(len(audio_data) * 1000 / bytes_per_second)
 
 
 def _export_tencent_pcm_to_mp3(audio_data: bytes, *, sample_rate: int) -> bytes:
@@ -689,7 +689,7 @@ def _group_tencent_subtitle_cues_by_source_text(
     def _time_at_weight(target_weight: float) -> int:
         if total_cue_weight <= 0:
             ratio = target_weight / total_sentence_weight
-            return start_ms + int(round(duration_ms * ratio))
+            return start_ms + round(duration_ms * ratio)
 
         bounded_target = max(min(float(target_weight), float(total_cue_weight)), 0.0)
         consumed = 0.0
@@ -707,9 +707,7 @@ def _group_tencent_subtitle_cues_by_source_text(
                 continue
             if bounded_target <= consumed + weight:
                 ratio = (bounded_target - consumed) / weight
-                target_ms = cue_start_ms + int(
-                    round((cue_end_ms - cue_start_ms) * ratio)
-                )
+                target_ms = cue_start_ms + round((cue_end_ms - cue_start_ms) * ratio)
                 if bounded_target >= consumed + weight:
                     for next_cue, next_weight in zip(
                         normalized_cues[index + 1 :],
@@ -746,11 +744,11 @@ def _group_tencent_subtitle_cues_by_source_text(
             cue_start_ms = _time_at_weight(source_start_weight)
             cue_end_ms = _time_at_weight(source_end_weight)
         else:
-            cue_start_ms = start_ms + int(
-                round(duration_ms * sentence_cursor / total_sentence_weight)
+            cue_start_ms = start_ms + round(
+                duration_ms * sentence_cursor / total_sentence_weight
             )
-            cue_end_ms = start_ms + int(
-                round(duration_ms * next_sentence_cursor / total_sentence_weight)
+            cue_end_ms = start_ms + round(
+                duration_ms * next_sentence_cursor / total_sentence_weight
             )
 
         cue_start_ms = max(cue_start_ms, timeline_cursor_ms)
@@ -790,7 +788,7 @@ def _tencent_subtitle_time_ms(
         if value is None or value == "":
             continue
         try:
-            return int(round(float(value)))
+            return round(float(value))
         except (TypeError, ValueError):
             continue
     return int(default_ms or 0)

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -47,7 +47,7 @@ VOLCENGINE_TTS_WS_URL = "wss://openspeech.bytedance.com/api/v3/tts/bidirection"
 
 def _timestamp_seconds_to_ms(value: Any) -> int:
     try:
-        return max(int(round(float(value) * 1000)), 0)
+        return max(round(float(value) * 1000), 0)
     except (TypeError, ValueError):
         return 0
 
@@ -61,7 +61,7 @@ def _volcengine_time_ms(item: dict[str, Any], keys: tuple[str, ...]) -> int:
             continue
         if key.endswith(("_ms", "Ms")):
             try:
-                return max(int(round(float(value))), 0)
+                return max(round(float(value)), 0)
             except (TypeError, ValueError):
                 return 0
         return _timestamp_seconds_to_ms(value)

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -59,7 +59,7 @@ def _volcengine_time_ms(item: dict[str, Any], keys: tuple[str, ...]) -> int:
         value = item.get(key)
         if value is None or value == "":
             continue
-        if key.endswith("_ms") or key.endswith("Ms"):
+        if key.endswith(("_ms", "Ms")):
             try:
                 return max(int(round(float(value))), 0)
             except (TypeError, ValueError):
@@ -708,7 +708,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
         if subtitle_cues:
             total_duration_ms = max(
                 total_duration_ms,
-                max(int(cue.get("end_ms", 0) or 0) for cue in subtitle_cues),
+                *(int(cue.get("end_ms", 0) or 0) for cue in subtitle_cues),
             )
 
         logger.info(

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -190,7 +190,7 @@ def enable_commands(app: Flask):
             click.echo("=" * 50)
 
             all_passed = True
-            for table_name, result in consistency_results.items():
+            for result in consistency_results.values():
                 if result.is_consistent:
                     status_icon = click.style("✅", fg="green")
                     status_text = click.style("PASSED", fg="green")

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -968,7 +968,7 @@ class UnifiedMigrationTask:
         # Consistency Check Results
         report.append("DATA CONSISTENCY VERIFICATION")
         report.append("-" * 40)
-        for table_name, result in consistency_results.items():
+        for result in consistency_results.values():
             status = "✓ PASSED" if result.is_consistent else "✗ FAILED"
             report.append(f"{status} {result.table_pair}")
             report.append(

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1056,7 +1056,7 @@ async def main():
             logger.info("Starting data consistency verification...")
             consistency_results = await migration_task.verify_data_consistency()
 
-            for table_name, result in consistency_results.items():
+            for result in consistency_results.values():
                 status = "PASSED" if result.is_consistent else "FAILED"
                 print(f"{status}: {result.table_pair}")
                 if not result.is_consistent:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -311,11 +311,11 @@ class FallbackCacheProvider:
             "set",
             key,
             value,
+            *args,
             ex=ex,
             px=px,
             nx=nx,
             xx=xx,
-            *args,
             **kwargs,
         )
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1815,7 +1815,7 @@ class EnhancedConfig:
                 missing_required.append(f"- {var_name}: {env_var.description}")
                 continue
             # Get value (from environment or default)
-            value = raw_value if raw_value else env_var.default
+            value = raw_value or env_var.default
             # Validate value if present
             if value is not None and value != "":
                 try:
@@ -1991,7 +1991,7 @@ class EnhancedConfig:
         groups = {}
 
         # Filter and group variables
-        for var_name, env_var in self.env_vars.items():
+        for env_var in self.env_vars.values():
             # Apply filter
             if filter_type == "required" and not env_var.required:
                 continue

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2085,7 +2085,9 @@ __ENHANCED_CONFIG__ = EnhancedConfig(ENV_VARS)
 class Config(FlaskConfig):
     """Flask configuration wrapper with enhanced environment variable support."""
 
-    def __init__(self, parent: FlaskConfig, app: Flask, defaults: dict = {}):
+    def __init__(
+        self, parent: FlaskConfig, app: Flask, defaults: Optional[dict] = None
+    ):
         global __INSTANCE__
         self.parent = parent
         self.app = app

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -97,8 +97,7 @@ def _get_shifu_creator_bid_cached(app, shifu_bid: str) -> Optional[str]:
         lock_key = f"{cache_key}:lock"
         lock = cache_provider.lock(lock_key, timeout=5, blocking_timeout=1)
         if lock is None:
-            creator_bid = get_shifu_creator_bid(app, shifu_bid)
-            return creator_bid
+            return get_shifu_creator_bid(app, shifu_bid)
 
         acquired = lock.acquire(blocking=True)
         try:

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -24,7 +24,7 @@ def enable_plugins(app: Flask):
         dest_dir = os.path.join("flaskr", "plugins", repo_name)
         if os.path.exists(dest_dir):
             return
-        subprocess.run(["git", "clone", repo_url, dest_dir])
+        subprocess.run(["git", "clone", repo_url, dest_dir], check=False)
 
     @plugin.command(name="delete")
     @click.argument("repo_name")

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -30,7 +30,7 @@ def load_plugins_from_dir(
                     plugin_obj = importlib.import_module(
                         f"{directory}.{SRC_DIR}.{filename[:-3]}".replace(os.sep, ".")
                     )
-                    for name, obj in getmembers(plugin_obj):
+                    for _name, obj in getmembers(plugin_obj):
                         if (
                             isinstance(obj, type)
                             and issubclass(obj, BasePlugin)

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -119,10 +119,7 @@ def extensible(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
-        result = plugin_manager.execute_extensions(
-            func.__name__, result, *args, **kwargs
-        )
-        return result
+        return plugin_manager.execute_extensions(func.__name__, result, *args, **kwargs)
 
     return wrapper
 

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -210,7 +210,7 @@ def _validate_json_translations(app: Flask, root: Path):
                 problems.append(f"Malformed JSON in {file_path}: {exc}")
 
     if problems:
-        details = "\n - ".join(["Detected translation issues:"] + problems)
+        details = "\n - ".join(["Detected translation issues:", *problems])
         raise RuntimeError(details)
 
 

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -40,7 +40,7 @@ def _shared_json_root() -> Path:
 
 def _flatten_dict(data, prefix: str = ""):
     if not isinstance(data, dict):
-        key = prefix if prefix else ""
+        key = prefix or ""
         return {key: data} if key else {}
 
     flattened = {}

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -28,11 +28,11 @@ def _resolve_supported_language(raw_language: str | None) -> str | None:
         return None
 
     normalized_language_lower = normalized_language.lower()
-    for supported_language in _translations.keys():
+    for supported_language in _translations:
         if supported_language.lower() == normalized_language_lower:
             return supported_language
 
-    for supported_language in _translations.keys():
+    for supported_language in _translations:
         if supported_language.lower().startswith(normalized_language_lower):
             return supported_language
 

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -121,7 +121,6 @@ def fmt(o):
 def make_common_response(data):
     if data is None:
         data = {}
-    response = json.dumps(
+    return json.dumps(
         {"code": 0, "message": "success", "data": data}, default=fmt, ensure_ascii=False
     )
-    return response

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -532,8 +532,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         if not tmp_id:
             raise_param_error("temp_id")
         user_token = generate_temp_user(app, tmp_id, source, wx_code, language)
-        resp = make_response(make_common_response(user_token))
-        return resp
+        return make_response(make_common_response(user_token))
 
     @app.route(path_prefix + "/captcha", methods=["GET"])
     @bypass_token_validation
@@ -734,8 +733,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
                     **referral_fields,
                 ),
             )
-            resp = make_response(make_common_response(auth_result.token))
-            return resp
+            return make_response(make_common_response(auth_result.token))
 
     @app.route(path_prefix + "/login_sms", methods=["POST"])
     @bypass_token_validation

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -561,9 +561,7 @@ def _is_stripe_checkout_paid(
         return True
     if session.get("status") == "complete" and not session.get("payment_status"):
         return True
-    if intent and intent.get("status") == "succeeded":
-        return True
-    return False
+    return bool(intent and intent.get("status") == "succeeded")
 
 
 apply_billing_order_provider_update = _apply_billing_order_provider_update

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -1134,7 +1134,7 @@ def _load_target_renewal_event(
         )
         query = query.filter(
             BillingRenewalEvent.status.in_(
-                _CLAIMABLE_EVENT_STATUSES + (BILLING_RENEWAL_EVENT_STATUS_PROCESSING,)
+                (*_CLAIMABLE_EVENT_STATUSES, BILLING_RENEWAL_EVENT_STATUS_PROCESSING)
             )
         )
     else:

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -183,8 +183,7 @@ def _coerce_positive_int(
 def _normalize_optional_queue(value: Any, *, enabled: Any = False) -> str:
     if not _coerce_bool(enabled):
         return ""
-    queue = str(value or "").strip()
-    return queue
+    return str(value or "").strip()
 
 
 def _recover_stale_processing_renewal_events(

--- a/src/api/flaskr/service/billing/value_objects.py
+++ b/src/api/flaskr/service/billing/value_objects.py
@@ -57,7 +57,7 @@ class JsonObjectMap(MutableMapping[str, Any]):
     def get(self, key: str, default: Any = None) -> Any:
         return self.values.get(key, default)
 
-    def copy(self) -> "JsonObjectMap":
+    def copy(self) -> JsonObjectMap:
         return JsonObjectMap(values=dict(self.values))
 
     def to_metadata_json(self) -> dict[str, Any]:

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -243,9 +243,7 @@ def apply_billing_stripe_notification(
             _persist_billing_stripe_raw_snapshot(
                 order,
                 create_if_missing=False,
-                metadata=(metadata or refund_metadata)
-                if (metadata or refund_metadata)
-                else None,
+                metadata=(metadata or refund_metadata) or None,
                 checkout_session_id=(
                     stripe_object_id if stripe_object_id.startswith("cs_") else ""
                 ),

--- a/src/api/flaskr/service/check_risk/__init__.py
+++ b/src/api/flaskr/service/check_risk/__init__.py
@@ -1,1 +1,1 @@
-from .funcs import *  # noqa
+from .funcs import *  # noqa: F403

--- a/src/api/flaskr/service/common/__init__.py
+++ b/src/api/flaskr/service/common/__init__.py
@@ -1,1 +1,1 @@
-from .models import *  # noqa
+from .models import *  # noqa: F403

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -26,7 +26,7 @@ def register_dict(name, desp, items: dict):
     if name in DICTS:
         return
     dictItems = []
-    for key in items.keys():
+    for key in items:
         dictItems.append(DictItem(key, items[key]))
     DICTS[name] = Dict(name, desp, dictItems)
 

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -26,8 +26,8 @@ def register_dict(name, desp, items: dict):
     if name in DICTS:
         return
     dictItems = []
-    for key in items:
-        dictItems.append(DictItem(key, items[key]))
+    for key, value in items.items():
+        dictItems.append(DictItem(key, value))
     DICTS[name] = Dict(name, desp, dictItems)
 
 

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -156,8 +156,7 @@ def get_config(key: str, default: str = None) -> str:
     with nullcontext():
         # Only explicit env vars should bypass DB-backed config lookups.
         if has_explicit_env_override(key):
-            env_value = get_config_from_common(key, default)
-            return env_value
+            return get_config_from_common(key, default)
         try:
             cache_key = _get_config_cache_key(app, key)
             cache = redis.get(cache_key)

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -386,7 +386,7 @@ def _build_summary_statement(params: _Params) -> Select:
 
 def _row_to_dict(columns: Sequence[str], values: Sequence[Any]) -> Dict[str, Any]:
     row: Dict[str, Any] = {}
-    for col, val in zip(columns, values):
+    for col, val in zip(columns, values, strict=False):
         row[col] = _coerce_value(val)
     return row
 

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -326,7 +326,7 @@ def _build_detail_statement(params: _Params) -> Select:
     bu = BillUsageRecord.__table__
     cle = CreditLedgerEntry.__table__
 
-    stmt = (
+    return (
         select(
             bu.c.usage_bid,
             bu.c.created_at,
@@ -346,14 +346,13 @@ def _build_detail_statement(params: _Params) -> Select:
         .limit(params.limit)
         .offset(params.offset)
     )
-    return stmt
 
 
 def _build_summary_statement(params: _Params) -> Select:
     bu = BillUsageRecord.__table__
     cle = CreditLedgerEntry.__table__
 
-    stmt = (
+    return (
         select(
             func.count().label("total_records"),
             func.coalesce(func.sum(func.abs(cle.c.amount)), 0).label("total_credits"),
@@ -376,7 +375,6 @@ def _build_summary_statement(params: _Params) -> Select:
         .select_from(_join_conditions(params))
         .where(and_(*_where_clauses(params)))
     )
-    return stmt
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/flaskr/service/creator_analytics/pii.py
+++ b/src/api/flaskr/service/creator_analytics/pii.py
@@ -36,8 +36,7 @@ def redact_pii(text: str) -> str:
         return text
     text = _PHONE_CN_RE.sub("[REDACTED-PHONE]", text)
     text = _EMAIL_RE.sub("[REDACTED-EMAIL]", text)
-    text = _ID_CARD_RE.sub("[REDACTED-IDCARD]", text)
-    return text
+    return _ID_CARD_RE.sub("[REDACTED-IDCARD]", text)
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -973,12 +973,11 @@ def _load_dashboard_course_created_at(shifu_bid: str) -> Optional[datetime]:
     if latest_draft and latest_draft.created_at:
         return latest_draft.created_at
 
-    earliest_published_created_at = (
+    return (
         db.session.query(db.func.min(PublishedShifu.created_at))
         .filter(PublishedShifu.shifu_bid == shifu_bid)
         .scalar()
     )
-    return earliest_published_created_at
 
 
 def _resolve_dashboard_course_status(shifu_bid: str) -> str:

--- a/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
@@ -55,11 +55,7 @@ def _user_message_for_error(code: str, reason: str) -> str | None:
         return str(_("server.learn.askProviderNotMember"))
     if code in _AUTH_ERROR_CODES:
         return str(_("server.learn.askProviderAuthFailed"))
-    if (
-        code in _RATE_LIMIT_ERROR_CODES
-        or reason.startswith("qps_")
-        or reason.startswith("quota_")
-    ):
+    if code in _RATE_LIMIT_ERROR_CODES or reason.startswith(("qps_", "quota_")):
         return str(_("server.learn.askProviderRateLimited"))
     return None
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1664,7 +1664,7 @@ class RunScriptContextV2:
     def _stop_if_requested(self) -> None:
         if self._stop_requested():
             self.app.logger.info("run_script context cancelled")
-            raise GeneratorExit()
+            raise GeneratorExit
 
     def _iter_until_active(self, items: Iterable[Any]) -> Generator[Any, None, None]:
         for item in items:
@@ -1960,14 +1960,14 @@ class RunScriptContextV2:
                 raise_error("server.shifu.lessonNotFoundInCourse")
             if outline_item_info_db.type == UNIT_TYPE_VALUE_NORMAL:
                 if (not self._is_paid) and (not self._preview_mode):
-                    raise PaidException()
+                    raise PaidException
             elif outline_item_info_db.type == UNIT_TYPE_VALUE_TRIAL:
                 if (
                     not self._preview_mode
                     and not self._user_info.mobile
                     and not self._user_info.email
                 ):
-                    raise UserNotLoginException()
+                    raise UserNotLoginException
             parent_path = _find_outline_path_or_raise(self._struct, outline_bid)
             attend_info = None
             new_records: list[LearnProgressRecord] = []

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2336,8 +2336,6 @@ class RunScriptContextV2:
         app.logger.info(f"ask_input: {ask_input}")
         if isinstance(ask_input, dict):
             ask_input = ask_input.get("input", "")
-        else:
-            ask_input = ask_input
         if isinstance(ask_input, list):
             ask_input = ",".join(ask_input)
         app.logger.info(f"ask_input: {ask_input}")

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -351,7 +351,7 @@ def handle_input_ask(
         )
     )
     llm_system_prompt = follow_up_info.ask_prompt.replace(
-        "{shifu_system_message}", base_system_prompt if base_system_prompt else ""
+        "{shifu_system_message}", base_system_prompt or ""
     )
     # Append language instruction if use_learner_language is enabled
     if use_learner_language:
@@ -392,7 +392,7 @@ def handle_input_ask(
             .limit(ask_max_history_len)
             .all()
         )
-        history_scripts = history_scripts[::-1]
+        history_scripts.reverse()
         for script in history_scripts:
             if script.type in [BLOCK_TYPE_MDASK_VALUE, BLOCK_TYPE_MDINTERACTION_VALUE]:
                 history_message = {

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -250,7 +250,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         description="Whether the published lesson content is newer than this user's latest learning progress",
         required=False,
     )
-    children: list["LearnOutlineItemInfoDTO"] = Field(
+    children: list[LearnOutlineItemInfoDTO] = Field(
         ..., description="outline children", required=False
     )
 
@@ -262,7 +262,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         status: LearnStatus,
         type: OutlineType,
         is_paid: bool,
-        children: list["LearnOutlineItemInfoDTO"],
+        children: list[LearnOutlineItemInfoDTO],
         has_content_update_for_current_user: bool = False,
     ):
         super().__init__(
@@ -341,7 +341,7 @@ class AudioSegmentDTO(BaseModel):
     is_final: bool = Field(
         default=False, description="Whether this is the last segment"
     )
-    subtitle_cues: List["SubtitleCueDTO"] = Field(
+    subtitle_cues: List[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cues available up to the current streamed segment",
     )
@@ -356,7 +356,7 @@ class AudioSegmentDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List["SubtitleCueDTO"]] = None,
+        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
     ):
         super().__init__(
             position=position,
@@ -410,7 +410,7 @@ class AudioCompleteDTO(BaseModel):
     audio_url: str = Field(..., description="OSS URL of complete audio")
     audio_bid: str = Field(..., description="Audio business identifier")
     duration_ms: int = Field(..., description="Total audio duration in milliseconds")
-    subtitle_cues: List["SubtitleCueDTO"] = Field(
+    subtitle_cues: List[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cue list aligned with synthesized TTS segments",
     )
@@ -424,7 +424,7 @@ class AudioCompleteDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List["SubtitleCueDTO"]] = None,
+        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
     ):
         super().__init__(
             position=position,
@@ -695,7 +695,7 @@ class ElementDTO(BaseModel):
         "sequence_number",
     )
 
-    def apply_patch(self, patch: "ElementDTO") -> None:
+    def apply_patch(self, patch: ElementDTO) -> None:
         for field_name in self._PATCH_FIELDS:
             setattr(self, field_name, getattr(patch, field_name))
 
@@ -849,7 +849,7 @@ class RunMarkdownFlowDTO(BaseModel):
 
     def set_mdflow_stream_parts(
         self, parts: list[tuple[str, str, int]] | None
-    ) -> "RunMarkdownFlowDTO":
+    ) -> RunMarkdownFlowDTO:
         normalized_parts: list[tuple[str, str, int]] = []
         for item in parts or []:
             if not isinstance(item, tuple) or len(item) != 3:

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -132,8 +132,7 @@ def _normalize_dt_to_utc(
 def _resolve_published_effective_updated_at(
     outline_item: PublishedOutlineItem,
 ) -> datetime | None:
-    updated_at = _normalize_dt_to_utc(getattr(outline_item, "updated_at", None))
-    return updated_at
+    return _normalize_dt_to_utc(getattr(outline_item, "updated_at", None))
 
 
 def _resolve_progress_effective_updated_at(

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -793,7 +793,7 @@ def _resolve_runtime_tts_voice_id(
     default_voice_settings = get_default_voice_settings(normalized_provider)
     fallback_voice_id = (getattr(default_voice_settings, "voice_id", "") or "").strip()
     if not fallback_voice_id and built_in_voice_ids:
-        fallback_voice_id = sorted(built_in_voice_ids)[0]
+        fallback_voice_id = min(built_in_voice_ids)
     app.logger.warning(
         "%s TTS voice_id %s is not a current built-in voice or ready cloned voice; falling back to %s",
         normalized_provider,

--- a/src/api/flaskr/service/learn/listen_element_history.py
+++ b/src/api/flaskr/service/learn/listen_element_history.py
@@ -292,7 +292,7 @@ def _enrich_elements_with_persisted_audio(
         return elements
 
     available_positions_by_block: dict[str, list[int]] = {}
-    for block_bid, position in latest_audio_by_key.keys():
+    for block_bid, position in latest_audio_by_key:
         available_positions_by_block.setdefault(block_bid, []).append(position)
     available_positions_by_block = {
         block_bid: sorted(set(positions))

--- a/src/api/flaskr/service/learn/listen_element_run_stream.py
+++ b/src/api/flaskr/service/learn/listen_element_run_stream.py
@@ -134,11 +134,11 @@ class ListenElementRunStreamMixin:
             position = self._normalize_live_audio_position(raw_position)
             if position not in positions:
                 positions.append(position)
-        for raw_position in state.audio_by_position.keys():
+        for raw_position in state.audio_by_position:
             position = self._normalize_live_audio_position(raw_position)
             if position not in positions:
                 positions.append(position)
-        for raw_position in state.live_audio_by_position.keys():
+        for raw_position in state.live_audio_by_position:
             position = self._normalize_live_audio_position(raw_position)
             if position not in positions:
                 positions.append(position)
@@ -694,8 +694,7 @@ class ListenElementRunStreamMixin:
                 position=position,
                 subtitle_cues=(
                     progressive_subtitle_cues
-                    if progressive_subtitle_cues
-                    else list(getattr(current_audio, "subtitle_cues", []) or [])
+                    or list(getattr(current_audio, "subtitle_cues", []) or [])
                 ),
             )
             segment_data = _audio_segment_payload(content)

--- a/src/api/flaskr/service/learn/preview_permissions.py
+++ b/src/api/flaskr/service/learn/preview_permissions.py
@@ -72,7 +72,7 @@ def _auth_types_to_permissions(auth_types: set[str]) -> set[str]:
             permissions.add("view")
         if lowered in {"edit", "write"} or lowered == "2":
             permissions.update({"view", "edit"})
-        if lowered in {"publish"} or lowered == "4":
+        if lowered in {"publish", "4"}:
             permissions.add("publish")
     return permissions
 

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -270,7 +270,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         app.logger.info(
             f"get shifu, shifu_bid: {shifu_bid}, preview_mode: {preview_mode}"
         )
-        preview_mode = True if preview_mode.lower() == "true" else False
+        preview_mode = preview_mode.lower() == "true"
         if preview_mode:
             user = resolve_preview_request_user(app)
             require_shifu_preview_permission(app, user.user_id, shifu_bid)
@@ -310,7 +310,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         app.logger.info(
             f"get outline item tree, shifu_bid: {shifu_bid}, preview_mode: {preview_mode}"
         )
-        preview_mode = True if preview_mode.lower() == "true" else False
+        preview_mode = preview_mode.lower() == "true"
         user_bid = request.user.user_id
         if preview_mode:
             require_shifu_preview_permission(app, user_bid, shifu_bid)
@@ -384,7 +384,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         app.logger.info(
             f"run outline item, shifu_bid: {shifu_bid}, outline_bid: {outline_bid}, preview_mode: {preview_mode}, listen: {listen}"
         )
-        preview_mode = True if preview_mode.lower() == "true" else False
+        preview_mode = preview_mode.lower() == "true"
         if preview_mode:
             require_shifu_preview_permission(app, user_bid, shifu_bid)
         _admit_creator_usage_for_shifu(
@@ -656,10 +656,8 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         app.logger.info(
             f"get learn element record, shifu_bid: {shifu_bid}, outline_bid: {outline_bid}, preview_mode: {preview_mode}"
         )
-        preview_mode = True if preview_mode.lower() == "true" else False
-        include_non_navigable = (
-            True if include_non_navigable.lower() == "true" else False
-        )
+        preview_mode = preview_mode.lower() == "true"
+        include_non_navigable = include_non_navigable.lower() == "true"
         user_bid = request.user.user_id
         if preview_mode:
             require_shifu_preview_permission(app, user_bid, shifu_bid)

--- a/src/api/flaskr/service/learn/run/emitter.py
+++ b/src/api/flaskr/service/learn/run/emitter.py
@@ -111,9 +111,9 @@ class RunEventEmitter:
                     )
                     continue
                 ctx._current_attend = ctx._get_current_attend(update.outline_bid)
-                if (
-                    ctx._current_attend.status == LEARN_STATUS_NOT_STARTED
-                    or ctx._current_attend.status == LEARN_STATUS_LOCKED
+                if ctx._current_attend.status in (
+                    LEARN_STATUS_NOT_STARTED,
+                    LEARN_STATUS_LOCKED,
                 ):
                     recorder.update_progress_pointer(
                         ctx._current_attend,

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -121,9 +121,7 @@ class RunStateResolver:
                 return True
             if outline_item_info.children[0].type == "outline":
                 return False
-        if outline_item_info.type == "outline":
-            return True
-        return False
+        return outline_item_info.type == "outline"
 
     def get_current_outline_block_count(self) -> int:
         """Determine the completion threshold for the current outline.

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -155,7 +155,7 @@ def get_fmt_prompt(
             app.logger.info("key not found:" + key + " ,user_id:" + user_id)
     app.logger.info(fmt_keys)
     if not keys:
-        prompt = input if not profile_tmplate else profile_tmplate
+        prompt = profile_tmplate or input
     else:
         prompt = safe_format_template(profile_tmplate, fmt_keys)
     app.logger.info(f"fomat input:{prompt}")
@@ -220,16 +220,14 @@ def get_follow_up_info_v2(
     shifu_ask_provider_config = normalize_ask_provider_config(
         getattr(shifu_info, "ask_provider_config", "{}")
     )
-    ask_model = shifu_info.ask_llm if shifu_info.ask_llm else shifu_info.llm
+    ask_model = shifu_info.ask_llm or shifu_info.llm
 
     for p in path:
         if p.type == "outline":
             outline_info = outline_infos_map.get(p.bid)
             if outline_info.ask_enabled_status != ASK_MODE_DEFAULT:
                 return FollowUpInfo(
-                    ask_model=outline_info.ask_llm
-                    if outline_info.ask_llm
-                    else ask_model,
+                    ask_model=outline_info.ask_llm or ask_model,
                     ask_prompt=outline_info.ask_llm_system_prompt,
                     ask_history_count=10,
                     ask_limit_count=10,

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -6,8 +6,8 @@ from typing import Any
 from ..common.dicts import register_dict
 from .consts import *  # noqa: F403
 
-register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa
-register_dict("learn_status", "学习状态", LEARN_STATUS_TYPES)  # noqa
+register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa: F405
+register_dict("learn_status", "学习状态", LEARN_STATUS_TYPES)  # noqa: F405
 
 
 def __getattr__(name: str) -> Any:

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -230,7 +230,7 @@ def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
                 coupon_filter = {}
             if "course_id" in coupon_filter:
                 course_id = coupon_filter["course_id"]
-                if course_id and course_id != "" and course_id != buy_record.shifu_bid:
+                if course_id and course_id not in ("", buy_record.shifu_bid):
                     raise_error("server.discount.discountNotApply")
 
         coupon_usage.status = COUPON_STATUS_USED

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -1338,9 +1338,7 @@ def _is_stripe_payment_successful(
             return True
         if session.get("status") == "complete":
             return True
-    if intent and intent.get("status") == "succeeded":
-        return True
-    return False
+    return bool(intent and intent.get("status") == "succeeded")
 
 
 def _apply_native_snapshot_update(

--- a/src/api/flaskr/service/order/open_api.py
+++ b/src/api/flaskr/service/order/open_api.py
@@ -89,14 +89,13 @@ def open_api_grant_order(
         if existing_order:
             return {"order_bid": existing_order.order_bid}
 
-    result = import_activation_order(
+    return import_activation_order(
         app,
         user_identify,
         shifu_bid,
         contact_type=user_identify_type,
         payment_channel="open_api",
     )
-    return result
 
 
 def open_api_revoke_order(

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -123,7 +123,7 @@ class PingxxProvider(PaymentProvider):
 
         charge = client.Charge.create(
             order_no=request.order_bid,
-            app=dict(id=app_id),
+            app={"id": app_id},
             channel=request.channel,
             amount=request.amount,
             client_ip=request.client_ip,

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -151,9 +151,7 @@ def check_text_content(
         1 if res.check_result == CHECK_RESULT_PASS else 0,
         "check_text",
     )
-    if res.check_result == CHECK_RESULT_REJECT:
-        return False
-    return True
+    return res.check_result != CHECK_RESULT_REJECT
 
 
 def get_profile_labels():
@@ -432,7 +430,7 @@ def get_user_profile_labels(
                     items=meta.get("items"),
                 )
             )
-    for key in PROFILES_LABLES.keys():
+    for key in PROFILES_LABLES:
         if key in mapping_keys:
             continue
         profile_key = key
@@ -444,11 +442,7 @@ def get_user_profile_labels(
                 ("select" if "items" in PROFILES_LABLES[profile_key] else "text"),
             ),
             "value": "",
-            "items": (
-                PROFILES_LABLES[profile_key]["items"]
-                if "items" in PROFILES_LABLES[profile_key]
-                else None
-            ),
+            "items": PROFILES_LABLES[profile_key].get("items"),
         }
         user_value = None
         profile_item = next(

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -353,8 +353,7 @@ def _parse_datetime(value: object, field_name: str) -> datetime | None:
         return None
     for datetime_format in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
         try:
-            parsed = datetime.strptime(normalized, datetime_format)
-            return parsed
+            return datetime.strptime(normalized, datetime_format)
         except ValueError:
             continue
     try:

--- a/src/api/flaskr/service/referral/dtos.py
+++ b/src/api/flaskr/service/referral/dtos.py
@@ -27,7 +27,7 @@ class InviteProfileDTO:
     available: bool = True
 
     @classmethod
-    def unavailable(cls) -> "InviteProfileDTO":
+    def unavailable(cls) -> InviteProfileDTO:
         return cls(
             campaign_bid="",
             campaign_code="",

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -139,9 +139,7 @@ def _within_window(
 ) -> bool:
     if starts_at is not None and starts_at > now:
         return False
-    if ends_at is not None and ends_at <= now:
-        return False
-    return True
+    return not (ends_at is not None and ends_at <= now)
 
 
 def _campaign_runtime_enabled(campaign: ReferralCampaign, *, now: datetime) -> bool:

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -623,7 +623,8 @@ _list_operator_courses_legacy = _operator_courses._list_operator_courses_legacy
 list_operator_courses = _operator_courses.list_operator_courses
 load_existing_demo_shifu_ids = _operator_courses.load_existing_demo_shifu_ids
 
-_OPERATOR_COURSE_FORWARDABLE_NAMES = _OPERATOR_COURSE_COMPAT_EXPORTS + (
+_OPERATOR_COURSE_FORWARDABLE_NAMES = (
+    *_OPERATOR_COURSE_COMPAT_EXPORTS,
     "check_text_with_risk_control",
     "datetime",
     "get_course_visit_count_30d",

--- a/src/api/flaskr/service/shifu/admin_dtos_courses.py
+++ b/src/api/flaskr/service/shifu/admin_dtos_courses.py
@@ -371,7 +371,7 @@ class AdminOperationCourseDetailChapterDTO(BaseModel):
         ..., description="Last modifier nickname", required=False
     )
     updated_at: datetime | None = Field(..., description="Updated at", required=False)
-    children: list["AdminOperationCourseDetailChapterDTO"] = Field(
+    children: list[AdminOperationCourseDetailChapterDTO] = Field(
         default_factory=list,
         description="Nested children",
         required=False,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -84,10 +84,8 @@ def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:
 
     metadata = _normalize_metadata_json(getattr(row, "extra", None))
     generation_name = str(metadata.get("generation_name", "") or "").strip().lower()
-    if (
-        "/user_follow_ask/" in generation_name
-        or generation_name.startswith("lesson_ask/")
-        or generation_name.startswith("lesson_preview_ask/")
+    if "/user_follow_ask/" in generation_name or generation_name.startswith(
+        ("lesson_ask/", "lesson_preview_ask/")
     ):
         return COURSE_CREDIT_USAGE_MODE_ASK
 

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -400,16 +400,11 @@ def get_operator_course_users(
                 if not any(keyword in value for value in haystack if value):
                     continue
 
-            if (
-                user_role_filter
-                and user_role_filter != "all"
-                and user_role != user_role_filter
-            ):
+            if user_role_filter and user_role_filter not in ("all", user_role):
                 continue
-            if (
-                learning_status_filter
-                and learning_status_filter != "all"
-                and learning_status != learning_status_filter
+            if learning_status_filter and learning_status_filter not in (
+                "all",
+                learning_status,
             ):
                 continue
             if payment_status_filter == "paid" and not is_paid:

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -564,7 +564,7 @@ def get_operator_user_credit_usage_detail(
         )
         generated_block_bids = [
             str(getattr(row, "generated_block_bid", "") or "").strip()
-            for row in detail_rows + [main_usage_row]
+            for row in [*detail_rows, main_usage_row]
         ]
         block_content_map = _load_generated_block_content_map(generated_block_bids)
         fallback_content = block_content_map.get(

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -136,10 +136,8 @@ def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:
 
     metadata = _normalize_metadata_json(getattr(row, "extra", None))
     generation_name = str(metadata.get("generation_name", "") or "").strip().lower()
-    if (
-        "/user_follow_ask/" in generation_name
-        or generation_name.startswith("lesson_ask/")
-        or generation_name.startswith("lesson_preview_ask/")
+    if "/user_follow_ask/" in generation_name or generation_name.startswith(
+        ("lesson_ask/", "lesson_preview_ask/")
     ):
         return COURSE_CREDIT_USAGE_MODE_ASK
 

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -509,11 +509,9 @@ def _load_operator_user_registration_source_map(
         return {}
 
     resolved_credential_rows = sorted(
-        list(
-            credential_rows
-            if credential_rows is not None
-            else _load_operator_user_auth_credentials(normalized_user_bids)
-        ),
+        credential_rows
+        if credential_rows is not None
+        else _load_operator_user_auth_credentials(normalized_user_bids),
         key=lambda credential: (
             getattr(credential, "created_at", None) or datetime.min,
             int(getattr(credential, "id", 0) or 0),
@@ -660,11 +658,9 @@ def _load_operator_user_contact_map(
         return {}
 
     resolved_credential_rows = sorted(
-        list(
-            credential_rows
-            if credential_rows is not None
-            else _load_operator_user_auth_credentials(user_bids)
-        ),
+        credential_rows
+        if credential_rows is not None
+        else _load_operator_user_auth_credentials(user_bids),
         key=lambda credential: int(getattr(credential, "id", 0) or 0),
         reverse=True,
     )

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -298,7 +298,7 @@ class SimpleOutlineDto(BaseModel):
         type: str | None = None,
         is_hidden: bool | None = None,
     ):
-        normalized_children: list["SimpleOutlineDto"] = []
+        normalized_children: list[SimpleOutlineDto] = []
         if children:
             for child in children:
                 if isinstance(child, SimpleOutlineDto):

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -305,7 +305,7 @@ def shifu_permission_verification(
                         permissions.add("view")
                     if lowered in {"edit", "write"} or lowered == "2":
                         permissions.update({"view", "edit"})
-                    if lowered in {"publish"} or lowered == "4":
+                    if lowered in {"publish", "4"}:
                         permissions.add("publish")
                 # Fallback to raw values if mapping failed
                 permissions = permissions or set(normalized)

--- a/src/api/flaskr/service/shifu/permissions.py
+++ b/src/api/flaskr/service/shifu/permissions.py
@@ -43,7 +43,7 @@ def _auth_types_to_permissions(auth_types: Set[str]) -> Set[str]:
             perms.add("view")
         if lowered in {"edit", "write"} or lowered == "2":
             perms.update({"view", "edit"})
-        if lowered in {"publish"} or lowered == "4":
+        if lowered in {"publish", "4"}:
             perms.add("publish")
     return perms
 

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -468,7 +468,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         page_index = request.args.get("page_index", 1)
         page_size = request.args.get("page_size", 10)
         is_favorite = request.args.get("is_favorite", "False")
-        is_favorite = True if is_favorite.lower() == "true" else False
+        is_favorite = is_favorite.lower() == "true"
         archived_param = request.args.get("archived")
         archived = False
         if archived_param is not None:
@@ -1049,7 +1049,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         shifu_bid = request.view_args.get("shifu_bid")
         is_favorite = request.get_json().get("is_favorite")
         if isinstance(is_favorite, str):
-            is_favorite = True if is_favorite.lower() == "true" else False
+            is_favorite = is_favorite.lower() == "true"
         elif isinstance(is_favorite, bool):
             is_favorite = is_favorite
         else:

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -2513,12 +2513,11 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 prompt_file.content_type if prompt_file is not None else ""
             ),
         )
-        response = current_app.response_class(
+        return current_app.response_class(
             response=make_common_response(serialize_minimax_cloned_voice(row)),
             status=202,
             mimetype="application/json",
         )
-        return response
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1050,9 +1050,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         is_favorite = request.get_json().get("is_favorite")
         if isinstance(is_favorite, str):
             is_favorite = is_favorite.lower() == "true"
-        elif isinstance(is_favorite, bool):
-            is_favorite = is_favorite
-        else:
+        elif not isinstance(is_favorite, bool):
             raise_param_error("is_favorite is not a boolean")
         return make_common_response(
             mark_or_unmark_favorite_shifu(app, user_id, shifu_bid, is_favorite)

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -567,7 +567,7 @@ def save_shifu_draft_info(
                     shifu_temperature if shifu_temperature is not None else 0.3
                 ),
                 price=shifu_price,
-                llm_system_prompt=shifu_system_prompt if shifu_system_prompt else "",
+                llm_system_prompt=shifu_system_prompt or "",
                 ask_enabled_status=ask_enabled_status,
                 ask_llm=ask_model,
                 ask_llm_temperature=ask_temperature,

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -271,8 +271,7 @@ def get_shifu_history(app, shifu_bid: str) -> HistoryItem:
             .first()
         )
         if not shifu_history:
-            init_history = HistoryItem(bid=shifu_bid, id=0, type="shifu", children=[])
-            return init_history
+            return HistoryItem(bid=shifu_bid, id=0, type="shifu", children=[])
         return HistoryItem.from_json(shifu_history.struct)
 
 

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -129,7 +129,7 @@ def export_shifu(app: Flask, shifu_id: str, file_path: str) -> str:
 
         # Write to file
         os.makedirs(
-            os.path.dirname(file_path) if os.path.dirname(file_path) else ".",
+            os.path.dirname(file_path) or ".",
             exist_ok=True,
         )
         with open(file_path, "w", encoding="utf-8") as f:
@@ -423,7 +423,7 @@ def import_shifu(
             new_structure = rebuild_structure(structure_data)
             if new_structure:
                 # Save outline tree history
-                outline_tree = new_structure.children if new_structure.children else []
+                outline_tree = new_structure.children or []
                 save_outline_tree_history(
                     app, user_id, shifu_bid, outline_tree, new_shifu.id
                 )

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -412,9 +412,7 @@ def get_shifu_mdflow_history_version_detail(
                     else ""
                 )
                 user_name = (
-                    (user.nickname if user.nickname else "")
-                    or masked_identifier
-                    or version.updated_user_bid
+                    user.nickname or masked_identifier or version.updated_user_bid
                 )
 
         return {

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -752,7 +752,7 @@ def get_unit_by_id(app, user_id: str, unit_id: str):
         if not unit:
             raise_error("server.shifu.unitNotFound")
         unit_type: str = UNIT_TYPE_VALUES_REVERSE.get(unit.type, UNIT_TYPE_TRIAL)
-        is_hidden: bool = True if unit.hidden == 1 else False
+        is_hidden: bool = unit.hidden == 1
 
         return OutlineDto(
             bid=unit.outline_item_bid,

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -472,7 +472,7 @@ def _make_ask_prompt(
     Returns:
         Ask prompt
     """
-    result = ask_prompt.format(
+    return ask_prompt.format(
         learned=("\n" + learned_text) if learned_text else "",
         unlearned=("\n" + unlearned_text) if unlearned_text else "",
         # Runtime placeholders: shifu_system_message is filled on every ask;
@@ -483,7 +483,6 @@ def _make_ask_prompt(
         knowledge_rule="{knowledge_rule}",
         knowledge_section="{knowledge_section}",
     )
-    return result
 
 
 def _get_summary(app, prompt, model_name, user_id=None, temperature=0.8):

--- a/src/api/flaskr/service/shifu/struct_utils.py
+++ b/src/api/flaskr/service/shifu/struct_utils.py
@@ -28,7 +28,7 @@ def find_node_with_parents(
     if root.bid == target_bid:
         return current_path.copy()
 
-    for i, child in enumerate(root.children):
+    for _i, child in enumerate(root.children):
         result = find_node_with_parents(child, target_bid, current_path)
         if result:
             return result

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -149,7 +149,7 @@ def normalize_audio_blob(
             "unable to decode audio; please record again or upload mp3, m4a, or wav"
         ) from exc
 
-    duration_ms = int(len(segment))
+    duration_ms = len(segment)
     if purpose == "source":
         if duration_ms < _SOURCE_MIN_DURATION_MS:
             raise ValueError("source audio must be at least 10 seconds")

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -806,7 +806,7 @@ def synthesize_long_text_to_oss(
                 provider,
             )
         audio_parts = [b""] * len(segments)
-        segment_map = {idx: segment for idx, segment in enumerate(segments)}
+        segment_map = dict(enumerate(segments))
 
         def _synthesize_in_app_context(segment_text: str):
             with app.app_context():

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -821,8 +821,8 @@ class StreamingTTSProcessor:
                 int(cue.get("end_ms", source_start_ms) or source_start_ms),
                 source_start_ms,
             )
-            start_ms = timeline_start_ms + int(round(source_start_ms * scale))
-            end_ms = timeline_start_ms + int(round(source_cue_end_ms * scale))
+            start_ms = timeline_start_ms + round(source_start_ms * scale)
+            end_ms = timeline_start_ms + round(source_cue_end_ms * scale)
             start_ms = min(max(start_ms, last_end_ms), timeline_end_ms)
             if start_ms >= timeline_end_ms:
                 continue
@@ -930,7 +930,7 @@ class StreamingTTSProcessor:
             if raw_value is None or raw_value == "":
                 continue
             try:
-                return int(round(float(raw_value)))
+                return round(float(raw_value))
             except (TypeError, ValueError):
                 continue
         return int(default_ms or 0)
@@ -1034,8 +1034,8 @@ class StreamingTTSProcessor:
             if index == len(units) - 1:
                 unit_duration_ms = remaining_duration_ms
             elif safe_duration_ms > 0:
-                unit_duration_ms = int(
-                    round(remaining_duration_ms * weights[index] / remaining_weight)
+                unit_duration_ms = round(
+                    remaining_duration_ms * weights[index] / remaining_weight
                 )
                 unit_duration_ms = max(min(unit_duration_ms, remaining_duration_ms), 0)
             else:
@@ -1161,11 +1161,11 @@ class StreamingTTSProcessor:
                 source_start_ms,
             )
             start_ms = min(
-                int(round(source_start_ms * scale)),
+                round(source_start_ms * scale),
                 safe_live_request_end_ms,
             )
             end_ms = min(
-                int(round(source_cue_end_ms * scale)),
+                round(source_cue_end_ms * scale),
                 safe_live_request_end_ms,
             )
             live_cues.append(
@@ -1227,7 +1227,7 @@ class StreamingTTSProcessor:
             int(tail_candidate.get("end_ms", 0) or 0),
         )
         remaining = [dict(cue) for cue in incoming[incoming_tail_index + 1 :]]
-        return frozen_prefix + [previous_tail] + remaining
+        return [*frozen_prefix, previous_tail, *remaining]
 
     def _normalize_minimax_live_request_cues(
         self,

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -2182,8 +2182,7 @@ class AVStreamingTTSProcessor:
         if not segments:
             return
         self._next_element_index = max(
-            self._next_element_index,
-            max(seg.element_index + 1 for seg in segments),
+            self._next_element_index, *(seg.element_index + 1 for seg in segments)
         )
 
     def _finalize_current(

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -2160,8 +2160,7 @@ class AVStreamingTTSProcessor:
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         if (chunk or "").strip():
             self._current_segment_has_speakable_text = True
-        for event in processor.process_chunk(chunk):
-            yield event
+        yield from processor.process_chunk(chunk)
 
     @property
     def next_element_index(self) -> int:

--- a/src/api/flaskr/service/tts/tts_usage_recorder.py
+++ b/src/api/flaskr/service/tts/tts_usage_recorder.py
@@ -17,8 +17,8 @@ from flaskr.service.tts import resolve_tts_billable_chars
 
 
 def build_tts_metadata(
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
 ) -> dict:
     """Build metadata dict from voice and audio settings.
 
@@ -42,16 +42,16 @@ def build_tts_metadata(
 
 
 def record_tts_segment_usage(
-    app: "Flask",
-    usage_context: "UsageContext",
+    app: Flask,
+    usage_context: UsageContext,
     provider: str,
     model: str,
     segment_text: str,
     word_count: int,
     duration_ms: int,
     latency_ms: int,
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
     is_stream: bool,
     parent_usage_bid: str,
     segment_index: int,
@@ -103,8 +103,8 @@ def record_tts_segment_usage(
 
 
 def record_tts_aggregated_usage(
-    app: "Flask",
-    usage_context: "UsageContext",
+    app: Flask,
+    usage_context: UsageContext,
     usage_bid: str,
     provider: str,
     model: str,
@@ -113,8 +113,8 @@ def record_tts_aggregated_usage(
     total_word_count: int,
     duration_ms: int,
     segment_count: int,
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
     is_stream: bool = True,
     total_usage_characters: int = 0,
 ) -> None:

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -47,7 +47,7 @@ STATE_TTL = 900
 
 def _encode_state(app, payload: Dict[str, Any]) -> str:
     now = int(time.time())
-    token = jwt.encode(
+    return jwt.encode(
         {
             "iat": now,
             "exp": now + STATE_TTL,
@@ -57,7 +57,6 @@ def _encode_state(app, payload: Dict[str, Any]) -> str:
         app.config["SECRET_KEY"],
         algorithm="HS256",
     )
-    return token
 
 
 def _decode_state(app, state: str) -> Optional[Dict[str, Any]]:

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -303,7 +303,7 @@ def verify_phone_code(
     if code != FIX_CHECK_CODE:
         cached = None
         cached_phone = normalized_phone
-        for code_key, lookup_phone in zip(code_keys, lookup_phones):
+        for code_key, lookup_phone in zip(code_keys, lookup_phones, strict=False):
             cached = redis.get(code_key)
             if cached is not None:
                 cached_phone = lookup_phone

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -238,7 +238,7 @@ def _build_user_aggregate(
     credentials: Optional[List[AuthCredential]] = None,
 ) -> UserAggregate:
     summaries = _summarize_credentials(credentials or [])
-    aggregate = UserAggregate(
+    return UserAggregate(
         user_bid=entity.user_bid,
         identify=entity.user_identify or "",
         nickname=entity.nickname or "",
@@ -256,7 +256,6 @@ def _build_user_aggregate(
         is_creator=bool(entity.is_creator),
         is_operator=bool(entity.is_operator),
     )
-    return aggregate
 
 
 def get_user_entity_by_bid(

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -206,9 +206,9 @@ def _normalize_identifier(provider: str, identifier: Optional[str]) -> str:
     if not identifier:
         return ""
     normalized = identifier.strip()
-    if provider in {"email"}:
+    if provider == "email":
         return normalized.lower()
-    if provider in {"phone"}:
+    if provider == "phone":
         return normalize_phone_identifier(normalized)
     return normalized
 

--- a/src/api/flaskr/service/user/verification_codes.py
+++ b/src/api/flaskr/service/user/verification_codes.py
@@ -181,7 +181,9 @@ def consume_verification_code(app: Flask, *, identifier: str, code: str) -> None
 
     cached = None
     cached_identifier = identifier
-    for cache_key, lookup_identifier in zip(cache_keys, lookup_identifiers):
+    for cache_key, lookup_identifier in zip(
+        cache_keys, lookup_identifiers, strict=False
+    ):
         cached = redis.get(cache_key)
         if cached is not None:
             cached_identifier = lookup_identifier

--- a/src/api/flaskr/util/compare.py
+++ b/src/api/flaskr/util/compare.py
@@ -2,10 +2,10 @@ import decimal
 
 
 def compare_decimal(a, b):
-    a_temp = decimal.Decimal(str(a if a else 0)).quantize(
+    a_temp = decimal.Decimal(str(a or 0)).quantize(
         decimal.Decimal("0.01"), rounding=decimal.ROUND_DOWN
     )
-    b_temp = decimal.Decimal(str(b if b else 0)).quantize(
+    b_temp = decimal.Decimal(str(b or 0)).quantize(
         decimal.Decimal("0.01"), rounding=decimal.ROUND_DOWN
     )
     return a_temp == b_temp

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -90,9 +90,9 @@ def include_object(object, name, type_, reflected, compare_to):
         if hasattr(object, "table"):
             table_name = object.table.name
             # the system tables
-            if table_name in system_tables or table_name.startswith("information_"):
-                return False
-            return True
+            return not (
+                table_name in system_tables or table_name.startswith("information_")
+            )
         return False
 
     return True

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -240,7 +240,7 @@ def _format_stream_parts(
 def _group_expected_stream_elements(
     parts: list[tuple[str, str, int]],
 ) -> list[ExpectedStreamElement]:
-    grouped: "OrderedDict[int, ExpectedStreamElement]" = OrderedDict()
+    grouped: OrderedDict[int, ExpectedStreamElement] = OrderedDict()
     for content, stream_type, number in parts:
         if not content or not stream_type:
             continue

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -530,7 +530,7 @@ def _analyze_stream_only(
             )
 
         for idx, (expected_item, observed_item) in enumerate(
-            zip(expected, observed), start=1
+            zip(expected, observed, strict=False), start=1
         ):
             expected_type = _element_type_from_mdflow_stream(
                 expected_item.stream_type, expected_item.content_text

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -193,7 +193,7 @@ def _detect_issues(
         )
 
     for idx, (expected, observed) in enumerate(
-        zip(expected_segments, observed_segments), start=1
+        zip(expected_segments, observed_segments, strict=False), start=1
     ):
         if expected != observed:
             if _normalize_text(expected) == _normalize_text(observed):

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -141,7 +141,7 @@ for rel in sorted(route_files):
             ):
                 env[arg.arg] = a.defaults[di].value
         # keyword-only defaults
-        for arg, d in zip(a.kwonlyargs, a.kw_defaults):
+        for arg, d in zip(a.kwonlyargs, a.kw_defaults, strict=False):
             if (
                 d is not None
                 and isinstance(d, ast.Constant)

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -43,7 +43,7 @@ def add_tree(base_pkg, base_dir):
             if fn == "__init__.py":
                 name = ".".join(parts)
             else:
-                name = ".".join(parts + [fn[:-3]])
+                name = ".".join([*parts, fn[:-3]])
             mods[name] = os.path.join(rel, fn)
 
 

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -110,8 +110,7 @@ roots = set()
 for name, rel in mods.items():
     if (
         name in ("app", "celery_app")
-        or rel.startswith("scripts" + os.sep)
-        or rel.startswith("flaskr/command")
+        or rel.startswith(("scripts" + os.sep, "flaskr/command"))
         or name == "flaskr.route"
     ):
         roots.add(name)

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -50,7 +50,7 @@ def grep_paths(root, extra_args=None):
         return set()
     # no quote anchoring: f-strings like f"{base}/api/x/{bid}/export" must hit
     cmd = ["grep", "-rhoE", r"/api/[^'\"`[:space:]]*", root]
-    out = subprocess.run(cmd, capture_output=True, text=True).stdout
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False).stdout
     paths = set()
     for line in out.splitlines():
         p = line.strip().rstrip(".,;:)]}")
@@ -109,7 +109,9 @@ for line in open(BACKEND_ROUTES, encoding="utf-8"):
 def match(be_segs, fe_segs):
     if len(be_segs) != len(fe_segs):
         return False
-    return all(a == b or a == "*" or b == "*" for a, b in zip(be_segs, fe_segs))
+    return all(
+        a == b or a == "*" or b == "*" for a, b in zip(be_segs, fe_segs, strict=False)
+    )
 
 
 rows = []

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -38,7 +38,7 @@ def norm(path):
     for s in path.split("/"):
         if not s:
             continue
-        if "${" in s or "{" in s or s.startswith(":") or s.startswith("<"):
+        if "${" in s or "{" in s or s.startswith((":", "<")):
             segs.append("*")
         else:
             segs.append(s)
@@ -110,7 +110,7 @@ def match(be_segs, fe_segs):
     if len(be_segs) != len(fe_segs):
         return False
     return all(
-        a == b or a == "*" or b == "*" for a, b in zip(be_segs, fe_segs, strict=False)
+        a in (b, "*") or b == "*" for a, b in zip(be_segs, fe_segs, strict=False)
     )
 
 
@@ -124,7 +124,7 @@ for method, path, segs, src in be:
     low = path.lower() + " " + src.lower()
     if re.search(r"callback|notify|webhook", low) or path.startswith("/api/open-api/"):
         consumers.append("external-callback")
-    if path in ("/health",) or path.startswith("/internal/") or "observability" in src:
+    if path == "/health" or path.startswith("/internal/") or "observability" in src:
         consumers.append("ops")
     if not consumers:
         consumers = ["NO-KNOWN-CONSUMER"]

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -259,8 +259,7 @@ def _escape_markdown_cell(value: Any) -> str:
     # Avoid breaking Markdown tables.
     cell = cell.replace("|", "\\|")
     # Render newlines as <br> so the table stays intact.
-    cell = cell.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "<br>")
-    return cell
+    return cell.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "<br>")
 
 
 def _render_markdown(rows: list[ReportRow], *, output_path: str) -> str:

--- a/src/api/tests/__init__.py
+++ b/src/api/tests/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from flaskr.common.config import get_config
 
-from .test_app import *  # noqa
+from .test_app import *  # noqa: F403
 
 # Load a deterministic, test-only dotenv (skip user/global .env files)
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env.test", override=True)

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -44,7 +44,7 @@ def test_worker_process_init_signal_disposes_pools(app):
 
 
 def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     disposed = []
 

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -39,7 +39,7 @@ def _operational(errno: int) -> OperationalError:
 
 
 @pytest.mark.parametrize(
-    "exc,expected",
+    ("exc", "expected"),
     [
         (GeneratorExit(), True),
         (_FakeGreenletExit(), True),

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -146,7 +146,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
     """The global teardown guard must fire on abnormal context exits and run
     BEFORE Flask-SQLAlchemy's remove (reverse registration order).
     """
-    import flaskr.dao as dao
+    from flaskr import dao
 
     order = []
     monkeypatch.setattr(
@@ -174,7 +174,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
 
 
 def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(
@@ -193,7 +193,7 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
 def test_release_session_classified_invalidates_during_propagating_interrupt(
     app, monkeypatch
 ):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     order = []
     monkeypatch.setattr(
@@ -238,7 +238,7 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
 
 
 def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -167,7 +167,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
 
     with pytest.raises(_Interrupt):
         with app.app_context():
-            raise _Interrupt()
+            raise _Interrupt
 
     assert order[0] == "invalidate:appcontext teardown interrupt"
     assert "remove" in order
@@ -213,7 +213,7 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
 
     with app.app_context():
         try:
-            raise _Interrupt()
+            raise _Interrupt
         except _Interrupt:
             pass
         # No in-flight exception here: plain removal, no invalidate.
@@ -223,7 +223,7 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
 
         try:
             try:
-                raise _Interrupt()
+                raise _Interrupt
             finally:
                 # In-flight BaseException visible via sys.exc_info in finally:
                 # invalidate must run BEFORE removal, otherwise remove() emits

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -8,8 +8,8 @@ recirculating them.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from sqlalchemy.pool import QueuePool
 
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -9,8 +9,8 @@ statement via the per-connection journal.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.dao import db
 from sqlalchemy import text
 from sqlalchemy.exc import DisconnectionError

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -9,8 +9,8 @@ record BEFORE any interruption propagates.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from sqlalchemy.exc import DisconnectionError
 
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -234,8 +234,8 @@ def isolate_env_for_non_app_tests(request):
     if "app" in request.fixturenames:
         yield
         return
-    original = {key: os.environ.get(key) for key in ENV_VARS.keys()}
-    for key in ENV_VARS.keys():
+    original = {key: os.environ.get(key) for key in ENV_VARS}
+    for key in ENV_VARS:
         os.environ.pop(key, None)
 
     # Some tests monkeypatch env vars while a session-scoped Flask app has

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -122,7 +122,7 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
             captured["config"] = config
 
         def send_sms_with_options(self, request, runtime):
-            raise DummyError()
+            raise DummyError
 
     def fake_assert(message):
         captured["assert_message"] = message

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -205,7 +205,7 @@ def mock_validate_user(monkeypatch, user_bid: str, *, is_creator: bool = False) 
 
 def seed_golden_user(app, user_bid: str) -> None:
     """Ensure a learner row exists for load_user_aggregate()."""
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.service.user.models import UserInfo
 
     with app.app_context():
@@ -231,7 +231,7 @@ def golden_shifu(app):
     Idempotent: existing golden rows are removed before reseeding so every
     test starts from the same published structure regardless of ordering.
     """
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.service.shifu.models import (
         LogPublishedStruct,
         PublishedOutlineItem,

--- a/src/api/tests/golden/normalize.py
+++ b/src/api/tests/golden/normalize.py
@@ -67,8 +67,7 @@ class IdNormalizer:
     def normalize_string(self, value: str) -> str:
         value = UUID_RE.sub(self._replace_match, value)
         value = HEX_ID_RE.sub(self._replace_match, value)
-        value = ISO_TS_RE.sub("<TS>", value)
-        return value
+        return ISO_TS_RE.sub("<TS>", value)
 
     def normalize_value(self, value: Any, field_name: str | None = None) -> Any:
         if isinstance(value, str):

--- a/src/api/tests/golden/test_api_json_golden.py
+++ b/src/api/tests/golden/test_api_json_golden.py
@@ -56,7 +56,7 @@ JSON_GOLDEN_CASES = [
 
 
 @pytest.mark.parametrize(
-    "fixture_key,path",
+    ("fixture_key", "path"),
     JSON_GOLDEN_CASES,
     ids=[case[0] for case in JSON_GOLDEN_CASES],
 )

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -27,7 +27,8 @@ def _load_migration_module(path=MIGRATION_PATH):
         "test_learner_profile_migration_module",
         path,
     )
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -5,10 +5,10 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import flaskr.service.billing.checkout as billing_checkout_module
 import flaskr.service.billing.subscriptions as billing_subscriptions_module
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.i18n import load_translations, set_language
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/cycle_state_test_helpers.py
+++ b/src/api/tests/service/billing/cycle_state_test_helpers.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,
     BILLING_INTERVAL_MONTH,

--- a/src/api/tests/service/billing/renewal_execution_app_fixture.py
+++ b/src/api/tests/service/billing/renewal_execution_app_fixture.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from tests.common.fixtures.bill_products import build_bill_products
 
 

--- a/src/api/tests/service/billing/renewal_execution_test_helpers.py
+++ b/src/api/tests/service/billing/renewal_execution_test_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_INTERVAL_MONTH,
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.customization as billing_customization_module
 import flaskr.service.billing.queries as billing_queries_module
@@ -13,6 +12,7 @@ import flaskr.service.billing.serializers as billing_serializers_module
 import flaskr.service.billing.wallets as billing_wallets_module
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.i18n import _translations, load_translations, set_language
 from flaskr.service.billing.campaigns import (
     build_admin_billing_campaign_detail,

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -1,4 +1,4 @@
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing import admin_ops_state
 
 

--- a/src/api/tests/service/billing/test_billing_admission.py
+++ b/src/api/tests/service/billing/test_billing_admission.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.admission import admit_creator_usage
 from flaskr.service.billing.consts import (
     BILLING_ENTITLEMENT_PRIORITY_CLASS_VIP,

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.route.callback import register_callback_handler
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_CANCELED,

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -4,9 +4,9 @@ import json
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import notifications as billing_notifications
 from flaskr.service.billing.cli import register_billing_commands
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -4,9 +4,9 @@ import json
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.cli import register_billing_commands
 from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -313,14 +313,10 @@ def test_audit_credit_state_rejects_invalid_explicit_as_of(
     billing_credit_audit_app: Flask,
 ) -> None:
     with billing_credit_audit_app.app_context():
-        try:
+        with pytest.raises(ValueError, match="Unable to parse as_of value"):
             audit_credit_state(
                 creator_bid="creator-audit-invalid-time", as_of="bad-date"
             )
-        except ValueError as exc:
-            assert "Unable to parse as_of value" in str(exc)
-        else:
-            raise AssertionError("Expected invalid as_of to raise ValueError")
 
     runner = billing_credit_audit_app.test_cli_runner()
     result = runner.invoke(

--- a/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_cycle_state_repair.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_repair.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.billing import subscriptions as subscriptions_mod
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
+++ b/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,

--- a/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,

--- a/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_METRIC_LLM_OUTPUT_TOKENS,

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.domains as billing_domains
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.common.shifu_context import get_shifu_creator_bid, with_shifu_context
 from flaskr.service.billing.consts import (
     BILLING_DOMAIN_BINDING_STATUS_DISABLED,

--- a/src/api/tests/service/billing/test_billing_entitlements.py
+++ b/src/api/tests/service/billing/test_billing_entitlements.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ENTITLEMENT_ANALYTICS_TIER_ENTERPRISE,
     BILLING_ENTITLEMENT_PRIORITY_CLASS_PRIORITY,

--- a/src/api/tests/service/billing/test_billing_ownership.py
+++ b/src/api/tests/service/billing/test_billing_ownership.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.ownership import (
     resolve_shifu_creator_bid,
     resolve_usage_creator_bid,

--- a/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
+++ b/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.billing import subscriptions as subscriptions_mod
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_renewal_event_basics.py
+++ b/src/api/tests/service/billing/test_billing_renewal_event_basics.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,

--- a/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_FAILED,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.entitlements as billing_entitlements_module
 import flaskr.service.billing.queries as billing_queries_module
@@ -13,6 +12,7 @@ import flaskr.service.billing.read_models as billing_read_models_module
 import flaskr.service.billing.serializers as billing_serializers_module
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.service.billing.capabilities import build_billing_route_bootstrap
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -5,9 +5,9 @@ import types
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -9,9 +9,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_ORDER_STATUS_PENDING,

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
+++ b/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     CREDIT_BUCKET_CATEGORY_FREE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_credit_grant_allocation_views.py
+++ b/src/api/tests/service/billing/test_credit_grant_allocation_views.py
@@ -4,9 +4,9 @@ import math
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_MANUAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -24,9 +24,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.i18n import load_translations
 from flaskr.service.billing import credit_notifications

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -8,9 +8,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_TOPUP,

--- a/src/api/tests/service/billing/test_grant_manual_entitlement.py
+++ b/src/api/tests/service/billing/test_grant_manual_entitlement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _cleanup(app, creator_bid: str) -> None:

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_TTS_REQUEST_COUNT,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_CANCELED,

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -25,9 +25,9 @@ from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing import renewal_event_transitions

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-import flaskr.common.public_urls as public_urls
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
+from flaskr.common import public_urls
 from flaskr.common.config import ENV_VARS
 from flaskr.route import config as config_route
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.charges import (
     build_usage_metric_charges,
     resolve_credit_multiplier_label,

--- a/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
+++ b/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 
 
 @pytest.fixture

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -97,7 +97,7 @@ def test_read_storage_bytes_fetches_from_oss_when_local_file_is_missing(
     monkeypatch,
     tmp_path,
 ):
-    import flaskr.service.common.storage as storage
+    from flaskr.service.common import storage
     from flaskr.service.common.oss_utils import OSSConfig
 
     _make_storage_app(monkeypatch, tmp_path, "oss")

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -52,7 +52,7 @@ def app():
     db.init_app(flask_app)
     with flask_app.app_context():
         db.create_all()
-    yield flask_app
+    return flask_app
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/creator_analytics/test_whitelist.py
+++ b/src/api/tests/service/creator_analytics/test_whitelist.py
@@ -80,7 +80,7 @@ def test_aggregate_functions_are_allowed(table_key: str) -> None:
 def test_shifu_user_archives_has_no_deleted_column() -> None:
     spec = WHITELIST["shifu_user_archives"]
     assert spec.has_deleted is False
-    assert "deleted" not in spec.model.__table__.c.keys()
+    assert "deleted" not in spec.model.__table__.c
 
 
 @pytest.mark.parametrize(
@@ -90,14 +90,14 @@ def test_shifu_user_archives_has_no_deleted_column() -> None:
 def test_other_tables_have_deleted_column(table_key: str) -> None:
     spec = WHITELIST[table_key]
     assert spec.has_deleted is True
-    assert "deleted" in spec.model.__table__.c.keys()
+    assert "deleted" in spec.model.__table__.c
 
 
 @pytest.mark.parametrize("table_key", sorted(SHIFU_SCOPED_TABLE_KEYS))
 def test_shifu_scoped_tables_have_shifu_bid_column(table_key: str) -> None:
     spec = WHITELIST[table_key]
     assert spec.has_shifu_bid is True
-    assert "shifu_bid" in spec.model.__table__.c.keys(), (
+    assert "shifu_bid" in spec.model.__table__.c, (
         f"{table_key} declares has_shifu_bid=True but the column is missing"
     )
 
@@ -106,7 +106,7 @@ def test_user_users_is_global_table() -> None:
     """user_users has no shifu_bid column; gated by permission check instead."""
     spec = WHITELIST["user_users"]
     assert spec.has_shifu_bid is False
-    assert "shifu_bid" not in spec.model.__table__.c.keys()
+    assert "shifu_bid" not in spec.model.__table__.c
 
 
 def test_shifu_bid_and_deleted_are_never_user_addressable() -> None:

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -8,8 +8,8 @@ a payload smoke for emitter-side event construction.
 import types
 import unittest
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 from flaskr.service.learn.learn_dtos import GeneratedType

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -14,9 +14,9 @@ the change:
   the last finalized block.
 """
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 from flaskr.service.learn.run.recorder import RunRecorder
 from flaskr.service.order.consts import (

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -32,8 +32,7 @@ class _FakeResponse:
 
     def iter_lines(self, decode_unicode=True):
         _ = decode_unicode
-        for line in self._lines:
-            yield line
+        yield from self._lines
 
     def raise_for_status(self):
         if self._http_error is not None:

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -866,9 +866,11 @@ def test_get_biji_knowledge_adapter_maps_business_errors_to_user_messages(
         monkeypatch.setattr(
             get_biji_knowledge_adapter.requests,
             "post",
-            lambda *_args, **_kwargs: _FakeResponse(
-                status_code=status_code,
-                json_data={"success": False, "data": None, "error": error_body},
+            lambda *_args, _status_code=status_code, _error_body=error_body, **_kwargs: (
+                _FakeResponse(
+                    status_code=_status_code,
+                    json_data={"success": False, "data": None, "error": _error_body},
+                )
             ),
         )
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2506,7 +2506,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         self.assertTrue(all("?[" not in m["content"] for m in transformed))
         # Roles strictly alternate: no two adjacent user messages.
         roles = [m["role"] for m in transformed]
-        for prev, cur in zip(roles, roles[1:]):
+        for prev, cur in zip(roles, roles[1:], strict=False):
             self.assertFalse(
                 prev == "user" and cur == "user",
                 f"adjacent user messages in {roles}",

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -100,6 +100,7 @@ if not hasattr(dao, "redis_client"):
 
 import itertools
 
+import pytest
 from flaskr.service.learn import context_v2 as context_v2_module
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.context_v2 import (
@@ -224,7 +225,7 @@ class OutlinePathGuardTests(unittest.TestCase):
             "flaskr.service.learn.context_v2.raise_error",
             side_effect=RuntimeError("lesson missing"),
         ) as raise_error_mock:
-            with self.assertRaises(RuntimeError):
+            with pytest.raises(RuntimeError):
                 _find_outline_path_or_raise(root, "missing-outline")
 
         raise_error_mock.assert_called_once_with("server.shifu.lessonNotFoundInCourse")
@@ -803,7 +804,7 @@ class StreamTtsGateTests(unittest.TestCase):
 
             stop_event.set()
             stream.release_second.set()
-            with self.assertRaises(GeneratorExit):
+            with pytest.raises(GeneratorExit):
                 next(iterator)
 
         assert stream.close_calls == 1

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -98,6 +98,8 @@ if dao.db is None:
 if not hasattr(dao, "redis_client"):
     dao.redis_client = None
 
+import itertools
+
 from flaskr.service.learn import context_v2 as context_v2_module
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.context_v2 import (
@@ -2506,7 +2508,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         self.assertTrue(all("?[" not in m["content"] for m in transformed))
         # Roles strictly alternate: no two adjacent user messages.
         roles = [m["role"] for m in transformed]
-        for prev, cur in zip(roles, roles[1:], strict=False):
+        for prev, cur in itertools.pairwise(roles):
             self.assertFalse(
                 prev == "user" and cur == "user",
                 f"adjacent user messages in {roles}",

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2426,7 +2426,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         ctx = _make_context()
 
         def _raise_paid(_app):
-            raise PaidException()
+            raise PaidException
 
         ctx.run_inner = _raise_paid
         ctx._emit_feedback_after_exception_gate = lambda: iter(["feedback"])

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -83,7 +83,7 @@ _install_litellm_stub()
 _install_openai_responses_stub()
 
 # Ensure minimal SQLAlchemy bindings exist so model classes can be defined.
-import flaskr.dao as dao
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-context-v2")

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-context-v2-tts-runtime-voice-bootstrap")

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -15,9 +15,9 @@ import pytest
 
 @pytest.fixture
 def adapter_app():
-    import flaskr.dao as dao
     import flaskr.service.learn.models  # noqa: F401
     from flask import Flask
+    from flaskr import dao
 
     app = Flask("test-handle-ask-adapter")
     app.config.update(

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-generated-block-tts-av-mode")

--- a/src/api/tests/service/learn/test_get_current_attend_placeholders.py
+++ b/src/api/tests/service/learn/test_get_current_attend_placeholders.py
@@ -14,9 +14,9 @@ drive the placeholder loop directly against a real session.
 
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 from flaskr.service.learn.models import LearnProgressRecord
 from flaskr.service.order.consts import LEARN_STATUS_NOT_STARTED

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover - optional dependency
     redis_stub.Redis = _RedisStub
     sys.modules["redis"] = redis_stub
 
-import flaskr.dao as dao
+from flaskr import dao
 
 # Ensure SQLAlchemy is available for model declarations.
 if dao.db is None:

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -1,9 +1,9 @@
 import types
 import unittest
 
-import flaskr.dao as dao
 from flask import Flask, request
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-learn-record")

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -2,8 +2,8 @@ import json
 import unittest
 from datetime import datetime
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.lesson_feedback import (
     _sync_feedback_to_generated_block,
     build_lesson_feedback_interaction_md,

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-listen-element-history-subtitles")

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -231,7 +231,8 @@ def test_desync_forensics_capture_fingerprints_the_stale_response():
             return 555001
 
     class _FakeConnection:
-        class connection:
+        # Mirrors SQLAlchemy's lowercase `connection.connection` attribute chain.
+        class connection:  # noqa: N801
             dbapi_connection = _FakeRaw()
 
     described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
@@ -280,7 +281,8 @@ def test_desync_forensics_logs_only_packet_header_not_payload():
                 return 1
 
         class _FakeConnection:
-            class connection:
+            # Mirrors SQLAlchemy's lowercase `connection.connection` chain.
+            class connection:  # noqa: N801
                 dbapi_connection = None
 
         _FakeConnection.connection.dbapi_connection = _FakeRaw()

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1845,7 +1845,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app):
         )
 
         def _raise_paid(self, current_app):
-            raise PaidException()
+            raise PaidException
             yield  # pragma: no cover
 
         ctx.run_inner = types.MethodType(_raise_paid, ctx)

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-listen-elements-legacy-record")

--- a/src/api/tests/service/learn/test_preview_permissions.py
+++ b/src/api/tests/service/learn/test_preview_permissions.py
@@ -2,7 +2,7 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _seed_course(app, shifu_bid: str, owner_bid: str) -> None:

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -1057,7 +1057,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
                 type=GeneratedType.CONTENT,
                 content="hello",
             )
-            raise runscript_v2.BreakException()
+            raise runscript_v2.BreakException
 
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_FAILED,
     TTS_MINIMAX_CLONE_STATUS_READY,

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -176,8 +176,7 @@ def _simulate_sse_for_block(app, block, *, with_av_contract=True):
             ]
         )
 
-        streamed = list(adapter.process(events))
-    return streamed
+        return list(adapter.process(events))
 
 
 # ---------------------------------------------------------------------------

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -442,14 +442,14 @@ class TestSSEElementSplitFromDB:
             # Extract meaningful text tokens from original (skip markdown syntax)
             import re
 
-            original_words = set(
+            original_words = {
                 w
                 for w in re.findall(r"[\w\u4e00-\u9fff]+", original_content)
                 if len(w) > 1
-            )
-            combined_words = set(
+            }
+            combined_words = {
                 w for w in re.findall(r"[\w\u4e00-\u9fff]+", combined) if len(w) > 1
-            )
+            }
 
             if original_words:
                 coverage = len(original_words & combined_words) / len(original_words)
@@ -505,7 +505,7 @@ class TestSSEElementSplitFromDB:
                 ct = j.get("content", "")
 
                 # SVG content should have SVG element type
-                if "<svg" in ct.lower() and et != "svg" and et != "html":
+                if "<svg" in ct.lower() and et not in {"svg", "html"}:
                     # Diagnose: check what av_contract produced
                     with app.app_context():
                         av = build_av_segmentation_contract(content, bid)

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -211,7 +211,7 @@ class TestSSEElementSplitFromDB:
             "errors": [],
         }
 
-        for i, block in enumerate(blocks):
+        for _i, block in enumerate(blocks):
             content = block["generated_content"]
             if not content or not content.strip():
                 stats["empty_content_skipped"] += 1

--- a/src/api/tests/service/metering/test_billing_boundary.py
+++ b/src/api/tests/service/metering/test_billing_boundary.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.models import (
     CreditLedgerEntry,
     CreditWallet,

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -388,7 +388,7 @@ def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch):
             pass
 
         def commit(self):
-            raise _Interrupt()
+            raise _Interrupt
 
     monkeypatch.setattr(
         recorder_module, "db", type("D", (), {"session": _InterruptedSession()})

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.metering import UsageContext, record_llm_usage, record_tts_usage
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -2,7 +2,7 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _seed_shifu(app, shifu_bid: str, owner_bid: str) -> None:

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -6,10 +6,10 @@ from types import SimpleNamespace
 from typing import Any
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import pytest
 from cryptography.fernet import Fernet
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.entitlements import grant_creator_manual_entitlement
 from flaskr.service.billing.models import BillingOrder
 from flaskr.service.order.consts import ORDER_STATUS_TO_BE_PAID

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -218,7 +218,7 @@ class _FakeSaasColumn:
     def __eq__(self, value: object) -> tuple[str, object]:  # type: ignore[override]
         return self.name, value
 
-    def desc(self) -> "_FakeSaasColumn":
+    def desc(self) -> _FakeSaasColumn:
         return self
 
 
@@ -231,10 +231,10 @@ class _FakeSaasQuery:
         self._fake_saas = fake_saas
         self._conditions = conditions or []
 
-    def filter(self, *conditions: tuple[str, object]) -> "_FakeSaasQuery":
+    def filter(self, *conditions: tuple[str, object]) -> _FakeSaasQuery:
         return _FakeSaasQuery(self._fake_saas, [*self._conditions, *conditions])
 
-    def order_by(self, *_args) -> "_FakeSaasQuery":
+    def order_by(self, *_args) -> _FakeSaasQuery:
         return self
 
     def first(self):

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.checkout import (
     _persist_billing_native_raw_snapshot,
     load_billing_order_for_native_event,

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import db
 from flaskr.service.order.consts import ORDER_STATUS_REFUND, ORDER_STATUS_SUCCESS
 from flaskr.service.order.funs import get_payment_details, refund_order_payment

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import importlib
 from datetime import datetime
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -12,9 +12,9 @@ import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.service.order import funs as order_funs
 from flaskr.service.order.consts import (

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -1,4 +1,4 @@
-import flaskr.service.profile.profile_manage as profile_manage
+from flaskr.service.profile import profile_manage
 from flaskr.service.profile.profile_manage import (
     add_profile_item_quick,
     get_profile_item_definition_list,

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -1,9 +1,9 @@
 import os
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.config.funcs as config_funcs
 import pytest
+from flaskr import dao
 
 _dummy_lock = SimpleNamespace(
     acquire=lambda *args, **kwargs: False, release=lambda *args, **kwargs: None

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import AppException
@@ -870,12 +871,9 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
         with patch(
             "flaskr.service.shifu.admin._load_latest_shifu_seeds"
         ) as latest_mock:
-            try:
+            with pytest.raises(AppException) as exc_info:
                 list_operator_courses(app, 1, 20, {"quick_filter": "invalid"})
-            except AppException as exc:
-                assert exc.code is not None
-            else:
-                raise AssertionError("Expected AppException for invalid quick_filter")
+            assert exc_info.value.code is not None
 
     overview_mock.assert_not_called()
     latest_mock.assert_not_called()

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.common.models import AppException
 
 

--- a/src/api/tests/service/shifu/test_demo_courses.py
+++ b/src/api/tests/service/shifu/test_demo_courses.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.service.shifu.models import PublishedShifu
 

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.common.models import ERROR_CODE
 
 

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -101,5 +101,5 @@ def test_skips_deleted_versions(app):
             for row in iter_outline_item_versions_desc(SHIFU, OUTLINE, batch_size=2)
         ]
 
-        assert got == [ids[0]] + ids[2:]
+        assert got == [ids[0], *ids[2:]]
         _cleanup()

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -2,8 +2,8 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.common import config as config_module
 from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
 from flaskr.service.billing.models import BillingOrder, BillingProduct

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 
 
 def _seed_shifu(

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.shifu.consts import STATUS_DRAFT, STATUS_PUBLISHED
 from flaskr.service.shifu.models import (
     DraftOutlineItem,

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -5,9 +5,9 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.util.datetime import now_utc
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_TTS_REQUEST_COUNT,
     CREDIT_BUCKET_CATEGORY_FREE,

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -109,7 +109,7 @@ class TestFinalizeSegmentation:
         # Verify multiple segments were submitted
         assert len(submitted_texts) > 0
         # Each segment should end at a sentence boundary (except possibly the last)
-        for i, text in enumerate(submitted_texts[:-1]):
+        for _i, text in enumerate(submitted_texts[:-1]):
             assert text.rstrip().endswith((".", "!", "?", "。", "！", "？"))
 
     @patch("flaskr.service.tts.streaming_tts._tts_executor")

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -21,7 +21,7 @@ _TENCENT_MESSAGE = (
 
 
 @pytest.mark.parametrize(
-    "message,expected",
+    ("message", "expected"),
     [
         (_TENCENT_MESSAGE, True),
         ("HTTP 429 Too many requests", True),

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-streaming-tts-subtitles")

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -17,8 +17,7 @@ class _FakeSSEStreamingResponse:
 
     def iter_lines(self, decode_unicode=True):
         _ = decode_unicode
-        for line in self._lines:
-            yield line
+        yield from self._lines
 
     def close(self):
         self.closed = True

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -131,6 +131,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     import flaskr.api.tts as tts_api
     from flaskr.api.tts import tencent_provider
     from flaskr.common.config import ENV_VARS
+    from flaskr.service.common.models import AppException
     from flaskr.service.tts.validation import validate_tts_settings_strict
 
     expected_config_keys = {
@@ -176,7 +177,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     assert validated.provider == "tencent"
     assert validated.model == ""
 
-    with pytest.raises(Exception):
+    with pytest.raises(AppException):
         validate_tts_settings_strict(
             provider="tencent",
             model="",
@@ -386,7 +387,7 @@ def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match="Tencent TTS error InvalidParameter.Voice",
+        match=r"Tencent TTS error InvalidParameter\.Voice",
     ):
         list(
             tencent_provider.TencentTTSProvider().stream_synthesize(

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -130,7 +130,7 @@ def test_tencent_sse_tc3_headers_sign_exact_request_payload():
 
 def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     import flaskr.api.tts as tts_api
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.common.config import ENV_VARS
     from flaskr.service.tts.validation import validate_tts_settings_strict
 
@@ -191,7 +191,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
 def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
     monkeypatch,
 ):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
     _patch_tencent_config(monkeypatch, tencent_provider)
@@ -275,7 +275,7 @@ def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
 def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
     monkeypatch,
 ):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
     _patch_tencent_config(monkeypatch, tencent_provider)
@@ -360,7 +360,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
 
 
 def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
 
     _patch_tencent_config(monkeypatch, tencent_provider)
 

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -123,7 +123,7 @@ def test_provider_config_exposes_two_model_tiers_with_tagged_voices():
     large_voices = [
         voice for voice in cfg.voices if voice["resource_id"] == "large-model"
     ]
-    assert {"value": v["value"] for v in premium_voices}  # non-empty
+    assert {v["value"] for v in premium_voices}  # non-empty
     assert all(v["value"].startswith("101") for v in premium_voices)
     assert all(v["value"][:3] in {"501", "601"} for v in large_voices)
 

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -37,7 +37,7 @@ class _FakeResponse:
 
 
 @pytest.mark.parametrize(
-    "value,expected",
+    ("value", "expected"),
     [
         ("S_xxxxxxxxxx", True),
         ("S_xxxxxxxxx", True),

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -1,7 +1,7 @@
 import threading
 from types import SimpleNamespace
 
-import flaskr.api.tts.volcengine_provider as volcengine_provider
+from flaskr.api.tts import volcengine_provider
 
 
 def test_volcengine_ws_get_credentials_prefers_volcengine_tts_keys(monkeypatch):

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -414,7 +414,8 @@ def test_replace_and_clear_learner_profile(app, monkeypatch):
     assert loaded["has_learner_profile"] is True
     assert loaded["nickname"] == "小明"
     assert loaded["max_length"] == 1000
-    assert first_updated_at is not None and first_updated_at.endswith("Z")
+    assert first_updated_at is not None
+    assert first_updated_at.endswith("Z")
     assert unchanged["learner_profile_updated_at"] == first_updated_at
     assert cleared["learner_profile"] == ""
     assert cleared["learner_profile_updated_at"] is None

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -964,7 +964,7 @@ def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch):
 
 
 def test_save_moderates_once_when_state_creation_retries(app, monkeypatch):
-    import flaskr.service.profile.learner_profile as learner_profile
+    from flaskr.service.profile import learner_profile
 
     moderation_calls: list[str] = []
     operation_calls = 0

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -42,7 +42,7 @@ def test_reset_password_does_not_create_new_user(test_client, app):
 
 
 def test_set_password_requires_login_and_verification_code(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
 
     phone = "15500001111"
 
@@ -86,7 +86,7 @@ def test_set_password_requires_login_and_verification_code(test_client, app):
 
 
 def test_password_login_after_setting_password(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
 
     phone = "15500002222"
     password = "Abcd1234"
@@ -118,13 +118,13 @@ def test_password_login_after_setting_password(test_client, app):
 
 
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         PROFILE_ONBOARDING_VERSION,
         load_learner_profile_state,
     )
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo, UserOnboardingState
     from flaskr.service.user.repository import create_user_entity
     from flaskr.service.user.utils import generate_token
@@ -245,8 +245,8 @@ def test_password_login_merges_authenticated_guest_learner_profile(test_client, 
 
 
 def test_password_login_never_merges_from_a_registered_account(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
 
     source_phone = "15500002334"
@@ -296,8 +296,8 @@ def test_password_login_never_merges_from_a_registered_account(test_client, app)
 
 
 def test_password_login_ignores_invalid_and_expired_optional_tokens(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
     from flaskr.service.user.repository import create_user_entity
 
@@ -376,7 +376,7 @@ def test_sms_login_route_logs_in_with_phone_code(test_client):
 
 
 def test_sms_login_route_does_not_rebind_authenticated_account_phone(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential
     from flaskr.service.user.models import UserInfo as UserEntity
 

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -67,11 +67,12 @@ def test_profile_onboarding_config_roundtrip(app, monkeypatch):
 
 
 def test_profile_onboarding_config_rejects_non_whitelisted_variable(app):
+    from flaskr.service.common.models import AppException
     from flaskr.service.common.profile_onboarding import (
         update_profile_onboarding_config,
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(AppException):
         update_profile_onboarding_config(
             app,
             payload={

--- a/src/api/tests/service/user/test_repository.py
+++ b/src/api/tests/service/user/test_repository.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import datetime
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import db
 from flaskr.service.user.consts import (
     CREDENTIAL_STATE_UNVERIFIED,

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -5,9 +5,9 @@ import json
 import uuid
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.framework.plugin import plugin_manager as plugin_manager_module
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -57,9 +57,8 @@ def _post_json(client, path: str, payload: dict, headers: dict | None = None):
 @pytest.fixture
 def user_trial_client(monkeypatch, tmp_path):
     import flaskr.service.billing.auth_hooks as _billing_auth_hooks  # noqa: F401
-    import flaskr.service.user.email_flow as email_flow
-    import flaskr.service.user.phone_flow as phone_flow
     import flaskr.service.user.utils as user_utils
+    from flaskr.service.user import email_flow, phone_flow
     from flaskr.service.user.auth.providers import (
         password as _password_provider,  # noqa: F401
     )

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -51,10 +51,10 @@ def _reset_shifu_tables() -> None:
 
 
 def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeypatch):
-    import flaskr.service.user.phone_flow as phone_flow
     from flask import Flask
     from flask_sqlalchemy import SQLAlchemy
     from flaskr import dao
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.consts import (
         USER_STATE_REGISTERED,
         USER_STATE_UNREGISTERED,
@@ -128,7 +128,7 @@ def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeyp
 
 
 def test_phone_flow_sets_user_identify(app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     # Bypass code storage by using universal code
@@ -157,7 +157,7 @@ def test_phone_flow_sets_user_identify(app):
 
 
 def test_email_flow_sets_user_identify(app):
-    import flaskr.service.user.email_flow as email_flow
+    from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     with app.app_context():
@@ -247,8 +247,8 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
 
 
 def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():
@@ -281,8 +281,8 @@ def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
 
 
 def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -329,8 +329,8 @@ def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
 
 
 def test_phone_flow_accepts_prefixed_pending_db_code(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -377,8 +377,8 @@ def test_phone_flow_accepts_prefixed_pending_db_code(app):
 
 
 def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
-    import flaskr.service.user.verification_codes as verification_codes
     from flaskr.dao import db
+    from flaskr.service.user import verification_codes
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():
@@ -415,9 +415,9 @@ def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
 
 
 def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
     from flaskr.service.shifu.models import DraftShifu, PublishedShifu
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     shifu_bid = uuid.uuid4().hex[:32]
@@ -466,8 +466,8 @@ def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
 
 
 def test_email_flow_verifies_code_from_db_when_cache_missing(app):
-    import flaskr.service.user.email_flow as email_flow
     from flaskr.dao import db
+    from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -38,10 +38,10 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
         repo_module.db.session, "begin_nested", lambda: nested, raising=False
     )
 
-    import pytest as _pytest
+    import pytest
 
     # Desync inside the body: invalidate only, savepoint untouched.
-    with _pytest.raises(ResourceClosedError):
+    with pytest.raises(ResourceClosedError):
         with repo_module.transactional_session():
             raise ResourceClosedError("desynced")
     assert events == [("invalidate", "transactional_session desync")]
@@ -49,7 +49,7 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     events.clear()
 
     # Ordinary error: savepoint rollback then classified session cleanup.
-    with _pytest.raises(ValueError):
+    with pytest.raises(ValueError):
         with repo_module.transactional_session():
             raise ValueError("business")
     assert events == [("cleanup", "transactional_session")]

--- a/src/api/tests/test_profile.py
+++ b/src/api/tests/test_profile.py
@@ -1,4 +1,4 @@
-import flaskr.service.profile.profile_manage as profile_manage
+from flaskr.service.profile import profile_manage
 from flaskr.service.profile.profile_manage import (
     add_profile_item_quick,
     get_profile_item_definition_list,

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.dao import retry_on_deadlock
 from sqlalchemy.exc import OperationalError
 
@@ -101,7 +101,7 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch):
 
 
 def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(
@@ -124,7 +124,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
 
 
 def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -20,7 +20,7 @@ def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
     with app.app_context():
         with pytest.raises(_Interrupt):
             with unit_of_work():
-                raise _Interrupt()
+                raise _Interrupt
 
     assert invalidations == ["unit_of_work interrupt"]
 

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 
     invalidations = []
@@ -26,7 +26,7 @@ def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
 
 
 def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 
     outcomes = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Get as much value out of ruff as possible while guaranteeing that nothing about the
running system changes. Work was done in that order of preference:

1. **Enforce what the code already satisfies** — configuration only, no code touched.
2. **Unlock more rules with rewrites that are exact equivalents** of the code they replace.
3. **Keep a rule usable when it only fails in test/tooling code** — select it and carve the
   directory out under `[lint.per-file-ignores]`, instead of dropping the rule everywhere.

## Result

| | main | this branch |
| --- | --- | --- |
| ruff rules enforced | 182 | **654** |
| rules dropped | — | 0 |
| stable rules the repo satisfies but does not enforce | 419 | **0** |

Verification (full log in the artifact below):

- `ruff check` and `ruff format --check` clean across all 972 files.
- Backend suite: `2865 passed, 15 skipped` — identical before and after.
- Generated Swagger component schemas: **byte-identical** to `main` (2108 lines, covering
  every DTO module whose annotations were touched).
- Backend route surface from `scripts/inventory/extract_routes.py`: **identical** 257
  method+path entries (only source line numbers moved).
- `lefthook run pre-commit`, `check_repo_harness.py`, `check_architecture_boundaries.py` pass.

## Commits

Each commit adopts one family of rules: fix the code repo-wide, then move the rule codes
into `select`.

- `chore: enforce every ruff rule the codebase already satisfies` — configuration only,
  182 → 601 rules, zero lines of code changed.
- `refactor: state the zip and subprocess defaults explicitly` — `strict=False`,
  `check=False` (B905, PLW1510).
- `refactor: simplify equivalent boolean, membership and comprehension code` — 91 sites
  (SIM103/118/2xx/4xx, FURB110/171/187/192, PLR1714, PLW3301, PIE810, PERF102, C4xx, RSE102).
- `refactor: return expressions directly instead of via a temporary` — RET504.
- `refactor: drop statements that never did anything` — self-assignments, redundant
  `global`, unused loop variables (B007, PLC0414, PLW0127, PLW0602).
- `refactor: use the direct form of round, unpacking and capture_output` — RUF005, RUF007,
  RUF046, UP022, plus a pinned `target-version`.
- `refactor: import submodules with from-import in tests` — 122 sites (PLR0402).
- `refactor: name the suppressed rules and tidy annotations and pytest calls` — PGH004,
  UP028, UP037, PT006/013/017/018/022/027.
- `refactor: tighten the last flagged assertions, defaults and fake classes` — 13 more
  rules including **S101**, so `assert` (stripped under `python -O`) is now blocked in the
  served backend while staying allowed in the pytest suites and maintenance scripts.
- `chore: document the per-directory ruff carve-outs`.

## What stays off, and why

`ruff.toml` documents every non-enforced rule. Highlights:

- **Formatter-owned** rules from ruff's own conflicting-rules list (`W191`, `D206`, `D300`,
  `Q000`-`Q004`, `COM812`, `COM819`, `ISC002`), plus `D203` / `D213` which ruff reports as
  incompatible with the `D211` / `D212` members that are enabled.
- **The numpydoc section rules** (`D214`, `D215`, `D405`-`D410`, `D412`, `D414`, `D416`):
  route docstrings embed the flasgger/Swagger spec after a `---` line, and those rules read
  YAML keys as section headers, so their fixes would corrupt the published API docs.
- **`RUF100`**, which would delete the deliberate `# noqa: BLE001 / DTZ001 / SLF001` markers.
- **`RET503`**: the functions it flags end in `raise_error()`, which always raises; ruff does
  not follow `NoReturn` across modules, so its fix appends unreachable `return None`.
- **`D301` / `FLY002` / `UP031`**: their fixes would change rendered help text and doctests,
  or turn signing payloads and SQL statements into longer, less clear strings.
- `target-version` is pinned to the version ruff already resolves to, so a ruff release
  cannot start rewriting code into syntax that needs a newer interpreter.

Each partially selected group carries an `-- off: ...` comment listing exactly the members
that still have violations (137 rules), so the remaining backlog is explicit rather than
implied.

[ruff_rule_coverage_verification.log](https://cursor.com/agents/bc-294d73af-177a-463e-ae72-ab4685d9202a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fruff_rule_coverage_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-294d73af-177a-463e-ae72-ab4685d9202a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294d73af-177a-463e-ae72-ab4685d9202a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

