### PR TITLE
style: enforce ruff PLW0108 (forwarding lambdas)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -94,6 +94,7 @@ select = [
     "PLC0414", # import alias that repeats the name
     "PLR1",    # useless return, repeated comparison, manual min()/max()
     "PLR5",    # else: if ... that should be elif
+    "PLW0108", # lambda that only forwards its arguments
     "PLW3",    # nested min/max calls
     "PT001",   # pytest.fixture with empty parentheses
     "PT006",   # wrong type for parametrize argument names

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -319,7 +319,7 @@ class UnifiedMigrationTask:
                 target_key,
                 offset,
             )
-            return await loop.run_in_executor(None, lambda: future.result())
+            return await loop.run_in_executor(None, future.result)
 
     def _process_batch_sync(
         self,

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -51,9 +51,9 @@ def test_dify_adapter_streams_success_content(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     def _fake_post(*_args, **kwargs):
@@ -107,9 +107,9 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     def _raise_timeout(*_args, **_kwargs):
@@ -155,9 +155,9 @@ def test_coze_adapter_http_error_raises_provider_error(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     http_error = requests.HTTPError("boom")
@@ -196,9 +196,9 @@ def test_coze_workflow_adapter_streams_success_content(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     def _fake_post(url, **kwargs):
@@ -259,9 +259,9 @@ def test_coze_workflow_adapter_nonzero_code_raises_provider_error(app, monkeypat
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     monkeypatch.setattr(
@@ -350,9 +350,9 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     def _fake_post(url, **kwargs):
@@ -391,9 +391,9 @@ def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch):
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     request_state = {}
@@ -473,9 +473,9 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(app, monkeypatc
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
 
     request_state = {}
@@ -676,9 +676,9 @@ def test_get_biji_knowledge_adapter_without_runtime_emits_snippets(app, monkeypa
     monkeypatch.setattr(
         common,
         "get_config",
-        lambda key: {
+        {
             "ASK_PROVIDER_TIMEOUT_SECONDS": 20,
-        }.get(key),
+        }.get,
     )
     monkeypatch.setattr(
         get_biji_knowledge_adapter.requests,

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -272,7 +272,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
             return "result"
 
         self.assertEqual(
-            ctx._run_async_in_safe_context(lambda: sample()),
+            ctx._run_async_in_safe_context(sample),
             "result",
         )
 
@@ -284,7 +284,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
 
         async def runner():
             self.assertEqual(
-                ctx._run_async_in_safe_context(lambda: sample()),
+                ctx._run_async_in_safe_context(sample),
                 "loop",
             )
 

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -84,11 +84,11 @@ def _patch_run_tts_processor(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts: b"".join(parts),
+        b"".join,
     )
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.concat_audio_best_effort",
-        lambda parts: b"".join(parts),
+        b"".join,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -85,11 +85,6 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         "resolve_payment_integration_for_new_order",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(
-        order_funs,
-        "_generate_pingxx_charge",
-        lambda **kwargs: _fake_pingxx_charge(**kwargs),
-    )
 
     def _fake_pingxx_charge(**kwargs):
         buy_record = kwargs["buy_record"]
@@ -104,6 +99,12 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
             "legacy-qr-url",
             payment_channel="pingxx",
         )
+
+    monkeypatch.setattr(
+        order_funs,
+        "_generate_pingxx_charge",
+        _fake_pingxx_charge,
+    )
 
     init_result = init_buy_record(
         legacy_order_app,
@@ -333,7 +334,7 @@ def test_creator_payment_config_smoke_supports_alipay_and_wechatpay_checkout(
     monkeypatch.setattr(
         order_funs,
         "get_payment_provider",
-        lambda provider_name: FakeNativeProvider(provider_name),
+        FakeNativeProvider,
     )
     monkeypatch.setattr(
         order_funs, "get_shifu_creator_bid", lambda _app, _bid: "teacher-pay-1"

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -747,7 +747,7 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
-    monkeypatch.setattr(admin_courses_module, "now_utc", lambda: FixedDateTime.now())
+    monkeypatch.setattr(admin_courses_module, "now_utc", FixedDateTime.now)
 
     app = Flask(__name__)
     recent_course = DummyCourse(
@@ -888,7 +888,7 @@ def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
-    monkeypatch.setattr(admin_courses_module, "now_utc", lambda: FixedDateTime.now())
+    monkeypatch.setattr(admin_courses_module, "now_utc", FixedDateTime.now)
 
     draft_only_bid = uuid.uuid4().hex[:32]
     published_only_bid = uuid.uuid4().hex[:32]

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -154,7 +154,7 @@ def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch):
     monkeypatch.setattr(
         shifu_publish_funcs,
         "get_latest_shifu_draft",
-        lambda _shifu_id: _make_draft(_shifu_id),
+        _make_draft,
         raising=False,
     )
 

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -271,7 +271,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
@@ -403,7 +403,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
@@ -533,7 +533,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
@@ -656,7 +656,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
@@ -802,7 +802,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        SimpleNamespace,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -329,7 +329,7 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
 
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone.MiniMaxVoiceCloneClient",
-        lambda: FakeClient(),
+        FakeClient,
     )
 
     submitted = submit_minimax_voice_clone(
@@ -447,7 +447,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     monkeypatch.setattr(
         minimax_voice_clone,
         "MiniMaxVoiceCloneClient",
-        lambda: FakeClient(),
+        FakeClient,
     )
 
     submitted = submit_minimax_voice_clone(
@@ -611,7 +611,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
     monkeypatch.setattr(
         minimax_voice_clone,
         "MiniMaxVoiceCloneClient",
-        lambda: FakeClient(),
+        FakeClient,
     )
 
     result = minimax_voice_clone._execute_clone_processing(

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -524,7 +524,7 @@ class TestStreamingSynthesisRetries:
                 }
             ],
         )
-        mock_concat_audio.side_effect = lambda parts: b"".join(parts)
+        mock_concat_audio.side_effect = b"".join
         mock_get_duration.return_value = 500
         mock_upload.return_value = ("https://example.com/audio.mp3", "bucket")
 
@@ -604,7 +604,7 @@ class TestStreamingSynthesisRetries:
                 ],
             ),
         ]
-        mock_concat_audio.side_effect = lambda parts: b"".join(parts)
+        mock_concat_audio.side_effect = b"".join
         mock_get_duration.return_value = 400
         mock_upload.return_value = ("https://example.com/retry.mp3", "bucket")
 

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -66,7 +66,7 @@ class TestStreamingTtsSubtitles:
         )
         monkeypatch.setattr(
             "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-            lambda parts: b"".join(parts),
+            b"".join,
         )
         monkeypatch.setattr(
             "flaskr.service.tts.streaming_tts.get_audio_duration_ms",

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -551,7 +551,7 @@ def test_load_and_register_model_max_output_tokens(monkeypatch):
     monkeypatch.setattr(
         llm.litellm,
         "register_model",
-        lambda model_map: captured.update(model_map),
+        captured.update,
         raising=False,
     )
 

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -383,7 +383,7 @@ def test_save_shifu_mdflow_serializes_with_outline_structure_writes(app, monkeyp
 
     monkeypatch.setattr(
         "flaskr.service.shifu.shifu_mdflow_funcs.lock_shifu_for_outline_write",
-        lambda bid: lock_calls.append(bid),
+        lock_calls.append,
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.shifu_mdflow_funcs.check_text_with_risk_control",

--- a/src/api/tests/test_pingpp.py
+++ b/src/api/tests/test_pingpp.py
@@ -33,7 +33,7 @@ def test_create_pingxx_order_builds_request(app, monkeypatch):
                 provider_reference="ref", raw_response={"id": "ch"}
             )
 
-    monkeypatch.setattr(pingxx_order, "_get_provider", lambda: FakeProvider())
+    monkeypatch.setattr(pingxx_order, "_get_provider", FakeProvider)
 
     order = pingxx_order.create_pingxx_order(
         app,


### PR DESCRIPTION
# Summary

Layer 6/8 of the ruff A-group stack. Enables `PLW0108` permanently in `ruff.toml` and replaces lambdas that only forward their arguments to another callable with that callable itself, e.g. `lambda parts: b"".join(parts)` → `b"".join`, `lambda: FakeClient()` → `FakeClient`, `lambda key: {...}.get(key)` → `{...}.get` (13 files, almost all tests).

One autofix needed a follow-up: in `test_legacy_purchase_flow.py` the lambda referenced a local helper defined *after* the `monkeypatch.setattr` call, so the direct reference would raise `UnboundLocalError`; the helper definition was moved above the setattr.

Verified with full lint and the backend test suite at the stack top.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style/lint alignment with no intended behavior change; the migration `run_in_executor` and test mock substitutions are equivalent to the removed lambdas.
> 
> **Overview**
> **Enables Ruff rule `PLW0108`** in `ruff.toml` so lambdas that only forward arguments to another callable are flagged repo-wide.
> 
> **Replaces those lambdas with the target callable** across ~13 files—mostly test `monkeypatch.setattr` stubs (e.g. `dict.get`, `b"".join`, `FakeClient`, `SimpleNamespace`) plus small production/test cleanups in `unified_migration_task.py` (`future.result` for `run_in_executor`) and `test_context_v2.py` (pass coroutine functions directly instead of `lambda: sample()`).
> 
> **One manual fix in `test_legacy_purchase_flow.py`:** `_fake_pingxx_charge` is defined *before* `monkeypatch.setattr` so the non-lambda reference does not hit `UnboundLocalError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02046984bc5a25e261462db6a6efe17bffd1e654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->