### PR TITLE
style: enforce ruff UP045 (Optional[T] to T | None)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -193,6 +193,7 @@ select = [
     "UP049",   # private type parameter that should be _T
     "UP05",    # useless class __metaclass__ = type
     "FURB157", # verbose Decimal constructor
+    "UP045", # Optional[T] to T | None
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Generator, List, Tuple
 
 import requests
 
@@ -95,23 +95,23 @@ class ProviderConfig:
     wildcard_prefixes: Tuple[str, ...] = ()
     config_hint: str = ""
     custom_llm_provider: str | None = None
-    model_loader: Optional[
+    model_loader: (
         Callable[
-            ["ProviderConfig", Dict[str, str], Optional[str]],
-            List[str | Tuple[str, str]],
+            ["ProviderConfig", Dict[str, str], str | None], List[str | Tuple[str, str]]
         ]
-    ] = None
-    reload_params: Optional[Callable[[str, float], Dict[str, Any]]] = None
+        | None
+    ) = None
+    reload_params: Callable[[str, float], Dict[str, Any]] | None = None
 
 
 @dataclass
 class ProviderState:
     enabled: bool
-    params: Optional[Dict[str, str]]
+    params: Dict[str, str] | None
     models: List[str]
     prefix: str = ""
     wildcard_prefixes: Tuple[str, ...] = ()
-    reload_params: Optional[Callable[[str, float], Dict[str, Any]]] = None
+    reload_params: Callable[[str, float], Dict[str, Any]] | None = None
 
 
 MODEL_ALIAS_MAP: Dict[str, Tuple[str, str]] = {}
@@ -570,7 +570,7 @@ def _iter_stream_with_precontent_retry(
             )
 
 
-def _resolve_provider_for_model(model: str) -> Tuple[Optional[str], str]:
+def _resolve_provider_for_model(model: str) -> Tuple[str | None, str]:
     alias = MODEL_ALIAS_MAP.get(model)
     if alias:
         return alias
@@ -585,7 +585,7 @@ def _resolve_provider_for_model(model: str) -> Tuple[Optional[str], str]:
 
 
 def _load_gemini_models(
-    config: ProviderConfig, params: Dict[str, str], base_url: Optional[str]
+    config: ProviderConfig, params: Dict[str, str], base_url: str | None
 ) -> List[str | Tuple[str, str]]:
     models: List[str | Tuple[str, str]] = []
     api_key = params.get("api_key")
@@ -622,7 +622,7 @@ def _load_gemini_models(
 
 
 def _load_deepseek_models(
-    config: ProviderConfig, params: Dict[str, str], base_url: Optional[str]
+    config: ProviderConfig, params: Dict[str, str], base_url: str | None
 ) -> List[str | Tuple[str, str]]:
     api_key = params.get("api_key", "")
     try:
@@ -991,12 +991,12 @@ def invoke_llm(
     system: str | None = None,
     json: bool = False,
     generation_name: str = "invoke_llm",
-    usage_context: Optional[UsageContext] = None,
-    usage_scene: Optional[str | int] = None,
-    billable: Optional[int] = None,
-    request_id: Optional[str] = None,
-    trace_id: Optional[str] = None,
-    usage_metadata: Optional[Dict[str, Any]] = None,
+    usage_context: UsageContext | None = None,
+    usage_scene: str | int | None = None,
+    billable: int | None = None,
+    request_id: str | None = None,
+    trace_id: str | None = None,
+    usage_metadata: Dict[str, Any] | None = None,
     **kwargs,
 ) -> Generator[LLMStreamResponse, None, None]:
     stream_flag = bool(kwargs.get("stream", True))
@@ -1174,12 +1174,12 @@ def chat_llm(
     messages: list,
     json: bool = False,
     generation_name: str = "user_follow_ask",
-    usage_context: Optional[UsageContext] = None,
-    usage_scene: Optional[str | int] = None,
-    billable: Optional[int] = None,
-    request_id: Optional[str] = None,
-    trace_id: Optional[str] = None,
-    usage_metadata: Optional[Dict[str, Any]] = None,
+    usage_context: UsageContext | None = None,
+    usage_scene: str | int | None = None,
+    billable: int | None = None,
+    request_id: str | None = None,
+    trace_id: str | None = None,
+    usage_metadata: Dict[str, Any] | None = None,
     **kwargs,
 ) -> Generator[LLMStreamResponse, None, None]:
     app.logger.info(f"chat_llm [{model}] {messages} ,json:{json} ,kwargs:{kwargs}")

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -14,7 +14,6 @@ The provider can be selected per-Shifu configuration.
 import json
 import logging
 from decimal import Decimal, InvalidOperation
-from typing import Optional
 
 from flask import has_request_context, request
 
@@ -169,9 +168,9 @@ def get_default_audio_settings(provider_name: str = "") -> AudioSettings:
 
 def synthesize_text(
     text: str,
-    voice_settings: Optional[VoiceSettings] = None,
-    audio_settings: Optional[AudioSettings] = None,
-    model: Optional[str] = None,
+    voice_settings: VoiceSettings | None = None,
+    audio_settings: AudioSettings | None = None,
+    model: str | None = None,
     provider_name: str = "",
 ) -> TTSResult:
     """Synthesize text to speech.

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -20,7 +20,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Tuple
 from urllib.parse import quote
 
 import requests
@@ -50,7 +50,7 @@ class AliyunNlsToken:
     def expires_in_seconds(self) -> int:
         return max(0, int(self.expire_time - time.time()))
 
-    def is_expired(self, now: Optional[float] = None) -> bool:
+    def is_expired(self, now: float | None = None) -> bool:
         now_ts = time.time() if now is None else float(now)
         return self.expire_time <= int(now_ts)
 
@@ -104,7 +104,7 @@ def _get_lock_key() -> str:
     return f"{prefix}tts:aliyun:nls_token:lock"
 
 
-def _decode_cache_value(raw: Any) -> Optional[AliyunNlsToken]:
+def _decode_cache_value(raw: Any) -> AliyunNlsToken | None:
     if raw is None:
         return None
     if isinstance(raw, bytes):

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -9,7 +9,7 @@ API Reference:
 """
 
 import logging
-from typing import List, Optional
+from typing import List
 
 import requests
 
@@ -1231,9 +1231,9 @@ class AliyunTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         """Synthesize text to speech using Aliyun TTS.
 

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -10,7 +10,7 @@ API Reference:
 import hashlib
 import logging
 import time
-from typing import List, Optional
+from typing import List
 
 import requests
 
@@ -777,9 +777,9 @@ class BaiduTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         """Synthesize text to speech using Baidu TTS.
 

--- a/src/api/flaskr/api/tts/base.py
+++ b/src/api/flaskr/api/tts/base.py
@@ -8,7 +8,7 @@ used interchangeably.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
 class TTSProvider(StrEnum):
@@ -50,7 +50,7 @@ class ProviderConfig:
     speed: ParamRange
     pitch: ParamRange
     supports_emotion: bool
-    models: Optional[List[Dict[str, str]]] = None
+    models: List[Dict[str, str]] | None = None
     voices: List[Dict[str, str]] = field(default_factory=list)
     emotions: List[Dict[str, str]] = field(default_factory=list)
     supports_custom_voice_id: bool = False
@@ -142,9 +142,9 @@ class BaseTTSProvider(ABC):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         """Synthesize text to speech.
 

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -6,7 +6,7 @@ This module provides TTS synthesis using Minimax's Text-to-Speech API (t2a_v2).
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List
 from urllib.parse import urlencode
 
 import requests
@@ -85,7 +85,7 @@ MINIMAX_EMOTIONS = [
 ]
 
 
-def _resolve_minimax_model(model: Optional[str]) -> str:
+def _resolve_minimax_model(model: str | None) -> str:
     valid_models = {m["value"] for m in MINIMAX_MODELS}
     requested_model = (model or "").strip()
     if requested_model and requested_model not in valid_models:
@@ -355,9 +355,9 @@ class MinimaxTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         """Synthesize text to speech using Minimax TTS.
 
@@ -421,9 +421,9 @@ class MinimaxTTSProvider(BaseTTSProvider):
     def stream_synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> Iterator[MinimaxHTTPStreamChunk]:
         """Synthesize text with MiniMax HTTP streaming.
 
@@ -537,10 +537,10 @@ class MinimaxTTSProvider(BaseTTSProvider):
     def _call_api(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
         output_format: str = "hex",
-        model: Optional[str] = None,
+        model: str | None = None,
     ) -> Dict[str, Any]:
         """Call Minimax TTS API.
 

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -16,7 +16,7 @@ import logging
 import time
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -346,7 +346,7 @@ def _normalize_tencent_voice_id(voice_id: Any) -> str:
     return normalized_voice_id
 
 
-def _resolve_tencent_model(model: Optional[str], emotion: str = "") -> str:
+def _resolve_tencent_model(model: str | None, emotion: str = "") -> str:
     _ = emotion
     normalized_model = str(model or "").strip()
     if normalized_model == TENCENT_DEFAULT_MODEL:
@@ -376,7 +376,7 @@ def build_tencent_sse_payload(
     text: str,
     voice_settings: VoiceSettings,
     audio_settings: AudioSettings,
-    model: Optional[str] = None,
+    model: str | None = None,
 ) -> dict[str, Any]:
     voice_id = _normalize_tencent_voice_id(
         getattr(voice_settings, "voice_id", "") or TENCENT_DEFAULT_VOICE_ID
@@ -435,7 +435,7 @@ def build_tencent_tc3_headers(
     payload_json: str,
     secret_id: str,
     secret_key: str,
-    timestamp: Optional[int] = None,
+    timestamp: int | None = None,
 ) -> dict[str, str]:
     request_timestamp = int(timestamp if timestamp is not None else time.time())
     request_date = dt.datetime.fromtimestamp(
@@ -796,7 +796,7 @@ def _tencent_subtitle_time_ms(
 
 def _tencent_subtitle_index(
     raw_item: dict[str, Any], keys: tuple[str, ...]
-) -> Optional[int]:
+) -> int | None:
     for key in keys:
         if key not in raw_item:
             continue
@@ -819,7 +819,7 @@ def normalize_tencent_subtitle_cues(
     source_text: str = "",
 ) -> list[dict[str, Any]]:
     cues: list[dict[str, Any]] = []
-    seen_cue_keys: set[tuple[str, int, int, Optional[int], Optional[int]]] = set()
+    seen_cue_keys: set[tuple[str, int, int, int | None, int | None]] = set()
     for raw_item in list(subtitles or []):
         if not isinstance(raw_item, dict):
             continue
@@ -909,7 +909,7 @@ def _group_tencent_subtitle_cues_by_sentence(
     cues: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     grouped: list[dict[str, Any]] = []
-    current: Optional[dict[str, Any]] = None
+    current: dict[str, Any] | None = None
 
     for cue in normalize_subtitle_cues(cues):
         text = str(cue.get("text", "") or "").strip()
@@ -1060,7 +1060,7 @@ def parse_tencent_sse_message(
     payload: dict[str, Any],
     *,
     request_text: str,
-) -> Optional[TencentSSEStreamChunk]:
+) -> TencentSSEStreamChunk | None:
     message = _unwrap_tencent_sse_payload(payload)
     error_payload = _get_first_present(message, "Error", "error")
     message_type = str(
@@ -1201,9 +1201,9 @@ class TencentTTSProvider(BaseTTSProvider):
     def stream_synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ):
         if not self.is_configured():
             raise ValueError("Tencent TTS is not configured")
@@ -1288,9 +1288,9 @@ class TencentTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         if not self.is_configured():
             raise ValueError("Tencent TTS is not configured")

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -26,7 +26,7 @@ import json
 import logging
 import time
 import uuid
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import requests
 
@@ -159,7 +159,7 @@ def build_texttovoice_tc3_headers(
     payload_json: str,
     secret_id: str,
     secret_key: str,
-    timestamp: Optional[int] = None,
+    timestamp: int | None = None,
 ) -> Dict[str, str]:
     request_timestamp = int(timestamp if timestamp is not None else time.time())
     request_date = dt.datetime.fromtimestamp(
@@ -216,7 +216,7 @@ def build_texttovoice_tc3_headers(
     }
 
 
-def _resolve_sample_rate(voice_id: str, model: Optional[str]) -> int:
+def _resolve_sample_rate(voice_id: str, model: str | None) -> int:
     voice_model = _VOICE_MODEL_BY_ID.get(str(voice_id or "").strip())
     effective_model = voice_model or (model or "").strip()
     if effective_model == TENCENT_TEXTTOVOICE_LARGE_MODEL:
@@ -380,9 +380,9 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         if not text or not text.strip():
             raise ValueError("Text cannot be empty")

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import base64
 import logging
 import uuid
-from typing import List, Optional
+from typing import List
 
 import requests
 from requests import Response
@@ -178,9 +178,9 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         if not text or not text.strip():
             raise ValueError("Text cannot be empty")

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -14,7 +14,7 @@ import logging
 import struct
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -102,11 +102,11 @@ class ProtocolFrame:
     message_flags: int
     serialization: SerializationMethod
     compression: CompressionMethod
-    event: Optional[Event]
-    session_id: Optional[str]
-    connection_id: Optional[str]
+    event: Event | None
+    session_id: str | None
+    connection_id: str | None
     payload: bytes | Dict[str, Any] | None
-    error_code: Optional[int] = None
+    error_code: int | None = None
 
 
 class VolcengineProtocol:
@@ -116,8 +116,8 @@ class VolcengineProtocol:
     HEADER_SIZE = 0b0001  # 4 bytes (multiplied by 4)
 
     def __init__(self):
-        self.connection_id: Optional[str] = None
-        self.session_id: Optional[str] = None
+        self.connection_id: str | None = None
+        self.session_id: str | None = None
 
     def encode_start_connection(self) -> bytes:
         """Encode StartConnection frame."""
@@ -301,10 +301,10 @@ class VolcengineProtocol:
         compression = CompressionMethod(byte2 & 0x0F)
 
         offset = header_size
-        event: Optional[Event] = None
-        session_id: Optional[str] = None
-        connection_id: Optional[str] = None
-        error_code: Optional[int] = None
+        event: Event | None = None
+        session_id: str | None = None
+        connection_id: str | None = None
+        error_code: int | None = None
 
         # Check if frame has event number
         has_event = (message_flags & MessageFlag.WITH_EVENT) != 0
@@ -413,8 +413,8 @@ class VolcengineProtocol:
         message_flags: int,
         serialization: SerializationMethod,
         compression: CompressionMethod,
-        event: Optional[Event] = None,
-        payload: Optional[Dict[str, Any]] = None,
+        event: Event | None = None,
+        payload: Dict[str, Any] | None = None,
     ) -> bytes:
         """Encode a frame without session/connection ID."""
         frame = bytearray()
@@ -466,7 +466,7 @@ class VolcengineProtocol:
         compression: CompressionMethod,
         event: Event,
         session_id: str,
-        payload: Optional[Dict[str, Any]] = None,
+        payload: Dict[str, Any] | None = None,
     ) -> bytes:
         """Encode a frame with session ID."""
         frame = bytearray()

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -12,7 +12,7 @@ import logging
 import re
 import threading
 import uuid
-from typing import Any, List, Optional
+from typing import Any, List
 
 from flaskr.api.tts.base import (
     AudioSettings,
@@ -423,9 +423,9 @@ class VolcengineTTSProvider(BaseTTSProvider):
     def synthesize(
         self,
         text: str,
-        voice_settings: Optional[VoiceSettings] = None,
-        audio_settings: Optional[AudioSettings] = None,
-        model: Optional[str] = None,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
     ) -> TTSResult:
         """Synthesize text to speech using Volcengine TTS.
 
@@ -487,7 +487,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
         # Collect audio data
         audio_chunks: List[bytes] = []
         subtitle_cues: list[dict[str, Any]] = []
-        error_message: Optional[str] = None
+        error_message: str | None = None
         connection_established = threading.Event()
         session_started = threading.Event()
         session_finished = threading.Event()

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -8,7 +8,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -104,8 +104,8 @@ class UnifiedMigrationTask:
 
     def __init__(
         self,
-        database_url: Optional[str] = None,
-        config: Optional[MigrationConfig] = None,
+        database_url: str | None = None,
+        config: MigrationConfig | None = None,
     ):
         if database_url is None:
             database_url = _resolve_default_database_url()

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class CacheLock(Protocol):
-    def acquire(self, blocking: bool = True, blocking_timeout: Optional[int] = None):
+    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
         raise NotImplementedError
 
     def release(self) -> None:
@@ -20,15 +20,15 @@ class CacheProvider(Protocol):
     def get(self, key: str):
         raise NotImplementedError
 
-    def getex(self, key: str, ex: Optional[int] = None, px: Optional[int] = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None):
         raise NotImplementedError
 
     def set(
         self,
         key: str,
         value: Any,
-        ex: Optional[int] = None,
-        px: Optional[int] = None,
+        ex: int | None = None,
+        px: int | None = None,
         nx: bool = False,
         xx: bool = False,
         *args,
@@ -51,8 +51,8 @@ class CacheProvider(Protocol):
     def lock(
         self,
         key: str,
-        timeout: Optional[int] = None,
-        blocking_timeout: Optional[int] = None,
+        timeout: int | None = None,
+        blocking_timeout: int | None = None,
     ):
         raise NotImplementedError
 
@@ -75,15 +75,15 @@ class _DynamicRedisCacheProvider:
     def get(self, key: str):
         return self._client().get(key)
 
-    def getex(self, key: str, ex: Optional[int] = None, px: Optional[int] = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None):
         return self._client().getex(key, ex=ex, px=px)
 
     def set(
         self,
         key: str,
         value: Any,
-        ex: Optional[int] = None,
-        px: Optional[int] = None,
+        ex: int | None = None,
+        px: int | None = None,
         nx: bool = False,
         xx: bool = False,
         *args,
@@ -109,8 +109,8 @@ class _DynamicRedisCacheProvider:
     def lock(
         self,
         key: str,
-        timeout: Optional[int] = None,
-        blocking_timeout: Optional[int] = None,
+        timeout: int | None = None,
+        blocking_timeout: int | None = None,
     ):
         return self._client().lock(
             key, timeout=timeout, blocking_timeout=blocking_timeout
@@ -120,7 +120,7 @@ class _DynamicRedisCacheProvider:
 @dataclass
 class _InMemoryEntry:
     value: bytes
-    expires_at: Optional[float]
+    expires_at: float | None
 
 
 class _InMemoryLock:
@@ -128,7 +128,7 @@ class _InMemoryLock:
         self._lock = lock
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: Optional[int] = None):
+    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
         if not blocking:
             acquired = self._lock.acquire(blocking=False)
         elif blocking_timeout is None:
@@ -179,7 +179,7 @@ class InMemoryCacheProvider:
             entry = self._store.get(key)
             return entry.value if entry is not None else None
 
-    def getex(self, key: str, ex: Optional[int] = None, px: Optional[int] = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None):
         with self._mu:
             self._purge_if_expired(key)
             entry = self._store.get(key)
@@ -195,8 +195,8 @@ class InMemoryCacheProvider:
         self,
         key: str,
         value: Any,
-        ex: Optional[int] = None,
-        px: Optional[int] = None,
+        ex: int | None = None,
+        px: int | None = None,
         nx: bool = False,
         xx: bool = False,
         *args,
@@ -208,7 +208,7 @@ class InMemoryCacheProvider:
                 return False
             if xx and key not in self._store:
                 return False
-            expires_at: Optional[float] = None
+            expires_at: float | None = None
             if ex is None and args:
                 ex = args[0]
             if ex is not None:
@@ -259,8 +259,8 @@ class InMemoryCacheProvider:
     def lock(
         self,
         key: str,
-        timeout: Optional[int] = None,
-        blocking_timeout: Optional[int] = None,
+        timeout: int | None = None,
+        blocking_timeout: int | None = None,
     ):
         with self._mu:
             lock = self._locks.get(key)
@@ -293,15 +293,15 @@ class FallbackCacheProvider:
     def get(self, key: str):
         return self._call("get", key)
 
-    def getex(self, key: str, ex: Optional[int] = None, px: Optional[int] = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None):
         return self._call("getex", key, ex=ex, px=px)
 
     def set(
         self,
         key: str,
         value: Any,
-        ex: Optional[int] = None,
-        px: Optional[int] = None,
+        ex: int | None = None,
+        px: int | None = None,
         nx: bool = False,
         xx: bool = False,
         *args,
@@ -334,8 +334,8 @@ class FallbackCacheProvider:
     def lock(
         self,
         key: str,
-        timeout: Optional[int] = None,
-        blocking_timeout: Optional[int] = None,
+        timeout: int | None = None,
+        blocking_timeout: int | None = None,
     ):
         return self._call(
             "lock", key, timeout=timeout, blocking_timeout=blocking_timeout

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Type
 
 from flask import Config as FlaskConfig
 from flask import Flask
@@ -23,7 +23,7 @@ class EnvVar:
     example: Any = None  # Optional value to emit in generated example files
     type: Type = str  # Using Type annotation to avoid conflict
     description: str = ""
-    validator: Optional[Callable[[Any], bool]] = None
+    validator: Callable[[Any], bool] | None = None
     secret: bool = False
     group: str = "general"
     depends_on: List[str] = field(default_factory=list)
@@ -2251,7 +2251,7 @@ def has_explicit_env_override(key: str) -> bool:
     return key in os.environ
 
 
-def get_explicit_env_override(key: str) -> Optional[str]:
+def get_explicit_env_override(key: str) -> str | None:
     """Return the raw environment value for a config key, or None when unset.
 
     Unlike ``get_config``, this never substitutes the registry default and

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 import contextlib
 import threading
 from functools import wraps
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 _context_local = threading.local()
 
 
-def set_shifu_context(
-    shifu_bid: Optional[str], shifu_creator_bid: Optional[str]
-) -> None:
+def set_shifu_context(shifu_bid: str | None, shifu_creator_bid: str | None) -> None:
     """Set the shifu context for the current thread.
 
     Args:
@@ -36,7 +34,7 @@ def clear_shifu_context() -> None:
             delattr(_context_local, attr)
 
 
-def get_shifu_creator_bid() -> Optional[str]:
+def get_shifu_creator_bid() -> str | None:
     """Get current shifu creator user business identifier from context."""
     return getattr(_context_local, "shifu_creator_bid", None)
 
@@ -52,7 +50,7 @@ def get_shifu_context_snapshot() -> Dict[str, Any]:
     }
 
 
-def apply_shifu_context_snapshot(snapshot: Optional[Dict[str, Any]]) -> None:
+def apply_shifu_context_snapshot(snapshot: Dict[str, Any] | None) -> None:
     """Apply a previously captured shifu context snapshot to the current thread.
 
     Args:
@@ -67,7 +65,7 @@ def apply_shifu_context_snapshot(snapshot: Optional[Dict[str, Any]]) -> None:
         _context_local.shifu_creator_bid = snapshot.get("shifu_creator_bid")
 
 
-def _get_shifu_creator_bid_cached(app, shifu_bid: str) -> Optional[str]:
+def _get_shifu_creator_bid_cached(app, shifu_bid: str) -> str | None:
     """Resolve creator bid for a shifu with a lightweight Redis cache.
 
     The mapping (shifu_bid -> creator_bid) is effectively immutable, so we can
@@ -125,7 +123,7 @@ def _get_shifu_creator_bid_cached(app, shifu_bid: str) -> Optional[str]:
         return get_shifu_creator_bid(app, shifu_bid)
 
 
-def _resolve_host_creator_bid(app, host: str) -> Optional[str]:
+def _resolve_host_creator_bid(app, host: str) -> str | None:
     """Resolve creator_bid from a verified custom domain host."""
     normalized_host = str(host or "").strip()
     if not normalized_host:
@@ -142,7 +140,7 @@ def _resolve_host_creator_bid(app, host: str) -> Optional[str]:
         return None
 
 
-def _extract_request_host(request) -> Optional[str]:
+def _extract_request_host(request) -> str | None:
     forwarded_host = str(request.headers.get("X-Forwarded-Host", "") or "").strip()
     if forwarded_host:
         return forwarded_host.split(",", 1)[0].strip()
@@ -151,7 +149,7 @@ def _extract_request_host(request) -> Optional[str]:
 
 
 def with_shifu_context(
-    resolve_shifu_bid: Optional[Callable[..., Optional[str]]] = None,
+    resolve_shifu_bid: Callable[..., str | None] | None = None,
 ) -> Callable:
     """Decorator to automatically populate shifu context for a route handler.
 
@@ -175,7 +173,7 @@ def with_shifu_context(
 
             clear_shifu_context()
 
-            shifu_bid: Optional[str] = None
+            shifu_bid: str | None = None
             if resolve_shifu_bid is not None:
                 try:
                     shifu_bid = resolve_shifu_bid(*args, **kwargs)

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 import requests
 
@@ -209,8 +209,8 @@ def upload_to_oss(
     file_id: str,
     content_type: str,
     profile: str = OSS_PROFILE_DEFAULT,
-    config: Optional[OSSConfig] = None,
-    bucket: Optional[oss2.Bucket] = None,
+    config: OSSConfig | None = None,
+    bucket: oss2.Bucket | None = None,
     warm_up: bool = True,
 ) -> tuple[str, str]:
     resolved_config = config or get_oss_config(profile)

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -46,7 +46,7 @@ result so the summary is stable.
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 from flask import Flask
 from flaskr.i18n import _
@@ -160,10 +160,10 @@ class _Params:
         self,
         *,
         shifu_bid: str,
-        start_date: Optional[date],
-        end_date: Optional[date],
-        usage_scene: Optional[Tuple[int, ...]],
-        usage_type: Optional[Tuple[int, ...]],
+        start_date: date | None,
+        end_date: date | None,
+        usage_scene: Tuple[int, ...] | None,
+        usage_type: Tuple[int, ...] | None,
         limit: int,
         offset: int,
     ) -> None:
@@ -215,7 +215,7 @@ def _parse_payload(payload: Any, limit_max: int) -> _Params:
     )
 
 
-def _parse_optional_date(raw: Any, field_name: str) -> Optional[date]:
+def _parse_optional_date(raw: Any, field_name: str) -> date | None:
     if raw is None or raw == "":
         return None
     if not isinstance(raw, str):
@@ -233,7 +233,7 @@ def _parse_optional_date(raw: Any, field_name: str) -> Optional[date]:
 
 def _parse_int_set(
     raw: Any, field_name: str, allowed: Iterable[int]
-) -> Optional[Tuple[int, ...]]:
+) -> Tuple[int, ...] | None:
     if raw is None:
         return None
     if not isinstance(raw, list) or not raw:
@@ -444,7 +444,7 @@ def _coerce_value(value: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _raise(error_name: str, detail: Optional[str] = None) -> None:
+def _raise(error_name: str, detail: str | None = None) -> None:
     message = _(error_name)
     if detail:
         message = f"{message} ({detail})"

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -14,7 +14,7 @@ names registered in ``src/api/error_codes.json``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, List, Mapping, Sequence, Tuple
 
 from flaskr.i18n import _
 from flaskr.service.common.models import ERROR_CODE, AppException
@@ -87,7 +87,7 @@ _SHIFU_META_TABLES = frozenset({"shifu_published_shifus", "shifu_draft_shifus"})
 _LIKE_MIN_NON_WILDCARD_CHARS = 2
 
 
-def _raise(error_name: str, detail: Optional[str] = None) -> None:
+def _raise(error_name: str, detail: str | None = None) -> None:
     """Raise an :class:`AppException` with a stable error name.
 
     ``detail`` is appended in parentheses so the client gets actionable
@@ -110,7 +110,7 @@ class Filter:
 @dataclass(frozen=True)
 class Aggregate:
     fn: str
-    field: Optional[str]
+    field: str | None
     alias: str
     distinct: bool = False
 
@@ -279,7 +279,7 @@ def _parse_aggregates(raw: Any, spec: TableSpec) -> List[Aggregate]:
 
         field_name = item.get("field")
         if fn == "count" and field_name is None:
-            target_field: Optional[str] = None
+            target_field: str | None = None
         else:
             if not isinstance(field_name, str):
                 _raise(
@@ -659,7 +659,7 @@ def _enforce_shifu_meta_table_constraints(
                 )
 
 
-def _default_alias(fn: str, field_name: Optional[str]) -> str:
+def _default_alias(fn: str, field_name: str | None) -> str:
     base = field_name or "rows"
     return f"{fn}_{base}"
 

--- a/src/api/flaskr/service/creator_analytics/engine.py
+++ b/src/api/flaskr/service/creator_analytics/engine.py
@@ -13,7 +13,7 @@ plain ``{"columns": [...], "rows": [...]}`` dict suitable for the HTTP layer.
 from __future__ import annotations
 
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from flask import Flask
 from flaskr.dao import db
@@ -23,8 +23,8 @@ from sqlalchemy.sql import Select
 
 _FALLBACK_WARNED = False
 _lock = threading.Lock()
-_engine: Optional[Engine] = None
-_engine_uri: Optional[str] = None
+_engine: Engine | None = None
+_engine_uri: str | None = None
 
 
 def get_analytics_engine(app: Flask) -> Engine:

--- a/src/api/flaskr/service/creator_analytics/whitelist.py
+++ b/src/api/flaskr/service/creator_analytics/whitelist.py
@@ -19,7 +19,7 @@ builder, driven by :class:`TableSpec` flags:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet, Mapping, Optional, Type
+from typing import FrozenSet, Mapping, Type
 
 from flaskr.service.billing.models import BillingDailyUsageMetric
 from flaskr.service.learn.models import (
@@ -74,7 +74,7 @@ class TableSpec:
     # Used for creator-owned metadata tables (shifu_published_shifus /
     # shifu_draft_shifus) so the row's creator must match the caller. Pairs
     # with has_shifu_bid for a double-gate: shifu permission AND row ownership.
-    creator_scoped_column: Optional[str] = None
+    creator_scoped_column: str | None = None
     # When True, sql_builder injects AND status = 1 to exclude rerolled /
     # superseded history rows. Only enabled where status semantics are
     # "1 = current, 0 = history" (e.g. learn_generated_blocks).

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Sequence, Set, Tuple
 
 from flask import Flask
 from flaskr.dao import db
@@ -101,7 +101,7 @@ def _format_percentage(numerator: int, denominator: int) -> str:
     return _format_money((Decimal(numerator) * Decimal(100)) / Decimal(denominator))
 
 
-def _format_average_score(value: Optional[Decimal]) -> str:
+def _format_average_score(value: Decimal | None) -> str:
     if value is None:
         return ""
     return f"{value:.1f}"
@@ -344,7 +344,7 @@ def _build_follow_up_user_keyword_filter(
 def _resolve_follow_up_matching_outline_bids(
     outline_context_map: Dict[str, Dict[str, str]],
     chapter_keyword: str,
-) -> Optional[Set[str]]:
+) -> Set[str] | None:
     normalized_keyword = str(chapter_keyword or "").strip().lower()
     if not normalized_keyword:
         return None
@@ -910,13 +910,13 @@ def _load_dashboard_course_meta_map(user_id: str) -> Dict[str, _DashboardCourseM
 def _load_dashboard_course_meta(
     user_id: str,
     shifu_bid: str,
-) -> Optional[_DashboardCourseMeta]:
+) -> _DashboardCourseMeta | None:
     normalized_user_id = str(user_id or "").strip()
     normalized_shifu_bid = str(shifu_bid or "").strip()
     if not normalized_user_id or not normalized_shifu_bid:
         return None
 
-    latest_row: Optional[PublishedShifu] = (
+    latest_row: PublishedShifu | None = (
         PublishedShifu.query.filter(
             PublishedShifu.shifu_bid == normalized_shifu_bid,
             PublishedShifu.created_user_bid == normalized_user_id,
@@ -946,7 +946,7 @@ def _load_dashboard_course_meta(
 def _load_dashboard_entry_courses(
     user_id: str,
     *,
-    keyword: Optional[str] = None,
+    keyword: str | None = None,
 ) -> List[_DashboardCourseMeta]:
     courses = list(_load_dashboard_course_meta_map(user_id).values())
     normalized_keyword = str(keyword or "").strip().lower()
@@ -961,8 +961,8 @@ def _load_dashboard_entry_courses(
     return courses
 
 
-def _load_dashboard_course_created_at(shifu_bid: str) -> Optional[datetime]:
-    latest_draft: Optional[DraftShifu] = (
+def _load_dashboard_course_created_at(shifu_bid: str) -> datetime | None:
+    latest_draft: DraftShifu | None = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,
             DraftShifu.deleted == 0,
@@ -1152,7 +1152,7 @@ def _load_dashboard_course_joined_at_map(
 
     joined_at_map: Dict[str, datetime] = {}
 
-    def _merge_rows(rows: Sequence[tuple[str, Optional[datetime]]]) -> None:
+    def _merge_rows(rows: Sequence[tuple[str, datetime | None]]) -> None:
         for user_bid, joined_at in rows:
             normalized_user_bid = str(user_bid or "").strip()
             if not normalized_user_bid or not joined_at:
@@ -1366,8 +1366,8 @@ def _count_completed_learners(shifu_bid: str, leaf_outline_bids: List[str]) -> i
 def _collect_dashboard_entry_metrics(
     shifu_bids: List[str],
     *,
-    start_dt: Optional[datetime],
-    end_dt_exclusive: Optional[datetime],
+    start_dt: datetime | None,
+    end_dt_exclusive: datetime | None,
 ) -> _DashboardEntryMetrics:
     if not shifu_bids:
         return _DashboardEntryMetrics()
@@ -1495,14 +1495,14 @@ def build_dashboard_entry(
     app: Flask,
     user_id: str,
     *,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    keyword: Optional[str] = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    keyword: str | None = None,
     page_index: int = 1,
     page_size: int = 20,
-    timezone_name: Optional[str] = None,
+    timezone_name: str | None = None,
 ) -> DashboardEntryDTO:
-    def _parse_optional_date(raw: Optional[str]) -> Optional[date]:
+    def _parse_optional_date(raw: str | None) -> date | None:
         if raw is None:
             return None
         text = str(raw).strip()
@@ -1628,11 +1628,11 @@ def _build_dashboard_course_learners(
     leaf_outline_bids: Sequence[str],
     page_index: int,
     page_size: int,
-    keyword: Optional[str],
-    learning_status: Optional[str],
-    last_learning_start_time: Optional[str],
-    last_learning_end_time: Optional[str],
-    timezone_name: Optional[str],
+    keyword: str | None,
+    learning_status: str | None,
+    last_learning_start_time: str | None,
+    last_learning_end_time: str | None,
+    timezone_name: str | None,
 ) -> DashboardCourseDetailLearnersDTO:
     safe_page_size = min(
         max(int(page_size or 20), 1),
@@ -1999,11 +1999,11 @@ def _build_dashboard_course_learners(
 
 
 def _parse_dashboard_date_boundary(
-    value: Optional[str],
+    value: str | None,
     *,
     param_name: str,
     end_of_day: bool = False,
-) -> Optional[datetime]:
+) -> datetime | None:
     normalized = str(value or "").strip()
     if not normalized:
         return None
@@ -2019,8 +2019,8 @@ def _parse_dashboard_date_boundary(
 
 def _validate_dashboard_date_range(
     *,
-    start_dt: Optional[datetime],
-    end_dt_exclusive: Optional[datetime],
+    start_dt: datetime | None,
+    end_dt_exclusive: datetime | None,
     start_param_name: str,
     end_param_name: str,
 ) -> None:
@@ -2037,13 +2037,13 @@ def build_dashboard_course_follow_ups(
     *,
     page_index: int = 1,
     page_size: int = 20,
-    keyword: Optional[str] = None,
-    user_bid: Optional[str] = None,
-    chapter_keyword: Optional[str] = None,
-    source_status: Optional[str] = None,
-    start_time: Optional[str] = None,
-    end_time: Optional[str] = None,
-    timezone_name: Optional[str] = None,
+    keyword: str | None = None,
+    user_bid: str | None = None,
+    chapter_keyword: str | None = None,
+    source_status: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    timezone_name: str | None = None,
 ) -> DashboardCourseFollowUpListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -2267,7 +2267,7 @@ def build_dashboard_course_follow_up_detail(
     shifu_bid: str,
     generated_block_bid: str,
     *,
-    timezone_name: Optional[str] = None,
+    timezone_name: str | None = None,
 ) -> DashboardCourseFollowUpDetailDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -2382,13 +2382,13 @@ def build_dashboard_course_ratings(
     *,
     page_index: int = 1,
     page_size: int = 20,
-    keyword: Optional[str] = None,
-    chapter_keyword: Optional[str] = None,
-    score: Optional[str] = None,
-    has_comment: Optional[str] = None,
-    start_time: Optional[str] = None,
-    end_time: Optional[str] = None,
-    timezone_name: Optional[str] = None,
+    keyword: str | None = None,
+    chapter_keyword: str | None = None,
+    score: str | None = None,
+    has_comment: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    timezone_name: str | None = None,
 ) -> DashboardCourseRatingListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -2595,11 +2595,11 @@ def build_dashboard_course_learners(
     *,
     page_index: int = 1,
     page_size: int = 20,
-    keyword: Optional[str] = None,
-    learning_status: Optional[str] = None,
-    last_learning_start_time: Optional[str] = None,
-    last_learning_end_time: Optional[str] = None,
-    timezone_name: Optional[str] = None,
+    keyword: str | None = None,
+    learning_status: str | None = None,
+    last_learning_start_time: str | None = None,
+    last_learning_end_time: str | None = None,
+    timezone_name: str | None = None,
 ) -> DashboardCourseDetailLearnersDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -2632,7 +2632,7 @@ def build_dashboard_course_detail(
     user_id: str,
     shifu_bid: str,
     *,
-    timezone_name: Optional[str] = None,
+    timezone_name: str | None = None,
 ) -> DashboardCourseDetailDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import dataclass, replace
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Callable, Generator, Iterable, Optional, Union
+from typing import Any, Callable, Generator, Iterable, Union
 
 from flask import Flask
 from flaskr.api.llm import chat_llm, get_allowed_models, get_current_models
@@ -411,13 +411,13 @@ class MdflowContextV2:
         self,
         *,
         document: str,
-        document_prompt: Optional[str] = None,
-        llm_provider: Optional[LLMProvider] = None,
-        interaction_prompt: Optional[str] = None,
-        interaction_error_prompt: Optional[str] = None,
+        document_prompt: str | None = None,
+        llm_provider: LLMProvider | None = None,
+        interaction_prompt: str | None = None,
+        interaction_error_prompt: str | None = None,
         use_learner_language: bool = False,
         visual_mode: bool = True,
-        output_language: Optional[str] = None,
+        output_language: str | None = None,
     ):
         self._mdflow = MarkdownFlow(
             document=document,
@@ -452,9 +452,9 @@ class MdflowContextV2:
         *,
         block_index: int,
         mode: ProcessMode,
-        context: Optional[list[dict[str, str]]] = None,
-        variables: Optional[dict] = None,
-        user_input: Optional[dict[str, list[str]]] = None,
+        context: list[dict[str, str]] | None = None,
+        variables: dict | None = None,
+        user_input: dict[str, list[str]] | None = None,
     ):
         return self._mdflow.process(
             block_index=block_index,
@@ -466,8 +466,8 @@ class MdflowContextV2:
 
     @staticmethod
     def normalize_context_messages(
-        context: Optional[Iterable[dict[str, str]]],
-    ) -> Optional[list[dict[str, str]]]:
+        context: Iterable[dict[str, str]] | None,
+    ) -> list[dict[str, str]] | None:
         if not context:
             return None
         filtered: list[dict[str, str]] = []
@@ -483,9 +483,9 @@ class MdflowContextV2:
 
     @staticmethod
     def filter_context_by_output_language(
-        context: Optional[list[dict[str, str]]],
+        context: list[dict[str, str]] | None,
         output_language: str,
-    ) -> Optional[list[dict[str, str]]]:
+    ) -> list[dict[str, str]] | None:
         if not context:
             return context
         normalized_language = (output_language or "").strip().lower()
@@ -528,7 +528,7 @@ class MdflowContextV2:
 
     @staticmethod
     def flatten_user_input_map(
-        user_input: Optional[dict[str, list[str]]],
+        user_input: dict[str, list[str]] | None,
     ) -> str:
         if not user_input:
             return ""
@@ -544,7 +544,7 @@ class MdflowContextV2:
     def build_context_from_blocks(
         blocks: Iterable["LearnGeneratedBlock"],
         document: str,
-        variables: Optional[dict] = None,
+        variables: dict | None = None,
     ) -> list[dict[str, str]]:
         message_list: list[dict[str, str]] = []
         mdflow_context = MdflowContextV2(document=document)
@@ -627,8 +627,8 @@ class _PreviewContextStore:
         user_bid: str,
         shifu_bid: str,
         outline_bid: str,
-        ttl_seconds: Optional[int] = None,
-        language: Optional[str] = None,
+        ttl_seconds: int | None = None,
+        language: str | None = None,
     ):
         self._cache = cache_provider
         self._ttl_seconds = ttl_seconds or self._DEFAULT_TTL_SECONDS
@@ -680,7 +680,7 @@ class _PreviewContextStore:
                 messages.append({"role": "assistant", "content": assistant_text})
         return messages
 
-    def _load_entries(self, document: str) -> Optional[list[dict]]:
+    def _load_entries(self, document: str) -> list[dict] | None:
         payload = self.load()
         if not payload:
             return None
@@ -725,7 +725,7 @@ class _PreviewContextStore:
         block-based truncation in get_context() preserves them.
         """
         entries: list[dict] = []
-        pending_user: Optional[str] = None
+        pending_user: str | None = None
         for item in context or []:
             if not isinstance(item, dict):
                 continue
@@ -771,8 +771,8 @@ class _PreviewContextStore:
         self,
         document: str,
         block_index: int,
-        user_message: Optional[str],
-        assistant_message: Optional[str],
+        user_message: str | None,
+        assistant_message: str | None,
     ) -> None:
         if not user_message and not assistant_message:
             return
@@ -1080,7 +1080,7 @@ class RunScriptPreviewContextV2:
         preview_request: PlaygroundPreviewRequest,
         user_bid: str,
         shifu_bid: str,
-    ) -> Optional[dict]:
+    ) -> dict | None:
         request_variables = (
             dict(preview_request.variables)
             if isinstance(preview_request.variables, dict)
@@ -1111,7 +1111,7 @@ class RunScriptPreviewContextV2:
     def _iter_preview_generated_events(
         self,
         *,
-        result: Optional[LLMResult] | Generator[LLMResult, None, None],
+        result: LLMResult | Generator[LLMResult, None, None] | None,
         outline_bid: str,
         block_index: int,
         current_block,
@@ -1163,7 +1163,7 @@ class RunScriptPreviewContextV2:
     def _preview_events_from_result(
         self,
         *,
-        llm_result: Optional[LLMResult],
+        llm_result: LLMResult | None,
         outline_bid: str,
         generated_block_bid: str,
         current_block,
@@ -1252,12 +1252,12 @@ class RunScriptPreviewContextV2:
     def _resolve_document_prompt(
         self,
         preview_request: PlaygroundPreviewRequest,
-        outline: Optional[DraftOutlineItem | PublishedOutlineItem],
-        shifu: Optional[DraftShifu | PublishedShifu],
+        outline: DraftOutlineItem | PublishedOutlineItem | None,
+        shifu: DraftShifu | PublishedShifu | None,
         shifu_bid: str,
         outline_bid: str,
         user_bid: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         course_prompt: str | None = None
         if preview_request.document_prompt:
             prompt = preview_request.document_prompt.strip()
@@ -1306,8 +1306,8 @@ class RunScriptPreviewContextV2:
         self,
         shifu_bid: str,
         outline_bid: str,
-        outline_record: Optional[DraftOutlineItem | PublishedOutlineItem],
-    ) -> Optional[str]:
+        outline_record: DraftOutlineItem | PublishedOutlineItem | None,
+    ) -> str | None:
         target_bid = outline_record.outline_item_bid if outline_record else outline_bid
         if not target_bid:
             return None
@@ -1378,8 +1378,8 @@ class RunScriptPreviewContextV2:
     def _resolve_llm_settings(
         self,
         preview_request: PlaygroundPreviewRequest,
-        outline: Optional[DraftOutlineItem | PublishedOutlineItem],
-        shifu: Optional[DraftShifu | PublishedShifu],
+        outline: DraftOutlineItem | PublishedOutlineItem | None,
+        shifu: DraftShifu | PublishedShifu | None,
     ) -> tuple[str, float]:
         def _normalize_model(value: object | None) -> str | None:
             if value is None:
@@ -1461,7 +1461,7 @@ class RunScriptPreviewContextV2:
 
     def _get_outline_record(
         self, shifu_bid: str, outline_bid: str
-    ) -> Optional[DraftOutlineItem | PublishedOutlineItem]:
+    ) -> DraftOutlineItem | PublishedOutlineItem | None:
         outline = (
             DraftOutlineItem.query.filter(
                 DraftOutlineItem.shifu_bid == shifu_bid,
@@ -1485,7 +1485,7 @@ class RunScriptPreviewContextV2:
 
     def _get_shifu_record(
         self, shifu_bid: str, has_draft_outline: bool
-    ) -> Optional[DraftShifu | PublishedShifu]:
+    ) -> DraftShifu | PublishedShifu | None:
         if has_draft_outline:
             shifu = (
                 DraftShifu.query.filter(
@@ -1505,7 +1505,7 @@ class RunScriptPreviewContextV2:
             .first()
         )
 
-    def _decimal_to_float(self, value) -> Optional[float]:
+    def _decimal_to_float(self, value) -> float | None:
         if value is None:
             return None
         if isinstance(value, Decimal):

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PrivateAttr
@@ -364,7 +364,7 @@ class AudioSegmentDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
+        subtitle_cues: List[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -432,7 +432,7 @@ class AudioCompleteDTO(BaseModel):
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
         av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
+        subtitle_cues: List[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -533,7 +533,7 @@ class ElementAudioDTO(BaseModel):
         audio_bid: str,
         duration_ms: int,
         position: int = 0,
-        subtitle_cues: Optional[List[SubtitleCueDTO]] = None,
+        subtitle_cues: List[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -586,7 +586,7 @@ class ElementPayloadDTO(BaseModel):
     def __init__(
         self,
         audio: ElementAudioDTO | None = None,
-        previous_visuals: Optional[List[ElementVisualDTO]] = None,
+        previous_visuals: List[ElementVisualDTO] | None = None,
         anchor_element_bid: str | None = None,
         ask_element_bid: str | None = None,
         user_input: str | None = None,
@@ -891,33 +891,33 @@ class RunMarkdownFlowDTO(BaseModel):
 
 
 class PlaygroundPreviewRequest(BaseModel):
-    content: Optional[str] = Field(
+    content: str | None = Field(
         default=None, description="Markdown-Flow document content"
     )
     block_index: int = Field(..., description="Block index to preview")
-    context: Optional[List[Dict[str, str]]] = Field(
+    context: List[Dict[str, str]] | None = Field(
         default=None, description="Conversation context messages"
     )
-    variables: Optional[Dict[str, Any]] = Field(
+    variables: Dict[str, Any] | None = Field(
         default=None,
         description="Variables to replace inside Markdown-Flow document",
     )
-    user_input: Optional[Dict[str, List[str]]] = Field(
+    user_input: Dict[str, List[str]] | None = Field(
         default=None, description="User input when previewing interaction blocks"
     )
-    document_prompt: Optional[str] = Field(
+    document_prompt: str | None = Field(
         default=None, description="Document level system prompt"
     )
-    interaction_prompt: Optional[str] = Field(
+    interaction_prompt: str | None = Field(
         default=None, description="Interaction render prompt override"
     )
-    interaction_error_prompt: Optional[str] = Field(
+    interaction_error_prompt: str | None = Field(
         default=None, description="Interaction error prompt override"
     )
-    model: Optional[str] = Field(
+    model: str | None = Field(
         default=None, description="Target LLM model used during preview"
     )
-    temperature: Optional[float] = Field(
+    temperature: float | None = Field(
         default=None,
         ge=0.0,
         le=2.0,
@@ -937,19 +937,19 @@ class LearnElementRecordDTO(BaseModel):
     elements: List[ElementDTO] = Field(
         default_factory=list, description="Listen-mode final element snapshots"
     )
-    events: Optional[List[RunElementSSEMessageDTO]] = Field(
+    events: List[RunElementSSEMessageDTO] | None = Field(
         default=None, description="Optional listen-mode event stream replay"
     )
-    last_progress_updated_at: Optional[str] = Field(
+    last_progress_updated_at: str | None = Field(
         default=None,
         description="Latest update time for the learner's progress on this lesson",
     )
 
     def __init__(
         self,
-        elements: Optional[List[ElementDTO]] = None,
-        events: Optional[List[RunElementSSEMessageDTO]] = None,
-        last_progress_updated_at: Optional[str] = None,
+        elements: List[ElementDTO] | None = None,
+        events: List[RunElementSSEMessageDTO] | None = None,
+        last_progress_updated_at: str | None = None,
     ):
         super().__init__(
             elements=elements or [],

--- a/src/api/flaskr/service/learn/preview_permissions.py
+++ b/src/api/flaskr/service/learn/preview_permissions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
 
 from flask import Flask, request
 from flaskr.service.common import raise_error
@@ -15,7 +14,7 @@ BUILTIN_DEMO_TITLES = {
 }
 
 
-def _extract_preview_token() -> Optional[str]:
+def _extract_preview_token() -> str | None:
     token = request.cookies.get("token", None)
     if not token:
         token = request.args.get("token", None)
@@ -121,7 +120,7 @@ def is_builtin_demo_shifu(app: Flask, shifu_bid: str) -> bool:
     return False
 
 
-def _get_shifu_creator_bid(app: Flask, shifu_bid: str) -> Optional[str]:
+def _get_shifu_creator_bid(app: Flask, shifu_bid: str) -> str | None:
     with app.app_context():
         for row in _load_course_rows(shifu_bid):
             creator_bid = str(getattr(row, "created_user_bid", "") or "").strip()

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -7,7 +7,7 @@ import time
 import traceback
 import uuid
 from datetime import datetime
-from typing import Any, Generator, Optional
+from typing import Any, Generator
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as cache_provider
@@ -284,7 +284,7 @@ def _clear_run_script_status(app: Flask, user_bid: str, outline_bid: str) -> Non
 
 def _get_run_script_started_at(
     app: Flask, user_bid: str, outline_bid: str
-) -> Optional[int]:
+) -> int | None:
     try:
         raw = cache_provider.get(_get_run_script_status_key(app, user_bid, outline_bid))
     except Exception as exc:
@@ -683,8 +683,8 @@ def run_script(
     reload_element_bid: str | None = None,
     listen: bool = False,
     preview_mode: bool = False,
-    shifu_context_snapshot: Optional[dict[str, Any]] = None,
-    language: Optional[str] = None,
+    shifu_context_snapshot: dict[str, Any] | None = None,
+    language: str | None = None,
 ) -> Generator[str, None, None]:
     timeout = RUN_SCRIPT_TIMEOUT_SECONDS
     blocking_timeout = 1

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import Flask
 from flaskr.dao import cleanup_session_after, db, invalidate_session
@@ -38,7 +38,7 @@ class UsageContext:
     request_id: str = ""
     trace_id: str = ""
     usage_scene: int = BILL_USAGE_SCENE_PROD
-    billable: Optional[int] = None
+    billable: int | None = None
 
 
 def _resolve_billable(app: Flask, *, context: UsageContext, usage_scene: int) -> int:
@@ -128,7 +128,7 @@ def record_llm_usage(
     latency_ms: int = 0,
     status: int = 0,
     error_message: str = "",
-    extra: Optional[Dict[str, Any]] = None,
+    extra: Dict[str, Any] | None = None,
 ) -> str:
     usage_bid = generate_id(app)
     normalized_usage_scene = normalize_usage_scene(context.usage_scene)
@@ -211,7 +211,7 @@ def record_tts_usage(
     app: Flask,
     context: UsageContext,
     *,
-    usage_bid: Optional[str] = None,
+    usage_bid: str | None = None,
     provider: str,
     model: str,
     is_stream: bool,
@@ -227,7 +227,7 @@ def record_tts_usage(
     segment_count: int = 0,
     status: int = 0,
     error_message: str = "",
-    extra: Optional[Dict[str, Any]] = None,
+    extra: Dict[str, Any] | None = None,
     enqueue_settlement: bool = True,
 ) -> str:
     resolved_usage_bid = usage_bid or generate_id(app)

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from flask import Flask
 from flaskr.dao import db
@@ -179,7 +179,7 @@ def normalize_contact_identifier(identifier: str, contact_type: str) -> str:
     return None
 
 
-def _format_decimal(value: Optional[Decimal]) -> str:
+def _format_decimal(value: Decimal | None) -> str:
     """Format a Decimal or numeric string to trimmed two-decimal string."""
     if value is None:
         return "0"
@@ -189,7 +189,7 @@ def _format_decimal(value: Optional[Decimal]) -> str:
     return normalized
 
 
-def _format_cents(value: Optional[int]) -> str:
+def _format_cents(value: int | None) -> str:
     """Convert cents integer to string representation in units."""
     if value is None:
         return "0"
@@ -199,7 +199,7 @@ def _format_cents(value: Optional[int]) -> str:
         return "0"
 
 
-def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
+def _parse_datetime(value: str, is_end: bool = False) -> datetime | None:
     """Parse date/time string with multiple formats; auto fill day bounds."""
     if not value:
         return None
@@ -227,7 +227,7 @@ def _parse_datetime(value: str, is_end: bool = False) -> Optional[datetime]:
     return None
 
 
-def _normalize_order_status_filter(value: Any) -> Optional[int]:
+def _normalize_order_status_filter(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
@@ -240,7 +240,7 @@ def _normalize_order_status_filter(value: Any) -> Optional[int]:
 
 def _normalize_order_datetime_filter(
     value: Any, *, is_end: bool = False
-) -> Optional[datetime]:
+) -> datetime | None:
     if isinstance(value, datetime):
         return value
     return _parse_datetime(str(value or "").strip(), is_end=is_end)
@@ -612,7 +612,7 @@ def _build_order_item(
     order: Order,
     shifu_map: Dict[str, DraftShifu | PublishedShifu],
     user_map: Dict[str, Dict[str, str]],
-    coupon_map: Optional[Dict[str, List[str]]] = None,
+    coupon_map: Dict[str, List[str]] | None = None,
 ) -> OrderAdminSummaryDTO:
     """Build admin order summary DTO from order plus shifu/user lookups."""
     shifu = shifu_map.get(order.shifu_bid)
@@ -658,7 +658,7 @@ def import_activation_order(
     app: Flask,
     mobile: str,
     course_id: str,
-    user_nick_name: Optional[str] = None,
+    user_nick_name: str | None = None,
     contact_type: str = "phone",
     allow_empty_nickname: bool = False,
     payment_channel: str = "manual",
@@ -761,7 +761,7 @@ def import_activation_orders(
     app: Flask,
     mobiles: List[str],
     course_id: str,
-    user_nick_name: Optional[str] = None,
+    user_nick_name: str | None = None,
     contact_type: str = "phone",
 ) -> Dict[str, Any]:
     """Bulk import activation orders from a list of phone/email identifiers."""
@@ -859,7 +859,7 @@ def list_orders(
     user_id: str,
     page_index: int,
     page_size: int,
-    filters: Optional[Dict[str, Any]] = None,
+    filters: Dict[str, Any] | None = None,
 ) -> PageNationDTO:
     """List orders visible to the current operator with optional filters."""
     with app.app_context():
@@ -953,7 +953,7 @@ def list_operator_orders(
     app: Flask,
     page_index: int,
     page_size: int,
-    filters: Optional[Dict[str, Any]] = None,
+    filters: Dict[str, Any] | None = None,
 ) -> PageNationDTO:
     """List global orders for operator views with cross-course filters."""
     with app.app_context():
@@ -1138,7 +1138,7 @@ def _load_order_coupons(order_bid: str) -> List[OrderAdminCouponDTO]:
     return coupons
 
 
-def _load_payment_detail(order: Order) -> Optional[OrderAdminPaymentDTO]:
+def _load_payment_detail(order: Order) -> OrderAdminPaymentDTO | None:
     """Build payment detail DTO from channel-specific order records."""
     payment_channel = order.payment_channel or ""
     if payment_channel == "stripe":

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -1,6 +1,6 @@
 import decimal
 import json
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from flask import Flask
 from flaskr.api.doc.feishu import send_notify
@@ -27,7 +27,7 @@ from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc
 
 
-def _get_course_id_from_filter(coupon: Coupon) -> Optional[str]:
+def _get_course_id_from_filter(coupon: Coupon) -> str | None:
     """Extract course_id from coupon.filter; return None if missing/invalid/empty."""
     if not coupon or not coupon.filter:
         return None
@@ -63,7 +63,7 @@ def _pick_coupon_candidate(
     coupons_by_code: List[Coupon],
     shifu_bid: str,
     user_id: str,
-) -> Tuple[Optional[CouponUsageModel], Optional[Coupon], bool]:
+) -> Tuple[CouponUsageModel | None, Coupon | None, bool]:
     """Pick a coupon_usage/coupon pair that matches the current course.
     Returns (usage, coupon, has_candidate_with_same_code).
     """
@@ -71,7 +71,7 @@ def _pick_coupon_candidate(
 
     def select(
         usages: List[CouponUsageModel],
-    ) -> Tuple[Optional[CouponUsageModel], Optional[Coupon]]:
+    ) -> Tuple[CouponUsageModel | None, Coupon | None]:
         for usage in usages:
             coupon = coupons_by_bid.get(getattr(usage, "coupon_bid", None))
             if coupon and _coupon_matches_course(coupon, shifu_bid):

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -3,7 +3,7 @@ import decimal
 import json
 import re
 from contextlib import contextmanager, nullcontext, suppress
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Tuple
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import pytz
@@ -303,7 +303,7 @@ def _sync_order_campaign_pricing(
     buy_record: Order,
     user_id: str,
     course_id: str,
-    active_id: Optional[str],
+    active_id: str | None,
 ) -> Tuple[List, decimal.Decimal]:
     """Refresh eligible campaigns for an unpaid order and recalculate paid price.
 
@@ -492,7 +492,7 @@ class BuyRecordDTO:
         channel,
         qr_url,
         payment_channel: str = "",
-        payment_payload: Optional[Dict[str, Any]] = None,
+        payment_payload: Dict[str, Any] | None = None,
     ):
         self.order_id = record_id
         self.user_id = user_id
@@ -519,7 +519,7 @@ def generate_charge(
     record_id: str,
     channel: str,
     client_ip: str,
-    payment_channel: Optional[str] = None,
+    payment_channel: str | None = None,
 ) -> BuyRecordDTO:
     """Generate charge"""
     with _app_context_scope(app), unit_of_work():
@@ -673,10 +673,10 @@ def _order_credential_scope(app: Flask, order: Order, context=None):
 
 def _resolve_payment_channel(
     *,
-    payment_channel_hint: Optional[str],
-    channel_hint: Optional[str],
-    stored_channel: Optional[str],
-    additional_enabled_providers: Optional[set[str]] = None,
+    payment_channel_hint: str | None,
+    channel_hint: str | None,
+    stored_channel: str | None,
+    additional_enabled_providers: set[str] | None = None,
 ) -> Tuple[str, str]:
     """Resolve the provider and provider-specific channel based on hints."""
     return resolve_payment_channel(
@@ -718,9 +718,7 @@ def _format_response_channel(payment_channel: str, provider_channel: str) -> str
     return provider_channel
 
 
-def _sanitize_pingxx_text(
-    value: Optional[str], *, fallback: str, max_length: int
-) -> str:
+def _sanitize_pingxx_text(value: str | None, *, fallback: str, max_length: int) -> str:
     text = (value or fallback or "").strip()
     text = re.sub(r"[\r\n\t]+", " ", text)
     text = re.sub(r"\s{2,}", " ", text).strip()
@@ -746,7 +744,7 @@ def _generate_pingxx_charge(
     pingpp_id = get_config("PINGXX_APP_ID")
     provider_options: Dict[str, Any] = {"app_id": pingpp_id}
     charge_extra: Dict[str, Any] = {}
-    qr_url_key: Optional[str] = None
+    qr_url_key: str | None = None
     product_id = course.bid
 
     if channel == "wx_pub_qr":  # wxpay scan
@@ -1150,8 +1148,8 @@ def _generate_wechatpay_charge(
 def sync_stripe_checkout_session(
     app: Flask,
     order_id: str,
-    session_id: Optional[str] = None,
-    expected_user: Optional[str] = None,
+    session_id: str | None = None,
+    expected_user: str | None = None,
 ):
     with _app_context_scope(app), unit_of_work():
         order = (
@@ -1215,8 +1213,8 @@ def sync_native_payment_order(
     app: Flask,
     order_id: str,
     *,
-    expected_user: Optional[str] = None,
-    payment_channel: Optional[str] = None,
+    expected_user: str | None = None,
+    payment_channel: str | None = None,
 ):
     with _app_context_scope(app), unit_of_work():
         order = (
@@ -1298,7 +1296,7 @@ def _update_stripe_order_snapshot(
     *,
     stripe_order: StripeOrder,
     session: Dict[str, Any],
-    intent: Optional[Dict[str, Any]],
+    intent: Dict[str, Any] | None,
 ):
     if session:
         stripe_order.checkout_session_id = session.get(
@@ -1330,7 +1328,7 @@ def _update_stripe_order_snapshot(
 
 
 def _is_stripe_payment_successful(
-    *, session: Optional[Dict[str, Any]], intent: Optional[Dict[str, Any]]
+    *, session: Dict[str, Any] | None, intent: Dict[str, Any] | None
 ) -> bool:
     if session:
         if session.get("payment_status") == "paid":
@@ -1402,7 +1400,7 @@ def _is_native_payment_successful(
 def _extract_native_notification_amount(
     provider: str,
     payload: Dict[str, Any],
-) -> Optional[int]:
+) -> int | None:
     trade_payload = extract_native_trade_payload(payload)
     if provider == "alipay":
         total_amount = (
@@ -1523,7 +1521,7 @@ def handle_stripe_webhook(
         }, 202
 
     with _app_context_scope(app), unit_of_work():
-        stripe_order: Optional[StripeOrder] = (
+        stripe_order: StripeOrder | None = (
             legacy_stripe_snapshot_query()
             .filter(StripeOrder.order_bid == order_bid)
             .order_by(StripeOrder.id.desc())
@@ -1612,8 +1610,8 @@ def handle_stripe_webhook(
 def refund_order_payment(
     app: Flask,
     order_bid: str,
-    amount: Optional[int] = None,
-    reason: Optional[str] = None,
+    amount: int | None = None,
+    reason: str | None = None,
 ) -> Dict[str, Any]:
     with _app_context_scope(app), unit_of_work():
         order = Order.query.filter(Order.order_bid == order_bid).first()

--- a/src/api/flaskr/service/order/open_api.py
+++ b/src/api/flaskr/service/order/open_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import Flask
 from flaskr.dao import db
@@ -27,7 +27,7 @@ def verify_course_ownership(app: Flask, owner_bid: str, shifu_bid: str) -> None:
         raise_error("server.openapi.courseOwnershipRequired")
 
 
-def _find_active_order(user_bid: str, shifu_bid: str) -> Optional[Order]:
+def _find_active_order(user_bid: str, shifu_bid: str) -> Order | None:
     """Find the latest active order for a user and course."""
     return (
         Order.query.filter(

--- a/src/api/flaskr/service/order/payment_channel_resolution.py
+++ b/src/api/flaskr/service/order/payment_channel_resolution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Tuple
 
 from flaskr.service.common.models import raise_error
 from flaskr.service.config import get_config
@@ -8,11 +8,11 @@ from flaskr.service.config import get_config
 
 def resolve_payment_channel(
     *,
-    payment_channel_hint: Optional[str],
-    channel_hint: Optional[str],
-    stored_channel: Optional[str],
-    default_pingxx_channel: Optional[str] = None,
-    additional_enabled_providers: Optional[Iterable[str]] = None,
+    payment_channel_hint: str | None,
+    channel_hint: str | None,
+    stored_channel: str | None,
+    default_pingxx_channel: str | None = None,
+    additional_enabled_providers: Iterable[str] | None = None,
 ) -> Tuple[str, str]:
     """Resolve the payment provider and provider-specific channel from config."""
     requested_payment_channel = (payment_channel_hint or "").strip().lower()

--- a/src/api/flaskr/service/order/payment_providers/base.py
+++ b/src/api/flaskr/service/order/payment_providers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 
 @dataclass(slots=True)
@@ -27,8 +27,8 @@ class PaymentCreationResult:
 
     provider_reference: str
     raw_response: Dict[str, Any]
-    client_secret: Optional[str] = None
-    checkout_session_id: Optional[str] = None
+    client_secret: str | None = None
+    checkout_session_id: str | None = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -39,7 +39,7 @@ class PaymentNotificationResult:
     order_bid: str
     status: str
     provider_payload: Dict[str, Any]
-    charge_id: Optional[str] = None
+    charge_id: str | None = None
 
 
 @dataclass(slots=True)
@@ -57,8 +57,8 @@ class PaymentRefundRequest:
     """Request payload for initiating a refund."""
 
     order_bid: str
-    amount: Optional[int] = None
-    reason: Optional[str] = None
+    amount: int | None = None
+    reason: str | None = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from typing import Optional
 
 from flask import Flask
 from flaskr.api.check import (
@@ -35,7 +34,7 @@ def _get_latest_variable_value(
     values: list[VariableValue],
     variable_key: str,
     shifu_bid: str,
-) -> Optional[VariableValue]:
+) -> VariableValue | None:
     """Return the newest variable value row from a pre-fetched, id-desc sorted
     collection.
 
@@ -49,7 +48,7 @@ def _get_latest_variable_value(
     """
     target_shifu = shifu_bid or ""
 
-    def _pick(scope_shifu_bid: str) -> Optional[VariableValue]:
+    def _pick(scope_shifu_bid: str) -> VariableValue | None:
         return next(
             (
                 item
@@ -69,7 +68,7 @@ def _get_latest_variable_value(
     return None
 
 
-def _ensure_user_aggregate(user_id: str) -> Optional[UserAggregate]:
+def _ensure_user_aggregate(user_id: str) -> UserAggregate | None:
     aggregate = load_user_aggregate(user_id)
     if aggregate:
         return aggregate
@@ -78,7 +77,7 @@ def _ensure_user_aggregate(user_id: str) -> Optional[UserAggregate]:
 
 
 def _update_aggregate_field(
-    aggregate: Optional[UserAggregate], mapping: str, value
+    aggregate: UserAggregate | None, mapping: str, value
 ) -> None:
     if not aggregate:
         return
@@ -119,7 +118,7 @@ def _apply_core_mapping(user_id: str, mapping: str, value):
     return normalized
 
 
-def _current_core_value(aggregate: Optional[UserAggregate], mapping: str):
+def _current_core_value(aggregate: UserAggregate | None, mapping: str):
     if not aggregate:
         return None
     if mapping == "name":

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -6,7 +6,7 @@ import math
 import secrets
 import string
 from datetime import UTC, datetime, timedelta
-from typing import Dict, Optional
+from typing import Dict
 
 from flask import Flask
 from flaskr.dao import db
@@ -1124,7 +1124,7 @@ def _load_order_map(order_bids: list[str]) -> Dict[str, Order]:
 
 
 def _calculate_coupon_usage_discount_amount(
-    order: Optional[Order], usage: CouponUsage
+    order: Order | None, usage: CouponUsage
 ) -> str:
     if order is None:
         return _format_decimal(usage.value)

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, Sequence, Set
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.dao import db
@@ -50,7 +50,7 @@ from sqlalchemy import and_, case, literal, not_
 from sqlalchemy.orm import defer
 
 
-def _format_average_score(value: Optional[Decimal]) -> str:
+def _format_average_score(value: Decimal | None) -> str:
     if value is None:
         return ""
     return f"{value:.1f}"
@@ -81,9 +81,9 @@ class OperatorCourseListSeed:
     llm: str
     created_user_bid: str
     updated_user_bid: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
-    has_course_prompt: Optional[bool] = None
+    created_at: datetime | None
+    updated_at: datetime | None
+    has_course_prompt: bool | None = None
 
 
 @dataclass
@@ -95,13 +95,13 @@ class OperatorCourseListCandidate:
     llm: str
     created_user_bid: str
     updated_user_bid: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
+    created_at: datetime | None
+    updated_at: datetime | None
     selected_source: str
     course_status: str
-    activity_updated_at: Optional[datetime] = None
+    activity_updated_at: datetime | None = None
     activity_updated_user_bid: str = ""
-    has_course_prompt: Optional[bool] = None
+    has_course_prompt: bool | None = None
 
 
 def _build_operator_course_list_seed(row) -> OperatorCourseListSeed:
@@ -168,9 +168,9 @@ def _build_latest_operator_course_rows_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
 ):
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -209,9 +209,9 @@ def _build_latest_operator_course_rows_subquery(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
     alias_name: str,
 ):
     base_query = _build_latest_operator_course_rows_query(
@@ -231,9 +231,9 @@ def _build_operator_course_candidate_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
     include_activity: bool = False,
 ):
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
@@ -529,11 +529,11 @@ def _build_latest_shifus_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
     lightweight: bool = False,
 ):
     is_mapped_model = hasattr(model, "__mapper__")
@@ -570,11 +570,11 @@ def _load_latest_shifus(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
 ):
@@ -617,11 +617,11 @@ def _load_latest_shifu_seeds(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
 ) -> list[OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
@@ -687,7 +687,7 @@ def _build_course_summary(
     course,
     user_map: Dict[str, Dict[str, str]],
     course_status: str,
-    activity: Optional[Dict[str, Any]] = None,
+    activity: Dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     return build_admin_operation_course_summary(
         course,
@@ -721,7 +721,7 @@ def _resolve_course_quick_filter(value: str) -> str:
 
 
 def _resolve_created_last_7d_window(
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> tuple[datetime, datetime]:
     current = now or now_utc()
     start = (current - timedelta(days=6)).replace(
@@ -874,7 +874,7 @@ def _merge_courses(
 
 def _load_latest_course_versions(
     shifu_bid: str,
-) -> tuple[Optional[DraftShifu], Optional[PublishedShifu]]:
+) -> tuple[DraftShifu | None, PublishedShifu | None]:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_course_summary_mapper.py
+++ b/src/api/flaskr/service/shifu/admin_course_summary_mapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import current_app
 from flaskr.service.shifu.admin_dtos_courses import AdminOperationCourseSummaryDTO
@@ -12,7 +12,7 @@ def build_admin_operation_course_summary(
     *,
     user_map: Dict[str, Dict[str, str]],
     course_status: str,
-    activity: Optional[Dict[str, Any]] = None,
+    activity: Dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     resolved_activity = activity or {}
     creator = user_map.get(course.created_user_bid or "", {})

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import math
 import re
 from decimal import Decimal
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Sequence
 
 from flask import Flask
 from flaskr.api.llm import PROVIDER_STATES, get_current_models
@@ -441,7 +441,7 @@ def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
 def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
-    outline_item_bids: Optional[Sequence[str]] = None,
+    outline_item_bids: Sequence[str] | None = None,
 ):
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
@@ -711,7 +711,7 @@ def _build_operator_course_credit_usage_detail_item(
     usage_row: BillUsageRecord,
     ledger_amount: Any,
     model_label_resolver: _CourseCreditUsageModelLabelResolver,
-    output_summary: Optional[str] = None,
+    output_summary: str | None = None,
 ) -> AdminOperationCourseCreditUsageDetailItemDTO:
     return AdminOperationCourseCreditUsageDetailItemDTO(
         usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
@@ -978,7 +978,7 @@ def get_operator_course_credit_usages(
     shifu_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> AdminOperationCourseCreditUsageListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -1303,7 +1303,7 @@ def get_operator_course_credit_usage_details(
     shifu_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> AdminOperationCourseCreditUsageDetailListDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -6,7 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Dict, Optional, Sequence
+from typing import Dict, Sequence
 
 from flask import Flask
 from flaskr.common.umami_client import get_course_visit_count_30d
@@ -65,7 +65,7 @@ from flaskr.service.shifu.models import (
 )
 
 
-def _resolve_learning_permission(item_type: Optional[int]) -> str:
+def _resolve_learning_permission(item_type: int | None) -> str:
     if item_type == UNIT_TYPE_VALUE_GUEST:
         return "guest"
     if item_type == UNIT_TYPE_VALUE_TRIAL:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime
-from typing import Any, Dict, Optional, Sequence, Set
+from typing import Any, Dict, Sequence, Set
 
 from flask import Flask
 from flaskr.dao import db
@@ -124,7 +124,7 @@ def _build_follow_up_user_keyword_filter(
 def _resolve_follow_up_matching_outline_bids(
     outline_context_map: Dict[str, Dict[str, str]],
     chapter_keyword: str,
-) -> Optional[Set[str]]:
+) -> Set[str] | None:
     normalized_keyword = str(chapter_keyword or "").strip().lower()
     if not normalized_keyword:
         return None
@@ -561,7 +561,7 @@ def get_operator_course_follow_ups(
     shifu_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
     include_summary: bool = True,
 ) -> AdminOperationCourseFollowUpListDTO:
     with app.app_context():

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, Sequence, Set
 
 from flask import Flask, current_app
 from flaskr.dao import db
@@ -72,9 +72,9 @@ class OperatorCourseListSeed:
     tts_model: str
     created_user_bid: str
     updated_user_bid: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
-    has_course_prompt: Optional[bool] = None
+    created_at: datetime | None
+    updated_at: datetime | None
+    has_course_prompt: bool | None = None
 
 
 @dataclass
@@ -87,13 +87,13 @@ class OperatorCourseListCandidate:
     tts_model: str
     created_user_bid: str
     updated_user_bid: str
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
+    created_at: datetime | None
+    updated_at: datetime | None
     selected_source: str
     course_status: str
-    activity_updated_at: Optional[datetime] = None
+    activity_updated_at: datetime | None = None
     activity_updated_user_bid: str = ""
-    has_course_prompt: Optional[bool] = None
+    has_course_prompt: bool | None = None
 
 
 def _build_operator_course_list_seed(row) -> OperatorCourseListSeed:
@@ -163,10 +163,10 @@ def _build_latest_operator_course_rows_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
 ):
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -258,10 +258,10 @@ def _build_latest_operator_course_rows_subquery(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
     alias_name: str,
 ):
     base_query = _build_latest_operator_course_rows_query(
@@ -284,10 +284,10 @@ def _build_operator_course_candidate_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
     include_activity: bool = False,
 ):
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
@@ -606,12 +606,12 @@ def _build_latest_shifus_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
     lightweight: bool = False,
 ):
     is_mapped_model = hasattr(model, "__mapper__")
@@ -715,12 +715,12 @@ def _load_latest_shifus(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
 ):
@@ -770,12 +770,12 @@ def _load_latest_shifu_seeds(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Optional[Set[str]] = None,
-    creator_bids: Optional[Set[str]],
-    start_time: Optional[datetime],
-    end_time: Optional[datetime],
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    matching_course_bids: Set[str] | None = None,
+    creator_bids: Set[str] | None,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
 ) -> list[OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
@@ -845,7 +845,7 @@ def _build_course_summary(
     course,
     user_map: Dict[str, Dict[str, str]],
     course_status: str,
-    activity: Optional[Dict[str, Any]] = None,
+    activity: Dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     return build_admin_operation_course_summary(
         course,
@@ -876,8 +876,8 @@ def _apply_operator_course_list_filters(
     *,
     course_status: str,
     quick_filter: str,
-    updated_start_time: Optional[datetime],
-    updated_end_time: Optional[datetime],
+    updated_start_time: datetime | None,
+    updated_end_time: datetime | None,
     apply_updated_filters: bool,
 ):
     if course_status in {COURSE_STATUS_PUBLISHED, COURSE_STATUS_UNPUBLISHED}:
@@ -934,7 +934,7 @@ def _apply_operator_course_list_filters(
 
 
 def _resolve_created_last_7d_window(
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> tuple[datetime, datetime]:
     current = now or now_utc()
     start = (current - timedelta(days=6)).replace(
@@ -954,7 +954,7 @@ def _load_course_activity_map(
 def _load_recent_learning_active_course_bids(
     *,
     since: datetime,
-    shifu_bids: Optional[Sequence[str]] = None,
+    shifu_bids: Sequence[str] | None = None,
 ) -> Set[str]:
     query = db.session.query(LearnProgressRecord.shifu_bid).filter(
         LearnProgressRecord.deleted == 0,
@@ -979,7 +979,7 @@ def _load_recent_learning_active_course_bids(
 def _load_recent_paid_order_course_bids(
     *,
     since: datetime,
-    shifu_bids: Optional[Sequence[str]] = None,
+    shifu_bids: Sequence[str] | None = None,
 ) -> Set[str]:
     query = db.session.query(Order.shifu_bid).filter(
         Order.deleted == 0,
@@ -1051,7 +1051,7 @@ def _build_operator_course_query_filter(
     shifu_bid_column: Any,
     course_query: str,
     *,
-    matching_course_bids: Optional[Set[str]] = None,
+    matching_course_bids: Set[str] | None = None,
 ) -> Any | None:
     normalized_course_query = str(course_query or "").strip()
     if not normalized_course_query:
@@ -1250,7 +1250,7 @@ def _list_operator_courses_legacy(
     app: Flask,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> AdminOperationCourseListDTO:
     safe_page_index = max(int(page_index or 1), 1)
     safe_page_size = min(max(int(page_size or 20), 1), MAX_PAGE_SIZE)
@@ -1304,7 +1304,7 @@ def _list_operator_courses_legacy(
     def resolve_activity(course) -> Dict[str, Any]:
         return activity_map.get(str(course.shifu_bid or "").strip(), {})
 
-    def resolve_updated_at(course) -> Optional[datetime]:
+    def resolve_updated_at(course) -> datetime | None:
         activity = resolve_activity(course)
         return activity.get("updated_at") or course.updated_at
 
@@ -1430,7 +1430,7 @@ def list_operator_courses(
     app: Flask,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> AdminOperationCourseListDTO:
     with app.app_context():
         if not _can_use_operator_course_sql_optimization(app):

--- a/src/api/flaskr/service/shifu/admin_operations/courses_ratings.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_ratings.py
@@ -6,7 +6,6 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import math
-from typing import Optional
 
 from flask import Flask
 from flaskr.dao import db
@@ -57,7 +56,7 @@ def get_operator_course_ratings(
     shifu_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
     include_summary: bool = True,
 ) -> AdminOperationCourseRatingListDTO:
     with app.app_context():
@@ -85,7 +84,7 @@ def get_operator_course_ratings(
         start_time = filters.get("start_time")
         end_time = filters.get("end_time")
 
-        normalized_score_filter: Optional[int] = None
+        normalized_score_filter: int | None = None
         if score_filter:
             if score_filter not in {"1", "2", "3", "4", "5"}:
                 raise_param_error("score")

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -9,7 +9,7 @@ import re
 import sys
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, Sequence, Set
 
 from flask import current_app
 from flaskr.dao import db
@@ -311,7 +311,7 @@ def _get_legacy_admin_symbol(name: str, fallback: Any) -> Any:
     return getattr(admin_module, name, fallback)
 
 
-def _format_decimal(value: Optional[Decimal]) -> str:
+def _format_decimal(value: Decimal | None) -> str:
     if value is None:
         return "0"
     normalized = value if isinstance(value, str) else f"{value:.2f}"
@@ -320,7 +320,7 @@ def _format_decimal(value: Optional[Decimal]) -> str:
     return normalized
 
 
-def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
+def _coerce_operator_datetime(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -351,7 +351,7 @@ def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
     return None
 
 
-def _format_average_score(value: Optional[Decimal]) -> str:
+def _format_average_score(value: Decimal | None) -> str:
     if value is None:
         return ""
     return f"{value:.1f}"
@@ -514,7 +514,7 @@ def _build_course_order_amount_expr():
     )
 
 
-def _find_matching_creator_bids(keyword: str) -> Optional[Set[str]]:
+def _find_matching_creator_bids(keyword: str) -> Set[str] | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None
@@ -621,7 +621,7 @@ def _merge_courses(
 
 def _load_latest_course_versions(
     shifu_bid: str,
-) -> tuple[Optional[DraftShifu], Optional[PublishedShifu]]:
+) -> tuple[DraftShifu | None, PublishedShifu | None]:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, Optional, Sequence, Set
+from typing import Any, Dict, Sequence, Set
 
 from flask import Flask
 from flaskr.dao import db
@@ -170,7 +170,7 @@ def _load_course_user_joined_at_map(
     user_bids: Sequence[str],
     *,
     creator_user_bid: str,
-    course_created_at: Optional[datetime],
+    course_created_at: datetime | None,
 ) -> Dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
@@ -294,7 +294,7 @@ def get_operator_course_users(
     shifu_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> PageNationDTO:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Sequence
 
 from flask import current_app
 from flaskr.service.user.models import AuthCredential
@@ -9,7 +9,7 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.timezone import serialize_with_app_timezone
 
 
-def coerce_operator_datetime(value: Any) -> Optional[datetime]:
+def coerce_operator_datetime(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import Flask
 from flaskr.dao import db
@@ -293,7 +293,7 @@ def get_operator_user_credits(
     user_bid: str,
     page_index: int,
     page_size: int,
-    filters: Optional[Dict[str, Any]] = None,
+    filters: Dict[str, Any] | None = None,
 ) -> AdminOperationUserCreditLedgerPageDTO:
     with app.app_context():
         normalized_user_bid = str(user_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
@@ -197,7 +195,7 @@ def list_operator_users(
     app: Flask,
     page_index: int,
     page_size: int,
-    filters: Optional[dict] = None,
+    filters: dict | None = None,
 ) -> AdminOperationUserListDTO:
     with app.app_context():
         safe_page_index = max(int(page_index or 1), 1)

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from decimal import Decimal
-from typing import Any, Optional, Sequence, Set
+from typing import Any, Sequence, Set
 
 from flask import Flask
 from flaskr.api.tts import get_default_voice_settings, synthesize_text
@@ -66,7 +66,7 @@ def _decimal_to_str(value: Any) -> str:
     return str(value)
 
 
-def _find_matching_course_bids(keyword: str) -> Optional[Set[str]]:
+def _find_matching_course_bids(keyword: str) -> Set[str] | None:
     normalized = _normalize_text(keyword)
     if not normalized:
         return None
@@ -96,7 +96,7 @@ def _find_matching_course_bids(keyword: str) -> Optional[Set[str]]:
     }
 
 
-def _find_matching_voice_owner_bids(keyword: str) -> Optional[Set[str]]:
+def _find_matching_voice_owner_bids(keyword: str) -> Set[str] | None:
     normalized = _normalize_text(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import current_app
 from flaskr.service.user.consts import (
@@ -278,7 +278,7 @@ USER_STATE_TO_OPERATOR_STATUS = {
 }
 
 
-def _format_decimal(value: Optional[Decimal]) -> str:
+def _format_decimal(value: Decimal | None) -> str:
     if value is None:
         return "0"
     normalized = value if isinstance(value, str) else f"{value:.2f}"
@@ -287,7 +287,7 @@ def _format_decimal(value: Optional[Decimal]) -> str:
     return normalized
 
 
-def _coerce_operator_datetime(value: Any) -> Optional[datetime]:
+def _coerce_operator_datetime(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime
 from decimal import Decimal
 from json import JSONDecodeError
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Sequence
 
 from flask import current_app
 from flaskr.dao import db
@@ -374,7 +374,7 @@ def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
 def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
-    outline_item_bids: Optional[Sequence[str]] = None,
+    outline_item_bids: Sequence[str] | None = None,
 ):
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
@@ -643,7 +643,7 @@ def _load_course_credit_usage_output_summary_map(
 def _build_operator_course_credit_usage_detail_item(
     usage_row: BillUsageRecord,
     ledger_amount: Any,
-    output_summary: Optional[str] = None,
+    output_summary: str | None = None,
 ) -> AdminOperationCourseCreditUsageDetailItemDTO:
     return AdminOperationCourseCreditUsageDetailItemDTO(
         usage_bid=str(getattr(usage_row, "usage_bid", "") or ""),
@@ -1148,7 +1148,7 @@ def _resolve_operator_user_credit_grant_source_filter(value: str) -> str:
 def _build_operator_user_credit_merged_metadata(
     row: CreditLedgerEntry,
     *,
-    order_map: Optional[Dict[str, BillingOrder]] = None,
+    order_map: Dict[str, BillingOrder] | None = None,
 ) -> Dict[str, Any]:
     metadata = _normalize_metadata_json(row.metadata_json)
     normalized_source_bid = str(row.source_bid or "").strip()
@@ -1241,12 +1241,12 @@ def _load_operator_user_credit_summary_map(
     order_map = _load_billing_order_map(
         [str(bucket.source_bid or "").strip() for bucket in buckets]
     )
-    order_type_cache: Dict[str, Optional[int]] = {
+    order_type_cache: Dict[str, int | None] = {
         bill_order_bid: int(order.order_type or 0)
         for bill_order_bid, order in order_map.items()
     }
 
-    def load_order_type(bill_order_bid: str) -> Optional[int]:
+    def load_order_type(bill_order_bid: str) -> int | None:
         normalized_bill_order_bid = str(bill_order_bid or "").strip()
         if not normalized_bill_order_bid:
             return None
@@ -1695,8 +1695,8 @@ def _resolve_usage_detail_item_content(
 def _build_operator_user_credit_ledger_item(
     row: CreditLedgerEntry,
     *,
-    order_map: Optional[Dict[str, BillingOrder]] = None,
-    usage_context_map: Optional[Dict[str, Dict[str, str]]] = None,
+    order_map: Dict[str, BillingOrder] | None = None,
+    usage_context_map: Dict[str, Dict[str, str]] | None = None,
 ) -> AdminOperationUserCreditLedgerItemDTO:
     merged_metadata = _build_operator_user_credit_merged_metadata(
         row,

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Optional, Sequence, Set
+from typing import Any, Dict, Sequence, Set
 
 from flaskr.dao import db
 from flaskr.service.common.models import (
@@ -252,7 +252,7 @@ def _build_course_order_amount_expr():
     )
 
 
-def _find_matching_creator_bids(keyword: str) -> Optional[Set[str]]:
+def _find_matching_creator_bids(keyword: str) -> Set[str] | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None
@@ -307,7 +307,7 @@ def _resolve_operator_user_quick_filter(value: str) -> str:
 
 def _resolve_recent_days_window(
     days: int,
-    now: Optional[datetime] = None,
+    now: datetime | None = None,
 ) -> tuple[datetime, datetime]:
     safe_days = max(int(days or 0), 1)
     current = now or now_utc()
@@ -449,7 +449,7 @@ def _build_registered_user_timestamp_subquery():
     )
 
 
-def _load_learner_user_bids(user_bids: Optional[Sequence[str]] = None) -> Set[str]:
+def _load_learner_user_bids(user_bids: Sequence[str] | None = None) -> Set[str]:
     learner_subquery = _build_learner_user_bid_subquery()
     query = db.session.query(learner_subquery.c.user_bid)
     normalized_user_bids = [
@@ -499,8 +499,8 @@ def _load_operator_user_auth_credentials(
 def _load_operator_user_registration_source_map(
     user_bids: Sequence[str],
     *,
-    users: Optional[Sequence[UserEntity]] = None,
-    credential_rows: Optional[Sequence[AuthCredential]] = None,
+    users: Sequence[UserEntity] | None = None,
+    credential_rows: Sequence[AuthCredential] | None = None,
 ) -> Dict[str, str]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
@@ -651,8 +651,8 @@ def _load_operator_user_last_learning_map(
 def _load_operator_user_contact_map(
     user_bids: Sequence[str],
     *,
-    users: Optional[Sequence[UserEntity]] = None,
-    credential_rows: Optional[Sequence[AuthCredential]] = None,
+    users: Sequence[UserEntity] | None = None,
+    credential_rows: Sequence[AuthCredential] | None = None,
 ) -> Dict[str, Dict[str, Any]]:
     if not user_bids:
         return {}
@@ -724,7 +724,7 @@ def _load_operator_user_contact_map(
     return contact_map
 
 
-def _find_matching_user_bids_by_identifier(keyword: str) -> Optional[Set[str]]:
+def _find_matching_user_bids_by_identifier(keyword: str) -> Set[str] | None:
     normalized = str(keyword or "").strip()
     if not normalized:
         return None
@@ -761,14 +761,12 @@ def _build_operator_user_summary(
     last_learning_map: Dict[str, datetime],
     credit_summary_map: Dict[str, Dict[str, Any]],
     *,
-    learning_courses_map: Optional[
-        Dict[str, list[AdminOperationUserCourseSummaryDTO]]
-    ] = None,
-    created_courses_map: Optional[
-        Dict[str, list[AdminOperationUserCourseSummaryDTO]]
-    ] = None,
-    learning_course_count_map: Optional[Dict[str, int]] = None,
-    created_course_count_map: Optional[Dict[str, int]] = None,
+    learning_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]]
+    | None = None,
+    created_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]]
+    | None = None,
+    learning_course_count_map: Dict[str, int] | None = None,
+    created_course_count_map: Dict[str, int] | None = None,
 ) -> AdminOperationUserSummaryDTO:
     user_bid = str(user.user_bid or "").strip()
     contact = contact_map.get(user.user_bid or "", {})

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, Set
 
 from flaskr.dao import db
 from sqlalchemy import and_, or_
@@ -13,7 +13,7 @@ def _record_course_activity(
     activity_map: Dict[str, Dict[str, Any]],
     *,
     shifu_bid: str,
-    updated_at: Optional[datetime],
+    updated_at: datetime | None,
     updated_user_bid: str,
     prefer_on_equal: bool = False,
 ) -> None:

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -10,7 +10,7 @@ import json
 import math
 from datetime import datetime
 from time import perf_counter
-from typing import Any, Optional
+from typing import Any
 
 from flask import Flask
 from flaskr.i18n import _
@@ -131,7 +131,7 @@ def return_shifu_draft_dto(
     shifu_draft: DraftShifu,
     base_url: str,
     readonly: bool,
-    archived_override: Optional[bool] = None,
+    archived_override: bool | None = None,
     can_manage_archive: bool = False,
     can_publish: bool = False,
 ) -> ShifuDetailDto:

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -37,7 +37,7 @@ format:
 
 import queue
 import re
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, TypeVar
 
 from flask import Flask
 from flaskr.dao import db
@@ -159,7 +159,7 @@ def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str):
     return latest_content_revision
 
 
-def _mask_phone_identifier(identifier: Optional[str]) -> str:
+def _mask_phone_identifier(identifier: str | None) -> str:
     if not identifier:
         return ""
     digits = re.sub(r"\D", "", identifier)
@@ -170,7 +170,7 @@ def _mask_phone_identifier(identifier: Optional[str]) -> str:
     return digits or ""
 
 
-def _mask_email_identifier(identifier: Optional[str]) -> str:
+def _mask_email_identifier(identifier: str | None) -> str:
     if not identifier:
         return ""
     local, _, domain = identifier.partition("@")
@@ -182,7 +182,7 @@ def _mask_email_identifier(identifier: Optional[str]) -> str:
     return f"{masked_local}@{domain}"
 
 
-def _mask_contact_identifier(identifier: Optional[str]) -> str:
+def _mask_contact_identifier(identifier: str | None) -> str:
     if not identifier:
         return ""
     if "@" in identifier:
@@ -233,7 +233,7 @@ def get_shifu_draft_revision(
         return int(latest.id) if latest else 0
 
 
-def mask_contact_identifier(identifier: Optional[str]) -> str:
+def mask_contact_identifier(identifier: str | None) -> str:
     """Public wrapper for contact identifier masking."""
     return _mask_contact_identifier(identifier)
 

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -1,7 +1,7 @@
 import json
 import os
 from decimal import Decimal
-from typing import Dict, Optional
+from typing import Dict
 
 from flask import Flask
 from flaskr.common.i18n_utils import get_markdownflow_output_language
@@ -140,7 +140,7 @@ def export_shifu(app: Flask, shifu_id: str, file_path: str) -> str:
 
 def import_shifu(
     app: Flask,
-    shifu_id: Optional[str],
+    shifu_id: str | None,
     file: FileStorage,
     user_id: str,
     commit: bool = True,

--- a/src/api/flaskr/service/shifu/struct_utils.py
+++ b/src/api/flaskr/service/shifu/struct_utils.py
@@ -6,14 +6,12 @@ Author: yfge
 Date: 2025-08-07
 """
 
-from typing import Optional
-
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
 
 def find_node_with_parents(
-    root: HistoryItem, target_bid: str, current_path: Optional[list[HistoryItem]] = None
-) -> Optional[list[HistoryItem]]:
+    root: HistoryItem, target_bid: str, current_path: list[HistoryItem] | None = None
+) -> list[HistoryItem] | None:
     """Find node with parents
     Args:
         root: Root node

--- a/src/api/flaskr/service/shifu/utils.py
+++ b/src/api/flaskr/service/shifu/utils.py
@@ -6,8 +6,6 @@ Author: yfge
 Date: 2025-08-07
 """
 
-from typing import Optional
-
 from flask import Flask
 from flaskr.service.resource.models import Resource
 
@@ -60,7 +58,7 @@ def parse_shifu_res_bid(res_url: str):
     return ""
 
 
-def get_shifu_creator_bid(app: Flask, shifu_bid: str) -> Optional[str]:
+def get_shifu_creator_bid(app: Flask, shifu_bid: str) -> str | None:
     """Resolve the creator user business identifier for a given shifu.
 
     Args:

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -5,7 +5,7 @@ This module provides audio concatenation and processing functions using pydub/ff
 
 import io
 import logging
-from typing import List, Optional, Sequence
+from typing import List, Sequence
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -43,7 +43,7 @@ def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3"):
     return AudioSegment.from_file(audio_io, format=input_format)
 
 
-def try_get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> Optional[int]:
+def try_get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> int | None:
     """Return decoded audio duration, or None when the bytes are not decodable."""
     if not audio_data:
         return 0
@@ -253,7 +253,7 @@ def export_audio_range_best_effort(
     audio_data: bytes,
     *,
     start_ms: int = 0,
-    end_ms: Optional[int] = None,
+    end_ms: int | None = None,
     input_format: str = "mp3",
     output_format: str = "mp3",
 ) -> tuple[bytes, int]:

--- a/src/api/flaskr/service/tts/boundary_strategies.py
+++ b/src/api/flaskr/service/tts/boundary_strategies.py
@@ -10,8 +10,6 @@ src/cook-web/src/c-utils/listen-mode/visual-boundary-detector.ts
 
 from __future__ import annotations
 
-from typing import Optional
-
 from flaskr.service.tts.patterns import (
     AV_IFRAME_CLOSE,
     AV_SVG_CLOSE,
@@ -26,7 +24,7 @@ from flaskr.service.tts.pipeline import (
 )
 
 
-def _find_close_end(raw: str, close_pattern) -> Optional[int]:
+def _find_close_end(raw: str, close_pattern) -> int | None:
     if not raw:
         return None
     close = close_pattern.search(raw)
@@ -38,7 +36,7 @@ def _find_close_end(raw: str, close_pattern) -> Optional[int]:
 class FenceBoundaryStrategy:
     """Strategy for fenced code blocks (```)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         if not raw:
             return None
         # Find closing ``` after the opening (skip first 3 chars)
@@ -51,14 +49,14 @@ class FenceBoundaryStrategy:
 class SvgBoundaryStrategy:
     """Strategy for SVG elements (<svg>...</svg>)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         return _find_close_end(raw, AV_SVG_CLOSE)
 
 
 class IframeBoundaryStrategy:
     """Strategy for iframe elements (<iframe>...</iframe>)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         end = _find_close_end(raw, AV_IFRAME_CLOSE)
         if end is None:
             return None
@@ -68,21 +66,21 @@ class IframeBoundaryStrategy:
 class VideoBoundaryStrategy:
     """Strategy for video elements (<video>...</video>)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         return _find_close_end(raw, AV_VIDEO_CLOSE)
 
 
 class HtmlTableBoundaryStrategy:
     """Strategy for HTML table elements (<table>...</table>)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         return _find_close_end(raw, AV_TABLE_CLOSE)
 
 
 class MarkdownTableBoundaryStrategy:
     r"""Strategy for markdown tables (| A | B |\n| --- | --- |)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         if not raw:
             return None
         fence_ranges = _get_fence_ranges(raw)
@@ -98,7 +96,7 @@ class MarkdownTableBoundaryStrategy:
 class SandboxBoundaryStrategy:
     """Strategy for HTML sandbox blocks (div, section, article, etc.)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         if not raw:
             return None
         end, complete = _find_html_block_end_with_complete(raw, 0)
@@ -108,7 +106,7 @@ class SandboxBoundaryStrategy:
 class MarkdownImageBoundaryStrategy:
     """Strategy for markdown images (![alt](url))."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         if not raw:
             return None
         start = raw.find("![")
@@ -126,7 +124,7 @@ class MarkdownImageBoundaryStrategy:
 class HtmlImageBoundaryStrategy:
     """Strategy for HTML image tags (<img ...>)."""
 
-    def find_end(self, raw: str) -> Optional[int]:
+    def find_end(self, raw: str) -> int | None:
         if not raw:
             return None
         close = raw.find(">")
@@ -149,7 +147,7 @@ BOUNDARY_STRATEGIES = {
 }
 
 
-def find_boundary_end(kind: str, raw: str) -> Optional[int]:
+def find_boundary_end(kind: str, raw: str) -> int | None:
     r"""Find the end position of a visual element boundary.
 
     Args:

--- a/src/api/flaskr/service/tts/cloned_voice_registry.py
+++ b/src/api/flaskr/service/tts/cloned_voice_registry.py
@@ -14,7 +14,7 @@ write path (``admin_operations/voice_clones.py``).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable
 
 from flaskr.service.tts.minimax_voice_clone import is_valid_minimax_custom_voice_id
 from flaskr.service.tts.models import (
@@ -54,7 +54,7 @@ _CLONE_PROVIDER_SPECS: dict[str, ClonedVoiceProviderSpec] = {
 }
 
 
-def get_clone_provider_spec(provider: str) -> Optional[ClonedVoiceProviderSpec]:
+def get_clone_provider_spec(provider: str) -> ClonedVoiceProviderSpec | None:
     return _CLONE_PROVIDER_SPECS.get((provider or "").strip().lower())
 
 
@@ -63,8 +63,8 @@ def supports_cloned_voices(provider: str) -> bool:
 
 
 def find_ready_cloned_voice(
-    *, provider: str, voice_id: str, owner_user_bid: Optional[str] = None
-) -> Optional[TTSMiniMaxClonedVoice]:
+    *, provider: str, voice_id: str, owner_user_bid: str | None = None
+) -> TTSMiniMaxClonedVoice | None:
     """Latest ready, non-deleted clone row for (provider, voice_id).
 
     ``owner_user_bid=None`` skips owner scoping (strict validation, runtime);
@@ -89,7 +89,7 @@ def find_ready_cloned_voice(
 
 def find_tracked_cloned_voice(
     *, provider: str, voice_id: str, shifu_bid: str
-) -> Optional[TTSMiniMaxClonedVoice]:
+) -> TTSMiniMaxClonedVoice | None:
     """Latest non-deleted row this shifu tracks, regardless of status."""
     normalized_voice_id = (voice_id or "").strip()
     if not normalized_voice_id:

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -22,7 +22,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Sequence
 
 from flask import Flask
 from flaskr.api.tts import (
@@ -635,7 +635,7 @@ def split_text_for_tts(
     text: str,
     *,
     provider_name: str,
-    max_segment_chars: Optional[int] = None,
+    max_segment_chars: int | None = None,
 ) -> list[str]:
     """Split text into segments suitable for unified TTS synthesis.
 
@@ -689,14 +689,14 @@ def synthesize_long_text_to_oss(
     model: str = "",
     voice_id: str = "",
     language: str = "",
-    max_segment_chars: Optional[int] = None,
+    max_segment_chars: int | None = None,
     max_workers: int = 4,
     sleep_between_segments: float = 0.0,
-    audio_bid: Optional[str] = None,
-    voice_settings: Optional[VoiceSettings] = None,
-    audio_settings: Optional[AudioSettings] = None,
-    usage_context: Optional[UsageContext] = None,
-    parent_usage_bid: Optional[str] = None,
+    audio_bid: str | None = None,
+    voice_settings: VoiceSettings | None = None,
+    audio_settings: AudioSettings | None = None,
+    usage_context: UsageContext | None = None,
+    parent_usage_bid: str | None = None,
 ) -> SynthesizeToOssResult:
     """Synthesize a long text, upload the final audio to OSS, and return URL + metrics.
 
@@ -725,7 +725,7 @@ def synthesize_long_text_to_oss(
     raw_length = len(text or "")
     cleaned_length = len(cleaned_text or "")
     usage_parent_bid = ""
-    usage_metadata: Optional[dict] = None
+    usage_metadata: dict | None = None
     total_word_count = 0
     total_output_chars = 0
     if usage_context is not None:

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -8,7 +8,7 @@ import math
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -183,9 +183,7 @@ def _model_scope_key(*, provider: str, api_key: str, model: str) -> str:
     return base
 
 
-def _parse_timestamp(
-    raw: Optional[bytes | str | float | int], *, default: float
-) -> float:
+def _parse_timestamp(raw: bytes | str | float | None, *, default: float) -> float:
     if raw is None:
         return default
     if isinstance(raw, bytes):

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List
 
 from flask import Flask
 from flaskr.api.tts import (
@@ -232,12 +232,12 @@ class TTSSegment:
 
     index: int
     text: str
-    audio_data: Optional[bytes] = None
+    audio_data: bytes | None = None
     duration_ms: int = 0
     word_count: int = 0
     usage_characters: int = 0
     latency_ms: int = 0
-    error: Optional[str] = None
+    error: str | None = None
     is_ready: bool = False
     subtitle_cues: list[dict[str, Any]] = field(default_factory=list)
 
@@ -275,7 +275,7 @@ class StreamingTTSProcessor:
         tts_model: str = "",
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-        av_contract: Optional[Dict[str, Any]] = None,
+        av_contract: Dict[str, Any] | None = None,
         usage_scene: int = BILL_USAGE_SCENE_PROD,
     ):
         self.app = app
@@ -764,7 +764,7 @@ class StreamingTTSProcessor:
         audio_data: bytes,
         duration_ms: int,
         is_final: bool = False,
-        subtitle_cues: Optional[list[dict[str, Any]]] = None,
+        subtitle_cues: list[dict[str, Any]] | None = None,
     ) -> RunMarkdownFlowDTO:
         base64_audio = base64.b64encode(audio_data).decode("utf-8")
         return RunMarkdownFlowDTO(
@@ -1282,7 +1282,7 @@ class StreamingTTSProcessor:
         provider_offset_ms: int,
         live_offset_ms: int,
         live_request_end_ms: int,
-        previous_live_cues: Optional[list[dict[str, Any]]] = None,
+        previous_live_cues: list[dict[str, Any]] | None = None,
     ) -> list[dict[str, Any]]:
         incoming_live_cues = self._scale_minimax_cues_to_live_request(
             subtitle_cues,
@@ -1306,7 +1306,7 @@ class StreamingTTSProcessor:
         audio_data: bytes,
         duration_ms: int,
         text: str,
-        subtitle_cues: Optional[list[dict[str, Any]]] = None,
+        subtitle_cues: list[dict[str, Any]] | None = None,
     ) -> tuple[int, RunMarkdownFlowDTO]:
         with self._lock:
             segment_index = self._segment_index
@@ -1333,8 +1333,8 @@ class StreamingTTSProcessor:
         raw_text: str,
         cleaned_text: str,
         cleaned_text_length: int,
-        subtitle_cues: Optional[list[dict[str, Any]]] = None,
-        event_subtitle_cues: Optional[list[dict[str, Any]]] = None,
+        subtitle_cues: list[dict[str, Any]] | None = None,
+        event_subtitle_cues: list[dict[str, Any]] | None = None,
         commit: bool = True,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         if not all_segments:
@@ -1462,7 +1462,7 @@ class StreamingTTSProcessor:
         request_text: str,
         request_format: str,
         request_index: int,
-    ) -> Optional[_MinimaxFallbackAudio]:
+    ) -> _MinimaxFallbackAudio | None:
         try:
             result = provider.synthesize(
                 text=request_text,
@@ -1708,7 +1708,7 @@ class StreamingTTSProcessor:
                 )
                 yield event
 
-            fallback_audio: Optional[_MinimaxFallbackAudio] = None
+            fallback_audio: _MinimaxFallbackAudio | None = None
             if live_request_emitted_ms <= 0:
                 fallback_audio = self._synthesize_minimax_complete_fallback(
                     provider,
@@ -2108,16 +2108,16 @@ class AVStreamingTTSProcessor:
         self.element_index_offset = int(element_index_offset or 0)
 
         self._position_cursor = 0
-        self._current_processor: Optional[StreamingTTSProcessor] = None
+        self._current_processor: StreamingTTSProcessor | None = None
         self._raw_buffer = ""
         self._raw_full_content = ""
-        self._av_contract: Optional[Dict[str, Any]] = None
+        self._av_contract: Dict[str, Any] | None = None
         self._next_element_index = self.element_index_offset
         self._current_segment_has_speakable_text = False
 
         # When we hit a non-speakable block boundary (e.g. `<svg>`), we may need to
         # wait for its closing marker before resuming segmentation.
-        self._skip_mode: Optional[str] = (
+        self._skip_mode: str | None = (
             None
             # 'fence' | 'svg' | 'iframe' | 'video' | 'html_table' | 'md_table' | 'sandbox' | 'md_img'
         )
@@ -2199,7 +2199,7 @@ class AVStreamingTTSProcessor:
         if did_complete or had_speakable_text:
             self._position_cursor += 1
 
-    def _find_next_boundary(self, raw: str) -> Optional[tuple[str, int, int, bool]]:
+    def _find_next_boundary(self, raw: str) -> tuple[str, int, int, bool] | None:
         return _find_next_av_boundary(raw, include_partial_md_image=True)
 
     def process_chunk(self, chunk: str) -> Generator[RunMarkdownFlowDTO, None, None]:

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import Flask
 from flaskr.service.common.dtos import UserInfo, UserToken
@@ -48,14 +48,12 @@ class VerificationRequest(_BaseDTO):
 class OAuthCallbackRequest(_BaseDTO):
     """Normalized payload for OAuth callback handlers."""
 
-    state: Optional[str] = Field(
-        None, description="Opaque state value returned by OAuth"
-    )
-    code: Optional[str] = Field(None, description="Authorization code or token")
+    state: str | None = Field(None, description="Opaque state value returned by OAuth")
+    code: str | None = Field(None, description="Authorization code or token")
     raw_request_args: Dict[str, Any] = Field(
         default_factory=dict, description="Complete callback request arguments"
     )
-    current_user_id: Optional[str] = Field(
+    current_user_id: str | None = Field(
         None,
         description="User ID resolved from temporary token, if any",
     )
@@ -66,7 +64,7 @@ class AuthResult(_BaseDTO):
 
     user: UserInfo = Field(..., description="Resolved user information DTO")
     token: UserToken = Field(..., description="Issued login token")
-    credential: Optional[AuthCredential] = Field(
+    credential: AuthCredential | None = Field(
         None, description="Persisted credential record when available"
     )
     is_new_user: bool = Field(

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import jwt
 from authlib.integrations.requests_client import OAuth2Session
@@ -59,7 +59,7 @@ def _encode_state(app, payload: Dict[str, Any]) -> str:
     )
 
 
-def _decode_state(app, state: str) -> Optional[Dict[str, Any]]:
+def _decode_state(app, state: str) -> Dict[str, Any] | None:
     try:
         decoded = jwt.decode(state, app.config["SECRET_KEY"], algorithms=["HS256"])
     except jwt.exceptions.ExpiredSignatureError:
@@ -70,7 +70,7 @@ def _decode_state(app, state: str) -> Optional[Dict[str, Any]]:
     return payload if isinstance(payload, dict) else None
 
 
-def _extract_browser_language() -> Optional[str]:
+def _extract_browser_language() -> str | None:
     """Extract a reasonable UI language from the incoming request.
 
     Priority:
@@ -101,7 +101,7 @@ def _extract_browser_language() -> Optional[str]:
     return f"{primary}-{region}"
 
 
-def _resolve_redirect_uri(app, explicit_uri: Optional[str] = None) -> str:
+def _resolve_redirect_uri(app, explicit_uri: str | None = None) -> str:
     del app, explicit_uri
     return build_google_oauth_callback_url()
 
@@ -186,7 +186,7 @@ class GoogleAuthProvider(AuthProvider):
 
         redirect_uri = None
         login_context = None
-        language: Optional[str] = None
+        language: str | None = None
         try:
             redirect_uri = state_payload.get("redirect_uri")
             login_context = state_payload.get("login_context")

--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import jwt
 from flask import Flask, has_app_context
 from flaskr.i18n import get_i18n_list
@@ -154,7 +152,7 @@ def verify_sms_code(
     chekcode: str,
     course_id: str | None = None,
     language: str | None = None,
-    login_context: Optional[str] = None,
+    login_context: str | None = None,
 ) -> UserToken:
     provider = get_provider("phone")
     request = VerificationRequest(

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -34,7 +34,7 @@ from flaskr.util.datetime import now_utc
 FIX_CHECK_CODE = None
 
 
-def configure_fix_check_code(value: Optional[str]) -> None:
+def configure_fix_check_code(value: str | None) -> None:
     global FIX_CHECK_CODE
     FIX_CHECK_CODE = value
 
@@ -84,12 +84,12 @@ def _consume_latest_email_code_from_db(app: Flask, email: str, code: str) -> str
 
 def verify_email_code(
     app: Flask,
-    user_id: Optional[str],
+    user_id: str | None,
     email: str,
     code: str,
-    course_id: Optional[str] = None,
-    language: Optional[str] = None,
-) -> Tuple[UserToken, bool, Dict[str, Optional[str]]]:
+    course_id: str | None = None,
+    language: str | None = None,
+) -> Tuple[UserToken, bool, Dict[str, str | None]]:
     # Local import avoids circular dependency during module initialization.
     from flaskr.service.profile.funcs import (
         get_user_profile_labels,

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -48,12 +48,12 @@ FIX_CHECK_CODE = None
 BOOTSTRAP_LOCK_NAME = "user_first_verified_bootstrap"
 
 
-def configure_fix_check_code(value: Optional[str]) -> None:
+def configure_fix_check_code(value: str | None) -> None:
     global FIX_CHECK_CODE
     FIX_CHECK_CODE = value
 
 
-def _acquire_bootstrap_lock(app: Flask, timeout_seconds: int = 5) -> Optional[bool]:
+def _acquire_bootstrap_lock(app: Flask, timeout_seconds: int = 5) -> bool | None:
     bind = db.session.get_bind()
     dialect_name = getattr(getattr(bind, "dialect", None), "name", "")
     if dialect_name != "mysql":
@@ -130,7 +130,7 @@ def _consume_latest_sms_code_from_db(app: Flask, phone: str, code: str) -> str:
 
 
 def migrate_user_study_record(
-    app: Flask, from_user_id: str, to_user_id: str, course_id: Optional[str] = None
+    app: Flask, from_user_id: str, to_user_id: str, course_id: str | None = None
 ) -> None:
     from flaskr.service.learn.models import LearnProgressRecord
 
@@ -275,13 +275,13 @@ def init_first_course(app: Flask, user_id: str) -> bool:
 
 def verify_phone_code(
     app: Flask,
-    user_id: Optional[str],
+    user_id: str | None,
     phone: str,
     code: str,
-    course_id: Optional[str] = None,
-    language: Optional[str] = None,
-    login_context: Optional[str] = None,
-) -> Tuple[UserToken, bool, Dict[str, Optional[str]]]:
+    course_id: str | None = None,
+    language: str | None = None,
+    login_context: str | None = None,
+) -> Tuple[UserToken, bool, Dict[str, str | None]]:
     # Local import avoids circular dependency during module initialization.
     from flaskr.service.profile.funcs import (
         get_user_profile_labels,

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -7,7 +7,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from flask import Flask
 from flaskr.dao import (
@@ -63,7 +63,7 @@ class CredentialSummary:
     subject_id: str
     subject_format: str
     state: int
-    metadata: Dict[str, Optional[str]] = field(default_factory=dict)
+    metadata: Dict[str, str | None] = field(default_factory=dict)
 
     @property
     def is_verified(self) -> bool:
@@ -76,14 +76,14 @@ class UserAggregate:
     identify: str
     nickname: str
     learner_profile: str
-    learner_profile_updated_at: Optional[datetime]
+    learner_profile_updated_at: datetime | None
     avatar: str
-    birthday: Optional[date]
+    birthday: date | None
     language: str
     state: int
     deleted: bool
     created_at: datetime
-    creator_activated_at: Optional[datetime]
+    creator_activated_at: datetime | None
     updated_at: datetime
     credentials: List[CredentialSummary] = field(default_factory=list)
     is_creator: bool = False
@@ -91,7 +91,7 @@ class UserAggregate:
 
     def _preferred_identifier(
         self, provider: str, *, prefer_verified: bool = True
-    ) -> Optional[CredentialSummary]:
+    ) -> CredentialSummary | None:
         matches = [c for c in self.credentials if c.provider == provider]
         if not matches:
             return None
@@ -202,7 +202,7 @@ class UserAggregate:
         )
 
 
-def _normalize_identifier(provider: str, identifier: Optional[str]) -> str:
+def _normalize_identifier(provider: str, identifier: str | None) -> str:
     if not identifier:
         return ""
     normalized = identifier.strip()
@@ -235,7 +235,7 @@ def _summarize_credentials(
 def _build_user_aggregate(
     entity: UserEntity,
     *,
-    credentials: Optional[List[AuthCredential]] = None,
+    credentials: List[AuthCredential] | None = None,
 ) -> UserAggregate:
     summaries = _summarize_credentials(credentials or [])
     return UserAggregate(
@@ -260,7 +260,7 @@ def _build_user_aggregate(
 
 def get_user_entity_by_bid(
     user_bid: str, *, include_deleted: bool = False
-) -> Optional[UserEntity]:
+) -> UserEntity | None:
     query = UserEntity.query.filter_by(user_bid=user_bid)
     if not include_deleted:
         query = query.filter_by(deleted=0)
@@ -272,10 +272,10 @@ def _ensure_user_entity(user_bid: str) -> UserEntity:
     if entity:
         return entity
     identify = user_bid
-    nickname: Optional[str] = None
-    language: Optional[str] = None
-    avatar: Optional[str] = None
-    birthday: Optional[date] = None
+    nickname: str | None = None
+    language: str | None = None
+    avatar: str | None = None
+    birthday: date | None = None
 
     try:
         from flaskr.service.profile.models import VariableValue  # type: ignore
@@ -331,7 +331,7 @@ def load_user_aggregate(
     *,
     include_deleted: bool = False,
     with_credentials: bool = True,
-) -> Optional[UserAggregate]:
+) -> UserAggregate | None:
     entity = get_user_entity_by_bid(user_bid, include_deleted=include_deleted)
     if not entity:
         return None
@@ -344,8 +344,8 @@ def load_user_aggregate(
 def load_user_aggregate_by_identifier(
     identifier: str,
     *,
-    providers: Optional[List[str]] = None,
-) -> Optional[UserAggregate]:
+    providers: List[str] | None = None,
+) -> UserAggregate | None:
     normalized = identifier.strip() if identifier else ""
     if not normalized:
         return None
@@ -395,7 +395,7 @@ def ensure_user_aggregate(
     app: Flask,
     *,
     user_bid: str,
-    defaults: Optional[Dict[str, Any]] = None,
+    defaults: Dict[str, Any] | None = None,
 ) -> Tuple[UserAggregate, bool]:
     """Ensure a user aggregate exists for ``user_bid``.
 
@@ -416,7 +416,7 @@ def ensure_user_for_identifier(
     *,
     provider: str,
     identifier: str,
-    defaults: Optional[Dict[str, Any]] = None,
+    defaults: Dict[str, Any] | None = None,
 ) -> Tuple[UserAggregate, bool]:
     """Find or create a user aggregate bound to a provider identifier."""
     defaults = defaults or {}
@@ -460,8 +460,8 @@ def ensure_user_for_identifier(
 def mark_user_roles(
     user_bid: str,
     *,
-    is_creator: Optional[bool] = None,
-    is_operator: Optional[bool] = None,
+    is_creator: bool | None = None,
+    is_operator: bool | None = None,
 ) -> None:
     """Persist role flags on the canonical entity."""
     if is_creator is None and is_operator is None:
@@ -479,13 +479,13 @@ def create_user_entity(
     *,
     user_bid: str,
     identify: str,
-    nickname: Optional[str] = None,
-    learner_profile: Optional[str] = None,
-    learner_profile_updated_at: Optional[datetime] = None,
-    language: Optional[str] = None,
-    avatar: Optional[str] = None,
-    state: Optional[int] = None,
-    birthday: Optional[date] = None,
+    nickname: str | None = None,
+    learner_profile: str | None = None,
+    learner_profile_updated_at: datetime | None = None,
+    language: str | None = None,
+    avatar: str | None = None,
+    state: int | None = None,
+    birthday: date | None = None,
 ) -> UserEntity:
     entity = UserEntity(
         user_bid=user_bid,
@@ -509,16 +509,16 @@ def create_user_entity(
 def update_user_entity_fields(
     entity: UserEntity,
     *,
-    identify: Optional[str] = None,
-    nickname: Optional[str] = None,
-    learner_profile: Optional[str] = None,
-    learner_profile_updated_at: Optional[datetime] = None,
+    identify: str | None = None,
+    nickname: str | None = None,
+    learner_profile: str | None = None,
+    learner_profile_updated_at: datetime | None = None,
     update_learner_profile_timestamp: bool = False,
-    avatar: Optional[str] = None,
-    language: Optional[str] = None,
-    state: Optional[int] = None,
-    birthday: Optional[date] = None,
-    deleted: Optional[bool] = None,
+    avatar: str | None = None,
+    language: str | None = None,
+    state: int | None = None,
+    birthday: date | None = None,
+    deleted: bool | None = None,
 ) -> UserEntity:
     if identify is not None:
         entity.user_identify = _normalize_identifier("", identify)
@@ -545,7 +545,7 @@ def update_user_entity_fields(
 def upsert_user_entity(
     *,
     user_bid: str,
-    defaults: Optional[Dict[str, Any]] = None,
+    defaults: Dict[str, Any] | None = None,
 ) -> Tuple[UserEntity, bool]:
     defaults = dict(defaults or {})
     entity = get_user_entity_by_bid(user_bid, include_deleted=True)
@@ -618,7 +618,7 @@ def _normalize_user_state(raw_state) -> int:
 class UserProfileSnapshot:
     user_bid: str
     legacy: Dict[str, Any] = field(default_factory=dict)
-    credentials: List[Dict[str, Optional[str]]] = field(default_factory=list)
+    credentials: List[Dict[str, str | None]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -664,15 +664,13 @@ def build_user_profile_snapshot_from_aggregate(
     )
 
 
-def serialize_raw_profile(
-    provider_name: str, metadata: Dict[str, Optional[str]]
-) -> str:
+def serialize_raw_profile(provider_name: str, metadata: Dict[str, str | None]) -> str:
     return json.dumps(
         {"provider": provider_name, "metadata": metadata}, ensure_ascii=False
     )
 
 
-def deserialize_raw_profile(record: AuthCredential) -> Dict[str, Optional[str]]:
+def deserialize_raw_profile(record: AuthCredential) -> Dict[str, str | None]:
     if not record.raw_profile:
         return {}
     try:
@@ -715,7 +713,7 @@ def upsert_credential(
     subject_id: str,
     subject_format: str,
     identifier: str,
-    metadata: Dict[str, Optional[str]],
+    metadata: Dict[str, str | None],
     verified: bool,
 ) -> AuthCredential:
     raw_identifier = (identifier or "").strip()
@@ -763,8 +761,8 @@ def upsert_credential(
 
 
 def find_credential(
-    *, provider_name: str, identifier: str, user_bid: Optional[str] = None
-) -> Optional[AuthCredential]:
+    *, provider_name: str, identifier: str, user_bid: str | None = None
+) -> AuthCredential | None:
     raw_identifier = (identifier or "").strip()
     identifier = _normalize_identifier(provider_name, identifier)
     lookup_identifiers = [identifier]
@@ -781,7 +779,7 @@ def find_credential(
 
 
 def list_credentials(
-    *, user_bid: str, provider_name: Optional[str] = None
+    *, user_bid: str, provider_name: str | None = None
 ) -> List[AuthCredential]:
     query = AuthCredential.query.filter_by(user_bid=user_bid, deleted=0)
     if provider_name:
@@ -789,7 +787,7 @@ def list_credentials(
     return query.all()
 
 
-def get_first_verified_credential_created_at(*, user_bid: str) -> Optional[datetime]:
+def get_first_verified_credential_created_at(*, user_bid: str) -> datetime | None:
     row = (
         AuthCredential.query.filter(
             AuthCredential.deleted == 0,
@@ -809,11 +807,11 @@ def upsert_wechat_credentials(
     app: Flask,
     *,
     user_bid: str,
-    open_id: Optional[str],
-    union_id: Optional[str],
-    open_identifier: Optional[str] = None,
-    union_identifier: Optional[str] = None,
-    metadata: Optional[Dict[str, Optional[str]]] = None,
+    open_id: str | None,
+    union_id: str | None,
+    open_identifier: str | None = None,
+    union_identifier: str | None = None,
+    metadata: Dict[str, str | None] | None = None,
     verified: bool = True,
 ) -> List[AuthCredential]:
     metadata = metadata or {}

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import datetime
 from dataclasses import dataclass
-from typing import Optional
 
 from flask import Flask
 from flaskr.common.cache_provider import cache
@@ -66,7 +65,7 @@ class TokenStoreProvider:
 
     def get_and_refresh(
         self, app: Flask, *, token: str, expected_user_id: str, ttl_seconds: int
-    ) -> Optional[TokenLookupResult]:
+    ) -> TokenLookupResult | None:
         if not token or not expected_user_id:
             return None
 

--- a/src/api/flaskr/service/user/verification_codes.py
+++ b/src/api/flaskr/service/user/verification_codes.py
@@ -8,7 +8,7 @@ resetting passwords where we only want to validate ownership of an identifier.
 from __future__ import annotations
 
 import datetime
-from typing import Literal, Optional
+from typing import Literal
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -102,7 +102,7 @@ def consume_verification_code(app: Flask, *, identifier: str, code: str) -> None
     if not code:
         raise_param_error("code")
 
-    fix_code: Optional[str] = app.config.get("UNIVERSAL_VERIFICATION_CODE")
+    fix_code: str | None = app.config.get("UNIVERSAL_VERIFICATION_CODE")
     if fix_code and code == fix_code:
         # Universal code is accepted in dev/test environments and should not
         # affect cache/db state.

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -18,7 +18,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 # Ensure `/app` (repo root for src/api) is on sys.path when executed as a file path.
 _API_ROOT = Path(__file__).resolve().parents[1]
@@ -418,7 +418,7 @@ def main():
             voice_label = case.get("voice_label", "")
 
             try:
-                result: Optional[SynthesizeToOssResult] = None
+                result: SynthesizeToOssResult | None = None
                 elapsed = 0.0
                 t0 = time.monotonic()
                 result = synthesize_long_text_to_oss(

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 
 class FakeRedisLock:
@@ -8,7 +8,7 @@ class FakeRedisLock:
         self._key = key
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: Optional[int] = None):
+    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
         if self._locks.get(self._key, False):
             return False
         self._locks[self._key] = True
@@ -54,7 +54,7 @@ class FakeRedis:
             return None
         return self._store.get(key)
 
-    def getex(self, key: str, ex: Optional[int] = None, px: Optional[int] = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None):
         value = self.get(key)
         if value is None:
             return None
@@ -68,8 +68,8 @@ class FakeRedis:
         self,
         key: str,
         value: Any,
-        ex: Optional[int] = None,
-        px: Optional[int] = None,
+        ex: int | None = None,
+        px: int | None = None,
         nx: bool = False,
         xx: bool = False,
         *args,
@@ -126,8 +126,8 @@ class FakeRedis:
     def lock(
         self,
         key: str,
-        timeout: Optional[int] = None,
-        blocking_timeout: Optional[int] = None,
+        timeout: int | None = None,
+        blocking_timeout: int | None = None,
     ):
         return FakeRedisLock(self._locks, key)
 

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import List, Optional
+from typing import List
 
 from flaskr.route.common import fmt
 from flaskr.service.common.dto_base import AutoJsonMixin
@@ -19,9 +19,9 @@ class SampleDTO(AutoJsonMixin, BaseModel):
     text: str = Field(...)
     number: int = Field(...)
     flag: bool = Field(...)
-    amount: Optional[Decimal] = Field(default=None)
-    happened_at: Optional[datetime] = Field(default=None)
-    child: Optional[ChildDTO] = Field(default=None)
+    amount: Decimal | None = Field(default=None)
+    happened_at: datetime | None = Field(default=None)
+    child: ChildDTO | None = Field(default=None)
     children: List[ChildDTO] = Field(default_factory=list)
     tags: List[str] = Field(default_factory=list)
 

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Optional
 
 import pytest
 from flaskr.dao import db
@@ -159,7 +158,7 @@ def seed_progress(
     user_bid: str,
     status: int,
     outline_item_bid: str = "outline-1",
-    progress_record_bid: Optional[str] = None,
+    progress_record_bid: str | None = None,
 ) -> str:
     now = now_utc()
     record_bid = progress_record_bid or f"pr-{shifu_bid}-{user_bid}-{status}"
@@ -207,7 +206,7 @@ def seed_generated_block(
     role: int,
     content: str,
     progress_record_bid: str = "pr-default",
-    generated_block_bid: Optional[str] = None,
+    generated_block_bid: str | None = None,
     outline_item_bid: str = "",
     position: int = 0,
     status: int = 1,
@@ -264,7 +263,7 @@ def seed_bill_usage_record(
     usage_scene: int = 1203,
     provider: str = "deepseek",
     model: str = "deepseek-v4-flash",
-    created_at: Optional[datetime] = None,
+    created_at: datetime | None = None,
     deleted: int = 0,
 ) -> str:
     """Seed one BillUsageRecord row for credit-detail E2E tests.
@@ -302,8 +301,8 @@ def seed_credit_ledger_entry(
     entry_type: int = CREDIT_LEDGER_ENTRY_TYPE_CONSUME,
     wallet_bid: str = "",
     wallet_bucket_bid: str = "",
-    idempotency_key: Optional[str] = None,
-    created_at: Optional[datetime] = None,
+    idempotency_key: str | None = None,
+    created_at: datetime | None = None,
     deleted: int = 0,
 ) -> str:
     """Seed one CreditLedgerEntry row.
@@ -345,7 +344,7 @@ def seed_bill_daily_metric(
     billing_metric: int = 1,
     consumed_credits: float = 10.0,
     record_count: int = 5,
-    daily_usage_metric_bid: Optional[str] = None,
+    daily_usage_metric_bid: str | None = None,
 ) -> None:
     """Seed one BillingDailyUsageMetric row for E2E credit-query tests."""
     bid = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **02 / 22**. Base: `cursor/ruff-furb157-5253` (#2477).

Enables `UP045` and rewrites `Optional[T]` to `T | None`, matching already-on `UP007`. Drops unused `Optional` imports. One union is reordered so `None` is last (`RUF036`).

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows FURB157. Next: UP006 (#2478).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized nullable type annotations across the application and test suite using Python’s `| None` syntax.
  * Removed obsolete optional-type imports and enabled linting to identify outdated annotation patterns.
  * No runtime behavior or end-user functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->