### PR TITLE
style: import members with from-import instead of aliases

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -103,6 +103,7 @@ select = [
     "PLC0207", # str.split without maxsplit when one segment is used
     "PLC0208", # iteration over a set literal
     "PLC0414", # import alias that repeats the name
+    "PLR0402", # import module.member as member that should be from-import
     "PLR1",    # useless return, repeated comparison, manual min()/max()
     "PLR5",    # else: if ... that should be elif
     "PLW0108", # lambda that only forwards its arguments

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -44,7 +44,7 @@ def test_worker_process_init_signal_disposes_pools(app):
 
 
 def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     disposed = []
 

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -146,7 +146,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
     """The global teardown guard must fire on abnormal context exits and run
     BEFORE Flask-SQLAlchemy's remove (reverse registration order).
     """
-    import flaskr.dao as dao
+    from flaskr import dao
 
     order = []
     monkeypatch.setattr(
@@ -174,7 +174,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
 
 
 def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(
@@ -193,7 +193,7 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
 def test_release_session_classified_invalidates_during_propagating_interrupt(
     app, monkeypatch
 ):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     order = []
     monkeypatch.setattr(
@@ -238,7 +238,7 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
 
 
 def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -8,8 +8,8 @@ recirculating them.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from sqlalchemy.pool import QueuePool
 
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -9,8 +9,8 @@ statement via the per-connection journal.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.dao import db
 from sqlalchemy import text
 from sqlalchemy.exc import DisconnectionError

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -9,8 +9,8 @@ record BEFORE any interruption propagates.
 
 import socket
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from sqlalchemy.exc import DisconnectionError
 
 

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -205,7 +205,7 @@ def mock_validate_user(monkeypatch, user_bid: str, *, is_creator: bool = False) 
 
 def seed_golden_user(app, user_bid: str) -> None:
     """Ensure a learner row exists for load_user_aggregate()."""
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.service.user.models import UserInfo
 
     with app.app_context():
@@ -231,7 +231,7 @@ def golden_shifu(app):
     Idempotent: existing golden rows are removed before reseeding so every
     test starts from the same published structure regardless of ordering.
     """
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.service.shifu.models import (
         LogPublishedStruct,
         PublishedOutlineItem,

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -5,10 +5,10 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import flaskr.service.billing.checkout as billing_checkout_module
 import flaskr.service.billing.subscriptions as billing_subscriptions_module
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.i18n import load_translations, set_language
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/cycle_state_test_helpers.py
+++ b/src/api/tests/service/billing/cycle_state_test_helpers.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,
     BILLING_INTERVAL_MONTH,

--- a/src/api/tests/service/billing/renewal_execution_app_fixture.py
+++ b/src/api/tests/service/billing/renewal_execution_app_fixture.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from tests.common.fixtures.bill_products import build_bill_products
 
 

--- a/src/api/tests/service/billing/renewal_execution_test_helpers.py
+++ b/src/api/tests/service/billing/renewal_execution_test_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_INTERVAL_MONTH,
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.customization as billing_customization_module
 import flaskr.service.billing.queries as billing_queries_module
@@ -13,6 +12,7 @@ import flaskr.service.billing.serializers as billing_serializers_module
 import flaskr.service.billing.wallets as billing_wallets_module
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.i18n import _translations, load_translations, set_language
 from flaskr.service.billing.campaigns import (
     build_admin_billing_campaign_detail,

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -1,4 +1,4 @@
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing import admin_ops_state
 
 

--- a/src/api/tests/service/billing/test_billing_admission.py
+++ b/src/api/tests/service/billing/test_billing_admission.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.admission import admit_creator_usage
 from flaskr.service.billing.consts import (
     BILLING_ENTITLEMENT_PRIORITY_CLASS_VIP,

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.route.callback import register_callback_handler
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_CANCELED,

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -4,9 +4,9 @@ import json
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import notifications as billing_notifications
 from flaskr.service.billing.cli import register_billing_commands
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -4,9 +4,9 @@ import json
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.cli import register_billing_commands
 from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_bucket_realign.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_cycle_state_repair.py
+++ b/src/api/tests/service/billing/test_billing_cycle_state_repair.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.billing import subscriptions as subscriptions_mod
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
+++ b/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,

--- a/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
     CREDIT_LEDGER_ENTRY_TYPE_GRANT,

--- a/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_METRIC_LLM_OUTPUT_TOKENS,

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.domains as billing_domains
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.common.shifu_context import get_shifu_creator_bid, with_shifu_context
 from flaskr.service.billing.consts import (
     BILLING_DOMAIN_BINDING_STATUS_DISABLED,

--- a/src/api/tests/service/billing/test_billing_entitlements.py
+++ b/src/api/tests/service/billing/test_billing_entitlements.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ENTITLEMENT_ANALYTICS_TIER_ENTERPRISE,
     BILLING_ENTITLEMENT_PRIORITY_CLASS_PRIORITY,

--- a/src/api/tests/service/billing/test_billing_ownership.py
+++ b/src/api/tests/service/billing/test_billing_ownership.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.ownership import (
     resolve_shifu_creator_bid,
     resolve_usage_creator_bid,

--- a/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
+++ b/src/api/tests/service/billing/test_billing_renewal_activation_guards.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.billing import subscriptions as subscriptions_mod
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_SUBSCRIPTION_START,

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_renewal_event_basics.py
+++ b/src/api/tests/service/billing/test_billing_renewal_event_basics.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,

--- a/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_FAILED,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.entitlements as billing_entitlements_module
 import flaskr.service.billing.queries as billing_queries_module
@@ -13,6 +12,7 @@ import flaskr.service.billing.read_models as billing_read_models_module
 import flaskr.service.billing.serializers as billing_serializers_module
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.service.billing.capabilities import build_billing_route_bootstrap
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_PER_CYCLE,

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -5,9 +5,9 @@ import types
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.checkout import sync_billing_order
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -9,9 +9,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_ORDER_STATUS_PENDING,

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask, jsonify, request
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,
     BILLING_ORDER_STATUS_PAID,

--- a/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
+++ b/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
@@ -4,9 +4,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
     CREDIT_BUCKET_CATEGORY_TOPUP,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_TOPUP,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
     CREDIT_BUCKET_CATEGORY_FREE,

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_credit_grant_allocation_views.py
+++ b/src/api/tests/service/billing/test_credit_grant_allocation_views.py
@@ -4,9 +4,9 @@ import math
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_MANUAL,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -24,9 +24,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.i18n import load_translations
 from flaskr.service.billing import credit_notifications

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -8,9 +8,9 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_TOPUP,

--- a/src/api/tests/service/billing/test_grant_manual_entitlement.py
+++ b/src/api/tests/service/billing/test_grant_manual_entitlement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _cleanup(app, creator_bid: str) -> None:

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_TTS_REQUEST_COUNT,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.i18n import load_translations
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_CANCELED,

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from datetime import timedelta
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL,

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -25,9 +25,9 @@ from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing import renewal_event_transitions

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-import flaskr.common.public_urls as public_urls
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
+from flaskr.common import public_urls
 from flaskr.common.config import ENV_VARS
 from flaskr.route import config as config_route
 from flaskr.service.billing.consts import (

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.charges import (
     build_usage_metric_charges,
     resolve_credit_multiplier_label,

--- a/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
+++ b/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 
 
 @pytest.fixture

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -97,7 +97,7 @@ def test_read_storage_bytes_fetches_from_oss_when_local_file_is_missing(
     monkeypatch,
     tmp_path,
 ):
-    import flaskr.service.common.storage as storage
+    from flaskr.service.common import storage
     from flaskr.service.common.oss_utils import OSSConfig
 
     _make_storage_app(monkeypatch, tmp_path, "oss")

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -8,8 +8,8 @@ a payload smoke for emitter-side event construction.
 import types
 import unittest
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 from flaskr.service.learn.learn_dtos import GeneratedType

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -14,9 +14,9 @@ the change:
   the last finalized block.
 """
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 from flaskr.service.learn.run.recorder import RunRecorder
 from flaskr.service.order.consts import (

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -83,7 +83,7 @@ _install_litellm_stub()
 _install_openai_responses_stub()
 
 # Ensure minimal SQLAlchemy bindings exist so model classes can be defined.
-import flaskr.dao as dao
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-context-v2")

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-context-v2-tts-runtime-voice-bootstrap")

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -15,9 +15,9 @@ import pytest
 
 @pytest.fixture
 def adapter_app():
-    import flaskr.dao as dao
     import flaskr.service.learn.models  # noqa: F401
     from flask import Flask
+    from flaskr import dao
 
     app = Flask("test-handle-ask-adapter")
     app.config.update(

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-generated-block-tts-av-mode")

--- a/src/api/tests/service/learn/test_get_current_attend_placeholders.py
+++ b/src/api/tests/service/learn/test_get_current_attend_placeholders.py
@@ -14,9 +14,9 @@ drive the placeholder loop directly against a real session.
 
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 from flaskr.service.learn.models import LearnProgressRecord
 from flaskr.service.order.consts import LEARN_STATUS_NOT_STARTED

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover - optional dependency
     redis_stub.Redis = _RedisStub
     sys.modules["redis"] = redis_stub
 
-import flaskr.dao as dao
+from flaskr import dao
 
 # Ensure SQLAlchemy is available for model declarations.
 if dao.db is None:

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -1,9 +1,9 @@
 import types
 import unittest
 
-import flaskr.dao as dao
 from flask import Flask, request
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-learn-record")

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -2,8 +2,8 @@ import json
 import unittest
 from datetime import datetime
 
-import flaskr.dao as dao
 from flask import Flask
+from flaskr import dao
 from flaskr.service.learn.lesson_feedback import (
     _sync_feedback_to_generated_block,
     build_lesson_feedback_interaction_md,

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-listen-element-history-subtitles")

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-listen-elements-legacy-record")

--- a/src/api/tests/service/learn/test_preview_permissions.py
+++ b/src/api/tests/service/learn/test_preview_permissions.py
@@ -2,7 +2,7 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _seed_course(app, shifu_bid: str, owner_bid: str) -> None:

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_FAILED,
     TTS_MINIMAX_CLONE_STATUS_READY,

--- a/src/api/tests/service/metering/test_billing_boundary.py
+++ b/src/api/tests/service/metering/test_billing_boundary.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.models import (
     CreditLedgerEntry,
     CreditWallet,

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.metering import UsageContext, record_llm_usage, record_tts_usage
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -2,7 +2,7 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 
 
 def _seed_shifu(app, shifu_bid: str, owner_bid: str) -> None:

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -6,10 +6,10 @@ from types import SimpleNamespace
 from typing import Any
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import pytest
 from cryptography.fernet import Fernet
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.entitlements import grant_creator_manual_entitlement
 from flaskr.service.billing.models import BillingOrder
 from flaskr.service.order.consts import ORDER_STATUS_TO_BE_PAID

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.checkout import (
     _persist_billing_native_raw_snapshot,
     load_billing_order_for_native_event,

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import db
 from flaskr.service.order.consts import ORDER_STATUS_REFUND, ORDER_STATUS_SUCCESS
 from flaskr.service.order.funs import get_payment_details, refund_order_payment

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import importlib
 from datetime import datetime
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_ORDER_STATUS_PENDING,

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -12,9 +12,9 @@ import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import uow
 from flaskr.service.order import funs as order_funs
 from flaskr.service.order.consts import (

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -1,4 +1,4 @@
-import flaskr.service.profile.profile_manage as profile_manage
+from flaskr.service.profile import profile_manage
 from flaskr.service.profile.profile_manage import (
     add_profile_item_quick,
     get_profile_item_definition_list,

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -1,9 +1,9 @@
 import os
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import flaskr.service.config.funcs as config_funcs
 import pytest
+from flaskr import dao
 
 _dummy_lock = SimpleNamespace(
     acquire=lambda *args, **kwargs: False, release=lambda *args, **kwargs: None

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.service.common.models import AppException
 
 

--- a/src/api/tests/service/shifu/test_demo_courses.py
+++ b/src/api/tests/service/shifu/test_demo_courses.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.service.shifu.models import PublishedShifu
 

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.common.models import ERROR_CODE
 
 

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -3,8 +3,8 @@ import json
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.common import config as config_module
 from flaskr.service.billing.consts import BILLING_TRIAL_PRODUCT_BID
 from flaskr.service.billing.models import BillingOrder, BillingProduct

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 
 
 def _seed_shifu(

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 
-import flaskr.dao as dao
+from flaskr import dao
 from flaskr.service.shifu.consts import STATUS_DRAFT, STATUS_PUBLISHED
 from flaskr.service.shifu.models import (
     DraftOutlineItem,

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -5,9 +5,9 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import flaskr.common.config as common_config
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.util.datetime import now_utc
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_TTS_REQUEST_COUNT,
     CREDIT_BUCKET_CATEGORY_FREE,

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -1,6 +1,6 @@
-import flaskr.dao as dao
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flaskr import dao
 
 if dao.db is None:
     _test_app = Flask("test-streaming-tts-subtitles")

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -124,7 +124,7 @@ def test_tencent_sse_tc3_headers_sign_exact_request_payload():
 
 def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     import flaskr.api.tts as tts_api
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.common.config import ENV_VARS
     from flaskr.service.tts.validation import validate_tts_settings_strict
 
@@ -185,7 +185,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
 def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
     monkeypatch,
 ):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
     _patch_tencent_config(monkeypatch, tencent_provider)
@@ -269,7 +269,7 @@ def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
 def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
     monkeypatch,
 ):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
     _patch_tencent_config(monkeypatch, tencent_provider)
@@ -354,7 +354,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
 
 
 def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch):
-    import flaskr.api.tts.tencent_provider as tencent_provider
+    from flaskr.api.tts import tencent_provider
 
     _patch_tencent_config(monkeypatch, tencent_provider)
 

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -1,7 +1,7 @@
 import threading
 from types import SimpleNamespace
 
-import flaskr.api.tts.volcengine_provider as volcengine_provider
+from flaskr.api.tts import volcengine_provider
 
 
 def test_volcengine_ws_get_credentials_prefers_volcengine_tts_keys(monkeypatch):

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -965,7 +965,7 @@ def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch):
 
 
 def test_save_moderates_once_when_state_creation_retries(app, monkeypatch):
-    import flaskr.service.profile.learner_profile as learner_profile
+    from flaskr.service.profile import learner_profile
 
     moderation_calls: list[str] = []
     operation_calls = 0

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -42,7 +42,7 @@ def test_reset_password_does_not_create_new_user(test_client, app):
 
 
 def test_set_password_requires_login_and_verification_code(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
 
     phone = "15500001111"
 
@@ -86,7 +86,7 @@ def test_set_password_requires_login_and_verification_code(test_client, app):
 
 
 def test_password_login_after_setting_password(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
 
     phone = "15500002222"
     password = "Abcd1234"
@@ -118,13 +118,13 @@ def test_password_login_after_setting_password(test_client, app):
 
 
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         PROFILE_ONBOARDING_VERSION,
         load_learner_profile_state,
     )
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo, UserOnboardingState
     from flaskr.service.user.repository import create_user_entity
     from flaskr.service.user.utils import generate_token
@@ -245,8 +245,8 @@ def test_password_login_merges_authenticated_guest_learner_profile(test_client, 
 
 
 def test_password_login_never_merges_from_a_registered_account(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
 
     source_phone = "15500002334"
@@ -294,8 +294,8 @@ def test_password_login_never_merges_from_a_registered_account(test_client, app)
 
 
 def test_password_login_ignores_invalid_and_expired_optional_tokens(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
     from flaskr.service.user.repository import create_user_entity
 
@@ -374,7 +374,7 @@ def test_sms_login_route_logs_in_with_phone_code(test_client):
 
 
 def test_sms_login_route_does_not_rebind_authenticated_account_phone(test_client, app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential
     from flaskr.service.user.models import UserInfo as UserEntity
 

--- a/src/api/tests/service/user/test_repository.py
+++ b/src/api/tests/service/user/test_repository.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import datetime
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.dao import db
 from flaskr.service.user.consts import (
     CREDENTIAL_STATE_UNVERIFIED,

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -5,9 +5,9 @@ import json
 import uuid
 from decimal import Decimal
 
-import flaskr.dao as dao
 import pytest
 from flask import Flask
+from flaskr import dao
 from flaskr.framework.plugin import plugin_manager as plugin_manager_module
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -57,9 +57,8 @@ def _post_json(client, path: str, payload: dict, headers: dict | None = None):
 @pytest.fixture
 def user_trial_client(monkeypatch, tmp_path):
     import flaskr.service.billing.auth_hooks as _billing_auth_hooks  # noqa: F401
-    import flaskr.service.user.email_flow as email_flow
-    import flaskr.service.user.phone_flow as phone_flow
     import flaskr.service.user.utils as user_utils
+    from flaskr.service.user import email_flow, phone_flow
     from flaskr.service.user.auth.providers import (
         password as _password_provider,  # noqa: F401
     )

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -51,10 +51,10 @@ def _reset_shifu_tables() -> None:
 
 
 def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeypatch):
-    import flaskr.service.user.phone_flow as phone_flow
     from flask import Flask
     from flask_sqlalchemy import SQLAlchemy
     from flaskr import dao
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.consts import (
         USER_STATE_REGISTERED,
         USER_STATE_UNREGISTERED,
@@ -128,7 +128,7 @@ def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeyp
 
 
 def test_phone_flow_sets_user_identify(app):
-    import flaskr.service.user.phone_flow as phone_flow
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     # Bypass code storage by using universal code
@@ -157,7 +157,7 @@ def test_phone_flow_sets_user_identify(app):
 
 
 def test_email_flow_sets_user_identify(app):
-    import flaskr.service.user.email_flow as email_flow
+    from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     with app.app_context():
@@ -247,8 +247,8 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
 
 
 def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():
@@ -281,8 +281,8 @@ def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
 
 
 def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -329,8 +329,8 @@ def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
 
 
 def test_phone_flow_accepts_prefixed_pending_db_code(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -377,8 +377,8 @@ def test_phone_flow_accepts_prefixed_pending_db_code(app):
 
 
 def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
-    import flaskr.service.user.verification_codes as verification_codes
     from flaskr.dao import db
+    from flaskr.service.user import verification_codes
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():
@@ -415,9 +415,9 @@ def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
 
 
 def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
-    import flaskr.service.user.phone_flow as phone_flow
     from flaskr.dao import db
     from flaskr.service.shifu.models import DraftShifu, PublishedShifu
+    from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
     shifu_bid = uuid.uuid4().hex[:32]
@@ -466,8 +466,8 @@ def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
 
 
 def test_email_flow_verifies_code_from_db_when_cache_missing(app):
-    import flaskr.service.user.email_flow as email_flow
     from flaskr.dao import db
+    from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserVerifyCode
 
     with app.app_context():

--- a/src/api/tests/test_profile.py
+++ b/src/api/tests/test_profile.py
@@ -1,4 +1,4 @@
-import flaskr.service.profile.profile_manage as profile_manage
+from flaskr.service.profile import profile_manage
 from flaskr.service.profile.profile_manage import (
     add_profile_item_quick,
     get_profile_item_definition_list,

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
-import flaskr.dao as dao
 import pytest
+from flaskr import dao
 from flaskr.dao import retry_on_deadlock
 from sqlalchemy.exc import OperationalError
 
@@ -101,7 +101,7 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch):
 
 
 def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(
@@ -124,7 +124,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
 
 
 def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
 
     invalidations = []
     monkeypatch.setattr(

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 
     invalidations = []
@@ -26,7 +26,7 @@ def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
 
 
 def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
-    import flaskr.dao as dao
+    from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 
     outcomes = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 8/11. Base: `cursor/ruff-up007-453b` (#2469).

`import flaskr.dao as dao` and similar aliases are rewritten as `from flaskr import dao`. Import blocks are re-sorted. Ruff `PLR0402` is enabled.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. #2466 SIM115
5. #2467 B904
6. #2468 UP037
7. #2469 UP007
8. **this PR** — PLR0402
9. SIM102 collapsible-if
10. SIM117 multiple-with-statements
11. TRY400 error-instead-of-exception
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

