### PR TITLE
fix: chain wrapped exceptions with raise from

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -77,6 +77,7 @@ select = [
     "B023",    # closure that captures a loop variable by reference
     "B026",    # star-arg unpacking after a keyword argument
     "B035",    # dict comprehension with a static key
+    "B904",    # raise inside except without from
     "B905",    # zip() without an explicit strict argument
     "C4",      # comprehension and collection-literal simplifications
     "D202",    # blank line after a function docstring

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -145,4 +145,4 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
     except URLError:
         raise
     except OSError as err:
-        raise URLError(err)
+        raise URLError(err) from err

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1381,11 +1381,11 @@ class AliyunTTSProvider(BaseTTSProvider):
             except ValueError as e:
                 if "Aliyun TTS API error" in str(e):
                     raise
-                raise ValueError(f"Aliyun TTS API error: {response.text[:200]}")
+                raise ValueError(f"Aliyun TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
             logger.error(f"Aliyun TTS request failed: {e}")
-            raise ValueError(f"Aliyun TTS request failed: {e}")
+            raise ValueError(f"Aliyun TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:
         """Get Aliyun provider configuration for frontend."""

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -702,7 +702,7 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
 
     except requests.RequestException as e:
         logger.error(f"Failed to get Baidu access token: {e}")
-        raise ValueError(f"Failed to get Baidu access token: {e}")
+        raise ValueError(f"Failed to get Baidu access token: {e}") from e
 
 
 # Frontend-formatted voice list
@@ -910,12 +910,12 @@ class BaiduTTSProvider(BaseTTSProvider):
                 error_code = result.get("err_no", "unknown")
                 error_msg = result.get("err_msg", "Unknown error")
                 raise ValueError(f"Baidu TTS API error {error_code}: {error_msg}")
-            except ValueError:
-                raise ValueError(f"Baidu TTS API error: {response.text[:200]}")
+            except ValueError as e:
+                raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
             logger.error(f"Baidu TTS request failed: {e}")
-            raise ValueError(f"Baidu TTS request failed: {e}")
+            raise ValueError(f"Baidu TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:
         """Get Baidu provider configuration for frontend."""

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -358,9 +358,11 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             body = response.json()
         except requests.RequestException as exc:
             logger.error("Tencent TextToVoice request failed: %s", exc)
-            raise ValueError(f"Tencent TextToVoice request failed: {exc}")
+            raise ValueError(f"Tencent TextToVoice request failed: {exc}") from exc
         except ValueError as exc:
-            raise ValueError(f"Tencent TextToVoice returned invalid JSON: {exc}")
+            raise ValueError(
+                f"Tencent TextToVoice returned invalid JSON: {exc}"
+            ) from exc
 
         result = body.get("Response") or {}
         error = result.get("Error")
@@ -397,8 +399,10 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
         )
         try:
             voice_type = int(voice_id)
-        except (TypeError, ValueError):
-            raise ValueError(f"Invalid Tencent TextToVoice voice id: {voice_id}")
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid Tencent TextToVoice voice id: {voice_id}"
+            ) from exc
 
         sample_rate = _resolve_sample_rate(voice_id, model)
         speed = float(voice_settings.speed or 0)

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -162,7 +162,7 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.error(f"Migration failed: {e}")
-            raise click.ClickException(f"Migration failed: {e}")
+            raise click.ClickException(f"Migration failed: {e}") from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -217,7 +217,7 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.error(f"Verification failed: {e}")
-            raise click.ClickException(f"Verification failed: {e}")
+            raise click.ClickException(f"Verification failed: {e}") from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -301,7 +301,7 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.error(f"Status check failed: {e}")
-            raise click.ClickException(f"Status check failed: {e}")
+            raise click.ClickException(f"Status check failed: {e}") from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -334,7 +334,7 @@ def enable_commands(app: Flask):
                 )
         except Exception as e:
             click.echo(click.style(f"❌ Export failed: {e}", fg="red"))
-            raise click.ClickException(f"Export failed: {e}")
+            raise click.ClickException(f"Export failed: {e}") from e
 
     @console.command(name="import_shifu")
     @click.argument("file_path")
@@ -396,7 +396,7 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             click.echo(click.style(f"❌ Import failed: {e}", fg="red"))
-            raise click.ClickException(f"Import failed: {e}")
+            raise click.ClickException(f"Import failed: {e}") from e
 
     @console.command(name="update_demo_shifu")
     def update_demo_shifu_command():

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -450,7 +450,9 @@ class UnifiedMigrationTask:
                     if (
                         error_count > self.config.batch_size * 0.5
                     ):  # If more than 50% errors
-                        raise Exception(f"Too many errors in batch: {error_count}")
+                        raise Exception(
+                            f"Too many errors in batch: {error_count}"
+                        ) from e
 
             # Commit the batch
             session.commit()

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -59,17 +59,17 @@ class EnvVar:
         if self.type is int:
             try:
                 return int(value)
-            except ValueError:
+            except ValueError as exc:
                 raise EnvironmentConfigError(
                     f"Invalid integer value for {self.name}: {value}"
-                )
+                ) from exc
         elif self.type is float:
             try:
                 return float(value)
-            except ValueError:
+            except ValueError as exc:
                 raise EnvironmentConfigError(
                     f"Invalid float value for {self.name}: {value}"
-                )
+                ) from exc
         elif self.type is list:
             if isinstance(value, str):
                 return [item.strip() for item in value.split(",") if item.strip()]

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -110,7 +110,7 @@ def _decrypt_config(app: Flask, encrypted_value: str) -> str:
             decrypted_value = fernet.decrypt(encrypted_value.encode())
             return decrypted_value.decode()
         except Exception as e:
-            raise ValueError(f"Failed to decrypt config value: {e!s}")
+            raise ValueError(f"Failed to decrypt config value: {e!s}") from e
 
 
 def _get_config_cache_key(app: Flask, key: str) -> str:

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -35,4 +35,6 @@ def load_prompt_template(template_name: str) -> str:
         with open(template_path, encoding="utf-8") as f:
             return f.read()
     except Exception as e:
-        raise OSError(f"Failed to read prompt template file {template_path}: {e!s}")
+        raise OSError(
+            f"Failed to read prompt template file {template_path}: {e!s}"
+        ) from e


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 5/11. Base: `cursor/ruff-sim115-453b` (#2466).

Several `except` handlers wrapped the original error in a new exception without `raise ... from`. That hides the cause in tracebacks.

This chains those re-wraps and enables ruff `B904`.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. #2466 SIM115
5. **this PR** — B904
6. UP037 quoted-annotation
7. UP007 non-pep604-annotation-union
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

