### PR TITLE
style: apply mechanical ruff cleanups for datetime parsing, subprocess, and enums

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -90,12 +90,14 @@ select = [
     "FLY",     # static str.join that should be an f-string
     "FURB11",  # conditional expression that should be or
     "FURB13",  # if-expression that should be min()/max()
+    "FURB162", # unnecessary Z-offset replacement before fromisoformat
     "FURB17",  # membership test against a single-item container
     "FURB18",  # list reversal via slicing, manual prefix/suffix stripping
     "FURB19",  # sorted() only to take the first item
     "LOG",     # flake8-logging (exc_info must name the exception outside except blocks)
     "PERF1",   # dict.items() when only one half is used
     "PIE",     # flake8-pie (redundant placeholders, dict kwargs, startswith)
+    "PLC0206", # dict iteration that extracts values by key lookup
     "PLC0207", # str.split without maxsplit when one segment is used
     "PLC0208", # iteration over a set literal
     "PLC0414", # import alias that repeats the name
@@ -104,6 +106,7 @@ select = [
     "PLW0108", # lambda that only forwards its arguments
     "PLW0127", # self-assignment of a variable
     "PLW0602", # global declaration without assignment
+    "PLW1510", # subprocess.run without an explicit check argument
     "PLW3",    # nested min/max calls
     "PT001",   # pytest.fixture with empty parentheses
     "PT006",   # wrong type for parametrize argument names
@@ -130,11 +133,13 @@ select = [
     "SIM3",    # yoda condition
     "SIM4",    # if-else block instead of dict.get
     "SIM9",    # dict.get(key, None)
+    "TRY203",  # exception handler that only re-raises
     "UP01",    # redundant str.encode/open() arguments
     "UP02",    # capture_output, deprecated OSError alias, yield from
     "UP031",   # percent formatting that should be str.format
     "UP032",   # str.format that should be an f-string
     "UP034",   # extraneous parentheses
+    "UP042",   # str-and-Enum class that should be StrEnum
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -81,6 +81,7 @@ def _hooks_dir() -> Path | None:
             cwd=ROOT,
             capture_output=True,
             text=True,
+            check=False,
         )
         if configured.returncode == 0 and configured.stdout.strip():
             # git config values may use ~ / ~user; Path() does not expand it.

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -65,11 +65,7 @@ def _safe_asyncio_run(coro, *args, **kwargs):
         if "cannot be called from a running event loop" not in message:
             # Preserve original behaviour for unrelated errors.
             raise
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # No running loop available, re-raise the original error.
-            raise
+        loop = asyncio.get_running_loop()
         try:
             loop.create_task(coro)
         except Exception:

--- a/src/api/flaskr/api/tts/base.py
+++ b/src/api/flaskr/api/tts/base.py
@@ -7,11 +7,11 @@ used interchangeably.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Dict, List, Optional
 
 
-class TTSProvider(str, Enum):
+class TTSProvider(StrEnum):
     """Supported TTS providers."""
 
     MINIMAX = "minimax"

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -24,7 +24,7 @@ def enable_plugins(app: Flask):
         dest_dir = os.path.join("flaskr", "plugins", repo_name)
         if os.path.exists(dest_dir):
             return
-        subprocess.run(["git", "clone", repo_url, dest_dir])
+        subprocess.run(["git", "clone", repo_url, dest_dir], check=False)
 
     @plugin.command(name="delete")
     @click.argument("repo_name")

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -79,7 +79,7 @@ def register_order_handler(app: Flask, path_prefix: str):
             except ValueError:
                 continue
         try:
-            parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(normalized)
         except ValueError:
             raise_param_error(field_name)
         if parsed.tzinfo is not None:

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -1236,7 +1236,7 @@ def _format_sms_datetime(app: Flask, value: Any) -> str:
         if not raw_value:
             return ""
         try:
-            resolved = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+            resolved = datetime.fromisoformat(raw_value)
         except ValueError:
             return raw_value
     return str(format_with_app_timezone(app, resolved, "%Y-%m-%d %H:%M:%S") or "")

--- a/src/api/flaskr/service/billing/primitives.py
+++ b/src/api/flaskr/service/billing/primitives.py
@@ -162,7 +162,7 @@ def coerce_datetime(value: Any) -> datetime | None:
             return None
         return datetime.fromtimestamp(epoch_seconds, UTC).replace(tzinfo=None)
     try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(text)
     except ValueError:
         return None
     if parsed.tzinfo is not None:

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -26,8 +26,8 @@ def register_dict(name, desp, items: dict):
     if name in DICTS:
         return
     dictItems = []
-    for key in items:
-        dictItems.append(DictItem(key, items[key]))
+    for key, value in items.items():
+        dictItems.append(DictItem(key, value))
     DICTS[name] = Dict(name, desp, dictItems)
 
 

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -218,7 +218,7 @@ def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
         except ValueError:
             continue
     try:
-        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return None
     if parsed.tzinfo is not None:

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -357,7 +357,7 @@ def _parse_datetime(value: object, field_name: str) -> datetime | None:
         except ValueError:
             continue
     try:
-        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         raise_param_error(field_name)
     if parsed.tzinfo is not None:

--- a/src/api/flaskr/service/referral/reward_queue.py
+++ b/src/api/flaskr/service/referral/reward_queue.py
@@ -54,7 +54,7 @@ def _parse_metadata_datetime(value: Any) -> datetime | None:
     if not normalized:
         return None
     try:
-        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return None
     return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -158,7 +158,7 @@ def _parse_datetime_filter(
         except ValueError:
             continue
     try:
-        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         raise_param_error(field_name)
     if parsed.tzinfo is not None:

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -50,7 +50,7 @@ def grep_paths(root, extra_args=None):
         return set()
     # no quote anchoring: f-strings like f"{base}/api/x/{bid}/export" must hit
     cmd = ["grep", "-rhoE", r"/api/[^'\"`[:space:]]*", root]
-    out = subprocess.run(cmd, capture_output=True, text=True).stdout
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False).stdout
     paths = set()
     for line in out.splitlines():
         p = line.strip().rstrip(".,;:)]}")


### PR DESCRIPTION
# Summary

Enables five behavior-preserving ruff rules — `FURB162`, `PLC0206`, `PLW1510`, `TRY203`, `UP042` — in `ruff.toml` and fixes all existing findings:

- `FURB162` (7 files): dropped redundant `.replace("Z", "+00:00")` before `datetime.fromisoformat(...)` — the `Z` suffix is parsed natively since Python 3.11 (target-version is pinned to py311)
- `PLW1510` (3 call sites): added explicit `check=False` to `subprocess.run` calls in `scripts/check_dev_tools.py` (inspects `returncode` itself), `flaskr/framework/plugin/enable_plugin.py`, and `src/api/scripts/inventory/match_routes.py` (grep exits non-zero on no match by design) — `check=False` is the current implicit behavior, so nothing changes at runtime
- `PLC0206`: `register_dict` in `flaskr/service/common/dicts.py` now iterates `items.items()` instead of re-looking up each key
- `TRY203`: removed a `try/except RuntimeError: raise` wrapper around `asyncio.get_running_loop()` in `flaskr/api/llm/__init__.py` — the exception propagates identically without the handler
- `UP042`: `TTSProvider(str, Enum)` → `TTSProvider(StrEnum)` in `flaskr/api/tts/base.py`

Part of the ongoing ruff cleanup (round 4, middle of a 3-PR stack; based on the B-rules PR). Verified with `ruff check`, `ruff format --check`, `lefthook run pre-commit --all-files`, and the backend test suites for billing, order, referral, common, tts, and api modules.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical lint-driven edits with no intended behavior change; datetime parsing relies on py311 `fromisoformat` Z support already assumed by the project.
> 
> **Overview**
> Adds **FURB162**, **PLC0206**, **PLW1510**, **TRY203**, and **UP042** to `ruff.toml` and fixes all current violations repo-wide.
> 
> **ISO datetimes:** Seven call sites stop rewriting `Z` to `+00:00` before `datetime.fromisoformat` (billing, orders, referral, admin routes, etc.); Python 3.11 parses `Z` directly, matching the pinned target version.
> 
> **Subprocess:** Three `subprocess.run` calls get explicit `check=False` where return codes are handled manually or non-zero exit is expected (`check_dev_tools`, plugin `git clone`, route-inventory grep).
> 
> **Other cleanups:** `register_dict` iterates `items.items()` instead of key re-lookup; `TTSProvider` becomes `StrEnum`; the redundant `try/except` around `asyncio.get_running_loop()` in the LiteLLM `asyncio.run` patch is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d72025149c1e99fd6b668500748bbca236f320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->