### PR TITLE
style: enforce ruff PGH004 (named noqa codes)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -210,6 +210,7 @@ select = [
     "PTH208", # os.listdir to Path.iterdir
     "PTH123", # open() to Path.open
     "PTH118", # os.path.join to Path slash
+    "PGH004", # blanket noqa
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -80,7 +80,7 @@ def create_app() -> Flask:
 
     # Init LLM
     with app.app_context():
-        from flaskr.api import llm  # noqa
+        from flaskr.api import llm  # noqa: F401
     # init langfuse
     from flaskr import api
 

--- a/src/api/flaskr/api/__init__.py
+++ b/src/api/flaskr/api/__init__.py
@@ -1,1 +1,1 @@
-from .langfuse import init_langfuse  # noqa
+from .langfuse import init_langfuse  # noqa: F401

--- a/src/api/flaskr/service/check_risk/__init__.py
+++ b/src/api/flaskr/service/check_risk/__init__.py
@@ -1,1 +1,1 @@
-from .funcs import *  # noqa
+from .funcs import *  # noqa: F403

--- a/src/api/flaskr/service/common/__init__.py
+++ b/src/api/flaskr/service/common/__init__.py
@@ -1,1 +1,1 @@
-from .models import *  # noqa
+from .models import *  # noqa: F403

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -6,8 +6,8 @@ from typing import Any
 from ..common.dicts import register_dict
 from .consts import *  # noqa: F403
 
-register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa
-register_dict("learn_status", "学习状态", LEARN_STATUS_TYPES)  # noqa
+register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa: F405
+register_dict("learn_status", "学习状态", LEARN_STATUS_TYPES)  # noqa: F405
 
 
 def __getattr__(name: str) -> Any:

--- a/src/api/tests/__init__.py
+++ b/src/api/tests/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from flaskr.common.config import get_config
 
-from .test_app import *  # noqa
+from .test_app import *  # noqa: F403
 
 # Load a deterministic, test-only dotenv (skip user/global .env files)
 load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env.test", override=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **19 / 22**. Base: `cursor/ruff-pth118-5253` (#2493).

Replaces blanket `# noqa` comments with the specific rule codes they were silencing (`F401`, `F403`, `F405`) and enables `PGH004` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PTH118. Next: PGH003 (#2495).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

