### PR TITLE
chore: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend-tests:
     name: Run backend tests

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/check-markdown-flow-release.yml
+++ b/.github/workflows/check-markdown-flow-release.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-markdown-flow-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-markdown-flow-release.yml
+++ b/.github/workflows/check-markdown-flow-release.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/check-markdown-flow-ui-release.yml
+++ b/.github/workflows/check-markdown-flow-ui-release.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-markdown-flow-ui-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-markdown-flow-ui-release.yml
+++ b/.github/workflows/check-markdown-flow-ui-release.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   contract-tests:
     name: Run contract tests

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - 'src/cook-web/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -11,7 +11,7 @@ on:
       - 'src/cook-web/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/repo-harness.yml
+++ b/.github/workflows/repo-harness.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/repo-harness.yml
+++ b/.github/workflows/repo-harness.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   repo-harness:
     runs-on: ubuntu-latest

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   runtime-harness:
     runs-on: ubuntu-latest

--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 3 * * 1,4'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/translations-check.yml
+++ b/.github/workflows/translations-check.yml
@@ -11,6 +11,10 @@ on:
     # Twice a week at 03:00 UTC to catch drift in long-lived branches
     - cron: '0 3 * * 1,4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-translations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

PR CI wall time is almost entirely runner-queue wait, not execution. Measured over the last ~600 runs (job-level `created → started` vs `started → completed`):

| Workflow | queue (median) | exec (median) |
| --- | --- | --- |
| Check markdown-flow release pin | 20–28 min | 0.2 min |
| Check markdown-flow-ui release pin | 20–30 min | 0.1 min |
| translations-check | 27–30 min | 0.2 min |
| Repo Harness | 26–28 min | 0.2 min |
| Contract Tests | 20–26 min | 1.3 min |
| Backend Tests | 7–28 min | 1.4 min |
| Lint | 14–21 min | 0.9 min |
| Runtime Harness | 8–23 min | 7.5–9.4 min |

The org is on the GitHub Free plan, so all repos share **20 concurrent standard runner slots**. In one 45-minute window, 46 head commits produced **538 pull_request runs** (~12 per commit, vs. 8 workflows) — roughly 870 job-minutes of demand against 900 job-minutes of capacity, i.e. ~97% utilization, which is why every job sits in the queue for 20+ minutes.

A large share of that demand is waste: only `lint.yml` declared a `concurrency` group, so superseded runs kept running. PR #2484 produced 40 runs for 3 commits, and two commits each triggered *two* complete 8-workflow sets that all ran to completion.

This adds the same block to the eight PR-triggered workflows that lacked it:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Both expressions matter:

- `cancel-in-progress` is conditional so only superseded PR pushes get cancelled — pushes to `main` and the scheduled `translations-check` run must never cancel each other.
- The group falls back to `github.run_id` (not `github.ref`) for non-PR events, so each such run gets its own group and behaves exactly as it does today. Grouping them per branch would serialize `main` pushes, and GitHub cancels a *pending* run when a newer one joins the group — a back-to-back merge could then leave an intermediate commit with no checks at all.

Release and publish automation (`build-latest`, `build-on-release`, `prepare-release`, `bump-markdown-flow*`, `harness-gardening`) is deliberately untouched, since cancelling those could abort a publish. `lint.yml` already had a group, and its `autofix` job — the repository's only required status check — is unchanged.

Follow-ups from the same analysis, coming as a separate PR: Docker layer + Playwright browser caching and a narrower trigger for `Runtime Harness` (~2/3 of all CI compute), merging the four sub-15-second checks into one job, and merging Contract Tests into Backend Tests to share one dependency install.

Verification: all touched YAML parses, `git diff` confirms no trigger/path-filter/permission/step changes, and `python scripts/check_repo_harness.py` plus `lefthook run pre-commit` pass.


Link to Devin session: https://app.devin.ai/sessions/8015f9bb56b1446ea7e008821062d5e8
Requested by: @sunner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation run management across validation and release workflows.
  * Superseded pull request runs are now canceled automatically to reduce redundant processing.
  * Non-pull-request runs use unique identifiers, allowing independent executions to proceed without interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->