### PR TITLE
style: enforce ruff PT009 (unittest-style assertions to plain asserts)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -98,6 +98,7 @@ select = [
     "PLW3",    # nested min/max calls
     "PT001",   # pytest.fixture with empty parentheses
     "PT006",   # wrong type for parametrize argument names
+    "PT009",   # unittest-style assertion that should be a plain assert
     "PT018",   # composite assertion
     "PT02",    # fixture yielding without teardown, unittest-style assertRaises
     "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)

--- a/scripts/test_prettier_check_changed.py
+++ b/scripts/test_prettier_check_changed.py
@@ -64,7 +64,7 @@ class PrettierCheckChangedTest(unittest.TestCase):
     def commit_changes(self, message: str) -> str:
         run(["git", "add", "."], self.repo)
         result = run(["git", "commit", "-m", message], self.repo)
-        self.assertEqual(result.returncode, 0, result.stderr)
+        assert result.returncode == 0, result.stderr
         return run(["git", "rev-parse", "HEAD"], self.repo).stdout.strip()
 
     def test_checks_only_changed_cook_web_files(self) -> None:
@@ -80,10 +80,10 @@ class PrettierCheckChangedTest(unittest.TestCase):
             self.script_env(),
         )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
+        assert result.returncode == 0, result.stderr
         args = self.args_file.read_text().splitlines()
-        self.assertEqual(args[:4], ["prettier", "--check", "--ignore-unknown", "--"])
-        self.assertCountEqual(args[4:], ["docs/notes.md", "src/existing.ts"])
+        assert args[:4] == ["prettier", "--check", "--ignore-unknown", "--"]
+        assert sorted(args[4:]) == sorted(["docs/notes.md", "src/existing.ts"])
 
     def test_skips_prettier_when_no_cook_web_files_changed(self) -> None:
         (self.repo / "src/api/app.py").write_text("print('outside only')\n")
@@ -95,9 +95,9 @@ class PrettierCheckChangedTest(unittest.TestCase):
             self.script_env(),
         )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertFalse(self.args_file.exists())
-        self.assertIn("No changed Cook Web files", result.stdout)
+        assert result.returncode == 0, result.stderr
+        assert not self.args_file.exists()
+        assert "No changed Cook Web files" in result.stdout
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -91,9 +91,9 @@ class EmitterAccessorTests(unittest.TestCase):
 
         emitter = ctx._event_emitter
 
-        self.assertIsInstance(emitter, RunEventEmitter)
-        self.assertIs(emitter._context, ctx)
-        self.assertIs(ctx._event_emitter, emitter)
+        assert isinstance(emitter, RunEventEmitter)
+        assert emitter._context is ctx
+        assert ctx._event_emitter is emitter
 
 
 class WrapperDelegationTests(unittest.TestCase):
@@ -105,33 +105,25 @@ class WrapperDelegationTests(unittest.TestCase):
     def test_render_outline_updates_delegates(self):
         updates = [object()]
         events = list(self.ctx._render_outline_updates(updates, new_chapter=True))
-        self.assertEqual(events, ["outline-event"])
-        self.assertEqual(
-            self.emitter.calls, [("render_outline_updates", updates, True)]
-        )
+        assert events == ["outline-event"]
+        assert self.emitter.calls == [("render_outline_updates", updates, True)]
 
     def test_emit_next_chapter_interaction_delegates(self):
         progress = object()
         events = list(self.ctx._emit_next_chapter_interaction(progress))
-        self.assertEqual(events, ["next-event"])
-        self.assertEqual(
-            self.emitter.calls, [("emit_next_chapter_interaction", progress)]
-        )
+        assert events == ["next-event"]
+        assert self.emitter.calls == [("emit_next_chapter_interaction", progress)]
 
     def test_emit_lesson_feedback_interaction_delegates(self):
         progress = object()
         events = list(self.ctx._emit_lesson_feedback_interaction(progress))
-        self.assertEqual(events, ["feedback-event"])
-        self.assertEqual(
-            self.emitter.calls, [("emit_lesson_feedback_interaction", progress)]
-        )
+        assert events == ["feedback-event"]
+        assert self.emitter.calls == [("emit_lesson_feedback_interaction", progress)]
 
     def test_is_access_gate_blocking_interaction_delegates(self):
         parsed = {"buttons": []}
-        self.assertTrue(self.ctx._is_access_gate_blocking_interaction(parsed))
-        self.assertEqual(
-            self.emitter.calls, [("is_access_gate_blocking_interaction", parsed)]
-        )
+        assert self.ctx._is_access_gate_blocking_interaction(parsed)
+        assert self.emitter.calls == [("is_access_gate_blocking_interaction", parsed)]
 
     def test_maybe_emit_feedback_after_access_gate_delegates(self):
         parsed = {"buttons": []}
@@ -143,32 +135,26 @@ class WrapperDelegationTests(unittest.TestCase):
                 is_tail_gate=True,
             )
         )
-        self.assertEqual(events, ["gate-feedback-event"])
-        self.assertEqual(
-            self.emitter.calls,
-            [("maybe_emit_feedback_after_access_gate", parsed, progress, True)],
-        )
+        assert events == ["gate-feedback-event"]
+        assert self.emitter.calls == [
+            ("maybe_emit_feedback_after_access_gate", parsed, progress, True)
+        ]
 
     def test_emit_feedback_after_exception_gate_delegates(self):
         events = list(self.ctx._emit_feedback_after_exception_gate())
-        self.assertEqual(events, ["exception-feedback-event"])
-        self.assertEqual(self.emitter.calls, [("emit_feedback_after_exception_gate",)])
+        assert events == ["exception-feedback-event"]
+        assert self.emitter.calls == [("emit_feedback_after_exception_gate",)]
 
     def test_ensure_current_attend_for_gate_interaction_delegates(self):
-        self.assertEqual(
-            self.ctx._ensure_current_attend_for_gate_interaction(), "attend"
-        )
-        self.assertEqual(
-            self.emitter.calls, [("ensure_current_attend_for_gate_interaction",)]
-        )
+        assert self.ctx._ensure_current_attend_for_gate_interaction() == "attend"
+        assert self.emitter.calls == [("ensure_current_attend_for_gate_interaction",)]
 
     def test_emit_current_progress_gate_interaction_delegates(self):
         events = list(self.ctx._emit_current_progress_gate_interaction("content"))
-        self.assertEqual(events, ["gate-interaction-event"])
-        self.assertEqual(
-            self.emitter.calls,
-            [("emit_current_progress_gate_interaction", "content")],
-        )
+        assert events == ["gate-interaction-event"]
+        assert self.emitter.calls == [
+            ("emit_current_progress_gate_interaction", "content")
+        ]
 
     def test_emit_completion_tail_interactions_delegates(self):
         progress = object()
@@ -179,11 +165,10 @@ class WrapperDelegationTests(unittest.TestCase):
                 has_next_outline_item=False,
             )
         )
-        self.assertEqual(events, ["tail-event"])
-        self.assertEqual(
-            self.emitter.calls,
-            [("emit_completion_tail_interactions", progress, True, False)],
-        )
+        assert events == ["tail-event"]
+        assert self.emitter.calls == [
+            ("emit_completion_tail_interactions", progress, True, False)
+        ]
 
 
 class EmitterContextSeamTests(unittest.TestCase):
@@ -214,8 +199,8 @@ class EmitterContextSeamTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["next", "feedback"])
-        self.assertEqual(events, ["next-event", "feedback-event"])
+        assert calls == ["next", "feedback"]
+        assert events == ["next-event", "feedback-event"]
 
     def test_access_gate_feedback_uses_context_overrides(self):
         ctx = _make_context()
@@ -236,8 +221,8 @@ class EmitterContextSeamTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["feedback"])
-        self.assertEqual(events, ["feedback-event"])
+        assert calls == ["feedback"]
+        assert events == ["feedback-event"]
 
 
 class EmitterPayloadSmokeTests(unittest.TestCase):
@@ -280,19 +265,17 @@ class EmitterPayloadSmokeTests(unittest.TestCase):
                 )
             )
 
-            self.assertEqual(len(events), 1)
+            assert len(events) == 1
             event = events[0]
-            self.assertEqual(event.type, GeneratedType.INTERACTION)
-            self.assertEqual(event.outline_bid, "outline-1")
-            self.assertIn(CONTEXT_INTERACTION_NEXT, event.content)
+            assert event.type == GeneratedType.INTERACTION
+            assert event.outline_bid == "outline-1"
+            assert CONTEXT_INTERACTION_NEXT in event.content
 
             stored_blocks = LearnGeneratedBlock.query.filter(
                 LearnGeneratedBlock.progress_record_bid == "progress-1"
             ).all()
-            self.assertEqual(len(stored_blocks), 1)
-            self.assertEqual(
-                stored_blocks[0].generated_block_bid, event.generated_block_bid
-            )
+            assert len(stored_blocks) == 1
+            assert stored_blocks[0].generated_block_bid == event.generated_block_bid
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -202,7 +202,7 @@ class OutlinePathGuardTests(unittest.TestCase):
         with patch.object(context_v2_module.db.session, "query", return_value=query):
             result = ctx._get_next_outline_item()
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_find_outline_path_returns_path_when_outline_exists(self):
         root = HistoryItem(
@@ -216,7 +216,7 @@ class OutlinePathGuardTests(unittest.TestCase):
 
         path = _find_outline_path_or_raise(root, "outline-bid")
 
-        self.assertEqual([item.bid for item in path], ["shifu-bid", "outline-bid"])
+        assert [item.bid for item in path] == ["shifu-bid", "outline-bid"]
 
     def test_find_outline_path_raises_app_error_when_outline_missing(self):
         root = HistoryItem(bid="shifu-bid", id=1, type="shifu", children=[])
@@ -245,7 +245,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
 
         result = ctx._collect_async_generator(sample)
 
-        self.assertEqual(result, ["one", "two"])
+        assert result == ["one", "two"]
 
     def test_inside_running_loop(self):
         ctx = _make_context()
@@ -255,7 +255,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
 
         async def runner():
             result = ctx._collect_async_generator(sample)
-            self.assertEqual(result, ["alpha"])
+            assert result == ["alpha"]
 
         asyncio.run(runner())
 
@@ -271,10 +271,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
         async def sample():
             return "result"
 
-        self.assertEqual(
-            ctx._run_async_in_safe_context(sample),
-            "result",
-        )
+        assert ctx._run_async_in_safe_context(sample) == "result"
 
     def test_inside_running_loop(self):
         ctx = _make_context()
@@ -283,10 +280,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
             return "loop"
 
         async def runner():
-            self.assertEqual(
-                ctx._run_async_in_safe_context(sample),
-                "loop",
-            )
+            assert ctx._run_async_in_safe_context(sample) == "loop"
 
         asyncio.run(runner())
 
@@ -328,27 +322,27 @@ class NextChapterInteractionTests(unittest.TestCase):
             events = list(
                 self.ctx._emit_next_chapter_interaction(self.ctx._current_attend)
             )
-            self.assertEqual(len(events), 1)
+            assert len(events) == 1
             next_event = events[0]
-            self.assertEqual(next_event.type, GeneratedType.INTERACTION)
-            self.assertIn(CONTEXT_INTERACTION_NEXT, next_event.content)
+            assert next_event.type == GeneratedType.INTERACTION
+            assert CONTEXT_INTERACTION_NEXT in next_event.content
 
             stored_blocks = LearnGeneratedBlock.query.filter(
                 LearnGeneratedBlock.progress_record_bid
                 == self.ctx._current_attend.progress_record_bid
             ).all()
-            self.assertEqual(len(stored_blocks), 1)
+            assert len(stored_blocks) == 1
 
-            self.assertEqual(
-                list(self.ctx._emit_next_chapter_interaction(self.ctx._current_attend)),
-                [],
+            assert (
+                list(self.ctx._emit_next_chapter_interaction(self.ctx._current_attend))
+                == []
             )
-            self.assertEqual(
+            assert (
                 LearnGeneratedBlock.query.filter(
                     LearnGeneratedBlock.progress_record_bid
                     == self.ctx._current_attend.progress_record_bid
-                ).count(),
-                1,
+                ).count()
+                == 1
             )
 
 
@@ -358,23 +352,17 @@ class AccessGateFeedbackHelperTests(unittest.TestCase):
         ctx._is_paid = False
         ctx._user_info = types.SimpleNamespace(mobile="")
 
-        self.assertTrue(
-            ctx._is_access_gate_blocking_interaction(
-                {"buttons": [{"value": "_sys_pay"}]}
-            )
+        assert ctx._is_access_gate_blocking_interaction(
+            {"buttons": [{"value": "_sys_pay"}]}
         )
-        self.assertTrue(
-            ctx._is_access_gate_blocking_interaction(
-                {"buttons": [{"value": "_sys_login"}]}
-            )
+        assert ctx._is_access_gate_blocking_interaction(
+            {"buttons": [{"value": "_sys_login"}]}
         )
 
         ctx._is_paid = True
         ctx._user_info = types.SimpleNamespace(mobile="13800000000")
-        self.assertFalse(
-            ctx._is_access_gate_blocking_interaction(
-                {"buttons": [{"value": "_sys_pay"}, {"value": "_sys_login"}]}
-            )
+        assert not ctx._is_access_gate_blocking_interaction(
+            {"buttons": [{"value": "_sys_pay"}, {"value": "_sys_login"}]}
         )
 
 
@@ -402,8 +390,8 @@ class CompletionTailInteractionTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["next", "feedback"])
-        self.assertEqual(events, ["next-event", "feedback-event"])
+        assert calls == ["next", "feedback"]
+        assert events == ["next-event", "feedback-event"]
 
     def test_skips_next_when_no_next_outline(self):
         ctx = _make_context()
@@ -428,8 +416,8 @@ class CompletionTailInteractionTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["feedback"])
-        self.assertEqual(events, ["feedback-event"])
+        assert calls == ["feedback"]
+        assert events == ["feedback-event"]
 
     def test_emits_only_next_when_not_completed(self):
         ctx = _make_context()
@@ -454,8 +442,8 @@ class CompletionTailInteractionTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(calls, ["next"])
-        self.assertEqual(events, ["next-event"])
+        assert calls == ["next"]
+        assert events == ["next-event"]
 
 
 class RuntimeOutlineBlockCountTests(unittest.TestCase):
@@ -522,12 +510,9 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
                 _FakeMarkdownFlow,
             ),
         ):
-            self.assertEqual(ctx._get_next_outline_item(), [])
+            assert ctx._get_next_outline_item() == []
 
-        self.assertEqual(
-            get_outline_item_mock.call_args.kwargs.get("outline_item_id"),
-            1,
-        )
+        assert get_outline_item_mock.call_args.kwargs.get("outline_item_id") == 1
 
     def test_get_run_script_info_uses_outline_row_id_from_struct(self):
         ctx = _make_context()
@@ -572,11 +557,8 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         ):
             run_info = ctx._get_run_script_info(attend)
 
-        self.assertIsNotNone(run_info)
-        self.assertEqual(
-            get_outline_item_mock.call_args.kwargs.get("outline_item_id"),
-            42,
-        )
+        assert run_info is not None
+        assert get_outline_item_mock.call_args.kwargs.get("outline_item_id") == 42
 
 
 class ExceptionGateFeedbackTests(unittest.TestCase):
@@ -637,13 +619,13 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
             )
             dao.db.session.commit()
             events = list(self.ctx._emit_feedback_after_exception_gate())
-            self.assertEqual(len(events), 1)
-            self.assertEqual(events[0].type, GeneratedType.INTERACTION)
+            assert len(events) == 1
+            assert events[0].type == GeneratedType.INTERACTION
 
     def test_skips_when_no_completed_progress(self):
         with self.app.app_context():
             events = list(self.ctx._emit_feedback_after_exception_gate())
-            self.assertEqual(events, [])
+            assert events == []
 
     def test_skips_completed_progress_without_generated_blocks(self):
         with self.app.app_context():
@@ -658,7 +640,7 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
             )
             dao.db.session.commit()
             events = list(self.ctx._emit_feedback_after_exception_gate())
-            self.assertEqual(events, [])
+            assert events == []
 
 
 class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
@@ -703,11 +685,11 @@ class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
             progress = LearnProgressRecord.query.one()
             block = LearnGeneratedBlock.query.one()
 
-        self.assertEqual(len(events), 1)
-        self.assertEqual(progress.status, LEARN_STATUS_NOT_STARTED)
-        self.assertEqual(block.progress_record_bid, progress.progress_record_bid)
-        self.assertEqual(block.outline_item_bid, "outline-locked")
-        self.assertEqual(block.block_content_conf, "?[server.order.checkout//_sys_pay]")
+        assert len(events) == 1
+        assert progress.status == LEARN_STATUS_NOT_STARTED
+        assert block.progress_record_bid == progress.progress_record_bid
+        assert block.outline_item_bid == "outline-locked"
+        assert block.block_content_conf == "?[server.order.checkout//_sys_pay]"
 
 
 class StreamTtsGateTests(unittest.TestCase):
@@ -717,18 +699,18 @@ class StreamTtsGateTests(unittest.TestCase):
         ctx._input_type = "normal"
         ctx._preview_mode = False
         ctx._listen = True
-        self.assertTrue(ctx._should_stream_tts())
+        assert ctx._should_stream_tts()
 
         ctx._listen = False
-        self.assertFalse(ctx._should_stream_tts())
+        assert not ctx._should_stream_tts()
 
         ctx._preview_mode = True
         ctx._listen = True
-        self.assertFalse(ctx._should_stream_tts())
+        assert not ctx._should_stream_tts()
 
         ctx._preview_mode = False
         ctx._input_type = "ask"
-        self.assertFalse(ctx._should_stream_tts())
+        assert not ctx._should_stream_tts()
 
     def test_iter_stream_result_with_idle_callback_drains_while_waiting(self):
         app = Flask("stream-tts-idle-drain")
@@ -940,12 +922,12 @@ class ReloadFromElementBidTests(unittest.TestCase):
                 LearnGeneratedElement.element_bid == "later-element-1"
             ).first()
 
-            self.assertEqual(progress.block_position, 2)
-            self.assertEqual(progress.status, LEARN_STATUS_IN_PROGRESS)
-            self.assertEqual(interaction_block.status, 1)
-            self.assertEqual(later_block.status, 0)
-            self.assertIsNotNone(later_element)
-            self.assertEqual(later_element.status, 0)
+            assert progress.block_position == 2
+            assert progress.status == LEARN_STATUS_IN_PROGRESS
+            assert interaction_block.status == 1
+            assert later_block.status == 0
+            assert later_element is not None
+            assert later_element.status == 0
 
     def test_reload_preserves_ask_and_answer_blocks(self):
         with self.app.app_context():
@@ -1054,10 +1036,10 @@ class ReloadFromElementBidTests(unittest.TestCase):
             dao.db.session.refresh(answer_block)
             dao.db.session.refresh(later_block)
 
-            self.assertEqual(target_block.status, 0)
-            self.assertEqual(later_block.status, 0)
-            self.assertEqual(ask_block.status, 1)
-            self.assertEqual(answer_block.status, 1)
+            assert target_block.status == 0
+            assert later_block.status == 0
+            assert ask_block.status == 1
+            assert answer_block.status == 1
 
 
 class StreamTtsTeardownTests(unittest.TestCase):
@@ -1093,10 +1075,10 @@ class StreamTtsTeardownTests(unittest.TestCase):
                 )
             )
 
-        self.assertEqual(events, ["content-flush", "audio-complete"])
-        self.assertEqual(flush_calls, ["flush"])
-        self.assertEqual(processor.finalize_calls, [False])
-        self.assertEqual(ctx._element_index_cursor, 5)
+        assert events == ["content-flush", "audio-complete"]
+        assert flush_calls == ["flush"]
+        assert processor.finalize_calls == [False]
+        assert ctx._element_index_cursor == 5
 
     def test_teardown_skips_emit_on_generator_exit(self):
         app = Flask("stream-tts-teardown-generator-exit")
@@ -1131,10 +1113,10 @@ class StreamTtsTeardownTests(unittest.TestCase):
                 )
             )
 
-        self.assertEqual(events, [])
-        self.assertEqual(flush_calls, [])
-        self.assertEqual(processor.finalize_calls, 0)
-        self.assertEqual(ctx._element_index_cursor, 1)
+        assert events == []
+        assert flush_calls == []
+        assert processor.finalize_calls == 0
+        assert ctx._element_index_cursor == 1
 
 
 class MdflowContextCompatibilityTests(unittest.TestCase):
@@ -1150,7 +1132,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
             context = MdflowContextV2(document="doc", visual_mode=False)
 
-        self.assertIsInstance(context._mdflow, FakeMarkdownFlow)
+        assert isinstance(context._mdflow, FakeMarkdownFlow)
 
     def test_init_calls_visual_mode_when_api_exists(self):
         class FakeMarkdownFlow:
@@ -1166,7 +1148,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
             context = MdflowContextV2(document="doc", visual_mode=False)
 
-        self.assertFalse(context._mdflow.visual_mode)
+        assert not context._mdflow.visual_mode
 
     def test_init_uses_explicit_output_language_when_enabled(self):
         class FakeMarkdownFlow:
@@ -1190,7 +1172,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 output_language="zh-CN",
             )
 
-        self.assertEqual(context._mdflow.output_language, "简体中文")
+        assert context._mdflow.output_language == "简体中文"
 
     def test_filter_context_removes_stale_english_output_instruction(self):
         context = [
@@ -1207,7 +1189,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
             "zh-CN",
         )
 
-        self.assertEqual(filtered, context[1:])
+        assert filtered == context[1:]
 
 
 class RuntimeOutputLanguageTests(unittest.TestCase):
@@ -1220,7 +1202,7 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
                 {"sys_user_language": "en-US", "language": "en-US"}
             )
 
-        self.assertEqual(output_language, "zh-CN")
+        assert output_language == "zh-CN"
 
     def test_runtime_language_overlays_stale_production_prompt_variables(self):
         stored_profile = {
@@ -1238,12 +1220,12 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
                 use_learner_language=True,
             )
 
-        self.assertEqual(output_language, "fr-FR")
-        self.assertEqual(runtime_profile["sys_user_language"], "fr-FR")
-        self.assertEqual(runtime_profile["language"], "fr-FR")
-        self.assertEqual(runtime_profile["sys_user_nickname"], "Learner")
-        self.assertEqual(stored_profile["sys_user_language"], "zh-CN")
-        self.assertEqual(stored_profile["language"], "zh-CN")
+        assert output_language == "fr-FR"
+        assert runtime_profile["sys_user_language"] == "fr-FR"
+        assert runtime_profile["language"] == "fr-FR"
+        assert runtime_profile["sys_user_nickname"] == "Learner"
+        assert stored_profile["sys_user_language"] == "zh-CN"
+        assert stored_profile["language"] == "zh-CN"
 
     def test_runtime_language_keeps_profile_variables_when_feature_is_disabled(self):
         stored_profile = {
@@ -1260,9 +1242,9 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
                 use_learner_language=False,
             )
 
-        self.assertEqual(output_language, "fr-FR")
-        self.assertEqual(runtime_profile, stored_profile)
-        self.assertIsNot(runtime_profile, stored_profile)
+        assert output_language == "fr-FR"
+        assert runtime_profile == stored_profile
+        assert runtime_profile is not stored_profile
 
 
 class PreviewResolveLlmSettingsTests(unittest.TestCase):
@@ -1298,8 +1280,8 @@ class PreviewResolveLlmSettingsTests(unittest.TestCase):
                 shifu,
             )
 
-        self.assertEqual(model, "ark/deepseek-v3-2")
-        self.assertEqual(temperature, 0.3)
+        assert model == "ark/deepseek-v3-2"
+        assert temperature == 0.3
 
 
 class PreviewResolveVariablesTests(unittest.TestCase):
@@ -1324,9 +1306,9 @@ class PreviewResolveVariablesTests(unittest.TestCase):
                 shifu_bid="shifu-1",
             )
 
-        self.assertEqual(variables.get("sys_user_language"), "zh-CN")
-        self.assertEqual(variables.get("language"), "zh-CN")
-        self.assertEqual(variables.get("sys_user_nickname"), "017")
+        assert variables.get("sys_user_language") == "zh-CN"
+        assert variables.get("language") == "zh-CN"
+        assert variables.get("sys_user_nickname") == "017"
         mock_fetch.assert_called_once_with(app, "user-1", "shifu-1")
 
     def test_empty_sys_user_language_uses_request_language(self):
@@ -1353,8 +1335,8 @@ class PreviewResolveVariablesTests(unittest.TestCase):
                 shifu_bid="shifu-1",
             )
 
-        self.assertEqual(variables.get("sys_user_language"), "zh-CN")
-        self.assertEqual(variables.get("language"), "zh-CN")
+        assert variables.get("sys_user_language") == "zh-CN"
+        assert variables.get("language") == "zh-CN"
 
     def test_request_language_overrides_stale_profile_language(self):
         app = Flask("preview-variables-request-language")
@@ -1374,8 +1356,8 @@ class PreviewResolveVariablesTests(unittest.TestCase):
                 shifu_bid="shifu-1",
             )
 
-        self.assertEqual(variables.get("sys_user_language"), "zh-CN")
-        self.assertEqual(variables.get("language"), "zh-CN")
+        assert variables.get("sys_user_language") == "zh-CN"
+        assert variables.get("language") == "zh-CN"
 
     def test_keeps_existing_sys_user_language(self):
         app = Flask("preview-variables-existing")
@@ -1395,8 +1377,8 @@ class PreviewResolveVariablesTests(unittest.TestCase):
                 shifu_bid="shifu-1",
             )
 
-        self.assertEqual(variables.get("sys_user_language"), "fr-FR")
-        self.assertEqual(variables.get("language"), "fr-FR")
+        assert variables.get("sys_user_language") == "fr-FR"
+        assert variables.get("language") == "fr-FR"
         mock_fetch.assert_called_once_with(app, "user-1", "shifu-1")
 
 
@@ -1408,23 +1390,20 @@ class CoursePromptCompositionTests(unittest.TestCase):
         course_prompt: str,
         learner_profile: str,
     ) -> None:
-        self.assertIsNotNone(prompt)
+        assert prompt is not None
         assert prompt is not None
         composition_index = prompt.index("<composition_contract>")
         course_index = prompt.index("<course_prompt>")
         learner_profile_opening_tag = '<learner_profile format="json-string">'
         profile_index = prompt.index(learner_profile_opening_tag)
-        self.assertLess(composition_index, course_index)
-        self.assertLess(course_index, profile_index)
-        self.assertIn(
-            f"<course_prompt>\n{course_prompt}\n</course_prompt>",
-            prompt,
+        assert composition_index < course_index
+        assert course_index < profile_index
+        assert f"<course_prompt>\n{course_prompt}\n</course_prompt>" in prompt
+        assert (
+            f'{learner_profile_opening_tag}\n"{learner_profile}"\n</learner_profile>'
+            in prompt
         )
-        self.assertIn(
-            f'{learner_profile_opening_tag}\n"{learner_profile}"\n</learner_profile>',
-            prompt,
-        )
-        self.assertEqual(prompt.count(LEARNER_PROFILE_PROMPT_MARKER), 1)
+        assert prompt.count(LEARNER_PROFILE_PROMPT_MARKER) == 1
 
     def test_runtime_getter_returns_course_prompt_with_current_learner_profile(self):
         app = Flask("runtime-course-prompt-profile")
@@ -1485,7 +1464,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
             learner_profile="最近关注知识管理",
         )
         assert prompt is not None
-        self.assertNotIn("FALLBACK RULE", prompt)
+        assert "FALLBACK RULE" not in prompt
         mock_load.assert_called_once_with("user-1")
 
     def test_formal_preview_uses_current_explicit_nickname_without_profile_text(self):
@@ -1519,9 +1498,9 @@ class CoursePromptCompositionTests(unittest.TestCase):
         encoded_context = prompt.split('<learner_profile format="json-string">\n', 1)[
             1
         ].split("\n</learner_profile>", 1)[0]
-        self.assertEqual(
-            json.loads(encoded_context),
-            'Preferred form of address (learner-authored): "Current Learner"',
+        assert (
+            json.loads(encoded_context)
+            == 'Preferred form of address (learner-authored): "Current Learner"'
         )
 
     def test_formal_preview_reloads_profile_for_each_request(self):
@@ -1562,8 +1541,8 @@ class CoursePromptCompositionTests(unittest.TestCase):
             course_prompt="PREVIEW COURSE RULE",
             learner_profile="偏好图解",
         )
-        self.assertEqual(cleared_prompt, "PREVIEW COURSE RULE")
-        self.assertEqual(mock_load.call_args_list, [call("user-1"), call("user-1")])
+        assert cleared_prompt == "PREVIEW COURSE RULE"
+        assert mock_load.call_args_list == [call("user-1"), call("user-1")]
 
     def test_formal_preview_recomposes_client_envelope_for_current_learner(self):
         app = Flask("preview-course-prompt-current-account")
@@ -1608,8 +1587,8 @@ class CoursePromptCompositionTests(unittest.TestCase):
             learner_profile="CURRENT ACCOUNT PROFILE",
         )
         assert current_prompt is not None
-        self.assertNotIn("PREVIOUS ACCOUNT PROFILE", current_prompt)
-        self.assertEqual(cleared_prompt, "PREVIEW COURSE RULE")
+        assert "PREVIOUS ACCOUNT PROFILE" not in current_prompt
+        assert cleared_prompt == "PREVIEW COURSE RULE"
 
     def test_preview_learner_lookup_failure_cleans_the_database_session(self):
         app = Flask("preview-course-prompt-lookup-failure")
@@ -1627,7 +1606,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
         ):
             learner = preview_ctx._load_learner_for_course_prompt("user-1")
 
-        self.assertIsNone(learner)
+        assert learner is None
         mock_cleanup.assert_called_once_with(
             lookup_error,
             source="preview learner profile lookup",
@@ -1675,8 +1654,8 @@ class PreviewRunLlmLoggingTests(unittest.TestCase):
         ):
             output = provider.complete(messages=[{"role": "user", "content": "hello"}])
 
-        self.assertEqual(output, "First line\nSecond line")
-        self.assertIs(captured["parent_observation"], parent_observation)
+        assert output == "First line\nSecond line"
+        assert captured["parent_observation"] is parent_observation
         mock_info.assert_any_call(
             "preview llm output | shifu_bid=%s | outline_bid=%s | session_id=%s | scene=%s | model=%s | temperature=%s | output=%s",
             "shifu-1",
@@ -1745,8 +1724,8 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
                 preview_mode=False,
             )
 
-        self.assertIs(captured["client"], sentinel_client)
-        self.assertEqual(captured["trace_payload"]["id"], "req-trace-1")
+        assert captured["client"] is sentinel_client
+        assert captured["trace_payload"]["id"] == "req-trace-1"
 
     def test_set_input_normalizes_structured_value_for_trace(self):
         ctx = _make_context()
@@ -1754,8 +1733,8 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         ctx.set_input({"lang": ["Python", "Go"], "level": ["Beginner"]}, "select")
 
-        self.assertEqual(ctx._trace_args["input"], "Python, Go, Beginner")
-        self.assertEqual(ctx._trace_args["input_type"], "select")
+        assert ctx._trace_args["input"] == "Python, Go, Beginner"
+        assert ctx._trace_args["input_type"] == "select"
 
     def test_set_input_normalizes_python_literal_string_for_trace(self):
         ctx = _make_context()
@@ -1763,7 +1742,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         ctx.set_input("{'lang': ['Python', 'Go']}", "select")
 
-        self.assertEqual(ctx._trace_args["input"], "Python, Go")
+        assert ctx._trace_args["input"] == "Python, Go"
 
     def test_runtime_finalize_skips_empty_output_overwrite(self):
         ctx = _make_context()
@@ -1778,15 +1757,12 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         ctx._finalize_langfuse_trace()
 
-        self.assertEqual(
-            ctx._trace.updated,
-            {
-                "user_id": "user-1",
-                "session_id": "session-1",
-                "name": "lesson_runtime/trace/Outline",
-            },
-        )
-        self.assertEqual(ctx._trace_root_span.end_kwargs, {})
+        assert ctx._trace.updated == {
+            "user_id": "user-1",
+            "session_id": "session-1",
+            "name": "lesson_runtime/trace/Outline",
+        }
+        assert ctx._trace_root_span.end_kwargs == {}
 
     def test_runtime_finalize_uses_accumulated_output(self):
         ctx = _make_context()
@@ -1802,11 +1778,11 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         ctx._finalize_langfuse_trace()
 
-        self.assertEqual(ctx._trace.updated["output"], "chunk-1chunk-2")
-        self.assertEqual(
-            ctx._trace_root_span.end_kwargs,
-            {"input": "student input", "output": "chunk-1chunk-2"},
-        )
+        assert ctx._trace.updated["output"] == "chunk-1chunk-2"
+        assert ctx._trace_root_span.end_kwargs == {
+            "input": "student input",
+            "output": "chunk-1chunk-2",
+        }
 
     def test_append_langfuse_output_normalizes_python_literal_string(self):
         ctx = _make_context()
@@ -1814,7 +1790,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         ctx.append_langfuse_output("['part-1', 'part-2']")
 
-        self.assertEqual(ctx._langfuse_output_chunks, ['["part-1", "part-2"]'])
+        assert ctx._langfuse_output_chunks == ['["part-1", "part-2"]']
 
 
 class PreviewLangfuseTraceTests(unittest.TestCase):
@@ -1935,15 +1911,15 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 )
             )
 
-        self.assertTrue(messages)
-        self.assertEqual(captured["trace_payload"]["id"], "preview-req-trace-1")
-        self.assertEqual(captured["trace_payload"]["session_id"], "preview-session-1")
-        self.assertEqual(captured["trace"].updated["input"], "Prompt block")
-        self.assertEqual(captured["trace"].updated["output"], "Hello preview")
-        self.assertEqual(
-            captured["root_span"].end_kwargs,
-            {"input": "Prompt block", "output": "Hello preview"},
-        )
+        assert messages
+        assert captured["trace_payload"]["id"] == "preview-req-trace-1"
+        assert captured["trace_payload"]["session_id"] == "preview-session-1"
+        assert captured["trace"].updated["input"] == "Prompt block"
+        assert captured["trace"].updated["output"] == "Hello preview"
+        assert captured["root_span"].end_kwargs == {
+            "input": "Prompt block",
+            "output": "Hello preview",
+        }
 
 
 class PreviewElementizationTests(unittest.TestCase):
@@ -1963,12 +1939,9 @@ class PreviewElementizationTests(unittest.TestCase):
             is_user_input_validation=False,
         )
 
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].type, GeneratedType.CONTENT)
-        self.assertEqual(
-            events[0].get_mdflow_stream_parts(),
-            [("Hello preview", "text", 0)],
-        )
+        assert len(events) == 1
+        assert events[0].type == GeneratedType.CONTENT
+        assert events[0].get_mdflow_stream_parts() == [("Hello preview", "text", 0)]
 
     def test_preview_content_stream_emits_element_and_done(self):
         app = Flask("preview-content-stream")
@@ -2006,19 +1979,19 @@ class PreviewElementizationTests(unittest.TestCase):
         )
 
         element_messages = [item for item in messages if item.type == "element"]
-        self.assertGreaterEqual(len(element_messages), 2)
-        self.assertEqual(content_chunks, ["Hello preview"])
-        self.assertEqual(element_messages[0].content.element_type, ElementType.TEXT)
-        self.assertFalse(element_messages[0].content.is_final)
-        self.assertEqual(element_messages[-1].content.element_type, ElementType.TEXT)
-        self.assertTrue(element_messages[-1].content.is_final)
+        assert len(element_messages) >= 2
+        assert content_chunks == ["Hello preview"]
+        assert element_messages[0].content.element_type == ElementType.TEXT
+        assert not element_messages[0].content.is_final
+        assert element_messages[-1].content.element_type == ElementType.TEXT
+        assert element_messages[-1].content.is_final
         done_messages = [
             item for item in messages if item.type == GeneratedType.DONE.value
         ]
-        self.assertEqual(len(done_messages), 2)
-        self.assertFalse(done_messages[0].is_terminal)
-        self.assertEqual(messages[-1].type, GeneratedType.DONE.value)
-        self.assertTrue(messages[-1].is_terminal)
+        assert len(done_messages) == 2
+        assert not done_messages[0].is_terminal
+        assert messages[-1].type == GeneratedType.DONE.value
+        assert messages[-1].is_terminal
 
     def test_preview_content_uses_formatted_elements_when_top_level_content_empty(self):
         app = Flask("preview-content-formatted-elements")
@@ -2056,16 +2029,16 @@ class PreviewElementizationTests(unittest.TestCase):
         )
 
         element_messages = [item for item in messages if item.type == "element"]
-        self.assertGreaterEqual(len(element_messages), 2)
-        self.assertEqual(content_chunks, ["Visual caption"])
-        self.assertEqual(element_messages[0].content.content_text, "Visual caption")
+        assert len(element_messages) >= 2
+        assert content_chunks == ["Visual caption"]
+        assert element_messages[0].content.content_text == "Visual caption"
         done_messages = [
             item for item in messages if item.type == GeneratedType.DONE.value
         ]
-        self.assertEqual(len(done_messages), 2)
-        self.assertFalse(done_messages[0].is_terminal)
-        self.assertEqual(messages[-1].type, GeneratedType.DONE.value)
-        self.assertTrue(messages[-1].is_terminal)
+        assert len(done_messages) == 2
+        assert not done_messages[0].is_terminal
+        assert messages[-1].type == GeneratedType.DONE.value
+        assert messages[-1].is_terminal
 
     def test_preview_interaction_validation_uses_formatted_elements_when_content_empty(
         self,
@@ -2108,16 +2081,16 @@ class PreviewElementizationTests(unittest.TestCase):
         )
 
         element_messages = [item for item in messages if item.type == "element"]
-        self.assertGreaterEqual(len(element_messages), 2)
-        self.assertEqual(content_chunks, ["Validation error"])
-        self.assertEqual(element_messages[0].content.content_text, "Validation error")
+        assert len(element_messages) >= 2
+        assert content_chunks == ["Validation error"]
+        assert element_messages[0].content.content_text == "Validation error"
         done_messages = [
             item for item in messages if item.type == GeneratedType.DONE.value
         ]
-        self.assertEqual(len(done_messages), 2)
-        self.assertFalse(done_messages[0].is_terminal)
-        self.assertEqual(messages[-1].type, GeneratedType.DONE.value)
-        self.assertTrue(messages[-1].is_terminal)
+        assert len(done_messages) == 2
+        assert not done_messages[0].is_terminal
+        assert messages[-1].type == GeneratedType.DONE.value
+        assert messages[-1].is_terminal
 
     def test_preview_interaction_stream_emits_interaction_element_and_done(self):
         app = Flask("preview-interaction-stream")
@@ -2150,20 +2123,20 @@ class PreviewElementizationTests(unittest.TestCase):
         )
 
         element_messages = [item for item in messages if item.type == "element"]
-        self.assertEqual(len(element_messages), 1)
+        assert len(element_messages) == 1
         interaction = element_messages[0].content
-        self.assertEqual(interaction.element_type, ElementType.INTERACTION)
-        self.assertEqual(interaction.role, "ui")
-        self.assertEqual(interaction.content_text, "Please choose one")
-        self.assertEqual(content_chunks, [])
-        self.assertEqual(langfuse_output_chunks, ["Please choose one"])
+        assert interaction.element_type == ElementType.INTERACTION
+        assert interaction.role == "ui"
+        assert interaction.content_text == "Please choose one"
+        assert content_chunks == []
+        assert langfuse_output_chunks == ["Please choose one"]
         done_messages = [
             item for item in messages if item.type == GeneratedType.DONE.value
         ]
-        self.assertEqual(len(done_messages), 2)
-        self.assertFalse(done_messages[0].is_terminal)
-        self.assertEqual(messages[-1].type, GeneratedType.DONE.value)
-        self.assertTrue(messages[-1].is_terminal)
+        assert len(done_messages) == 2
+        assert not done_messages[0].is_terminal
+        assert messages[-1].type == GeneratedType.DONE.value
+        assert messages[-1].is_terminal
 
 
 class _InMemoryCache:
@@ -2229,7 +2202,7 @@ class PreviewSentPromptCaptureTests(unittest.TestCase):
             )
         )
 
-        self.assertEqual(sent_prompt_chunks, ["P-PREVIEW"])
+        assert sent_prompt_chunks == ["P-PREVIEW"]
 
     def test_update_preview_context_prefers_sent_prompt(self):
         app = Flask("preview-prompt-store")
@@ -2256,9 +2229,9 @@ class PreviewSentPromptCaptureTests(unittest.TestCase):
             "re-rendered block",
         )
 
-        self.assertEqual(appended[0][2], "P-PREVIEW")
+        assert appended[0][2] == "P-PREVIEW"
         # Without a captured prompt the legacy rendering still applies.
-        self.assertEqual(appended[1][2], "re-rendered block")
+        assert appended[1][2] == "re-rendered block"
 
 
 class PreviewContextStoreTruncationTests(unittest.TestCase):
@@ -2270,38 +2243,29 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 4)
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "u0"},
-                {"role": "assistant", "content": "a0"},
-                {"role": "user", "content": "u1"},
-                {"role": "assistant", "content": "a1"},
-                {"role": "user", "content": "u2"},
-                {"role": "assistant", "content": "a2"},
-                {"role": "user", "content": "u3"},
-                {"role": "assistant", "content": "a3"},
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "u0"},
+            {"role": "assistant", "content": "a0"},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "u3"},
+            {"role": "assistant", "content": "a3"},
+        ]
 
     def test_reselect_drops_entries_at_or_above_block_index(self):
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 2)
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "u0"},
-                {"role": "assistant", "content": "a0"},
-                {"role": "user", "content": "u1"},
-                {"role": "assistant", "content": "a1"},
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "u0"},
+            {"role": "assistant", "content": "a0"},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+        ]
         persisted = store.load()
-        self.assertEqual(
-            [entry["block_index"] for entry in persisted["entries"]],
-            [0, 1],
-        )
+        assert [entry["block_index"] for entry in persisted["entries"]] == [0, 1]
 
     def test_repeated_reselect_does_not_grow(self):
         store, _cache, doc = _make_preview_store()
@@ -2315,38 +2279,32 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
             index_counts[entry["block_index"]] = (
                 index_counts.get(entry["block_index"], 0) + 1
             )
-        self.assertEqual(index_counts.get(2), 1)
-        self.assertEqual(index_counts.get(0), 1)
-        self.assertEqual(index_counts.get(1), 1)
+        assert index_counts.get(2) == 1
+        assert index_counts.get(0) == 1
+        assert index_counts.get(1) == 1
 
     def test_backtrack_to_earlier_block(self):
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 1)
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "u0"},
-                {"role": "assistant", "content": "a0"},
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "u0"},
+            {"role": "assistant", "content": "a0"},
+        ]
         persisted = store.load()
-        self.assertEqual(
-            [entry["block_index"] for entry in persisted["entries"]],
-            [0],
-        )
+        assert [entry["block_index"] for entry in persisted["entries"]] == [0]
 
     def test_block_index_zero_clears(self):
         store, cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2])
-        self.assertEqual(store.get_context(doc, 0), [])
-        self.assertEqual(cache.store, {})
+        assert store.get_context(doc, 0) == []
+        assert cache.store == {}
 
     def test_document_hash_change_clears(self):
         store, cache, _doc = _make_preview_store(doc="doc-A")
         self._populate(store, "doc-A", [0, 1, 2])
-        self.assertEqual(store.get_context("doc-B", 3), [])
-        self.assertEqual(cache.store, {})
+        assert store.get_context("doc-B", 3) == []
+        assert cache.store == {}
 
     def test_legacy_flat_schema_clears(self):
         store, cache, doc = _make_preview_store()
@@ -2359,34 +2317,31 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
                 ],
             }
         )
-        self.assertEqual(store.get_context(doc, 3), [])
-        self.assertEqual(cache.store, {})
+        assert store.get_context(doc, 3) == []
+        assert cache.store == {}
 
     def test_append_skips_when_both_empty(self):
         store, cache, doc = _make_preview_store()
         store.append_context(doc, 2, None, None)
-        self.assertEqual(cache.store, {})
+        assert cache.store == {}
 
     def test_append_user_only_and_assistant_only(self):
         store, _cache, doc = _make_preview_store()
         store.append_context(doc, 1, "user-only", None)
         store.append_context(doc, 2, None, "assistant-only")
         messages = store.get_context(doc, 3)
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "user-only"},
-                {"role": "assistant", "content": "assistant-only"},
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "user-only"},
+            {"role": "assistant", "content": "assistant-only"},
+        ]
 
     def test_missing_document_hash_clears_entries(self):
         store, cache, doc = _make_preview_store()
         store.save(
             {"entries": [{"block_index": 1, "user": "stale", "assistant": "stale"}]}
         )
-        self.assertEqual(store.get_context(doc, 3), [])
-        self.assertEqual(cache.store, {})
+        assert store.get_context(doc, 3) == []
+        assert cache.store == {}
 
     def test_empty_document_hash_clears_entries(self):
         store, cache, doc = _make_preview_store()
@@ -2396,8 +2351,8 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
                 "entries": [{"block_index": 1, "user": "stale", "assistant": "stale"}],
             }
         )
-        self.assertEqual(store.get_context(doc, 3), [])
-        self.assertEqual(cache.store, {})
+        assert store.get_context(doc, 3) == []
+        assert cache.store == {}
 
     def test_replace_context_pairs_messages_with_sentinel_index(self):
         store, _cache, doc = _make_preview_store()
@@ -2410,17 +2365,14 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
             ],
         )
         persisted = store.load()
-        self.assertTrue(all(entry["block_index"] < 0 for entry in persisted["entries"]))
+        assert all(entry["block_index"] < 0 for entry in persisted["entries"])
         # A real block_index request should preserve all sentinel entries.
         messages = store.get_context(doc, 5)
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "ctx-u-0"},
-                {"role": "assistant", "content": "ctx-a-0"},
-                {"role": "user", "content": "ctx-u-1"},
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "ctx-u-0"},
+            {"role": "assistant", "content": "ctx-a-0"},
+            {"role": "user", "content": "ctx-u-1"},
+        ]
 
 
 class RuntimeExceptionLangfuseTests(unittest.TestCase):
@@ -2438,7 +2390,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         with patch("flaskr.service.learn.context_v2._", lambda key: key):
             outputs = list(ctx.run(app))
 
-        self.assertEqual(outputs, ["?[server.order.checkout//_sys_pay]", "feedback"])
+        assert outputs == ["?[server.order.checkout//_sys_pay]", "feedback"]
 
 
 class BuildContextFromBlocksTests(unittest.TestCase):
@@ -2486,8 +2438,8 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         interaction_msgs = [
             m for m in messages if m["role"] == "assistant" and "?[" in m["content"]
         ]
-        self.assertEqual(len(interaction_msgs), 1)
-        self.assertIn("%{{nickname}}", interaction_msgs[0]["content"])
+        assert len(interaction_msgs) == 1
+        assert "%{{nickname}}" in interaction_msgs[0]["content"]
 
     def test_transform_expands_interaction_without_adjacent_users(self):
         app = Flask(__name__)
@@ -2504,15 +2456,14 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         transformed = mf._transform_context_messages(messages, {"nickname": "Alice"})
 
         # Interaction answer becomes user(value)+assistant("ok").
-        self.assertIn({"role": "user", "content": "Alice"}, transformed)
+        assert {"role": "user", "content": "Alice"} in transformed
         # No raw interaction syntax leaks after transform.
-        self.assertTrue(all("?[" not in m["content"] for m in transformed))
+        assert all("?[" not in m["content"] for m in transformed)
         # Roles strictly alternate: no two adjacent user messages.
         roles = [m["role"] for m in transformed]
         for prev, cur in itertools.pairwise(roles):
-            self.assertFalse(
-                prev == "user" and cur == "user",
-                f"adjacent user messages in {roles}",
+            assert not (prev == "user" and cur == "user"), (
+                f"adjacent user messages in {roles}"
             )
 
 
@@ -2553,8 +2504,8 @@ class BuildContextGenerationPromptReplayTests(unittest.TestCase):
             )
 
         # The stored prompt wins even though nickname now resolves to Alice.
-        self.assertEqual(messages[0]["role"], "user")
-        self.assertEqual(messages[0]["content"], self.STORED_PROMPT)
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == self.STORED_PROMPT
 
     def test_missing_or_empty_prompt_falls_back_to_current_rendering(self):
         blocks = [
@@ -2579,9 +2530,9 @@ class BuildContextGenerationPromptReplayTests(unittest.TestCase):
             )
 
         user_messages = [m for m in messages if m["role"] == "user"]
-        self.assertEqual(len(user_messages), 2)
-        self.assertIn("Alice", user_messages[0]["content"])
-        self.assertEqual(user_messages[1]["content"], "Second content.")
+        assert len(user_messages) == 2
+        assert "Alice" in user_messages[0]["content"]
+        assert user_messages[1]["content"] == "Second content."
 
 
 class StreamContentBlockPromptCaptureTests(unittest.TestCase):
@@ -2664,17 +2615,16 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
             ]
         )
         finalize_call = ctx._recorder.finalize_streamed_block.call_args
-        self.assertEqual(finalize_call.kwargs["generation_prompt"], "P-EXACT")
-        self.assertEqual(finalize_call.args[1], "Hello world")
+        assert finalize_call.kwargs["generation_prompt"] == "P-EXACT"
+        assert finalize_call.args[1] == "Hello world"
 
     def test_promptless_stream_falls_back_to_rendered_block_source(self):
         ctx, _events = self._run_stream_phase(
             [LLMResult(content="Preserved Alice text.", type="text", number=0)]
         )
         finalize_call = ctx._recorder.finalize_streamed_block.call_args
-        self.assertEqual(
-            finalize_call.kwargs["generation_prompt"],
-            'Preserved """Alice""" text.',
+        assert (
+            finalize_call.kwargs["generation_prompt"] == 'Preserved """Alice""" text.'
         )
 
 
@@ -2717,18 +2667,15 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
                 self._blocks("猎头公司"), self.DOC, {}
             )
 
-        self.assertEqual(
-            messages,
-            [
-                {"role": "user", "content": "Content one."},
-                {"role": "assistant", "content": "reply zero"},
-                {
-                    "role": "assistant",
-                    "content": self.INTERACTION,
-                    USER_ANSWER_CONTEXT_KEY: "猎头公司",
-                },
-            ],
-        )
+        assert messages == [
+            {"role": "user", "content": "Content one."},
+            {"role": "assistant", "content": "reply zero"},
+            {
+                "role": "assistant",
+                "content": self.INTERACTION,
+                USER_ANSWER_CONTEXT_KEY: "猎头公司",
+            },
+        ]
 
     def test_empty_selection_carries_empty_user_answer(self):
         app = Flask(__name__)
@@ -2739,14 +2686,11 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
 
         # The empty answer travels with the message; the library skips the
         # turn instead of fabricating a {user: "ok"} pair.
-        self.assertEqual(
-            messages[-1],
-            {
-                "role": "assistant",
-                "content": self.INTERACTION,
-                USER_ANSWER_CONTEXT_KEY: "",
-            },
-        )
+        assert messages[-1] == {
+            "role": "assistant",
+            "content": self.INTERACTION,
+            USER_ANSWER_CONTEXT_KEY: "",
+        }
 
     def test_library_expands_answer_and_skips_empty_turns(self):
         """End-to-end: the context built here goes through markdown-flow's
@@ -2764,29 +2708,22 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
 
         mdflow = MarkdownFlow(self.DOC)
         transformed = mdflow._transform_context_messages(answered, {})
-        self.assertEqual(
-            transformed,
-            [
-                {"role": "user", "content": "Content one."},
-                {"role": "assistant", "content": "reply zero"},
-                {"role": "user", "content": "猎头公司"},
-                {"role": "assistant", "content": "ok"},
-            ],
-        )
-        self.assertTrue(all("?[" not in m["content"] for m in transformed))
-        self.assertTrue(
-            all(USER_ANSWER_CONTEXT_KEY not in m for m in transformed),
-            "extension fields must never reach the LLM",
+        assert transformed == [
+            {"role": "user", "content": "Content one."},
+            {"role": "assistant", "content": "reply zero"},
+            {"role": "user", "content": "猎头公司"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        assert all("?[" not in m["content"] for m in transformed)
+        assert all(USER_ANSWER_CONTEXT_KEY not in m for m in transformed), (
+            "extension fields must never reach the LLM"
         )
 
         transformed_empty = mdflow._transform_context_messages(unanswered, {})
-        self.assertEqual(
-            transformed_empty,
-            [
-                {"role": "user", "content": "Content one."},
-                {"role": "assistant", "content": "reply zero"},
-            ],
-        )
+        assert transformed_empty == [
+            {"role": "user", "content": "Content one."},
+            {"role": "assistant", "content": "reply zero"},
+        ]
 
     def test_variable_free_text_input_carries_the_learner_answer(self):
         document = "Content one.\n---\n?[...What is your name?]\n---\nSecond content."
@@ -2796,17 +2733,14 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
                 self._blocks("Alice"), document, {}
             )
 
-        self.assertEqual(
-            messages[-1],
-            {
-                "role": "assistant",
-                "content": "?[...What is your name?]",
-                USER_ANSWER_CONTEXT_KEY: "Alice",
-            },
-        )
+        assert messages[-1] == {
+            "role": "assistant",
+            "content": "?[...What is your name?]",
+            USER_ANSWER_CONTEXT_KEY: "Alice",
+        }
         transformed = MarkdownFlow(document)._transform_context_messages(messages, {})
-        self.assertIn({"role": "user", "content": "Alice"}, transformed)
-        self.assertTrue(all("?[" not in m["content"] for m in transformed))
+        assert {"role": "user", "content": "Alice"} in transformed
+        assert all("?[" not in m["content"] for m in transformed)
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -143,32 +143,28 @@ class LearnRecordLoadTests(unittest.TestCase):
             preview_mode=False,
         )
 
-        self.assertEqual(len(record.records), 3)
+        assert len(record.records) == 3
 
         content_record = record.records[0]
-        self.assertEqual(content_record.block_type, BlockType.CONTENT)
-        self.assertEqual(content_record.content, content_block.generated_content)
-        self.assertNotEqual(content_record.content, content_block.block_content_conf)
-        self.assertEqual(content_record.user_input, "")
-        self.assertEqual(content_record.like_status, LikeStatus.NONE)
+        assert content_record.block_type == BlockType.CONTENT
+        assert content_record.content == content_block.generated_content
+        assert content_record.content != content_block.block_content_conf
+        assert content_record.user_input == ""
+        assert content_record.like_status == LikeStatus.NONE
 
         error_record = record.records[1]
-        self.assertEqual(error_record.block_type, BlockType.ERROR_MESSAGE)
-        self.assertEqual(error_record.content, error_block.generated_content)
-        self.assertEqual(error_record.user_input, "")
-        self.assertEqual(error_record.like_status, LikeStatus.NONE)
+        assert error_record.block_type == BlockType.ERROR_MESSAGE
+        assert error_record.content == error_block.generated_content
+        assert error_record.user_input == ""
+        assert error_record.like_status == LikeStatus.NONE
 
         interaction_record = record.records[2]
-        self.assertEqual(interaction_record.block_type, BlockType.INTERACTION)
-        self.assertEqual(
-            interaction_record.content, interaction_block.block_content_conf
-        )
-        self.assertEqual(
-            interaction_record.user_input, interaction_block.generated_content
-        )
-        self.assertNotEqual(interaction_record.content, interaction_record.user_input)
+        assert interaction_record.block_type == BlockType.INTERACTION
+        assert interaction_record.content == interaction_block.block_content_conf
+        assert interaction_record.user_input == interaction_block.generated_content
+        assert interaction_record.content != interaction_record.user_input
         # Interaction blocks should not carry like status in API responses.
-        self.assertEqual(interaction_record.like_status, LikeStatus.NONE)
+        assert interaction_record.like_status == LikeStatus.NONE
 
     def test_mdflow_context_loads_generated_and_user_inputs(self):
         """Verify mdflow run uses generated content for context and real user input values."""
@@ -303,20 +299,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         ):
             list(ctx.run_inner(self.app))
 
-        self.assertEqual(
-            FakeMarkdownFlow.last_context,
-            [
-                {"role": "user", "content": "md content"},
-                {"role": "assistant", "content": teacher_block.generated_content},
-            ],
+        assert FakeMarkdownFlow.last_context == [
+            {"role": "user", "content": "md content"},
+            {"role": "assistant", "content": teacher_block.generated_content},
+        ]
+        assert (
+            teacher_block.block_content_conf
+            not in FakeMarkdownFlow.last_context[0]["content"]
         )
-        self.assertNotIn(
-            teacher_block.block_content_conf,
-            FakeMarkdownFlow.last_context[0]["content"],
-        )
-        self.assertNotIn(
-            student_block.block_content_conf,
-            FakeMarkdownFlow.last_context[1]["content"],
+        assert (
+            student_block.block_content_conf
+            not in FakeMarkdownFlow.last_context[1]["content"]
         )
 
     def test_run_progresses_across_content_blocks_until_interaction(self):
@@ -438,23 +431,20 @@ class LearnRecordLoadTests(unittest.TestCase):
             while ctx.has_next():
                 events.extend(list(ctx.run(self.app)))
 
-        self.assertEqual(
-            [event.type for event in events],
-            [
-                GeneratedType.CONTENT,
-                GeneratedType.BREAK,
-                GeneratedType.CONTENT,
-                GeneratedType.BREAK,
-                GeneratedType.INTERACTION,
-            ],
-        )
-        self.assertEqual(
-            [event.content for event in events[:4:2]],
-            ["first content", "second content"],
-        )
-        self.assertEqual(events[-1].content, "?[Continue//continue]")
-        self.assertEqual(progress.block_position, 2)
-        self.assertFalse(ctx._can_continue)
+        assert [event.type for event in events] == [
+            GeneratedType.CONTENT,
+            GeneratedType.BREAK,
+            GeneratedType.CONTENT,
+            GeneratedType.BREAK,
+            GeneratedType.INTERACTION,
+        ]
+        assert [event.content for event in events[:4:2]] == [
+            "first content",
+            "second content",
+        ]
+        assert events[-1].content == "?[Continue//continue]"
+        assert progress.block_position == 2
+        assert not ctx._can_continue
 
     def test_run_inner_skips_duplicate_fixed_output_after_interaction_input(self):
         """Avoid replaying an already generated fixed output after interaction submit."""
@@ -567,17 +557,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         ):
             events = list(ctx.run_inner(self.app))
 
-        self.assertEqual(events, [])
-        self.assertFalse(FakeMarkdownFlow.process_called)
-        self.assertEqual(progress.block_position, 1)
-        self.assertTrue(ctx._can_continue)
-        self.assertEqual(
+        assert events == []
+        assert not FakeMarkdownFlow.process_called
+        assert progress.block_position == 1
+        assert ctx._can_continue
+        assert (
             LearnGeneratedBlock.query.filter(
                 LearnGeneratedBlock.progress_record_bid == progress.progress_record_bid,
                 LearnGeneratedBlock.type == BLOCK_TYPE_MDCONTENT_VALUE,
                 LearnGeneratedBlock.status == 1,
-            ).count(),
-            1,
+            ).count()
+            == 1
         )
 
     def test_run_inner_realigns_index_to_pending_interaction_after_submit(self):
@@ -694,11 +684,11 @@ class LearnRecordLoadTests(unittest.TestCase):
         ):
             events = list(ctx.run_inner(self.app))
 
-        self.assertEqual(events, [])
-        self.assertFalse(FakeMarkdownFlow.process_called)
-        self.assertEqual(progress.block_position, 1)
-        self.assertEqual(ctx._run_type, RunType.INPUT)
-        self.assertTrue(ctx._can_continue)
+        assert events == []
+        assert not FakeMarkdownFlow.process_called
+        assert progress.block_position == 1
+        assert ctx._run_type == RunType.INPUT
+        assert ctx._can_continue
 
     def test_run_inner_does_not_realign_on_empty_auto_input(self):
         """Empty auto-run input should not be treated as a real interaction submit."""
@@ -814,11 +804,11 @@ class LearnRecordLoadTests(unittest.TestCase):
         ):
             events = list(ctx.run_inner(self.app))
 
-        self.assertEqual(events, [])
-        self.assertFalse(FakeMarkdownFlow.process_called)
-        self.assertEqual(progress.block_position, 0)
-        self.assertEqual(ctx._run_type, RunType.OUTPUT)
-        self.assertTrue(ctx._can_continue)
+        assert events == []
+        assert not FakeMarkdownFlow.process_called
+        assert progress.block_position == 0
+        assert ctx._run_type == RunType.OUTPUT
+        assert ctx._can_continue
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -150,10 +150,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertEqual(result.records[0].block_type, BlockType.INTERACTION)
-        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert result.records[0].block_type == BlockType.INTERACTION
+        assert CONTEXT_INTERACTION_NEXT in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_uses_persisted_button_when_present(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -187,11 +187,11 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
+        assert len(result.records) == 2
         record = result.records[0]
-        self.assertEqual(record.generated_block_bid, block.generated_block_bid)
-        self.assertIn(CONTEXT_INTERACTION_NEXT, record.content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert record.generated_block_bid == block.generated_block_bid
+        assert CONTEXT_INTERACTION_NEXT in record.content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_no_button_when_not_completed(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -207,7 +207,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(result.records, [])
+        assert result.records == []
 
     def test_feedback_when_completed_without_next(self):
         self._seed_struct(["outline-1"])
@@ -223,8 +223,8 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 1)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[0].content))
+        assert len(result.records) == 1
+        assert is_lesson_feedback_interaction(result.records[0].content)
 
     def test_feedback_after_pay_gate_when_in_progress(self):
         self._seed_struct(["outline-1"])
@@ -241,9 +241,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertIn("_sys_pay", result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert "_sys_pay" in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_feedback_after_login_gate_when_in_progress(self):
         self._seed_struct(["outline-1"])
@@ -260,9 +260,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertIn("_sys_login", result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert "_sys_login" in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_no_next_button_when_completed_with_pay_gate(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -279,10 +279,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertIn("_sys_pay", result.records[0].content)
-        self.assertNotIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert "_sys_pay" in result.records[0].content
+        assert CONTEXT_INTERACTION_NEXT not in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_inserts_fallback_next_before_existing_feedback(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -303,9 +303,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert CONTEXT_INTERACTION_NEXT in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
     def test_moves_existing_feedback_to_tail_when_next_already_persisted(self):
         self._seed_struct(["outline-1", "outline-2"])
@@ -332,9 +332,9 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 False,
             )
 
-        self.assertEqual(len(result.records), 2)
-        self.assertIn(CONTEXT_INTERACTION_NEXT, result.records[0].content)
-        self.assertTrue(is_lesson_feedback_interaction(result.records[1].content))
+        assert len(result.records) == 2
+        assert CONTEXT_INTERACTION_NEXT in result.records[0].content
+        assert is_lesson_feedback_interaction(result.records[1].content)
 
 
 if __name__ == "__main__":

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -98,20 +98,20 @@ class LessonFeedbackTests(unittest.TestCase):
             LearnLessonFeedback.outline_item_bid == "outline-1",
             LearnLessonFeedback.deleted == 0,
         ).all()
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0].score, 3)
-        self.assertEqual(rows[0].comment, "Need more examples")
-        self.assertEqual(rows[0].mode, "listen")
-        self.assertEqual(rows[0].progress_record_bid, "progress-1")
-        self.assertEqual(rows[0].bid, rows[0].lesson_feedback_bid)
-        self.assertEqual(first["lesson_feedback_bid"], second["lesson_feedback_bid"])
+        assert len(rows) == 1
+        assert rows[0].score == 3
+        assert rows[0].comment == "Need more examples"
+        assert rows[0].mode == "listen"
+        assert rows[0].progress_record_bid == "progress-1"
+        assert rows[0].bid == rows[0].lesson_feedback_bid
+        assert first["lesson_feedback_bid"] == second["lesson_feedback_bid"]
 
         synced_block = LearnGeneratedBlock.query.filter(
             LearnGeneratedBlock.generated_block_bid == "block-1"
         ).first()
         synced_generated_content = json.loads(synced_block.generated_content)
-        self.assertEqual(synced_generated_content.get("score"), 3)
-        self.assertEqual(synced_generated_content.get("comment"), "Need more examples")
+        assert synced_generated_content.get("score") == 3
+        assert synced_generated_content.get("comment") == "Need more examples"
 
     def test_sync_generated_block_does_not_autoflush_pending_duplicate_feedback(self):
         interaction = LearnGeneratedBlock(
@@ -162,8 +162,8 @@ class LessonFeedbackTests(unittest.TestCase):
             )
 
         synced_generated_content = json.loads(interaction.generated_content)
-        self.assertEqual(synced_generated_content.get("score"), 5)
-        self.assertEqual(synced_generated_content.get("comment"), "new")
+        assert synced_generated_content.get("score") == 5
+        assert synced_generated_content.get("comment") == "new"
         dao.db.session.rollback()
 
     def test_list_feedback_serializes_timestamps_as_utc_iso_z(self):
@@ -191,9 +191,9 @@ class LessonFeedbackTests(unittest.TestCase):
             page_size=20,
         )
 
-        self.assertEqual(result["total"], 1)
-        self.assertEqual(result["items"][0]["created_at"], "2026-06-30T11:57:03Z")
-        self.assertEqual(result["items"][0]["updated_at"], "2026-06-30T12:08:09Z")
+        assert result["total"] == 1
+        assert result["items"][0]["created_at"] == "2026-06-30T11:57:03Z"
+        assert result["items"][0]["updated_at"] == "2026-06-30T12:08:09Z"
 
 
 if __name__ == "__main__":

--- a/src/api/tests/test_langfuse.py
+++ b/src/api/tests/test_langfuse.py
@@ -18,18 +18,18 @@ TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 class CoerceTraceIdTests(unittest.TestCase):
     def test_passes_through_valid_w3c_trace_id(self):
         valid = "0123456789abcdef0123456789abcdef"
-        self.assertEqual(coerce_langfuse_trace_id(valid), valid)
+        assert coerce_langfuse_trace_id(valid) == valid
 
     def test_maps_arbitrary_ids_deterministically(self):
         first = coerce_langfuse_trace_id("my-request-id")
         second = coerce_langfuse_trace_id("my-request-id")
-        self.assertEqual(first, second)
-        self.assertRegex(first, TRACE_ID_RE)
-        self.assertNotEqual(first, coerce_langfuse_trace_id("other-request-id"))
+        assert first == second
+        assert re.search(TRACE_ID_RE, first)
+        assert first != coerce_langfuse_trace_id("other-request-id")
 
     def test_generates_random_id_when_seed_missing(self):
         generated = coerce_langfuse_trace_id(None)
-        self.assertRegex(generated, TRACE_ID_RE)
+        assert re.search(TRACE_ID_RE, generated)
 
 
 class RequestTraceIdTests(unittest.TestCase):
@@ -43,9 +43,8 @@ class RequestTraceIdTests(unittest.TestCase):
         thread_local.request_id = "thread-local-request-id"
 
         with app.test_request_context(headers={"X-Request-ID": "header-request-id"}):
-            self.assertEqual(
-                get_request_trace_id(),
-                coerce_langfuse_trace_id("thread-local-request-id"),
+            assert get_request_trace_id() == coerce_langfuse_trace_id(
+                "thread-local-request-id"
             )
 
     def test_falls_back_to_request_header(self):
@@ -57,9 +56,8 @@ class RequestTraceIdTests(unittest.TestCase):
         original_request = get_request_trace_id.__globals__["request"]
         get_request_trace_id.__globals__["request"] = fake_request
         try:
-            self.assertEqual(
-                get_request_trace_id(),
-                coerce_langfuse_trace_id("header-request-id"),
+            assert get_request_trace_id() == coerce_langfuse_trace_id(
+                "header-request-id"
             )
         finally:
             get_request_trace_id.__globals__["request"] = original_request
@@ -68,7 +66,7 @@ class RequestTraceIdTests(unittest.TestCase):
         fake_uuid = types.SimpleNamespace(hex="0123456789abcdef0123456789abcdef")
 
         with patch("flaskr.api.langfuse.uuid.uuid4", return_value=fake_uuid):
-            self.assertEqual(get_request_trace_id(), fake_uuid.hex)
+            assert get_request_trace_id() == fake_uuid.hex
 
 
 class ResolveLangfuseTraceIdTests(unittest.TestCase):
@@ -79,14 +77,14 @@ class ResolveLangfuseTraceIdTests(unittest.TestCase):
 
     def test_prefers_explicit_string_trace_id(self):
         observation = types.SimpleNamespace(trace_id="observation-trace-id")
-        self.assertEqual(
-            resolve_langfuse_trace_id(observation, "explicit-trace-id"),
-            "explicit-trace-id",
+        assert (
+            resolve_langfuse_trace_id(observation, "explicit-trace-id")
+            == "explicit-trace-id"
         )
 
     def test_falls_back_to_observation_string_trace_id(self):
         observation = types.SimpleNamespace(trace_id="observation-trace-id")
-        self.assertEqual(resolve_langfuse_trace_id(observation), "observation-trace-id")
+        assert resolve_langfuse_trace_id(observation) == "observation-trace-id"
 
     def test_ignores_non_string_trace_id_from_mock_client(self):
         # When Langfuse is disabled, observations are MockClient instances whose
@@ -94,16 +92,14 @@ class ResolveLangfuseTraceIdTests(unittest.TestCase):
         # ``trace_id``. That object must never be used as the trace id.
         thread_local.request_id = "request-trace-id"
 
-        self.assertEqual(
-            resolve_langfuse_trace_id(MockClient()),
-            coerce_langfuse_trace_id("request-trace-id"),
+        assert resolve_langfuse_trace_id(MockClient()) == coerce_langfuse_trace_id(
+            "request-trace-id"
         )
 
     def test_ignores_empty_string_trace_ids(self):
         thread_local.request_id = "request-trace-id"
         observation = types.SimpleNamespace(trace_id="")
 
-        self.assertEqual(
-            resolve_langfuse_trace_id(observation, ""),
-            coerce_langfuse_trace_id("request-trace-id"),
+        assert resolve_langfuse_trace_id(observation, "") == coerce_langfuse_trace_id(
+            "request-trace-id"
         )


### PR DESCRIPTION
# Summary

Layer 7/8 of the ruff A-group stack. Enables `PT009` permanently in `ruff.toml` and rewrites unittest-style assertion calls (`assertEqual`, `assertTrue`, `assertIn`, ...) in 7 test files as plain `assert` statements, which pytest introspects for richer failure output.

One call has no mechanical equivalent and was converted by hand, preserving its unordered-comparison semantics:

```diff
-self.assertCountEqual(args[4:], ["docs/notes.md", "src/existing.ts"])
+assert sorted(args[4:]) == sorted(["docs/notes.md", "src/existing.ts"])
```

All touched test files pass; verified with full lint and the backend test suite at the stack top.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion style and lint config; no production code paths change.
> 
> **Overview**
> **Enables Ruff `PT009`** in `ruff.toml` so unittest-style assertion helpers are flagged going forward.
> 
> **Rewrites tests** in seven files (`scripts/test_prettier_check_changed.py`, learn service tests, `test_langfuse.py`, etc.) from `self.assertEqual` / `assertTrue` / `assertIn` / … to plain `assert`, keeping behavior the same while letting pytest report failures with clearer introspection.
> 
> The only non-mechanical change is in the Prettier changed-files test: `assertCountEqual` on the npx argument tail becomes `sorted(args[4:]) == sorted([...])` so unordered file lists are still compared correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700852e0976cf56915a417bbc181803b0a0ea336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->