### PR TITLE
feat: add course default listen mode setting

### DIFF
--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -165,6 +165,11 @@ class LearnShifuInfoDTO(BaseModel):
     avatar: str = Field(..., description="shifu avatar", required=False)
     price: str = Field(..., description="shifu price", required=False)
     tts_enabled: bool = Field(False, description="tts enabled", required=False)
+    default_listen_mode_enabled: bool = Field(
+        False,
+        description="Default learner mode to listen when TTS is enabled",
+        required=False,
+    )
 
     def __init__(
         self,
@@ -175,6 +180,7 @@ class LearnShifuInfoDTO(BaseModel):
         avatar: str,
         price: str,
         tts_enabled: bool = False,
+        default_listen_mode_enabled: bool = False,
     ):
         super().__init__(
             bid=bid,
@@ -184,6 +190,7 @@ class LearnShifuInfoDTO(BaseModel):
             avatar=avatar,
             price=price,
             tts_enabled=tts_enabled,
+            default_listen_mode_enabled=default_listen_mode_enabled,
         )
 
     def __json__(self):
@@ -195,6 +202,7 @@ class LearnShifuInfoDTO(BaseModel):
             "avatar": self.avatar,
             "price": self.price,
             "tts_enabled": self.tts_enabled,
+            "default_listen_mode_enabled": self.default_listen_mode_enabled,
         }
 
 

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -265,6 +265,9 @@ def get_shifu_info(app: Flask, shifu_bid: str, preview_mode: bool) -> LearnShifu
             price=str(shifu.price),
             keywords=shifu.keywords.split(",") if shifu.keywords else [],
             tts_enabled=tts_enabled,
+            default_listen_mode_enabled=bool(
+                getattr(shifu, "default_listen_mode_enabled", 0)
+            ),
         )
 
 

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -143,6 +143,11 @@ class ShifuDetailDto(BaseModel):
         required=False,
     )
     tts_emotion: str = Field("", description="TTS emotion setting", required=False)
+    default_listen_mode_enabled: bool = Field(
+        False,
+        description="Default learner mode to listen when TTS is enabled",
+        required=False,
+    )
     use_learner_language: bool = Field(
         False,
         description="Use learner language for AI output",
@@ -199,6 +204,7 @@ class ShifuDetailDto(BaseModel):
         tts_speed: float = 1.0,
         tts_pitch: int = 0,
         tts_emotion: str = "",
+        default_listen_mode_enabled: bool = False,
         use_learner_language: bool = False,
         ask_enabled_status: int = 5101,
         ask_model: str = "",
@@ -230,6 +236,7 @@ class ShifuDetailDto(BaseModel):
             tts_speed=tts_speed,
             tts_pitch=tts_pitch,
             tts_emotion=tts_emotion,
+            default_listen_mode_enabled=default_listen_mode_enabled,
             use_learner_language=use_learner_language,
             ask_enabled_status=ask_enabled_status,
             ask_model=ask_model,
@@ -263,6 +270,7 @@ class ShifuDetailDto(BaseModel):
             "tts_speed": self.tts_speed,
             "tts_pitch": self.tts_pitch,
             "tts_emotion": self.tts_emotion,
+            "default_listen_mode_enabled": self.default_listen_mode_enabled,
             "use_learner_language": self.use_learner_language,
             "ask_enabled_status": self.ask_enabled_status,
             "ask_model": self.ask_model,

--- a/src/api/flaskr/service/shifu/models.py
+++ b/src/api/flaskr/service/shifu/models.py
@@ -272,6 +272,12 @@ class DraftShifu(db.Model):
         default="",
         comment="TTS emotion setting",
     )
+    default_listen_mode_enabled = Column(
+        SmallInteger,
+        nullable=False,
+        default=0,
+        comment="Default learner mode to listen when TTS is enabled",
+    )
 
     # Language Output Configuration
     use_learner_language = Column(
@@ -335,6 +341,7 @@ class DraftShifu(db.Model):
             tts_speed=self.tts_speed,
             tts_pitch=self.tts_pitch,
             tts_emotion=self.tts_emotion,
+            default_listen_mode_enabled=self.default_listen_mode_enabled,
             use_learner_language=self.use_learner_language,
             deleted=self.deleted,
             created_at=self.created_at,
@@ -366,6 +373,7 @@ class DraftShifu(db.Model):
             and compare_decimal(self.tts_speed, other.tts_speed)
             and self.tts_pitch == other.tts_pitch
             and self.tts_emotion == other.tts_emotion
+            and (self.default_listen_mode_enabled == other.default_listen_mode_enabled)
             and self.use_learner_language == other.use_learner_language
         )
 
@@ -703,6 +711,12 @@ class PublishedShifu(db.Model):
         nullable=False,
         default="",
         comment="TTS emotion setting",
+    )
+    default_listen_mode_enabled = Column(
+        SmallInteger,
+        nullable=False,
+        default=0,
+        comment="Default learner mode to listen when TTS is enabled",
     )
 
     # Language Output Configuration

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -908,6 +908,9 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                     tts_emotion:
                         type: string
                         description: TTS emotion setting
+                    default_listen_mode_enabled:
+                        type: boolean
+                        description: Default learner mode to listen when TTS is enabled
         responses:
             200:
                 description: save shifu detail success
@@ -972,6 +975,15 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         tts_speed = json_data.get("tts_speed")
         tts_pitch = 0 if "tts_pitch" in json_data else None
         tts_emotion = "" if "tts_emotion" in json_data else None
+        default_listen_mode_enabled = json_data.get("default_listen_mode_enabled")
+        if isinstance(default_listen_mode_enabled, str):
+            if default_listen_mode_enabled not in {"true", "false"}:
+                raise_param_error("default_listen_mode_enabled")
+            default_listen_mode_enabled = default_listen_mode_enabled == "true"
+        elif default_listen_mode_enabled is not None and not isinstance(
+            default_listen_mode_enabled, bool
+        ):
+            raise_param_error("default_listen_mode_enabled")
         # Language Output Configuration
         use_learner_language = json_data.get("use_learner_language")
         if isinstance(use_learner_language, str):
@@ -998,6 +1010,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 tts_speed=tts_speed,
                 tts_pitch=tts_pitch,
                 tts_emotion=tts_emotion,
+                default_listen_mode_enabled=default_listen_mode_enabled,
                 use_learner_language=use_learner_language,
                 ask_enabled_status=ask_enabled_status,
                 ask_model=ask_model,

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -186,6 +186,9 @@ def return_shifu_draft_dto(
         else 1.0,
         tts_pitch=int(shifu_draft.tts_pitch) if shifu_draft.tts_pitch else 0,
         tts_emotion=shifu_draft.tts_emotion or "",
+        default_listen_mode_enabled=bool(
+            getattr(shifu_draft, "default_listen_mode_enabled", 0)
+        ),
         use_learner_language=bool(getattr(shifu_draft, "use_learner_language", 0)),
         ask_enabled_status=int(
             getattr(shifu_draft, "ask_enabled_status", ASK_MODE_DEFAULT)
@@ -391,6 +394,7 @@ def save_shifu_draft_info(
     tts_speed: float | None = None,
     tts_pitch: int | None = None,
     tts_emotion: str | None = None,
+    default_listen_mode_enabled: bool | None = None,
     use_learner_language: bool | None = None,
     ask_enabled_status: int | None = None,
     ask_model: str | None = None,
@@ -419,6 +423,7 @@ def save_shifu_draft_info(
         tts_speed: TTS speech speed
         tts_pitch: TTS pitch adjustment
         tts_emotion: TTS emotion setting
+        default_listen_mode_enabled: Default learner mode to listen when TTS is enabled
         use_learner_language: Whether to use learner's language for AI output
         ask_enabled_status: Ask mode status
         ask_model: Ask model name
@@ -500,6 +505,8 @@ def save_shifu_draft_info(
             tts_speed = validated.speed
             tts_pitch = validated.pitch
             tts_emotion = validated.emotion
+        if not merged_tts_enabled:
+            default_listen_mode_enabled = False
 
         # Validate input lengths (only when provided — PATCH callers may omit
         # name/description entirely, which must mean "leave unchanged").
@@ -580,6 +587,7 @@ def save_shifu_draft_info(
                 tts_speed=tts_speed if tts_speed is not None else 1.0,
                 tts_pitch=tts_pitch if tts_pitch is not None else 0,
                 tts_emotion=tts_emotion or "",
+                default_listen_mode_enabled=(1 if default_listen_mode_enabled else 0),
                 use_learner_language=1 if use_learner_language else 0,
                 deleted=0,
                 created_user_bid=user_id,
@@ -632,6 +640,10 @@ def save_shifu_draft_info(
                 new_shifu_draft.tts_pitch = tts_pitch
             if tts_emotion_provided:
                 new_shifu_draft.tts_emotion = tts_emotion or ""
+            if default_listen_mode_enabled is not None:
+                new_shifu_draft.default_listen_mode_enabled = (
+                    1 if default_listen_mode_enabled else 0
+                )
             if use_learner_language is not None:
                 new_shifu_draft.use_learner_language = 1 if use_learner_language else 0
             new_shifu_draft.updated_user_bid = user_id

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -140,6 +140,9 @@ def publish_shifu_draft(
         shifu_published.tts_speed = shifu_draft.tts_speed
         shifu_published.tts_pitch = shifu_draft.tts_pitch
         shifu_published.tts_emotion = shifu_draft.tts_emotion
+        shifu_published.default_listen_mode_enabled = getattr(
+            shifu_draft, "default_listen_mode_enabled", 0
+        )
         # Learner language setting
         shifu_published.use_learner_language = getattr(
             shifu_draft, "use_learner_language", 0

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -52,6 +52,7 @@ class ShifuInfoDto(BaseModel):
     avatar: str
     price: Decimal
     outline_items: List["ShifuOutlineItemDto"]
+    default_listen_mode_enabled: bool = False
     use_learner_language: bool = False
 
     def __json__(self):
@@ -135,6 +136,9 @@ def get_shifu_outline_tree(
             avatar=get_shifu_res_url(shifu.avatar_res_bid),
             price=shifu.price,
             outline_items=[],
+            default_listen_mode_enabled=bool(
+                getattr(shifu, "default_listen_mode_enabled", 0)
+            ),
             use_learner_language=bool(getattr(shifu, "use_learner_language", 0)),
         )
 
@@ -202,6 +206,9 @@ def get_shifu_dto(app: Flask, shifu_bid: str, is_preview: bool = False) -> Shifu
         avatar=get_shifu_res_url(shifu.avatar_res_bid),
         price=shifu.price,
         outline_items=[],
+        default_listen_mode_enabled=bool(
+            getattr(shifu, "default_listen_mode_enabled", 0)
+        ),
         use_learner_language=bool(getattr(shifu, "use_learner_language", 0)),
     )
 

--- a/src/api/migrations/versions/a9c3d5e7f1b2_add_default_listen_mode_setting.py
+++ b/src/api/migrations/versions/a9c3d5e7f1b2_add_default_listen_mode_setting.py
@@ -1,0 +1,42 @@
+"""add default listen mode setting
+
+Revision ID: a9c3d5e7f1b2
+Revises: f9a2b3c4d5e6
+Create Date: 2026-08-18 13:18:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a9c3d5e7f1b2"
+down_revision = "f9a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "shifu_draft_shifus",
+        sa.Column(
+            "default_listen_mode_enabled",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default="0",
+            comment="Default learner mode to listen when TTS is enabled",
+        ),
+    )
+    op.add_column(
+        "shifu_published_shifus",
+        sa.Column(
+            "default_listen_mode_enabled",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default="0",
+            comment="Default learner mode to listen when TTS is enabled",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("shifu_published_shifus", "default_listen_mode_enabled")
+    op.drop_column("shifu_draft_shifus", "default_listen_mode_enabled")

--- a/src/api/tests/golden/fixtures/api_shifu_info.json
+++ b/src/api/tests/golden/fixtures/api_shifu_info.json
@@ -11,6 +11,7 @@
     ],
     "avatar": "",
     "price": "0.00",
-    "tts_enabled": false
+    "tts_enabled": false,
+    "default_listen_mode_enabled": false
   }
 }

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -27,7 +27,7 @@ def test_alembic_migrations_have_single_head():
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
 
-    assert heads == ["f9a2b3c4d5e6"]
+    assert heads == ["a9c3d5e7f1b2"]
 
 
 def _get_base_mysql_uri() -> str:

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -340,6 +340,136 @@ def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
         assert latest.tts_emotion == ""
 
 
+def test_save_shifu_draft_info_persists_default_listen_mode_setting(app, monkeypatch):
+    from flaskr.service.shifu import shifu_draft_funcs
+    from flaskr.service.shifu.models import DraftShifu
+
+    shifu_bid = "test-save-shifu-default-listen"
+    owner_bid = "owner-default-listen"
+    _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.23"))
+    _mock_shifu_permissions(monkeypatch)
+
+    monkeypatch.setattr(
+        shifu_draft_funcs,
+        "validate_tts_settings_strict",
+        lambda **kwargs: SimpleNamespace(
+            provider=kwargs["provider"],
+            model=kwargs["model"],
+            voice_id=kwargs["voice_id"],
+            speed=kwargs["speed"],
+            pitch=kwargs["pitch"],
+            emotion=kwargs["emotion"],
+        ),
+        raising=False,
+    )
+
+    result = shifu_draft_funcs.save_shifu_draft_info(
+        app=app,
+        user_id=owner_bid,
+        shifu_id=shifu_bid,
+        shifu_name="Test Shifu",
+        shifu_description="desc",
+        shifu_avatar="res",
+        shifu_keywords=["test"],
+        shifu_model="gpt-test",
+        shifu_temperature=0.3,
+        shifu_price=1.23,
+        shifu_system_prompt="",
+        base_url="http://localhost:5000",
+        tts_enabled=True,
+        tts_provider="minimax",
+        tts_model="speech-01-turbo",
+        tts_voice_id="voice-1",
+        tts_speed=1.2,
+        default_listen_mode_enabled=True,
+    )
+
+    assert result.default_listen_mode_enabled is True
+
+    with app.app_context():
+        latest = (
+            DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+            .order_by(DraftShifu.id.desc())
+            .first()
+        )
+        assert latest is not None
+        assert latest.default_listen_mode_enabled == 1
+
+
+def test_save_shifu_draft_info_clears_default_listen_mode_when_tts_is_disabled(
+    app, monkeypatch
+):
+    from flaskr.service.shifu import shifu_draft_funcs
+    from flaskr.service.shifu.models import DraftShifu
+
+    shifu_bid = "test-save-shifu-default-listen-disabled"
+    owner_bid = "owner-default-listen-disabled"
+    _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.23"))
+    _mock_shifu_permissions(monkeypatch)
+
+    with app.app_context():
+        draft = (
+            DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+            .order_by(DraftShifu.id.desc())
+            .first()
+        )
+        draft.tts_enabled = 1
+        draft.default_listen_mode_enabled = 1
+        dao.db.session.commit()
+
+    result = shifu_draft_funcs.save_shifu_draft_info(
+        app=app,
+        user_id=owner_bid,
+        shifu_id=shifu_bid,
+        shifu_name="Test Shifu",
+        shifu_description="desc",
+        shifu_avatar="res",
+        shifu_keywords=["test"],
+        shifu_model="gpt-test",
+        shifu_temperature=0.3,
+        shifu_price=1.23,
+        shifu_system_prompt="",
+        base_url="http://localhost:5000",
+        tts_enabled=False,
+    )
+
+    assert result.default_listen_mode_enabled is False
+
+    with app.app_context():
+        latest = (
+            DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0)
+            .order_by(DraftShifu.id.desc())
+            .first()
+        )
+        assert latest is not None
+        assert latest.tts_enabled == 0
+        assert latest.default_listen_mode_enabled == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    ["yes", "", " true ", "TRUE", 1, 0, [], {}],
+)
+def test_save_shifu_detail_route_rejects_invalid_default_listen_mode_enabled(
+    app, test_client, monkeypatch, invalid_value
+):
+    shifu_bid = "test-save-shifu-default-listen-invalid"
+    owner_bid = "owner-default-listen-invalid"
+    _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.23"))
+    _mock_route_user(monkeypatch, owner_bid)
+    _mock_route_permission(monkeypatch, {"edit": True})
+
+    response = test_client.post(
+        f"/api/shifu/shifus/{shifu_bid}/detail",
+        json={"default_listen_mode_enabled": invalid_value},
+        headers={"Token": "test-token"},
+    )
+    payload = response.get_json(force=True)
+
+    assert response.status_code == 200
+    assert payload["code"] != 0
+
+
 def test_get_draft_meta_route_serializes_utc_timestamp(app, test_client, monkeypatch):
     from flaskr.service.shifu.models import DraftOutlineItem
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -8,6 +8,7 @@ from flaskr.service.shifu.models import (
     DraftOutlineItem,
     DraftShifu,
     PublishedOutlineItem,
+    PublishedShifu,
 )
 
 
@@ -286,6 +287,8 @@ def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
             title="Draft",
             description="Desc",
             keywords="a,b",
+            tts_enabled=1,
+            default_listen_mode_enabled=1,
         )
         outline = DraftOutlineItem(
             outline_item_bid="publish-preserve-outline-lesson",
@@ -318,9 +321,19 @@ def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
             .order_by(PublishedOutlineItem.id.desc())
             .first()
         )
+        published_shifu = (
+            PublishedShifu.query.filter_by(
+                shifu_bid="publish-preserve-outline-updated-at",
+                deleted=0,
+            )
+            .order_by(PublishedShifu.id.desc())
+            .first()
+        )
 
     assert published_outline is not None
     assert published_outline.updated_at == draft_updated_at
+    assert published_shifu is not None
+    assert published_shifu.default_listen_mode_enabled == 1
     assert outline_load_calls == [
         (("publish-preserve-outline-updated-at",), {"include_content": True})
     ]

--- a/src/api/tests/test_learn_api.py
+++ b/src/api/tests/test_learn_api.py
@@ -23,6 +23,8 @@ def test_get_shifu_info_returns_dto(app):
             description="Desc",
             price=Decimal("9.99"),
             keywords="a,b",
+            tts_enabled=1,
+            default_listen_mode_enabled=1,
         )
         db.session.add(shifu)
         db.session.commit()
@@ -32,6 +34,9 @@ def test_get_shifu_info_returns_dto(app):
     assert dto.title == "Test Shifu"
     assert dto.price == "9.99"
     assert dto.keywords == ["a", "b"]
+    assert dto.tts_enabled is True
+    assert dto.default_listen_mode_enabled is True
+    assert dto.__json__()["default_listen_mode_enabled"] is True
 
 
 def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
@@ -43,6 +48,7 @@ def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
             price=Decimal("1.00"),
             keywords="listen",
             tts_enabled=1,
+            default_listen_mode_enabled=1,
         )
         published = PublishedShifu(
             shifu_bid="shifu-learn-tts",
@@ -51,6 +57,7 @@ def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
             price=Decimal("2.00"),
             keywords="listen",
             tts_enabled=0,
+            default_listen_mode_enabled=0,
         )
         db.session.add_all([draft, published])
         db.session.commit()
@@ -60,8 +67,10 @@ def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
 
     assert preview_dto.title == "Draft Shifu"
     assert preview_dto.tts_enabled is True
+    assert preview_dto.default_listen_mode_enabled is True
     assert live_dto.title == "Published Shifu"
     assert live_dto.tts_enabled is False
+    assert live_dto.default_listen_mode_enabled is False
 
 
 def test_get_outline_item_tree_preview_mode(app):

--- a/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.test.ts
@@ -37,10 +37,50 @@ describe('resolveCourseLearningMode', () => {
     ).toBe('read');
   });
 
+  it('defaults to listen when the teacher enables default listen mode', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: true,
+        courseDefaultListenModeEnabled: true,
+        canUseClassroomMode: false,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('listen');
+  });
+
+  it('falls back to read when teacher default listen mode is enabled but course listen mode is disabled', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: false,
+        courseDefaultListenModeEnabled: true,
+        canUseClassroomMode: false,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+
+  it('keeps read when teacher default listen mode is enabled but course listen capability is still unknown', () => {
+    expect(
+      resolveCourseLearningMode({
+        courseTtsEnabled: null,
+        courseDefaultListenModeEnabled: true,
+        canUseClassroomMode: false,
+        hasListenModeOverride: false,
+        listenModeParam: null,
+        storedLearningMode: null,
+      }),
+    ).toBe('read');
+  });
+
   it('respects an explicit stored read preference', () => {
     expect(
       resolveCourseLearningMode({
         courseTtsEnabled: true,
+        courseDefaultListenModeEnabled: true,
         canUseClassroomMode: false,
         hasListenModeOverride: false,
         listenModeParam: null,

--- a/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/learningModePreference.ts
@@ -2,6 +2,7 @@ import type { LearningMode } from './learningModeOptions';
 
 type ResolveCourseLearningModeArgs = {
   courseTtsEnabled: boolean | null;
+  courseDefaultListenModeEnabled?: boolean | null;
   canUseClassroomMode: boolean | null;
   hasListenModeOverride: boolean;
   listenModeParam: boolean | null;
@@ -11,6 +12,7 @@ type ResolveCourseLearningModeArgs = {
 
 export const resolveCourseLearningMode = ({
   courseTtsEnabled,
+  courseDefaultListenModeEnabled = null,
   canUseClassroomMode,
   hasListenModeOverride,
   listenModeParam,
@@ -49,6 +51,10 @@ export const resolveCourseLearningMode = ({
 
   if (storedLearningMode === 'read') {
     return 'read';
+  }
+
+  if (courseDefaultListenModeEnabled === true && courseTtsEnabled === true) {
+    return 'listen';
   }
 
   return 'read';

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -133,15 +133,20 @@ export default function ChatLayout({
 
   const {
     courseTtsEnabled,
+    courseDefaultListenModeEnabled,
     updateCourseName,
     updateCourseAvatar,
     updateCourseTtsEnabled,
+    updateCourseDefaultListenModeEnabled,
   } = useCourseStore(
     useShallow((state: CourseStoreState) => ({
       courseTtsEnabled: state.courseTtsEnabled,
+      courseDefaultListenModeEnabled: state.courseDefaultListenModeEnabled,
       updateCourseName: state.updateCourseName,
       updateCourseAvatar: state.updateCourseAvatar,
       updateCourseTtsEnabled: state.updateCourseTtsEnabled,
+      updateCourseDefaultListenModeEnabled:
+        state.updateCourseDefaultListenModeEnabled,
     })),
   );
 
@@ -406,6 +411,7 @@ export default function ChatLayout({
     const storedLearningMode = readLearningModeFromStorage(storageCourseId);
     const nextLearningMode = resolveCourseLearningMode({
       courseTtsEnabled,
+      courseDefaultListenModeEnabled,
       canUseClassroomMode: canUseClassroomModeForCourse,
       hasListenModeOverride,
       listenModeParam,
@@ -421,6 +427,7 @@ export default function ChatLayout({
     updateLearningMode(nextLearningMode);
   }, [
     courseTtsEnabled,
+    courseDefaultListenModeEnabled,
     canUseClassroomModeForCourse,
     hasListenModeOverride,
     listenModeParam,
@@ -468,6 +475,8 @@ export default function ChatLayout({
   ]);
 
   useEffect(() => {
+    let canceled = false;
+
     const fetchCourseInfo = async () => {
       if (!envDataInitialized) return;
       if (courseId) {
@@ -479,19 +488,28 @@ export default function ChatLayout({
               ? `${window.location.pathname}${window.location.search}`
               : '',
         });
+        updateCourseTtsEnabled(null);
+        updateCourseDefaultListenModeEnabled(null);
         try {
           const resp = await getCourseInfo(courseId, isPreviewMode);
+          if (canceled) {
+            return;
+          }
           debugInfo('[course-info] request success', {
             courseId,
             previewMode: isPreviewMode,
             courseName: resp.course_name,
             coursePrice: resp.course_price,
             ttsEnabled: resp.course_tts_enabled,
+            defaultListenModeEnabled: resp.default_listen_mode_enabled,
           });
           setShowVip(resp.course_price > 0);
           updateCourseName(resp.course_name);
           updateCourseAvatar(resp.course_avatar);
           updateCourseTtsEnabled(resp.course_tts_enabled ?? null);
+          updateCourseDefaultListenModeEnabled(
+            resp.default_listen_mode_enabled ?? null,
+          );
           if (isPreviewMode) {
             setClassroomAccessCourseId(courseId);
             updateCanUseClassroomMode(true);
@@ -522,6 +540,9 @@ export default function ChatLayout({
           const isCourseNotFound = Boolean(
             (error as { isCourseNotFound?: boolean })?.isCourseNotFound,
           );
+          if (canceled) {
+            return;
+          }
           debugError('[course-info] request failed', {
             courseId,
             previewMode: isPreviewMode,
@@ -576,6 +597,9 @@ export default function ChatLayout({
       }
     };
     fetchCourseInfo();
+    return () => {
+      canceled = true;
+    };
   }, [
     courseId,
     envDataInitialized,
@@ -584,6 +608,7 @@ export default function ChatLayout({
     updateCourseName,
     updateCourseAvatar,
     updateCourseTtsEnabled,
+    updateCourseDefaultListenModeEnabled,
     updateCanUseClassroomMode,
     isPreviewMode,
   ]);

--- a/src/cook-web/src/app/c/[[...id]]/layout.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/layout.tsx
@@ -134,19 +134,18 @@ export default function ChatLayout({
   const {
     courseTtsEnabled,
     courseDefaultListenModeEnabled,
+    courseSettingsCourseId,
     updateCourseName,
     updateCourseAvatar,
-    updateCourseTtsEnabled,
-    updateCourseDefaultListenModeEnabled,
+    updateCourseSettings,
   } = useCourseStore(
     useShallow((state: CourseStoreState) => ({
       courseTtsEnabled: state.courseTtsEnabled,
       courseDefaultListenModeEnabled: state.courseDefaultListenModeEnabled,
+      courseSettingsCourseId: state.courseSettingsCourseId,
       updateCourseName: state.updateCourseName,
       updateCourseAvatar: state.updateCourseAvatar,
-      updateCourseTtsEnabled: state.updateCourseTtsEnabled,
-      updateCourseDefaultListenModeEnabled:
-        state.updateCourseDefaultListenModeEnabled,
+      updateCourseSettings: state.updateCourseSettings,
     })),
   );
 
@@ -182,11 +181,18 @@ export default function ChatLayout({
   const hasClassroomModeOverride = urlModeParam === 'classroom';
   const canUseClassroomModeForCourse =
     classroomAccessCourseId === storageCourseId ? canUseClassroomMode : null;
-  const isCourseListenModeAvailable = courseTtsEnabled === true;
+  const courseSettingsMatchStorage = courseSettingsCourseId === storageCourseId;
+  const courseTtsEnabledForMode = courseSettingsMatchStorage
+    ? courseTtsEnabled
+    : null;
+  const courseDefaultListenModeEnabledForMode = courseSettingsMatchStorage
+    ? courseDefaultListenModeEnabled
+    : null;
+  const isCourseListenModeAvailable = courseTtsEnabledForMode === true;
   const hasListenModeUrlOverride = urlModeParam === 'listen';
   const hasClassroomModeUrlOverride = urlModeParam === 'classroom';
   const showLearningModeToggle =
-    courseTtsEnabled === null
+    courseTtsEnabledForMode === null
       ? listenModeParam === true ||
         hasListenModeUrlOverride ||
         hasClassroomModeUrlOverride ||
@@ -410,8 +416,8 @@ export default function ChatLayout({
   useEffect(() => {
     const storedLearningMode = readLearningModeFromStorage(storageCourseId);
     const nextLearningMode = resolveCourseLearningMode({
-      courseTtsEnabled,
-      courseDefaultListenModeEnabled,
+      courseTtsEnabled: courseTtsEnabledForMode,
+      courseDefaultListenModeEnabled: courseDefaultListenModeEnabledForMode,
       canUseClassroomMode: canUseClassroomModeForCourse,
       hasListenModeOverride,
       listenModeParam,
@@ -426,8 +432,8 @@ export default function ChatLayout({
 
     updateLearningMode(nextLearningMode);
   }, [
-    courseTtsEnabled,
-    courseDefaultListenModeEnabled,
+    courseTtsEnabledForMode,
+    courseDefaultListenModeEnabledForMode,
     canUseClassroomModeForCourse,
     hasListenModeOverride,
     listenModeParam,
@@ -488,8 +494,10 @@ export default function ChatLayout({
               ? `${window.location.pathname}${window.location.search}`
               : '',
         });
-        updateCourseTtsEnabled(null);
-        updateCourseDefaultListenModeEnabled(null);
+        updateCourseSettings(null, {
+          ttsEnabled: null,
+          defaultListenModeEnabled: null,
+        });
         try {
           const resp = await getCourseInfo(courseId, isPreviewMode);
           if (canceled) {
@@ -506,10 +514,10 @@ export default function ChatLayout({
           setShowVip(resp.course_price > 0);
           updateCourseName(resp.course_name);
           updateCourseAvatar(resp.course_avatar);
-          updateCourseTtsEnabled(resp.course_tts_enabled ?? null);
-          updateCourseDefaultListenModeEnabled(
-            resp.default_listen_mode_enabled ?? null,
-          );
+          updateCourseSettings(courseId, {
+            ttsEnabled: resp.course_tts_enabled ?? null,
+            defaultListenModeEnabled: resp.default_listen_mode_enabled ?? null,
+          });
           if (isPreviewMode) {
             setClassroomAccessCourseId(courseId);
             updateCanUseClassroomMode(true);
@@ -607,8 +615,7 @@ export default function ChatLayout({
     t,
     updateCourseName,
     updateCourseAvatar,
-    updateCourseTtsEnabled,
-    updateCourseDefaultListenModeEnabled,
+    updateCourseSettings,
     updateCanUseClassroomMode,
     isPreviewMode,
   ]);

--- a/src/cook-web/src/c-api/course.ts
+++ b/src/cook-web/src/c-api/course.ts
@@ -100,6 +100,7 @@ export const getCourseInfo = async (
       course_teacher_avatar: res.avatar,
       course_avatar: res.avatar,
       course_tts_enabled: !!res?.tts_enabled,
+      default_listen_mode_enabled: !!res?.default_listen_mode_enabled,
     };
   } catch (rawError: any) {
     const error = new CourseInfoFetchError(rawError);

--- a/src/cook-web/src/c-store/useCourseStore.ts
+++ b/src/cook-web/src/c-store/useCourseStore.ts
@@ -15,6 +15,9 @@ export const useCourseStore = create<
     courseTtsEnabled: null,
     updateCourseTtsEnabled: courseTtsEnabled =>
       set(() => ({ courseTtsEnabled })),
+    courseDefaultListenModeEnabled: null,
+    updateCourseDefaultListenModeEnabled: courseDefaultListenModeEnabled =>
+      set(() => ({ courseDefaultListenModeEnabled })),
     lessonId: undefined,
     updateLessonId: lessonId => set(() => ({ lessonId })),
     chapterId: '',

--- a/src/cook-web/src/c-store/useCourseStore.ts
+++ b/src/cook-web/src/c-store/useCourseStore.ts
@@ -18,6 +18,16 @@ export const useCourseStore = create<
     courseDefaultListenModeEnabled: null,
     updateCourseDefaultListenModeEnabled: courseDefaultListenModeEnabled =>
       set(() => ({ courseDefaultListenModeEnabled })),
+    courseSettingsCourseId: null,
+    updateCourseSettings: (
+      courseSettingsCourseId,
+      { ttsEnabled, defaultListenModeEnabled },
+    ) =>
+      set(() => ({
+        courseSettingsCourseId,
+        courseTtsEnabled: ttsEnabled,
+        courseDefaultListenModeEnabled: defaultListenModeEnabled,
+      })),
     lessonId: undefined,
     updateLessonId: lessonId => set(() => ({ lessonId })),
     chapterId: '',

--- a/src/cook-web/src/c-types/index.ts
+++ b/src/cook-web/src/c-types/index.ts
@@ -30,6 +30,8 @@ export interface CourseInfo {
   course_desc: string;
   course_keywords: string;
   course_price: number;
+  course_tts_enabled?: boolean;
+  default_listen_mode_enabled?: boolean;
   [key: string]: any;
 }
 

--- a/src/cook-web/src/c-types/store.ts
+++ b/src/cook-web/src/c-types/store.ts
@@ -91,9 +91,11 @@ export interface CourseStoreState {
   courseName: string;
   courseAvatar: string;
   courseTtsEnabled: boolean | null;
+  courseDefaultListenModeEnabled: boolean | null;
   updateCourseAvatar: (avatar: string) => void;
   updateCourseName: (name: string) => void;
   updateCourseTtsEnabled: (enabled: boolean | null) => void;
+  updateCourseDefaultListenModeEnabled: (enabled: boolean | null) => void;
   lessonId: string | undefined;
   updateLessonId: (id: string) => void;
   chapterId: string;

--- a/src/cook-web/src/c-types/store.ts
+++ b/src/cook-web/src/c-types/store.ts
@@ -92,10 +92,18 @@ export interface CourseStoreState {
   courseAvatar: string;
   courseTtsEnabled: boolean | null;
   courseDefaultListenModeEnabled: boolean | null;
+  courseSettingsCourseId: string | null;
   updateCourseAvatar: (avatar: string) => void;
   updateCourseName: (name: string) => void;
   updateCourseTtsEnabled: (enabled: boolean | null) => void;
   updateCourseDefaultListenModeEnabled: (enabled: boolean | null) => void;
+  updateCourseSettings: (
+    courseId: string | null,
+    settings: {
+      ttsEnabled: boolean | null;
+      defaultListenModeEnabled: boolean | null;
+    },
+  ) => void;
   lessonId: string | undefined;
   updateLessonId: (id: string) => void;
   chapterId: string;

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -255,6 +255,7 @@ export default function ShifuSettingDialog({
   const [minimaxCloneDialogOpen, setMinimaxCloneDialogOpen] = useState(false);
   const [minimaxManualVoiceId, setMinimaxManualVoiceId] = useState('');
   const ttsProviderToastShownRef = useRef(false);
+  const settingsRequestSeqRef = useRef(0);
 
   // Language Output Configuration state
   const [useLearnerLanguage, setUseLearnerLanguage] = useState(false);
@@ -1173,6 +1174,10 @@ export default function ShifuSettingDialog({
   );
 
   const init = async () => {
+    const requestSeq = settingsRequestSeqRef.current + 1;
+    settingsRequestSeqRef.current = requestSeq;
+    const isActiveRequest = () => settingsRequestSeqRef.current === requestSeq;
+
     ttsProviderToastShownRef.current = false;
     setSettingsLoading(true);
     try {
@@ -1181,6 +1186,10 @@ export default function ShifuSettingDialog({
           shifu_bid: shifuId,
         })) as Shifu,
       );
+
+      if (!isActiveRequest()) {
+        return;
+      }
 
       if (result) {
         form.reset({
@@ -1237,6 +1246,9 @@ export default function ShifuSettingDialog({
         setUseLearnerLanguage(result.use_learner_language ?? false);
       }
     } catch (error) {
+      if (!isActiveRequest()) {
+        return;
+      }
       console.error('Failed to load shifu settings:', error);
       toast({
         title:
@@ -1246,7 +1258,9 @@ export default function ShifuSettingDialog({
         variant: 'destructive',
       });
     } finally {
-      setSettingsLoading(false);
+      if (isActiveRequest()) {
+        setSettingsLoading(false);
+      }
     }
   };
 

--- a/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/cook-web/src/components/shifu-setting/ShifuSetting.tsx
@@ -149,6 +149,7 @@ interface Shifu {
   tts_speed?: number;
   tts_pitch?: number;
   tts_emotion?: string;
+  default_listen_mode_enabled?: boolean;
   // Language Output Configuration
   use_learner_language?: boolean;
 }
@@ -237,12 +238,15 @@ export default function ShifuSettingDialog({
   } | null>(null);
 
   // TTS Configuration state
+  const [settingsLoading, setSettingsLoading] = useState(false);
   const [ttsEnabled, setTtsEnabled] = useState(false);
   const [ttsProvider, setTtsProvider] = useState('');
   const [ttsModel, setTtsModel] = useState('');
   const [ttsVoiceId, setTtsVoiceId] = useState('');
   const [ttsSpeed, setTtsSpeed] = useState<number | null>(1.0);
   const [ttsSpeedInput, setTtsSpeedInput] = useState<string>('1.0');
+  const [defaultListenModeEnabled, setDefaultListenModeEnabled] =
+    useState(false);
   const [minimaxClonedVoices, setMinimaxClonedVoices] = useState<
     MiniMaxClonedVoice[]
   >([]);
@@ -1109,6 +1113,9 @@ export default function ShifuSettingDialog({
           tts_speed: speedValue,
           tts_pitch: 0,
           tts_emotion: '',
+          default_listen_mode_enabled: ttsEnabled
+            ? defaultListenModeEnabled
+            : false,
           // Language Output Configuration
           use_learner_language: useLearnerLanguage,
         };
@@ -1150,6 +1157,7 @@ export default function ShifuSettingDialog({
       ttsModel,
       ttsVoiceId,
       speedValue,
+      defaultListenModeEnabled,
       useLearnerLanguage,
       askConfigMeta,
       askModel,
@@ -1166,62 +1174,79 @@ export default function ShifuSettingDialog({
 
   const init = async () => {
     ttsProviderToastShownRef.current = false;
-    const result = normalizeShifuDetail(
-      (await api.getShifuDetail({
-        shifu_bid: shifuId,
-      })) as Shifu,
-    );
+    setSettingsLoading(true);
+    try {
+      const result = normalizeShifuDetail(
+        (await api.getShifuDetail({
+          shifu_bid: shifuId,
+        })) as Shifu,
+      );
 
-    if (result) {
-      form.reset({
-        name: result.name,
-        description: result.description,
-        price: (result.price ?? 0).toFixed(2),
-        model: result.model || '',
-        temperature: result.temperature + '',
-        systemPrompt: result.system_prompt || '',
+      if (result) {
+        form.reset({
+          name: result.name,
+          description: result.description,
+          price: (result.price ?? 0).toFixed(2),
+          model: result.model || '',
+          temperature: result.temperature + '',
+          systemPrompt: result.system_prompt || '',
+        });
+        const rawAskProviderConfig =
+          result.ask_provider_config &&
+          typeof result.ask_provider_config === 'object' &&
+          !Array.isArray(result.ask_provider_config)
+            ? result.ask_provider_config
+            : {};
+        const rawAskProviderInnerConfig =
+          rawAskProviderConfig.config &&
+          typeof rawAskProviderConfig.config === 'object' &&
+          !Array.isArray(rawAskProviderConfig.config)
+            ? rawAskProviderConfig.config
+            : {};
+        setAskModel(result.ask_model || '');
+        setAskTemperature(result.ask_temperature ?? ASK_TEMPERATURE_MIN);
+        setAskTemperatureInput(
+          String(result.ask_temperature ?? ASK_TEMPERATURE_MIN),
+        );
+        setAskProvider(
+          (rawAskProviderConfig.provider || ASK_PROVIDER_LLM).toLowerCase(),
+        );
+        setAskProviderConfig(rawAskProviderInnerConfig);
+        setAskProviderObjectInputs({});
+        setAskPreviewLoading(false);
+        setAskPreviewQuery('');
+        setAskPreviewResult('');
+        setAskPreviewMeta(null);
+        setKeywords(result.keywords || []);
+        setUploadedImageUrl(result.avatar || '');
+        // Set TTS Configuration
+        setTtsEnabled(result.tts_enabled || false);
+        setTtsProvider((result.tts_provider || '').toLowerCase());
+        setTtsModel(result.tts_model || '');
+        setTtsVoiceId(result.tts_voice_id || '');
+        setTtsSpeed(result.tts_speed ?? 1.0);
+        setDefaultListenModeEnabled(
+          Boolean(result.tts_enabled && result.default_listen_mode_enabled),
+        );
+        setTtsSpeedInput(
+          result.tts_speed === null || result.tts_speed === undefined
+            ? ''
+            : String(result.tts_speed),
+        );
+        // Set Language Output Configuration
+        setUseLearnerLanguage(result.use_learner_language ?? false);
+      }
+    } catch (error) {
+      console.error('Failed to load shifu settings:', error);
+      toast({
+        title:
+          error instanceof Error
+            ? error.message
+            : t('common.core.unknownError'),
+        variant: 'destructive',
       });
-      const rawAskProviderConfig =
-        result.ask_provider_config &&
-        typeof result.ask_provider_config === 'object' &&
-        !Array.isArray(result.ask_provider_config)
-          ? result.ask_provider_config
-          : {};
-      const rawAskProviderInnerConfig =
-        rawAskProviderConfig.config &&
-        typeof rawAskProviderConfig.config === 'object' &&
-        !Array.isArray(rawAskProviderConfig.config)
-          ? rawAskProviderConfig.config
-          : {};
-      setAskModel(result.ask_model || '');
-      setAskTemperature(result.ask_temperature ?? ASK_TEMPERATURE_MIN);
-      setAskTemperatureInput(
-        String(result.ask_temperature ?? ASK_TEMPERATURE_MIN),
-      );
-      setAskProvider(
-        (rawAskProviderConfig.provider || ASK_PROVIDER_LLM).toLowerCase(),
-      );
-      setAskProviderConfig(rawAskProviderInnerConfig);
-      setAskProviderObjectInputs({});
-      setAskPreviewLoading(false);
-      setAskPreviewQuery('');
-      setAskPreviewResult('');
-      setAskPreviewMeta(null);
-      setKeywords(result.keywords || []);
-      setUploadedImageUrl(result.avatar || '');
-      // Set TTS Configuration
-      setTtsEnabled(result.tts_enabled || false);
-      setTtsProvider((result.tts_provider || '').toLowerCase());
-      setTtsModel(result.tts_model || '');
-      setTtsVoiceId(result.tts_voice_id || '');
-      setTtsSpeed(result.tts_speed ?? 1.0);
-      setTtsSpeedInput(
-        result.tts_speed === null || result.tts_speed === undefined
-          ? ''
-          : String(result.tts_speed),
-      );
-      // Set Language Output Configuration
-      setUseLearnerLanguage(result.use_learner_language ?? false);
+    } finally {
+      setSettingsLoading(false);
     }
   };
 
@@ -1429,6 +1454,12 @@ export default function ShifuSettingDialog({
         updateOpen(false);
         return true;
       }
+      if (settingsLoading) {
+        if (needClose) {
+          updateOpen(true);
+        }
+        return false;
+      }
       const isNameValid = await form.trigger('name');
       const isPriceValid = await form.trigger('price');
       if (!isPriceValid) {
@@ -1459,7 +1490,7 @@ export default function ShifuSettingDialog({
       await onSubmit(form.getValues(), needClose, saveType);
       return true;
     },
-    [form, onSubmit, updateOpen, t, currentShifu?.readonly],
+    [form, onSubmit, updateOpen, t, currentShifu?.readonly, settingsLoading],
   );
 
   useEffect(() => {
@@ -1957,12 +1988,30 @@ export default function ShifuSettingDialog({
                     <Switch
                       checked={ttsEnabled}
                       onCheckedChange={setTtsEnabled}
-                      disabled={currentShifu?.readonly}
+                      disabled={currentShifu?.readonly || settingsLoading}
                     />
                   </div>
 
                   {ttsEnabled && (
                     <>
+                      <div className='flex items-start justify-between mb-4'>
+                        <div className='space-y-1 pr-4'>
+                          <FormLabel className='text-sm font-medium text-foreground'>
+                            {t('module.shifuSetting.defaultListenModeTitle')}
+                          </FormLabel>
+                          <p className='text-xs text-muted-foreground'>
+                            {t(
+                              'module.shifuSetting.defaultListenModeDescription',
+                            )}
+                          </p>
+                        </div>
+                        <Switch
+                          checked={defaultListenModeEnabled}
+                          onCheckedChange={setDefaultListenModeEnabled}
+                          disabled={currentShifu?.readonly || settingsLoading}
+                        />
+                      </div>
+
                       {/* Model Selection */}
                       <div className='space-y-2 mb-4'>
                         <FormLabel className='text-sm font-medium text-foreground'>

--- a/src/i18n/en-US/modules/shifu-setting.json
+++ b/src/i18n/en-US/modules/shifu-setting.json
@@ -110,6 +110,8 @@
   "askTemperatureHint": "Control how varied follow-up answers can be (0-2, 0 is recommended)",
   "askTitle": "Learner follow-up settings",
   "debugDisabledBySoftLimit": "Credit balance is below the reminder threshold. Debug preview is disabled.",
+  "defaultListenModeDescription": "When enabled, learners start this course in listen mode by default",
+  "defaultListenModeTitle": "Open in listen by default",
   "draftConflictDescription": "This course was updated by {phone}. Load the latest content to continue editing safely.",
   "draftConflictRefresh": "Load latest",
   "draftConflictSynced": "This lesson was updated by {phone}. Synced the latest content.",

--- a/src/i18n/fr-FR/modules/shifu-setting.json
+++ b/src/i18n/fr-FR/modules/shifu-setting.json
@@ -110,6 +110,8 @@
   "askTemperatureHint": "Contrôler la variété des réponses aux questions (0-2, 0 est recommandé)",
   "askTitle": "Questions des apprenants",
   "debugDisabledBySoftLimit": "Le solde de crédits est sous le seuil d’alerte. La prévisualisation de débogage est désactivée.",
+  "defaultListenModeDescription": "Une fois activé, les apprenants commencent ce cours en mode écoute par défaut",
+  "defaultListenModeTitle": "Ouvrir en écoute par défaut",
   "draftConflictDescription": "Ce cours a été mis à jour par {phone}. Chargez le contenu le plus récent pour continuer à modifier en sécurité.",
   "draftConflictRefresh": "Charger la dernière version",
   "draftConflictSynced": "Cette leçon a été mise à jour par {phone}. Le contenu le plus récent a été synchronisé.",

--- a/src/i18n/zh-CN/modules/shifu-setting.json
+++ b/src/i18n/zh-CN/modules/shifu-setting.json
@@ -110,6 +110,8 @@
   "askTemperatureHint": "控制回答问题的发散程度（取值范围 0-2，建议用 0）",
   "askTitle": "追问的知识来源",
   "debugDisabledBySoftLimit": "积分余额已低于提醒阈值，暂不能使用调试预览。",
+  "defaultListenModeDescription": "开启后，学员默认进入听课模式学习",
+  "defaultListenModeTitle": "默认进入听课",
   "draftConflictDescription": "课程已被 {phone} 修改，请加载最新内容获取最新记录",
   "draftConflictRefresh": "加载最新内容",
   "draftConflictSynced": "该章节已被 {phone} 更新，已同步最新内容。",


### PR DESCRIPTION
## Summary

Reintroduces the course setting that lets teachers choose listen mode as the learner default when TTS is enabled. Learner mode resolution now keeps URL overrides first, then stored user choice, then the teacher default, and finally the system default read mode. The branch also adds backend persistence, API fields, a migration based on the current main migration head, and focused regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shifu setting to open courses in listening mode by default.
  * The option is available when text-to-speech is enabled and is preserved when publishing courses.
  * Learners now start in listening mode when configured, while existing preferences and overrides remain respected.
  * Added localized setting labels and descriptions in English, French, and Simplified Chinese.

* **Bug Fixes**
  * Prevented listening mode from remaining enabled when text-to-speech is disabled.
  * Improved handling of course information loading after the page is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->