### PR TITLE
fix: resolve latent bug patterns flagged by ruff bugbear and pylint rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -69,9 +69,13 @@ select = [
     "YTT",     # sys.version checks that break on two-digit versions
     # Mechanical, behavior-preserving cleanups; each was applied repo-wide
     # with `ruff check --fix` in the commit that selected it here.
+    "B006",    # mutable default argument value
     "B007",    # loop control variable not used in the loop body
     "B009",    # getattr with a constant attribute name
     "B010",    # setattr with a constant attribute name
+    "B023",    # closure that captures a loop variable by reference
+    "B026",    # star-arg unpacking after a keyword argument
+    "B035",    # dict comprehension with a static key
     "B905",    # zip() without an explicit strict argument
     "C4",      # comprehension and collection-literal simplifications
     "D202",    # blank line after a function docstring
@@ -98,6 +102,8 @@ select = [
     "PLR1",    # useless return, repeated comparison, manual min()/max()
     "PLR5",    # else: if ... that should be elif
     "PLW0108", # lambda that only forwards its arguments
+    "PLW0127", # self-assignment of a variable
+    "PLW0602", # global declaration without assignment
     "PLW3",    # nested min/max calls
     "PT001",   # pytest.fixture with empty parentheses
     "PT006",   # wrong type for parametrize argument names

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -143,8 +143,6 @@ def get_tts_provider(provider_name: str = "") -> BaseTTSProvider:
         ValueError: If no configured provider is available
 
     """
-    global _provider_instances
-
     provider_name = _resolve_provider_name(provider_name)
 
     # Get or create provider instance

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -669,8 +669,6 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
 
     Token is cached and refreshed when expired.
     """
-    global _token_cache
-
     # Check cache
     current_time = time.time()
     if _token_cache["access_token"] and _token_cache["expires_at"] > current_time + 300:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -311,11 +311,11 @@ class FallbackCacheProvider:
             "set",
             key,
             value,
+            *args,
             ex=ex,
             px=px,
             nx=nx,
             xx=xx,
-            *args,
             **kwargs,
         )
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2082,7 +2082,7 @@ __ENHANCED_CONFIG__ = EnhancedConfig(ENV_VARS)
 class Config(FlaskConfig):
     """Flask configuration wrapper with enhanced environment variable support."""
 
-    def __init__(self, parent: FlaskConfig, app: Flask, defaults: dict = {}):
+    def __init__(self, parent: FlaskConfig, app: Flask, defaults: dict | None = None):
         global __INSTANCE__
         self.parent = parent
         self.app = app

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2336,8 +2336,6 @@ class RunScriptContextV2:
         app.logger.info(f"ask_input: {ask_input}")
         if isinstance(ask_input, dict):
             ask_input = ask_input.get("input", "")
-        else:
-            ask_input = ask_input
         if isinstance(ask_input, list):
             ask_input = ",".join(ask_input)
         app.logger.info(f"ask_input: {ask_input}")

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1047,9 +1047,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         is_favorite = request.get_json().get("is_favorite")
         if isinstance(is_favorite, str):
             is_favorite = is_favorite.lower() == "true"
-        elif isinstance(is_favorite, bool):
-            is_favorite = is_favorite
-        else:
+        elif not isinstance(is_favorite, bool):
             raise_param_error("is_favorite is not a boolean")
         return make_common_response(
             mark_or_unmark_favorite_shifu(app, user_id, shifu_bid, is_favorite)

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -866,9 +866,11 @@ def test_get_biji_knowledge_adapter_maps_business_errors_to_user_messages(
         monkeypatch.setattr(
             get_biji_knowledge_adapter.requests,
             "post",
-            lambda *_args, **_kwargs: _FakeResponse(
-                status_code=status_code,
-                json_data={"success": False, "data": None, "error": error_body},
+            lambda *_args, status_code=status_code, error_body=error_body, **_kwargs: (
+                _FakeResponse(
+                    status_code=status_code,
+                    json_data={"success": False, "data": None, "error": error_body},
+                )
             ),
         )
 

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -123,7 +123,7 @@ def test_provider_config_exposes_two_model_tiers_with_tagged_voices():
     large_voices = [
         voice for voice in cfg.voices if voice["resource_id"] == "large-model"
     ]
-    assert {"value": v["value"] for v in premium_voices}  # non-empty
+    assert premium_voices  # non-empty
     assert all(v["value"].startswith("101") for v in premium_voices)
     assert all(v["value"][:3] in {"501", "601"} for v in large_voices)
 


### PR DESCRIPTION
# Summary

Enables six ruff rules that catch real bug-risk patterns — `B006` (mutable default argument), `B023` (closure capturing a loop variable), `B026` (star-arg unpacking after keyword arguments), `B035` (static-key dict comprehension), `PLW0127` (self-assignment), `PLW0602` (global declaration without assignment) — in `ruff.toml` and fixes all existing findings:

- `Config.__init__` in `flaskr/common/config.py`: `defaults: dict = {}` → `defaults: dict | None = None` (the parameter is never read, so no None-guard is needed)
- `flaskr/common/cache_provider.py`: moved `*args` before the keyword arguments in the `set` wrapper's `self._call(...)` call
- `tests/service/learn/test_ask_provider_adapters.py`: bound `status_code`/`error_body` as lambda default arguments so each loop iteration's fake response keeps its own values
- `tests/service/tts/test_tencent_texttovoice_provider.py`: `assert {"value": v["value"] for v in premium_voices}` → `assert premium_voices`
- `flaskr/service/learn/context_v2.py` and `flaskr/service/shifu/route.py`: removed `x = x` self-assignment dead code (the shifu route keeps its bool-validation branch via `elif not isinstance(is_favorite, bool)`)
- `flaskr/api/tts/__init__.py` and `flaskr/api/tts/baidu_provider.py`: dropped `global` declarations for `_provider_instances` / `_token_cache`, which are only mutated in place, never rebound

Part of the ongoing ruff cleanup (round 4, bottom of a 3-PR stack). Verified with `ruff check`, `ruff format --check`, `lefthook run pre-commit --all-files`, and the backend test suites for the touched modules.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly lint enforcement and dead-code removal; the cache `set` argument order fix is the only functional change in production code and aligns forwarding with other cache providers.
> 
> **Overview**
> Turns on six ruff rules in `ruff.toml` (**B006**, **B023**, **B026**, **B035**, **PLW0127**, **PLW0602**) and clears existing violations with small, behavior-preserving edits.
> 
> **Config & cache:** `Config.__init__` no longer uses a mutable `{}` default for `defaults` (`dict | None = None`; the arg is unused today). `FallbackCacheProvider.set` forwards `*args` before keyword args so the Redis/in-memory `set` wrappers receive positional expiry args correctly.
> 
> **Runtime cleanup:** Removes no-op `global` lines in TTS provider/token helpers (in-place dict updates only), dead self-assignments in learn `context_v2` and shifu favorite handling (bool validation unchanged via `elif not isinstance(...)`), and tightens a Tencent TTS test assertion.
> 
> **Tests:** Ask-provider error tests bind loop variables as lambda defaults so each iteration’s mocked HTTP status/body stays distinct (fixes **B023**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad1dd32ef3c0ff99066fcd9d92e9a30a59fc5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->