### PR TITLE
style: enforce ruff PTH112 (os.path.isdir to Path.is_dir)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -203,6 +203,7 @@ select = [
     "PTH119", # os.path.basename to Path.name
     "PTH103", # os.makedirs to Path.mkdir
     "PTH206", # os.sep split to Path.parts
+    "PTH112", # os.path.isdir to Path.is_dir
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 import click
 from alembic import command
@@ -42,7 +43,7 @@ def enable_plugins(app: Flask):
         plugins = [
             name
             for name in os.listdir(plugins_dir)
-            if os.path.isdir(os.path.join(plugins_dir, name))
+            if Path(os.path.join(plugins_dir, name)).is_dir()
         ]
         for plugin in plugins:
             if plugin == "__pycache__":

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -1,8 +1,8 @@
 import importlib
 import os
 from functools import partial
-from pathlib import Path
 from inspect import getmembers, isfunction
+from pathlib import Path
 
 from flask import Flask
 

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 from functools import partial
+from pathlib import Path
 from inspect import getmembers, isfunction
 
 from flask import Flask
@@ -49,7 +50,7 @@ def load_plugins_from_dir(
             file_path = os.path.join(directory, filename)
             if filename == TRANSLATIONS_DEFAULT_NAME:
                 load_translations(app, file_path)
-            elif os.path.isdir(file_path):
+            elif Path(file_path).is_dir():
                 load_from_directory(file_path, plugin_manager)
             elif filename.endswith(".py") and filename != "__init__.py":
                 module_name = filename[:-3]
@@ -65,7 +66,7 @@ def load_plugins_from_dir(
     with app.app_context():
         files = os.listdir(plugins_dir)
         for file in files:
-            if os.path.isdir(os.path.join(plugins_dir, file)):
+            if Path(os.path.join(plugins_dir, file)).is_dir():
                 app.logger.info(f"begin load plugin: {file}")
                 try:
                     load_from_directory(os.path.join(plugins_dir, file), plugin_manager)

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -220,11 +220,11 @@ def _load_python_translations(app: Flask, translations_dir: Path):
 
     for lang in os.listdir(translations_dir):
         lang_dir = os.path.join(translations_dir, lang)
-        if os.path.isdir(lang_dir) and lang_dir != "__pycache__" and lang_dir[0] != ".":
+        if Path(lang_dir).is_dir() and lang_dir != "__pycache__" and lang_dir[0] != ".":
             app.logger.info("load_python_translations lang: %s", lang)
             for module_name in os.listdir(lang_dir):
                 module_path = os.path.join(lang_dir, module_name)
-                if os.path.isdir(module_path):
+                if Path(module_path).is_dir():
                     for file_name in os.listdir(module_path):
                         if file_name.endswith(".py"):
                             file_path = os.path.join(module_path, file_name)

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -121,7 +121,7 @@ for name, rel in mods.items():
 svc_dir = os.path.join(ROOT, "flaskr", "service")
 for top in sorted(os.listdir(svc_dir)):
     top_path = os.path.join(svc_dir, top)
-    if not os.path.isdir(top_path):
+    if not Path(top_path).is_dir():
         continue
     for dirpath, dirnames, filenames in os.walk(top_path):
         dirnames[:] = [

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -47,7 +47,7 @@ def norm(path):
 
 
 def grep_paths(root, extra_args=None):
-    if not os.path.isdir(root):
+    if not Path(root).is_dir():
         return set()
     # no quote anchoring: f-strings like f"{base}/api/x/{bid}/export" must hit
     cmd = ["grep", "-rhoE", r"/api/[^'\"`[:space:]]*", root]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **12 / 22**. Base: `cursor/ruff-pth206-5253` (#2486).

Replaces `os.path.isdir(...)` with `Path(...).is_dir()` in plugin loaders, i18n discovery, and inventory scripts, and enables `PTH112` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH206. Next: PTH120 (#2488).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

