### PR TITLE
chore: enforce ruff on the full repository

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,10 @@ name: Lint
 # not duplicated here. ESLint mirrors the old pre-commit.ci behaviour (auto-fix
 # only, never a hard gate), since cook-web carries known eslint warnings.
 #
-# Auto-fixes are scoped to the files changed in the PR (like pre-commit.ci), so
-# pre-existing non-conforming files elsewhere are never reformatted.
+# Auto-fixes stay scoped to the files changed in the PR (like pre-commit.ci),
+# so unrelated trees are not rewritten. Ruff check and format are then
+# enforced on the whole repository so the pinned rule set in ruff.toml is a
+# repo-wide gate, including PRs that only change ruff.toml.
 
 on:
   pull_request:
@@ -120,6 +122,7 @@ jobs:
           [ -n "$txt" ] && check-merge-conflict $txt
           all=$(cat /tmp/changed.txt)
           [ -n "$all" ] && check-symlinks $all
-          py=$(sel '\.py$'); [ -n "$py" ] && ruff check $py
+          ruff check .
+          ruff format --check .
           python3 scripts/check_backend_hardcoded_cn.py
           echo "Lint hard-fail checks passed."

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,16 +25,17 @@
 # Other rule groups from ruff 0.16's broadened defaults were evaluated and
 # deliberately left off:
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
-#   tuples/lists, not a missed comma.
+#   tuples/lists, not a missed comma. ISC001/ISC002 also conflict with the
+#   formatter.
 # - BLE001 / S110 / S112: blind/except-pass handlers are deliberate fail-open
 #   patterns here (moderation, logging, notification side channels).
 # - G001 / G003 / G004: f-string logging is the established house style; the
 #   lazy-%-formatting argument does not outweigh the churn. G201 IS enabled --
 #   `.exception(...)` is strictly equivalent to `.error(..., exc_info=True)`.
-# - SIM* / RUF012 / RUF013 / RUF046 / UP* as whole groups: style or
-#   modernization churn with no bug-catching value for this codebase today.
-#   Individual members that are mechanical and behavior-preserving are listed
-#   in the select block below; the rest stay off.
+# - RUF012 / UP* as whole groups: style or modernization churn with no
+#   bug-catching value for this codebase today. Individual members that are
+#   mechanical and behavior-preserving (or already satisfied) are listed in
+#   the select block below; the rest stay off.
 # - RUF100: with a narrow select list, ruff reports deliberate `# noqa:
 #   BLE001 / DTZ001 / SLF001 / S102` markers as unused simply because those
 #   rules are off here, so enforcing it would delete documentation of
@@ -55,30 +56,28 @@ select = [
     "F",       # pyflakes
     "DTZ",     # process-time-zone-dependent datetime calls (see ignore below)
     "EXE",     # shebang vs executable-bit consistency
+    "G002",    # logging percent-format with extra args
+    "G010",    # logging.warn that should be logging.warning
+    "G101",    # logging extra keys that clash with LogRecord attributes
     "G2",      # .error(..., exc_info=True) -> .exception(...)
     "I",       # import sorting and grouping
     "RUF05",   # unused unpacked variable
     # Rule groups the codebase already satisfies, selected to keep it that way.
+    "ASYNC",   # blocking I/O / sleep / subprocess inside async functions
+    "B",       # flake8-bugbear
     "FA",      # missing from __future__ import annotations
     "ICN",     # import naming conventions
     "INT",     # gettext calls with f-strings
+    "PLE",     # pylint errors (yield/return in __init__, invalid dunders, ...)
     "Q",       # quote style, matching the formatter
+    "SIM",     # flake8-simplify
     "SLOT",    # subclasses of str/tuple/namedtuple without __slots__
     "T1",      # leftover debugger calls
     "W",       # pycodestyle warnings
     "YTT",     # sys.version checks that break on two-digit versions
     # Mechanical, behavior-preserving cleanups; each was applied repo-wide
-    # with `ruff check --fix` in the commit that selected it here.
-    "B006",    # mutable default argument value
-    "B007",    # loop control variable not used in the loop body
-    "B009",    # getattr with a constant attribute name
-    "B010",    # setattr with a constant attribute name
-    "B017",    # pytest.raises(Exception) that should name a concrete type
-    "B023",    # closure that captures a loop variable by reference
-    "B026",    # star-arg unpacking after a keyword argument
-    "B035",    # dict comprehension with a static key
-    "B904",    # raise inside except without from
-    "B905",    # zip() without an explicit strict argument
+    # with `ruff check --fix` in the commit that selected it here. Prefixes
+    # below also lock in already-clean members of the same family.
     "C4",      # comprehension and collection-literal simplifications
     "D202",    # blank line after a function docstring
     "D209",    # closing quotes of a multi-line docstring not on their own line
@@ -90,69 +89,106 @@ select = [
     "D411",    # missing blank line before section
     "D413",    # missing blank line after the last docstring section
     "FLY",     # static str.join that should be an f-string
+    "FURB10",  # print("") that should be print()
     "FURB11",  # conditional expression that should be or
+    "FURB12",  # for-loop writes / for line in f.readlines()
     "FURB13",  # if-expression that should be min()/max()
-    "FURB162", # unnecessary Z-offset replacement before fromisoformat
+    "FURB16",  # bit_count, log base, from_float, isinstance(..., type(None))
     "FURB17",  # membership test against a single-item container
     "FURB18",  # list reversal via slicing, manual prefix/suffix stripping
     "FURB19",  # sorted() only to take the first item
     "LOG",     # flake8-logging (exc_info must name the exception outside except blocks)
     "PERF1",   # dict.items() when only one half is used
+    "PERF203", # try/except inside a loop that should be lifted out
+    "PERF402", # list(seq) / list.copy() that should be a slice or list()
+    "PERF403", # for-loop dict fill that should be a dict comprehension
     "PIE",     # flake8-pie (redundant placeholders, dict kwargs, startswith)
-    "PLC0206", # dict iteration that extracts values by key lookup
-    "PLC0207", # str.split without maxsplit when one segment is used
-    "PLC0208", # iteration over a set literal
+    "PLC01",   # TypeVar variance / name mismatch
+    "PLC02",   # dict iteration, split(maxsplit), set-literal iteration, __slots__
     "PLC0414", # import alias that repeats the name
+    "PLC1802", # len() used as a boolean test
+    "PLC2",    # non-ASCII identifiers / import names
+    "PLC3",    # unnecessary direct lambda call
+    "PLR01",   # comparison with itself / of two constants
+    "PLR0206", # property with parameters
     "PLR0402", # import module.member as member that should be from-import
     "PLR1",    # useless return, repeated comparison, manual min()/max()
+    "PLR2044", # empty comment
     "PLR5",    # else: if ... that should be elif
-    "PLW0108", # lambda that only forwards its arguments
-    "PLW0127", # self-assignment of a variable
+    "PLW01",   # useless else on loop, assert on string, nan comparison, ...
+    "PLW0211", # staticmethod whose first arg is named self
+    "PLW0245", # super without parentheses
+    "PLW0406", # module imports itself
     "PLW0602", # global declaration without assignment
-    "PLW1510", # subprocess.run without an explicit check argument
+    "PLW0604", # global at module level
+    "PLW0642", # assignment to self/cls
+    "PLW0711", # excepting a binary operation
+    "PLW15",   # bad open mode, shallow copy of os.environ, subprocess preexec_fn
+    "PLW2101", # useless with lock
     "PLW3",    # nested min/max calls
-    "PT001",   # pytest.fixture with empty parentheses
-    "PT006",   # wrong type for parametrize argument names
-    "PT009",   # unittest-style assertion that should be a plain assert
+    "PT00",    # pytest.fixture / parametrize / patch / raises basics
+    "PT010",   # pytest.raises without an exception type
     "PT013",   # pytest imported with an alias or from-import
+    "PT014",   # duplicate parametrize cases
+    "PT015",   # assertion that is always false
+    "PT016",   # pytest.fail without a message
     "PT017",   # assertion on an exception captured in an except block
     "PT018",   # composite assertion
+    "PT019",   # fixture requested as a parameter without a value
     "PT02",    # fixture yielding without teardown, unittest-style assertRaises
+    "PT03",    # pytest.warns too broad / with multiple statements
     "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)
     "RET",     # flake8-return (explicit, non-redundant return statements)
     "RSE",     # unnecessary parentheses on a raised exception
     "RUF005",  # list concatenation that should be unpacking
     "RUF006",  # asyncio.create_task result that is never stored
     "RUF007",  # zip of a list and its own tail
+    "RUF008",  # mutable dataclass default
+    "RUF009",  # function call in a dataclass default
     "RUF010",  # explicit str()/repr() call inside an f-string
     "RUF013",  # implicit Optional annotation
+    "RUF015",  # next(iter(...)) that should index the first element
+    "RUF016",  # invalid index type
+    "RUF017",  # quadratic list summation
+    "RUF018",  # assignment expression in an assert
+    "RUF019",  # unnecessary key-in-dict check before a subscript
     "RUF02",   # unparenthesized and inside or, unsorted __all__/__slots__
     "RUF03",   # None not at the end of a union
-    "RUF043",  # pytest.raises match pattern with unescaped metacharacters
-    "RUF046",  # unnecessary int() cast around an int-returning call
+    "RUF04",   # pytest.raises match, nested literals, dataclass Enum, ...
+    "RUF06",   # empty-collection membership, duplicate __all__, permissions
+    "RUF101",  # noqa that should name the redirected rule
     "RUF102",  # noqa directive naming an unknown rule
-    "SIM102",  # nested if that should be a single compound if
-    "SIM103",  # condition returned as True/False branches
-    "SIM105",  # try-except-pass that should be contextlib.suppress
-    "SIM108",  # if-else assignment that should be a ternary
-    "SIM114",  # if branches with identical bodies
-    "SIM115",  # open() without a context manager
-    "SIM117",  # nested with that should be a single multi-context with
-    "SIM118",  # key in dict.keys()
-    "SIM2",    # redundant True/False and twisted conditional expressions
-    "SIM3",    # yoda condition
-    "SIM4",    # if-else block instead of dict.get
-    "SIM9",    # dict.get(key, None)
-    "TRY203",  # exception handler that only re-raises
+    "RUF103",  # invalid suppression comment
+    "RUF104",  # unmatched suppression comment
+    "RUF200",  # invalid pyproject.toml
+    "TRY2",    # verbose re-raise / exception handler that only re-raises
     "TRY400",  # logging.error inside except that should be logging.exception
+    "UP001",   # useless __metaclass__ = type
+    "UP003",   # type(int/float/str) that should be the class object
+    "UP004",   # useless object inheritance
+    "UP005",   # deprecated unittest alias
+    "UP007",   # Union[X, Y] annotation that should be X | Y
+    "UP008",   # super(Class, self) that should be super()
+    "UP009",   # UTF-8 encoding declaration
     "UP01",    # redundant str.encode/open() arguments
     "UP02",    # capture_output, deprecated OSError alias, yield from
+    "UP030",   # format with unused literal arguments
     "UP031",   # percent formatting that should be str.format
     "UP032",   # str.format that should be an f-string
-    "UP007",   # Union[X, Y] annotation that should be X | Y
+    "UP033",   # lru_cache(maxsize=None) that should be cache
     "UP034",   # extraneous parentheses
+    "UP036",   # outdated sys.version_info block
     "UP037",   # quoted annotation that can be a bare type
+    "UP039",   # unnecessary parentheses on a class
+    "UP040",   # TypeAlias that should be type
+    "UP041",   # asyncio.TimeoutError alias that should be TimeoutError
     "UP042",   # str-and-Enum class that should be StrEnum
+    "UP043",   # unnecessary default type arguments
+    "UP044",   # Unpack[] that should be *
+    "UP046",   # Generic class that should use PEP 695 syntax
+    "UP047",   # Generic function that should use PEP 695 syntax
+    "UP049",   # private type parameter that should be _T
+    "UP05",    # useless class __metaclass__ = type
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1048,8 +1048,13 @@ async def main():
             )
 
             if args.output_file:
-                with open(args.output_file, "w", encoding="utf-8") as f:
-                    f.write(report)
+                output_file = args.output_file
+
+                def _write_report() -> None:
+                    with open(output_file, "w", encoding="utf-8") as handle:
+                        handle.write(report)
+
+                await asyncio.to_thread(_write_report)
                 logger.info(f"Report saved to: {args.output_file}")
             else:
                 print(report)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **01 / ~110**. Base: `main`. Lowest risk in the series.

Two layers:

1. **CI** runs `ruff check .` and `ruff format --check .` on the whole tree (not only files changed in the PR).
2. **Rule set** locks in remaining already-clean groups (`B`, `SIM`, `PLE`, `ASYNC`, plus 0-hit members of existing families). Enabled stable rules: 349 → 531.

This is the foundation. Each remaining actionable ruff rule gets its own stacked PR on top, ordered low risk → high risk. House-convention rules stay off (`COM812`, `DTZ001`/`DTZ007`/`DTZ901`, `E501`, `ISC004`, `G001`/`G003`/`G004`, `BLE001`/`S110`/`S112`, `D405`/`D406`/`D407`, `RUF012`).

`select = ["ALL"]` is intentionally not used: it would fail CI with ~37k remaining diagnostics.

## Stack (low → high), current landing

| # | Rule | PR |
| ---: | --- | --- |
| 01 | CI + already-clean groups | this PR |
| 02 | FURB157 | #2477 |
| 03 | UP045 | #2476 |
| 04 | UP006 | #2478 |
| 05 | PTH109 | #2479 |
| 06 | PTH107 | #2483 |
| 07 | PTH106 | #2480 |
| 08 | ARG004 | #2482 |
| 09 | PLW1641 | #2481 |
| 10 | PTH119 | #2484 |
| 11 | PTH103 | #2485 |
| 12 | PTH206 | #2486 |
| 13 | PTH112 | #2487 |
| 14 | PTH120 | #2488 |
| 15 | PTH100 | #2489 |
| 16 | PTH110 | #2490 |
| 17 | PTH208 | #2491 |
| 18 | PTH123 | #2492 |
| 19 | PTH118 | #2493 |
| 20 | PGH004 | #2494 |
| 21 | PGH003 | #2495 |
| 22 | PLW2901 | #2496 |
| 23 | A006 | #2497 |

Merge from the bottom: this PR first, then each stacked PR onto the previous branch.

## Verification

- `ruff check .` (enforced set) — All checks passed
- `ruff format --check .` — 973 files already formatted

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

