### PR TITLE
fix: log exceptions with traceback inside except blocks

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -144,6 +144,7 @@ select = [
     "SIM4",    # if-else block instead of dict.get
     "SIM9",    # dict.get(key, None)
     "TRY203",  # exception handler that only re-raises
+    "TRY400",  # logging.error inside except that should be logging.exception
     "UP01",    # redundant str.encode/open() arguments
     "UP02",    # capture_output, deprecated OSError alias, yield from
     "UP031",   # percent formatting that should be str.format

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -92,7 +92,7 @@ def ilivedata_check(
     try:
         ret = send(query_body, signature, now_date, pid, timeout=timeout_seconds)
     except URLError as err:
-        app.logger.error("ilivedata request failed: %s", err)
+        app.logger.exception("ilivedata request failed: %s", err)
         return CheckResultDTO(
             check_result=CHECK_RESULT_UNKNOWN,
             risk_labels=[],

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -151,7 +151,7 @@ def yidun_check(
             raw_data=response_json,
         )
     except Exception as ex:
-        app.logger.error("yidun check error: %r", ex)
+        app.logger.exception("yidun check error: %r", ex)
         return CheckResultDTO(
             check_result=CHECK_RESULT_UNKNOWN,
             risk_labels=[],

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1384,7 +1384,7 @@ class AliyunTTSProvider(BaseTTSProvider):
                 raise ValueError(f"Aliyun TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
-            logger.error(f"Aliyun TTS request failed: {e}")
+            logger.exception(f"Aliyun TTS request failed: {e}")
             raise ValueError(f"Aliyun TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -701,7 +701,7 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
         return access_token
 
     except requests.RequestException as e:
-        logger.error(f"Failed to get Baidu access token: {e}")
+        logger.exception(f"Failed to get Baidu access token: {e}")
         raise ValueError(f"Failed to get Baidu access token: {e}") from e
 
 
@@ -914,7 +914,7 @@ class BaiduTTSProvider(BaseTTSProvider):
                 raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
-            logger.error(f"Baidu TTS request failed: {e}")
+            logger.exception(f"Baidu TTS request failed: {e}")
             raise ValueError(f"Baidu TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -357,7 +357,7 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             )
             body = response.json()
         except requests.RequestException as exc:
-            logger.error("Tencent TextToVoice request failed: %s", exc)
+            logger.exception("Tencent TextToVoice request failed: %s", exc)
             raise ValueError(f"Tencent TextToVoice request failed: {exc}") from exc
         except ValueError as exc:
             raise ValueError(

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -277,7 +277,7 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
             result = response.json()
         except ValueError as exc:
             body_preview = (response.text or "")[:2000]
-            logger.error(
+            logger.exception(
                 "Volcengine HTTP TTS invalid JSON response: url=%s status=%s reqid=%s content_type=%s body=%s",
                 response.url,
                 response.status_code,

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -390,7 +390,7 @@ class VolcengineProtocol:
                         try:
                             payload = json.loads(payload_data.decode("utf-8"))
                         except json.JSONDecodeError as e:
-                            logger.error(f"Failed to parse JSON payload: {e}")
+                            logger.exception(f"Failed to parse JSON payload: {e}")
                             payload = payload_data
                     else:
                         payload = payload_data

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -581,7 +581,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
                         session_finished.set()
 
             except Exception as e:
-                logger.error(f"Error processing message: {e}")
+                logger.exception(f"Error processing message: {e}")
                 error_message = str(e)
                 session_started.set()
                 session_finished.set()

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -161,7 +161,7 @@ def enable_commands(app: Flask):
             )
 
         except Exception as e:
-            logger.error(f"Migration failed: {e}")
+            logger.exception(f"Migration failed: {e}")
             raise click.ClickException(f"Migration failed: {e}") from e
         finally:
             if "migration_task" in locals():
@@ -216,7 +216,7 @@ def enable_commands(app: Flask):
                 click.echo("Consider re-running the migration for failed tables.")
 
         except Exception as e:
-            logger.error(f"Verification failed: {e}")
+            logger.exception(f"Verification failed: {e}")
             raise click.ClickException(f"Verification failed: {e}") from e
         finally:
             if "migration_task" in locals():
@@ -300,7 +300,7 @@ def enable_commands(app: Flask):
                 click.echo(f"\nCould not read migration log: {e}")
 
         except Exception as e:
-            logger.error(f"Status check failed: {e}")
+            logger.exception(f"Status check failed: {e}")
             raise click.ClickException(f"Status check failed: {e}") from e
         finally:
             if "migration_task" in locals():

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -271,7 +271,7 @@ class UnifiedMigrationTask:
                 sys.stdout.flush()
 
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"Batch processing failed for {source_table} at offset {offset}: {e}"
                 )
                 errors.append(f"Batch error at offset {offset}: {e!s}")
@@ -445,7 +445,7 @@ class UnifiedMigrationTask:
                     error_count += 1
                     error_msg = f"Record migration failed for {getattr(record, key_field)}: {e!s}"
                     error_messages.append(error_msg)
-                    logger.error(error_msg)
+                    logger.exception(error_msg)
 
                     if (
                         error_count > self.config.batch_size * 0.5
@@ -474,7 +474,7 @@ class UnifiedMigrationTask:
 
         except Exception as e:
             session.rollback()
-            logger.error(f"Batch processing failed: {e}")
+            logger.exception(f"Batch processing failed: {e}")
             raise
         finally:
             session.close()
@@ -521,7 +521,7 @@ class UnifiedMigrationTask:
                 )
 
             except Exception as e:
-                logger.error(f"Consistency check failed for {source_table}: {e}")
+                logger.exception(f"Consistency check failed for {source_table}: {e}")
                 results[source_table] = ConsistencyCheckResult(
                     table_pair=f"{source_table} -> {target_table}",
                     old_count=0,
@@ -589,7 +589,7 @@ class UnifiedMigrationTask:
             return passed, mismatches
 
         except Exception as e:
-            logger.error(f"Sample integrity check failed: {e}")
+            logger.exception(f"Sample integrity check failed: {e}")
             return False, [f"Integrity check error: {e!s}"]
         finally:
             session.close()
@@ -619,7 +619,7 @@ class UnifiedMigrationTask:
             return True  # Basic existence check for other tables
 
         except Exception as e:
-            logger.error(f"Record mapping verification failed: {e}")
+            logger.exception(f"Record mapping verification failed: {e}")
             return False
 
     # Table mapping functions
@@ -713,7 +713,7 @@ class UnifiedMigrationTask:
             ).fetchone()
             return result is not None
         except Exception as e:
-            logger.error(f"Error checking table existence {table_name}: {e}")
+            logger.exception(f"Error checking table existence {table_name}: {e}")
             return False
         finally:
             session.close()
@@ -730,7 +730,7 @@ class UnifiedMigrationTask:
             count = session.execute(text(query)).scalar()
             return count or 0
         except Exception as e:
-            logger.error(f"Error getting table count for {table_name}: {e}")
+            logger.exception(f"Error getting table count for {table_name}: {e}")
             return 0
 
     def _check_column_exists_with_session(
@@ -750,7 +750,7 @@ class UnifiedMigrationTask:
             ).scalar()
             return result > 0
         except Exception as e:
-            logger.error(
+            logger.exception(
                 f"Error checking column existence {table_name}.{column_name}: {e}"
             )
             return False
@@ -775,7 +775,7 @@ class UnifiedMigrationTask:
             count = session.execute(text(query)).scalar()
             return count or 0
         except Exception as e:
-            logger.error(f"Error getting table count for {table_name}: {e}")
+            logger.exception(f"Error getting table count for {table_name}: {e}")
             return 0
         finally:
             session.close()
@@ -924,7 +924,7 @@ class UnifiedMigrationTask:
 
             session.commit()
         except Exception as e:
-            logger.error(f"Error creating sync log table: {e}")
+            logger.exception(f"Error creating sync log table: {e}")
 
     def generate_migration_report(
         self,

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2096,7 +2096,7 @@ class Config(FlaskConfig):
             self.enhanced.validate_environment(allow_conversion_errors=True)
             app.logger.info("Environment configuration validated successfully")
         except EnvironmentConfigError as e:
-            app.logger.error(f"Environment configuration error: {e}")
+            app.logger.exception(f"Environment configuration error: {e}")
             raise
         self._populate_redis_prefixes()
 

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -175,7 +175,7 @@ def init_log(app: Flask) -> Flask:
                     request_body["Raw"] = request.get_data(as_text=True)
                 app.logger.info(f"Request body: {request_body}")
             except Exception as e:
-                app.logger.error(f"Failed to get request body: {e}")
+                app.logger.exception(f"Failed to get request body: {e}")
         else:
             app.logger.info(f"Request method: {request.method}")
 
@@ -199,7 +199,7 @@ def init_log(app: Flask) -> Flask:
             response_data = response.get_data(as_text=True)
             app.logger.info(f"Response: {response_data}")
         except Exception as e:
-            app.logger.error(f"Error logging response: {e!s}")
+            app.logger.exception(f"Error logging response: {e!s}")
         return response
 
     host_name = socket.gethostname()

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -41,7 +41,7 @@ class PluginHotReloader:
 
             self.app.logger.info(f"Hot reload plugin success: {plugin_path}")
         except Exception as e:
-            self.app.logger.error(
+            self.app.logger.exception(
                 f"Hot reload plugin failed: {plugin_path}, error: {e!s}"
             )
 
@@ -85,7 +85,7 @@ class PluginHotReloader:
             self.app.logger.info(f"Plugin unloaded: {module_name}")
 
         except Exception as e:
-            self.app.logger.error(f"Failed to unload plugin {plugin_path}: {e!s}")
+            self.app.logger.exception(f"Failed to unload plugin {plugin_path}: {e!s}")
 
     def _register_plugin(self, module):
         """Register a newly loaded plugin
@@ -113,7 +113,9 @@ class PluginHotReloader:
             self.app.logger.info(f"Plugin registered: {module.__name__}")
 
         except Exception as e:
-            self.app.logger.error(f"Failed to register plugin {module.__name__}: {e!s}")
+            self.app.logger.exception(
+                f"Failed to register plugin {module.__name__}: {e!s}"
+            )
 
 
 class PluginFileHandler(FileSystemEventHandler):

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -71,7 +71,7 @@ def load_plugins_from_dir(
                     load_from_directory(os.path.join(plugins_dir, file), plugin_manager)
                     app.logger.info(f"load plugin: {file} success")
                 except Exception as e:
-                    app.logger.error(f"load plugin: {file} error: {e}")
+                    app.logger.exception(f"load plugin: {file} error: {e}")
             else:
                 app.logger.warning(f"skip non-directory file: {file}")
     return plugins

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -74,7 +74,7 @@ def _load_json_translations(app: Flask, root: Path):
             metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
             language_codes = metadata.get("locales", {}).keys()
         except Exception as exc:  # pragma: no cover - defensive log
-            app.logger.error(
+            app.logger.exception(
                 "Failed to parse locales metadata at %s: %s", metadata_path, exc
             )
 
@@ -107,7 +107,7 @@ def _load_json_translations(app: Flask, root: Path):
             try:
                 content = json.loads(file_path.read_text(encoding="utf-8"))
             except Exception as exc:  # pragma: no cover - IO errors are logged
-                app.logger.error(
+                app.logger.exception(
                     "Failed to load translation file %s: %s", file_path, exc
                 )
                 continue
@@ -256,7 +256,7 @@ def load_translations(app: Flask, translations_dir=None):
     try:
         _validate_json_translations(app, shared_root)
     except Exception as exc:
-        app.logger.error("i18n validation failed: %s", exc)
+        app.logger.exception("i18n validation failed: %s", exc)
         raise
 
     _load_json_translations(app, shared_root)

--- a/src/api/flaskr/service/common/credit_rate_references.py
+++ b/src/api/flaskr/service/common/credit_rate_references.py
@@ -23,7 +23,7 @@ def load_llm_credit_1x_per_1000_output_tokens() -> Decimal | None:
     try:
         value = Decimal(str(raw_value).strip())
     except (InvalidOperation, TypeError, ValueError):
-        logger.error(
+        logger.exception(
             "%s must be a positive decimal; got %r",
             LLM_CREDIT_1X_PER_1000_CONFIG,
             raw_value,

--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -219,7 +219,7 @@ class ListenElementRunPersistenceMixin:
             # later request that checks it out; the caller's rollback then
             # completes on session state alone.
             with contextlib.suppress(Exception):
-                current_app.logger.error(
+                current_app.logger.exception(
                     "Listen element SELECT hit a desynced connection; forensics: %s",
                     _describe_desynced_connection(result, connection),
                 )

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -1910,12 +1910,12 @@ def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
                     try:
                         set_user_state(buy_record.user_bid, USER_STATE_PAID)
                     except Exception as e:
-                        app.logger.error("update user state error:%s", e)
+                        app.logger.exception("update user state error:%s", e)
                     buy_record.status = ORDER_STATUS_SUCCESS
                 send_order_feishu(app, buy_record.order_bid)
                 return query_buy_record(app, buy_record.order_bid)
             except Exception as e:
-                app.logger.error(
+                app.logger.exception(
                     f'success buy record from pingxx charge:"{charge_id}" error:{e}'
                 )
             finally:
@@ -1942,7 +1942,7 @@ def success_buy_record(app: Flask, record_id: str):
             try:
                 set_user_state(buy_record.user_bid, USER_STATE_PAID)
             except Exception as e:
-                app.logger.error("update user state error:%s", e)
+                app.logger.exception("update user state error:%s", e)
             buy_record.status = ORDER_STATUS_SUCCESS
             # Notify only once the SUCCESS flip is durable: nested inside a
             # caller's unit of work this defers to the caller's commit (and

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -187,7 +187,7 @@ class AlipayProvider(PaymentProvider):
                 AlipayTradeQueryRequest,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
-            app.logger.error("Alipay SDK is not available: %s", exc)
+            app.logger.exception("Alipay SDK is not available: %s", exc)
             raise RuntimeError("alipay-sdk-python is required for Alipay") from exc
 
         return {
@@ -211,7 +211,7 @@ class AlipayProvider(PaymentProvider):
                 verify_with_rsa,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
-            app.logger.error("Alipay signature utility is not available: %s", exc)
+            app.logger.exception("Alipay signature utility is not available: %s", exc)
             raise RuntimeError("Alipay signature utility is required") from exc
 
         public_key = _read_required_key("ALIPAY_PUBLIC_KEY_PATH", "ALIPAY_PUBLIC_KEY")

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -62,7 +62,7 @@ class PingxxProvider(PaymentProvider):
         try:
             client = _get_pingpp_client()
         except Exception as exc:  # pragma: no cover
-            app.logger.error("Pingxx dependency is not available: %s", exc)
+            app.logger.exception("Pingxx dependency is not available: %s", exc)
             raise RuntimeError("Pingxx dependency is not available") from exc
 
         api_key = get_config("PINGXX_SECRET_KEY")

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -26,7 +26,7 @@ class StripeProvider(PaymentProvider):
         try:
             import stripe  # type: ignore
         except ImportError as exc:  # pragma: no cover - surfaced during runtime
-            app.logger.error("Stripe SDK is not installed")
+            app.logger.exception("Stripe SDK is not installed")
             raise RuntimeError("Stripe SDK is required for Stripe payments") from exc
         return stripe
 
@@ -282,7 +282,9 @@ class StripeProvider(PaymentProvider):
                 raw_body_str, sig_header, webhook_secret
             )
         except Exception as exc:  # pragma: no cover - handled in caller
-            app.logger.error("Stripe webhook signature verification failed: %s", exc)
+            app.logger.exception(
+                "Stripe webhook signature verification failed: %s", exc
+            )
             raise
 
         return self._build_notification_from_event(event)

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -241,10 +241,12 @@ def upload_url(app, user_id: str, url: str) -> str:
             return result.url
 
         except requests.RequestException as e:
-            app.logger.error(f"Failed to download image from URL: {url}, error: {e!s}")
+            app.logger.exception(
+                f"Failed to download image from URL: {url}, error: {e!s}"
+            )
             raise_error("server.file.fileDownloadFailed")
         except Exception as e:
-            app.logger.error(f"Failed to upload image to OSS: {url}, error: {e!s}")
+            app.logger.exception(f"Failed to upload image to OSS: {url}, error: {e!s}")
             raise_error("server.file.fileUploadFailed")
 
 
@@ -375,11 +377,11 @@ def get_video_info(app, user_id: str, url: str) -> dict:
                 raise_error("server.file.videoUnsupportedVideoSite")
 
         except requests.RequestException as e:
-            app.logger.error(f"Failed to fetch video info from {url}: {e!s}")
+            app.logger.exception(f"Failed to fetch video info from {url}: {e!s}")
             raise_error("server.file.videoNetworkError")
         except KeyError as e:
-            app.logger.error(f"Missing expected field in API response: {e!s}")
+            app.logger.exception(f"Missing expected field in API response: {e!s}")
             raise_error("server.file.videoParseError")
         except Exception as e:
-            app.logger.error(f"Unexpected error getting video info: {e!s}")
+            app.logger.exception(f"Unexpected error getting video info: {e!s}")
             raise_error("server.file.videoGetInfoError")

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -166,7 +166,7 @@ def import_shifu(
                 file_content = file_content.decode("utf-8")
             import_data = json.loads(file_content)
         except Exception as e:
-            app.logger.error(f"Failed to parse JSON file: {e}")
+            app.logger.exception(f"Failed to parse JSON file: {e}")
             raise_error("server.shifu.importFileInvalid")
 
         # Validate import data

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -674,7 +674,7 @@ class StreamingTTSProcessor:
                 segment.error = str(e)
                 segment.is_ready = True
             except Exception as e:
-                logger.error(
+                logger.exception(
                     "TTS segment %s failed: %s provider=%s model=%s "
                     "text_len=%s text_preview=%r",
                     segment.index,
@@ -1450,7 +1450,7 @@ class StreamingTTSProcessor:
                 final_duration_ms,
             )
         except Exception as e:
-            logger.error(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
+            logger.exception(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
             # The swallowed error may be a desync surfaced by the audio
             # record write; classify so an interrupted exchange discards the
             # connection instead of leaving it for the next statement.
@@ -2032,7 +2032,7 @@ class StreamingTTSProcessor:
             try:
                 future.result(timeout=60)  # Max 60s per segment
             except Exception as e:
-                logger.error(f"TTS future failed: {e}")
+                logger.exception(f"TTS future failed: {e}")
 
         # Yield any remaining segments
         yield from self._yield_ready_segments()

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -11,7 +11,6 @@ import logging
 import os
 import threading
 import time
-import traceback
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -1450,7 +1449,7 @@ class StreamingTTSProcessor:
                 final_duration_ms,
             )
         except Exception as e:
-            logger.exception(f"Failed to finalize TTS: {e}\n{traceback.format_exc()}")
+            logger.exception(f"Failed to finalize TTS: {e}")
             # The swallowed error may be a desync surfaced by the audio
             # record write; classify so an interrupted exchange discards the
             # connection instead of leaving it for the next statement.

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -318,7 +318,7 @@ def send_email_code(
             user_verify_code.verify_code_send = 1
             db.session.commit()
         except Exception as e:
-            app.logger.error(f"Failed to send verification code to {email}: {e!s}")
+            app.logger.exception(f"Failed to send verification code to {email}: {e!s}")
             raise_error("server.user.emailSendFailed")
         return {"expire_in": app.config["MAIL_CODE_EXPIRE_TIME"]}
 

--- a/src/api/tests/common/test_config.py
+++ b/src/api/tests/common/test_config.py
@@ -61,8 +61,8 @@ class TestConfigInitialization:
         with pytest.raises(EnvironmentConfigError):
             Config(parent_config, app)
 
-        # Verify error was logged
-        app.logger.error.assert_called()
+        # Verify error was logged with traceback
+        app.logger.exception.assert_called()
 
     def test_global_instance_set(self, monkeypatch):
         """Test that global instance is set on initialization."""

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -325,7 +325,7 @@ class TestStreamingSynthesisRetries:
         assert result.error == "No audio data received from Tencent TTS"
         assert result.is_ready is True
         warning_args = mock_logger.warning.call_args.args
-        error_args = mock_logger.error.call_args.args
+        error_args = mock_logger.exception.call_args.args
         assert "text_preview=%r" in warning_args[0]
         assert "这句有文字但腾讯没返回。" in warning_args
         assert "text_preview=%r" in error_args[0]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Stacked ruff adoption PR 11/11. Base: `cursor/ruff-sim117-453b` (#2472).

`logging.error` inside `except` blocks is replaced with `logging.exception` so the traceback is attached. Tests that asserted `logger.error` now assert `logger.exception`. The streaming TTS finalize log no longer also inlines `traceback.format_exc()`, so the same stack is not printed twice. Ruff `TRY400` is enabled.

## Stack

1. #2463 RUF006
2. #2464 B017
3. #2465 PT017
4. #2466 SIM115
5. #2467 B904
6. #2468 UP037
7. #2469 UP007
8. #2470 PLR0402
9. #2471 SIM102
10. #2472 SIM117
11. **this PR** — TRY400
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-790b36fc-742c-49e2-9b2e-9028fb82453b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-790b36fc-742c-49e2-9b2e-9028fb82453b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

