### PR TITLE
style: enforce ruff PTH206 (os.sep split to Path.parts)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -202,6 +202,7 @@ select = [
     "PLW1641", # __eq__ without __hash__
     "PTH119", # os.path.basename to Path.name
     "PTH103", # os.makedirs to Path.mkdir
+    "PTH206", # os.sep split to Path.parts
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -23,6 +23,7 @@ import ast
 import os
 import sys
 from collections import defaultdict
+from pathlib import Path
 
 ROOT = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
@@ -36,7 +37,7 @@ def add_tree(base_pkg, base_dir):
     for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, base_dir)):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
         rel = os.path.relpath(dirpath, ROOT)
-        parts = rel.split(os.sep)
+        parts = Path(rel).parts
         for fn in filenames:
             if not fn.endswith(".py"):
                 continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **11 / 22**. Base: `cursor/ruff-pth103-5253` (#2485).

Replaces `rel.split(os.sep)` with `Path(rel).parts` in the import-graph inventory script and enables `PTH206` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH103. Next: PTH112 (#2487).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

