### PR TITLE
style: enforce ruff A006 (lambda arg shadows builtin)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -213,6 +213,7 @@ select = [
     "PGH004", # blanket noqa
     "PGH003", # blanket type ignore
     "PLW2901", # redefined loop name
+    "A006", # lambda arg shadows builtin
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -267,7 +267,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 1000,
+        lambda _audio, **_kwargs: 1000,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -399,7 +399,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 1000,
+        lambda _audio, **_kwargs: 1000,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -529,7 +529,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 1200,
+        lambda _audio, **_kwargs: 1200,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -652,7 +652,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 3000,
+        lambda _audio, **_kwargs: 3000,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -798,7 +798,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 3000,
+        lambda _audio, **_kwargs: 3000,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -931,7 +931,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 2200,
+        lambda _audio, **_kwargs: 2200,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -1073,7 +1073,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 2000,
+        lambda _audio, **_kwargs: 2000,
     )
     saved_records = []
 
@@ -1226,7 +1226,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 5400,
+        lambda _audio, **_kwargs: 5400,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",
@@ -1380,7 +1380,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
-        lambda _audio, format="mp3": 6364,
+        lambda _audio, **_kwargs: 6364,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.build_completed_audio_record",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -155,7 +155,7 @@ def test_normalize_audio_blob_validates_duration_and_exports_wav(monkeypatch) ->
     monkeypatch.setattr(
         minimax_voice_clone.AudioSegment,
         "from_file",
-        lambda _stream, format=None: FakeSegment(),
+        lambda _stream, **_kwargs: FakeSegment(),
         raising=False,
     )
 

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -331,7 +331,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
     monkeypatch.setattr(
         tencent_provider,
         "try_get_audio_duration_ms",
-        lambda audio_data, format="mp3": 600 if audio_data else 0,
+        lambda audio_data, **_kwargs: 600 if audio_data else 0,
     )
 
     result = tencent_provider.TencentTTSProvider().synthesize(

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -193,7 +193,7 @@ def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch):
     monkeypatch.setattr(
         module,
         "try_get_audio_duration_ms",
-        lambda audio, format="mp3": 1234,
+        lambda audio, **_kwargs: 1234,
     )
 
     provider = module.TencentTextToVoiceProvider()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked ruff PR **22 / 22**. Base: `cursor/ruff-plw2901-5253` (#2496).

TTS test doubles no longer use a lambda argument named `format` (builtin shadow). They still accept `format=` via `**_kwargs`. Enables `A006` in `ruff.toml`.

## Stack

#2475 is closed; the series starts at #2477 against `main`. Follows PLW2901. Next remaining rules: PERF401, ERA001, TRY004, PT012, PT011, A001, A002.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6526d25-5eee-40fa-a400-1d2bcf9b5253&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

