### PR TITLE
style: enforce ruff PTH103 (os.makedirs to Path.mkdir)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -201,6 +201,7 @@ select = [
     "ARG004", # unused staticmethod argument
     "PLW1641", # __eq__ without __hash__
     "PTH119", # os.path.basename to Path.name
+    "PTH103", # os.makedirs to Path.mkdir
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 
 import colorlog
 import pytz
@@ -232,7 +233,7 @@ def init_log(app: Flask) -> Flask:
     log_file = app.config.get("LOGGING_PATH", "logs/ai-shifu.log")
     log_dir = os.path.dirname(log_file)
     if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
+        Path(log_dir).mkdir(parents=True)
     file_handler = TimedRotatingFileHandler(log_file, when="midnight", backupCount=7)
     file_handler.setFormatter(formatter)
     console_handler = logging.StreamHandler()

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -1,6 +1,7 @@
 import json
 import os
 from decimal import Decimal
+from pathlib import Path
 
 from flask import Flask
 from flaskr.common.i18n_utils import get_markdownflow_output_language
@@ -127,10 +128,7 @@ def export_shifu(app: Flask, shifu_id: str, file_path: str) -> str:
         }
 
         # Write to file
-        os.makedirs(
-            os.path.dirname(file_path) or ".",
-            exist_ok=True,
-        )
+        Path(os.path.dirname(file_path) or ".").mkdir(parents=True, exist_ok=True)
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(export_data, f, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **10 / 22**. Base: `cursor/ruff-pth119-5253` (#2484).

Replaces `os.makedirs(...)` with `Path(...).mkdir(parents=True)` in log directory setup and shifu export, and enables `PTH103` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH119. Next: PTH206 (#2486).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

