### PR TITLE
style: open inventory files with context managers

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -133,6 +133,7 @@ select = [
     "SIM105",  # try-except-pass that should be contextlib.suppress
     "SIM108",  # if-else assignment that should be a ternary
     "SIM114",  # if branches with identical bodies
+    "SIM115",  # open() without a context manager
     "SIM118",  # key in dict.keys()
     "SIM2",    # redundant True/False and twisted conditional expressions
     "SIM3",    # yoda condition

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -37,8 +37,9 @@ for base in ("flaskr/route", "flaskr/service", "flaskr/common"):
         for fn in filenames:
             if fn.endswith(".py"):
                 p = os.path.join(dirpath, fn)
-                if ".route(" in open(p, encoding="utf-8").read():
-                    route_files.append(os.path.relpath(p, ROOT))
+                with open(p, encoding="utf-8") as route_file:
+                    if ".route(" in route_file.read():
+                        route_files.append(os.path.relpath(p, ROOT))
 
 results = []
 
@@ -123,7 +124,8 @@ def collect_routes(scope_body, env, rel):
 
 
 for rel in sorted(route_files):
-    src = open(os.path.join(ROOT, rel), encoding="utf-8").read()
+    with open(os.path.join(ROOT, rel), encoding="utf-8") as route_file:
+        src = route_file.read()
     tree = ast.parse(src)
     for fn in tree.body:
         if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -57,7 +57,8 @@ for top in ("app.py", "celery_app.py"):
 edges = defaultdict(set)
 for name, rel in mods.items():
     try:
-        tree = ast.parse(open(os.path.join(ROOT, rel), encoding="utf-8").read())
+        with open(os.path.join(ROOT, rel), encoding="utf-8") as source_file:
+            tree = ast.parse(source_file.read())
     except SyntaxError as e:
         print(f"SYNTAX ERROR {rel}: {e}", file=sys.stderr)
         continue

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -68,7 +68,11 @@ surfaces = {}
 
 # --- cook-web ---------------------------------------------------------------
 fe = set()
-cat = open(os.path.join(ROOT, "src/cook-web/src/api/api.ts"), encoding="utf-8").read()
+cat = None
+with open(
+    os.path.join(ROOT, "src/cook-web/src/api/api.ts"), encoding="utf-8"
+) as catalog_file:
+    cat = catalog_file.read()
 for m in re.finditer(
     r"'(GET|POST|PUT|DELETE|PATCH|STREAM|STREAMLINE|PROXY)\s+([^']+)'", cat
 ):
@@ -84,7 +88,8 @@ cli = grep_paths(SKILLS)
 # relative paths in shifu-cli.py are joined onto /api/shifu
 cli_file = os.path.join(SKILLS, "skills/ai-shifu-course-creator/scripts/shifu-cli.py")
 if os.path.exists(cli_file):
-    src = open(cli_file, encoding="utf-8").read()
+    with open(cli_file, encoding="utf-8") as cli_source:
+        src = cli_source.read()
     for m in re.finditer(
         r"""["'](/(?:shifus|upfile|url-upfile|mdflow)[^"']*)["']""", src
     ):
@@ -96,14 +101,15 @@ surfaces["miniprogram"] = grep_paths(MINIAPP)
 
 # --- backend routes ----------------------------------------------------------
 be = []
-for line in open(BACKEND_ROUTES, encoding="utf-8"):
-    if line.startswith("#"):
-        continue
-    mm = re.match(r"(\S+)\s+(\S+)\s+\[(.*)\]", line.strip())
-    if not mm:
-        continue
-    method, path, src = mm.groups()
-    be.append((method, path, norm(path), src))
+with open(BACKEND_ROUTES, encoding="utf-8") as backend_routes:
+    for line in backend_routes:
+        if line.startswith("#"):
+            continue
+        mm = re.match(r"(\S+)\s+(\S+)\s+\[(.*)\]", line.strip())
+        if not mm:
+            continue
+        method, path, src = mm.groups()
+        be.append((method, path, norm(path), src))
 
 
 def match(be_segs, fe_segs):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 4/11. Base: `cursor/ruff-pt017-453b` (#2465).

The backend inventory scripts opened files without a context manager. This wraps those `open()` calls in `with` and enables ruff `SIM115`.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. **this PR** — SIM115
5. B904 raise-without-from-inside-except
6. UP037 quoted-annotation
7. UP007 non-pep604-annotation-union
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

