### PR TITLE
style: enforce ruff PTH110 (os.path.exists to Path.exists)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -206,6 +206,7 @@ select = [
     "PTH112", # os.path.isdir to Path.is_dir
     "PTH120", # os.path.dirname to Path.parent
     "PTH100", # os.path.abspath to Path.resolve
+    "PTH110", # os.path.exists to Path.exists
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 from io import BytesIO
 from pathlib import Path
 
@@ -358,7 +357,7 @@ def enable_commands(app: Flask):
         """
         try:
             # Check if file exists
-            if not os.path.exists(file_path):
+            if not Path(file_path).exists():
                 raise click.ClickException(f"File not found: {file_path}")
 
             click.echo(f"Importing shifu from {file_path}...")

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import socket
 import threading
 import time
@@ -232,7 +231,7 @@ def init_log(app: Flask) -> Flask:
     )
     log_file = app.config.get("LOGGING_PATH", "logs/ai-shifu.log")
     log_dir = str(Path(log_file).parent)
-    if not os.path.exists(log_dir):
+    if not Path(log_dir).exists():
         Path(log_dir).mkdir(parents=True)
     file_handler = TimedRotatingFileHandler(log_file, when="midnight", backupCount=7)
     file_handler.setFormatter(formatter)

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -23,7 +23,7 @@ def enable_plugins(app: Flask):
         """Add a plugin by cloning the repository."""
         repo_name = repo_url.split("/")[-1].replace(".git", "")
         dest_dir = os.path.join("flaskr", "plugins", repo_name)
-        if os.path.exists(dest_dir):
+        if Path(dest_dir).exists():
             return
         subprocess.run(["git", "clone", repo_url, dest_dir], check=False)
 
@@ -32,7 +32,7 @@ def enable_plugins(app: Flask):
     def delete(repo_name):
         """Delete a plugin by its repository name."""
         dest_dir = os.path.join("flaskr", "plugins", repo_name)
-        if not os.path.exists(dest_dir):
+        if not Path(dest_dir).exists():
             return
         shutil.rmtree(dest_dir)
 
@@ -59,7 +59,7 @@ def enable_plugins(app: Flask):
             app.logger.info(
                 f"plugin: {plugin.name}, migration_dir: {plugin.migration_dir}"
             )
-            if plugin.migration_dir and os.path.exists(plugin.migration_dir):
+            if plugin.migration_dir and Path(plugin.migration_dir).exists():
                 plugins.append(plugin)
         return plugins
 

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import base64
 import json
-import os
 import re
 import threading
 from functools import wraps
+from pathlib import Path
 from typing import Any
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -70,7 +70,7 @@ class PingxxProvider(PaymentProvider):
         private_key_path = get_config("PINGXX_PRIVATE_KEY_PATH")
         if not private_key and not private_key_path:
             raise RuntimeError("Pingxx private key is not configured")
-        if not private_key and not os.path.exists(private_key_path):
+        if not private_key and not Path(private_key_path).exists():
             app.logger.error("Pingxx private key not found at %s", private_key_path)
             raise FileNotFoundError(private_key_path)
 

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -28,7 +28,7 @@ def load_prompt_template(template_name: str) -> str:
     template_path = os.path.join(prompts_dir, template_name)
 
     # Check if file exists
-    if not os.path.exists(template_path):
+    if not Path(template_path).exists():
         raise FileNotFoundError(f"Prompt template file not found: {template_path}")
 
     # Read file content

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -51,7 +51,7 @@ def add_tree(base_pkg, base_dir):
 add_tree("flaskr", "flaskr")
 add_tree("scripts", "scripts")
 for top in ("app.py", "celery_app.py"):
-    if os.path.exists(os.path.join(ROOT, top)):
+    if Path(os.path.join(ROOT, top)).exists():
         mods[top[:-3]] = top
 
 # ---- parse imports ---------------------------------------------------------

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -88,7 +88,7 @@ surfaces["cook-web"] = fe
 cli = grep_paths(SKILLS)
 # relative paths in shifu-cli.py are joined onto /api/shifu
 cli_file = os.path.join(SKILLS, "skills/ai-shifu-course-creator/scripts/shifu-cli.py")
-if os.path.exists(cli_file):
+if Path(cli_file).exists():
     with open(cli_file, encoding="utf-8") as cli_source:
         src = cli_source.read()
     for m in re.finditer(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **15 / 22**. Base: `cursor/ruff-pth100-5253` (#2489).

Replaces `os.path.exists(...)` with `Path(...).exists()` in CLI import, log setup, plugin commands, Pingxx private-key loading, prompt loading, and inventory scripts, and enables `PTH110` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH100. Next: PTH208 (#2491).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

