### PR TITLE
style: enforce ruff B007 (unused loop control variables)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -66,6 +66,7 @@ select = [
     "YTT",     # sys.version checks that break on two-digit versions
     # Mechanical, behavior-preserving cleanups; each was applied repo-wide
     # with `ruff check --fix` in the commit that selected it here.
+    "B007",    # loop control variable not used in the loop body
     "B009",    # getattr with a constant attribute name
     "B010",    # setattr with a constant attribute name
     "B905",    # zip() without an explicit strict argument

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -968,7 +968,7 @@ class UnifiedMigrationTask:
         # Consistency Check Results
         report.append("DATA CONSISTENCY VERIFICATION")
         report.append("-" * 40)
-        for table_name, result in consistency_results.items():
+        for result in consistency_results.values():
             status = "✓ PASSED" if result.is_consistent else "✗ FAILED"
             report.append(f"{status} {result.table_pair}")
             report.append(

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -30,7 +30,7 @@ def load_plugins_from_dir(
                     plugin_obj = importlib.import_module(
                         f"{directory}.{SRC_DIR}.{filename[:-3]}".replace(os.sep, ".")
                     )
-                    for name, obj in getmembers(plugin_obj):
+                    for _name, obj in getmembers(plugin_obj):
                         if (
                             isinstance(obj, type)
                             and issubclass(obj, BasePlugin)

--- a/src/api/flaskr/service/shifu/struct_utils.py
+++ b/src/api/flaskr/service/shifu/struct_utils.py
@@ -28,7 +28,7 @@ def find_node_with_parents(
     if root.bid == target_bid:
         return current_path.copy()
 
-    for i, child in enumerate(root.children):
+    for _i, child in enumerate(root.children):
         result = find_node_with_parents(child, target_bid, current_path)
         if result:
             return result

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -211,7 +211,7 @@ class TestSSEElementSplitFromDB:
             "errors": [],
         }
 
-        for i, block in enumerate(blocks):
+        for _i, block in enumerate(blocks):
             content = block["generated_content"]
             if not content or not content.strip():
                 stats["empty_content_skipped"] += 1

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -109,7 +109,7 @@ class TestFinalizeSegmentation:
         # Verify multiple segments were submitted
         assert len(submitted_texts) > 0
         # Each segment should end at a sentence boundary (except possibly the last)
-        for i, text in enumerate(submitted_texts[:-1]):
+        for _i, text in enumerate(submitted_texts[:-1]):
             assert text.rstrip().endswith((".", "!", "?", "。", "！", "？"))
 
     @patch("flaskr.service.tts.streaming_tts._tts_executor")


### PR DESCRIPTION
# Summary

Layer 3/8 of the ruff A-group stack. Enables `B007` permanently in `ruff.toml` and fixes its 5 findings:

- 3 `for i, x in enumerate(...)` loops whose body never uses the index: `i` renamed to `_i` (autofix).
- `unified_migration_task.py`: `for table_name, result in consistency_results.items()` with unused key becomes `for result in consistency_results.values()` (keeps the already-enabled PERF102 quiet).
- `load_plugin.py`: `for name, obj in getmembers(...)` with unused `name` renamed to `_name`.

Verified with full lint and the backend test suite at the stack top.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only enforcement plus naming/iteration tweaks with no logic changes.
> 
> **Overview**
> **Enables Ruff rule `B007`** in `ruff.toml` so unused loop control variables are caught going forward, alongside other mechanical flake8-bugbear cleanups.
> 
> **Fixes the five existing violations** with behavior-preserving edits: unused `enumerate` indices are renamed to `_i` in plugin loading, shifu tree walk, and two test loops; the migration report’s consistency section iterates `consistency_results.values()` instead of unpacking an unused dict key from `.items()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d84cd90eb967549dd8a60c89f3be95b64b1671c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->