### PR TITLE
style: enforce ruff PTH106 (os.rmdir to Path.rmdir)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -197,6 +197,7 @@ select = [
     "UP006", # List[T] to list[T]
     "PTH109", # os.getcwd to Path.cwd
     "PTH107", # os.remove to Path.unlink
+    "PTH106", # os.rmdir to Path.rmdir
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -2105,7 +2105,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         def cleanup(response):
             try:
                 file_path.unlink()
-                os.rmdir(temp_dir)
+                Path(temp_dir).rmdir()
             except OSError:
                 current_app.logger.warning(
                     "Failed to cleanup shifu export temp files", exc_info=True

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -29,7 +29,6 @@ Date: 2025-08-07
 """
 
 import json
-import os
 import re
 import tempfile
 import uuid


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **06 / 22**. Base: `cursor/ruff-pth107-5253` (#2483).

Replaces `os.rmdir(temp_dir)` with `Path(temp_dir).rmdir()` in the same shifu export cleanup path, drops the now-unused `os` import, and enables `PTH106` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH107. Next: ARG004 (#2482).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

