### PR TITLE
style: enforce ruff PTH120 (os.path.dirname to Path.parent)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -204,6 +204,7 @@ select = [
     "PTH103", # os.makedirs to Path.mkdir
     "PTH206", # os.sep split to Path.parts
     "PTH112", # os.path.isdir to Path.is_dir
+    "PTH120", # os.path.dirname to Path.parent
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -231,7 +231,7 @@ def init_log(app: Flask) -> Flask:
         },
     )
     log_file = app.config.get("LOGGING_PATH", "logs/ai-shifu.log")
-    log_dir = os.path.dirname(log_file)
+    log_dir = str(Path(log_file).parent)
     if not os.path.exists(log_dir):
         Path(log_dir).mkdir(parents=True)
     file_handler = TimedRotatingFileHandler(log_file, when="midnight", backupCount=7)

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -9,6 +9,7 @@ import select as select_module
 import sys
 import time
 import traceback
+from pathlib import Path
 
 import sqlparse
 from flask import Flask
@@ -599,7 +600,7 @@ def init_db(app: Flask):
             ):
                 stack = traceback.extract_stack()
                 project_root = os.path.abspath(
-                    os.path.join(os.path.dirname(__file__), "../../../")
+                    os.path.join(str(Path(__file__).parent), "../../../")
                 )
                 caller_info = "Unknown location"
 

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -1,5 +1,4 @@
 import json
-import os
 from decimal import Decimal
 from pathlib import Path
 
@@ -128,7 +127,7 @@ def export_shifu(app: Flask, shifu_id: str, file_path: str) -> str:
         }
 
         # Write to file
-        Path(os.path.dirname(file_path) or ".").mkdir(parents=True, exist_ok=True)
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(export_data, f, ensure_ascii=False, indent=2)
 

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 
 def load_prompt_template(template_name: str) -> str:
@@ -15,7 +16,7 @@ def load_prompt_template(template_name: str) -> str:
 
     """
     # Get the directory of current file
-    current_dir = os.path.dirname(os.path.abspath(__file__))
+    current_dir = str(Path(os.path.abspath(__file__)).parent)
     # Build prompts directory path
     prompts_dir = os.path.join(current_dir, "../../prompts")
 

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -12,9 +12,10 @@ Handles:
 
 import ast
 import os
+from pathlib import Path
 
 ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+    os.path.join(str(Path(os.path.abspath(__file__)).parent), "..", "..")
 )
 
 CALLED_PREFIX = {

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from pathlib import Path
 
 ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+    os.path.join(str(Path(os.path.abspath(__file__)).parent), "..", "..")
 )
 
 # ---- collect all project modules -----------------------------------------

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 from pathlib import Path
 
-_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT_DIR = str(Path(os.path.abspath(__file__)).parent)
 ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."))
 SP = os.environ.get("INVENTORY_WORK_DIR", str(Path.cwd()))
 BACKEND_ROUTES = os.path.join(SP, "routes-backend.txt")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **13 / 22**. Base: `cursor/ruff-pth112-5253` (#2487).

Replaces `os.path.dirname(...)` with `Path(...).parent` (stringified where callers still expect `str`) in log setup, SQL caller tracing, shifu export, prompt loading, and inventory scripts, and enables `PTH120` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH112. Next: PTH100 (#2489).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

