### PR TITLE
style: enforce ruff PTH109 (os.getcwd to Path.cwd)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -195,6 +195,7 @@ select = [
     "FURB157", # verbose Decimal constructor
     "UP045", # Optional[T] to T | None
     "UP006", # List[T] to list[T]
+    "PTH109", # os.getcwd to Path.cwd
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -21,10 +21,11 @@ Environment:
 import os
 import re
 import subprocess
+from pathlib import Path
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."))
-SP = os.environ.get("INVENTORY_WORK_DIR", os.getcwd())
+SP = os.environ.get("INVENTORY_WORK_DIR", str(Path.cwd()))
 BACKEND_ROUTES = os.path.join(SP, "routes-backend.txt")
 SKILLS = os.environ.get(
     "SKILLS_REPO", os.path.abspath(os.path.join(ROOT, "..", "skills"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **04 / 22**. Base: `cursor/ruff-up006-5253` (#2478).

Enables `PTH109` and replaces `os.getcwd()` with `str(Path.cwd())` in `src/api/scripts/inventory/match_routes.py`. The default inventory work dir stays a `str` so later path joins are unchanged.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows UP006. Next: PTH107 (#2483).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

