### PR TITLE
style: enforce ruff SIM108 (if-else assignments to ternaries)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -112,6 +112,7 @@ select = [
     "RUF102",  # noqa directive naming an unknown rule
     "SIM103",  # condition returned as True/False branches
     "SIM105",  # try-except-pass that should be contextlib.suppress
+    "SIM108",  # if-else assignment that should be a ternary
     "SIM114",  # if branches with identical bodies
     "SIM118",  # key in dict.keys()
     "SIM2",    # redundant True/False and twisted conditional expressions

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -218,10 +218,7 @@ def main() -> int:
         ns = key.split(".")[0] + "." + key.split(".")[1] if "." in key else key
         # Re-evaluate: namespace is up to the second segment for shapes like server.user.* or module.social.* or common.core.*
         parts = key.split(".")
-        if len(parts) >= 2:
-            ns = parts[0] + "." + parts[1]
-        else:
-            ns = parts[0]
+        ns = parts[0] + "." + parts[1] if len(parts) >= 2 else parts[0]
         ns_to_keys.setdefault(ns, []).append(key)
 
     # Write patches into each locale

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1938,10 +1938,7 @@ class EnhancedConfig:
             if env_var.group not in groups:
                 groups[env_var.group] = []
             value = self.get(var_name)
-            if env_var.secret and value:
-                display_value = "[REDACTED]"
-            else:
-                display_value = str(value)
+            display_value = "[REDACTED]" if env_var.secret and value else str(value)
             groups[env_var.group].append(f"  {var_name}: {display_value}")
         for group, items in sorted(groups.items()):
             print(f"\n[{group.upper()}]")

--- a/src/api/flaskr/common/swagger.py
+++ b/src/api/flaskr/common/swagger.py
@@ -90,10 +90,7 @@ def get_field_schema(typ, description: str = ""):
         elif typ is float:
             field_schema["type"] = "number"
     elif origin in (typing.Union, getattr(__import__("types"), "UnionType", ())):
-        if hasattr(typ, "__args__"):
-            union_types = typ.__args__
-        else:
-            union_types = args
+        union_types = typ.__args__ if hasattr(typ, "__args__") else args
 
         non_none_types = [t for t in union_types if t is not type(None)]
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -37,10 +37,7 @@ def _normalize_query(params: dict[str, Any] | None) -> str:
     encoded_parts: list[str] = []
     for key in sorted(params.keys()):
         value = params[key]
-        if isinstance(value, list):
-            values = value
-        else:
-            values = [value]
+        values = value if isinstance(value, list) else [value]
         for item in values:
             item_text = "" if item is None else str(item)
             encoded_parts.append(

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -305,10 +305,7 @@ def get_outline_item_tree(
                 .order_by(Order.id.desc())
                 .first()
             )
-            if not buy_record:
-                is_paid = False
-            else:
-                is_paid = True
+            is_paid = bool(buy_record)
         struct = (
             struct_model.query.filter(
                 struct_model.shifu_bid == shifu_bid, struct_model.deleted == 0

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -378,10 +378,7 @@ def run_script_inner(
                     .order_by(Order.id.desc())
                     .first()
                 )
-                if not success_buy_record:
-                    is_paid = False
-                else:
-                    is_paid = True
+                is_paid = bool(success_buy_record)
             else:
                 is_paid = True
 

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -183,10 +183,7 @@ def _format_decimal(value: Optional[Decimal]) -> str:
     """Format a Decimal or numeric string to trimmed two-decimal string."""
     if value is None:
         return "0"
-    if isinstance(value, str):
-        normalized = value
-    else:
-        normalized = f"{value:.2f}"
+    normalized = value if isinstance(value, str) else f"{value:.2f}"
     if normalized.endswith(".00"):
         return normalized[:-3]
     return normalized

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -154,10 +154,8 @@ class AICourseBuyRecordDTO:
 
     def __json__(self):
         def format_decimal(value):
-            if isinstance(value, str):
-                formatted_value = value  # Convert to string with two decimal places
-            else:
-                formatted_value = f"{value:.2f}"
+            # Convert to a string with two decimal places
+            formatted_value = value if isinstance(value, str) else f"{value:.2f}"
             # If the decimal part is .00, remove it
             if formatted_value.endswith(".00"):
                 return formatted_value[:-3]

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -314,10 +314,7 @@ def _get_legacy_admin_symbol(name: str, fallback: Any) -> Any:
 def _format_decimal(value: Optional[Decimal]) -> str:
     if value is None:
         return "0"
-    if isinstance(value, str):
-        normalized = value
-    else:
-        normalized = f"{value:.2f}"
+    normalized = value if isinstance(value, str) else f"{value:.2f}"
     if normalized.endswith(".00"):
         return normalized[:-3]
     return normalized

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -245,10 +245,7 @@ def _parse_positive_query_int(
 def _get_login_methods_enabled() -> set[str]:
     """Resolve enabled login methods from configuration."""
     raw = get_config("LOGIN_METHODS_ENABLED", "phone")
-    if isinstance(raw, (list, tuple, set)):
-        items = raw
-    else:
-        items = str(raw).split(",")
+    items = raw if isinstance(raw, (list, tuple, set)) else str(raw).split(",")
     methods = {str(item).strip().lower() for item in items if str(item).strip()}
     if "google" in methods:
         methods.add("email")

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -281,10 +281,7 @@ USER_STATE_TO_OPERATOR_STATUS = {
 def _format_decimal(value: Optional[Decimal]) -> str:
     if value is None:
         return "0"
-    if isinstance(value, str):
-        normalized = value
-    else:
-        normalized = f"{value:.2f}"
+    normalized = value if isinstance(value, str) else f"{value:.2f}"
     if normalized.endswith(".00"):
         return normalized[:-3]
     return normalized

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -289,10 +289,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     def _get_login_methods_enabled() -> set[str]:
         """Resolve enabled login methods from configuration."""
         raw = get_config("LOGIN_METHODS_ENABLED", "phone")
-        if isinstance(raw, (list, tuple, set)):
-            items = raw
-        else:
-            items = str(raw).split(",")
+        items = raw if isinstance(raw, (list, tuple, set)) else str(raw).split(",")
         methods = {str(item).strip().lower() for item in items if str(item).strip()}
         if "google" in methods:
             methods.add("email")

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -178,10 +178,7 @@ def _mask_email_identifier(identifier: Optional[str]) -> str:
         return _mask_phone_identifier(identifier)
     if not local:
         return f"***@{domain}"
-    if len(local) <= 1:
-        masked_local = f"{local[:1]}***"
-    else:
-        masked_local = f"{local[:2]}***"
+    masked_local = f"{local[:1]}***" if len(local) <= 1 else f"{local[:2]}***"
     return f"{masked_local}@{domain}"
 
 

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -71,10 +71,7 @@ def get_shifu_struct(
     """
     with app.app_context():
         app.logger.info(f"get_shifu_struct:{shifu_bid},{is_preview}")
-        if is_preview:
-            model = LogDraftStruct
-        else:
-            model = LogPublishedStruct
+        model = LogDraftStruct if is_preview else LogPublishedStruct
         shifu_struct = (
             model.query.filter(
                 model.shifu_bid == shifu_bid,
@@ -179,10 +176,7 @@ def get_shifu_dto(app: Flask, shifu_bid: str, is_preview: bool = False) -> Shifu
     Returns:
         ShifuInfoDto: Shifu dto
     """
-    if is_preview:
-        shifu_model = DraftShifu
-    else:
-        shifu_model = PublishedShifu
+    shifu_model = DraftShifu if is_preview else PublishedShifu
     shifu: Union[DraftShifu, PublishedShifu] = (
         shifu_model.query.filter(
             shifu_model.shifu_bid == shifu_bid,
@@ -219,10 +213,7 @@ def get_outline_item_dto(
     """
     app.logger.info(f"get_outline_item_dto: {outline_item_bid},{is_preview}")
 
-    if is_preview:
-        outline_item_model = DraftOutlineItem
-    else:
-        outline_item_model = PublishedOutlineItem
+    outline_item_model = DraftOutlineItem if is_preview else PublishedOutlineItem
     outline_item: Union[DraftOutlineItem, PublishedOutlineItem] = (
         outline_item_model.query.filter(
             outline_item_model.outline_item_bid == outline_item_bid,
@@ -260,10 +251,7 @@ def get_outline_item_dto_with_mdflow(
     outline_item_id: int | None = None,
 ) -> OutlineItemDtoWithMdflow:
     """Get outline item dto with mdflow"""
-    if is_preview:
-        outline_item_model = DraftOutlineItem
-    else:
-        outline_item_model = PublishedOutlineItem
+    outline_item_model = DraftOutlineItem if is_preview else PublishedOutlineItem
     outline_item: Union[DraftOutlineItem, PublishedOutlineItem, None] = None
     if outline_item_id:
         outline_item = (

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -104,10 +104,7 @@ class FakeRedis:
 
     def incr(self, key: str, amount: int = 1):
         current = self.get(key)
-        if current is None:
-            current_value = 0
-        else:
-            current_value = int(current)
+        current_value = 0 if current is None else int(current)
         new_value = current_value + amount
         self._store[key] = self._encode(new_value)
         ttl = self._expires.get(key)

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -50,10 +50,7 @@ class FakeCacheProvider:
         return self._lock
 
     def setex(self, key: str, _time_in_seconds: int, value):
-        if isinstance(value, bytes):
-            encoded = value
-        else:
-            encoded = str(value).encode("utf-8")
+        encoded = value if isinstance(value, bytes) else str(value).encode("utf-8")
         self.values[key] = encoded
         return True
 


### PR DESCRIPTION
# Summary

Layer 5/8 of the ruff A-group stack. Enables `SIM108` permanently in `ruff.toml` and rewrites if-else blocks that only assign one variable as ternary expressions (16 files, autofix plus one hand conversion in `order/funs.py` where an inline comment blocked the fix).

Two autofix results of the form `False if not x else True` (in `learn_funcs.py` and `runscript_v2.py`) were simplified further to `bool(x)`, since the mechanical ternary would immediately trip the already-enabled SIM211.

Verified with full lint and the backend test suite at the stack top (learn/order/shifu suites all pass).

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style refactors with equivalent semantics; no auth, data-model, or API contract changes.
> 
> **Overview**
> Enables **SIM108** in `ruff.toml` and rewrites single-variable if/else assignments as ternary expressions across scripts, API helpers, learn/order/shifu services, and test fakes.
> 
> Paid-status checks in learn flows now use `bool(buy_record)` instead of `False if not x else True` so the result stays compatible with existing **SIM2** rules. Decimal formatting, login-method config parsing, preview vs published model picks, and similar patterns are unchanged in behavior—only expression shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce06e52379dd61d3d68c7f6a29fe1369cdd2068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->