### PR TITLE
style: enforce ruff PTH100 (os.path.abspath to Path.resolve)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -205,6 +205,7 @@ select = [
     "PTH206", # os.sep split to Path.parts
     "PTH112", # os.path.isdir to Path.is_dir
     "PTH120", # os.path.dirname to Path.parent
+    "PTH100", # os.path.abspath to Path.resolve
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -599,8 +599,10 @@ def init_db(app: Flask):
                 conn, cursor, statement, parameters, context, executemany
             ):
                 stack = traceback.extract_stack()
-                project_root = os.path.abspath(
-                    os.path.join(str(Path(__file__).parent), "../../../")
+                project_root = str(
+                    Path(
+                        os.path.join(str(Path(__file__).parent), "../../../")
+                    ).resolve()
                 )
                 caller_info = "Unknown location"
 

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -16,7 +16,7 @@ def load_prompt_template(template_name: str) -> str:
 
     """
     # Get the directory of current file
-    current_dir = str(Path(os.path.abspath(__file__)).parent)
+    current_dir = str(Path(__file__).resolve().parent)
     # Build prompts directory path
     prompts_dir = os.path.join(current_dir, "../../prompts")
 

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -14,8 +14,8 @@ import ast
 import os
 from pathlib import Path
 
-ROOT = os.path.abspath(
-    os.path.join(str(Path(os.path.abspath(__file__)).parent), "..", "..")
+ROOT = str(
+    Path(os.path.join(str(Path(__file__).resolve().parent), "..", "..")).resolve()
 )
 
 CALLED_PREFIX = {

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -25,8 +25,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ROOT = os.path.abspath(
-    os.path.join(str(Path(os.path.abspath(__file__)).parent), "..", "..")
+ROOT = str(
+    Path(os.path.join(str(Path(__file__).resolve().parent), "..", "..")).resolve()
 )
 
 # ---- collect all project modules -----------------------------------------

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -23,12 +23,12 @@ import re
 import subprocess
 from pathlib import Path
 
-_SCRIPT_DIR = str(Path(os.path.abspath(__file__)).parent)
-ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."))
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+ROOT = str(Path(os.path.join(_SCRIPT_DIR, "..", "..", "..", "..")).resolve())
 SP = os.environ.get("INVENTORY_WORK_DIR", str(Path.cwd()))
 BACKEND_ROUTES = os.path.join(SP, "routes-backend.txt")
 SKILLS = os.environ.get(
-    "SKILLS_REPO", os.path.abspath(os.path.join(ROOT, "..", "skills"))
+    "SKILLS_REPO", str(Path(os.path.join(ROOT, "..", "skills")).resolve())
 )
 MINIAPP = os.environ.get("MINIAPP_REPO", "")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **14 / 22**. Base: `cursor/ruff-pth120-5253` (#2488).

Replaces `os.path.abspath(...)` with `Path(...).resolve()` (stringified where callers still expect `str`) in SQL caller tracing, prompt loading, and inventory scripts, and enables `PTH100` in `ruff.toml`.

`Path.resolve()` follows symlinks; these call sites are `__file__`-relative repo roots, so the resolved path is the intended one.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH120. Next: PTH110 (#2490).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

