### PR TITLE
style: enforce ruff UP006 (List[T] to list[T])

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -194,6 +194,7 @@ select = [
     "UP05",    # useless class __metaclass__ = type
     "FURB157", # verbose Decimal constructor
     "UP045", # Optional[T] to T | None
+    "UP006", # List[T] to list[T]
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, Set
+from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"
@@ -53,9 +53,9 @@ USE_TRANSLATION_ALIAS_PATTERN = re.compile(
 )
 
 
-def collect_frontend_namespaced_keys(text: str) -> Set[str]:
-    used: Set[str] = set()
-    alias_declarations: Dict[str, list[tuple[int, str]]] = {}
+def collect_frontend_namespaced_keys(text: str) -> set[str]:
+    used: set[str] = set()
+    alias_declarations: dict[str, list[tuple[int, str]]] = {}
 
     for match in USE_TRANSLATION_ALIAS_PATTERN.finditer(text):
         alias = match.group(1) or "t"
@@ -84,8 +84,8 @@ def collect_frontend_namespaced_keys(text: str) -> Set[str]:
     return used
 
 
-def collect_frontend_trans_keys(text: str) -> Set[str]:
-    used: Set[str] = set()
+def collect_frontend_trans_keys(text: str) -> set[str]:
+    used: set[str] = set()
     direct_key_pattern = re.compile(
         r"i18nKey\s*=\s*['\"]([A-Za-z0-9_.-]+)['\"]",
         re.DOTALL,
@@ -120,9 +120,9 @@ def iter_locale_dirs() -> Iterable[Path]:
             yield entry
 
 
-def flatten_translation(data, namespace: str) -> Dict[str, str]:
+def flatten_translation(data, namespace: str) -> dict[str, str]:
     if isinstance(data, dict):
-        items: Dict[str, str] = {}
+        items: dict[str, str] = {}
         flat_section = data.get("__flat__")
         if isinstance(flat_section, dict):
             for key, value in flat_section.items():
@@ -141,12 +141,12 @@ def flatten_translation(data, namespace: str) -> Dict[str, str]:
     return {namespace: data}
 
 
-def collect_defined_keys() -> Set[str]:
+def collect_defined_keys() -> set[str]:
     locale_dirs = list(iter_locale_dirs())
     if not locale_dirs:
         return set()
     reference_locale = locale_dirs[0]
-    defined: Set[str] = set()
+    defined: set[str] = set()
     for file_path in reference_locale.rglob("*.json"):
         rel = file_path.relative_to(reference_locale)
         namespace = str(rel.with_suffix("")).replace("/", ".")
@@ -161,8 +161,8 @@ def collect_defined_keys() -> Set[str]:
     return defined
 
 
-def load_metadata_namespaces() -> Set[str]:
-    namespaces: Set[str] = set()
+def load_metadata_namespaces() -> set[str]:
+    namespaces: set[str] = set()
     meta = I18N_DIR / "locales.json"
     if not meta.exists():
         return namespaces
@@ -176,9 +176,9 @@ def load_metadata_namespaces() -> Set[str]:
     return namespaces
 
 
-def collect_backend_keys() -> Set[str]:
+def collect_backend_keys() -> set[str]:
     patterns = BACKEND_PATTERNS
-    used: Set[str] = set()
+    used: set[str] = set()
     for file_path in BACKEND_DIR.rglob("*.py"):
         if file_path.suffix != ".py":
             continue
@@ -227,9 +227,9 @@ def collect_backend_keys() -> Set[str]:
     return used
 
 
-def collect_frontend_keys() -> Set[str]:
+def collect_frontend_keys() -> set[str]:
     patterns = FRONTEND_PATTERNS
-    used: Set[str] = set()
+    used: set[str] = set()
     extensions = (".ts", ".tsx", ".js", ".jsx")
     for root in (COOK_WEB_DIR, WEB_DIR):
         if not root.exists():
@@ -283,7 +283,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_allowlist(path: Path | None) -> Set[str]:
+def load_allowlist(path: Path | None) -> set[str]:
     if not path:
         return set()
 
@@ -294,7 +294,7 @@ def load_allowlist(path: Path | None) -> Set[str]:
             print(f"Allowlist file not found, treating as empty: {path}")
         return set()
 
-    allowed: Set[str] = set()
+    allowed: set[str] = set()
     for line in path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
@@ -307,7 +307,7 @@ def main() -> int:
     args = parse_args()
     defined_primary = collect_defined_keys()
     # Aliases for missing-key comparison only
-    aliases: Set[str] = set()
+    aliases: set[str] = set()
     for key in list(defined_primary):
         if key.startswith("module.backend."):
             aliases.add("server." + key[len("module.backend.") :])
@@ -363,7 +363,7 @@ def main() -> int:
     allowed_unused = [key for key in unused_keys_all if key in allowlist]
     missing_allow = load_allowlist(args.missing_allowlist)
     # Expand allowlist with alias keys to stabilize migration (server.* <-> module.backend.*)
-    missing_allow_expanded: Set[str] = set(missing_allow)
+    missing_allow_expanded: set[str] = set(missing_allow)
     for key in list(missing_allow):
         if key.startswith("module.backend."):
             missing_allow_expanded.add("server." + key[len("module.backend.") :])

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -7,7 +7,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"
@@ -26,18 +26,18 @@ def iter_locale_dirs() -> Iterable[Path]:
             yield entry
 
 
-def load_json(path: Path) -> Dict:
+def load_json(path: Path) -> dict:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
         raise TranslationError(f"Failed to parse JSON: {path} ({exc})") from exc
 
 
-def flatten_translation(data, namespace: str) -> Dict[str, str]:
+def flatten_translation(data, namespace: str) -> dict[str, str]:
     """Flatten nested translation JSON to dot-separated keys."""
 
     def _flatten(obj, prefix: str):
-        items: Dict[str, str] = {}
+        items: dict[str, str] = {}
         if isinstance(obj, dict):
             # __flat__ allows specifying exact keys without additional nesting
             flat_section = obj.get("__flat__")
@@ -66,12 +66,12 @@ def flatten_translation(data, namespace: str) -> Dict[str, str]:
 
 
 def validate_locale_files(locale_dirs: Iterable[Path]):
-    files_per_locale: Dict[str, Dict[str, Path]] = {}
-    flattened_per_locale: Dict[str, Dict[str, Dict[str, str]]] = {}
+    files_per_locale: dict[str, dict[str, Path]] = {}
+    flattened_per_locale: dict[str, dict[str, dict[str, str]]] = {}
 
     for locale_dir in locale_dirs:
-        files: Dict[str, Path] = {}
-        flattened: Dict[str, Dict[str, str]] = {}
+        files: dict[str, Path] = {}
+        flattened: dict[str, dict[str, str]] = {}
 
         for file_path in sorted(locale_dir.rglob("*.json")):
             rel = file_path.relative_to(locale_dir)

--- a/scripts/create_translation_namespace.py
+++ b/scripts/create_translation_namespace.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import List
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"
@@ -33,7 +32,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def iter_locale_dirs() -> List[Path]:
+def iter_locale_dirs() -> list[Path]:
     if not I18N_DIR.exists():
         raise RuntimeError(f"Translation directory not found: {I18N_DIR}")
 
@@ -48,7 +47,7 @@ def namespace_to_path(namespace: str) -> Path:
     return Path(relative)
 
 
-def ensure_namespace_files(namespace: str, keys: List[str] | None, force: bool) -> None:
+def ensure_namespace_files(namespace: str, keys: list[str] | None, force: bool) -> None:
     relative_path = namespace_to_path(namespace)
     locale_dirs = iter_locale_dirs()
 

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -18,7 +18,6 @@ import argparse
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"
@@ -30,8 +29,8 @@ def load_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def flatten_translation(data, namespace: str) -> Dict[str, str]:
-    def _flatten(obj, prefix: str, acc: Dict[str, str]):
+def flatten_translation(data, namespace: str) -> dict[str, str]:
+    def _flatten(obj, prefix: str, acc: dict[str, str]):
         if isinstance(obj, dict):
             flat_section = obj.get("__flat__")
             if isinstance(flat_section, dict):
@@ -50,13 +49,13 @@ def flatten_translation(data, namespace: str) -> Dict[str, str]:
     return _flatten(data, namespace, {})
 
 
-def collect_defined_keys() -> Tuple[Dict[str, Path], Set[str]]:
+def collect_defined_keys() -> tuple[dict[str, Path], set[str]]:
     """Return (namespace_to_relpath, defined_keys_set) using en-US as reference for mapping."""
     if not I18N_DIR.exists():
         raise FileNotFoundError(f"Shared i18n directory not found: {I18N_DIR}")
     # Choose en-US as mapping reference
-    mapping: Dict[str, Path] = {}
-    defined: Set[str] = set()
+    mapping: dict[str, Path] = {}
+    defined: set[str] = set()
     ref_dir = I18N_DIR / "en-US"
     if not ref_dir.exists():
         # fallback to first available
@@ -101,7 +100,7 @@ def collect_defined_keys() -> Tuple[Dict[str, Path], Set[str]]:
     return mapping, defined
 
 
-def load_metadata_namespaces() -> Set[str]:
+def load_metadata_namespaces() -> set[str]:
     meta_path = I18N_DIR / "locales.json"
     if not meta_path.exists():
         return set()
@@ -122,8 +121,8 @@ BACKEND_PATTERNS = [
 ]
 
 
-def collect_frontend_keys() -> Set[str]:
-    used: Set[str] = set()
+def collect_frontend_keys() -> set[str]:
+    used: set[str] = set()
     extensions = {".ts", ".tsx", ".js", ".jsx"}
     if not COOK_WEB_DIR.exists():
         return used
@@ -140,8 +139,8 @@ def collect_frontend_keys() -> Set[str]:
     return used
 
 
-def collect_backend_keys() -> Set[str]:
-    used: Set[str] = set()
+def collect_backend_keys() -> set[str]:
+    used: set[str] = set()
     for path in BACKEND_DIR.rglob("*.py"):
         try:
             text = path.read_text(encoding="utf-8", errors="ignore")
@@ -153,7 +152,7 @@ def collect_backend_keys() -> Set[str]:
     return used
 
 
-def set_nested(obj: dict, segments: List[str], value: str) -> None:
+def set_nested(obj: dict, segments: list[str], value: str) -> None:
     cur = obj
     for seg in segments[:-1]:
         if not isinstance(cur.get(seg), dict):
@@ -164,7 +163,7 @@ def set_nested(obj: dict, segments: List[str], value: str) -> None:
         cur[leaf] = value
 
 
-def prune_unused(obj: dict, valid: Set[str], prefix: str) -> dict:
+def prune_unused(obj: dict, valid: set[str], prefix: str) -> dict:
     # Remove keys whose full path (prefix.path) not in valid
     if not isinstance(obj, dict):
         return obj
@@ -213,7 +212,7 @@ def main() -> int:
         return 0
 
     # Prepare per-namespace patches
-    ns_to_keys: Dict[str, List[str]] = {}
+    ns_to_keys: dict[str, list[str]] = {}
     for key in missing:
         ns = key.split(".")[0] + "." + key.split(".")[1] if "." in key else key
         # Re-evaluate: namespace is up to the second segment for shapes like server.user.* or module.social.* or common.core.*

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
-from typing import Any, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Generator
 
 import requests
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -90,33 +90,33 @@ class ProviderConfig:
     prefix: str = ""
     fetch_models: bool = True
     filter_fn: Callable[[str], bool] | None = None
-    static_models: List[str] = field(default_factory=list)
-    extra_models: List[str] = field(default_factory=list)
-    wildcard_prefixes: Tuple[str, ...] = ()
+    static_models: list[str] = field(default_factory=list)
+    extra_models: list[str] = field(default_factory=list)
+    wildcard_prefixes: tuple[str, ...] = ()
     config_hint: str = ""
     custom_llm_provider: str | None = None
     model_loader: (
         Callable[
-            ["ProviderConfig", Dict[str, str], str | None], List[str | Tuple[str, str]]
+            ["ProviderConfig", dict[str, str], str | None], list[str | tuple[str, str]]
         ]
         | None
     ) = None
-    reload_params: Callable[[str, float], Dict[str, Any]] | None = None
+    reload_params: Callable[[str, float], dict[str, Any]] | None = None
 
 
 @dataclass
 class ProviderState:
     enabled: bool
-    params: Dict[str, str] | None
-    models: List[str]
+    params: dict[str, str] | None
+    models: list[str]
     prefix: str = ""
-    wildcard_prefixes: Tuple[str, ...] = ()
-    reload_params: Callable[[str, float], Dict[str, Any]] | None = None
+    wildcard_prefixes: tuple[str, ...] = ()
+    reload_params: Callable[[str, float], dict[str, Any]] | None = None
 
 
-MODEL_ALIAS_MAP: Dict[str, Tuple[str, str]] = {}
-PROVIDER_STATES: Dict[str, ProviderState] = {}
-MODEL_MAX_OUTPUT_TOKENS: Dict[str, int] = {}
+MODEL_ALIAS_MAP: dict[str, tuple[str, str]] = {}
+PROVIDER_STATES: dict[str, ProviderState] = {}
+MODEL_MAX_OUTPUT_TOKENS: dict[str, int] = {}
 _USAGE_OUTPUT_TEXT_MAX_LENGTH = 12000
 
 
@@ -169,9 +169,9 @@ def _extract_input_cache(usage: Any) -> int:
 
 
 def _attach_usage_output_text(
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
     response_text: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Store a bounded response excerpt for operator usage detail summaries."""
     normalized_response_text = str(response_text or "").strip()
     if not normalized_response_text or "output_text" in metadata:
@@ -295,7 +295,7 @@ def _resolve_allowed_model_config() -> tuple[list[str], list[str]]:
     return allowed, display_names
 
 
-def _load_and_register_model_max_output_tokens() -> Dict[str, int]:
+def _load_and_register_model_max_output_tokens() -> dict[str, int]:
     raw_limits = get_config("LLM_MODEL_MAX_OUTPUT_TOKENS", "")
     try:
         limits = parse_llm_model_max_output_tokens(raw_limits)
@@ -327,10 +327,10 @@ def _load_and_register_model_max_output_tokens() -> Dict[str, int]:
 
 
 def _register_provider_models(
-    config: ProviderConfig, raw_models: List[str | Tuple[str, str]]
-) -> List[str]:
+    config: ProviderConfig, raw_models: list[str | tuple[str, str]]
+) -> list[str]:
     seen = set()
-    display_models: List[str] = []
+    display_models: list[str] = []
     for model_id in raw_models:
         actual_model = None
         if isinstance(model_id, tuple):
@@ -374,7 +374,7 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
     ):
         base_url = None
         _log_info("Skipping GEMINI_API_URL override to use LiteLLM default endpoint")
-    params: Dict[str, str] = {"api_key": api_key}
+    params: dict[str, str] = {"api_key": api_key}
     if base_url:
         params["api_base"] = base_url
     if config.custom_llm_provider:
@@ -382,7 +382,7 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
     if config.model_loader:
         raw_models = config.model_loader(config, params, base_url)
     else:
-        raw_models: List[str | Tuple[str, str]] = list(config.static_models)
+        raw_models: list[str | tuple[str, str]] = list(config.static_models)
         if config.fetch_models:
             try:
                 fetched_models = _fetch_provider_models(api_key, base_url)
@@ -570,7 +570,7 @@ def _iter_stream_with_precontent_retry(
             )
 
 
-def _resolve_provider_for_model(model: str) -> Tuple[str | None, str]:
+def _resolve_provider_for_model(model: str) -> tuple[str | None, str]:
     alias = MODEL_ALIAS_MAP.get(model)
     if alias:
         return alias
@@ -585,9 +585,9 @@ def _resolve_provider_for_model(model: str) -> Tuple[str | None, str]:
 
 
 def _load_gemini_models(
-    config: ProviderConfig, params: Dict[str, str], base_url: str | None
-) -> List[str | Tuple[str, str]]:
-    models: List[str | Tuple[str, str]] = []
+    config: ProviderConfig, params: dict[str, str], base_url: str | None
+) -> list[str | tuple[str, str]]:
+    models: list[str | tuple[str, str]] = []
     api_key = params.get("api_key")
     if not api_key:
         return models
@@ -622,8 +622,8 @@ def _load_gemini_models(
 
 
 def _load_deepseek_models(
-    config: ProviderConfig, params: Dict[str, str], base_url: str | None
-) -> List[str | Tuple[str, str]]:
+    config: ProviderConfig, params: dict[str, str], base_url: str | None
+) -> list[str | tuple[str, str]]:
     api_key = params.get("api_key", "")
     try:
         return _fetch_provider_models(api_key, base_url)
@@ -645,7 +645,7 @@ DEEPSEEK_FALLBACK_MODELS = [
 ]
 
 
-def _reload_openai_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_openai_params(model_id: str, temperature: float) -> dict[str, Any]:
     if model_id.startswith("gpt-5"):
         try:
             model_info = litellm.get_model_info(
@@ -712,11 +712,11 @@ def _reload_openai_params(model_id: str, temperature: float) -> Dict[str, Any]:
     }
 
 
-def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_gemini_params(model_id: str, temperature: float) -> dict[str, Any]:
     # Gemini thinking is controlled via LiteLLM's reasoning_effort mapping. Some
     # Gemini model ids are not included in LiteLLM's supported-params table yet,
     # so explicitly allow reasoning_effort for Gemini requests.
-    params: Dict[str, Any] = {
+    params: dict[str, Any] = {
         "temperature": temperature,
         "allowed_openai_params": ["reasoning_effort"],
     }
@@ -734,7 +734,7 @@ def _reload_gemini_params(model_id: str, temperature: float) -> Dict[str, Any]:
     return params
 
 
-def _reload_ark_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_ark_params(model_id: str, temperature: float) -> dict[str, Any]:
     return {
         "temperature": temperature,
         "thinking": {"type": "disabled"},
@@ -744,21 +744,21 @@ def _reload_ark_params(model_id: str, temperature: float) -> Dict[str, Any]:
     }
 
 
-def _reload_silicon_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_silicon_params(model_id: str, temperature: float) -> dict[str, Any]:
     return {
         "temperature": temperature,
         "extra_body": {"enable_thinking": False},
     }
 
 
-def _reload_qwen_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_qwen_params(model_id: str, temperature: float) -> dict[str, Any]:
     return {
         "temperature": temperature,
         "extra_body": {"enable_thinking": False},
     }
 
 
-def _reload_deepseek_params(model_id: str, temperature: float) -> Dict[str, Any]:
+def _reload_deepseek_params(model_id: str, temperature: float) -> dict[str, Any]:
     return {
         "temperature": temperature,
         "reasoning_effort": "none",
@@ -848,7 +848,7 @@ def _apply_provider_params(
     kwargs.update(applied_params)
 
 
-LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
+LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
     ProviderConfig(
         key="openai",
         api_key_env="OPENAI_API_KEY",
@@ -932,7 +932,7 @@ LITELLM_PROVIDER_CONFIGS: List[ProviderConfig] = [
     ),
 ]
 
-PROVIDER_CONFIG_HINTS: Dict[str, str] = {}
+PROVIDER_CONFIG_HINTS: dict[str, str] = {}
 for config in LITELLM_PROVIDER_CONFIGS:
     PROVIDER_STATES[config.key] = _init_litellm_provider(config)
     PROVIDER_CONFIG_HINTS[config.key] = config.config_hint or config.api_key_env
@@ -996,7 +996,7 @@ def invoke_llm(
     billable: int | None = None,
     request_id: str | None = None,
     trace_id: str | None = None,
-    usage_metadata: Dict[str, Any] | None = None,
+    usage_metadata: dict[str, Any] | None = None,
     **kwargs,
 ) -> Generator[LLMStreamResponse, None, None]:
     stream_flag = bool(kwargs.get("stream", True))
@@ -1179,7 +1179,7 @@ def chat_llm(
     billable: int | None = None,
     request_id: str | None = None,
     trace_id: str | None = None,
-    usage_metadata: Dict[str, Any] | None = None,
+    usage_metadata: dict[str, Any] | None = None,
     **kwargs,
 ) -> Generator[LLMStreamResponse, None, None]:
     app.logger.info(f"chat_llm [{model}] {messages} ,json:{json} ,kwargs:{kwargs}")

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -20,7 +20,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any
 from urllib.parse import quote
 
 import requests
@@ -135,7 +135,7 @@ def _store_cache_value(value: AliyunNlsToken) -> None:
     cache.set(_get_cache_key(), payload, ex=ttl_seconds)
 
 
-def _get_access_keys() -> Tuple[str, str]:
+def _get_access_keys() -> tuple[str, str]:
     """Resolve AccessKeyId/AccessKeySecret for NLS CreateToken.
 
     Prefer the dedicated variables from Aliyun docs. Fall back to OSS keys when

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -9,7 +9,6 @@ API Reference:
 """
 
 import logging
-from typing import List
 
 import requests
 
@@ -1224,7 +1223,7 @@ class AliyunTTSProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_voices(self) -> List[dict]:
+    def get_supported_voices(self) -> list[dict]:
         """Get list of supported voices."""
         return ALIYUN_VOICES
 

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -10,7 +10,6 @@ API Reference:
 import hashlib
 import logging
 import time
-from typing import List
 
 import requests
 
@@ -770,7 +769,7 @@ class BaiduTTSProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_voices(self) -> List[dict]:
+    def get_supported_voices(self) -> list[dict]:
         """Get list of supported voices."""
         return BAIDU_VOICES
 

--- a/src/api/flaskr/api/tts/base.py
+++ b/src/api/flaskr/api/tts/base.py
@@ -8,7 +8,7 @@ used interchangeably.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Dict, List
+from typing import Any
 
 
 class TTSProvider(StrEnum):
@@ -32,7 +32,7 @@ class ParamRange:
     step: float
     default: float
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "min": self.min,
             "max": self.max,
@@ -50,13 +50,13 @@ class ProviderConfig:
     speed: ParamRange
     pitch: ParamRange
     supports_emotion: bool
-    models: List[Dict[str, str]] | None = None
-    voices: List[Dict[str, str]] = field(default_factory=list)
-    emotions: List[Dict[str, str]] = field(default_factory=list)
+    models: list[dict[str, str]] | None = None
+    voices: list[dict[str, str]] = field(default_factory=list)
+    emotions: list[dict[str, str]] = field(default_factory=list)
     supports_custom_voice_id: bool = False
     supports_voice_cloning: bool = False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         data = {
             "name": self.name,
             "label": self.label,
@@ -83,7 +83,7 @@ class TTSResult:
     format: str
     word_count: int = 0
     usage_characters: int = 0
-    subtitle_cues: List[Dict[str, Any]] = field(default_factory=list)
+    subtitle_cues: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -96,7 +96,7 @@ class VoiceSettings:
     emotion: str = ""
     volume: float = 1.0
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary format."""
         return {
             "voice_id": self.voice_id,
@@ -116,7 +116,7 @@ class AudioSettings:
     bitrate: int = 128000
     channel: int = 1
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary format."""
         return {
             "format": self.format,
@@ -170,11 +170,11 @@ class BaseTTSProvider(ABC):
     def get_default_audio_settings(self) -> AudioSettings:
         """Get default audio settings for this provider."""
 
-    def get_supported_emotions(self) -> List[str]:
+    def get_supported_emotions(self) -> list[str]:
         """Get list of supported emotions for this provider."""
         return []
 
-    def get_supported_voices(self) -> List[Dict[str, str]]:
+    def get_supported_voices(self) -> list[dict[str, str]]:
         """Get list of supported voices for this provider."""
         return []
 

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -6,7 +6,7 @@ This module provides TTS synthesis using Minimax's Text-to-Speech API (t2a_v2).
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List
+from typing import Any, Iterator
 from urllib.parse import urlencode
 
 import requests
@@ -101,8 +101,8 @@ def _build_minimax_voice_setting(
     voice_settings: VoiceSettings,
     *,
     model: str,
-) -> Dict[str, Any]:
-    voice_setting_dict: Dict[str, Any] = {
+) -> dict[str, Any]:
+    voice_setting_dict: dict[str, Any] = {
         "voice_id": voice_settings.voice_id,
         "speed": voice_settings.speed,
         "vol": voice_settings.volume,
@@ -149,7 +149,7 @@ def _minimax_model_tier(model: str) -> str:
     return ""
 
 
-def _parse_minimax_rpm_overrides() -> Dict[str, int]:
+def _parse_minimax_rpm_overrides() -> dict[str, int]:
     """Parse the optional MINIMAX_TTS_RPM_LIMITS JSON map (model -> rpm)."""
     raw = get_config("MINIMAX_TTS_RPM_LIMITS")
     if not raw:
@@ -165,7 +165,7 @@ def _parse_minimax_rpm_overrides() -> Dict[str, int]:
     if not isinstance(candidate, dict):
         logger.warning("Ignoring non-object MINIMAX_TTS_RPM_LIMITS: %r", raw)
         return {}
-    overrides: Dict[str, int] = {}
+    overrides: dict[str, int] = {}
     for key, value in candidate.items():
         try:
             overrides[str(key).strip()] = int(value)
@@ -203,8 +203,8 @@ class MinimaxHTTPStreamChunk:
     format: str = "mp3"
     word_count: int = 0
     usage_characters: int = 0
-    subtitles: List[Dict[str, Any]] = field(default_factory=list)
-    extra_info: Dict[str, Any] = field(default_factory=dict)
+    subtitles: list[dict[str, Any]] = field(default_factory=list)
+    extra_info: dict[str, Any] = field(default_factory=dict)
     trace_id: str = ""
 
 
@@ -215,14 +215,14 @@ def _build_minimax_tts_url() -> str:
     return f"{MINIMAX_TTS_API_URL}?{urlencode({'GroupId': group_id})}"
 
 
-def _ensure_minimax_base_resp(message: Dict[str, Any], prefix: str) -> None:
+def _ensure_minimax_base_resp(message: dict[str, Any], prefix: str) -> None:
     base_resp = message.get("base_resp") or {}
     status_code = int(base_resp.get("status_code") or 0)
     if status_code != 0:
         raise ValueError(_format_minimax_error(message, prefix))
 
 
-def _format_minimax_error(message: Dict[str, Any], prefix: str) -> str:
+def _format_minimax_error(message: dict[str, Any], prefix: str) -> str:
     base_resp = message.get("base_resp") or {}
     status_code = base_resp.get("status_code", "unknown")
     status_msg = base_resp.get("status_msg", "Unknown error")
@@ -231,7 +231,7 @@ def _format_minimax_error(message: Dict[str, Any], prefix: str) -> str:
     return f"{prefix}: {status_code} - {status_msg}{trace_suffix}"
 
 
-def _fetch_minimax_subtitle_file(url: str) -> List[Dict[str, Any]]:
+def _fetch_minimax_subtitle_file(url: str) -> list[dict[str, Any]]:
     if not url:
         return []
     try:
@@ -258,7 +258,7 @@ def _fetch_minimax_subtitle_file(url: str) -> List[Dict[str, Any]]:
     return []
 
 
-def _looks_like_subtitle_item(value: Dict[str, Any]) -> bool:
+def _looks_like_subtitle_item(value: dict[str, Any]) -> bool:
     if not str(value.get("text", "") or "").strip():
         return False
     return any(
@@ -276,7 +276,7 @@ def _looks_like_subtitle_item(value: Dict[str, Any]) -> bool:
     )
 
 
-def _collect_subtitle_items(value: Any) -> List[Dict[str, Any]]:
+def _collect_subtitle_items(value: Any) -> list[dict[str, Any]]:
     if isinstance(value, list):
         return [item for item in value if isinstance(item, dict)]
     if isinstance(value, dict):
@@ -291,7 +291,7 @@ def _collect_subtitle_items(value: Any) -> List[Dict[str, Any]]:
     return []
 
 
-def _extract_minimax_subtitles(message: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _extract_minimax_subtitles(message: dict[str, Any]) -> list[dict[str, Any]]:
     for container in (
         message.get("data"),
         message.get("extra_info"),
@@ -348,7 +348,7 @@ class MinimaxTTSProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_emotions(self) -> List[str]:
+    def get_supported_emotions(self) -> list[str]:
         """Get list of supported emotions."""
         return MINIMAX_ALLOWED_EMOTIONS
 
@@ -541,7 +541,7 @@ class MinimaxTTSProvider(BaseTTSProvider):
         audio_settings: AudioSettings | None = None,
         output_format: str = "hex",
         model: str | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Call Minimax TTS API.
 
         Args:

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -26,7 +26,6 @@ import json
 import logging
 import time
 import uuid
-from typing import Dict, List
 
 import requests
 
@@ -79,7 +78,7 @@ _TERMINAL_PUNCTUATION = "。！？!?；;\n"
 
 def _texttovoice_voice(
     value: str, label: str, model: str, language: str = "zh"
-) -> Dict[str, str]:
+) -> dict[str, str]:
     tier_label = {
         TENCENT_TEXTTOVOICE_PREMIUM_MODEL: "精品",
         TENCENT_TEXTTOVOICE_LARGE_MODEL: "大模型",
@@ -97,11 +96,11 @@ def _texttovoice_voice(
     }
 
 
-def _premium(value: str, label: str, language: str = "zh") -> Dict[str, str]:
+def _premium(value: str, label: str, language: str = "zh") -> dict[str, str]:
     return _texttovoice_voice(value, label, TENCENT_TEXTTOVOICE_PREMIUM_MODEL, language)
 
 
-def _large_model(value: str, label: str, language: str = "zh") -> Dict[str, str]:
+def _large_model(value: str, label: str, language: str = "zh") -> dict[str, str]:
     return _texttovoice_voice(value, label, TENCENT_TEXTTOVOICE_LARGE_MODEL, language)
 
 
@@ -160,7 +159,7 @@ def build_texttovoice_tc3_headers(
     secret_id: str,
     secret_key: str,
     timestamp: int | None = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     request_timestamp = int(timestamp if timestamp is not None else time.time())
     request_date = dt.datetime.fromtimestamp(
         request_timestamp,
@@ -232,8 +231,8 @@ def _text_weight(text: str) -> float:
     return sum(_char_weight(char) for char in text)
 
 
-def _hard_split(text: str) -> List[str]:
-    pieces: List[str] = []
+def _hard_split(text: str) -> list[str]:
+    pieces: list[str] = []
     current = ""
     current_weight = 0.0
     for char in text:
@@ -249,13 +248,13 @@ def _hard_split(text: str) -> List[str]:
     return pieces
 
 
-def _split_text(text: str) -> List[str]:
+def _split_text(text: str) -> list[str]:
     """Split text into segments within the TextToVoice request limit."""
     normalized = str(text or "").strip()
     if not normalized:
         return []
 
-    sentences: List[str] = []
+    sentences: list[str] = []
     current = ""
     for char in normalized:
         current += char
@@ -265,7 +264,7 @@ def _split_text(text: str) -> List[str]:
     if current:
         sentences.append(current)
 
-    segments: List[str] = []
+    segments: list[str] = []
     buffer = ""
     buffer_weight = 0.0
     for sentence in sentences:
@@ -322,7 +321,7 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_voices(self) -> List[Dict[str, str]]:
+    def get_supported_voices(self) -> list[dict[str, str]]:
         return [dict(voice) for voice in TENCENT_TEXTTOVOICE_VOICES]
 
     def _synthesize_segment(

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import base64
 import logging
 import uuid
-from typing import List
 
 import requests
 from requests import Response
@@ -150,7 +149,7 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_voices(self) -> List[dict]:
+    def get_supported_voices(self) -> list[dict]:
         """Get list of supported voices."""
         return VOLCENGINE_HTTP_VOICES
 

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -14,7 +14,7 @@ import logging
 import struct
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, Dict
+from typing import Any
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -105,7 +105,7 @@ class ProtocolFrame:
     event: Event | None
     session_id: str | None
     connection_id: str | None
-    payload: bytes | Dict[str, Any] | None
+    payload: bytes | dict[str, Any] | None
     error_code: int | None = None
 
 
@@ -364,7 +364,7 @@ class VolcengineProtocol:
                     offset += sess_id_len
 
         # Parse payload
-        payload: bytes | Dict[str, Any] | None = None
+        payload: bytes | dict[str, Any] | None = None
 
         if len(data) > offset:
             if message_type == MessageType.AUDIO_ONLY_RESPONSE:
@@ -414,7 +414,7 @@ class VolcengineProtocol:
         serialization: SerializationMethod,
         compression: CompressionMethod,
         event: Event | None = None,
-        payload: Dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
     ) -> bytes:
         """Encode a frame without session/connection ID."""
         frame = bytearray()
@@ -466,7 +466,7 @@ class VolcengineProtocol:
         compression: CompressionMethod,
         event: Event,
         session_id: str,
-        payload: Dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
     ) -> bytes:
         """Encode a frame with session ID."""
         frame = bytearray()

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -12,7 +12,7 @@ import logging
 import re
 import threading
 import uuid
-from typing import Any, List
+from typing import Any
 
 from flaskr.api.tts.base import (
     AudioSettings,
@@ -416,7 +416,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
             channel=1,
         )
 
-    def get_supported_voices(self) -> List[dict]:
+    def get_supported_voices(self) -> list[dict]:
         """Get list of supported voices."""
         return VOLCENGINE_VOICES
 
@@ -485,7 +485,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
         session_id = str(uuid.uuid4()).replace("-", "")
 
         # Collect audio data
-        audio_chunks: List[bytes] = []
+        audio_chunks: list[bytes] = []
         subtitle_cues: list[dict[str, Any]] = []
         error_message: str | None = None
         connection_established = threading.Event()

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -8,7 +8,6 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Tuple
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -48,7 +47,7 @@ class MigrationResult:
     error_records: int
     start_time: datetime
     end_time: datetime
-    errors: List[str]
+    errors: list[str]
 
     @property
     def duration(self) -> float:
@@ -71,7 +70,7 @@ class ConsistencyCheckResult:
     old_count: int
     new_count: int
     sample_integrity_passed: bool
-    data_mismatches: List[str]
+    data_mismatches: list[str]
 
     @property
     def count_match(self) -> bool:
@@ -159,7 +158,7 @@ class UnifiedMigrationTask:
 
         logger.info(f"Initialized unified migration task with database: {database_url}")
 
-    async def migrate_all_tables(self) -> Dict[str, MigrationResult]:
+    async def migrate_all_tables(self) -> dict[str, MigrationResult]:
         """Migrate all configured tables asynchronously"""
         logger.info("Starting unified migration for all tables...")
 
@@ -194,7 +193,7 @@ class UnifiedMigrationTask:
         return results
 
     async def _migrate_table_async(
-        self, source_table: str, table_config: Dict
+        self, source_table: str, table_config: dict
     ) -> MigrationResult:
         """Migrate a single table asynchronously"""
         logger.info(f"Starting migration for table: {source_table}")
@@ -305,7 +304,7 @@ class UnifiedMigrationTask:
         key_field: str,
         target_key: str,
         offset: int,
-    ) -> Dict:
+    ) -> dict:
         """Process a batch of records asynchronously"""
         loop = asyncio.get_event_loop()
 
@@ -329,7 +328,7 @@ class UnifiedMigrationTask:
         key_field: str,
         target_key: str,
         offset: int,
-    ) -> Dict:
+    ) -> dict:
         """Process a batch of records synchronously"""
         # Create a new session for this batch to avoid concurrency issues
         session = self.SessionClass()
@@ -479,7 +478,7 @@ class UnifiedMigrationTask:
         finally:
             session.close()
 
-    async def verify_data_consistency(self) -> Dict[str, ConsistencyCheckResult]:
+    async def verify_data_consistency(self) -> dict[str, ConsistencyCheckResult]:
         """Verify data consistency between old and new tables"""
         logger.info("Starting comprehensive data consistency verification...")
 
@@ -534,7 +533,7 @@ class UnifiedMigrationTask:
 
     async def _verify_sample_integrity_async(
         self, source_table: str, target_table: str, key_field: str, target_key: str
-    ) -> Tuple[bool, List[str]]:
+    ) -> tuple[bool, list[str]]:
         """Verify data integrity using random sampling"""
         session = self.SessionClass()
         try:
@@ -623,7 +622,7 @@ class UnifiedMigrationTask:
             return False
 
     # Table mapping functions
-    def _map_attendscript_to_progress_record(self, record) -> Dict:
+    def _map_attendscript_to_progress_record(self, record) -> dict:
         """Map ai_course_lesson_attend to learn_progress_records"""
         return {
             "progress_record_bid": getattr(record, "attend_id", ""),
@@ -638,7 +637,7 @@ class UnifiedMigrationTask:
             "updated_at": getattr(record, "updated", None),
         }
 
-    def _map_log_script_to_generated_block(self, record) -> Dict:
+    def _map_log_script_to_generated_block(self, record) -> dict:
         """Map ai_course_lesson_attendscript to learn_generated_blocks"""
         return {
             "generated_block_bid": getattr(record, "log_id", ""),
@@ -659,7 +658,7 @@ class UnifiedMigrationTask:
             "updated_at": getattr(record, "updated", None),
         }
 
-    def _map_discount_to_coupon(self, record) -> Dict:
+    def _map_discount_to_coupon(self, record) -> dict:
         """Map discount to promo_coupons"""
         return {
             "coupon_bid": record.discount_id,
@@ -680,7 +679,7 @@ class UnifiedMigrationTask:
             "updated_at": record.updated,
         }
 
-    def _map_discount_log_to_usage(self, record) -> Dict:
+    def _map_discount_log_to_usage(self, record) -> dict:
         """Map discount_use_log to promo_coupon_usages"""
         return {
             "coupon_usage_bid": record.record_id,
@@ -928,8 +927,8 @@ class UnifiedMigrationTask:
 
     def generate_migration_report(
         self,
-        migration_results: Dict[str, MigrationResult],
-        consistency_results: Dict[str, ConsistencyCheckResult],
+        migration_results: dict[str, MigrationResult],
+        consistency_results: dict[str, ConsistencyCheckResult],
     ) -> str:
         """Generate comprehensive migration report"""
         report = []

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable
 
 from flask import Config as FlaskConfig
 from flask import Flask
@@ -21,12 +21,12 @@ class EnvVar:
     required: bool = False  # Whether variable must be explicitly set in environment
     default: Any = None  # Default value if not set (only if required=False)
     example: Any = None  # Optional value to emit in generated example files
-    type: Type = str  # Using Type annotation to avoid conflict
+    type: type = str  # Using Type annotation to avoid conflict
     description: str = ""
     validator: Callable[[Any], bool] | None = None
     secret: bool = False
     group: str = "general"
-    depends_on: List[str] = field(default_factory=list)
+    depends_on: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         """Validate EnvVar configuration after initialization."""
@@ -103,7 +103,7 @@ def _is_valid_rpm_limits_json(value: Any) -> bool:
     return True
 
 
-def parse_llm_model_max_output_tokens(value: Any) -> Dict[str, int]:
+def parse_llm_model_max_output_tokens(value: Any) -> dict[str, int]:
     """Parse a routed model id -> maximum output token JSON map."""
     if value in (None, ""):
         return {}
@@ -117,7 +117,7 @@ def parse_llm_model_max_output_tokens(value: Any) -> Dict[str, int]:
     if not isinstance(candidate, dict):
         raise ValueError("must be a JSON object")
 
-    parsed: Dict[str, int] = {}
+    parsed: dict[str, int] = {}
     for model, max_output_tokens in candidate.items():
         if not isinstance(model, str) or not model.strip():
             raise ValueError("model ids must be non-empty strings")
@@ -143,7 +143,7 @@ def _is_valid_llm_model_max_output_tokens_json(value: Any) -> bool:
 
 
 # Environment variable registry
-ENV_VARS: Dict[str, EnvVar] = {
+ENV_VARS: dict[str, EnvVar] = {
     # Application Configuration
     "LOGGING_PATH": EnvVar(
         name="LOGGING_PATH",
@@ -1752,7 +1752,7 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
 }
 
 # Derived Redis prefixes built from REDIS_KEY_PREFIX
-REDIS_KEY_SUFFIXES: Dict[str, str] = {
+REDIS_KEY_SUFFIXES: dict[str, str] = {
     "REDIS_KEY_PREFIX_USER": "user:",
     "REDIS_KEY_PREFIX_RESET_PWD": "reset_pwd:",
     "REDIS_KEY_PREFIX_PHONE": "phone:",
@@ -1770,9 +1770,9 @@ REDIS_KEY_SUFFIXES: Dict[str, str] = {
 class EnhancedConfig:
     """Enhanced configuration management with validation and type safety."""
 
-    def __init__(self, env_vars: Dict[str, EnvVar]):
+    def __init__(self, env_vars: dict[str, EnvVar]):
         self.env_vars = env_vars
-        self._cache: Dict[str, Any] = {}
+        self._cache: dict[str, Any] = {}
         self._validated = False
 
     def validate_environment(self, allow_conversion_errors: bool = False) -> None:
@@ -1909,7 +1909,7 @@ class EnhancedConfig:
         except (TypeError, ValueError):
             return 0.0
 
-    def get_list(self, key: str) -> List[str]:
+    def get_list(self, key: str) -> list[str]:
         """Get list configuration value (comma-separated)."""
         value = self.get(key)
         if value is None:
@@ -2197,7 +2197,7 @@ class Config(FlaskConfig):
         """Get float configuration value."""
         return self.enhanced.get_float(key)
 
-    def get_list(self, key: str) -> List[str]:
+    def get_list(self, key: str) -> list[str]:
         """Get list configuration value."""
         return self.enhanced.get_list(key)
 

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from functools import wraps
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 _context_local = threading.local()
 
@@ -39,7 +39,7 @@ def get_shifu_creator_bid() -> str | None:
     return getattr(_context_local, "shifu_creator_bid", None)
 
 
-def get_shifu_context_snapshot() -> Dict[str, Any]:
+def get_shifu_context_snapshot() -> dict[str, Any]:
     """Capture the current shifu context as a plain dict.
 
     This snapshot can be passed into a background thread and applied there.
@@ -50,7 +50,7 @@ def get_shifu_context_snapshot() -> Dict[str, Any]:
     }
 
 
-def apply_shifu_context_snapshot(snapshot: Dict[str, Any] | None) -> None:
+def apply_shifu_context_snapshot(snapshot: dict[str, Any] | None) -> None:
     """Apply a previously captured shifu context snapshot to the current thread.
 
     Args:

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -4,7 +4,7 @@ import os
 import threading
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Iterable
 
 from flask import Flask
 

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -13,7 +13,7 @@ from flaskr.common.config import get_config
 TRANSLATIONS_DEFAULT_NAME = "i18n"
 
 _thread_local = threading.local()
-_translations: Dict[str, Dict[str, str]] = defaultdict(dict)
+_translations: dict[str, dict[str, str]] = defaultdict(dict)
 
 
 def _shared_json_root() -> Path:
@@ -151,7 +151,7 @@ def _validate_json_translations(app: Flask, root: Path):
             f"Missing shared i18n directory at '{root}'. Run the migration checklist to generate JSON translations."
         )
 
-    problems: List[str] = []
+    problems: list[str] = []
 
     metadata_path = root / "locales.json"
     metadata_declared_locales: set[str] = set()

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -46,7 +46,7 @@ result so the summary is stable.
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any, Dict, Iterable, List, Sequence, Tuple
+from typing import Any, Iterable, Sequence
 
 from flask import Flask
 from flaskr.i18n import _
@@ -76,7 +76,7 @@ _ALLOWED_USAGE_TYPES = frozenset({1101, 1102})
 _DEFAULT_LIMIT = 100
 
 
-def run(app: Flask, user_id: str, payload: Any) -> Dict[str, Any]:
+def run(app: Flask, user_id: str, payload: Any) -> dict[str, Any]:
     """Execute the credit-detail query for ``user_id``.
 
     Validates the payload, enforces the per-shifu permission check, then
@@ -162,8 +162,8 @@ class _Params:
         shifu_bid: str,
         start_date: date | None,
         end_date: date | None,
-        usage_scene: Tuple[int, ...] | None,
-        usage_type: Tuple[int, ...] | None,
+        usage_scene: tuple[int, ...] | None,
+        usage_type: tuple[int, ...] | None,
         limit: int,
         offset: int,
     ) -> None:
@@ -233,13 +233,13 @@ def _parse_optional_date(raw: Any, field_name: str) -> date | None:
 
 def _parse_int_set(
     raw: Any, field_name: str, allowed: Iterable[int]
-) -> Tuple[int, ...] | None:
+) -> tuple[int, ...] | None:
     if raw is None:
         return None
     if not isinstance(raw, list) or not raw:
         _raise(ERR_INVALID_DSL, f"'{field_name}' must be a non-empty list of integers")
     allowed_set = set(allowed)
-    out: List[int] = []
+    out: list[int] = []
     seen: set[int] = set()
     for item in raw:
         if isinstance(item, bool) or not isinstance(item, int):
@@ -382,14 +382,14 @@ def _build_summary_statement(params: _Params) -> Select:
 # ---------------------------------------------------------------------------
 
 
-def _row_to_dict(columns: Sequence[str], values: Sequence[Any]) -> Dict[str, Any]:
-    row: Dict[str, Any] = {}
+def _row_to_dict(columns: Sequence[str], values: Sequence[Any]) -> dict[str, Any]:
+    row: dict[str, Any] = {}
     for col, val in zip(columns, values, strict=False):
         row[col] = _coerce_value(val)
     return row
 
 
-def _summary_row_to_dict(summary_row: Any) -> Dict[str, Any]:
+def _summary_row_to_dict(summary_row: Any) -> dict[str, Any]:
     if summary_row is None:
         return {
             "total_records": 0,

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -14,7 +14,7 @@ names registered in ``src/api/error_codes.json``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List, Mapping, Sequence, Tuple
+from typing import Any, Mapping, Sequence
 
 from flaskr.i18n import _
 from flaskr.service.common.models import ERROR_CODE, AppException
@@ -126,15 +126,15 @@ class QueryDSL:
     shifu_bid: str
     table: str
     spec: TableSpec
-    select: Tuple[str, ...]
-    filters: Tuple[Filter, ...]
-    group_by: Tuple[str, ...]
-    aggregates: Tuple[Aggregate, ...]
-    order_by: Tuple[OrderBy, ...]
+    select: tuple[str, ...]
+    filters: tuple[Filter, ...]
+    group_by: tuple[str, ...]
+    aggregates: tuple[Aggregate, ...]
+    order_by: tuple[OrderBy, ...]
     limit: int
     offset: int
 
-    output_columns: Tuple[str, ...] = field(default_factory=tuple)
+    output_columns: tuple[str, ...] = field(default_factory=tuple)
     # Caller's authenticated user_id, threaded from funcs.run_dsl. Consumed
     # by sql_builder when the target TableSpec declares a
     # `creator_scoped_column` (currently the shifu metadata tables).
@@ -227,7 +227,7 @@ def parse_dsl(payload: Any, limit_max: int, user_id: str = "") -> QueryDSL:
 # ---------------------------------------------------------------------------
 
 
-def _parse_select(raw: Any, spec: TableSpec) -> List[str]:
+def _parse_select(raw: Any, spec: TableSpec) -> list[str]:
     if raw is None:
         return []
     if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
@@ -245,7 +245,7 @@ def _parse_select(raw: Any, spec: TableSpec) -> List[str]:
     return list(raw)
 
 
-def _parse_group_by(raw: Any, spec: TableSpec) -> List[str]:
+def _parse_group_by(raw: Any, spec: TableSpec) -> list[str]:
     if raw is None:
         return []
     if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
@@ -261,12 +261,12 @@ def _parse_group_by(raw: Any, spec: TableSpec) -> List[str]:
     return list(raw)
 
 
-def _parse_aggregates(raw: Any, spec: TableSpec) -> List[Aggregate]:
+def _parse_aggregates(raw: Any, spec: TableSpec) -> list[Aggregate]:
     if raw is None:
         return []
     if not isinstance(raw, list):
         _raise(ERR_INVALID_DSL, "'aggregate' must be a list of aggregate objects")
-    aggregates: List[Aggregate] = []
+    aggregates: list[Aggregate] = []
     seen_aliases: set[str] = set()
     for index, item in enumerate(raw):
         if not isinstance(item, Mapping):
@@ -327,12 +327,12 @@ def _parse_aggregates(raw: Any, spec: TableSpec) -> List[Aggregate]:
     return aggregates
 
 
-def _parse_filters(raw: Any, spec: TableSpec) -> List[Filter]:
+def _parse_filters(raw: Any, spec: TableSpec) -> list[Filter]:
     if raw is None:
         return []
     if not isinstance(raw, list):
         _raise(ERR_INVALID_DSL, "'where' must be a list of filter objects")
-    filters: List[Filter] = []
+    filters: list[Filter] = []
     for index, item in enumerate(raw):
         if not isinstance(item, Mapping):
             _raise(ERR_INVALID_DSL, f"where[{index}] must be an object")
@@ -359,13 +359,13 @@ def _parse_order_by(
     select: Sequence[str],
     aggregates: Sequence[Aggregate],
     group_by: Sequence[str],
-) -> List[OrderBy]:
+) -> list[OrderBy]:
     if raw is None:
         return []
     if not isinstance(raw, list):
         _raise(ERR_INVALID_DSL, "'order_by' must be a list")
     allowed_targets = set(select) | set(group_by) | {agg.alias for agg in aggregates}
-    out: List[OrderBy] = []
+    out: list[OrderBy] = []
     for index, item in enumerate(raw):
         if not isinstance(item, Mapping):
             _raise(ERR_INVALID_DSL, f"order_by[{index}] must be an object")
@@ -382,7 +382,7 @@ def _parse_order_by(
     return out
 
 
-def _parse_paging(raw_limit: Any, raw_offset: Any, limit_max: int) -> Tuple[int, int]:
+def _parse_paging(raw_limit: Any, raw_offset: Any, limit_max: int) -> tuple[int, int]:
     limit = raw_limit if raw_limit is not None else min(100, limit_max)
     if not isinstance(limit, int) or isinstance(limit, bool):
         _raise(ERR_INVALID_LIMIT, "'limit' must be an integer")

--- a/src/api/flaskr/service/creator_analytics/engine.py
+++ b/src/api/flaskr/service/creator_analytics/engine.py
@@ -13,7 +13,7 @@ plain ``{"columns": [...], "rows": [...]}`` dict suitable for the HTTP layer.
 from __future__ import annotations
 
 import threading
-from typing import Any, Dict, List
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -60,13 +60,13 @@ def get_analytics_engine(app: Flask) -> Engine:
         return _engine
 
 
-def run_query(app: Flask, stmt: Select) -> Dict[str, Any]:
+def run_query(app: Flask, stmt: Select) -> dict[str, Any]:
     """Execute ``stmt`` against the analytics engine and return columns/rows."""
     engine = get_analytics_engine(app)
     with engine.connect() as connection:
         result: Result = connection.execute(stmt)
         columns = list(result.keys())
-        rows: List[List[Any]] = [list(row) for row in result.fetchall()]
+        rows: list[list[Any]] = [list(row) for row in result.fetchall()]
     return {"columns": columns, "rows": rows}
 
 

--- a/src/api/flaskr/service/creator_analytics/funcs.py
+++ b/src/api/flaskr/service/creator_analytics/funcs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.i18n import _
@@ -17,7 +17,7 @@ from .sql_builder import build_statement
 ERR_NO_PERMISSION = "server.creatorAnalytics.noPermission"
 
 
-def run_dsl(app: Flask, user_id: str, payload: Any) -> Dict[str, Any]:
+def run_dsl(app: Flask, user_id: str, payload: Any) -> dict[str, Any]:
     """Execute a DSL query on behalf of ``user_id``.
 
     Steps:
@@ -104,7 +104,7 @@ def _user_bid_candidates(filters) -> list[str]:
     return out
 
 
-def _redact_user_users_rows(result: Dict[str, Any]) -> None:
+def _redact_user_users_rows(result: dict[str, Any]) -> None:
     """Sanitise ``user_users`` result rows in-place.
 
     - ``nickname``: full PII redaction via :func:`redact_pii` (phone/email

--- a/src/api/flaskr/service/creator_analytics/whitelist.py
+++ b/src/api/flaskr/service/creator_analytics/whitelist.py
@@ -19,7 +19,7 @@ builder, driven by :class:`TableSpec` flags:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet, Mapping, Type
+from typing import Mapping
 
 from flaskr.service.billing.models import BillingDailyUsageMetric
 from flaskr.service.learn.models import (
@@ -32,11 +32,11 @@ from flaskr.service.profile.models import VariableValue
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu, ShifuUserArchive
 from flaskr.service.user.models import UserInfo
 
-ALLOWED_AGGREGATE_FUNCTIONS: FrozenSet[str] = frozenset(
+ALLOWED_AGGREGATE_FUNCTIONS: frozenset[str] = frozenset(
     {"count", "count_distinct", "sum", "avg", "min", "max"}
 )
 
-ALLOWED_OPERATORS: FrozenSet[str] = frozenset(
+ALLOWED_OPERATORS: frozenset[str] = frozenset(
     {
         "=",
         "!=",
@@ -59,11 +59,11 @@ class TableSpec:
     """Declarative whitelist for one analyzable table."""
 
     table_key: str
-    model: Type
-    selectable: FrozenSet[str]
-    filterable: FrozenSet[str]
-    groupable: FrozenSet[str]
-    aggregatable: Mapping[str, FrozenSet[str]]
+    model: type
+    selectable: frozenset[str]
+    filterable: frozenset[str]
+    groupable: frozenset[str]
+    aggregatable: Mapping[str, frozenset[str]]
     has_deleted: bool
     # True for shifu-scoped tables (sql_builder injects WHERE shifu_bid=:sb).
     # False for global tables like user_users — permission is still enforced
@@ -81,9 +81,9 @@ class TableSpec:
     auto_filter_status_active: bool = False
 
 
-_DIMENSION_AGGS: FrozenSet[str] = frozenset({"count", "count_distinct"})
-_NUMERIC_AGGS: FrozenSet[str] = frozenset({"count", "sum", "avg", "min", "max"})
-_TIMESTAMP_AGGS: FrozenSet[str] = frozenset({"count", "min", "max"})
+_DIMENSION_AGGS: frozenset[str] = frozenset({"count", "count_distinct"})
+_NUMERIC_AGGS: frozenset[str] = frozenset({"count", "sum", "avg", "min", "max"})
+_TIMESTAMP_AGGS: frozenset[str] = frozenset({"count", "min", "max"})
 
 
 WHITELIST: Mapping[str, TableSpec] = {

--- a/src/api/flaskr/service/dashboard/dtos.py
+++ b/src/api/flaskr/service/dashboard/dtos.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
 
 from flaskr.common.swagger import register_schema_to_swagger
 from flaskr.service.common.dto_base import AutoJsonMixin
@@ -57,7 +56,7 @@ class DashboardEntryDTO(AutoJsonMixin, BaseModel):
     page_size: int = Field(..., description="Page size", required=False)
     page_count: int = Field(..., description="Page count", required=False)
     total: int = Field(..., description="Total course count", required=False)
-    items: List[DashboardEntryCourseItemDTO] = Field(
+    items: list[DashboardEntryCourseItemDTO] = Field(
         default_factory=list, description="Course rows", required=False
     )
 
@@ -161,7 +160,7 @@ class DashboardCourseDetailLearnersDTO(AutoJsonMixin, BaseModel):
     page_size: int = Field(..., description="Page size", required=False)
     page_count: int = Field(..., description="Page count", required=False)
     total: int = Field(..., description="Total learner count", required=False)
-    items: List[DashboardCourseDetailLearnerItemDTO] = Field(
+    items: list[DashboardCourseDetailLearnerItemDTO] = Field(
         default_factory=list, description="Learner rows", required=False
     )
 
@@ -239,7 +238,7 @@ class DashboardCourseFollowUpListDTO(AutoJsonMixin, BaseModel):
     page_size: int = Field(..., description="Page size", required=False)
     page_count: int = Field(..., description="Page count", required=False)
     total: int = Field(..., description="Total follow-up count", required=False)
-    items: List[DashboardCourseFollowUpItemDTO] = Field(
+    items: list[DashboardCourseFollowUpItemDTO] = Field(
         default_factory=list, description="Follow-up rows", required=False
     )
 
@@ -304,7 +303,7 @@ class DashboardCourseFollowUpDetailDTO(AutoJsonMixin, BaseModel):
     current_record: DashboardCourseFollowUpCurrentRecordDTO = Field(
         ..., description="Current follow-up record", required=False
     )
-    timeline: List[DashboardCourseFollowUpTimelineItemDTO] = Field(
+    timeline: list[DashboardCourseFollowUpTimelineItemDTO] = Field(
         default_factory=list, description="Follow-up timeline", required=False
     )
 
@@ -365,6 +364,6 @@ class DashboardCourseRatingListDTO(AutoJsonMixin, BaseModel):
     page_size: int = Field(..., description="Page size", required=False)
     page_count: int = Field(..., description="Page count", required=False)
     total: int = Field(..., description="Total rating count", required=False)
-    items: List[DashboardCourseRatingItemDTO] = Field(
+    items: list[DashboardCourseRatingItemDTO] = Field(
         default_factory=list, description="Rating rows", required=False
     )

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any, Dict, List, Sequence, Set, Tuple
+from typing import Any, Sequence
 
 from flask import Flask
 from flaskr.dao import db
@@ -74,11 +74,11 @@ class _DashboardCourseMeta:
 @dataclass
 class _DashboardEntryMetrics:
     learner_total: int = 0
-    learner_count_map: Dict[str, int] = field(default_factory=dict)
-    order_count_map: Dict[str, int] = field(default_factory=dict)
-    order_amount_map: Dict[str, Decimal] = field(default_factory=dict)
-    last_active_map: Dict[str, datetime] = field(default_factory=dict)
-    active_course_bids: Set[str] = field(default_factory=set)
+    learner_count_map: dict[str, int] = field(default_factory=dict)
+    order_count_map: dict[str, int] = field(default_factory=dict)
+    order_amount_map: dict[str, Decimal] = field(default_factory=dict)
+    last_active_map: dict[str, datetime] = field(default_factory=dict)
+    active_course_bids: set[str] = field(default_factory=set)
 
 
 DASHBOARD_COURSE_LEARNER_PAGE_SIZE_MAX = 100
@@ -214,14 +214,14 @@ def _build_dashboard_learner_keyword_filter(
 
 
 def _resolve_dashboard_outline_keyword_match_bids(
-    outline_context_map: Dict[str, Dict[str, str]],
+    outline_context_map: dict[str, dict[str, str]],
     keyword: str,
-) -> Set[str]:
+) -> set[str]:
     normalized_keyword = str(keyword or "").strip().lower()
     if not normalized_keyword:
         return set()
 
-    matched_outline_item_bids: Set[str] = set()
+    matched_outline_item_bids: set[str] = set()
     for outline_item_bid, context in outline_context_map.items():
         chapter_title = str(context.get("chapter_title", "") or "").lower()
         lesson_title = str(context.get("lesson_title", "") or "").lower()
@@ -236,13 +236,13 @@ def _resolve_dashboard_outline_keyword_match_bids(
 
 def _build_course_outline_context_map(
     outline_items: Sequence[PublishedOutlineItem],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     outline_item_map = {
         str(getattr(item, "outline_item_bid", "") or "").strip(): item
         for item in outline_items
         if str(getattr(item, "outline_item_bid", "") or "").strip()
     }
-    context_map: Dict[str, Dict[str, str]] = {}
+    context_map: dict[str, dict[str, str]] = {}
 
     for outline_item_bid, item in outline_item_map.items():
         lesson_title = str(getattr(item, "title", "") or "").strip()
@@ -342,9 +342,9 @@ def _build_follow_up_user_keyword_filter(
 
 
 def _resolve_follow_up_matching_outline_bids(
-    outline_context_map: Dict[str, Dict[str, str]],
+    outline_context_map: dict[str, dict[str, str]],
     chapter_keyword: str,
-) -> Set[str] | None:
+) -> set[str] | None:
     normalized_keyword = str(chapter_keyword or "").strip().lower()
     if not normalized_keyword:
         return None
@@ -789,7 +789,7 @@ def _build_follow_up_source_status_map(
 
 def _load_dashboard_course_user_contact_map(
     user_bids: Sequence[str],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -807,7 +807,7 @@ def _load_dashboard_course_user_contact_map(
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    contact_map: Dict[str, Dict[str, str]] = {
+    contact_map: dict[str, dict[str, str]] = {
         user_bid: {"mobile": "", "email": ""} for user_bid in normalized_user_bids
     }
     for credential in credential_rows:
@@ -850,7 +850,7 @@ def _load_dashboard_course_user_contact_map(
     return contact_map
 
 
-def _load_dashboard_course_meta_map(user_id: str) -> Dict[str, _DashboardCourseMeta]:
+def _load_dashboard_course_meta_map(user_id: str) -> dict[str, _DashboardCourseMeta]:
     owned_rows = (
         db.session.query(PublishedShifu.shifu_bid)
         .filter(
@@ -882,12 +882,12 @@ def _load_dashboard_course_meta_map(user_id: str) -> Dict[str, _DashboardCourseM
         .group_by(PublishedShifu.shifu_bid)
     ).subquery()
 
-    published_rows: List[PublishedShifu] = (
+    published_rows: list[PublishedShifu] = (
         db.session.query(PublishedShifu)
         .filter(PublishedShifu.id.in_(db.session.query(latest_subquery.c.max_id)))
         .all()
     )
-    course_map: Dict[str, _DashboardCourseMeta] = {}
+    course_map: dict[str, _DashboardCourseMeta] = {}
     for row in published_rows:
         shifu_bid = str(row.shifu_bid or "").strip()
         if not shifu_bid:
@@ -947,7 +947,7 @@ def _load_dashboard_entry_courses(
     user_id: str,
     *,
     keyword: str | None = None,
-) -> List[_DashboardCourseMeta]:
+) -> list[_DashboardCourseMeta]:
     courses = list(_load_dashboard_course_meta_map(user_id).values())
     normalized_keyword = str(keyword or "").strip().lower()
     if normalized_keyword:
@@ -997,7 +997,7 @@ def _resolve_dashboard_course_status(shifu_bid: str) -> str:
 
 def _load_dashboard_course_outline_items(
     shifu_bid: str,
-) -> List[PublishedOutlineItem]:
+) -> list[PublishedOutlineItem]:
     return (
         PublishedOutlineItem.query.filter(
             PublishedOutlineItem.shifu_bid == shifu_bid,
@@ -1012,7 +1012,7 @@ def _load_dashboard_course_outline_items(
     )
 
 
-def _load_course_leaf_outline_bids(shifu_bid: str) -> List[str]:
+def _load_course_leaf_outline_bids(shifu_bid: str) -> list[str]:
     outline_rows = (
         db.session.query(
             PublishedOutlineItem.outline_item_bid,
@@ -1028,8 +1028,8 @@ def _load_course_leaf_outline_bids(shifu_bid: str) -> List[str]:
     if not outline_rows:
         return []
 
-    visible_bids: Set[str] = set()
-    visible_parent_bids: Set[str] = set()
+    visible_bids: set[str] = set()
+    visible_parent_bids: set[str] = set()
     for outline_item_bid, parent_bid in outline_rows:
         normalized_outline_item_bid = str(outline_item_bid or "").strip()
         normalized_parent_bid = str(parent_bid or "").strip()
@@ -1045,8 +1045,8 @@ def _load_course_leaf_outline_bids(shifu_bid: str) -> List[str]:
     )
 
 
-def _load_course_learner_bids(shifu_bid: str) -> Set[str]:
-    learner_bids: Set[str] = set()
+def _load_course_learner_bids(shifu_bid: str) -> set[str]:
+    learner_bids: set[str] = set()
 
     progress_rows = (
         db.session.query(LearnProgressRecord.user_bid)
@@ -1081,7 +1081,7 @@ def _load_course_learner_bids(shifu_bid: str) -> Set[str]:
 
 def _load_dashboard_course_user_map(
     user_bids: Sequence[str],
-) -> Dict[str, UserEntity]:
+) -> dict[str, UserEntity]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1108,7 +1108,7 @@ def _load_dashboard_course_user_map(
 def _load_dashboard_course_last_learning_map(
     shifu_bid: str,
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1141,7 +1141,7 @@ def _load_dashboard_course_last_learning_map(
 def _load_dashboard_course_joined_at_map(
     shifu_bid: str,
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1150,7 +1150,7 @@ def _load_dashboard_course_joined_at_map(
     if not normalized_user_bids:
         return {}
 
-    joined_at_map: Dict[str, datetime] = {}
+    joined_at_map: dict[str, datetime] = {}
 
     def _merge_rows(rows: Sequence[tuple[str, datetime | None]]) -> None:
         for user_bid, joined_at in rows:
@@ -1211,7 +1211,7 @@ def _load_dashboard_course_learned_lesson_count_map(
     shifu_bid: str,
     user_bids: Sequence[str],
     leaf_outline_bids: Sequence[str],
-) -> Dict[str, int]:
+) -> dict[str, int]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1252,7 +1252,7 @@ def _load_dashboard_course_learned_lesson_count_map(
 def _load_dashboard_course_follow_up_count_map(
     shifu_bid: str,
     user_bids: Sequence[str],
-) -> Dict[str, int]:
+) -> dict[str, int]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1296,7 +1296,7 @@ def _resolve_dashboard_course_learning_status(
     return "not_started"
 
 
-def _count_completed_learners(shifu_bid: str, leaf_outline_bids: List[str]) -> int:
+def _count_completed_learners(shifu_bid: str, leaf_outline_bids: list[str]) -> int:
     if not leaf_outline_bids:
         return 0
 
@@ -1320,8 +1320,8 @@ def _count_completed_learners(shifu_bid: str, leaf_outline_bids: List[str]) -> i
         .all()
     )
 
-    completed_leaf_bids_by_user: Dict[str, Set[str]] = {}
-    records_by_user_and_outline: Dict[Tuple[str, str], List[int]] = {}
+    completed_leaf_bids_by_user: dict[str, set[str]] = {}
+    records_by_user_and_outline: dict[tuple[str, str], list[int]] = {}
 
     for user_bid, outline_item_bid, status in progress_rows:
         normalized_user_bid = str(user_bid or "").strip()
@@ -1364,7 +1364,7 @@ def _count_completed_learners(shifu_bid: str, leaf_outline_bids: List[str]) -> i
 
 
 def _collect_dashboard_entry_metrics(
-    shifu_bids: List[str],
+    shifu_bids: list[str],
     *,
     start_dt: datetime | None,
     end_dt_exclusive: datetime | None,
@@ -1372,7 +1372,7 @@ def _collect_dashboard_entry_metrics(
     if not shifu_bids:
         return _DashboardEntryMetrics()
 
-    learner_users_by_course: Dict[str, Set[str]] = {}
+    learner_users_by_course: dict[str, set[str]] = {}
 
     def _collect_learner(shifu_bid: object, user_bid: object) -> None:
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -1423,8 +1423,8 @@ def _collect_dashboard_entry_metrics(
     for shifu_bid, user_bid in manual_import_rows:
         _collect_learner(shifu_bid, user_bid)
 
-    learner_count_map: Dict[str, int] = {}
-    learner_total_users: Set[str] = set()
+    learner_count_map: dict[str, int] = {}
+    learner_total_users: set[str] = set()
     for shifu_bid, learner_bids in learner_users_by_course.items():
         learner_count_map[shifu_bid] = len(learner_bids)
         learner_total_users.update(learner_bids)
@@ -1444,8 +1444,8 @@ def _collect_dashboard_entry_metrics(
     if end_dt_exclusive is not None:
         order_query = order_query.filter(Order.created_at < end_dt_exclusive)
     order_rows = order_query.group_by(Order.shifu_bid).all()
-    order_count_map: Dict[str, int] = {}
-    order_amount_map: Dict[str, Decimal] = {}
+    order_count_map: dict[str, int] = {}
+    order_amount_map: dict[str, Decimal] = {}
     for shifu_bid, order_count, order_amount in order_rows:
         if not shifu_bid:
             continue
@@ -1470,7 +1470,7 @@ def _collect_dashboard_entry_metrics(
         )
 
     last_active_rows = last_active_query.group_by(LearnProgressRecord.shifu_bid).all()
-    last_active_map: Dict[str, datetime] = {}
+    last_active_map: dict[str, datetime] = {}
     for shifu_bid, last_active in last_active_rows:
         if not shifu_bid or not last_active:
             continue
@@ -1584,7 +1584,7 @@ def build_dashboard_entry(
         offset = (resolved_page - 1) * safe_page_size
         page_courses = courses[offset : offset + safe_page_size]
 
-        items: List[DashboardEntryCourseItemDTO] = []
+        items: list[DashboardEntryCourseItemDTO] = []
         for course in page_courses:
             shifu_bid = course.shifu_bid
             last_active = metrics.last_active_map.get(shifu_bid)
@@ -2214,7 +2214,7 @@ def build_dashboard_course_follow_ups(
                 ],
             )
 
-        items: List[DashboardCourseFollowUpItemDTO] = []
+        items: list[DashboardCourseFollowUpItemDTO] = []
         for row in paged_rows:
             generated_block_bid = str(
                 getattr(row, "generated_block_bid", "") or ""
@@ -2325,7 +2325,7 @@ def build_dashboard_course_follow_up_detail(
             },
         )
 
-        timeline: List[DashboardCourseFollowUpTimelineItemDTO] = []
+        timeline: list[DashboardCourseFollowUpTimelineItemDTO] = []
         for index, group in enumerate(groups):
             current_ask_block = group["ask_block"]
             is_current = index == selected_group_index
@@ -2545,7 +2545,7 @@ def build_dashboard_course_ratings(
         )
         user_map = _load_dashboard_course_user_map(page_user_bids)
         contact_map = _load_dashboard_course_user_contact_map(page_user_bids)
-        items: List[DashboardCourseRatingItemDTO] = []
+        items: list[DashboardCourseRatingItemDTO] = []
         for row in page_rows:
             user_bid = str(getattr(row, "user_bid", "") or "").strip()
             outline_item_bid = str(getattr(row, "outline_item_bid", "") or "").strip()

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any
 
 from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, PrivateAttr
@@ -340,7 +340,7 @@ class AudioSegmentDTO(BaseModel):
         default=None,
         description="Target mdflow stream element type when audio is bound directly",
     )
-    av_contract: Dict[str, Any] | None = Field(
+    av_contract: dict[str, Any] | None = Field(
         default=None, description="AV boundary contract metadata"
     )
     segment_index: int = Field(..., description="Segment sequence number")
@@ -349,7 +349,7 @@ class AudioSegmentDTO(BaseModel):
     is_final: bool = Field(
         default=False, description="Whether this is the last segment"
     )
-    subtitle_cues: List[SubtitleCueDTO] = Field(
+    subtitle_cues: list[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cues available up to the current streamed segment",
     )
@@ -363,8 +363,8 @@ class AudioSegmentDTO(BaseModel):
         position: int = 0,
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-        av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: List[SubtitleCueDTO] | None = None,
+        av_contract: dict[str, Any] | None = None,
+        subtitle_cues: list[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -412,13 +412,13 @@ class AudioCompleteDTO(BaseModel):
         default=None,
         description="Target mdflow stream element type when audio is bound directly",
     )
-    av_contract: Dict[str, Any] | None = Field(
+    av_contract: dict[str, Any] | None = Field(
         default=None, description="AV boundary contract metadata"
     )
     audio_url: str = Field(..., description="OSS URL of complete audio")
     audio_bid: str = Field(..., description="Audio business identifier")
     duration_ms: int = Field(..., description="Total audio duration in milliseconds")
-    subtitle_cues: List[SubtitleCueDTO] = Field(
+    subtitle_cues: list[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cue list aligned with synthesized TTS segments",
     )
@@ -431,8 +431,8 @@ class AudioCompleteDTO(BaseModel):
         position: int = 0,
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-        av_contract: Dict[str, Any] | None = None,
-        subtitle_cues: List[SubtitleCueDTO] | None = None,
+        av_contract: dict[str, Any] | None = None,
+        subtitle_cues: list[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -521,7 +521,7 @@ class ElementAudioDTO(BaseModel):
     audio_url: str = Field(..., description="Audio URL", required=False)
     audio_bid: str = Field(..., description="Audio business identifier", required=False)
     duration_ms: int = Field(..., description="Audio duration in ms", required=False)
-    subtitle_cues: List[SubtitleCueDTO] = Field(
+    subtitle_cues: list[SubtitleCueDTO] = Field(
         default_factory=list,
         description="Subtitle cue list aligned with the final audio",
         required=False,
@@ -533,7 +533,7 @@ class ElementAudioDTO(BaseModel):
         audio_bid: str,
         duration_ms: int,
         position: int = 0,
-        subtitle_cues: List[SubtitleCueDTO] | None = None,
+        subtitle_cues: list[SubtitleCueDTO] | None = None,
     ):
         super().__init__(
             position=position,
@@ -560,7 +560,7 @@ class ElementPayloadDTO(BaseModel):
     audio: ElementAudioDTO | None = Field(
         default=None, description="Final merged audio payload"
     )
-    previous_visuals: List[ElementVisualDTO] = Field(
+    previous_visuals: list[ElementVisualDTO] = Field(
         default_factory=list, description="Visual snapshots for the element"
     )
     anchor_element_bid: str | None = Field(
@@ -575,10 +575,10 @@ class ElementPayloadDTO(BaseModel):
         default=None,
         description="Interaction user input when available",
     )
-    diff_payload: List[Dict[str, Any]] | None = Field(
+    diff_payload: list[dict[str, Any]] | None = Field(
         default=None, description="Optional diff payload for incremental updates"
     )
-    asks: List[Dict[str, Any]] | None = Field(
+    asks: list[dict[str, Any]] | None = Field(
         default=None,
         description="Ask Q&A pairs embedded in anchor element",
     )
@@ -586,12 +586,12 @@ class ElementPayloadDTO(BaseModel):
     def __init__(
         self,
         audio: ElementAudioDTO | None = None,
-        previous_visuals: List[ElementVisualDTO] | None = None,
+        previous_visuals: list[ElementVisualDTO] | None = None,
         anchor_element_bid: str | None = None,
         ask_element_bid: str | None = None,
         user_input: str | None = None,
-        diff_payload: List[Dict[str, Any]] | None = None,
-        asks: List[Dict[str, Any]] | None = None,
+        diff_payload: list[dict[str, Any]] | None = None,
+        asks: list[dict[str, Any]] | None = None,
     ):
         super().__init__(
             audio=audio,
@@ -667,7 +667,7 @@ class ElementDTO(BaseModel):
     audio_url: str = Field(
         default="", description="Complete audio URL; empty until audio is finalized"
     )
-    audio_segments: List[Dict[str, Any]] = Field(
+    audio_segments: list[dict[str, Any]] = Field(
         default_factory=list, description="Streaming audio segment trail"
     )
     is_navigable: int = Field(default=1, description="Navigation flag")
@@ -756,7 +756,7 @@ class AudioBackfillReadyDTO(BaseModel):
     generated_block_bid: str = Field(
         ..., description="Generated block ready for persisted audio backfill"
     )
-    element_bids: List[str] = Field(
+    element_bids: list[str] = Field(
         default_factory=list,
         description="Persisted final element identifiers in this generated block",
     )
@@ -895,14 +895,14 @@ class PlaygroundPreviewRequest(BaseModel):
         default=None, description="Markdown-Flow document content"
     )
     block_index: int = Field(..., description="Block index to preview")
-    context: List[Dict[str, str]] | None = Field(
+    context: list[dict[str, str]] | None = Field(
         default=None, description="Conversation context messages"
     )
-    variables: Dict[str, Any] | None = Field(
+    variables: dict[str, Any] | None = Field(
         default=None,
         description="Variables to replace inside Markdown-Flow document",
     )
-    user_input: Dict[str, List[str]] | None = Field(
+    user_input: dict[str, list[str]] | None = Field(
         default=None, description="User input when previewing interaction blocks"
     )
     document_prompt: str | None = Field(
@@ -934,10 +934,10 @@ class PlaygroundPreviewRequest(BaseModel):
 
 @register_schema_to_swagger
 class LearnElementRecordDTO(BaseModel):
-    elements: List[ElementDTO] = Field(
+    elements: list[ElementDTO] = Field(
         default_factory=list, description="Listen-mode final element snapshots"
     )
-    events: List[RunElementSSEMessageDTO] | None = Field(
+    events: list[RunElementSSEMessageDTO] | None = Field(
         default=None, description="Optional listen-mode event stream replay"
     )
     last_progress_updated_at: str | None = Field(
@@ -947,8 +947,8 @@ class LearnElementRecordDTO(BaseModel):
 
     def __init__(
         self,
-        elements: List[ElementDTO] | None = None,
-        events: List[RunElementSSEMessageDTO] | None = None,
+        elements: list[ElementDTO] | None = None,
+        events: list[RunElementSSEMessageDTO] | None = None,
         last_progress_updated_at: str | None = None,
     ):
         super().__init__(

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import cleanup_session_after, db, invalidate_session
@@ -128,7 +128,7 @@ def record_llm_usage(
     latency_ms: int = 0,
     status: int = 0,
     error_message: str = "",
-    extra: Dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> str:
     usage_bid = generate_id(app)
     normalized_usage_scene = normalize_usage_scene(context.usage_scene)
@@ -227,7 +227,7 @@ def record_tts_usage(
     segment_count: int = 0,
     status: int = 0,
     error_message: str = "",
-    extra: Dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
     enqueue_settlement: bool = True,
 ) -> str:
     resolved_usage_bid = usage_bid or generate_id(app)

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -262,7 +262,7 @@ def _trim_import_activation_nickname(value: str) -> str:
 
 def parse_import_activation_entries(
     text: str, contact_type: str = "phone"
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Parse contact identifiers and optional nicknames from raw text."""
     if not text:
         return []
@@ -274,12 +274,12 @@ def parse_import_activation_entries(
     return _parse_import_activation_mobiles(safe_text)
 
 
-def _parse_import_activation_mobiles(text: str) -> List[Dict[str, str]]:
+def _parse_import_activation_mobiles(text: str) -> list[dict[str, str]]:
     """Parse phone identifiers and optional nicknames from raw text."""
     matches = list(IMPORT_ACTIVATION_MOBILE_PATTERN.finditer(text))
     if not matches:
         return []
-    entries: List[Dict[str, str]] = []
+    entries: list[dict[str, str]] = []
     for index, match in enumerate(matches):
         start = match.start()
         end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
@@ -291,9 +291,9 @@ def _parse_import_activation_mobiles(text: str) -> List[Dict[str, str]]:
     return entries
 
 
-def _parse_import_activation_emails(text: str) -> List[Dict[str, str]]:
+def _parse_import_activation_emails(text: str) -> list[dict[str, str]]:
     """Parse email identifiers and optional nicknames from raw text."""
-    entries: List[Dict[str, str]] = []
+    entries: list[dict[str, str]] = []
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line:
@@ -313,12 +313,12 @@ def _parse_import_activation_emails(text: str) -> List[Dict[str, str]]:
     return entries
 
 
-def _find_email_matches(line: str) -> List[tuple[int, int, str]]:
+def _find_email_matches(line: str) -> list[tuple[int, int, str]]:
     """Find email candidates in a line using linear scanning."""
     if "@" not in line:
         return []
     allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._%+-")
-    matches: List[tuple[int, int, str]] = []
+    matches: list[tuple[int, int, str]] = []
     seen: set[tuple[int, int]] = set()
     length = len(line)
     for index, char in enumerate(line):
@@ -346,11 +346,11 @@ def _find_email_matches(line: str) -> List[tuple[int, int, str]]:
 
 def _load_shifu_map(
     shifu_bids: list[str],
-) -> Dict[str, DraftShifu | PublishedShifu]:
+) -> dict[str, DraftShifu | PublishedShifu]:
     """Load shifu records for given bids, preferring published with draft fallback."""
     if not shifu_bids:
         return {}
-    shifu_map: Dict[str, DraftShifu | PublishedShifu] = {}
+    shifu_map: dict[str, DraftShifu | PublishedShifu] = {}
 
     published_shifus = (
         PublishedShifu.query.filter(
@@ -383,7 +383,7 @@ def _load_shifu_map(
     return shifu_map
 
 
-def _load_user_map(user_bids: list[str]) -> Dict[str, Dict[str, str]]:
+def _load_user_map(user_bids: list[str]) -> dict[str, dict[str, str]]:
     """Load user mobile/nickname info for given user bids."""
     if not user_bids:
         return {}
@@ -395,8 +395,8 @@ def _load_user_map(user_bids: list[str]) -> Dict[str, Dict[str, str]]:
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    phone_map: Dict[str, str] = {}
-    email_map: Dict[str, str] = {}
+    phone_map: dict[str, str] = {}
+    email_map: dict[str, str] = {}
     for credential in credentials:
         if not credential.user_bid:
             continue
@@ -406,7 +406,7 @@ def _load_user_map(user_bids: list[str]) -> Dict[str, Dict[str, str]]:
             email_map[credential.user_bid] = credential.identifier or ""
 
     users = UserEntity.query.filter(UserEntity.user_bid.in_(user_bids)).all()
-    user_map: Dict[str, Dict[str, str]] = {}
+    user_map: dict[str, dict[str, str]] = {}
     for user in users:
         mobile = phone_map.get(user.user_bid, "")
         email = email_map.get(user.user_bid, "")
@@ -423,7 +423,7 @@ def _load_user_map(user_bids: list[str]) -> Dict[str, Dict[str, str]]:
     return user_map
 
 
-def _load_coupon_code_map(order_bids: list[str]) -> Dict[str, List[str]]:
+def _load_coupon_code_map(order_bids: list[str]) -> dict[str, list[str]]:
     """Load coupon codes for given orders and map by order bid."""
     if not order_bids:
         return {}
@@ -435,7 +435,7 @@ def _load_coupon_code_map(order_bids: list[str]) -> Dict[str, List[str]]:
         .order_by(CouponUsage.id.desc())
         .all()
     )
-    coupon_map: Dict[str, List[str]] = defaultdict(list)
+    coupon_map: dict[str, list[str]] = defaultdict(list)
     for record in records:
         order_bid = record.order_bid or ""
         code = record.code or ""
@@ -462,7 +462,7 @@ def _build_coupon_usage_order_bid_subquery():
 def _resolve_order_source(
     *,
     payment_channel: str,
-    coupon_codes: List[str],
+    coupon_codes: list[str],
     paid_price: Decimal | str | None,
 ) -> tuple[str, str]:
     normalized_payment_channel = str(payment_channel or "").strip()
@@ -482,7 +482,7 @@ def _resolve_order_source(
     return ORDER_SOURCE_USER_PURCHASE, ORDER_SOURCE_KEY_MAP[ORDER_SOURCE_USER_PURCHASE]
 
 
-def _load_matching_user_bids_for_keyword(keyword: str) -> List[str]:
+def _load_matching_user_bids_for_keyword(keyword: str) -> list[str]:
     normalized_keyword = str(keyword or "").strip()
     if not normalized_keyword:
         return []
@@ -514,7 +514,7 @@ def _load_matching_user_bids_for_keyword(keyword: str) -> List[str]:
     return sorted(bid for bid in bids if bid)
 
 
-def _load_matching_shifu_bids_for_course_name(course_name: str) -> List[str]:
+def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
     normalized_course_name = str(course_name or "").strip()
     if not normalized_course_name:
         return []
@@ -610,9 +610,9 @@ def _apply_order_source_filter(query, order_source: str):
 
 def _build_order_item(
     order: Order,
-    shifu_map: Dict[str, DraftShifu | PublishedShifu],
-    user_map: Dict[str, Dict[str, str]],
-    coupon_map: Dict[str, List[str]] | None = None,
+    shifu_map: dict[str, DraftShifu | PublishedShifu],
+    user_map: dict[str, dict[str, str]],
+    coupon_map: dict[str, list[str]] | None = None,
 ) -> OrderAdminSummaryDTO:
     """Build admin order summary DTO from order plus shifu/user lookups."""
     shifu = shifu_map.get(order.shifu_bid)
@@ -662,7 +662,7 @@ def import_activation_order(
     contact_type: str = "phone",
     allow_empty_nickname: bool = False,
     payment_channel: str = "manual",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Create activation order for a user identified by phone or email."""
     normalized_identifier = normalize_contact_identifier(mobile, contact_type)
 
@@ -759,13 +759,13 @@ def import_activation_order(
 
 def import_activation_orders(
     app: Flask,
-    mobiles: List[str],
+    mobiles: list[str],
     course_id: str,
     user_nick_name: str | None = None,
     contact_type: str = "phone",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Bulk import activation orders from a list of phone/email identifiers."""
-    results: Dict[str, Any] = {"success": [], "failed": []}
+    results: dict[str, Any] = {"success": [], "failed": []}
     for mobile in mobiles:
         normalized_mobile = str(mobile or "").strip()
         try:
@@ -806,12 +806,12 @@ def import_activation_orders(
 
 def import_activation_orders_from_entries(
     app: Flask,
-    entries: List[Dict[str, str]],
+    entries: list[dict[str, str]],
     course_id: str,
     contact_type: str = "phone",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Bulk import activation orders from parsed phone/email+nickname entries."""
-    results: Dict[str, Any] = {"success": [], "failed": []}
+    results: dict[str, Any] = {"success": [], "failed": []}
     for entry in entries:
         normalized_mobile = str(entry.get("mobile", "")).strip()
         if not normalized_mobile:
@@ -859,7 +859,7 @@ def list_orders(
     user_id: str,
     page_index: int,
     page_size: int,
-    filters: Dict[str, Any] | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> PageNationDTO:
     """List orders visible to the current operator with optional filters."""
     with app.app_context():
@@ -953,7 +953,7 @@ def list_operator_orders(
     app: Flask,
     page_index: int,
     page_size: int,
-    filters: Dict[str, Any] | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> PageNationDTO:
     """List global orders for operator views with cross-course filters."""
     with app.app_context():
@@ -1085,13 +1085,13 @@ def get_operator_order_overview(app: Flask) -> OrderAdminOverviewDTO:
         )
 
 
-def _load_order_activities(order_bid: str) -> List[OrderAdminActivityDTO]:
+def _load_order_activities(order_bid: str) -> list[OrderAdminActivityDTO]:
     """Load activity records tied to an order and format as DTOs."""
     records = PromoRedemption.query.filter(
         PromoRedemption.order_bid == order_bid,
         PromoRedemption.deleted == 0,
     ).all()
-    activities: List[OrderAdminActivityDTO] = []
+    activities: list[OrderAdminActivityDTO] = []
     for record in records:
         activities.append(
             OrderAdminActivityDTO(
@@ -1109,13 +1109,13 @@ def _load_order_activities(order_bid: str) -> List[OrderAdminActivityDTO]:
     return activities
 
 
-def _load_order_coupons(order_bid: str) -> List[OrderAdminCouponDTO]:
+def _load_order_coupons(order_bid: str) -> list[OrderAdminCouponDTO]:
     """Load coupon usage records tied to an order and format as DTOs."""
     records = CouponUsage.query.filter(
         CouponUsage.order_bid == order_bid,
         CouponUsage.deleted == 0,
     ).all()
-    coupons: List[OrderAdminCouponDTO] = []
+    coupons: list[OrderAdminCouponDTO] = []
     for record in records:
         coupons.append(
             OrderAdminCouponDTO(

--- a/src/api/flaskr/service/order/admin_dtos.py
+++ b/src/api/flaskr/service/order/admin_dtos.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
 
 from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import BaseModel, Field
@@ -77,7 +76,7 @@ class OrderAdminSummaryDTO(BaseModel):
     order_source_key: str = Field(
         ..., description="Order source i18n key", required=False
     )
-    coupon_codes: List[str] = Field(
+    coupon_codes: list[str] = Field(
         default_factory=list,
         description="Coupon codes applied to this order",
         required=False,
@@ -105,7 +104,7 @@ class OrderAdminSummaryDTO(BaseModel):
         updated_at: datetime | None,
         order_source: str = "",
         order_source_key: str = "",
-        coupon_codes: List[str] | None = None,
+        coupon_codes: list[str] | None = None,
     ):
         super().__init__(
             order_bid=order_bid,
@@ -354,10 +353,10 @@ class OrderAdminDetailDTO(BaseModel):
     order: OrderAdminSummaryDTO = Field(
         ..., description="Order summary", required=False
     )
-    activities: List[OrderAdminActivityDTO] = Field(
+    activities: list[OrderAdminActivityDTO] = Field(
         ..., description="Order activities", required=False
     )
-    coupons: List[OrderAdminCouponDTO] = Field(
+    coupons: list[OrderAdminCouponDTO] = Field(
         ..., description="Order coupons", required=False
     )
     payment: OrderAdminPaymentDTO = Field(
@@ -367,8 +366,8 @@ class OrderAdminDetailDTO(BaseModel):
     def __init__(
         self,
         order: OrderAdminSummaryDTO,
-        activities: List[OrderAdminActivityDTO],
-        coupons: List[OrderAdminCouponDTO],
+        activities: list[OrderAdminActivityDTO],
+        coupons: list[OrderAdminCouponDTO],
         payment: OrderAdminPaymentDTO,
     ):
         super().__init__(

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -1,6 +1,5 @@
 import decimal
 import json
-from typing import List, Tuple
 
 from flask import Flask
 from flaskr.api.doc.feishu import send_notify
@@ -58,20 +57,20 @@ def _coupon_matches_course(coupon: Coupon, shifu_bid: str) -> bool:
 
 
 def _pick_coupon_candidate(
-    active_usages: List[CouponUsageModel],
+    active_usages: list[CouponUsageModel],
     coupons_by_bid: dict[str, Coupon],
-    coupons_by_code: List[Coupon],
+    coupons_by_code: list[Coupon],
     shifu_bid: str,
     user_id: str,
-) -> Tuple[CouponUsageModel | None, Coupon | None, bool]:
+) -> tuple[CouponUsageModel | None, Coupon | None, bool]:
     """Pick a coupon_usage/coupon pair that matches the current course.
     Returns (usage, coupon, has_candidate_with_same_code).
     """
     has_candidate_with_same_code = bool(active_usages or coupons_by_code)
 
     def select(
-        usages: List[CouponUsageModel],
-    ) -> Tuple[CouponUsageModel | None, Coupon | None]:
+        usages: list[CouponUsageModel],
+    ) -> tuple[CouponUsageModel | None, Coupon | None]:
         for usage in usages:
             coupon = coupons_by_bid.get(getattr(usage, "coupon_bid", None))
             if coupon and _coupon_matches_course(coupon, shifu_bid):
@@ -160,7 +159,7 @@ def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
         if order_coupon_useage:
             raise_error("server.discount.orderDiscountAlreadyUsed")
 
-        active_usages: List[CouponUsageModel] = (
+        active_usages: list[CouponUsageModel] = (
             CouponUsageModel.query.filter(
                 CouponUsageModel.code == coupon_code,
                 CouponUsageModel.status == COUPON_STATUS_ACTIVE,
@@ -177,7 +176,7 @@ def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
                 Coupon.deleted == 0,
             ).all()
             coupons_by_bid = {coupon.coupon_bid: coupon for coupon in coupons}
-        coupons_by_code: List[Coupon] = (
+        coupons_by_code: list[Coupon] = (
             Coupon.query.filter(
                 Coupon.code == coupon_code,
                 Coupon.deleted == 0,

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -3,7 +3,7 @@ import decimal
 import json
 import re
 from contextlib import contextmanager, nullcontext, suppress
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Any, Iterator
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import pytz
@@ -129,7 +129,7 @@ class AICourseBuyRecordDTO:
     discount: str
     active_discount: str
     value_to_pay: str
-    price_item: List[PayItemDto]
+    price_item: list[PayItemDto]
 
     def __init__(
         self,
@@ -304,7 +304,7 @@ def _sync_order_campaign_pricing(
     user_id: str,
     course_id: str,
     active_id: str | None,
-) -> Tuple[List, decimal.Decimal]:
+) -> tuple[list, decimal.Decimal]:
     """Refresh eligible campaigns for an unpaid order and recalculate paid price.
 
     Boundary-joining helper: it flushes but never commits; the pricing update
@@ -323,7 +323,7 @@ def _sync_order_campaign_pricing(
         for campaign_application in campaign_applications:
             discount_value += decimal.Decimal(campaign_application.discount_amount)
     coupon_discount_value = decimal.Decimal("0.00")
-    coupon_records: List[CouponUsageModel] = CouponUsageModel.query.filter(
+    coupon_records: list[CouponUsageModel] = CouponUsageModel.query.filter(
         CouponUsageModel.order_bid == buy_record.order_bid,
         CouponUsageModel.status == COUPON_STATUS_USED,
         CouponUsageModel.deleted == 0,
@@ -334,7 +334,7 @@ def _sync_order_campaign_pricing(
             for coupon_record in coupon_records
             if coupon_record.coupon_bid
         ]
-        coupon_map: Dict[str, Coupon] = {}
+        coupon_map: dict[str, Coupon] = {}
         if coupon_bids:
             coupon_map = {
                 coupon.coupon_bid: coupon
@@ -492,7 +492,7 @@ class BuyRecordDTO:
         channel,
         qr_url,
         payment_channel: str = "",
-        payment_payload: Dict[str, Any] | None = None,
+        payment_payload: dict[str, Any] | None = None,
     ):
         self.order_id = record_id
         self.user_id = user_id
@@ -677,7 +677,7 @@ def _resolve_payment_channel(
     channel_hint: str | None,
     stored_channel: str | None,
     additional_enabled_providers: set[str] | None = None,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Resolve the provider and provider-specific channel based on hints."""
     return resolve_payment_channel(
         payment_channel_hint=payment_channel_hint,
@@ -742,8 +742,8 @@ def _generate_pingxx_charge(
     """Boundary-joining helper: committed by generate_charge's unit of work."""
     provider = get_payment_provider("pingxx")
     pingpp_id = get_config("PINGXX_APP_ID")
-    provider_options: Dict[str, Any] = {"app_id": pingpp_id}
-    charge_extra: Dict[str, Any] = {}
+    provider_options: dict[str, Any] = {"app_id": pingpp_id}
+    charge_extra: dict[str, Any] = {}
     qr_url_key: str | None = None
     product_id = course.bid
 
@@ -860,7 +860,7 @@ def _generate_stripe_charge(
         "user_bid": buy_record.user_bid,
         "shifu_bid": buy_record.shifu_bid,
     }
-    provider_options: Dict[str, Any] = {
+    provider_options: dict[str, Any] = {
         "mode": resolved_mode,
         "metadata": metadata,
     }
@@ -1064,7 +1064,7 @@ def _generate_wechatpay_charge(
         fallback=sanitized_subject,
         max_length=127,
     )
-    extra: Dict[str, Any] = {
+    extra: dict[str, Any] = {
         "metadata": {
             "order_bid": buy_record.order_bid,
             "user_bid": buy_record.user_bid,
@@ -1121,7 +1121,7 @@ def _generate_wechatpay_charge(
     )
     db.session.add(snapshot)
 
-    payment_payload: Dict[str, Any] = {
+    payment_payload: dict[str, Any] = {
         "qr_url": qr_url,
         "credential": credential,
     }
@@ -1295,8 +1295,8 @@ def sync_native_payment_order(
 def _update_stripe_order_snapshot(
     *,
     stripe_order: StripeOrder,
-    session: Dict[str, Any],
-    intent: Dict[str, Any] | None,
+    session: dict[str, Any],
+    intent: dict[str, Any] | None,
 ):
     if session:
         stripe_order.checkout_session_id = session.get(
@@ -1328,7 +1328,7 @@ def _update_stripe_order_snapshot(
 
 
 def _is_stripe_payment_successful(
-    *, session: Dict[str, Any] | None, intent: Dict[str, Any] | None
+    *, session: dict[str, Any] | None, intent: dict[str, Any] | None
 ) -> bool:
     if session:
         if session.get("payment_status") == "paid":
@@ -1369,7 +1369,7 @@ def _apply_native_snapshot_update(
 
 def _native_raw_status(
     provider: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     fallback: str = "",
 ) -> str:
     return extract_native_trade_status(provider, payload) or str(fallback or "")
@@ -1377,7 +1377,7 @@ def _native_raw_status(
 
 def _native_snapshot_status(
     provider: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     raw_status: str,
 ) -> int:
     if raw_status and not extract_native_trade_status(provider, payload):
@@ -1391,7 +1391,7 @@ def _native_snapshot_status(
 
 def _is_native_payment_successful(
     provider: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
 ) -> bool:
     raw_status = _native_raw_status(provider, payload)
     return _native_snapshot_status(provider, payload, raw_status) == 1
@@ -1399,7 +1399,7 @@ def _is_native_payment_successful(
 
 def _extract_native_notification_amount(
     provider: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
 ) -> int | None:
     trade_payload = extract_native_trade_payload(payload)
     if provider == "alipay":
@@ -1470,7 +1470,7 @@ def handle_stripe_webhook(
     sig_header: str,
     *,
     expected_integration_bid: str = "",
-) -> Tuple[Dict[str, Any], int]:
+) -> tuple[dict[str, Any], int]:
     provider = get_payment_provider("stripe")
     try:
         notification: PaymentNotificationResult = provider.verify_webhook(
@@ -1612,7 +1612,7 @@ def refund_order_payment(
     order_bid: str,
     amount: int | None = None,
     reason: str | None = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     with _app_context_scope(app), unit_of_work():
         order = Order.query.filter(Order.order_bid == order_bid).first()
         if not order:
@@ -1679,7 +1679,7 @@ def refund_order_payment(
     }
 
 
-def get_payment_details(app: Flask, order_bid: str) -> Dict[str, Any]:
+def get_payment_details(app: Flask, order_bid: str) -> dict[str, Any]:
     # Read-only: reuses the caller's session so reads inside an open unit of
     # work see that transaction's pending state.
     with _app_context_scope(app):

--- a/src/api/flaskr/service/order/open_api.py
+++ b/src/api/flaskr/service/order/open_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -47,7 +47,7 @@ def open_api_query_order(
     shifu_bid: str,
     user_identify: str,
     user_identify_type: str = "phone",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Check if a user (by phone/email) has active order for a course."""
     with app.app_context():
         verify_course_ownership(app, owner_bid, shifu_bid)
@@ -71,7 +71,7 @@ def open_api_grant_order(
     shifu_bid: str,
     user_identify: str,
     user_identify_type: str = "phone",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Grant course access (create manual order).
 
     If the user already has an active order the existing order is
@@ -104,7 +104,7 @@ def open_api_revoke_order(
     shifu_bid: str,
     user_identify: str,
     user_identify_type: str = "phone",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Revoke course access by setting order status to REFUND (503)."""
     verify_course_ownership(app, owner_bid, shifu_bid)
     normalized = normalize_contact_identifier(user_identify, user_identify_type)

--- a/src/api/flaskr/service/order/payment_channel_resolution.py
+++ b/src/api/flaskr/service/order/payment_channel_resolution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from typing import Iterable
 
 from flaskr.service.common.models import raise_error
 from flaskr.service.config import get_config
@@ -13,7 +13,7 @@ def resolve_payment_channel(
     stored_channel: str | None,
     default_pingxx_channel: str | None = None,
     additional_enabled_providers: Iterable[str] | None = None,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Resolve the payment provider and provider-specific channel from config."""
     requested_payment_channel = (payment_channel_hint or "").strip().lower()
     requested_channel = (channel_hint or "").strip()

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import parse_qs
 
 from flask import Flask
@@ -93,7 +93,7 @@ class AlipayProvider(PaymentProvider):
         return self.create_payment(request=request, app=app)
 
     def verify_webhook(
-        self, *, headers: Dict[str, str], raw_body: bytes | str, app: Flask
+        self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
         del headers
         payload = _parse_form_payload(raw_body)
@@ -102,7 +102,7 @@ class AlipayProvider(PaymentProvider):
         return self._notification_from_payload(payload)
 
     def handle_notification(
-        self, *, payload: Dict[str, Any], app: Flask
+        self, *, payload: dict[str, Any], app: Flask
     ) -> PaymentNotificationResult:
         normalized_payload = dict(payload or {})
         if "raw_body" in normalized_payload:
@@ -201,7 +201,7 @@ class AlipayProvider(PaymentProvider):
 
     def _verify_notification_signature(
         self,
-        payload: Dict[str, Any],
+        payload: dict[str, Any],
         app: Flask,
     ) -> bool:
         self._load_sdk(app)
@@ -229,7 +229,7 @@ class AlipayProvider(PaymentProvider):
 
     def _notification_from_payload(
         self,
-        payload: Dict[str, Any],
+        payload: dict[str, Any],
     ) -> PaymentNotificationResult:
         return PaymentNotificationResult(
             order_bid=str(payload.get("out_trade_no") or ""),
@@ -260,7 +260,7 @@ def _format_cny_amount(amount: int) -> str:
     return format(yuan, "f")
 
 
-def _parse_alipay_response(raw_response: Any, response_key: str) -> Dict[str, Any]:
+def _parse_alipay_response(raw_response: Any, response_key: str) -> dict[str, Any]:
     if hasattr(raw_response, "to_dict"):
         raw_response = raw_response.to_dict()
     if isinstance(raw_response, str):
@@ -273,7 +273,7 @@ def _parse_alipay_response(raw_response: Any, response_key: str) -> Dict[str, An
     return raw_response
 
 
-def _parse_form_payload(raw_body: bytes | str) -> Dict[str, Any]:
+def _parse_form_payload(raw_body: bytes | str) -> dict[str, Any]:
     if isinstance(raw_body, bytes):
         raw_body = raw_body.decode("utf-8")
     raw_body = str(raw_body or "")

--- a/src/api/flaskr/service/order/payment_providers/base.py
+++ b/src/api/flaskr/service/order/payment_providers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any
 
 
 @dataclass(slots=True)
@@ -18,7 +18,7 @@ class PaymentRequest:
     subject: str
     body: str
     client_ip: str
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -26,10 +26,10 @@ class PaymentCreationResult:
     """Response data returned after creating a payment."""
 
     provider_reference: str
-    raw_response: Dict[str, Any]
+    raw_response: dict[str, Any]
     client_secret: str | None = None
     checkout_session_id: str | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -38,7 +38,7 @@ class PaymentNotificationResult:
 
     order_bid: str
     status: str
-    provider_payload: Dict[str, Any]
+    provider_payload: dict[str, Any]
     charge_id: str | None = None
 
 
@@ -47,9 +47,9 @@ class SubscriptionUpdateResult:
     """Normalized result returned from subscription state updates."""
 
     provider_reference: str
-    raw_response: Dict[str, Any]
+    raw_response: dict[str, Any]
     status: str
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -59,7 +59,7 @@ class PaymentRefundRequest:
     order_bid: str
     amount: int | None = None
     reason: str | None = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -67,7 +67,7 @@ class PaymentRefundResult:
     """Response payload returned from a refund request."""
 
     provider_reference: str
-    raw_response: Dict[str, Any]
+    raw_response: dict[str, Any]
     status: str
 
 
@@ -105,7 +105,7 @@ class PaymentProvider(ABC):
         )
 
     def verify_webhook(
-        self, *, headers: Dict[str, str], raw_body: bytes | str, app
+        self, *, headers: dict[str, str], raw_body: bytes | str, app
     ) -> PaymentNotificationResult:
         """Verify and normalize a provider webhook payload."""
         raise NotImplementedError(
@@ -113,7 +113,7 @@ class PaymentProvider(ABC):
         )
 
     def handle_notification(
-        self, *, payload: Dict[str, Any], app
+        self, *, payload: dict[str, Any], app
     ) -> PaymentNotificationResult:
         """Process provider webhook payloads."""
         return self.verify_webhook(

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -6,7 +6,7 @@ import os
 import re
 import threading
 from functools import wraps
-from typing import Any, Dict
+from typing import Any
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -100,9 +100,9 @@ class PingxxProvider(PaymentProvider):
             return text
         return cls._NON_BMP_RE.sub("", text).strip()
 
-    def _sanitize_extra(self, extra: Dict[str, Any]) -> Dict[str, Any]:
+    def _sanitize_extra(self, extra: dict[str, Any]) -> dict[str, Any]:
         """Recursively sanitize string values in charge extra dict."""
-        sanitized: Dict[str, Any] = {}
+        sanitized: dict[str, Any] = {}
         for k, v in extra.items():
             if isinstance(v, str):
                 sanitized[k] = self._sanitize_str(v)
@@ -117,7 +117,7 @@ class PingxxProvider(PaymentProvider):
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
         client = self._ensure_client(app)
-        provider_options: Dict[str, Any] = request.extra or {}
+        provider_options: dict[str, Any] = request.extra or {}
         app_id = provider_options.get("app_id") or get_config("PINGXX_APP_ID")
         charge_extra = provider_options.get("charge_extra", {})
 
@@ -162,7 +162,7 @@ class PingxxProvider(PaymentProvider):
         raise RuntimeError("Pingxx does not support subscriptions")
 
     def verify_webhook(
-        self, *, headers: Dict[str, str], raw_body: bytes | str, app: Flask
+        self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
         normalized_headers = {
             str(key).lower(): str(value) for key, value in (headers or {}).items()
@@ -188,7 +188,7 @@ class PingxxProvider(PaymentProvider):
                 hashes.SHA256(),
             )
         if not raw_body_str:
-            payload: Dict[str, Any] = {}
+            payload: dict[str, Any] = {}
         else:
             payload = json.loads(raw_body_str)
 
@@ -201,7 +201,7 @@ class PingxxProvider(PaymentProvider):
         )
 
     def handle_notification(
-        self, *, payload: Dict[str, Any], app: Flask
+        self, *, payload: dict[str, Any], app: Flask
     ) -> PaymentNotificationResult:
         if "raw_body" in payload:
             return self.verify_webhook(

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.service.config import get_config
@@ -30,14 +30,14 @@ class StripeProvider(PaymentProvider):
             raise RuntimeError("Stripe SDK is required for Stripe payments") from exc
         return stripe
 
-    def _client_options(self, app: Flask) -> tuple[Any, Dict[str, Any]]:
+    def _client_options(self, app: Flask) -> tuple[Any, dict[str, Any]]:
         stripe = self._ensure_client(app)
         secret_key = get_config("STRIPE_SECRET_KEY")
         if not secret_key:
             app.logger.error("STRIPE_SECRET_KEY configuration is missing")
             raise RuntimeError("STRIPE_SECRET_KEY must be configured for Stripe")
 
-        request_options: Dict[str, Any] = {"api_key": secret_key}
+        request_options: dict[str, Any] = {"api_key": secret_key}
         api_version = get_config("STRIPE_API_VERSION")
         if api_version:
             request_options["stripe_version"] = api_version
@@ -48,7 +48,7 @@ class StripeProvider(PaymentProvider):
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
         stripe, request_options = self._client_options(app)
-        options: Dict[str, Any] = request.extra or {}
+        options: dict[str, Any] = request.extra or {}
         mode = (options.get("mode") or request.channel or "payment_intent").lower()
         metadata = options.get("metadata", {}) or {}
         if hasattr(metadata, "to_dict"):
@@ -66,7 +66,7 @@ class StripeProvider(PaymentProvider):
                 )
 
             session_params = options.get("session_params", {})
-            params: Dict[str, Any] = {
+            params: dict[str, Any] = {
                 "mode": "payment",
                 "success_url": success_url,
                 "cancel_url": cancel_url,
@@ -136,7 +136,7 @@ class StripeProvider(PaymentProvider):
             session_dict = session.to_dict()
             payment_intent_id = session_dict.get("payment_intent")
             latest_charge_id = ""
-            payment_intent_object: Dict[str, Any] = {}
+            payment_intent_object: dict[str, Any] = {}
             if payment_intent_id:
                 payment_intent = stripe.PaymentIntent.retrieve(
                     payment_intent_id, **request_options
@@ -183,7 +183,7 @@ class StripeProvider(PaymentProvider):
     def create_subscription(
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
-        options: Dict[str, Any] = dict(request.extra or {})
+        options: dict[str, Any] = dict(request.extra or {})
         session_params = dict(options.get("session_params", {}) or {})
         session_params["mode"] = "subscription"
         options["mode"] = "checkout_session"
@@ -244,22 +244,22 @@ class StripeProvider(PaymentProvider):
 
     def retrieve_checkout_session(
         self, *, session_id: str, app: Flask
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stripe, request_options = self._client_options(app)
         return stripe.checkout.Session.retrieve(session_id, **request_options)
 
-    def retrieve_payment_intent(self, *, intent_id: str, app: Flask) -> Dict[str, Any]:
+    def retrieve_payment_intent(self, *, intent_id: str, app: Flask) -> dict[str, Any]:
         stripe, request_options = self._client_options(app)
         return stripe.PaymentIntent.retrieve(intent_id, **request_options)
 
     def retrieve_subscription(
         self, *, subscription_id: str, app: Flask
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stripe, request_options = self._client_options(app)
         return stripe.Subscription.retrieve(subscription_id, **request_options)
 
     def verify_webhook(
-        self, *, headers: Dict[str, str], raw_body: bytes | str, app: Flask
+        self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
         stripe, _request_options = self._client_options(app)
         webhook_secret = get_config("STRIPE_WEBHOOK_SECRET")
@@ -290,7 +290,7 @@ class StripeProvider(PaymentProvider):
         return self._build_notification_from_event(event)
 
     def handle_notification(
-        self, *, payload: Dict[str, Any], app: Flask
+        self, *, payload: dict[str, Any], app: Flask
     ) -> PaymentNotificationResult:
         headers = dict(payload.get("headers", {}) or {})
         sig_header = payload.get("sig_header", "")
@@ -361,7 +361,7 @@ class StripeProvider(PaymentProvider):
         self, *, request: PaymentRefundRequest, app: Flask
     ) -> PaymentRefundResult:
         stripe, request_options = self._client_options(app)
-        params: Dict[str, Any] = {}
+        params: dict[str, Any] = {}
         if request.amount is not None:
             params["amount"] = request.amount
         if request.reason:
@@ -394,7 +394,7 @@ class StripeProvider(PaymentProvider):
         )
 
     def _build_notification_from_event(
-        self, event: Dict[str, Any]
+        self, event: dict[str, Any]
     ) -> PaymentNotificationResult:
         data_object = event.get("data", {}).get("object", {}) or {}
         metadata = data_object.get("metadata", {}) or {}

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -5,7 +5,7 @@ import json
 import secrets
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import urlencode
 
 import requests
@@ -48,7 +48,7 @@ class WechatPayProvider(PaymentProvider):
         return self.create_payment(request=request, app=app)
 
     def verify_webhook(
-        self, *, headers: Dict[str, str], raw_body: bytes | str, app: Flask
+        self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
         raw_body_text = (
             raw_body.decode("utf-8") if isinstance(raw_body, bytes) else str(raw_body)
@@ -250,7 +250,7 @@ class WechatPayProvider(PaymentProvider):
     def _verify_notification_signature(
         self,
         *,
-        headers: Dict[str, str],
+        headers: dict[str, str],
         raw_body: str,
     ) -> None:
         normalized_headers = {
@@ -272,7 +272,7 @@ class WechatPayProvider(PaymentProvider):
 
     def _decrypt_notification_resource(
         self,
-        resource: Dict[str, Any],
+        resource: dict[str, Any],
     ) -> dict[str, Any]:
         if not resource:
             raise RuntimeError("WeChat Pay notification resource missing")

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -6,7 +6,6 @@ import math
 import secrets
 import string
 from datetime import UTC, datetime, timedelta
-from typing import Dict
 
 from flask import Flask
 from flaskr.dao import db
@@ -524,8 +523,8 @@ def _compute_campaign_status(campaign: PromoCampaign) -> str:
 
 def _build_coupon_item(
     coupon: Coupon,
-    course_map: Dict[str, DraftShifu | PublishedShifu],
-    user_name_map: Dict[str, str] | None = None,
+    course_map: dict[str, DraftShifu | PublishedShifu],
+    user_name_map: dict[str, str] | None = None,
 ) -> AdminPromotionCouponItemDTO:
     scope_type, shifu_bid = _parse_coupon_scope(coupon.filter or "{}")
     course = course_map.get(shifu_bid)
@@ -566,11 +565,11 @@ def _build_coupon_item(
 
 def _build_campaign_item(
     campaign: PromoCampaign,
-    course_map: Dict[str, DraftShifu | PublishedShifu],
+    course_map: dict[str, DraftShifu | PublishedShifu],
     applied_order_count: int,
     total_discount_amount: decimal.Decimal,
     has_redemptions: bool,
-    user_name_map: Dict[str, str] | None = None,
+    user_name_map: dict[str, str] | None = None,
 ) -> AdminPromotionCampaignItemDTO:
     computed_status = _compute_campaign_status(campaign)
     course = course_map.get(campaign.shifu_bid or "")
@@ -602,7 +601,7 @@ def _build_campaign_item(
     )
 
 
-def _load_user_name_map(user_bids: list[str]) -> Dict[str, str]:
+def _load_user_name_map(user_bids: list[str]) -> dict[str, str]:
     if not user_bids:
         return {}
     users = UserEntity.query.filter(UserEntity.user_bid.in_(user_bids)).all()
@@ -1116,7 +1115,7 @@ def update_operator_promotion_coupon_status(
         return {"coupon_bid": coupon.coupon_bid, "enabled": enabled_value}
 
 
-def _load_order_map(order_bids: list[str]) -> Dict[str, Order]:
+def _load_order_map(order_bids: list[str]) -> dict[str, Order]:
     if not order_bids:
         return {}
     orders = Order.query.filter(Order.order_bid.in_(order_bids)).all()
@@ -1343,7 +1342,7 @@ def list_operator_promotion_coupon_codes(
     return _build_paged_response(summary, page, page_size, summary.total, items)
 
 
-def _load_redemption_stats(promo_bids: list[str]) -> Dict[str, dict]:
+def _load_redemption_stats(promo_bids: list[str]) -> dict[str, dict]:
     if not promo_bids:
         return {}
     rows = (

--- a/src/api/flaskr/service/promo/admin_dtos.py
+++ b/src/api/flaskr/service/promo/admin_dtos.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Union, get_args, get_origin
+from typing import Union, get_args, get_origin
 
 from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
@@ -89,7 +89,7 @@ class AdminPromotionCouponItemDTO(_DTOBase):
     end_at: datetime | None = Field(..., description="Coupon end time", required=False)
     total_count: int = Field(..., description="Total count", required=False)
     used_count: int = Field(..., description="Used count", required=False)
-    ops_states: List[str] = Field(
+    ops_states: list[str] = Field(
         ..., description="Operator-facing operational states", required=False
     )
     computed_status: str = Field(..., description="Computed status", required=False)
@@ -261,4 +261,4 @@ class AdminPromotionListResponseDTO(_DTOBase):
     page_size: int = Field(..., description="Page size", required=False)
     total: int = Field(..., description="Total count", required=False)
     page_count: int = Field(..., description="Page count", required=False)
-    items: List[dict] = Field(..., description="List items", required=False)
+    items: list[dict] = Field(..., description="List items", required=False)

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Iterable, Sequence, Set
+from typing import Any, Iterable, Sequence
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.dao import db
@@ -168,7 +168,7 @@ def _build_latest_operator_course_rows_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
 ):
@@ -209,7 +209,7 @@ def _build_latest_operator_course_rows_subquery(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
@@ -231,7 +231,7 @@ def _build_operator_course_candidate_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
@@ -529,7 +529,7 @@ def _build_latest_shifus_query(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -570,7 +570,7 @@ def _load_latest_shifus(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -617,7 +617,7 @@ def _load_latest_shifu_seeds(
     *,
     shifu_bid: str,
     course_name: str,
-    creator_bids: Set[str] | None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -685,9 +685,9 @@ def _attach_course_prompt_flags(model, rows) -> None:
 
 def _build_course_summary(
     course,
-    user_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, str]],
     course_status: str,
-    activity: Dict[str, Any] | None = None,
+    activity: dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     return build_admin_operation_course_summary(
         course,
@@ -705,7 +705,7 @@ def _is_operator_visible_course(course) -> bool:
     )
 
 
-def _resolve_course_status(shifu_bid: str, published_bids: Set[str]) -> str:
+def _resolve_course_status(shifu_bid: str, published_bids: set[str]) -> str:
     if shifu_bid in published_bids:
         return COURSE_STATUS_PUBLISHED
     return COURSE_STATUS_UNPUBLISHED
@@ -734,7 +734,7 @@ def _resolve_created_last_7d_window(
 def _load_course_activity_map(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     return load_course_activity_map(drafts, published)
 
 
@@ -806,7 +806,7 @@ def _resolve_course_copy_title(source_title: str, requested_title: str) -> str:
 def _build_outline_history_tree(
     outlines: Sequence[DraftOutlineItem],
 ) -> list[HistoryItem]:
-    outline_children_map: Dict[str, list[DraftOutlineItem]] = {}
+    outline_children_map: dict[str, list[DraftOutlineItem]] = {}
     for outline in outlines:
         parent_bid = str(outline.parent_bid or "").strip()
         outline_children_map.setdefault(parent_bid, []).append(outline)
@@ -843,8 +843,8 @@ def _merge_courses(
     published: Iterable[PublishedShifu],
 ):
     course_map = {}
-    published_bids: Set[str] = set()
-    selected_sources: Dict[str, str] = {}
+    published_bids: set[str] = set()
+    selected_sources: dict[str, str] = {}
     for course in drafts:
         visible = _is_operator_visible_course(course)
         if visible:

--- a/src/api/flaskr/service/shifu/admin_course_summary_mapper.py
+++ b/src/api/flaskr/service/shifu/admin_course_summary_mapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from flask import current_app
 from flaskr.service.shifu.admin_dtos_courses import AdminOperationCourseSummaryDTO
@@ -10,9 +10,9 @@ from flaskr.service.shifu.admin_shared import _format_decimal
 def build_admin_operation_course_summary(
     course,
     *,
-    user_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, str]],
     course_status: str,
-    activity: Dict[str, Any] | None = None,
+    activity: dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     resolved_activity = activity or {}
     creator = user_map.get(course.created_user_bid or "", {})

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import math
 import re
 from decimal import Decimal
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 from flask import Flask
 from flaskr.api.llm import PROVIDER_STATES, get_current_models
@@ -301,8 +301,8 @@ def _build_operator_course_credit_usage_item(
     *,
     usage_row: BillUsageRecord,
     ledger_amount: Any,
-    user_map: Dict[str, Dict[str, Any]],
-    outline_context_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, Any]],
+    outline_context_map: dict[str, dict[str, str]],
     group_key: str = "",
     usage_count: int = 1,
     usage_mode: str = "",
@@ -847,7 +847,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
 def _build_operator_course_credit_metrics(
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     base_query = _build_operator_course_credit_usage_base_query(
         shifu_bid,
         outline_item_bids=leaf_outline_bids,
@@ -1379,7 +1379,7 @@ def get_operator_course_credit_usage_details(
 
 def _load_bill_usage_record_map(
     usage_bids: Sequence[str],
-) -> Dict[str, BillUsageRecord]:
+) -> dict[str, BillUsageRecord]:
     normalized_usage_bids = sorted(
         {
             str(usage_bid or "").strip()
@@ -1398,7 +1398,7 @@ def _load_bill_usage_record_map(
         .order_by(BillUsageRecord.id.desc())
         .all()
     )
-    usage_map: Dict[str, BillUsageRecord] = {}
+    usage_map: dict[str, BillUsageRecord] = {}
     for row in rows:
         usage_bid = str(row.usage_bid or "").strip()
         if usage_bid and usage_bid not in usage_map:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -6,7 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Dict, Sequence
+from typing import Sequence
 
 from flask import Flask
 from flaskr.common.umami_client import get_course_visit_count_30d
@@ -91,7 +91,7 @@ def _resolve_outline_prompt_source(item) -> str:
 def _resolve_prompt_with_fallback(
     *,
     outline_item,
-    outline_item_map: Dict[str, DraftOutlineItem | PublishedOutlineItem],
+    outline_item_map: dict[str, DraftOutlineItem | PublishedOutlineItem],
     course,
     field_name: str,
 ) -> tuple[str, str]:
@@ -118,13 +118,13 @@ def _resolve_prompt_with_fallback(
 
 def _build_chapter_tree(
     items,
-    user_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, str]],
     *,
-    follow_up_count_map: Dict[str, int],
-    rating_count_map: Dict[str, int],
-    rating_score_map: Dict[str, str],
+    follow_up_count_map: dict[str, int],
+    rating_count_map: dict[str, int],
+    rating_score_map: dict[str, str],
 ) -> list[AdminOperationCourseDetailChapterDTO]:
-    node_map: Dict[str, AdminOperationCourseDetailChapterDTO] = {}
+    node_map: dict[str, AdminOperationCourseDetailChapterDTO] = {}
     ordered_nodes: list[AdminOperationCourseDetailChapterDTO] = []
     for item in items:
         bid = str(item.outline_item_bid or "").strip()
@@ -186,7 +186,7 @@ def _build_chapter_tree(
 def _load_outline_learning_stats(
     shifu_bid: str,
     outline_item_bids: Sequence[str],
-) -> tuple[Dict[str, int], Dict[str, int], Dict[str, str]]:
+) -> tuple[dict[str, int], dict[str, int], dict[str, str]]:
     normalized_outline_item_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in outline_item_bids
@@ -231,8 +231,8 @@ def _load_outline_learning_stats(
         .group_by(LearnLessonFeedback.outline_item_bid)
         .all()
     )
-    rating_count_map: Dict[str, int] = {}
-    rating_score_map: Dict[str, str] = {}
+    rating_count_map: dict[str, int] = {}
+    rating_score_map: dict[str, str] = {}
     for outline_item_bid, count, score in rating_rows:
         normalized_outline_item_bid = str(outline_item_bid or "").strip()
         if not normalized_outline_item_bid:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime
-from typing import Any, Dict, Sequence, Set
+from typing import Any, Sequence
 
 from flask import Flask
 from flaskr.dao import db
@@ -122,9 +122,9 @@ def _build_follow_up_user_keyword_filter(
 
 
 def _resolve_follow_up_matching_outline_bids(
-    outline_context_map: Dict[str, Dict[str, str]],
+    outline_context_map: dict[str, dict[str, str]],
     chapter_keyword: str,
-) -> Set[str] | None:
+) -> set[str] | None:
     normalized_keyword = str(chapter_keyword or "").strip().lower()
     if not normalized_keyword:
         return None

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, Sequence, Set
+from typing import Any, Iterable, Sequence
 
 from flask import Flask, current_app
 from flaskr.dao import db
@@ -163,8 +163,8 @@ def _build_latest_operator_course_rows_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
 ):
@@ -258,8 +258,8 @@ def _build_latest_operator_course_rows_subquery(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
@@ -284,8 +284,8 @@ def _build_operator_course_candidate_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
@@ -606,8 +606,8 @@ def _build_latest_shifus_query(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -715,8 +715,8 @@ def _load_latest_shifus(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -770,8 +770,8 @@ def _load_latest_shifu_seeds(
     shifu_bid: str,
     course_name: str,
     course_query: str = "",
-    matching_course_bids: Set[str] | None = None,
-    creator_bids: Set[str] | None,
+    matching_course_bids: set[str] | None = None,
+    creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
     updated_start_time: datetime | None,
@@ -843,9 +843,9 @@ def _attach_course_prompt_flags(model, rows) -> None:
 
 def _build_course_summary(
     course,
-    user_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, str]],
     course_status: str,
-    activity: Dict[str, Any] | None = None,
+    activity: dict[str, Any] | None = None,
 ) -> AdminOperationCourseSummaryDTO:
     return build_admin_operation_course_summary(
         course,
@@ -855,7 +855,7 @@ def _build_course_summary(
     )
 
 
-def _resolve_course_status(shifu_bid: str, published_bids: Set[str]) -> str:
+def _resolve_course_status(shifu_bid: str, published_bids: set[str]) -> str:
     if shifu_bid in published_bids:
         return COURSE_STATUS_PUBLISHED
     return COURSE_STATUS_UNPUBLISHED
@@ -947,7 +947,7 @@ def _resolve_created_last_7d_window(
 def _load_course_activity_map(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     return load_course_activity_map(drafts, published)
 
 
@@ -955,7 +955,7 @@ def _load_recent_learning_active_course_bids(
     *,
     since: datetime,
     shifu_bids: Sequence[str] | None = None,
-) -> Set[str]:
+) -> set[str]:
     query = db.session.query(LearnProgressRecord.shifu_bid).filter(
         LearnProgressRecord.deleted == 0,
         LearnProgressRecord.status != LEARN_STATUS_RESET,
@@ -980,7 +980,7 @@ def _load_recent_paid_order_course_bids(
     *,
     since: datetime,
     shifu_bids: Sequence[str] | None = None,
-) -> Set[str]:
+) -> set[str]:
     query = db.session.query(Order.shifu_bid).filter(
         Order.deleted == 0,
         Order.status == ORDER_STATUS_SUCCESS,
@@ -1017,12 +1017,12 @@ def _build_latest_billing_order_subquery(*, creator_bid: str):
     )
 
 
-def _find_operator_course_bids_by_name(course_name: str) -> Set[str]:
+def _find_operator_course_bids_by_name(course_name: str) -> set[str]:
     normalized_course_name = str(course_name or "").strip().lower()
     if not normalized_course_name:
         return set()
 
-    def _load_matching_bids(model) -> Set[str]:
+    def _load_matching_bids(model) -> set[str]:
         latest_subquery = (
             db.session.query(db.func.max(model.id).label("max_id"))
             .filter(model.deleted == 0)
@@ -1041,7 +1041,7 @@ def _find_operator_course_bids_by_name(course_name: str) -> Set[str]:
             if str(shifu_bid or "").strip()
         }
 
-    matching_bids: Set[str] = set()
+    matching_bids: set[str] = set()
     matching_bids.update(_load_matching_bids(DraftShifu))
     matching_bids.update(_load_matching_bids(PublishedShifu))
     return matching_bids
@@ -1051,7 +1051,7 @@ def _build_operator_course_query_filter(
     shifu_bid_column: Any,
     course_query: str,
     *,
-    matching_course_bids: Set[str] | None = None,
+    matching_course_bids: set[str] | None = None,
 ) -> Any | None:
     normalized_course_query = str(course_query or "").strip()
     if not normalized_course_query:
@@ -1301,7 +1301,7 @@ def _list_operator_courses_legacy(
     )
     activity_map = _load_course_activity_map(draft_rows, published_rows)
 
-    def resolve_activity(course) -> Dict[str, Any]:
+    def resolve_activity(course) -> dict[str, Any]:
         return activity_map.get(str(course.shifu_bid or "").strip(), {})
 
     def resolve_updated_at(course) -> datetime | None:
@@ -1539,7 +1539,7 @@ def list_operator_courses(
         _attach_course_prompt_flags(DraftShifu, draft_page_items)
         _attach_course_prompt_flags(PublishedShifu, published_page_items)
 
-        def resolve_activity(course) -> Dict[str, Any]:
+        def resolve_activity(course) -> dict[str, Any]:
             return {
                 "updated_at": course.activity_updated_at or course.updated_at,
                 "updated_user_bid": course.activity_updated_user_bid

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -9,7 +9,7 @@ import re
 import sys
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict, Iterable, Sequence, Set
+from typing import Any, Iterable, Sequence
 
 from flask import current_app
 from flaskr.dao import db
@@ -357,7 +357,7 @@ def _format_average_score(value: Decimal | None) -> str:
     return f"{value:.1f}"
 
 
-def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
+def _normalize_metadata_json(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}
@@ -365,7 +365,7 @@ def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
 
 def _load_course_user_contact_map(
     user_bids: Sequence[str],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -383,7 +383,7 @@ def _load_course_user_contact_map(
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    contact_map: Dict[str, Dict[str, str]] = {
+    contact_map: dict[str, dict[str, str]] = {
         user_bid: {"mobile": "", "email": ""} for user_bid in normalized_user_bids
     }
     for credential in credential_rows:
@@ -426,7 +426,7 @@ def _load_course_user_contact_map(
     return contact_map
 
 
-def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
+def _load_user_map(user_bids: Sequence[str]) -> dict[str, dict[str, str]]:
     if not user_bids:
         return {}
 
@@ -439,8 +439,8 @@ def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    phone_map: Dict[str, str] = {}
-    email_map: Dict[str, str] = {}
+    phone_map: dict[str, str] = {}
+    email_map: dict[str, str] = {}
     for credential in credentials:
         user_bid = credential.user_bid or ""
         if not user_bid:
@@ -461,7 +461,7 @@ def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
         .order_by(UserEntity.id.asc())
         .all()
     )
-    user_map: Dict[str, Dict[str, str]] = {}
+    user_map: dict[str, dict[str, str]] = {}
     for user in users:
         mobile = phone_map.get(user.user_bid, "")
         email = email_map.get(user.user_bid, "")
@@ -514,7 +514,7 @@ def _build_course_order_amount_expr():
     )
 
 
-def _find_matching_creator_bids(keyword: str) -> Set[str] | None:
+def _find_matching_creator_bids(keyword: str) -> set[str] | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None
@@ -551,7 +551,7 @@ def _find_matching_creator_bids(keyword: str) -> Set[str] | None:
 
 def _load_operator_user_last_login_map(
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -590,8 +590,8 @@ def _merge_courses(
     published: Iterable[PublishedShifu],
 ):
     course_map = {}
-    published_bids: Set[str] = set()
-    selected_sources: Dict[str, str] = {}
+    published_bids: set[str] = set()
+    selected_sources: dict[str, str] = {}
     for course in drafts:
         visible = _is_operator_visible_course(course)
         if visible:
@@ -710,8 +710,8 @@ def _load_operator_course_outline_items(
 def _resolve_visible_leaf_outline_bids(
     outline_items: Sequence[DraftOutlineItem | PublishedOutlineItem],
 ) -> list[str]:
-    visible_item_bids: Set[str] = set()
-    visible_parent_bids: Set[str] = set()
+    visible_item_bids: set[str] = set()
+    visible_parent_bids: set[str] = set()
     for item in outline_items:
         outline_item_bid = str(getattr(item, "outline_item_bid", "") or "").strip()
         parent_bid = str(getattr(item, "parent_bid", "") or "").strip()
@@ -725,13 +725,13 @@ def _resolve_visible_leaf_outline_bids(
 
 def _build_course_outline_context_map(
     outline_items: Sequence[DraftOutlineItem | PublishedOutlineItem],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     outline_item_map = {
         str(getattr(item, "outline_item_bid", "") or "").strip(): item
         for item in outline_items
         if str(getattr(item, "outline_item_bid", "") or "").strip()
     }
-    context_map: Dict[str, Dict[str, str]] = {}
+    context_map: dict[str, dict[str, str]] = {}
 
     for outline_item_bid, item in outline_item_map.items():
         lesson_title = str(getattr(item, "title", "") or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -6,7 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 from flask import Flask, current_app
 from flaskr.common.cache_provider import cache as redis
@@ -134,7 +134,7 @@ def _resolve_course_copy_title(source_title: str, requested_title: str) -> str:
 def _build_outline_history_tree(
     outlines: Sequence[DraftOutlineItem],
 ) -> list[HistoryItem]:
-    outline_children_map: Dict[str, list[DraftOutlineItem]] = {}
+    outline_children_map: dict[str, list[DraftOutlineItem]] = {}
     for outline in outlines:
         parent_bid = str(outline.parent_bid or "").strip()
         outline_children_map.setdefault(parent_bid, []).append(outline)
@@ -264,7 +264,7 @@ def _prepare_operator_target_creator(
     identifier: str,
     previous_creator_user_bid: str = "",
     allow_same_user: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     normalized_contact_type = str(contact_type or "").strip().lower()
     normalized_identifier = _validate_operator_target_contact(
         normalized_contact_type, identifier
@@ -395,7 +395,7 @@ def transfer_operator_course_creator(
     contact_type: str,
     identifier: str,
     operator_user_bid: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
         normalized_contact_type = str(contact_type or "").strip().lower()
@@ -468,7 +468,7 @@ def copy_operator_course(
     identifier: str,
     operator_user_bid: str,
     new_course_name: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     with app.app_context():
         normalized_shifu_bid = str(shifu_bid or "").strip()
         normalized_contact_type = str(contact_type or "").strip().lower()
@@ -491,7 +491,7 @@ def copy_operator_course(
             new_course_name,
         )
         source_outlines = _load_latest_active_draft_outlines(normalized_shifu_bid)
-        outline_bid_map: Dict[str, str] = {
+        outline_bid_map: dict[str, str] = {
             str(item.outline_item_bid or "").strip(): generate_id(app)
             for item in source_outlines
         }
@@ -539,7 +539,7 @@ def copy_operator_course(
         source_outline_map = {
             str(item.outline_item_bid or "").strip(): item for item in source_outlines
         }
-        copied_outlines: Dict[str, DraftOutlineItem] = {}
+        copied_outlines: dict[str, DraftOutlineItem] = {}
 
         for source_outline in source_outlines:
             old_outline_bid = str(source_outline.outline_item_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, Sequence, Set
+from typing import Any, Sequence
 
 from flask import Flask
 from flaskr.dao import db
@@ -50,7 +50,7 @@ def _load_course_related_user_bids(
     shifu_bid: str,
     *,
     creator_user_bid: str,
-) -> tuple[Set[str], Set[str]]:
+) -> tuple[set[str], set[str]]:
     order_user_bids = {
         str(user_bid or "").strip()
         for (user_bid,) in db.session.query(Order.user_bid)
@@ -99,7 +99,7 @@ def _load_course_related_user_bids(
 def _load_course_user_paid_amount_map(
     shifu_bid: str,
     user_bids: Sequence[str],
-) -> Dict[str, Decimal]:
+) -> dict[str, Decimal]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -135,7 +135,7 @@ def _load_course_user_paid_amount_map(
 def _load_course_user_last_learning_map(
     shifu_bid: str,
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -171,7 +171,7 @@ def _load_course_user_joined_at_map(
     *,
     creator_user_bid: str,
     course_created_at: datetime | None,
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -180,7 +180,7 @@ def _load_course_user_joined_at_map(
     if not normalized_user_bids:
         return {}
 
-    joined_at_map: Dict[str, datetime] = {}
+    joined_at_map: dict[str, datetime] = {}
 
     def _merge_rows(rows: Sequence[tuple[str, Any]]) -> None:
         for user_bid, joined_at in rows:
@@ -250,7 +250,7 @@ def _load_course_user_learned_lesson_count_map(
     shifu_bid: str,
     user_bids: Sequence[str],
     leaf_outline_bids: Sequence[str],
-) -> Dict[str, int]:
+) -> dict[str, int]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 from flask import current_app
 from flaskr.service.user.models import AuthCredential
@@ -52,7 +52,7 @@ def format_operator_datetime(value: Any) -> str:
     return str(serialized_value or "").replace("+00:00", "Z")
 
 
-def load_operator_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
+def load_operator_user_map(user_bids: Sequence[str]) -> dict[str, dict[str, str]]:
     if not user_bids:
         return {}
 
@@ -71,8 +71,8 @@ def load_operator_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    phone_map: Dict[str, str] = {}
-    email_map: Dict[str, str] = {}
+    phone_map: dict[str, str] = {}
+    email_map: dict[str, str] = {}
     for credential in credentials:
         user_bid = credential.user_bid or ""
         if not user_bid:
@@ -93,7 +93,7 @@ def load_operator_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]
         .order_by(UserEntity.id.asc())
         .all()
     )
-    user_map: Dict[str, Dict[str, str]] = {}
+    user_map: dict[str, dict[str, str]] = {}
     for user in users:
         mobile = phone_map.get(user.user_bid, "")
         email = email_map.get(user.user_bid, "")

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -293,7 +293,7 @@ def get_operator_user_credits(
     user_bid: str,
     page_index: int,
     page_size: int,
-    filters: Dict[str, Any] | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> AdminOperationUserCreditLedgerPageDTO:
     with app.app_context():
         normalized_user_bid = str(user_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from decimal import Decimal
-from typing import Any, Sequence, Set
+from typing import Any, Sequence
 
 from flask import Flask
 from flaskr.api.tts import get_default_voice_settings, synthesize_text
@@ -66,7 +66,7 @@ def _decimal_to_str(value: Any) -> str:
     return str(value)
 
 
-def _find_matching_course_bids(keyword: str) -> Set[str] | None:
+def _find_matching_course_bids(keyword: str) -> set[str] | None:
     normalized = _normalize_text(keyword)
     if not normalized:
         return None
@@ -96,7 +96,7 @@ def _find_matching_course_bids(keyword: str) -> Set[str] | None:
     }
 
 
-def _find_matching_voice_owner_bids(keyword: str) -> Set[str] | None:
+def _find_matching_voice_owner_bids(keyword: str) -> set[str] | None:
     normalized = _normalize_text(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any
 
 from flask import current_app
 from flaskr.service.user.consts import (
@@ -318,7 +318,7 @@ def _coerce_operator_datetime(value: Any) -> datetime | None:
     return None
 
 
-def _normalize_metadata_json(value: Any) -> Dict[str, Any]:
+def _normalize_metadata_json(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}

--- a/src/api/flaskr/service/shifu/admin_user_courses.py
+++ b/src/api/flaskr/service/shifu/admin_user_courses.py
@@ -6,7 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, Sequence, Set
+from typing import Sequence
 
 from flaskr.dao import db
 from flaskr.service.learn.const import (
@@ -37,7 +37,7 @@ from flaskr.service.shifu.models import (
 
 def _build_operator_user_course_summary(
     course,
-    published_bids: Set[str],
+    published_bids: set[str],
     *,
     completed_lesson_count: int = 0,
     total_lesson_count: int = 0,
@@ -53,7 +53,7 @@ def _build_operator_user_course_summary(
 
 def _load_visible_published_leaf_outline_bids_by_shifu(
     shifu_bids: Sequence[str],
-) -> Dict[str, list[str]]:
+) -> dict[str, list[str]]:
     normalized_shifu_bids = [
         str(shifu_bid or "").strip() for shifu_bid in shifu_bids if shifu_bid
     ]
@@ -85,8 +85,8 @@ def _load_visible_published_leaf_outline_bids_by_shifu(
         .all()
     )
 
-    visible_bids_by_shifu: Dict[str, Set[str]] = {}
-    parent_bids_by_shifu: Dict[str, Set[str]] = {}
+    visible_bids_by_shifu: dict[str, set[str]] = {}
+    parent_bids_by_shifu: dict[str, set[str]] = {}
     for shifu_bid, outline_item_bid, parent_bid in outline_rows:
         normalized_shifu_bid = str(shifu_bid or "").strip()
         normalized_outline_item_bid = str(outline_item_bid or "").strip()
@@ -120,8 +120,8 @@ def _is_completed_leaf_progress_statuses(record_statuses: Sequence[int]) -> bool
 def _load_learning_progress_counts_by_user_and_course(
     user_bids: Sequence[str],
     shifu_bids: Sequence[str],
-    leaf_outline_bids_by_shifu: Dict[str, list[str]],
-) -> Dict[tuple[str, str], tuple[int, int]]:
+    leaf_outline_bids_by_shifu: dict[str, list[str]],
+) -> dict[tuple[str, str], tuple[int, int]]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -170,7 +170,7 @@ def _load_learning_progress_counts_by_user_and_course(
         .all()
     )
 
-    statuses_by_user_course_outline: Dict[tuple[str, str, str], list[int]] = {}
+    statuses_by_user_course_outline: dict[tuple[str, str, str], list[int]] = {}
     for user_bid, shifu_bid, outline_item_bid, status in progress_rows:
         normalized_user_bid = str(user_bid or "").strip()
         normalized_shifu_bid = str(shifu_bid or "").strip()
@@ -194,7 +194,7 @@ def _load_learning_progress_counts_by_user_and_course(
             [],
         ).append(int(status or 0))
 
-    completed_counts_by_user_course: Dict[tuple[str, str], int] = {}
+    completed_counts_by_user_course: dict[tuple[str, str], int] = {}
     for (
         user_bid,
         shifu_bid,
@@ -206,7 +206,7 @@ def _load_learning_progress_counts_by_user_and_course(
             completed_counts_by_user_course.get((user_bid, shifu_bid), 0) + 1
         )
 
-    progress_counts: Dict[tuple[str, str], tuple[int, int]] = {}
+    progress_counts: dict[tuple[str, str], tuple[int, int]] = {}
     for user_bid in normalized_user_bids:
         for shifu_bid in normalized_shifu_bids:
             total_lesson_count = len(leaf_outline_bids_by_shifu.get(shifu_bid, []))
@@ -222,8 +222,8 @@ def _load_learning_progress_counts_by_user_and_course(
 def _load_operator_user_course_maps(
     user_bids: Sequence[str],
 ) -> tuple[
-    Dict[str, list[AdminOperationUserCourseSummaryDTO]],
-    Dict[str, list[AdminOperationUserCourseSummaryDTO]],
+    dict[str, list[AdminOperationUserCourseSummaryDTO]],
+    dict[str, list[AdminOperationUserCourseSummaryDTO]],
 ]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
@@ -231,10 +231,10 @@ def _load_operator_user_course_maps(
     if not normalized_user_bids:
         return {}, {}
 
-    created_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]] = {
+    created_courses_map: dict[str, list[AdminOperationUserCourseSummaryDTO]] = {
         user_bid: [] for user_bid in normalized_user_bids
     }
-    learning_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]] = {
+    learning_courses_map: dict[str, list[AdminOperationUserCourseSummaryDTO]] = {
         user_bid: [] for user_bid in normalized_user_bids
     }
 
@@ -388,7 +388,7 @@ def _load_operator_user_course_maps(
 
 def _load_operator_user_course_count_maps(
     user_bids: Sequence[str],
-) -> tuple[Dict[str, int], Dict[str, int]]:
+) -> tuple[dict[str, int], dict[str, int]]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime
 from decimal import Decimal
 from json import JSONDecodeError
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
 from flask import current_app
 from flaskr.dao import db
@@ -236,8 +236,8 @@ def _build_operator_course_credit_usage_item(
     *,
     usage_row: BillUsageRecord,
     ledger_amount: Any,
-    user_map: Dict[str, Dict[str, Any]],
-    outline_context_map: Dict[str, Dict[str, str]],
+    user_map: dict[str, dict[str, Any]],
+    outline_context_map: dict[str, dict[str, str]],
     group_key: str = "",
     usage_count: int = 1,
     usage_mode: str = "",
@@ -772,7 +772,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
 def _build_operator_course_credit_metrics(
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     base_query = _build_operator_course_credit_usage_base_query(
         shifu_bid,
         outline_item_bids=leaf_outline_bids,
@@ -845,7 +845,7 @@ def _load_active_subscription_end_map(
     creator_bids: Sequence[str],
     *,
     as_of: datetime,
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_creator_bids = [
         str(creator_bid or "").strip() for creator_bid in creator_bids if creator_bid
     ]
@@ -885,7 +885,7 @@ def _load_active_subscription_end_map(
         )
         .all()
     )
-    best_by_creator: Dict[str, tuple] = {}
+    best_by_creator: dict[str, tuple] = {}
     for row in rows:
         sort_key = (
             row.product_sort_order if row.product_sort_order is not None else -1,
@@ -926,7 +926,7 @@ def _load_active_subscription_product_display_name_i18n_key(
     return str(getattr(product, "display_name_i18n_key", "") or "").strip()
 
 
-def _load_billing_order_map(source_bids: Sequence[str]) -> Dict[str, BillingOrder]:
+def _load_billing_order_map(source_bids: Sequence[str]) -> dict[str, BillingOrder]:
     normalized_source_bids = [
         str(source_bid or "").strip()
         for source_bid in source_bids
@@ -943,7 +943,7 @@ def _load_billing_order_map(source_bids: Sequence[str]) -> Dict[str, BillingOrde
         .order_by(BillingOrder.id.desc())
         .all()
     )
-    order_map: Dict[str, BillingOrder] = {}
+    order_map: dict[str, BillingOrder] = {}
     for row in rows:
         normalized_source_bid = str(row.bill_order_bid or "").strip()
         if normalized_source_bid and normalized_source_bid not in order_map:
@@ -966,7 +966,7 @@ def _collect_operator_user_credit_order_source_bids(
     ]
 
 
-def _resolve_operator_credit_usage_scene(metadata: Dict[str, Any]) -> int:
+def _resolve_operator_credit_usage_scene(metadata: dict[str, Any]) -> int:
     raw_usage_scene = metadata.get("usage_scene")
     try:
         return int(raw_usage_scene or 0)
@@ -982,7 +982,7 @@ def _operator_credit_int(value: Any, default: int = 0) -> int:
 def _resolve_operator_credit_display_entry_type(
     row: CreditLedgerEntry,
     *,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> str:
     usage_scene = _resolve_operator_credit_usage_scene(metadata)
     amount = Decimal(row.amount or 0)
@@ -1041,7 +1041,7 @@ def _resolve_operator_credit_display_entry_type(
 def _resolve_operator_credit_display_source_type(
     row: CreditLedgerEntry,
     *,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> str:
     source_type = _operator_credit_int(row.source_type)
     if source_type == CREDIT_SOURCE_TYPE_USAGE:
@@ -1076,7 +1076,7 @@ def _resolve_operator_credit_display_source_type(
 def _resolve_operator_credit_note_code(
     row: CreditLedgerEntry,
     *,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> str:
     note = str(metadata.get("note") or "").strip()
     if note:
@@ -1148,8 +1148,8 @@ def _resolve_operator_user_credit_grant_source_filter(value: str) -> str:
 def _build_operator_user_credit_merged_metadata(
     row: CreditLedgerEntry,
     *,
-    order_map: Dict[str, BillingOrder] | None = None,
-) -> Dict[str, Any]:
+    order_map: dict[str, BillingOrder] | None = None,
+) -> dict[str, Any]:
     metadata = _normalize_metadata_json(row.metadata_json)
     normalized_source_bid = str(row.source_bid or "").strip()
     order = (order_map or {}).get(normalized_source_bid)
@@ -1186,7 +1186,7 @@ def _is_operator_user_credit_other_row(row: CreditLedgerEntry) -> bool:
 def _resolve_operator_user_credit_grant_filter_key(
     row: CreditLedgerEntry,
     *,
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> str:
     source_type = _operator_credit_int(row.source_type)
     if source_type == CREDIT_SOURCE_TYPE_SUBSCRIPTION:
@@ -1203,7 +1203,7 @@ def _resolve_operator_user_credit_grant_filter_key(
 
 def _load_operator_user_credit_summary_map(
     user_bids: Sequence[str],
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -1237,11 +1237,11 @@ def _load_operator_user_credit_summary_map(
     )
 
     zero = Decimal(0)
-    summary_map: Dict[str, Dict[str, Any]] = {}
+    summary_map: dict[str, dict[str, Any]] = {}
     order_map = _load_billing_order_map(
         [str(bucket.source_bid or "").strip() for bucket in buckets]
     )
-    order_type_cache: Dict[str, int | None] = {
+    order_type_cache: dict[str, int | None] = {
         bill_order_bid: int(order.order_type or 0)
         for bill_order_bid, order in order_map.items()
     }
@@ -1324,7 +1324,7 @@ def _load_operator_user_credit_summary_map(
 def _build_operator_user_credit_summary(
     *,
     user: UserEntity,
-    credit_summary_map: Dict[str, Dict[str, Any]],
+    credit_summary_map: dict[str, dict[str, Any]],
 ) -> AdminOperationUserCreditSummaryDTO:
     user_bid = str(user.user_bid or "").strip()
     credit_summary = credit_summary_map.get(user_bid)
@@ -1369,7 +1369,7 @@ def _resolve_operator_user_credit_usage_scene(row: BillUsageRecord) -> str:
 
 def _load_operator_user_credit_usage_context_map(
     ledger_rows: Sequence[CreditLedgerEntry],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     usage_bids = sorted(
         {
             str(row.source_bid or "").strip()
@@ -1415,7 +1415,7 @@ def _load_operator_user_credit_usage_context_map(
         if str(getattr(course, "shifu_bid", "") or "").strip()
     }
 
-    outline_context_by_course: Dict[str, Dict[str, Dict[str, str]]] = {}
+    outline_context_by_course: dict[str, dict[str, dict[str, str]]] = {}
     for shifu_bid in shifu_bids:
         source = selected_sources.get(shifu_bid)
         if not source:
@@ -1425,7 +1425,7 @@ def _load_operator_user_credit_usage_context_map(
             _load_latest_outline_items(outline_model, shifu_bid)
         )
 
-    context_map: Dict[str, Dict[str, str]] = {}
+    context_map: dict[str, dict[str, str]] = {}
     for usage_row in usage_rows:
         usage_bid = str(getattr(usage_row, "usage_bid", "") or "").strip()
         shifu_bid = str(getattr(usage_row, "shifu_bid", "") or "").strip()
@@ -1454,7 +1454,7 @@ def _load_operator_user_credit_usage_context_map(
 
 def _resolve_operator_user_credit_usage_context(
     usage_row: BillUsageRecord,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     usage_bid = str(getattr(usage_row, "usage_bid", "") or "").strip()
     shifu_bid = str(getattr(usage_row, "shifu_bid", "") or "").strip()
     outline_item_bid = str(getattr(usage_row, "outline_item_bid", "") or "").strip()
@@ -1554,7 +1554,7 @@ def _load_operator_user_credit_usage_segment_rows(
 
 def _load_generated_block_content_map(
     generated_block_bids: Sequence[str],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     normalized_bids = sorted(
         {
             str(generated_block_bid or "").strip()
@@ -1573,7 +1573,7 @@ def _load_generated_block_content_map(
         .order_by(LearnGeneratedBlock.id.desc())
         .all()
     )
-    content_map: Dict[str, str] = {}
+    content_map: dict[str, str] = {}
     for row in rows:
         generated_block_bid = str(row.generated_block_bid or "").strip()
         if generated_block_bid and generated_block_bid not in content_map:
@@ -1585,7 +1585,7 @@ def _load_listen_segment_content_map(
     *,
     progress_record_bid: str,
     generated_block_bid: str,
-) -> Dict[int, str]:
+) -> dict[int, str]:
     normalized_progress_record_bid = str(progress_record_bid or "").strip()
     normalized_generated_block_bid = str(generated_block_bid or "").strip()
     if not normalized_progress_record_bid and not normalized_generated_block_bid:
@@ -1611,7 +1611,7 @@ def _load_listen_segment_content_map(
         LearnGeneratedElement.id.asc(),
     ).all()
 
-    content_map: Dict[int, str] = {}
+    content_map: dict[int, str] = {}
     fallback_index = 0
     for row in rows:
         content = str(row.content_text or "").strip()
@@ -1649,14 +1649,14 @@ def _allocate_usage_detail_credits(
     *,
     rows: Sequence[BillUsageRecord],
     total_consumed_credits: Decimal,
-) -> Dict[str, Decimal]:
+) -> dict[str, Decimal]:
     if not rows or total_consumed_credits <= 0:
         return {}
     total_units = sum(max(int(getattr(row, "total", 0) or 0), 0) for row in rows)
     if len(rows) == 1 or total_units <= 0:
         return {str(getattr(rows[0], "usage_bid", "") or ""): total_consumed_credits}
 
-    allocated: Dict[str, Decimal] = {}
+    allocated: dict[str, Decimal] = {}
     remaining = total_consumed_credits
     last_usage_bid = str(getattr(rows[-1], "usage_bid", "") or "")
     for row in rows[:-1]:
@@ -1674,8 +1674,8 @@ def _allocate_usage_detail_credits(
 def _resolve_usage_detail_item_content(
     row: BillUsageRecord,
     *,
-    block_content_map: Dict[str, str],
-    listen_content_map: Dict[int, str],
+    block_content_map: dict[str, str],
+    listen_content_map: dict[int, str],
     fallback_content: str,
 ) -> str:
     metadata = _normalize_metadata_json(getattr(row, "extra", None))
@@ -1695,8 +1695,8 @@ def _resolve_usage_detail_item_content(
 def _build_operator_user_credit_ledger_item(
     row: CreditLedgerEntry,
     *,
-    order_map: Dict[str, BillingOrder] | None = None,
-    usage_context_map: Dict[str, Dict[str, str]] | None = None,
+    order_map: dict[str, BillingOrder] | None = None,
+    usage_context_map: dict[str, dict[str, str]] | None = None,
 ) -> AdminOperationUserCreditLedgerItemDTO:
     merged_metadata = _build_operator_user_credit_merged_metadata(
         row,

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Dict, Sequence, Set
+from typing import Any, Sequence
 
 from flaskr.dao import db
 from flaskr.service.common.models import (
@@ -73,7 +73,7 @@ from sqlalchemy import case, or_
 
 def _load_course_user_contact_map(
     user_bids: Sequence[str],
-) -> Dict[str, Dict[str, str]]:
+) -> dict[str, dict[str, str]]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -91,7 +91,7 @@ def _load_course_user_contact_map(
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    contact_map: Dict[str, Dict[str, str]] = {
+    contact_map: dict[str, dict[str, str]] = {
         user_bid: {"mobile": "", "email": ""} for user_bid in normalized_user_bids
     }
     for credential in credential_rows:
@@ -134,7 +134,7 @@ def _load_course_user_contact_map(
     return contact_map
 
 
-def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
+def _load_user_map(user_bids: Sequence[str]) -> dict[str, dict[str, str]]:
     if not user_bids:
         return {}
 
@@ -147,8 +147,8 @@ def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
         .order_by(AuthCredential.id.desc())
         .all()
     )
-    phone_map: Dict[str, str] = {}
-    email_map: Dict[str, str] = {}
+    phone_map: dict[str, str] = {}
+    email_map: dict[str, str] = {}
     for credential in credentials:
         user_bid = credential.user_bid or ""
         if not user_bid:
@@ -169,7 +169,7 @@ def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
         .order_by(UserEntity.id.asc())
         .all()
     )
-    user_map: Dict[str, Dict[str, str]] = {}
+    user_map: dict[str, dict[str, str]] = {}
     for user in users:
         mobile = phone_map.get(user.user_bid, "")
         email = email_map.get(user.user_bid, "")
@@ -189,7 +189,7 @@ def _load_user_map(user_bids: Sequence[str]) -> Dict[str, Dict[str, str]]:
 
 def _load_operator_user_last_login_map(
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip()
         for user_bid in user_bids
@@ -252,7 +252,7 @@ def _build_course_order_amount_expr():
     )
 
 
-def _find_matching_creator_bids(keyword: str) -> Set[str] | None:
+def _find_matching_creator_bids(keyword: str) -> set[str] | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None
@@ -449,7 +449,7 @@ def _build_registered_user_timestamp_subquery():
     )
 
 
-def _load_learner_user_bids(user_bids: Sequence[str] | None = None) -> Set[str]:
+def _load_learner_user_bids(user_bids: Sequence[str] | None = None) -> set[str]:
     learner_subquery = _build_learner_user_bid_subquery()
     query = db.session.query(learner_subquery.c.user_bid)
     normalized_user_bids = [
@@ -501,7 +501,7 @@ def _load_operator_user_registration_source_map(
     *,
     users: Sequence[UserEntity] | None = None,
     credential_rows: Sequence[AuthCredential] | None = None,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -517,7 +517,7 @@ def _load_operator_user_registration_source_map(
             int(getattr(credential, "id", 0) or 0),
         ),
     )
-    registration_source_map: Dict[str, str] = {}
+    registration_source_map: dict[str, str] = {}
     for credential in resolved_credential_rows:
         user_bid = str(credential.user_bid or "").strip()
         if not user_bid or user_bid in registration_source_map:
@@ -561,7 +561,7 @@ def _load_operator_user_registration_source_map(
 
 def _load_operator_user_last_login_map(
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -589,7 +589,7 @@ def _load_operator_user_last_login_map(
 
 def _load_operator_user_total_paid_amount_map(
     user_bids: Sequence[str],
-) -> Dict[str, Decimal]:
+) -> dict[str, Decimal]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -621,7 +621,7 @@ def _load_operator_user_total_paid_amount_map(
 
 def _load_operator_user_last_learning_map(
     user_bids: Sequence[str],
-) -> Dict[str, datetime]:
+) -> dict[str, datetime]:
     normalized_user_bids = [
         str(user_bid or "").strip() for user_bid in user_bids if user_bid
     ]
@@ -653,7 +653,7 @@ def _load_operator_user_contact_map(
     *,
     users: Sequence[UserEntity] | None = None,
     credential_rows: Sequence[AuthCredential] | None = None,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     if not user_bids:
         return {}
 
@@ -664,7 +664,7 @@ def _load_operator_user_contact_map(
         key=lambda credential: int(getattr(credential, "id", 0) or 0),
         reverse=True,
     )
-    contact_map: Dict[str, Dict[str, Any]] = {
+    contact_map: dict[str, dict[str, Any]] = {
         user_bid: {"mobile": "", "email": "", "login_methods": []}
         for user_bid in user_bids
     }
@@ -724,7 +724,7 @@ def _load_operator_user_contact_map(
     return contact_map
 
 
-def _find_matching_user_bids_by_identifier(keyword: str) -> Set[str] | None:
+def _find_matching_user_bids_by_identifier(keyword: str) -> set[str] | None:
     normalized = str(keyword or "").strip()
     if not normalized:
         return None
@@ -753,20 +753,20 @@ def _find_matching_user_bids_by_identifier(keyword: str) -> Set[str] | None:
 
 def _build_operator_user_summary(
     user: UserEntity,
-    contact_map: Dict[str, Dict[str, Any]],
-    learner_user_bids: Set[str],
-    registration_source_map: Dict[str, str],
-    last_login_map: Dict[str, datetime],
-    total_paid_amount_map: Dict[str, Decimal],
-    last_learning_map: Dict[str, datetime],
-    credit_summary_map: Dict[str, Dict[str, Any]],
+    contact_map: dict[str, dict[str, Any]],
+    learner_user_bids: set[str],
+    registration_source_map: dict[str, str],
+    last_login_map: dict[str, datetime],
+    total_paid_amount_map: dict[str, Decimal],
+    last_learning_map: dict[str, datetime],
+    credit_summary_map: dict[str, dict[str, Any]],
     *,
-    learning_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]]
+    learning_courses_map: dict[str, list[AdminOperationUserCourseSummaryDTO]]
     | None = None,
-    created_courses_map: Dict[str, list[AdminOperationUserCourseSummaryDTO]]
+    created_courses_map: dict[str, list[AdminOperationUserCourseSummaryDTO]]
     | None = None,
-    learning_course_count_map: Dict[str, int] | None = None,
-    created_course_count_map: Dict[str, int] | None = None,
+    learning_course_count_map: dict[str, int] | None = None,
+    created_course_count_map: dict[str, int] | None = None,
 ) -> AdminOperationUserSummaryDTO:
     user_bid = str(user.user_bid or "").strip()
     contact = contact_map.get(user.user_bid or "", {})

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Set
+from typing import Any, Iterable
 
 from flaskr.dao import db
 from sqlalchemy import and_, or_
@@ -10,7 +10,7 @@ from .models import DraftOutlineItem, DraftShifu, PublishedOutlineItem, Publishe
 
 
 def _record_course_activity(
-    activity_map: Dict[str, Dict[str, Any]],
+    activity_map: dict[str, dict[str, Any]],
     *,
     shifu_bid: str,
     updated_at: datetime | None,
@@ -46,9 +46,9 @@ def load_course_activity_map(
     published: Iterable[PublishedShifu],
     *,
     include_published_outline: bool = True,
-) -> Dict[str, Dict[str, Any]]:
-    activity_map: Dict[str, Dict[str, Any]] = {}
-    shifu_bids: Set[str] = set()
+) -> dict[str, dict[str, Any]]:
+    activity_map: dict[str, dict[str, Any]] = {}
+    shifu_bids: set[str] = set()
 
     for course in list(drafts) + list(published):
         shifu_bid = str(course.shifu_bid or "").strip()

--- a/src/api/flaskr/service/shifu/demo_courses.py
+++ b/src/api/flaskr/service/shifu/demo_courses.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
-from typing import Any, Set
+from typing import Any
 
 from flask import Flask
 from flaskr.service.config.funcs import get_config as get_dynamic_config
 
-BUILTIN_DEMO_TITLES: Set[str] = {
+BUILTIN_DEMO_TITLES: set[str] = {
     "AI 师傅教学引导",
     "AI-Shifu Creation Guide",
 }
 
 
-def load_builtin_demo_titles() -> Set[str]:
+def load_builtin_demo_titles() -> set[str]:
     return set(BUILTIN_DEMO_TITLES)
 
 
-def load_demo_shifu_bids() -> Set[str]:
-    demo_bids: Set[str] = set()
+def load_demo_shifu_bids() -> set[str]:
+    demo_bids: set[str] = set()
     for key in ("DEMO_SHIFU_BID", "DEMO_EN_SHIFU_BID"):
         try:
             bid = str(get_dynamic_config(key, "") or "").strip()

--- a/src/api/flaskr/service/shifu/permissions.py
+++ b/src/api/flaskr/service/shifu/permissions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, Set
 
 from flask import Flask
 from flaskr.dao import db
@@ -10,7 +9,7 @@ from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
 DEFAULT_SHIFU_PERMISSIONS = {"view", "edit", "publish"}
 
 
-def _normalize_auth_types(raw_value: object) -> Set[str]:
+def _normalize_auth_types(raw_value: object) -> set[str]:
     """Normalize raw auth_type value to a set of trimmed strings."""
     if raw_value is None:
         return set()
@@ -32,11 +31,11 @@ def _normalize_auth_types(raw_value: object) -> Set[str]:
     return set()
 
 
-def _auth_types_to_permissions(auth_types: Set[str]) -> Set[str]:
+def _auth_types_to_permissions(auth_types: set[str]) -> set[str]:
     """Map stored auth_type values (strings or numeric codes) to normalized permissions.
     Codes: 1=view, 2=edit, 4=publish.
     """
-    perms: Set[str] = set()
+    perms: set[str] = set()
     for item in auth_types:
         lowered = item.lower()
         if lowered in {"view", "read", "readonly"} or lowered == "1":
@@ -48,10 +47,10 @@ def _auth_types_to_permissions(auth_types: Set[str]) -> Set[str]:
     return perms
 
 
-def get_user_shifu_permissions(app: Flask, user_id: str) -> Dict[str, Set[str]]:
+def get_user_shifu_permissions(app: Flask, user_id: str) -> dict[str, set[str]]:
     """Load all shifu permission sets for a user (owner + shared)."""
     with app.app_context():
-        permission_map: Dict[str, Set[str]] = {}
+        permission_map: dict[str, set[str]] = {}
 
         created_shifus = (
             db.session.query(DraftShifu.shifu_bid)

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -37,7 +37,7 @@ format:
 
 import queue
 import re
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 
 from flask import Flask
 from flaskr.dao import db
@@ -60,7 +60,7 @@ class HistoryItem(BaseModel, Generic[T]):
     bid: str
     id: int
     type: str
-    children: List["HistoryItem"] = []
+    children: list["HistoryItem"] = []
     child_count: int = 0
 
     def to_json(self):
@@ -479,7 +479,7 @@ def save_outline_tree_history(
     app: Flask,
     user_id: str,
     shifu_bid: str,
-    outline_tree: List[HistoryItem],
+    outline_tree: list[HistoryItem],
     shifu_id: int | None = None,
 ):
     """Save outline tree history

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -1,7 +1,6 @@
 import json
 import os
 from decimal import Decimal
-from typing import Dict
 
 from flask import Flask
 from flaskr.common.i18n_utils import get_markdownflow_output_language
@@ -300,15 +299,15 @@ def import_shifu(
             save_shifu_history(app, user_id, shifu_bid, new_shifu.id)
 
         # Create mapping from old outline_item_bid to new outline_item_bid
-        old_to_new_bid_map: Dict[str, str] = {}
+        old_to_new_bid_map: dict[str, str] = {}
 
         # Create a map of old_bid -> outline_item_data
-        outline_items_by_old_bid: Dict[str, dict] = {
+        outline_items_by_old_bid: dict[str, dict] = {
             item["outline_item_bid"]: item for item in outline_items_data
         }
 
         # Create all outline items first (without parent_bid, will update later)
-        created_items: Dict[str, DraftOutlineItem] = {}
+        created_items: dict[str, DraftOutlineItem] = {}
 
         for item_data in outline_items_data:
             old_bid = item_data["outline_item_bid"]

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -12,7 +12,6 @@ Date: 2025-08-07
 
 import queue
 from decimal import Decimal
-from typing import List
 
 from flask import Flask
 from flaskr.service.common import raise_error
@@ -37,7 +36,7 @@ class ShifuOutlineItemDto(BaseModel):
     title: str
     type: int  # 401 trial 402 normal
     shifu_bid: str
-    children: List["ShifuOutlineItemDto"]
+    children: list["ShifuOutlineItemDto"]
 
     def __json__(self):
         return self.model_dump_json(exclude_none=True)
@@ -51,7 +50,7 @@ class ShifuInfoDto(BaseModel):
     description: str
     avatar: str
     price: Decimal
-    outline_items: List["ShifuOutlineItemDto"]
+    outline_items: list["ShifuOutlineItemDto"]
     default_listen_mode_enabled: bool = False
     use_learner_language: bool = False
 

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -5,7 +5,7 @@ This module provides audio concatenation and processing functions using pydub/ff
 
 import io
 import logging
-from typing import List, Sequence
+from typing import Sequence
 
 from flaskr.common.log import AppLoggerProxy
 
@@ -65,7 +65,7 @@ def try_get_audio_duration_ms(audio_data: bytes, format: str = "mp3") -> int | N
 
 
 def concat_audio_mp3(
-    segments: List[bytes],
+    segments: list[bytes],
     output_format: str = "mp3",
     crossfade_ms: int = DEFAULT_CROSSFADE_MS,
 ) -> bytes:

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generator, List
+from typing import Any, Generator
 
 from flask import Flask
 from flaskr.api.tts import (
@@ -275,7 +275,7 @@ class StreamingTTSProcessor:
         tts_model: str = "",
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-        av_contract: Dict[str, Any] | None = None,
+        av_contract: dict[str, Any] | None = None,
         usage_scene: int = BILL_USAGE_SCENE_PROD,
     ):
         self.app = app
@@ -331,15 +331,15 @@ class StreamingTTSProcessor:
         )
 
         # Thread-safe queue for completed segments
-        self._completed_segments: Dict[int, TTSSegment] = {}
-        self._pending_futures: List[Future] = []
+        self._completed_segments: dict[int, TTSSegment] = {}
+        self._pending_futures: list[Future] = []
         self._next_yield_index = 0
         self._lock = threading.Lock()
 
         # Storage for all yielded audio data and text (for final concatenation/subtitles)
         # List of (index, audio_data, duration_ms, text)
-        self._all_audio_data: List[tuple] = []
-        self._segment_subtitle_cues: Dict[int, list[dict[str, Any]]] = {}
+        self._all_audio_data: list[tuple] = []
+        self._segment_subtitle_cues: dict[int, list[dict[str, Any]]] = {}
 
         # Check if TTS is configured for the specified provider
         self._enabled = is_tts_configured(tts_provider)
@@ -2111,7 +2111,7 @@ class AVStreamingTTSProcessor:
         self._current_processor: StreamingTTSProcessor | None = None
         self._raw_buffer = ""
         self._raw_full_content = ""
-        self._av_contract: Dict[str, Any] | None = None
+        self._av_contract: dict[str, Any] | None = None
         self._next_element_index = self.element_index_offset
         self._current_segment_has_speakable_text = False
 

--- a/src/api/flaskr/service/tts/tts_handler.py
+++ b/src/api/flaskr/service/tts/tts_handler.py
@@ -4,7 +4,6 @@ This module provides OSS upload utility for TTS audio files.
 """
 
 import logging
-from typing import Tuple
 
 from flask import Flask
 from flaskr.common.log import AppLoggerProxy
@@ -16,7 +15,7 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 
 def upload_audio_to_oss(
     app: Flask, audio_content: bytes, audio_bid: str
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Upload audio to OSS.
 
     Args:

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 from flask import Flask
 from flaskr.service.common.dtos import UserInfo, UserToken
@@ -20,7 +20,7 @@ class ChallengeRequest(_BaseDTO):
     """Request payload for providers that deliver a verification challenge."""
 
     identifier: str = Field(..., description="Unique identifier such as phone or email")
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict, description="Provider-specific auxiliary data"
     )
 
@@ -30,7 +30,7 @@ class ChallengeResponse(_BaseDTO):
 
     identifier: str = Field(..., description="Identifier the challenge was sent to")
     expire_in: int = Field(..., description="Expiration time in seconds")
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict, description="Provider-specific auxiliary data"
     )
 
@@ -40,7 +40,7 @@ class VerificationRequest(_BaseDTO):
 
     identifier: str = Field(..., description="Identifier being verified")
     code: str = Field(..., description="Verification code or token")
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict, description="Provider-specific auxiliary data"
     )
 
@@ -50,7 +50,7 @@ class OAuthCallbackRequest(_BaseDTO):
 
     state: str | None = Field(None, description="Opaque state value returned by OAuth")
     code: str | None = Field(None, description="Authorization code or token")
-    raw_request_args: Dict[str, Any] = Field(
+    raw_request_args: dict[str, Any] = Field(
         default_factory=dict, description="Complete callback request arguments"
     )
     current_user_id: str | None = Field(
@@ -70,7 +70,7 @@ class AuthResult(_BaseDTO):
     is_new_user: bool = Field(
         False, description="Indicates whether the auth flow created a new user"
     )
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict, description="Provider-specific auxiliary data"
     )
 
@@ -99,7 +99,7 @@ class AuthProvider(ABC):
     def verify(self, app: Flask, request: VerificationRequest) -> AuthResult:
         """Validate a user based on the incoming verification request."""
 
-    def begin_oauth(self, app: Flask, metadata: Dict[str, Any]) -> Any:
+    def begin_oauth(self, app: Flask, metadata: dict[str, Any]) -> Any:
         """Initiate an OAuth flow (optional)."""
         raise NotImplementedError(
             f"Provider '{self.provider_name}' does not support OAuth begin"

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, Type
+from typing import Iterable
 
 from .base import AuthProvider
 
@@ -15,10 +15,10 @@ class ProviderNotFoundError(RuntimeError):
     """Raised when the requested provider has not been registered."""
 
 
-_REGISTRY: Dict[str, Type[AuthProvider]] = {}
+_REGISTRY: dict[str, type[AuthProvider]] = {}
 
 
-def register_provider(provider_cls: Type[AuthProvider]) -> None:
+def register_provider(provider_cls: type[AuthProvider]) -> None:
     """Register a provider class with the global registry."""
     provider_name = getattr(provider_cls, "provider_name", None)
     if not provider_name:

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 import time
-from typing import Any, Dict
+from typing import Any
 
 import jwt
 from authlib.integrations.requests_client import OAuth2Session
@@ -45,7 +45,7 @@ USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
 STATE_TTL = 900
 
 
-def _encode_state(app, payload: Dict[str, Any]) -> str:
+def _encode_state(app, payload: dict[str, Any]) -> str:
     now = int(time.time())
     return jwt.encode(
         {
@@ -59,7 +59,7 @@ def _encode_state(app, payload: Dict[str, Any]) -> str:
     )
 
 
-def _decode_state(app, state: str) -> Dict[str, Any] | None:
+def _decode_state(app, state: str) -> dict[str, Any] | None:
     try:
         decoded = jwt.decode(state, app.config["SECRET_KEY"], algorithms=["HS256"])
     except jwt.exceptions.ExpiredSignatureError:
@@ -130,7 +130,7 @@ class GoogleAuthProvider(AuthProvider):
             redirect_uri=redirect_uri,
         )
 
-    def begin_oauth(self, app, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def begin_oauth(self, app, metadata: dict[str, Any]) -> dict[str, Any]:
         redirect_uri = _resolve_redirect_uri(app, metadata.get("redirect_uri"))
         login_context = metadata.get("login_context")
         session = self._create_session(app, redirect_uri)
@@ -144,13 +144,13 @@ class GoogleAuthProvider(AuthProvider):
         # flow we only need an authorization code to fetch basic profile info.
         # Forcing "prompt=consent" and "access_type=offline" can add extra Google
         # interstitial/confirmation steps and degrades UX.
-        create_url_kwargs: Dict[str, Any] = {}
+        create_url_kwargs: dict[str, Any] = {}
         # Google respects both "hl" and (for some flows) "ui_locales".
         if ui_language:
             create_url_kwargs["hl"] = ui_language
             create_url_kwargs["ui_locales"] = ui_language
 
-        state_payload: Dict[str, Any] = {
+        state_payload: dict[str, Any] = {
             "redirect_uri": redirect_uri,
             "login_context": login_context,
         }
@@ -254,7 +254,7 @@ class GoogleAuthProvider(AuthProvider):
                     aggregate.user_bid, include_deleted=True
                 )
                 if entity:
-                    updates: Dict[str, Any] = {"identify": email}
+                    updates: dict[str, Any] = {"identify": email}
                     if email_verified and aggregate.state in (
                         USER_STATE_UNREGISTERED,
                         0,

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -89,7 +89,7 @@ def verify_email_code(
     code: str,
     course_id: str | None = None,
     language: str | None = None,
-) -> Tuple[UserToken, bool, Dict[str, str | None]]:
+) -> tuple[UserToken, bool, dict[str, str | None]]:
     # Local import avoids circular dependency during module initialization.
     from flaskr.service.profile.funcs import (
         get_user_profile_labels,
@@ -191,7 +191,7 @@ def verify_email_code(
                 target_aggregate.user_bid, include_deleted=True
             )
             if entity:
-                updates: Dict[str, Any] = {"identify": normalized_email}
+                updates: dict[str, Any] = {"identify": normalized_email}
                 promote_state = target_aggregate.state in (
                     USER_STATE_UNREGISTERED,
                     0,

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -281,7 +281,7 @@ def verify_phone_code(
     course_id: str | None = None,
     language: str | None = None,
     login_context: str | None = None,
-) -> Tuple[UserToken, bool, Dict[str, str | None]]:
+) -> tuple[UserToken, bool, dict[str, str | None]]:
     # Local import avoids circular dependency during module initialization.
     from flaskr.service.profile.funcs import (
         get_user_profile_labels,
@@ -427,7 +427,7 @@ def verify_phone_code(
                 target_aggregate.user_bid, include_deleted=True
             )
             if entity:
-                updates: Dict[str, Any] = {"identify": normalized_phone}
+                updates: dict[str, Any] = {"identify": normalized_phone}
                 promote_state = target_aggregate.state in (
                     USER_STATE_UNREGISTERED,
                     0,

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -7,7 +7,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import (
@@ -63,7 +63,7 @@ class CredentialSummary:
     subject_id: str
     subject_format: str
     state: int
-    metadata: Dict[str, str | None] = field(default_factory=dict)
+    metadata: dict[str, str | None] = field(default_factory=dict)
 
     @property
     def is_verified(self) -> bool:
@@ -85,7 +85,7 @@ class UserAggregate:
     created_at: datetime
     creator_activated_at: datetime | None
     updated_at: datetime
-    credentials: List[CredentialSummary] = field(default_factory=list)
+    credentials: list[CredentialSummary] = field(default_factory=list)
     is_creator: bool = False
     is_operator: bool = False
 
@@ -214,9 +214,9 @@ def _normalize_identifier(provider: str, identifier: str | None) -> str:
 
 
 def _summarize_credentials(
-    credentials: List[AuthCredential],
-) -> List[CredentialSummary]:
-    summaries: List[CredentialSummary] = []
+    credentials: list[AuthCredential],
+) -> list[CredentialSummary]:
+    summaries: list[CredentialSummary] = []
     for credential in credentials:
         summaries.append(
             CredentialSummary(
@@ -235,7 +235,7 @@ def _summarize_credentials(
 def _build_user_aggregate(
     entity: UserEntity,
     *,
-    credentials: List[AuthCredential] | None = None,
+    credentials: list[AuthCredential] | None = None,
 ) -> UserAggregate:
     summaries = _summarize_credentials(credentials or [])
     return UserAggregate(
@@ -335,7 +335,7 @@ def load_user_aggregate(
     entity = get_user_entity_by_bid(user_bid, include_deleted=include_deleted)
     if not entity:
         return None
-    credentials: List[AuthCredential] = []
+    credentials: list[AuthCredential] = []
     if with_credentials:
         credentials = list_credentials(user_bid=user_bid)
     return _build_user_aggregate(entity, credentials=credentials)
@@ -344,7 +344,7 @@ def load_user_aggregate(
 def load_user_aggregate_by_identifier(
     identifier: str,
     *,
-    providers: List[str] | None = None,
+    providers: list[str] | None = None,
 ) -> UserAggregate | None:
     normalized = identifier.strip() if identifier else ""
     if not normalized:
@@ -395,8 +395,8 @@ def ensure_user_aggregate(
     app: Flask,
     *,
     user_bid: str,
-    defaults: Dict[str, Any] | None = None,
-) -> Tuple[UserAggregate, bool]:
+    defaults: dict[str, Any] | None = None,
+) -> tuple[UserAggregate, bool]:
     """Ensure a user aggregate exists for ``user_bid``.
 
     Returns the aggregate together with a flag indicating whether it was created.
@@ -416,8 +416,8 @@ def ensure_user_for_identifier(
     *,
     provider: str,
     identifier: str,
-    defaults: Dict[str, Any] | None = None,
-) -> Tuple[UserAggregate, bool]:
+    defaults: dict[str, Any] | None = None,
+) -> tuple[UserAggregate, bool]:
     """Find or create a user aggregate bound to a provider identifier."""
     defaults = defaults or {}
     normalized = _normalize_identifier(provider, identifier)
@@ -545,8 +545,8 @@ def update_user_entity_fields(
 def upsert_user_entity(
     *,
     user_bid: str,
-    defaults: Dict[str, Any] | None = None,
-) -> Tuple[UserEntity, bool]:
+    defaults: dict[str, Any] | None = None,
+) -> tuple[UserEntity, bool]:
     defaults = dict(defaults or {})
     entity = get_user_entity_by_bid(user_bid, include_deleted=True)
     created = False
@@ -617,10 +617,10 @@ def _normalize_user_state(raw_state) -> int:
 @dataclass
 class UserProfileSnapshot:
     user_bid: str
-    legacy: Dict[str, Any] = field(default_factory=dict)
-    credentials: List[Dict[str, str | None]] = field(default_factory=list)
+    legacy: dict[str, Any] = field(default_factory=dict)
+    credentials: list[dict[str, str | None]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "user_bid": self.user_bid,
             "legacy": self.legacy,
@@ -664,13 +664,13 @@ def build_user_profile_snapshot_from_aggregate(
     )
 
 
-def serialize_raw_profile(provider_name: str, metadata: Dict[str, str | None]) -> str:
+def serialize_raw_profile(provider_name: str, metadata: dict[str, str | None]) -> str:
     return json.dumps(
         {"provider": provider_name, "metadata": metadata}, ensure_ascii=False
     )
 
 
-def deserialize_raw_profile(record: AuthCredential) -> Dict[str, str | None]:
+def deserialize_raw_profile(record: AuthCredential) -> dict[str, str | None]:
     if not record.raw_profile:
         return {}
     try:
@@ -693,7 +693,7 @@ def get_password_hash(credential: AuthCredential) -> str:
 
 def set_password_hash(credential: AuthCredential, password_hash: str) -> None:
     """Write password_hash into raw_profile JSON, preserving other fields."""
-    payload: Dict[str, Any] = {}
+    payload: dict[str, Any] = {}
     if credential.raw_profile:
         try:
             payload = json.loads(credential.raw_profile)
@@ -713,7 +713,7 @@ def upsert_credential(
     subject_id: str,
     subject_format: str,
     identifier: str,
-    metadata: Dict[str, str | None],
+    metadata: dict[str, str | None],
     verified: bool,
 ) -> AuthCredential:
     raw_identifier = (identifier or "").strip()
@@ -780,7 +780,7 @@ def find_credential(
 
 def list_credentials(
     *, user_bid: str, provider_name: str | None = None
-) -> List[AuthCredential]:
+) -> list[AuthCredential]:
     query = AuthCredential.query.filter_by(user_bid=user_bid, deleted=0)
     if provider_name:
         query = query.filter_by(provider_name=provider_name)
@@ -811,11 +811,11 @@ def upsert_wechat_credentials(
     union_id: str | None,
     open_identifier: str | None = None,
     union_identifier: str | None = None,
-    metadata: Dict[str, str | None] | None = None,
+    metadata: dict[str, str | None] | None = None,
     verified: bool = True,
-) -> List[AuthCredential]:
+) -> list[AuthCredential]:
     metadata = metadata or {}
-    credentials: List[AuthCredential] = []
+    credentials: list[AuthCredential] = []
 
     if open_id:
         credentials.append(

--- a/src/api/tests/common/fixtures/fake_llm.py
+++ b/src/api/tests/common/fixtures/fake_llm.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Generator, List
+from typing import Generator
 
 
 class FakeLLMResponse:
@@ -22,7 +22,7 @@ class FakeLLMResponse:
         self.choices = [SimpleNamespace(delta=SimpleNamespace(content=result))]
 
 
-def _stream_chunks(stream: bool) -> List[str]:
+def _stream_chunks(stream: bool) -> list[str]:
     if stream:
         return ["mock-", "llm"]
     return ["mock-llm"]

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -1,9 +1,9 @@
 import time
-from typing import Any, Dict
+from typing import Any
 
 
 class FakeRedisLock:
-    def __init__(self, locks: Dict[str, bool], key: str):
+    def __init__(self, locks: dict[str, bool], key: str):
         self._locks = locks
         self._key = key
         self._held = False
@@ -23,9 +23,9 @@ class FakeRedisLock:
 
 class FakeRedis:
     def __init__(self):
-        self._store: Dict[str, Any] = {}
-        self._expires: Dict[str, float] = {}
-        self._locks: Dict[str, bool] = {}
+        self._store: dict[str, Any] = {}
+        self._expires: dict[str, float] = {}
+        self._locks: dict[str, bool] = {}
 
     def _now(self) -> float:
         return time.time()

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -3,7 +3,6 @@
 import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import List
 
 from flaskr.route.common import fmt
 from flaskr.service.common.dto_base import AutoJsonMixin
@@ -22,8 +21,8 @@ class SampleDTO(AutoJsonMixin, BaseModel):
     amount: Decimal | None = Field(default=None)
     happened_at: datetime | None = Field(default=None)
     child: ChildDTO | None = Field(default=None)
-    children: List[ChildDTO] = Field(default_factory=list)
-    tags: List[str] = Field(default_factory=list)
+    children: list[ChildDTO] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
 
 
 class RenamedDTO(AutoJsonMixin, BaseModel):
@@ -32,7 +31,7 @@ class RenamedDTO(AutoJsonMixin, BaseModel):
 
     page: int = Field(...)
     internal_state: int = Field(default=0)
-    data: List[str] = Field(default_factory=list)
+    data: list[str] = Field(default_factory=list)
 
 
 def test_json_emits_fields_in_declaration_order_with_identity_keys():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **03 / 22**. Base: `cursor/ruff-up045-5253` (#2476).

Enables `UP006` and rewrites `typing.List` / `Dict` / `Tuple` annotations to `list` / `dict` / `tuple` (PEP 585, Python 3.11). Drops unused typing imports from package `__init__` modules that ruff will not auto-fix (re-export unsafe).

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows UP045. Next: PTH109 (#2479).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

