### PR TITLE
ci: make lint auto-fix push authenticate correctly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,10 @@ jobs:
             git add -A
             git commit -m "style: auto-fix from lint hooks"
             # Token supplied only here (branch name via env, never expanded in shell).
-            git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" \
+            # git-over-HTTPS on GitHub only accepts basic auth; a bearer header
+            # is answered with 401 and git then falls back to prompting.
+            auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
+            git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
               push origin "HEAD:${HEAD_REF}"
           else
             echo "::error::Auto-fixable lint issues found on a fork PR (cannot push fixes). Run 'lefthook run pre-commit --all-files' locally and push the result."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: lint-${{ github.ref }}
@@ -30,6 +30,9 @@ concurrency:
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    # Only this job pushes the auto-fix commit back to the PR branch.
+    permissions:
+      contents: write
     steps:
       - name: Check out PR branch
         uses: actions/checkout@v6


### PR DESCRIPTION
# Summary

The Lint workflow's auto-fix step commits the fixes but has never been able to push them: it supplies the token as `AUTHORIZATION: bearer ${GH_TOKEN}`, and GitHub's git-over-HTTPS endpoint does not accept bearer auth, so git falls back to prompting and the job dies with `fatal: could not read Username for 'https://github.com'` / exit 128 (e.g. https://github.com/ai-shifu/ai-shifu/pull/2371). Verified against `github.com/ai-shifu/ai-shifu.git/info/refs?service=git-receive-pack`: `bearer <token>` → 401, `basic base64(x-access-token:<token>)` → 200. No `style: auto-fix from lint hooks` commit exists anywhere in history since the step was introduced in #1992.

```diff
-git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" \
+auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
+git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
   push origin "HEAD:${HEAD_REF}"
```

The token still only appears in the push command (not in `.git/config`), matching the `persist-credentials: false` intent of the checkout step.

Note: PR #2371 will still fail Lint after this lands — it has a non-auto-fixable `SIM117` in `src/api/flaskr/api/langfuse.py:366` that the repo-wide `ruff check .` step catches.


Link to Devin session: https://app.devin.ai/sessions/f02defa8950b442bbad329128213fa7d
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 73d2029e5904dc7e44d6f5d1bf226c586e2d5575. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened security for automated code-quality fixes by limiting workflow permissions and improving authentication when changes are applied.
  * This maintenance update does not introduce any visible changes to the application’s features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->