### PR TITLE
style: enforce ruff PTH119 (os.path.basename to Path.name)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -200,6 +200,7 @@ select = [
     "PTH106", # os.rmdir to Path.rmdir
     "ARG004", # unused staticmethod argument
     "PLW1641", # __eq__ without __hash__
+    "PTH119", # os.path.basename to Path.name
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 from io import BytesIO
+from pathlib import Path
 
 import click
 from flask import Flask
@@ -374,7 +375,7 @@ def enable_commands(app: Flask):
             # Create FileStorage from bytes
             file_storage = FileStorage(
                 stream=BytesIO(file_content),
-                filename=os.path.basename(file_path),
+                filename=Path(file_path).name,
                 name="file",
             )
 

--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import os
 from io import BytesIO
 from pathlib import Path
 
@@ -74,7 +73,7 @@ def _process_demo_shifu(
     # Create FileStorage from bytes
     file_storage = FileStorage(
         stream=BytesIO(file_content),
-        filename=os.path.basename(demo_file_path),
+        filename=demo_file_path.name,
         name="file",
     )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **09 / 22**. Base: `cursor/ruff-plw1641-5253` (#2481).

Replaces `os.path.basename(...)` with `Path(...).name` in the shifu import CLI helpers and enables `PTH119` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PLW1641. Next: PTH103 (#2485).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

