### PR TITLE
fix: enforce ruff LOG (exc_info outside except blocks)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -85,6 +85,7 @@ select = [
     "FURB17",  # membership test against a single-item container
     "FURB18",  # list reversal via slicing, manual prefix/suffix stripping
     "FURB19",  # sorted() only to take the first item
+    "LOG",     # flake8-logging (exc_info must name the exception outside except blocks)
     "PERF1",   # dict.items() when only one half is used
     "PIE",     # flake8-pie (redundant placeholders, dict kwargs, startswith)
     "PLC0207", # str.split without maxsplit when one segment is used

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -104,7 +104,7 @@ class FeishuLogHandler(logging.Handler):
         try:
             from flask import current_app
 
-            current_app.logger.warning(message, exc, exc_info=True)
+            current_app.logger.warning(message, exc, exc_info=exc)
         except Exception:
             logging.getLogger(__name__).warning(message, exc, exc_info=True)
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -3432,7 +3432,7 @@ class RunScriptContextV2:
             app.logger.warning(
                 "Idle streaming TTS drain failed; disable for this block: %s",
                 exc,
-                exc_info=True,
+                exc_info=exc,
             )
             _disable_all_tts()
 


### PR DESCRIPTION
# Summary

Layer 2/8 of the ruff A-group stack. Enables the `LOG` group (flake8-logging) permanently in `ruff.toml` and fixes its two `LOG014` findings: logging helpers that run *outside* a lexical `except` block used `exc_info=True`, which logs whatever exception is currently being handled (possibly none) instead of the exception passed to the helper.

```diff
 def _report_delivery_failure(self, exc: Exception) -> None:   # common/log.py
-    current_app.logger.warning(message, exc, exc_info=True)
+    current_app.logger.warning(message, exc, exc_info=exc)

 def _handle_current_tts_drain_error(exc: Exception) -> None:  # learn/context_v2.py
-    app.logger.warning("...: %s", exc, exc_info=True)
+    app.logger.warning("...: %s", exc, exc_info=exc)
```

Passing the exception instance itself makes the logged traceback always the intended one, regardless of caller context. Verified with full lint and the backend test suite at the stack top.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving logging fixes plus lint config; no auth, data, or API contract changes.
> 
> **Overview**
> Enables the **flake8-logging `LOG` rule group** in `ruff.toml` so `exc_info` usage outside lexical `except` blocks is enforced going forward.
> 
> Fixes the two existing **LOG014** hits by logging the **passed-in exception** instead of `exc_info=True` in helpers that run after the original `except` has unwound: Feishu webhook delivery failures in `common/log.py` and idle streaming TTS drain errors in `learn/context_v2.py`. Tracebacks now always match the `exc` argument rather than whatever exception context happens to be active at log time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049ac61ab432af0654ee30054a92a308f9c2ca3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->