### PR TITLE
style: enforce ruff PTH118 (os.path.join to Path slash)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -209,6 +209,7 @@ select = [
     "PTH110", # os.path.exists to Path.exists
     "PTH208", # os.listdir to Path.iterdir
     "PTH123", # open() to Path.open
+    "PTH118", # os.path.join to Path slash
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,5 +1,6 @@
 import os
 import time
+from pathlib import Path
 
 from dotenv import load_dotenv
 from flasgger import Swagger
@@ -88,9 +89,9 @@ def create_app() -> Flask:
     from flaskr.framework.plugin.load_plugin import load_plugins_from_dir
     from flaskr.framework.plugin.plugin_manager import plugin_manager
 
-    load_plugins_from_dir(app, os.path.join("flaskr", "service"))
+    load_plugins_from_dir(app, str(Path("flaskr") / "service"))
     try:
-        load_plugins_from_dir(app, os.path.join("flaskr", "plugins"), plugin_manager)
+        load_plugins_from_dir(app, str(Path("flaskr") / "plugins"), plugin_manager)
     except Exception as e:
         app.logger.warning(f"load plugins error: {e}")
 

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -599,11 +599,7 @@ def init_db(app: Flask):
                 conn, cursor, statement, parameters, context, executemany
             ):
                 stack = traceback.extract_stack()
-                project_root = str(
-                    Path(
-                        os.path.join(str(Path(__file__).parent), "../../../")
-                    ).resolve()
-                )
+                project_root = str((Path(__file__).parent / "../../../").resolve())
                 caller_info = "Unknown location"
 
                 for frame in reversed(stack[:-2]):

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -22,7 +21,7 @@ def enable_plugins(app: Flask):
     def add(repo_url):
         """Add a plugin by cloning the repository."""
         repo_name = repo_url.split("/")[-1].replace(".git", "")
-        dest_dir = os.path.join("flaskr", "plugins", repo_name)
+        dest_dir = str(Path("flaskr") / "plugins" / repo_name)
         if Path(dest_dir).exists():
             return
         subprocess.run(["git", "clone", repo_url, dest_dir], check=False)
@@ -31,7 +30,7 @@ def enable_plugins(app: Flask):
     @click.argument("repo_name")
     def delete(repo_name):
         """Delete a plugin by its repository name."""
-        dest_dir = os.path.join("flaskr", "plugins", repo_name)
+        dest_dir = str(Path("flaskr") / "plugins" / repo_name)
         if not Path(dest_dir).exists():
             return
         shutil.rmtree(dest_dir)
@@ -39,7 +38,7 @@ def enable_plugins(app: Flask):
     @plugin.command(name="list")
     def list():
         """List all plugins."""
-        plugins_dir = os.path.join("flaskr", "plugins")
+        plugins_dir = str(Path("flaskr") / "plugins")
         plugins = [path.name for path in Path(plugins_dir).iterdir() if path.is_dir()]
         for plugin in plugins:
             if plugin == "__pycache__":

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -27,7 +27,7 @@ def load_plugins_from_dir(
         plugin_obj = None
         if SRC_DIR in files:
             for filename in [
-                path.name for path in Path(os.path.join(directory, SRC_DIR)).iterdir()
+                path.name for path in (Path(directory) / SRC_DIR).iterdir()
             ]:
                 if filename.endswith(".py"):
                     plugin_obj = importlib.import_module(
@@ -41,15 +41,15 @@ def load_plugins_from_dir(
                         ):
                             plugin_define = obj()
                             if MIGRATION_DIR in files:
-                                plugin_define.migration_dir = os.path.join(
-                                    directory, MIGRATION_DIR
+                                plugin_define.migration_dir = str(
+                                    Path(directory) / MIGRATION_DIR
                                 )
                             plugin_manager.plugins[plugin_define.name] = plugin_define
                             app.logger.info(f"load plugin: {plugin_define.name}")
         for filename in files:
             if filename in ("__pycache__", MIGRATION_DIR) or filename.startswith("."):
                 continue
-            file_path = os.path.join(directory, filename)
+            file_path = str(Path(directory) / filename)
             if filename == TRANSLATIONS_DEFAULT_NAME:
                 load_translations(app, file_path)
             elif Path(file_path).is_dir():
@@ -68,10 +68,10 @@ def load_plugins_from_dir(
     with app.app_context():
         files = [path.name for path in Path(plugins_dir).iterdir()]
         for file in files:
-            if Path(os.path.join(plugins_dir, file)).is_dir():
+            if (Path(plugins_dir) / file).is_dir():
                 app.logger.info(f"begin load plugin: {file}")
                 try:
-                    load_from_directory(os.path.join(plugins_dir, file), plugin_manager)
+                    load_from_directory(str(Path(plugins_dir) / file), plugin_manager)
                     app.logger.info(f"load plugin: {file} success")
                 except Exception as e:
                     app.logger.exception(f"load plugin: {file} error: {e}")

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -219,17 +219,17 @@ def _load_python_translations(app: Flask, translations_dir: Path):
         return
 
     for lang in (path.name for path in translations_dir.iterdir()):
-        lang_dir = os.path.join(translations_dir, lang)
+        lang_dir = str(Path(translations_dir) / lang)
         if Path(lang_dir).is_dir() and lang_dir != "__pycache__" and lang_dir[0] != ".":
             app.logger.info("load_python_translations lang: %s", lang)
             for module_name in (path.name for path in Path(lang_dir).iterdir()):
-                module_path = os.path.join(lang_dir, module_name)
+                module_path = str(Path(lang_dir) / module_name)
                 if Path(module_path).is_dir():
                     for file_name in (
                         path.name for path in Path(module_path).iterdir()
                     ):
                         if file_name.endswith(".py"):
-                            file_path = os.path.join(module_path, file_name)
+                            file_path = str(Path(module_path) / file_name)
                             spec = importlib.util.spec_from_file_location(
                                 module_name, file_path
                             )

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 
@@ -18,14 +17,14 @@ def load_prompt_template(template_name: str) -> str:
     # Get the directory of current file
     current_dir = str(Path(__file__).resolve().parent)
     # Build prompts directory path
-    prompts_dir = os.path.join(current_dir, "../../prompts")
+    prompts_dir = str(Path(current_dir) / "../../prompts")
 
     # Ensure filename has .md extension
     if not template_name.endswith(".md"):
         template_name = f"{template_name}.md"
 
     # Build complete file path
-    template_path = os.path.join(prompts_dir, template_name)
+    template_path = str(Path(prompts_dir) / template_name)
 
     # Check if file exists
     if not Path(template_path).exists():

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -14,9 +14,7 @@ import ast
 import os
 from pathlib import Path
 
-ROOT = str(
-    Path(os.path.join(str(Path(__file__).resolve().parent), "..", "..")).resolve()
-)
+ROOT = str((Path(__file__).resolve().parent / ".." / "..").resolve())
 
 CALLED_PREFIX = {
     "flaskr/route/common.py": "",
@@ -33,11 +31,11 @@ CALLED_PREFIX = {
 
 route_files = []
 for base in ("flaskr/route", "flaskr/service", "flaskr/common"):
-    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, base)):
+    for dirpath, dirnames, filenames in os.walk(str(Path(ROOT) / base)):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
         for fn in filenames:
             if fn.endswith(".py"):
-                p = os.path.join(dirpath, fn)
+                p = str(Path(dirpath) / fn)
                 with Path(p).open(encoding="utf-8") as route_file:
                     if ".route(" in route_file.read():
                         route_files.append(os.path.relpath(p, ROOT))
@@ -125,7 +123,7 @@ def collect_routes(scope_body, env, rel):
 
 
 for rel in sorted(route_files):
-    with Path(os.path.join(ROOT, rel)).open(encoding="utf-8") as route_file:
+    with (Path(ROOT) / rel).open(encoding="utf-8") as route_file:
         src = route_file.read()
     tree = ast.parse(src)
     for fn in tree.body:

--- a/src/api/scripts/inventory/filter_vulture.py
+++ b/src/api/scripts/inventory/filter_vulture.py
@@ -8,7 +8,6 @@
 Usage: filter_vulture.py <vulture-raw.txt> <src_api_root>
 """
 
-import os
 import re
 import sys
 from collections import Counter
@@ -26,7 +25,7 @@ file_cache = {}
 def get_lines(path):
     if path not in file_cache:
         try:
-            with Path(os.path.join(ROOT, path)).open(encoding="utf-8") as f:
+            with (Path(ROOT) / path).open(encoding="utf-8") as f:
                 file_cache[path] = f.readlines()
         except OSError:
             file_cache[path] = []

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -25,16 +25,14 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-ROOT = str(
-    Path(os.path.join(str(Path(__file__).resolve().parent), "..", "..")).resolve()
-)
+ROOT = str((Path(__file__).resolve().parent / ".." / "..").resolve())
 
 # ---- collect all project modules -----------------------------------------
 mods = {}  # module name -> relative file path
 
 
 def add_tree(base_pkg, base_dir):
-    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, base_dir)):
+    for dirpath, dirnames, filenames in os.walk(str(Path(ROOT) / base_dir)):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
         rel = os.path.relpath(dirpath, ROOT)
         parts = Path(rel).parts
@@ -45,20 +43,20 @@ def add_tree(base_pkg, base_dir):
                 name = ".".join(parts)
             else:
                 name = ".".join([*parts, fn[:-3]])
-            mods[name] = os.path.join(rel, fn)
+            mods[name] = str(Path(rel) / fn)
 
 
 add_tree("flaskr", "flaskr")
 add_tree("scripts", "scripts")
 for top in ("app.py", "celery_app.py"):
-    if Path(os.path.join(ROOT, top)).exists():
+    if (Path(ROOT) / top).exists():
         mods[top[:-3]] = top
 
 # ---- parse imports ---------------------------------------------------------
 edges = defaultdict(set)
 for name, rel in mods.items():
     try:
-        with Path(os.path.join(ROOT, rel)).open(encoding="utf-8") as source_file:
+        with (Path(ROOT) / rel).open(encoding="utf-8") as source_file:
             tree = ast.parse(source_file.read())
     except SyntaxError as e:
         print(f"SYNTAX ERROR {rel}: {e}", file=sys.stderr)
@@ -118,9 +116,9 @@ for name, rel in mods.items():
         roots.add(name)
 
 # plugin scan: emulate load_plugins_from_dir over flaskr/service
-svc_dir = os.path.join(ROOT, "flaskr", "service")
+svc_dir = str(Path(ROOT) / "flaskr" / "service")
 for top in sorted(path.name for path in Path(svc_dir).iterdir()):
-    top_path = os.path.join(svc_dir, top)
+    top_path = str(Path(svc_dir) / top)
     if not Path(top_path).is_dir():
         continue
     for dirpath, dirnames, filenames in os.walk(top_path):
@@ -131,7 +129,7 @@ for top in sorted(path.name for path in Path(svc_dir).iterdir()):
         ]
         for fn in filenames:
             if fn.endswith(".py") and fn != "__init__.py" and not fn.startswith("."):
-                rel = os.path.relpath(os.path.join(dirpath, fn), ROOT)
+                rel = os.path.relpath(str(Path(dirpath) / fn), ROOT)
                 name = rel[:-3].replace(os.sep, ".")
                 if name in mods:
                     roots.add(name)

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -24,12 +24,10 @@ import subprocess
 from pathlib import Path
 
 _SCRIPT_DIR = str(Path(__file__).resolve().parent)
-ROOT = str(Path(os.path.join(_SCRIPT_DIR, "..", "..", "..", "..")).resolve())
+ROOT = str((Path(_SCRIPT_DIR) / ".." / ".." / ".." / "..").resolve())
 SP = os.environ.get("INVENTORY_WORK_DIR", str(Path.cwd()))
-BACKEND_ROUTES = os.path.join(SP, "routes-backend.txt")
-SKILLS = os.environ.get(
-    "SKILLS_REPO", str(Path(os.path.join(ROOT, "..", "skills")).resolve())
-)
+BACKEND_ROUTES = str(Path(SP) / "routes-backend.txt")
+SKILLS = os.environ.get("SKILLS_REPO", str((Path(ROOT) / ".." / "skills").resolve()))
 MINIAPP = os.environ.get("MINIAPP_REPO", "")
 
 
@@ -70,7 +68,7 @@ surfaces = {}
 # --- cook-web ---------------------------------------------------------------
 fe = set()
 cat = None
-with Path(os.path.join(ROOT, "src/cook-web/src/api/api.ts")).open(
+with (Path(ROOT) / "src/cook-web/src/api/api.ts").open(
     encoding="utf-8"
 ) as catalog_file:
     cat = catalog_file.read()
@@ -81,13 +79,13 @@ for m in re.finditer(
     if not p.startswith("http"):
         p = "/api" + p
     fe.add(norm(p))
-fe |= grep_paths(os.path.join(ROOT, "src/cook-web/src"))
+fe |= grep_paths(str(Path(ROOT) / "src/cook-web/src"))
 surfaces["cook-web"] = fe
 
 # --- skills CLI --------------------------------------------------------------
 cli = grep_paths(SKILLS)
 # relative paths in shifu-cli.py are joined onto /api/shifu
-cli_file = os.path.join(SKILLS, "skills/ai-shifu-course-creator/scripts/shifu-cli.py")
+cli_file = str(Path(SKILLS) / "skills/ai-shifu-course-creator/scripts/shifu-cli.py")
 if Path(cli_file).exists():
     with Path(cli_file).open(encoding="utf-8") as cli_source:
         src = cli_source.read()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **18 / 22**. Base: `cursor/ruff-pth123-5253` (#2492).

Replaces `os.path.join(...)` with pathlib `/` joins (keeping `str(...)` where callers still expect strings) in plugin loading, prompt paths, SQL caller tracing, and inventory scripts, and enables `PTH118` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH123. Next: PGH004 (#2494).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

