### PR TITLE
style: enforce ruff ARG004 (unused staticmethod argument)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -198,6 +198,7 @@ select = [
     "PTH109", # os.getcwd to Path.cwd
     "PTH107", # os.remove to Path.unlink
     "PTH106", # os.rmdir to Path.rmdir
+    "ARG004", # unused staticmethod argument
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1672,7 +1672,7 @@ class RunScriptContextV2:
             yield item
 
     @staticmethod
-    def get_current_context(app: Flask) -> Union["RunScriptContextV2", None]:
+    def get_current_context(_app: Flask) -> Union["RunScriptContextV2", None]:
         if not hasattr(context_local, "current_context"):
             return None
         return context_local.current_context


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **07 / 22**. Base: `cursor/ruff-pth106-5253` (#2480).

Renames the unused staticmethod argument `get_current_context(app)` to `_app` in `learn/context_v2.py` and enables `ARG004` in `ruff.toml`. Callers still pass the Flask app positionally.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH106. Next: PLW1641 (#2481).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

