### PR TITLE
test: assert expected exceptions with pytest.raises

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -113,6 +113,7 @@ select = [
     "PT006",   # wrong type for parametrize argument names
     "PT009",   # unittest-style assertion that should be a plain assert
     "PT013",   # pytest imported with an alias or from-import
+    "PT017",   # assertion on an exception captured in an except block
     "PT018",   # composite assertion
     "PT02",    # fixture yielding without teardown, unittest-style assertRaises
     "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -313,14 +313,10 @@ def test_audit_credit_state_rejects_invalid_explicit_as_of(
     billing_credit_audit_app: Flask,
 ) -> None:
     with billing_credit_audit_app.app_context():
-        try:
+        with pytest.raises(ValueError, match="Unable to parse as_of value"):
             audit_credit_state(
                 creator_bid="creator-audit-invalid-time", as_of="bad-date"
             )
-        except ValueError as exc:
-            assert "Unable to parse as_of value" in str(exc)
-        else:
-            raise AssertionError("Expected invalid as_of to raise ValueError")
 
     runner = billing_credit_audit_app.test_cli_runner()
     result = runner.invoke(

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import AppException
@@ -870,12 +871,9 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
         with patch(
             "flaskr.service.shifu.admin._load_latest_shifu_seeds"
         ) as latest_mock:
-            try:
+            with pytest.raises(AppException) as excinfo:
                 list_operator_courses(app, 1, 20, {"quick_filter": "invalid"})
-            except AppException as exc:
-                assert exc.code is not None
-            else:
-                raise AssertionError("Expected AppException for invalid quick_filter")
+            assert excinfo.value.code is not None
 
     overview_mock.assert_not_called()
     latest_mock.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 3/11. Base: `cursor/ruff-b017-453b` (#2464).

Credit-audit and operator-course tests asserted on exceptions inside `except` blocks. This rewrites them as `pytest.raises(...)` and enables ruff `PT017`.

## Stack

1. #2463 RUF006
2. #2464 B017
3. **this PR** — PT017
4. SIM115 open-file-with-context-handler
5. B904 raise-without-from-inside-except
6. UP037 quoted-annotation
7. UP007 non-pep604-annotation-union
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

