### PR TITLE
test: assert concrete AppException instead of bare Exception

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -73,6 +73,7 @@ select = [
     "B007",    # loop control variable not used in the loop body
     "B009",    # getattr with a constant attribute name
     "B010",    # setattr with a constant attribute name
+    "B017",    # pytest.raises(Exception) that should name a concrete type
     "B023",    # closure that captures a loop variable by reference
     "B026",    # star-arg unpacking after a keyword argument
     "B035",    # dict comprehension with a static key

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -5,6 +5,7 @@ import json
 import re
 
 import pytest
+from flaskr.service.common.models import AppException
 
 
 class _FakeSSEStreamingResponse:
@@ -170,7 +171,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     assert validated.provider == "tencent"
     assert validated.model == ""
 
-    with pytest.raises(Exception):
+    with pytest.raises(AppException):
         validate_tts_settings_strict(
             provider="tencent",
             model="",

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from flaskr.dao import db
+from flaskr.service.common.models import AppException
 from flaskr.service.profile.models import VariableValue
 from flaskr.service.user.repository import create_user_entity
 
@@ -71,7 +72,7 @@ def test_profile_onboarding_config_rejects_non_whitelisted_variable(app):
         update_profile_onboarding_config,
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(AppException):
         update_profile_onboarding_config(
             app,
             payload={


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 2/11. Base: `cursor/ruff-ruf006-453b` (#2463).

Two tests used `pytest.raises(Exception)`, which also passes on unexpected errors. Both call sites raise `AppException` (`raise_error_with_args` / `raise_param_error`).

This names `AppException` and enables ruff `B017`.

## Stack

1. #2463 RUF006
2. **this PR** — B017
3. PT017 pytest-assert-in-except
4. SIM115 open-file-with-context-handler
5. B904 raise-without-from-inside-except
6. UP037 quoted-annotation
7. UP007 non-pep604-annotation-union
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

