### PR TITLE
style: enforce pytest import and raises-match conventions in tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -111,6 +111,7 @@ select = [
     "PT001",   # pytest.fixture with empty parentheses
     "PT006",   # wrong type for parametrize argument names
     "PT009",   # unittest-style assertion that should be a plain assert
+    "PT013",   # pytest imported with an alias or from-import
     "PT018",   # composite assertion
     "PT02",    # fixture yielding without teardown, unittest-style assertRaises
     "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)
@@ -122,6 +123,7 @@ select = [
     "RUF013",  # implicit Optional annotation
     "RUF02",   # unparenthesized and inside or, unsorted __all__/__slots__
     "RUF03",   # None not at the end of a union
+    "RUF043",  # pytest.raises match pattern with unescaped metacharacters
     "RUF046",  # unnecessary int() cast around an int-returning call
     "RUF102",  # noqa directive naming an unknown rule
     "SIM103",  # condition returned as True/False branches

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import hmac
 import json
+import re
 
 import pytest
 
@@ -379,7 +380,7 @@ def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch):
 
     with pytest.raises(
         ValueError,
-        match="Tencent TTS error InvalidParameter.Voice",
+        match=re.escape("Tencent TTS error InvalidParameter.Voice"),
     ):
         list(
             tencent_provider.TencentTTSProvider().stream_synthesize(

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -38,10 +38,10 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
         repo_module.db.session, "begin_nested", lambda: nested, raising=False
     )
 
-    import pytest as _pytest
+    import pytest
 
     # Desync inside the body: invalidate only, savepoint untouched.
-    with _pytest.raises(ResourceClosedError):
+    with pytest.raises(ResourceClosedError):
         with repo_module.transactional_session():
             raise ResourceClosedError("desynced")
     assert events == [("invalidate", "transactional_session desync")]
@@ -49,7 +49,7 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     events.clear()
 
     # Ordinary error: savepoint rollback then classified session cleanup.
-    with _pytest.raises(ValueError):
+    with pytest.raises(ValueError):
         with repo_module.transactional_session():
             raise ValueError("business")
     assert events == [("cleanup", "transactional_session")]


### PR DESCRIPTION
# Summary

Enables two test-hygiene ruff rules — `PT013` (pytest must be imported as `import pytest`) and `RUF043` (`pytest.raises(match=...)` patterns with metacharacters must be escaped or raw) — in `ruff.toml` and fixes the two existing findings:

- `tests/service/user/test_user_repository.py`: the function-local `import pytest as _pytest` loses its alias (`_pytest.raises` → `pytest.raises`); the import stays local to match the file's style
- `tests/service/tts/test_tencent_provider.py`: `match="Tencent TTS error InvalidParameter.Voice"` → `match=re.escape(...)` so the dot is asserted literally instead of matching any character

Part of the ongoing ruff cleanup (round 4, top of a 3-PR stack). Verified with `ruff check`, `ruff format --check`, `lefthook run pre-commit --all-files`, and the two touched test files.

Link to Devin session: https://app.devin.ai/sessions/8e5e0780db54419590888e7ff33145b0
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule additions and test-only assertion/import tweaks with no production code changes.
> 
> **Overview**
> Turns on **`PT013`** (pytest must be imported as `import pytest`, not aliased) and **`RUF043`** (`pytest.raises(match=...)` must not use unescaped regex metacharacters) in `ruff.toml`, and fixes the two existing violations.
> 
> In `test_user_repository.py`, the in-test `import pytest as _pytest` becomes `import pytest` with `pytest.raises` unchanged in behavior. In `test_tencent_provider.py`, the Tencent error assertion uses `match=re.escape("Tencent TTS error InvalidParameter.Voice")` so the dot in `InvalidParameter.Voice` is matched literally instead of as “any character.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68661385c3feeaae919637bbb1c8f855961f0dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->