### PR TITLE
style: write union annotations with X | Y

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -145,6 +145,7 @@ select = [
     "UP02",    # capture_output, deprecated OSError alias, yield from
     "UP031",   # percent formatting that should be str.format
     "UP032",   # str.format that should be an f-string
+    "UP007",   # Union[X, Y] annotation that should be X | Y
     "UP034",   # extraneous parentheses
     "UP037",   # quoted annotation that can be a bare type
     "UP042",   # str-and-Enum class that should be StrEnum

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 
 import requests
 
@@ -98,7 +98,7 @@ class ProviderConfig:
     model_loader: Optional[
         Callable[
             ["ProviderConfig", Dict[str, str], Optional[str]],
-            List[Union[str, Tuple[str, str]]],
+            List[str | Tuple[str, str]],
         ]
     ] = None
     reload_params: Optional[Callable[[str, float], Dict[str, Any]]] = None
@@ -327,7 +327,7 @@ def _load_and_register_model_max_output_tokens() -> Dict[str, int]:
 
 
 def _register_provider_models(
-    config: ProviderConfig, raw_models: List[Union[str, Tuple[str, str]]]
+    config: ProviderConfig, raw_models: List[str | Tuple[str, str]]
 ) -> List[str]:
     seen = set()
     display_models: List[str] = []
@@ -381,7 +381,7 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
     if config.model_loader:
         raw_models = config.model_loader(config, params, base_url)
     else:
-        raw_models: List[Union[str, Tuple[str, str]]] = list(config.static_models)
+        raw_models: List[str | Tuple[str, str]] = list(config.static_models)
         if config.fetch_models:
             try:
                 fetched_models = _fetch_provider_models(api_key, base_url)
@@ -585,8 +585,8 @@ def _resolve_provider_for_model(model: str) -> Tuple[Optional[str], str]:
 
 def _load_gemini_models(
     config: ProviderConfig, params: Dict[str, str], base_url: Optional[str]
-) -> List[Union[str, Tuple[str, str]]]:
-    models: List[Union[str, Tuple[str, str]]] = []
+) -> List[str | Tuple[str, str]]:
+    models: List[str | Tuple[str, str]] = []
     api_key = params.get("api_key")
     if not api_key:
         return models
@@ -622,7 +622,7 @@ def _load_gemini_models(
 
 def _load_deepseek_models(
     config: ProviderConfig, params: Dict[str, str], base_url: Optional[str]
-) -> List[Union[str, Tuple[str, str]]]:
+) -> List[str | Tuple[str, str]]:
     api_key = params.get("api_key", "")
     try:
         return _fetch_provider_models(api_key, base_url)
@@ -991,7 +991,7 @@ def invoke_llm(
     json: bool = False,
     generation_name: str = "invoke_llm",
     usage_context: Optional[UsageContext] = None,
-    usage_scene: Optional[Union[str, int]] = None,
+    usage_scene: Optional[str | int] = None,
     billable: Optional[int] = None,
     request_id: Optional[str] = None,
     trace_id: Optional[str] = None,
@@ -1174,7 +1174,7 @@ def chat_llm(
     json: bool = False,
     generation_name: str = "user_follow_ask",
     usage_context: Optional[UsageContext] = None,
-    usage_scene: Optional[Union[str, int]] = None,
+    usage_scene: Optional[str | int] = None,
     billable: Optional[int] = None,
     request_id: Optional[str] = None,
     trace_id: Optional[str] = None,

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -14,7 +14,7 @@ import logging
 import struct
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -105,7 +105,7 @@ class ProtocolFrame:
     event: Optional[Event]
     session_id: Optional[str]
     connection_id: Optional[str]
-    payload: Union[bytes, Dict[str, Any], None]
+    payload: bytes | Dict[str, Any] | None
     error_code: Optional[int] = None
 
 
@@ -360,7 +360,7 @@ class VolcengineProtocol:
                         offset += sess_id_len
 
         # Parse payload
-        payload: Union[bytes, Dict[str, Any], None] = None
+        payload: bytes | Dict[str, Any] | None = None
 
         if len(data) > offset:
             if message_type == MessageType.AUDIO_ONLY_RESPONSE:

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1556,12 +1556,12 @@ class RunScriptContextV2:
     _shifu_ids: list[str]
     _run_type: RunType
     _app: Flask
-    _shifu_model: Union[DraftShifu, PublishedShifu]
-    _outline_model: Union[DraftOutlineItem, PublishedOutlineItem]
+    _shifu_model: DraftShifu | PublishedShifu
+    _outline_model: DraftOutlineItem | PublishedOutlineItem
     _trace_args: dict
     _trace_id: str
     _shifu_info: ShifuInfoDto
-    _trace: Union[LangfuseTraceHandle, MockClient]
+    _trace: LangfuseTraceHandle | MockClient
     _trace_root_span: Any
     _input_type: str
     _input: str
@@ -1948,7 +1948,7 @@ class RunScriptContextV2:
             .first()
         )
         if not attend_info:
-            outline_item_info_db: Union[DraftOutlineItem, PublishedOutlineItem] = (
+            outline_item_info_db: DraftOutlineItem | PublishedOutlineItem = (
                 self._outline_model.query.filter(
                     self._outline_model.outline_item_bid == outline_bid,
                     self._outline_model.deleted == 0,
@@ -3591,15 +3591,15 @@ class RunScriptContextV2:
         path = list(reversed(path))
         outline_ids = [item.id for item in path if item.type == "outline"]
         shifu_ids = [item.id for item in path if item.type == "shifu"]
-        outline_item_info_db: Union[DraftOutlineItem, PublishedOutlineItem] = (
+        outline_item_info_db: DraftOutlineItem | PublishedOutlineItem = (
             self._outline_model.query.filter(
                 self._outline_model.id.in_(outline_ids),
                 self._outline_model.deleted == 0,
             ).all()
         )
-        outline_item_info_map: dict[
-            str, Union[DraftOutlineItem, PublishedOutlineItem]
-        ] = {o.id: o for o in outline_item_info_db}
+        outline_item_info_map: dict[str, DraftOutlineItem | PublishedOutlineItem] = {
+            o.id: o for o in outline_item_info_db
+        }
         course_prompt: str | None = None
         for id in outline_ids:
             outline_item_info = outline_item_info_map.get(id)
@@ -3615,7 +3615,7 @@ class RunScriptContextV2:
                 break
 
         if not course_prompt:
-            shifu_info_db: Union[DraftShifu, PublishedShifu] = (
+            shifu_info_db: DraftShifu | PublishedShifu = (
                 self._shifu_model.query.filter(
                     self._shifu_model.id.in_(shifu_ids),
                     self._shifu_model.deleted == 0,
@@ -3638,7 +3638,7 @@ class RunScriptContextV2:
         path.reverse()
         outline_ids = [item.id for item in path if item.type == "outline"]
         shifu_ids = [item.id for item in path if item.type == "shifu"]
-        outline_item_info_db: Union[DraftOutlineItem, PublishedOutlineItem] = (
+        outline_item_info_db: DraftOutlineItem | PublishedOutlineItem = (
             self._outline_model.query.filter(
                 self._outline_model.id.in_(outline_ids),
                 self._outline_model.deleted == 0,
@@ -3652,12 +3652,10 @@ class RunScriptContextV2:
                     model=outline_item_info.llm,
                     temperature=outline_item_info.llm_temperature,
                 )
-        shifu_info_db: Union[DraftShifu, PublishedShifu] = (
-            self._shifu_model.query.filter(
-                self._shifu_model.id.in_(shifu_ids),
-                self._shifu_model.deleted == 0,
-            ).first()
-        )
+        shifu_info_db: DraftShifu | PublishedShifu = self._shifu_model.query.filter(
+            self._shifu_model.id.in_(shifu_ids),
+            self._shifu_model.deleted == 0,
+        ).first()
         if shifu_info_db and shifu_info_db.llm:
             return LLMSettings(
                 model=shifu_info_db.llm, temperature=shifu_info_db.llm_temperature

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PrivateAttr
@@ -783,15 +783,15 @@ class RunElementSSEMessageDTO(BaseModel):
         default=None,
         description="Whether this event marks the terminal end of the run stream",
     )
-    content: Union[
-        str,
-        ElementDTO,
-        VariableUpdateDTO,
-        OutlineItemUpdateDTO,
-        AudioSegmentDTO,
-        AudioCompleteDTO,
-        AudioBackfillReadyDTO,
-    ] = Field(..., description="Run event content")
+    content: (
+        str
+        | ElementDTO
+        | VariableUpdateDTO
+        | OutlineItemUpdateDTO
+        | AudioSegmentDTO
+        | AudioCompleteDTO
+        | AudioBackfillReadyDTO
+    ) = Field(..., description="Run event content")
 
     def __json__(self):
         ret = {
@@ -821,13 +821,13 @@ class RunMarkdownFlowDTO(BaseModel):
         ..., description="generated block id", required=False
     )
     type: GeneratedType = Field(..., description="generated type", required=False)
-    content: Union[
-        str,
-        VariableUpdateDTO,
-        OutlineItemUpdateDTO,
-        AudioSegmentDTO,
-        AudioCompleteDTO,
-    ] = Field(..., description="generated content", required=True)
+    content: (
+        str
+        | VariableUpdateDTO
+        | OutlineItemUpdateDTO
+        | AudioSegmentDTO
+        | AudioCompleteDTO
+    ) = Field(..., description="generated content", required=True)
     anchor_element_bid: str = Field(
         default="",
         description="Anchor element bid for ASK events",
@@ -838,13 +838,11 @@ class RunMarkdownFlowDTO(BaseModel):
         outline_bid: str,
         generated_block_bid: str,
         type: GeneratedType,
-        content: Union[
-            str,
-            VariableUpdateDTO,
-            OutlineItemUpdateDTO,
-            AudioSegmentDTO,
-            AudioCompleteDTO,
-        ],
+        content: str
+        | VariableUpdateDTO
+        | OutlineItemUpdateDTO
+        | AudioSegmentDTO
+        | AudioCompleteDTO,
         anchor_element_bid: str = "",
     ):
         super().__init__(

--- a/src/api/flaskr/service/learn/run/emitter.py
+++ b/src/api/flaskr/service/learn/run/emitter.py
@@ -23,7 +23,7 @@ Event names, payload shapes, and sequencing are FROZEN per
 ``flaskr/service/learn/AGENTS.md``; the golden suite is the contract gate.
 """
 
-from typing import TYPE_CHECKING, Generator, Union
+from typing import TYPE_CHECKING, Generator
 
 from flaskr.dao import db
 from flaskr.i18n import _
@@ -75,15 +75,15 @@ class RunEventEmitter:
     ) -> Generator[str, None, None]:
         ctx = self._context
         shifu_bids = [o.outline_bid for o in outline_updates]
-        outline_item_info_db: Union[DraftOutlineItem, PublishedOutlineItem] = (
+        outline_item_info_db: DraftOutlineItem | PublishedOutlineItem = (
             ctx._outline_model.query.filter(
                 ctx._outline_model.outline_item_bid.in_(shifu_bids),
                 ctx._outline_model.deleted == 0,
             ).all()
         )
-        outline_item_info_map: dict[
-            str, Union[DraftOutlineItem, PublishedOutlineItem]
-        ] = {o.outline_item_bid: o for o in outline_item_info_db}
+        outline_item_info_map: dict[str, DraftOutlineItem | PublishedOutlineItem] = {
+            o.outline_item_bid: o for o in outline_item_info_db
+        }
         recorder = ctx._recorder
         for update in outline_updates:
             outline_item_info = outline_item_info_map.get(update.outline_bid)

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -31,7 +31,7 @@ PR3 scope notes (mirroring the emitter's PR1 conventions):
 """
 
 import queue
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.service.common import raise_error
@@ -352,7 +352,7 @@ class RunStateResolver:
                     q.put(child)
         return outline_struct
 
-    def get_outline_row_id(self, outline_item_bid: str) -> Union[int, None]:
+    def get_outline_row_id(self, outline_item_bid: str) -> int | None:
         ctx = self._context
         if not outline_item_bid:
             return None

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -12,7 +12,7 @@ Date: 2025-08-07
 
 import queue
 from decimal import Decimal
-from typing import List, Union
+from typing import List
 
 from flask import Flask
 from flaskr.service.common import raise_error
@@ -115,7 +115,7 @@ def get_shifu_outline_tree(
                     q.put(child)
         if len(shifu_ids) != 1:
             raise_error("server.shifu.shifuNotFound")
-        shifu: Union[DraftShifu, PublishedShifu] = shifu_model.query.filter(
+        shifu: DraftShifu | PublishedShifu = shifu_model.query.filter(
             shifu_model.id.in_(shifu_ids),
         ).first()
         if not shifu:
@@ -141,7 +141,7 @@ def get_shifu_outline_tree(
 
         def recurse_outline_item(item: HistoryItem) -> ShifuOutlineItemDto:
             if item.type == "outline":
-                outline_item: Union[DraftOutlineItem, PublishedOutlineItem] = (
+                outline_item: DraftOutlineItem | PublishedOutlineItem = (
                     outline_items_map.get(item.id)
                 )
                 if not outline_item:
@@ -181,7 +181,7 @@ def get_shifu_dto(app: Flask, shifu_bid: str, is_preview: bool = False) -> Shifu
         ShifuInfoDto: Shifu dto
     """
     shifu_model = DraftShifu if is_preview else PublishedShifu
-    shifu: Union[DraftShifu, PublishedShifu] = (
+    shifu: DraftShifu | PublishedShifu = (
         shifu_model.query.filter(
             shifu_model.shifu_bid == shifu_bid,
             shifu_model.deleted == 0,
@@ -221,7 +221,7 @@ def get_outline_item_dto(
     app.logger.info(f"get_outline_item_dto: {outline_item_bid},{is_preview}")
 
     outline_item_model = DraftOutlineItem if is_preview else PublishedOutlineItem
-    outline_item: Union[DraftOutlineItem, PublishedOutlineItem] = (
+    outline_item: DraftOutlineItem | PublishedOutlineItem = (
         outline_item_model.query.filter(
             outline_item_model.outline_item_bid == outline_item_bid,
             outline_item_model.deleted == 0,
@@ -259,7 +259,7 @@ def get_outline_item_dto_with_mdflow(
 ) -> OutlineItemDtoWithMdflow:
     """Get outline item dto with mdflow"""
     outline_item_model = DraftOutlineItem if is_preview else PublishedOutlineItem
-    outline_item: Union[DraftOutlineItem, PublishedOutlineItem, None] = None
+    outline_item: DraftOutlineItem | PublishedOutlineItem | None = None
     if outline_item_id:
         outline_item = (
             outline_item_model.query.filter(

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -241,7 +241,7 @@ def init_first_course(app: Flask, user_id: str) -> bool:
         creator_granted_now = not bool(verified_users[0].is_creator)
         mark_user_roles(user_id, is_creator=True, is_operator=True)
 
-        ShifuModel: Union[PublishedShifu, DraftShifu] = PublishedShifu
+        ShifuModel: PublishedShifu | DraftShifu = PublishedShifu
         # Assign demo shifu only when there is exactly one published course
         course_count = PublishedShifu.query.filter(PublishedShifu.deleted == 0).count()
         if course_count == 0:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 7/11. Base: `cursor/ruff-up037-453b` (#2468).

Remaining `typing.Union[X, Y]` annotations are rewritten as `X | Y` (Python 3.10+ / repo target 3.11). Unused `Union` imports are removed. Ruff `UP007` is enabled.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. #2466 SIM115
5. #2467 B904
6. #2468 UP037
7. **this PR** — UP007
8. PLR0402 manual-from-import
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

