### PR TITLE
style: enforce ruff PTH208 (os.listdir to Path.iterdir)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -207,6 +207,7 @@ select = [
     "PTH120", # os.path.dirname to Path.parent
     "PTH100", # os.path.abspath to Path.resolve
     "PTH110", # os.path.exists to Path.exists
+    "PTH208", # os.listdir to Path.iterdir
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -40,11 +40,7 @@ def enable_plugins(app: Flask):
     def list():
         """List all plugins."""
         plugins_dir = os.path.join("flaskr", "plugins")
-        plugins = [
-            name
-            for name in os.listdir(plugins_dir)
-            if Path(os.path.join(plugins_dir, name)).is_dir()
-        ]
+        plugins = [path.name for path in Path(plugins_dir).iterdir() if path.is_dir()]
         for plugin in plugins:
             if plugin == "__pycache__":
                 continue

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -23,10 +23,12 @@ def load_plugins_from_dir(
     app.logger.info(f"load modules from: {plugins_dir}")
 
     def load_from_directory(directory, plugin_manager: PluginManager = None):
-        files = os.listdir(directory)
+        files = [path.name for path in Path(directory).iterdir()]
         plugin_obj = None
         if SRC_DIR in files:
-            for filename in os.listdir(os.path.join(directory, SRC_DIR)):
+            for filename in [
+                path.name for path in Path(os.path.join(directory, SRC_DIR)).iterdir()
+            ]:
                 if filename.endswith(".py"):
                     plugin_obj = importlib.import_module(
                         f"{directory}.{SRC_DIR}.{filename[:-3]}".replace(os.sep, ".")
@@ -64,7 +66,7 @@ def load_plugins_from_dir(
                         wrapped_func()
 
     with app.app_context():
-        files = os.listdir(plugins_dir)
+        files = [path.name for path in Path(plugins_dir).iterdir()]
         for file in files:
             if Path(os.path.join(plugins_dir, file)).is_dir():
                 app.logger.info(f"begin load plugin: {file}")

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -218,14 +218,16 @@ def _load_python_translations(app: Flask, translations_dir: Path):
     if not translations_dir.exists():
         return
 
-    for lang in os.listdir(translations_dir):
+    for lang in (path.name for path in translations_dir.iterdir()):
         lang_dir = os.path.join(translations_dir, lang)
         if Path(lang_dir).is_dir() and lang_dir != "__pycache__" and lang_dir[0] != ".":
             app.logger.info("load_python_translations lang: %s", lang)
-            for module_name in os.listdir(lang_dir):
+            for module_name in (path.name for path in Path(lang_dir).iterdir()):
                 module_path = os.path.join(lang_dir, module_name)
                 if Path(module_path).is_dir():
-                    for file_name in os.listdir(module_path):
+                    for file_name in (
+                        path.name for path in Path(module_path).iterdir()
+                    ):
                         if file_name.endswith(".py"):
                             file_path = os.path.join(module_path, file_name)
                             spec = importlib.util.spec_from_file_location(

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -119,7 +119,7 @@ for name, rel in mods.items():
 
 # plugin scan: emulate load_plugins_from_dir over flaskr/service
 svc_dir = os.path.join(ROOT, "flaskr", "service")
-for top in sorted(os.listdir(svc_dir)):
+for top in sorted(path.name for path in Path(svc_dir).iterdir()):
     top_path = os.path.join(svc_dir, top)
     if not Path(top_path).is_dir():
         continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **16 / 22**. Base: `cursor/ruff-pth110-5253` (#2490).

Replaces `os.listdir(...)` with `Path(...).iterdir()` while keeping entry names as strings, and enables `PTH208` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH110. Next: PTH123 (#2492).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized directory scanning across plugin discovery, plugin management, translation loading, and inventory tools.
  * Improved consistency by using pathlib-based directory iteration.

* **Chores**
  * Added linting enforcement to identify legacy directory-listing patterns and encourage modern path handling.

* **Bug Fixes**
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->