### PR TITLE
style: enforce ruff UP031 (percent formatting to str.format)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -117,6 +117,7 @@ select = [
     "SIM9",    # dict.get(key, None)
     "UP01",    # redundant str.encode/open() arguments
     "UP02",    # capture_output, deprecated OSError alias, yield from
+    "UP031",   # percent formatting that should be str.format
     "UP032",   # str.format that should be an f-string
     "UP034",   # extraneous parentheses
 ]

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -181,14 +181,14 @@ def migrate_user_study_record(
 
     db.session.execute(
         text(
-            "update learn_progress_records set user_bid = '%s' where id in (%s)"
-            % (to_user_id, ",".join(str(attend.id) for attend in migrate_attends))
+            "update learn_progress_records set user_bid = '{}' where id in ({})".format(
+                to_user_id, ",".join(str(attend.id) for attend in migrate_attends)
+            )
         )
     )
     db.session.execute(
         text(
-            "update learn_generated_blocks set user_bid = '%s' where progress_record_bid in (%s)"
-            % (
+            "update learn_generated_blocks set user_bid = '{}' where progress_record_bid in ({})".format(
                 to_user_id,
                 ",".join(
                     "'" + str(attend.progress_record_bid) + "'"

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -58,7 +58,7 @@ def literal(node, env):
             elif isinstance(v, ast.FormattedValue):
                 out += literal(v.value, env)
         return out
-    return "<expr:%s>" % ast.unparse(node)
+    return f"<expr:{ast.unparse(node)}>"
 
 
 def config_get_default(node):


### PR DESCRIPTION
# Summary

Layer 1/8 of the ruff A-group stack. Enables `UP031` permanently in `ruff.toml` and applies its fix: the 3 remaining `"..." % (...)` percent-formatting expressions (two SQL-text builders in `flaskr/service/user/phone_flow.py`, one AST label in `scripts/inventory/extract_routes.py`) become equivalent `.format(...)` calls.

Verified with `ruff check .`, `ruff format --check .`, `lefthook run pre-commit --all-files`, and the backend test suite (only the 5 known SQLite `concat()` failures in `test_admin_course_detail.py`, which also fail on `main`).

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical formatting-only edits; study-record migration SQL still uses the same string-interpolation pattern as before, with no new logic paths.
> 
> **Overview**
> **Enables Ruff rule `UP031`** in `ruff.toml` so percent-style string formatting is flagged going forward.
> 
> **Replaces the last three `%` format sites** with equivalent `.format(...)` in `migrate_user_study_record` (two raw SQL `text()` strings in `phone_flow.py`) and with an f-string for the AST fallback label in `extract_routes.py`. No intended behavior change—style/lint alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef5f6d7c483b5fd85be34f9f8a4ed6f8a208e466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal formatting practices without changing application behavior.
  * Improved SQL and diagnostic expression formatting while preserving existing output.

* **Chores**
  * Expanded automated linting checks to identify outdated percent-style formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->