### PR TITLE
style: enforce ruff SIM105 (try-except-pass to contextlib.suppress)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -111,6 +111,7 @@ select = [
     "RUF046",  # unnecessary int() cast around an int-returning call
     "RUF102",  # noqa directive naming an unknown rule
     "SIM103",  # condition returned as True/False branches
+    "SIM105",  # try-except-pass that should be contextlib.suppress
     "SIM114",  # if branches with identical bodies
     "SIM118",  # key in dict.keys()
     "SIM2",    # redundant True/False and twisted conditional expressions

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import re
 import sys
@@ -289,10 +290,8 @@ def load_allowlist(path: Path | None) -> Set[str]:
     # Be resilient if legacy CI passes an allowlist path that no longer exists.
     # Treat missing file as empty allowlist instead of failing hard.
     if not path.exists():
-        try:
+        with contextlib.suppress(Exception):
             print(f"Allowlist file not found, treating as empty: {path}")
-        except Exception:
-            pass
         return set()
 
     allowed: Set[str] = set()

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -12,6 +12,7 @@ Docs:
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import hmac
 import json
@@ -276,10 +277,8 @@ def get_aliyun_nls_token(
             raise
     finally:
         if acquired:
-            try:
+            with contextlib.suppress(Exception):
                 lock.release()
-            except Exception:
-                pass
 
 
 def is_aliyun_nls_token_configured() -> bool:

--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -13,6 +13,7 @@ turns the anonymous stderr traceback into an attributable event.
 
 from __future__ import annotations
 
+import contextlib
 import os
 
 _OBSERVER_FLAG = "_ai_shifu_hub_error_observer"
@@ -58,7 +59,7 @@ def install_hub_error_observer(logger, hub=None) -> bool:
         # Log BEFORE delegating: the original handler may re-raise for
         # system errors. Nothing in here may raise or block - a failure in
         # the error path would take down the hub itself.
-        try:
+        with contextlib.suppress(Exception):
             logger.error(
                 "gevent hub error (pid=%s): context=%s exc=%s: %s. "
                 "A crashed hub callback can break a greenlet wakeup and "
@@ -69,8 +70,6 @@ def install_hub_error_observer(logger, hub=None) -> bool:
                 value,
                 exc_info=(exc_type, value, tb) if exc_type is not None else None,
             )
-        except Exception:
-            pass
         return original_handle_error(context, exc_type, value, tb)
 
     hub.handle_error = handle_error

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -7,6 +7,7 @@ background threads spawned from that request.
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
@@ -114,10 +115,8 @@ def _get_shifu_creator_bid_cached(app, shifu_bid: str) -> Optional[str]:
             return creator_bid
         finally:
             if acquired:
-                try:
+                with contextlib.suppress(Exception):
                     lock.release()
-                except Exception:
-                    pass
     except Exception:
         try:
             from flaskr.service.shifu.utils import get_shifu_creator_bid  # type: ignore

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -682,10 +682,8 @@ def run_with_redis(app, key, timeout: int, func, args):
             try:
                 return func(*args)
             finally:
-                try:
+                with contextlib.suppress(Exception):
                     lock.release()
-                except Exception:
-                    pass
         else:
             app.logger.info(f"run_with_redis get lock failed {key}")
             return None

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1,3 +1,4 @@
+import contextlib
 from functools import wraps
 
 from flask import Flask, current_app, make_response, request
@@ -667,10 +668,8 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
         # Best-effort language override for the email subject.
         if language:
-            try:
+            with contextlib.suppress(Exception):
                 set_language(language)
-            except Exception:
-                pass
 
         if "X-Forwarded-For" in request.headers:
             client_ip = request.headers["X-Forwarded-For"].split(",")[0].strip()
@@ -1045,10 +1044,8 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         password = request.get_json().get("password", None)
         language = request.get_json().get("language", None)
         if language:
-            try:
+            with contextlib.suppress(Exception):
                 set_language(language)
-            except Exception:
-                pass
         if not identifier:
             raise_param_error("identifier")
         if not password:

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import Any, Iterator
 
 from flask import Flask
@@ -71,10 +71,8 @@ def _admin_ops_lock(key: str) -> Iterator[None]:
     try:
         yield
     finally:
-        try:
+        with suppress(Exception):
             lock.release()
-        except Exception:
-            pass
 
 
 def _read_map(key: str) -> dict[str, Any]:

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterator
@@ -391,10 +391,8 @@ def _subscription_checkout_lock(app: Flask, creator_bid: str) -> Iterator[None]:
     try:
         yield
     finally:
-        try:
+        with suppress(Exception):
             lock.release()
-        except Exception:
-            pass
 
 
 _CREDIT_LEDGER_LOCK_TIMEOUT_SECONDS = 60

--- a/src/api/flaskr/service/billing/manual_plan_grants.py
+++ b/src/api/flaskr/service/billing/manual_plan_grants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -420,7 +421,5 @@ def grant_manual_plan_to_user(
                 reused_existing_request=False,
             )
         finally:
-            try:
+            with contextlib.suppress(LockError):
                 grant_lock.release()
-            except LockError:
-                pass

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
@@ -559,10 +559,8 @@ def _usage_settlement_lock(app: Flask, *, creator_bid: str, usage_bid: str):
         yield
     finally:
         if acquired and lock is not None:
-            try:
+            with suppress(Exception):
                 lock.release()
-            except Exception:
-                pass
 
 
 def _load_usage_record(

--- a/src/api/flaskr/service/learn/ask_provider_adapters/common.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/common.py
@@ -1,5 +1,6 @@
 """Shared helpers for ask provider adapters."""
 
+import contextlib
 import json
 from functools import lru_cache
 from typing import Any, Iterable
@@ -155,10 +156,8 @@ def extract_text(payload: Any) -> str:
 
     nested_data = payload.get("data")
     if isinstance(nested_data, str):
-        try:
+        with contextlib.suppress(Exception):
             nested_data = json.loads(nested_data)
-        except Exception:
-            pass
     nested_text = extract_text(nested_data)
     if nested_text:
         return nested_text

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -7,6 +7,7 @@ Billing settlement stays asynchronous; request threads stop after raw
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -57,11 +58,9 @@ def _persist_usage_record(app: Flask, record: BillUsageRecord) -> bool:
             db.session.commit()
             return True
         except Exception as exc:
-            try:
+            # Never mask the persistence failure with a logging failure.
+            with contextlib.suppress(Exception):
                 app.logger.exception("Usage metering persist failed: %s", exc)
-            except Exception:
-                # Never mask the persistence failure with a logging failure.
-                pass
             # Clean up INSIDE the pushed context so it targets the session
             # that actually failed - the previous cleanup ran after the
             # context pop and rolled back the CALLER's session instead.
@@ -107,14 +106,12 @@ def _enqueue_usage_settlement(app: Flask, *, usage_bid: str) -> None:
             return
         task.apply_async(kwargs={"usage_bid": normalized_usage_bid})
     except Exception as exc:
-        try:
+        with contextlib.suppress(Exception):
             app.logger.exception(
                 "Usage settlement enqueue failed for usage_bid=%s: %s",
                 normalized_usage_bid,
                 exc,
             )
-        except Exception:
-            pass
 
 
 def record_llm_usage(

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -2,7 +2,7 @@ import datetime
 import decimal
 import json
 import re
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager, nullcontext, suppress
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -295,10 +295,8 @@ def _order_init_lock(app: Flask, user_id: str, course_id: str) -> Iterator[None]
         yield
     finally:
         if acquired and lock is not None:
-            try:
+            with suppress(Exception):
                 lock.release()
-            except Exception:
-                pass
 
 
 def _sync_order_campaign_pricing(

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -24,6 +24,8 @@ except Exception:  # pragma: no cover - exercised only when pydub is missing.
             raise RuntimeError("audio decoder is not available")
 
 
+import contextlib
+
 from flaskr.common.config import get_config
 from flaskr.dao import db
 from flaskr.service.billing.api import (
@@ -988,10 +990,8 @@ def _delete_resource_object(app: Flask, resource_bid: str) -> None:
         return
     _PENDING_AUDIO_BLOBS.pop(normalized, None)
     temp_path = _temp_resource_path(normalized)
-    try:
+    with contextlib.suppress(Exception):
         temp_path.unlink(missing_ok=True)
-    except Exception:
-        pass
     with app.app_context():
         resource = Resource.query.filter(Resource.resource_id == normalized).first()
         if resource is not None:
@@ -1025,10 +1025,8 @@ def _read_resource_bytes(resource_bid: str) -> bytes:
 def _cleanup_raw_resources(app: Flask, row: TTSMiniMaxClonedVoice) -> None:
     for resource_bid in (row.source_audio_resource_bid, row.prompt_audio_resource_bid):
         if resource_bid:
-            try:
+            with contextlib.suppress(Exception):
                 _delete_resource_object(app, resource_bid)
-            except Exception:
-                pass
 
 
 def _remember_resource_bytes(resource_bid: str, data: bytes) -> None:

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import datetime
 from dataclasses import dataclass
 from typing import Optional
@@ -104,10 +105,8 @@ class TokenStoreProvider:
         with db.session.begin_nested():
             record.token_expired_at = new_expires_at
 
-        try:
+        with contextlib.suppress(Exception):
             self._cache.set(cache_key, expected_user_id, ex=ttl_seconds)
-        except Exception:
-            pass
 
         return TokenLookupResult(user_id=expected_user_id)
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -80,6 +80,8 @@ def _compile_bigint_sqlite(_type, _compiler, **_kw):
 if dao.db is None:
     dao.db = SQLAlchemy()
 
+import contextlib
+
 from tests.common.fixtures.fake_llm import (
     fake_chat_llm,
     fake_get_allowed_models,
@@ -243,10 +245,8 @@ def isolate_env_for_non_app_tests(request):
     # reflects per-test env changes.
     from flaskr.common import config as config_module
 
-    try:
+    with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
-    except Exception:
-        pass
     try:
         if config_module.__INSTANCE__ is not None:
             config_module.__INSTANCE__.enhanced._cache.clear()
@@ -259,10 +259,8 @@ def isolate_env_for_non_app_tests(request):
         else:
             os.environ[key] = value
 
-    try:
+    with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
-    except Exception:
-        pass
     try:
         if config_module.__INSTANCE__ is not None:
             config_module.__INSTANCE__.enhanced._cache.clear()

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import json
 import logging
 import sys
@@ -221,10 +222,8 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
             error_log="synthesize generated block audio failed",
         )
         with caplog.at_level(logging.WARNING):
-            try:
+            with contextlib.suppress(AppException):
                 list(resp.response)
-            except AppException:
-                pass
 
     assert (
         "synthesize generated block audio failed: TTS provider quota exceeded"
@@ -255,10 +254,8 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog):
             error_log="synthesize generated block audio failed",
         )
         with caplog.at_level(logging.ERROR):
-            try:
+            with contextlib.suppress(RuntimeError):
                 list(resp.response)
-            except RuntimeError:
-                pass
 
     assert "synthesize generated block audio failed" in caplog.text
     assert [record for record in caplog.records if record.levelno >= logging.ERROR]

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import uuid
 from datetime import datetime
@@ -214,10 +215,8 @@ def _mock_operator(monkeypatch, user_id: str = SOURCE_OPERATOR_BID):
 
 
 def _clear_config_caches() -> None:
-    try:
+    with contextlib.suppress(AttributeError, KeyError, TypeError):
         config_module.__ENHANCED_CONFIG__._cache.clear()
-    except (AttributeError, KeyError, TypeError):
-        pass
     try:
         if config_module.__INSTANCE__ is not None:
             config_module.__INSTANCE__.enhanced._cache.clear()

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 from decimal import Decimal
 from types import SimpleNamespace
@@ -57,10 +58,8 @@ def _mock_user(monkeypatch, user_id: str, is_creator: bool = True):
 
 
 def _clear_config_caches() -> None:
-    try:
+    with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
-    except Exception:
-        pass
     try:
         if config_module.__INSTANCE__ is not None:
             config_module.__INSTANCE__.enhanced._cache.clear()

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import uuid
 from datetime import datetime
@@ -125,10 +126,8 @@ def _mock_operator(monkeypatch, user_id: str = "operator-1"):
 
 
 def _clear_config_caches() -> None:
-    try:
+    with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
-    except Exception:
-        pass
     try:
         if config_module.__INSTANCE__ is not None:
             config_module.__INSTANCE__.enhanced._cache.clear()


### PR DESCRIPTION
# Summary

Layer 4/8 of the ruff A-group stack. Enables `SIM105` permanently in `ruff.toml` and converts every `try: ... except X: pass` block that only silences an exception into `with contextlib.suppress(X): ...` (20 files, autofix plus the required `import contextlib` additions).

One occurrence was converted by hand: the nested logging guard in `flaskr/service/metering/recorder.py`, keeping its "never mask the persistence failure with a logging failure" comment attached to the suppress block.

Verified with full lint and the backend test suite at the stack top (includes the metering/billing suites).

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, behavior-preserving refactors across many files with no change to which exceptions are swallowed; risk is limited to import/typo mistakes, which lint and tests are meant to catch.
> 
> **Overview**
> **Enables Ruff `SIM105`** in `ruff.toml` and replaces bare `try` / `except …: pass` blocks with `contextlib.suppress` (or `from contextlib import suppress` where billing modules already use `contextmanager`).
> 
> The sweep covers **best-effort** paths unchanged in intent: Redis lock `release()`, optional `set_language` on login/email routes, gevent hub error logging, metering persist/enqueue logging guards, TTS temp file cleanup, token cache writes, and test helpers that drain generators or clear config caches. **`manual_plan_grants`** narrows suppression to `LockError` on grant lock release.
> 
> No new control flow beyond the style rule; fail-open behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8233d6fc0d2985c8d1ed879020eb9d884f2c3f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->