### PR TITLE
style: pin ruff target-version to py311 and adopt datetime.UTC

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -46,6 +46,9 @@
 #   generated API docs. D209 / D212 / D403 / D411 / D413 are safe here because
 #   they never rewrite a line inside the YAML block.
 
+# Matches the Python pinned by src/api/Dockerfile and the CI workflows.
+target-version = "py311"
+
 [lint]
 select = [
     "E",       # pycodestyle errors (E501 ignored below)

--- a/scripts/harness/trace_run.py
+++ b/scripts/harness/trace_run.py
@@ -8,7 +8,7 @@ import json
 import re
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -81,11 +81,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return datetime.now(UTC).isoformat(timespec="seconds")
 
 
 def default_run_id() -> str:
-    return "run-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return "run-" + datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def safe_relative(path: Path) -> str:

--- a/scripts/run_harness_gardening.py
+++ b/scripts/run_harness_gardening.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from build_repo_knowledge_index import (
@@ -46,7 +46,7 @@ RETIRED_TERM_SCAN_PATHS = (
 
 def stale_review_docs() -> list[str]:
     stale: list[str] = []
-    cutoff = datetime.now(timezone.utc).date().toordinal() - REVIEW_WINDOW_DAYS
+    cutoff = datetime.now(UTC).date().toordinal() - REVIEW_WINDOW_DAYS
     for category in ("design-docs", "product-specs"):
         for path in sorted((DOCS_ROOT / category).glob("*.md")):
             if path.name == "index.md":

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -440,7 +440,7 @@ def build_tencent_tc3_headers(
     request_timestamp = int(timestamp if timestamp is not None else time.time())
     request_date = dt.datetime.fromtimestamp(
         request_timestamp,
-        tz=dt.timezone.utc,
+        tz=dt.UTC,
     ).strftime("%Y-%m-%d")
     canonical_headers = (
         "content-type:application/json\n"

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -164,7 +164,7 @@ def build_texttovoice_tc3_headers(
     request_timestamp = int(timestamp if timestamp is not None else time.time())
     request_date = dt.datetime.fromtimestamp(
         request_timestamp,
-        tz=dt.timezone.utc,
+        tz=dt.UTC,
     ).strftime("%Y-%m-%d")
     canonical_headers = (
         "content-type:application/json\n"

--- a/src/api/flaskr/common/umami_client.py
+++ b/src/api/flaskr/common/umami_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -209,7 +209,7 @@ def _fetch_distinct_ids_for_event(
     if "x-umami-api-key" not in headers and "Authorization" not in headers:
         return 0
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     start_at = int((now - timedelta(days=30)).timestamp() * 1000)
     end_at = int(now.timestamp() * 1000)
 

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -109,8 +109,8 @@ def fmt(o):
         # convert aware values to UTC, always emitting ISO 8601 with a 'Z'
         # suffix. Display-time timezone conversion is a pure frontend concern.
         if o.tzinfo is None:
-            o = o.replace(tzinfo=datetime.timezone.utc)
-        return o.astimezone(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+            o = o.replace(tzinfo=datetime.UTC)
+        return o.astimezone(datetime.UTC).isoformat().replace("+00:00", "Z")
     if isinstance(o, datetime.date):
         return o.isoformat()
     if isinstance(o, decimal.Decimal):

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from flask import Flask, request
 
@@ -83,7 +83,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         except ValueError:
             raise_param_error(field_name)
         if parsed.tzinfo is not None:
-            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            parsed = parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
 
     def _parse_admin_pagination():

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -6,7 +6,7 @@ import json
 import re
 from copy import deepcopy
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -739,8 +739,8 @@ def _format_operator_datetime(app: Flask, value: datetime | None) -> str:
     if not value:
         return ""
     if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _load_notification_template(template_code: str) -> NotificationTemplate | None:
@@ -2543,9 +2543,7 @@ def _is_quiet_hours(policy: dict[str, Any], now: datetime | None = None) -> bool
             if now is None:
                 current = datetime.now(policy_timezone)
             elif current.tzinfo is None or current.utcoffset() is None:
-                current = current.replace(tzinfo=timezone.utc).astimezone(
-                    policy_timezone
-                )
+                current = current.replace(tzinfo=UTC).astimezone(policy_timezone)
             else:
                 current = current.astimezone(policy_timezone)
         except ZoneInfoNotFoundError:

--- a/src/api/flaskr/service/billing/primitives.py
+++ b/src/api/flaskr/service/billing/primitives.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
@@ -152,7 +152,7 @@ def coerce_datetime(value: Any) -> datetime | None:
     if isinstance(value, (int, float)):
         if value <= 0:
             return None
-        return datetime.fromtimestamp(value, timezone.utc).replace(tzinfo=None)
+        return datetime.fromtimestamp(value, UTC).replace(tzinfo=None)
     text = str(value).strip()
     if not text:
         return None
@@ -160,13 +160,13 @@ def coerce_datetime(value: Any) -> datetime | None:
         epoch_seconds = int(text)
         if epoch_seconds <= 0:
             return None
-        return datetime.fromtimestamp(epoch_seconds, timezone.utc).replace(tzinfo=None)
+        return datetime.fromtimestamp(epoch_seconds, UTC).replace(tzinfo=None)
     try:
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
     except ValueError:
         return None
     if parsed.tzinfo is not None:
-        return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed.astimezone(UTC).replace(tzinfo=None)
     return parsed
 
 

--- a/src/api/flaskr/service/billing/queries.py
+++ b/src/api/flaskr/service/billing/queries.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import calendar
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -270,10 +270,7 @@ def calculate_self_managed_billing_cycle_end_after_boundary(
 
 
 def to_self_managed_cycle_local_time(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    else:
-        value = value.astimezone(timezone.utc)
+    value = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
     return value.astimezone(_SELF_MANAGED_CYCLE_TIMEZONE)
 
 
@@ -281,7 +278,7 @@ def self_managed_local_day_end_to_utc_naive(value: datetime) -> datetime:
     if value.tzinfo is None:
         value = value.replace(tzinfo=_SELF_MANAGED_CYCLE_TIMEZONE)
     local_day_end = end_of_day(value).astimezone(_SELF_MANAGED_CYCLE_TIMEZONE)
-    return local_day_end.astimezone(timezone.utc).replace(tzinfo=None)
+    return local_day_end.astimezone(UTC).replace(tzinfo=None)
 
 
 def end_of_day(value: datetime) -> datetime:

--- a/src/api/flaskr/service/billing/reserved_renewal_activation.py
+++ b/src/api/flaskr/service/billing/reserved_renewal_activation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Protocol
 
@@ -80,7 +80,7 @@ class ReservedActivationTarget:
 def _normalize_utc_datetime(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value
-    return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value.astimezone(UTC).replace(tzinfo=None)
 
 
 def _datetime_sort_value(value: datetime | None) -> datetime:

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -4,7 +4,7 @@ import copy
 import hashlib
 import hmac
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any, Generator
 from urllib.parse import quote
 
@@ -62,7 +62,7 @@ def _build_volc_signature_headers(
     service: str,
     region: str,
 ) -> dict[str, str]:
-    x_date = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    x_date = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     short_x_date = x_date[:8]
     x_content_sha256 = _hash_sha256(body)
 

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -5,7 +5,7 @@ import queue
 import time
 import uuid
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from flask import Flask, has_request_context, request
 from flaskr.api.tts import (
@@ -125,8 +125,8 @@ def _normalize_dt_to_utc(
     if value is None:
         return None
     if value.tzinfo is not None:
-        return value.astimezone(timezone.utc)
-    return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(UTC)
+    return value.replace(tzinfo=UTC)
 
 
 def _resolve_published_effective_updated_at(

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import re
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -222,7 +222,7 @@ def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
     except ValueError:
         return None
     if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
     return parsed
     return None
 

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -5,7 +5,7 @@ import json
 import math
 import secrets
 import string
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Dict, Optional
 
 from flask import Flask
@@ -136,7 +136,7 @@ def _parse_datetime(value: str, field_name: str, *, is_end: bool = False) -> dat
     if parsed is None:
         raise_param_error(field_name)
     if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
     return parsed
 
 

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from math import ceil
 from typing import Any
@@ -361,7 +361,7 @@ def _parse_datetime(value: object, field_name: str) -> datetime | None:
     except ValueError:
         raise_param_error(field_name)
     if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc)
+        parsed = parsed.astimezone(UTC)
     return parsed.replace(tzinfo=None)
 
 

--- a/src/api/flaskr/service/referral/reward_queue.py
+++ b/src/api/flaskr/service/referral/reward_queue.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -35,8 +35,8 @@ def _serialize_dt(value: datetime | None) -> str | None:
     if value is None:
         return None
     if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _serialize_decimal(value: Decimal | None) -> str | None:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Dict, Iterable, Optional, Sequence, Set
 
@@ -325,7 +325,7 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
         return None
     if isinstance(value, datetime):
         if value.tzinfo is not None:
-            return value.astimezone(timezone.utc).replace(tzinfo=None)
+            return value.astimezone(UTC).replace(tzinfo=None)
         return value
     if isinstance(value, str):
         normalized = value.strip()
@@ -342,7 +342,7 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
             )
             return None
         if parsed.tzinfo is not None:
-            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
     current_app.logger.warning(
         "Unexpected operator datetime value type '%s'",

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from flask import Flask, request
 from flaskr.common.config import get_config
@@ -162,7 +162,7 @@ def _parse_datetime_filter(
     except ValueError:
         raise_param_error(field_name)
     if parsed.tzinfo is not None:
-        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
     return parsed
 
 

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any, Dict, Optional, Sequence
 
 from flask import current_app
@@ -14,7 +14,7 @@ def coerce_operator_datetime(value: Any) -> Optional[datetime]:
         return None
     if isinstance(value, datetime):
         if value.tzinfo is not None:
-            return value.astimezone(timezone.utc).replace(tzinfo=None)
+            return value.astimezone(UTC).replace(tzinfo=None)
         return value
     if isinstance(value, str):
         normalized = value.strip()
@@ -31,7 +31,7 @@ def coerce_operator_datetime(value: Any) -> Optional[datetime]:
             )
             return None
         if parsed.tzinfo is not None:
-            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
     current_app.logger.warning(
         "Unexpected operator datetime value type '%s'",

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -6,7 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
@@ -292,7 +292,7 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
         return None
     if isinstance(value, datetime):
         if value.tzinfo is not None:
-            return value.astimezone(timezone.utc).replace(tzinfo=None)
+            return value.astimezone(UTC).replace(tzinfo=None)
         return value
     if isinstance(value, str):
         normalized = value.strip()
@@ -309,7 +309,7 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
             )
             return None
         if parsed.tzinfo is not None:
-            return parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
     current_app.logger.warning(
         "Unexpected operator datetime value type '%s'",

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from flask import Flask
@@ -50,7 +50,7 @@ def _serialize_datetime(value: datetime | None) -> str | None:
         return None
     if value.tzinfo is None:
         return f"{value.isoformat()}Z"
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _parse_rollout_threshold(value: Any) -> datetime | None:
@@ -65,9 +65,7 @@ def _parse_rollout_threshold(value: Any) -> datetime | None:
         try:
             parsed = datetime.fromisoformat(candidate)
             return (
-                parsed.astimezone(timezone.utc).replace(tzinfo=None)
-                if parsed.tzinfo
-                else parsed
+                parsed.astimezone(UTC).replace(tzinfo=None) if parsed.tzinfo else parsed
             )
         except ValueError:
             continue
@@ -110,7 +108,7 @@ def _resolve_user_segment(user: UserEntity | None) -> str:
     if eligible_at is None:
         return USER_SEGMENT_INELIGIBLE
     if getattr(eligible_at, "tzinfo", None) is not None:
-        eligible_at = eligible_at.astimezone(timezone.utc).replace(tzinfo=None)
+        eligible_at = eligible_at.astimezone(UTC).replace(tzinfo=None)
 
     existing_rollout_threshold = _parse_rollout_threshold(
         get_dynamic_config(EXISTING_CREATOR_ROLLOUT_CONFIG_KEY, "")

--- a/src/api/flaskr/util/datetime.py
+++ b/src/api/flaskr/util/datetime.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytz
 from flask import Flask
@@ -12,7 +12,7 @@ def now_utc() -> datetime:
     compared with existing naive timestamps without raising. It is computed
     from ``timezone.utc`` so it does not depend on the process ``TZ`` setting.
     """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 def to_utc_iso(value: datetime | None) -> str | None:
@@ -27,8 +27,8 @@ def to_utc_iso(value: datetime | None) -> str | None:
     if value is None:
         return None
     if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def get_now_time(app: Flask):

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -416,7 +416,7 @@ def main() -> int:
     output_path = args.output or _default_output_path()
     cases_bytes = args.cases.read_bytes()
     report = {
-        "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "runner": {
             "name": "codex-cli",
             "version": _codex_version(),

--- a/src/api/tests/common/test_now_utc.py
+++ b/src/api/tests/common/test_now_utc.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from flaskr.util.datetime import now_utc, to_utc_iso
 
@@ -8,7 +8,7 @@ def test_now_utc_returns_naive_utc() -> None:
     # Naive (tz-unaware) so it stays comparable with existing naive timestamps.
     assert value.tzinfo is None
     # Value tracks real UTC, independent of the process TZ.
-    reference = datetime.now(timezone.utc).replace(tzinfo=None)
+    reference = datetime.now(UTC).replace(tzinfo=None)
     assert abs((reference - value).total_seconds()) < 5
 
 
@@ -24,7 +24,7 @@ def test_model_timestamp_default_writes_utc(app) -> None:
 
         created = row.created
         assert created.tzinfo is None
-        reference = datetime.now(timezone.utc).replace(tzinfo=None)
+        reference = datetime.now(UTC).replace(tzinfo=None)
         assert abs((reference - created).total_seconds()) < 60
 
 

--- a/src/api/tests/service/billing/test_billing_dtos.py
+++ b/src/api/tests/service/billing/test_billing_dtos.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from flaskr.service.billing.dtos import (
@@ -86,7 +86,7 @@ def test_billing_dto_json_serializes_nested_models_and_decimal_inputs() -> None:
     assert payload["trial_offer"]["status"] == "granted"
     assert payload["trial_offer"]["product_code"] == "creator-plan-trial"
     assert payload["trial_offer"]["welcome_dialog_acknowledged_at"] == datetime(
-        2026, 4, 10, 0, 0, tzinfo=timezone.utc
+        2026, 4, 10, 0, 0, tzinfo=UTC
     )
 
 
@@ -175,8 +175,8 @@ def test_billing_dto_json_serializes_metric_breakdowns_and_bucket_lists() -> Non
                 "source_type": "subscription",
                 "source_bid": "sub-1",
                 "available_credits": 97.5,
-                "effective_from": datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc),
-                "effective_to": datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc),
+                "effective_from": datetime(2026, 4, 1, 0, 0, tzinfo=UTC),
+                "effective_to": datetime(2026, 5, 1, 0, 0, tzinfo=UTC),
                 "priority": 20,
                 "status": "active",
             }

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import flaskr.dao as dao
@@ -28,7 +28,7 @@ _MONTHLY_PLAN_CREDITS = Decimal("5.0000000000")
 
 
 def _utc_epoch(value: datetime) -> int:
-    return int(value.replace(tzinfo=timezone.utc).timestamp())
+    return int(value.replace(tzinfo=UTC).timestamp())
 
 
 @pytest.fixture

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import flaskr.dao as dao
@@ -49,7 +49,7 @@ from tests.common.fixtures.bill_products import build_bill_products
 
 
 def _utc_epoch(value: datetime) -> int:
-    return int(value.replace(tzinfo=timezone.utc).timestamp())
+    return int(value.replace(tzinfo=UTC).timestamp())
 
 
 @pytest.fixture

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -23,7 +23,7 @@ from flaskr.service.user.repository import (
     upsert_credential,
 )
 
-PROFILE_UPDATED_AT = datetime(2026, 8, 12, 8, 30, tzinfo=timezone.utc)
+PROFILE_UPDATED_AT = datetime(2026, 8, 12, 8, 30, tzinfo=UTC)
 
 
 def _stub_activation_order_side_effects(monkeypatch) -> None:

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -166,7 +166,7 @@ def test_init_buy_record_timeout_flip_persists_with_replacement_order(
 ):
     """(b) Clean run: the timeout flip and the new order commit together."""
     monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
-    stale_created_at = datetime.datetime.now(datetime.timezone.utc).replace(
+    stale_created_at = datetime.datetime.now(datetime.UTC).replace(
         tzinfo=None
     ) - datetime.timedelta(hours=2)
     origin_bid = _seed_order(created_at=stale_created_at)
@@ -195,7 +195,7 @@ def test_init_buy_record_timeout_flip_rolls_back_on_late_failure(
     replacement order.
     """
     monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
-    stale_created_at = datetime.datetime.now(datetime.timezone.utc).replace(
+    stale_created_at = datetime.datetime.now(datetime.UTC).replace(
         tzinfo=None
     ) - datetime.timedelta(hours=2)
     origin_bid = _seed_order(created_at=stale_created_at)

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -767,7 +767,7 @@ def test_coerce_operator_datetime_normalizes_offset_values_to_utc(app):
             2026, 5, 22, 2, 0, 0
         )
         assert _coerce_operator_datetime(
-            datetime(2026, 5, 22, 10, 0, 0, tzinfo=timezone.utc)
+            datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
         ) == datetime(2026, 5, 22, 10, 0, 0)
 
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -185,8 +185,8 @@ def _mock_operator(
 def _z(value):
     """Serialize a datetime the way flaskr.route.common.fmt does (UTC ISO 'Z')."""
     if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _build_active_window(

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -14,8 +14,8 @@ from flaskr.service.profile import learner_profile_optimizer as optimizer
 from flaskr.service.user.models import UserInfo, UserOnboardingState
 from flaskr.service.user.repository import create_user_entity
 
-PROFILE_UPDATED_AT = datetime(2026, 8, 14, 8, 30, tzinfo=timezone.utc)
-STATE_COMPLETED_AT = datetime(2026, 8, 14, 8, 45, tzinfo=timezone.utc)
+PROFILE_UPDATED_AT = datetime(2026, 8, 14, 8, 30, tzinfo=UTC)
+STATE_COMPLETED_AT = datetime(2026, 8, 14, 8, 45, tzinfo=UTC)
 
 
 def _create_profile_state(user_bid: str, *, language: str = "zh-CN") -> None:

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from flaskr.api.check.dto import (
@@ -19,12 +19,12 @@ from flaskr.service.user.repository import (
     upsert_credential,
 )
 
-PROFILE_UPDATED_AT = datetime(2026, 8, 1, 8, 30, tzinfo=timezone.utc)
+PROFILE_UPDATED_AT = datetime(2026, 8, 1, 8, 30, tzinfo=UTC)
 
 
 def _assert_orm_utc(value: datetime | None, expected: datetime) -> None:
     assert value is not None
-    assert value.replace(tzinfo=timezone.utc) == expected
+    assert value.replace(tzinfo=UTC) == expected
 
 
 def _create_user(

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from flaskr.dao import db
@@ -33,12 +33,12 @@ from flaskr.service.user.repository import (
 )
 from sqlalchemy.orm.attributes import set_committed_value
 
-PROFILE_UPDATED_AT = datetime(2026, 8, 2, 6, 30, tzinfo=timezone.utc)
+PROFILE_UPDATED_AT = datetime(2026, 8, 2, 6, 30, tzinfo=UTC)
 
 
 def _assert_orm_utc(value: datetime | None, expected: datetime) -> None:
     assert value is not None
-    assert value.replace(tzinfo=timezone.utc) == expected
+    assert value.replace(tzinfo=UTC) == expected
 
 
 class _FakeRedis:
@@ -186,7 +186,7 @@ def test_merge_helper_preserves_target_profile_and_state(app):
             learner_profile="source profile",
             learner_profile_updated_at=PROFILE_UPDATED_AT,
         )
-        target_updated_at = datetime(2026, 8, 3, 7, 45, tzinfo=timezone.utc)
+        target_updated_at = datetime(2026, 8, 3, 7, 45, tzinfo=UTC)
         target = _create_user(
             identify=uuid.uuid4().hex,
             nickname="Target name",

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -1,6 +1,6 @@
 import json
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import jwt
 
@@ -132,7 +132,7 @@ def test_password_login_merges_authenticated_guest_learner_profile(test_client, 
     target_phone = "15500002332"
     password = "Abcd1234"
     guest_profile = "可以叫我小雨。password merge sentinel"
-    profile_updated_at = datetime(2026, 8, 4, 5, 30, tzinfo=timezone.utc)
+    profile_updated_at = datetime(2026, 8, 4, 5, 30, tzinfo=UTC)
 
     with app.app_context():
         guest = create_user_entity(
@@ -235,7 +235,7 @@ def test_password_login_merges_authenticated_guest_learner_profile(test_client, 
         assert stored_target.nickname == "小雨"
         assert stored_target.learner_profile_updated_at is not None
         assert (
-            stored_target.learner_profile_updated_at.replace(tzinfo=timezone.utc)
+            stored_target.learner_profile_updated_at.replace(tzinfo=UTC)
             == profile_updated_at
         )
         assert stored_guest.learner_profile == guest_profile
@@ -262,9 +262,7 @@ def test_password_login_never_merges_from_a_registered_account(test_client, app)
         )
         source = UserInfo.query.filter_by(user_bid=source_token.userInfo.user_id).one()
         source.learner_profile = "registered profile must stay isolated"
-        source.learner_profile_updated_at = datetime(
-            2026, 8, 4, 5, 45, tzinfo=timezone.utc
-        )
+        source.learner_profile_updated_at = datetime(2026, 8, 4, 5, 45, tzinfo=UTC)
         target_user_id = target_token.userInfo.user_id
         target = UserInfo.query.filter_by(user_bid=target_user_id).one()
         target.nickname = "Existing target"
@@ -316,7 +314,7 @@ def test_password_login_ignores_invalid_and_expired_optional_tokens(test_client,
             identify="password-expired-token-guest",
             nickname="Guest",
             learner_profile="expired token profile",
-            learner_profile_updated_at=datetime(2026, 8, 4, 6, 0, tzinfo=timezone.utc),
+            learner_profile_updated_at=datetime(2026, 8, 4, 6, 0, tzinfo=UTC),
         )
         db.session.commit()
         expired_token = jwt.encode(


### PR DESCRIPTION
# Summary

Layer 8/8 (top) of the ruff A-group stack. Sets `target-version = "py311"` in `ruff.toml` — matching the Python pinned by `src/api/Dockerfile` and every CI workflow — so ruff checks against the interpreter the code actually runs on.

Pinning py311 exposes 65 `UP017` findings under the already-selected `UP01` group; the fix replaces `datetime.timezone.utc` with the `datetime.UTC` alias repo-wide (37 files), plus the import cleanups that follow. One newly-short if-else in `billing/queries.py` that SIM108 started flagging after the rewrite was collapsed to its ternary.

Verified at this stack top with `ruff check .`, `ruff format --check .`, `lefthook run pre-commit --all-files`, and the full backend test suite (2860 passed; only the 5 known SQLite `concat()` failures in `test_admin_course_detail.py`, which also fail on `main`).

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical alias swap with equivalent semantics; no auth or data-model changes, only lint/config alignment.
> 
> **Overview**
> **Ruff** now sets `target-version = "py311"` in `ruff.toml`, aligned with the API Dockerfile and CI, so lint rules match the runtime interpreter.
> 
> That pin surfaces **UP017** across the repo; the change mechanically swaps `datetime.timezone.utc` for the **`datetime.UTC`** alias (imports updated from `timezone` to `UTC`) in harness scripts, API routes, billing/order/admin services, TTS signing, Umami analytics windows, and matching tests. UTC storage and naive-UTC semantics are unchanged—only the spelling of the timezone constant.
> 
> A small **SIM108** cleanup in `billing/queries.py` collapses a shortened if/else in `to_self_managed_cycle_local_time` to a ternary after the rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3debc8ec9d9d275e668beeea4e886a7d5321e829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->