### PR TITLE
fix: keep published course links free of extra parameters

### DIFF
--- a/src/cook-web/src/components/header/Header.test.tsx
+++ b/src/cook-web/src/components/header/Header.test.tsx
@@ -88,17 +88,40 @@ jest.mock('@/components/ui/DropdownMenu', () => ({
   DropdownMenuItem: ({
     children,
     onSelect,
-  }: React.PropsWithChildren<{ onSelect?: () => void }>) => (
-    <div
-      onClick={() => {
-        onSelect?.();
-      }}
-      onKeyDown={() => undefined}
-      role='presentation'
-    >
-      {children}
-    </div>
-  ),
+    disabled,
+  }: React.PropsWithChildren<{
+    onSelect?: () => void;
+    disabled?: boolean;
+  }>) => {
+    if (!React.isValidElement(children)) {
+      return (
+        <button
+          type='button'
+          disabled={disabled}
+          onClick={() => {
+            onSelect?.();
+          }}
+        >
+          {children}
+        </button>
+      );
+    }
+
+    const child = children as React.ReactElement<{
+      onClick?: React.MouseEventHandler<HTMLElement>;
+      disabled?: boolean;
+    }>;
+
+    return React.cloneElement(child, {
+      disabled: Boolean(disabled || child.props.disabled),
+      onClick: (event: React.MouseEvent<HTMLElement>) => {
+        child.props.onClick?.(event);
+        if (!disabled) {
+          onSelect?.();
+        }
+      },
+    });
+  },
 }));
 
 const renderHeader = () =>

--- a/src/cook-web/src/components/header/Header.test.tsx
+++ b/src/cook-web/src/components/header/Header.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import api from '@/api';
+import { AlertProvider } from '@/components/ui/UseAlert';
+import Header from './Header';
+
+const mockSaveMdflow = jest.fn();
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    publishShifu: jest.fn(),
+  },
+}));
+
+jest.mock('@/store', () => ({
+  useShifu: () => ({
+    isSaving: false,
+    error: null,
+    currentShifu: {
+      bid: 'course-1',
+      name: 'Published Course',
+      canPublish: true,
+      url: 'https://example.test/c/course-1',
+      tts_enabled: true,
+    },
+    actions: {
+      saveMdflow: mockSaveMdflow,
+      loadShifu: jest.fn(),
+    },
+  }),
+}));
+
+jest.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
+jest.mock('@/c-common/hooks/useTracking', () => ({
+  useTracking: () => ({
+    trackEvent: jest.fn(),
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.ComponentProps<'a'> & { href: string }) => (
+    <a
+      href={href}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock('@/components/preview', () => ({
+  __esModule: true,
+  default: () => <div data-testid='preview' />,
+}));
+
+jest.mock('@/components/shifu-setting', () => ({
+  __esModule: true,
+  default: () => <div data-testid='shifu-setting' />,
+}));
+
+jest.mock('@/components/ui/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: React.PropsWithChildren<{ onSelect?: () => void }>) => (
+    <div
+      onClick={() => {
+        onSelect?.();
+      }}
+      onKeyDown={() => undefined}
+      role='presentation'
+    >
+      {children}
+    </div>
+  ),
+}));
+
+const renderHeader = () =>
+  render(
+    <AlertProvider>
+      <Header />
+    </AlertProvider>,
+  );
+
+describe('Header publish success link', () => {
+  beforeEach(() => {
+    mockSaveMdflow.mockReset().mockResolvedValue(undefined);
+    (api.publishShifu as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('shows a parameterless learning link after publishing', async () => {
+    (api.publishShifu as jest.Mock).mockResolvedValue(
+      'https://example.test/c/course-1?mode=listen&lessonid=lesson-2#outline',
+    );
+
+    renderHeader();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'component.header.publish' }),
+    );
+
+    const learningLink = await screen.findByRole('link', {
+      name: 'https://example.test/c/course-1',
+    });
+    expect(learningLink).toHaveAttribute(
+      'href',
+      'https://example.test/c/course-1',
+    );
+    expect(learningLink.getAttribute('href')).not.toContain('?');
+  });
+
+  test('keeps the success dialog link parameterless when opening a learning mode fails', async () => {
+    (api.publishShifu as jest.Mock).mockResolvedValue(
+      'https://example.test/c/course-1',
+    );
+    jest.spyOn(window, 'open').mockReturnValue(null);
+
+    renderHeader();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'component.header.publishAndOpenClassroomMode',
+      }),
+    );
+
+    const learningLink = await screen.findByRole('link', {
+      name: 'https://example.test/c/course-1',
+    });
+    expect(learningLink).toHaveAttribute(
+      'href',
+      'https://example.test/c/course-1',
+    );
+    expect(learningLink.getAttribute('href')).not.toContain('mode=');
+  });
+});

--- a/src/cook-web/src/components/header/Header.test.tsx
+++ b/src/cook-web/src/components/header/Header.test.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import api from '@/api';
 import { AlertProvider } from '@/components/ui/UseAlert';
 import Header from './Header';
 
 const mockSaveMdflow = jest.fn();
+const mockToast = jest.fn();
+const mockCurrentShifu = {
+  bid: 'course-1',
+  name: 'Published Course',
+  canPublish: true,
+  url: 'https://example.test/c/course-1',
+  tts_enabled: true,
+};
 
 jest.mock('@/api', () => ({
   __esModule: true,
@@ -17,13 +25,7 @@ jest.mock('@/store', () => ({
   useShifu: () => ({
     isSaving: false,
     error: null,
-    currentShifu: {
-      bid: 'course-1',
-      name: 'Published Course',
-      canPublish: true,
-      url: 'https://example.test/c/course-1',
-      tts_enabled: true,
-    },
+    currentShifu: mockCurrentShifu,
     actions: {
       saveMdflow: mockSaveMdflow,
       loadShifu: jest.fn(),
@@ -33,7 +35,7 @@ jest.mock('@/store', () => ({
 
 jest.mock('@/hooks/useToast', () => ({
   useToast: () => ({
-    toast: jest.fn(),
+    toast: mockToast,
   }),
 }));
 
@@ -134,12 +136,39 @@ const renderHeader = () =>
 describe('Header publish success link', () => {
   beforeEach(() => {
     mockSaveMdflow.mockReset().mockResolvedValue(undefined);
+    mockToast.mockReset();
+    mockCurrentShifu.url = 'https://example.test/c/course-1';
     (api.publishShifu as jest.Mock).mockReset();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
+
+  const expectNoRejectedLearningLink = () => {
+    expect(
+      screen.queryByRole('button', {
+        name: 'component.header.copyLearningLink',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('component.header.learningLink'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'javascript:alert(1)' }),
+    ).not.toBeInTheDocument();
+    for (const link of screen.queryAllByRole('link', { hidden: true })) {
+      const href = link.getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href).not.toMatch(/^javascript:/i);
+    }
+  };
 
   test('shows a parameterless learning link after publishing', async () => {
     (api.publishShifu as jest.Mock).mockResolvedValue(
@@ -184,5 +213,67 @@ describe('Header publish success link', () => {
       'https://example.test/c/course-1',
     );
     expect(learningLink.getAttribute('href')).not.toContain('mode=');
+  });
+
+  test('omits the learning link when the published URL is rejected', async () => {
+    (api.publishShifu as jest.Mock).mockResolvedValue('javascript:alert(1)');
+
+    renderHeader();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'component.header.publish' }),
+    );
+
+    await screen.findByText('component.header.publishSuccess');
+    expectNoRejectedLearningLink();
+  });
+
+  test('closes the pending tab instead of navigating when the published URL is rejected', async () => {
+    const pendingWindow = {
+      closed: false,
+      close: jest.fn(function closePendingWindow() {
+        this.closed = true;
+      }),
+      location: { href: 'about:blank' },
+      opener: {} as Window | null,
+    };
+    const openSpy = jest
+      .spyOn(window, 'open')
+      .mockReturnValue(pendingWindow as unknown as Window);
+    (api.publishShifu as jest.Mock).mockResolvedValue('javascript:alert(1)');
+
+    renderHeader();
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'component.header.publishAndOpenListenMode',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(pendingWindow.close).toHaveBeenCalled();
+    });
+    expect(pendingWindow.location.href).toBe('about:blank');
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+    await screen.findByText('component.header.publishSuccess');
+    expectNoRejectedLearningLink();
+  });
+
+  test('does not copy a rejected published URL for a learning mode', async () => {
+    mockCurrentShifu.url = 'javascript:alert(1)';
+
+    renderHeader();
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'component.header.copyListenModeLink',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: 'component.header.copyLinkFailed',
+        variant: 'destructive',
+      });
+    });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
   });
 });

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -44,6 +44,7 @@ import { cn } from '@/lib/utils';
 import {
   buildCourseLearningUrl,
   buildLearningModeUrl,
+  buildParameterlessCourseUrl,
   isPublishLearningModeAvailable,
   PUBLISH_LEARNING_MODES,
 } from './publishLearningMode';
@@ -232,6 +233,7 @@ const Header = ({
     publishedUrl: string,
     mode?: LearningMode,
   ) => {
+    const shareUrl = buildParameterlessCourseUrl(publishedUrl);
     alert.showAlert({
       title: t('component.header.publishSuccess'),
       confirmText: t('component.header.publishSuccessDone'),
@@ -267,19 +269,19 @@ const Header = ({
             </div>
             <div className='flex items-center gap-2 rounded-md border border-blue-100 bg-blue-50 px-3 py-2'>
               <a
-                href={publishedUrl}
+                href={shareUrl}
                 target='_blank'
                 rel='noopener noreferrer'
                 className='min-w-0 flex-1 break-all text-sm font-medium text-blue-600 hover:underline'
               >
-                {publishedUrl}
+                {shareUrl}
               </a>
               <button
                 type='button'
                 aria-label={t('component.header.copyLearningLink')}
                 className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-blue-600 transition-colors hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300'
                 onClick={() => {
-                  void copyPublishedUrl(publishedUrl, mode);
+                  void copyPublishedUrl(shareUrl, mode);
                 }}
               >
                 <Copy className='h-4 w-4' />
@@ -336,7 +338,7 @@ const Header = ({
           return;
         }
 
-        showPublishSuccessAlert(buildLearningModeUrl(result, mode), mode);
+        showPublishSuccessAlert(result, mode);
         return;
       }
 

--- a/src/cook-web/src/components/header/Header.tsx
+++ b/src/cook-web/src/components/header/Header.tsx
@@ -197,8 +197,17 @@ const Header = ({
       return;
     }
 
+    const url = getLearningModeUrl(mode);
+    if (!url) {
+      toast({
+        title: t('component.header.copyLinkFailed'),
+        variant: 'destructive',
+      });
+      return;
+    }
+
     try {
-      await writeClipboardText(getLearningModeUrl(mode));
+      await writeClipboardText(url);
       trackEvent('creator_publish_link_copy', {
         shifu_bid: currentShifu?.bid || '',
         learning_mode: mode,
@@ -215,6 +224,14 @@ const Header = ({
     publishedUrl: string,
     mode?: LearningMode,
   ) => {
+    if (!publishedUrl) {
+      toast({
+        title: t('component.header.copyLinkFailed'),
+        variant: 'destructive',
+      });
+      return;
+    }
+
     try {
       await writeClipboardText(publishedUrl);
       trackEvent('creator_publish_link_copy', {
@@ -263,31 +280,33 @@ const Header = ({
             </div>
             <p>{t('component.header.publishSuccessAudienceDescription')}</p>
           </div>
-          <div className='space-y-1.5'>
-            <div className='text-xs font-medium text-foreground'>
-              {t('component.header.learningLink')}
+          {shareUrl ? (
+            <div className='space-y-1.5'>
+              <div className='text-xs font-medium text-foreground'>
+                {t('component.header.learningLink')}
+              </div>
+              <div className='flex items-center gap-2 rounded-md border border-blue-100 bg-blue-50 px-3 py-2'>
+                <a
+                  href={shareUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='min-w-0 flex-1 break-all text-sm font-medium text-blue-600 hover:underline'
+                >
+                  {shareUrl}
+                </a>
+                <button
+                  type='button'
+                  aria-label={t('component.header.copyLearningLink')}
+                  className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-blue-600 transition-colors hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300'
+                  onClick={() => {
+                    void copyPublishedUrl(shareUrl, mode);
+                  }}
+                >
+                  <Copy className='h-4 w-4' />
+                </button>
+              </div>
             </div>
-            <div className='flex items-center gap-2 rounded-md border border-blue-100 bg-blue-50 px-3 py-2'>
-              <a
-                href={shareUrl}
-                target='_blank'
-                rel='noopener noreferrer'
-                className='min-w-0 flex-1 break-all text-sm font-medium text-blue-600 hover:underline'
-              >
-                {shareUrl}
-              </a>
-              <button
-                type='button'
-                aria-label={t('component.header.copyLearningLink')}
-                className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-blue-600 transition-colors hover:bg-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-300'
-                onClick={() => {
-                  void copyPublishedUrl(shareUrl, mode);
-                }}
-              >
-                <Copy className='h-4 w-4' />
-              </button>
-            </div>
-          </div>
+          ) : null}
         </div>
       ),
     });
@@ -298,6 +317,11 @@ const Header = ({
     pendingWindow?: Window | null,
   ) => {
     const targetUrl = buildLearningModeUrl(courseUrl, mode);
+    if (!targetUrl) {
+      pendingWindow?.close();
+      return false;
+    }
+
     if (pendingWindow && !pendingWindow.closed) {
       pendingWindow.opener = null;
       pendingWindow.location.href = targetUrl;

--- a/src/cook-web/src/components/header/publishLearningMode.test.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.test.ts
@@ -18,15 +18,13 @@ describe('publish learning mode urls', () => {
     expect(buildCourseLearningUrl('course 1')).toBe('/c/course%201');
   });
 
-  test('sets mode and removes legacy listen query while preserving other url parts', () => {
+  test('builds a learning-mode url from a stripped course link', () => {
     expect(
       buildLearningModeUrl(
         `${TEST_ORIGIN}/c/course-1?listen=1&lessonid=lesson-2#outline`,
         'classroom',
       ),
-    ).toBe(
-      `${TEST_ORIGIN}/c/course-1?lessonid=lesson-2&mode=classroom#outline`,
-    );
+    ).toBe(`${TEST_ORIGIN}/c/course-1?mode=classroom`);
   });
 
   test('resolves relative course urls with the provided origin', () => {

--- a/src/cook-web/src/components/header/publishLearningMode.test.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.test.ts
@@ -1,6 +1,7 @@
 import {
   buildCourseLearningUrl,
   buildLearningModeUrl,
+  buildParameterlessCourseUrl,
   isPublishLearningModeAvailable,
 } from './publishLearningMode';
 
@@ -32,6 +33,27 @@ describe('publish learning mode urls', () => {
     expect(
       buildLearningModeUrl('/c/course-1', 'listen', 'https://host.test'),
     ).toBe('https://host.test/c/course-1?mode=listen');
+  });
+
+  test('strips query params and hash from absolute published urls', () => {
+    expect(
+      buildParameterlessCourseUrl(
+        `${TEST_ORIGIN}/c/course-1?mode=classroom&lessonid=lesson-2#outline`,
+      ),
+    ).toBe(`${TEST_ORIGIN}/c/course-1`);
+  });
+
+  test('strips query params from relative published urls', () => {
+    expect(
+      buildParameterlessCourseUrl(
+        '/c/course-1?listen=1&preview=true',
+        'https://host.test',
+      ),
+    ).toBe('/c/course-1');
+  });
+
+  test('returns an empty string for blank published urls', () => {
+    expect(buildParameterlessCourseUrl('   ')).toBe('');
   });
 
   test('disables listen publish links only when tts is disabled', () => {

--- a/src/cook-web/src/components/header/publishLearningMode.test.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.test.ts
@@ -54,6 +54,20 @@ describe('publish learning mode urls', () => {
     expect(buildParameterlessCourseUrl('   ')).toBe('');
   });
 
+  test('rejects javascript and data urls without a learning mode', () => {
+    expect(buildParameterlessCourseUrl('javascript:alert(1)')).toBe('');
+    expect(
+      buildParameterlessCourseUrl('data:text/html,<script>alert(1)</script>'),
+    ).toBe('');
+  });
+
+  test('rejects javascript and data urls when adding a learning mode', () => {
+    expect(buildLearningModeUrl('javascript:alert(1)', 'listen')).toBe('');
+    expect(
+      buildLearningModeUrl('data:text/html,<script>alert(1)</script>', 'read'),
+    ).toBe('');
+  });
+
   test('disables listen publish links only when tts is disabled', () => {
     expect(
       isPublishLearningModeAvailable({

--- a/src/cook-web/src/components/header/publishLearningMode.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.ts
@@ -26,6 +26,32 @@ export const buildCourseLearningUrl = (
   return `/c/${encodeURIComponent(courseId)}`;
 };
 
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+export const buildParameterlessCourseUrl = (
+  courseUrl: string,
+  origin = typeof window !== 'undefined'
+    ? window.location.origin
+    : 'http://localhost',
+) => {
+  const normalizedUrl = courseUrl.trim();
+  if (!normalizedUrl) {
+    return '';
+  }
+
+  const url = new URL(normalizedUrl, origin);
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+
+  if (ABSOLUTE_URL_PATTERN.test(normalizedUrl)) {
+    return url.toString();
+  }
+
+  return url.pathname;
+};
+
 export const buildLearningModeUrl = (
   courseUrl: string,
   mode: LearningMode,

--- a/src/cook-web/src/components/header/publishLearningMode.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.ts
@@ -28,11 +28,18 @@ export const buildCourseLearningUrl = (
 
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 
-export const buildParameterlessCourseUrl = (
+const getDefaultOrigin = () =>
+  typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+
+const buildCourseUrl = (
   courseUrl: string,
-  origin = typeof window !== 'undefined'
-    ? window.location.origin
-    : 'http://localhost',
+  {
+    mode,
+    origin = getDefaultOrigin(),
+  }: {
+    mode?: LearningMode;
+    origin?: string;
+  } = {},
 ) => {
   const normalizedUrl = courseUrl.trim();
   if (!normalizedUrl) {
@@ -45,6 +52,11 @@ export const buildParameterlessCourseUrl = (
   url.search = '';
   url.hash = '';
 
+  if (mode) {
+    url.searchParams.set('mode', mode);
+    return url.toString();
+  }
+
   if (ABSOLUTE_URL_PATTERN.test(normalizedUrl)) {
     return url.toString();
   }
@@ -52,15 +64,13 @@ export const buildParameterlessCourseUrl = (
   return url.pathname;
 };
 
+export const buildParameterlessCourseUrl = (
+  courseUrl: string,
+  origin?: string,
+) => buildCourseUrl(courseUrl, { origin });
+
 export const buildLearningModeUrl = (
   courseUrl: string,
   mode: LearningMode,
-  origin = typeof window !== 'undefined'
-    ? window.location.origin
-    : 'http://localhost',
-) => {
-  const url = new URL(courseUrl, origin);
-  url.searchParams.set('mode', mode);
-  url.searchParams.delete('listen');
-  return url.toString();
-};
+  origin?: string,
+) => buildCourseUrl(courseUrl, { mode, origin });

--- a/src/cook-web/src/components/header/publishLearningMode.ts
+++ b/src/cook-web/src/components/header/publishLearningMode.ts
@@ -46,22 +46,30 @@ const buildCourseUrl = (
     return '';
   }
 
-  const url = new URL(normalizedUrl, origin);
-  url.username = '';
-  url.password = '';
-  url.search = '';
-  url.hash = '';
+  try {
+    const url = new URL(normalizedUrl, origin);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return '';
+    }
 
-  if (mode) {
-    url.searchParams.set('mode', mode);
-    return url.toString();
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+
+    if (mode) {
+      url.searchParams.set('mode', mode);
+      return url.toString();
+    }
+
+    if (ABSOLUTE_URL_PATTERN.test(normalizedUrl)) {
+      return url.toString();
+    }
+
+    return url.pathname;
+  } catch {
+    return '';
   }
-
-  if (ABSOLUTE_URL_PATTERN.test(normalizedUrl)) {
-    return url.toString();
-  }
-
-  return url.pathname;
 };
 
 export const buildParameterlessCourseUrl = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

The course publish success dialog always showed whatever URL the publish flow had just built. When “publish and open a learning mode” failed to open a tab, that URL included `mode` (and could keep other query params). Students and teachers are supposed to share the same clean course link.

This change strips query parameters and fragments before the dialog renders or copies the learning link, so the popup URL is always `/c/<course>` with no extra parameters.

The parameterless publish link and learning-mode publish link now share one course URL builder. Both start from a stripped course URL; learning-mode links then add only `mode`. Unsafe `javascript:` and `data:` protocols are rejected.

When a published URL is rejected, the success dialog omits the learning link and copy control, copy actions toast a failure instead of writing an empty string, and a pending “open mode” tab is closed instead of navigating to a blank or current-page URL.

## Testing

- `cd src/cook-web && npm test -- --testPathPattern='src/components/header/' --no-coverage`
- 16 passing tests covering URL stripping, protocol rejection, shared publish URL building, the publish success dialog, and rejected-URL copy/open paths
- GUI/e2e was not run: the Cloud Agent MySQL start script failed in this environment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61e1f56a-e305-42ed-991b-c0479c29b933?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61e1f56a-e305-42ed-991b-c0479c29b933&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published learning links are simplified by removing credentials, query parameters, and fragments.
  * Learning-mode links retain only the course path and selected mode while preserving the original URL for launching.

* **Bug Fixes**
  * Success dialogs now display and copy a clean, parameterless learning link.
  * Invalid or unsupported links are safely rejected, with a failure notification and no unsafe navigation or clipboard copy.

* **Tests**
  * Added coverage for valid, blank, invalid, and mode-specific learning URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->