### PR TITLE
style: drop unnecessary quotes from type annotations

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -146,6 +146,7 @@ select = [
     "UP031",   # percent formatting that should be str.format
     "UP032",   # str.format that should be an f-string
     "UP034",   # extraneous parentheses
+    "UP037",   # quoted annotation that can be a bare type
     "UP042",   # str-and-Enum class that should be StrEnum
 ]
 ignore = [

--- a/src/api/flaskr/service/billing/value_objects.py
+++ b/src/api/flaskr/service/billing/value_objects.py
@@ -57,7 +57,7 @@ class JsonObjectMap(MutableMapping[str, Any]):
     def get(self, key: str, default: Any = None) -> Any:
         return self.values.get(key, default)
 
-    def copy(self) -> "JsonObjectMap":
+    def copy(self) -> JsonObjectMap:
         return JsonObjectMap(values=dict(self.values))
 
     def to_metadata_json(self) -> dict[str, Any]:

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -258,7 +258,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         description="Whether the published lesson content is newer than this user's latest learning progress",
         required=False,
     )
-    children: list["LearnOutlineItemInfoDTO"] = Field(
+    children: list[LearnOutlineItemInfoDTO] = Field(
         ..., description="outline children", required=False
     )
 
@@ -270,7 +270,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         status: LearnStatus,
         type: OutlineType,
         is_paid: bool,
-        children: list["LearnOutlineItemInfoDTO"],
+        children: list[LearnOutlineItemInfoDTO],
         has_content_update_for_current_user: bool = False,
     ):
         super().__init__(
@@ -349,7 +349,7 @@ class AudioSegmentDTO(BaseModel):
     is_final: bool = Field(
         default=False, description="Whether this is the last segment"
     )
-    subtitle_cues: List["SubtitleCueDTO"] = Field(
+    subtitle_cues: List[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cues available up to the current streamed segment",
     )
@@ -364,7 +364,7 @@ class AudioSegmentDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List["SubtitleCueDTO"]] = None,
+        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
     ):
         super().__init__(
             position=position,
@@ -418,7 +418,7 @@ class AudioCompleteDTO(BaseModel):
     audio_url: str = Field(..., description="OSS URL of complete audio")
     audio_bid: str = Field(..., description="Audio business identifier")
     duration_ms: int = Field(..., description="Total audio duration in milliseconds")
-    subtitle_cues: List["SubtitleCueDTO"] = Field(
+    subtitle_cues: List[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cue list aligned with synthesized TTS segments",
     )
@@ -432,7 +432,7 @@ class AudioCompleteDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List["SubtitleCueDTO"]] = None,
+        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
     ):
         super().__init__(
             position=position,
@@ -703,7 +703,7 @@ class ElementDTO(BaseModel):
         "sequence_number",
     )
 
-    def apply_patch(self, patch: "ElementDTO") -> None:
+    def apply_patch(self, patch: ElementDTO) -> None:
         for field_name in self._PATCH_FIELDS:
             setattr(self, field_name, getattr(patch, field_name))
 
@@ -857,7 +857,7 @@ class RunMarkdownFlowDTO(BaseModel):
 
     def set_mdflow_stream_parts(
         self, parts: list[tuple[str, str, int]] | None
-    ) -> "RunMarkdownFlowDTO":
+    ) -> RunMarkdownFlowDTO:
         normalized_parts: list[tuple[str, str, int]] = []
         for item in parts or []:
             if not isinstance(item, tuple) or len(item) != 3:

--- a/src/api/flaskr/service/referral/dtos.py
+++ b/src/api/flaskr/service/referral/dtos.py
@@ -27,7 +27,7 @@ class InviteProfileDTO:
     available: bool = True
 
     @classmethod
-    def unavailable(cls) -> "InviteProfileDTO":
+    def unavailable(cls) -> InviteProfileDTO:
         return cls(
             campaign_bid="",
             campaign_code="",

--- a/src/api/flaskr/service/shifu/admin_dtos_courses.py
+++ b/src/api/flaskr/service/shifu/admin_dtos_courses.py
@@ -371,7 +371,7 @@ class AdminOperationCourseDetailChapterDTO(BaseModel):
         ..., description="Last modifier nickname", required=False
     )
     updated_at: datetime | None = Field(..., description="Updated at", required=False)
-    children: list["AdminOperationCourseDetailChapterDTO"] = Field(
+    children: list[AdminOperationCourseDetailChapterDTO] = Field(
         default_factory=list,
         description="Nested children",
         required=False,

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -306,7 +306,7 @@ class SimpleOutlineDto(BaseModel):
         type: str | None = None,
         is_hidden: bool | None = None,
     ):
-        normalized_children: list["SimpleOutlineDto"] = []
+        normalized_children: list[SimpleOutlineDto] = []
         if children:
             for child in children:
                 if isinstance(child, SimpleOutlineDto):

--- a/src/api/flaskr/service/tts/tts_usage_recorder.py
+++ b/src/api/flaskr/service/tts/tts_usage_recorder.py
@@ -17,8 +17,8 @@ from flaskr.service.tts import resolve_tts_billable_chars
 
 
 def build_tts_metadata(
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
 ) -> dict:
     """Build metadata dict from voice and audio settings.
 
@@ -42,16 +42,16 @@ def build_tts_metadata(
 
 
 def record_tts_segment_usage(
-    app: "Flask",
-    usage_context: "UsageContext",
+    app: Flask,
+    usage_context: UsageContext,
     provider: str,
     model: str,
     segment_text: str,
     word_count: int,
     duration_ms: int,
     latency_ms: int,
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
     is_stream: bool,
     parent_usage_bid: str,
     segment_index: int,
@@ -103,8 +103,8 @@ def record_tts_segment_usage(
 
 
 def record_tts_aggregated_usage(
-    app: "Flask",
-    usage_context: "UsageContext",
+    app: Flask,
+    usage_context: UsageContext,
     usage_bid: str,
     provider: str,
     model: str,
@@ -113,8 +113,8 @@ def record_tts_aggregated_usage(
     total_word_count: int,
     duration_ms: int,
     segment_count: int,
-    voice_settings: "VoiceSettings",
-    audio_settings: "AudioSettings",
+    voice_settings: VoiceSettings,
+    audio_settings: AudioSettings,
     is_stream: bool = True,
     total_usage_characters: int = 0,
 ) -> None:

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -240,7 +240,7 @@ def _format_stream_parts(
 def _group_expected_stream_elements(
     parts: list[tuple[str, str, int]],
 ) -> list[ExpectedStreamElement]:
-    grouped: "OrderedDict[int, ExpectedStreamElement]" = OrderedDict()
+    grouped: OrderedDict[int, ExpectedStreamElement] = OrderedDict()
     for content, stream_type, number in parts:
         if not content or not stream_type:
             continue

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -219,7 +219,7 @@ class _FakeSaasColumn:
     def __eq__(self, value: object) -> tuple[str, object]:  # type: ignore[override]
         return self.name, value
 
-    def desc(self) -> "_FakeSaasColumn":
+    def desc(self) -> _FakeSaasColumn:
         return self
 
 
@@ -232,10 +232,10 @@ class _FakeSaasQuery:
         self._fake_saas = fake_saas
         self._conditions = conditions or []
 
-    def filter(self, *conditions: tuple[str, object]) -> "_FakeSaasQuery":
+    def filter(self, *conditions: tuple[str, object]) -> _FakeSaasQuery:
         return _FakeSaasQuery(self._fake_saas, [*self._conditions, *conditions])
 
-    def order_by(self, *_args) -> "_FakeSaasQuery":
+    def order_by(self, *_args) -> _FakeSaasQuery:
         return self
 
     def first(self):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 6/11. Base: `cursor/ruff-b904-453b` (#2467).

Several type annotations were quoted even though the names are already in scope on Python 3.11. This removes those quotes via ruff `UP037` and enables the rule.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. #2466 SIM115
5. #2467 B904
6. **this PR** — UP037
7. UP007 non-pep604-annotation-union
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

