### PR TITLE
style: enforce ruff PTH107 (os.remove to Path.unlink)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -196,6 +196,7 @@ select = [
     "UP045", # Optional[T] to T | None
     "UP006", # List[T] to list[T]
     "PTH109", # os.getcwd to Path.cwd
+    "PTH107", # os.remove to Path.unlink
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -2104,7 +2104,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         @after_this_request
         def cleanup(response):
             try:
-                os.remove(file_path)
+                file_path.unlink()
                 os.rmdir(temp_dir)
             except OSError:
                 current_app.logger.warning(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **05 / 22**. Base: `cursor/ruff-pth109-5253` (#2479).

Replaces `os.remove(file_path)` with `file_path.unlink()` in the shifu export cleanup path and enables `PTH107` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH109. Next: PTH106 (#2480).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

