### PR TITLE
refactor: import ABC types from collections.abc

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -27,6 +27,10 @@
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
 #   tuples/lists, not a missed comma. ISC001/ISC002 also conflict with the
 #   formatter.
+# - COM812: ruff lists it as conflicting with the formatter. Applying its
+#   6k fixes adds magic trailing commas that make `ruff format` re-explode
+#   every affected call and signature one argument per line -- a repo-wide
+#   reflow with no correctness value.
 # - BLE001 / S110 / S112: blind/except-pass handlers are deliberate fail-open
 #   patterns here (moderation, logging, notification side channels).
 # - G001 / G003 / G004: f-string logging is the established house style; the
@@ -183,6 +187,10 @@ select = [
     "UP032",   # str.format that should be an f-string
     "UP033",   # lru_cache(maxsize=None) that should be cache
     "UP034",   # extraneous parentheses
+    # UP035 is satisfied except in the two `admin` / `admin_operations.courses`
+    # compatibility shims, which re-export `typing.Dict` / `typing.Set` as part
+    # of their public surface and carry a file-level `# ruff: noqa: UP035`.
+    "UP035",   # import moved to another module (typing -> collections.abc)
     "UP036",   # outdated sys.version_info block
     "UP037",   # quoted annotation that can be a bare type
     "UP039",   # unnecessary parentheses on a class

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -8,8 +8,8 @@ import contextlib
 import json
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import json
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Callable, Generator
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
-from typing import Any, Callable, Generator
+from typing import Any
 
 import requests
 

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -5,8 +5,9 @@ This module provides TTS synthesis using Minimax's Text-to-Speech API (t2a_v2).
 
 import json
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any, Iterator
+from typing import Any
 from urllib.parse import urlencode
 
 import requests

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2,8 +2,9 @@ import json
 import logging
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from flask import Config as FlaskConfig
 from flask import Flask

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import contextlib
 import threading
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable
+from typing import Any
 
 _context_local = threading.local()
 

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -3,8 +3,8 @@ import json
 import os
 import threading
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from flask import Flask
 

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from contextlib import contextmanager, suppress
-from typing import Any, Iterator
+from typing import Any
 
 from flask import Flask
 from flaskr.service.common.models import raise_param_error

--- a/src/api/flaskr/service/billing/bucket_categories.py
+++ b/src/api/flaskr/service/billing/bucket_categories.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 
 from .consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Iterator
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from flask import Flask

--- a/src/api/flaskr/service/billing/cycle_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_transitions.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Callable
+from typing import Any
 
 from .consts import (
     BILLING_INTERVAL_DAY,

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Callable
+from typing import Any
 
 from flaskr.dao import db
 from flaskr.service.config import get_config

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 import requests
 

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -45,8 +45,9 @@ result so the summary is stable.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from datetime import date, datetime
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.i18n import _

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -13,8 +13,9 @@ names registered in ``src/api/error_codes.json``.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from flaskr.i18n import _
 from flaskr.service.common.models import ERROR_CODE, AppException

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -24,7 +24,8 @@ target dialect is MySQL — under SQLite (tests) the hint would not parse.
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from sqlalchemy import (
     Column,

--- a/src/api/flaskr/service/creator_analytics/whitelist.py
+++ b/src/api/flaskr/service/creator_analytics/whitelist.py
@@ -18,8 +18,8 @@ builder, driven by :class:`TableSpec` flags:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 from flaskr.service.billing.models import BillingDailyUsageMetric
 from flaskr.service.learn.models import (

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db

--- a/src/api/flaskr/service/learn/ask_provider_adapters/base.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/base.py
@@ -1,7 +1,8 @@
 """Base contracts and errors for ask provider adapters."""
 
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
-from typing import Any, Callable, Generator, Protocol
+from typing import Any, Protocol
 
 from flask import Flask
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/common.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/common.py
@@ -2,8 +2,9 @@
 
 import contextlib
 import json
+from collections.abc import Iterable
 from functools import lru_cache
-from typing import Any, Iterable
+from typing import Any
 
 import requests
 from flaskr.service.config import get_config

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
@@ -1,7 +1,8 @@
 """Coze ask provider adapter."""
 
 import json
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from flask import Flask

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
@@ -1,7 +1,8 @@
 """Coze workflow ask provider adapter."""
 
 import json
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from flask import Flask

--- a/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
@@ -1,7 +1,8 @@
 """Dify ask provider adapter."""
 
 import json
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from flask import Flask

--- a/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
@@ -9,7 +9,8 @@ emitting the formatted snippets directly.
 API reference: https://www.biji.com/openapi
 """
 
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 import requests
 from flask import Flask

--- a/src/api/flaskr/service/learn/ask_provider_adapters/llm_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/llm_adapter.py
@@ -1,6 +1,7 @@
 """Built-in LLM ask provider adapter."""
 
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flask import Flask
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/registry.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/registry.py
@@ -1,6 +1,7 @@
 """Ask provider adapter registry and routing entrypoints."""
 
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flask import Flask
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -4,8 +4,9 @@ import copy
 import hashlib
 import hmac
 import json
+from collections.abc import Generator
 from datetime import UTC, datetime
-from typing import Any, Generator
+from typing import Any
 from urllib.parse import quote
 
 import requests

--- a/src/api/flaskr/service/learn/ask_provider_langfuse.py
+++ b/src/api/flaskr/service/learn/ask_provider_langfuse.py
@@ -1,6 +1,7 @@
 """Langfuse helpers for external ask providers."""
 
-from typing import Any, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import Any
 
 from flask import Flask
 from flaskr.api.langfuse import (

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -4,10 +4,11 @@ import inspect
 import json
 import queue
 import threading
+from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass, replace
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Callable, Generator, Iterable, Union
+from typing import Any, Union
 
 from flask import Flask
 from flaskr.api.llm import chat_llm, get_allowed_models, get_current_models

--- a/src/api/flaskr/service/learn/listen_element_history.py
+++ b/src/api/flaskr/service/learn/listen_element_history.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (

--- a/src/api/flaskr/service/learn/listen_element_matching.py
+++ b/src/api/flaskr/service/learn/listen_element_matching.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from flaskr.service.learn.learn_dtos import ElementDTO, ElementType
 from flaskr.service.learn.listen_element_types import _default_is_speakable

--- a/src/api/flaskr/service/learn/listen_element_run_sidecar.py
+++ b/src/api/flaskr/service/learn/listen_element_run_sidecar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generator
+from collections.abc import Generator
 
 from flaskr.service.learn.learn_dtos import (
     ElementChangeType,

--- a/src/api/flaskr/service/learn/listen_element_run_stream.py
+++ b/src/api/flaskr/service/learn/listen_element_run_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flaskr.dao import db
 from flaskr.service.learn.learn_dtos import (

--- a/src/api/flaskr/service/learn/listen_elements.py
+++ b/src/api/flaskr/service/learn/listen_elements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Iterable
+from collections.abc import Iterable
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (

--- a/src/api/flaskr/service/learn/preview_elements.py
+++ b/src/api/flaskr/service/learn/preview_elements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Generator
+from collections.abc import Generator
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (

--- a/src/api/flaskr/service/learn/run/emitter.py
+++ b/src/api/flaskr/service/learn/run/emitter.py
@@ -23,7 +23,8 @@ Event names, payload shapes, and sequencing are FROZEN per
 ``flaskr/service/learn/AGENTS.md``; the golden suite is the contract gate.
 """
 
-from typing import TYPE_CHECKING, Generator
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.i18n import _

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -6,8 +6,9 @@ import threading
 import time
 import traceback
 import uuid
+from collections.abc import Generator
 from datetime import datetime
-from typing import Any, Generator
+from typing import Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as cache_provider

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import queue
 import threading
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 from flaskr.common.shifu_context import (
     apply_shifu_context_snapshot,

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -2,8 +2,9 @@ import datetime
 import decimal
 import json
 import re
+from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext, suppress
-from typing import Any, Iterator
+from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import pytz

--- a/src/api/flaskr/service/order/payment_channel_resolution.py
+++ b/src/api/flaskr/service/order/payment_channel_resolution.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from flaskr.service.common.models import raise_error
 from flaskr.service.config import get_config

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -6,18 +6,19 @@ monkeypatch targets keep working.
 Shim retained for one release cycle per backend-overhaul-master.md B5.
 """
 
-# ruff: noqa: F401, E402
+# ruff: noqa: F401, E402, UP035
 
 from __future__ import annotations
 
 import json
 import re
 import sys
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from json import JSONDecodeError
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Dict, Optional, Set
 
 from flask import current_app
 from flaskr.common.i18n_utils import get_markdownflow_output_language

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -5,10 +5,11 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_operations/courses.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses.py
@@ -6,17 +6,18 @@ monkeypatch targets keep working.
 Shim retained for one release cycle per backend-overhaul-master.md B5.
 """
 
-# ruff: noqa: F401
+# ruff: noqa: F401, UP035
 
 from __future__ import annotations
 
 import math
 import re
 import sys
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import Any, Dict, Iterable, Optional, Sequence, Set
+from typing import Any, Dict, Optional, Set
 
 from flask import Flask, current_app
 from flaskr.common.cache_provider import cache as redis

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import math
 import re
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.api.llm import PROVIDER_STATES, get_current_models

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -5,8 +5,8 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Sequence
 
 from flask import Flask
 from flaskr.common.umami_client import get_course_visit_count_30d

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -6,8 +6,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -5,9 +5,10 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from flask import Flask, current_app
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import re
 import sys
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Iterable, Sequence
+from typing import Any
 
 from flask import current_app
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -5,8 +5,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask, current_app
 from flaskr.common.cache_provider import cache as redis

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -5,9 +5,10 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any, Sequence
+from typing import Any
 
 from flask import current_app
 from flaskr.service.user.models import AuthCredential

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 from flask import Flask
 from flaskr.api.tts import get_default_voice_settings, synthesize_text

--- a/src/api/flaskr/service/shifu/admin_user_courses.py
+++ b/src/api/flaskr/service/shifu/admin_user_courses.py
@@ -5,8 +5,8 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Sequence
 
 from flaskr.dao import db
 from flaskr.service.learn.const import (

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -6,10 +6,11 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
 from json import JSONDecodeError
-from typing import Any, Sequence
+from typing import Any
 
 from flask import current_app
 from flaskr.dao import db

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -5,9 +5,10 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Sequence
+from typing import Any
 
 from flaskr.dao import db
 from flaskr.service.common.models import (

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any
 
 from flaskr.dao import db
 from sqlalchemy import and_, or_

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -5,7 +5,7 @@ This module provides audio concatenation and processing functions using pydub/ff
 
 import io
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 
 from flaskr.common.log import AppLoggerProxy
 

--- a/src/api/flaskr/service/tts/cloned_voice_registry.py
+++ b/src/api/flaskr/service/tts/cloned_voice_registry.py
@@ -13,8 +13,8 @@ write path (``admin_operations/voice_clones.py``).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from flaskr.service.tts.minimax_voice_clone import is_valid_minimax_custom_voice_id
 from flaskr.service.tts.models import (

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -20,9 +20,9 @@ import logging
 import re
 import time
 import uuid
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Sequence
 
 from flask import Flask
 from flaskr.api.tts import (

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -7,8 +7,8 @@ import logging
 import math
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from flaskr.common.log import AppLoggerProxy
 

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -12,9 +12,10 @@ import os
 import threading
 import time
 import uuid
+from collections.abc import Generator
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Generator
+from typing import Any
 
 from flask import Flask
 from flaskr.api.tts import (

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from .base import AuthProvider
 

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -26,9 +26,9 @@ import shutil
 import sys
 import tempfile
 from collections import Counter, OrderedDict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 os.environ.setdefault("SKIP_LOAD_DOTENV", "1")
 os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -19,9 +19,9 @@ import base64
 import json
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 from unittest.mock import MagicMock
 
 os.environ.setdefault("SKIP_LOAD_DOTENV", "1")

--- a/src/api/scripts/observability_consistency_probes.py
+++ b/src/api/scripts/observability_consistency_probes.py
@@ -8,10 +8,11 @@ import json
 import os
 import sys
 import time
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from flaskr.util.datetime import now_utc, to_utc_iso
 from sqlalchemy import Numeric, bindparam, inspect, text

--- a/src/api/tests/common/fixtures/billing_products.py
+++ b/src/api/tests/common/fixtures/billing_products.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from decimal import Decimal
-from typing import Any, Iterable, Mapping
+from typing import Any
 
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_MANUAL,

--- a/src/api/tests/common/fixtures/fake_llm.py
+++ b/src/api/tests/common/fixtures/fake_llm.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from types import SimpleNamespace
-from typing import Generator
 
 
 class FakeLLMResponse:


### PR DESCRIPTION
# Summary

Follow-up to the full-rule ruff audit (`ruff check --select ALL`): of everything ruff can fix automatically and safely, only `UP035` is worth taking. This applies it and locks it in.

- 68 imports moved off deprecated `typing` aliases, e.g. `from typing import Callable, Generator` -> `from collections.abc import Callable, Generator` (also `Iterable`, `Iterator`, `Mapping`, `Sequence`), across 67 backend/script files. `ruff check --fix` then re-sorted the 61 affected import blocks (`I001`).
- `UP035` added to `ruff.toml`. The two `shifu.admin` / `shifu.admin_operations.courses` compatibility shims re-export `typing.Dict` / `typing.Set` as part of their public surface, so their existing file-level `# ruff: noqa` gains `UP035` instead of being rewritten.

Deliberately not applied, and now documented in `ruff.toml`:

- `COM812` (6038 fixes) — ruff lists it as conflicting with its formatter. Applying it adds magic trailing commas, after which `ruff format` wants to reflow 333 files, exploding every affected call and signature to one argument per line. No correctness value.
- `D405` / `D406` / `D407` (5 fixes) — already documented: their fixes corrupt the flasgger YAML embedded in route docstrings.

No behavior change: `collections.abc` is where these ABCs have lived since 3.3, and the `typing` names are plain re-exports.

Verification: `ruff check .`, `ruff format --check .`, `lefthook run pre-commit` (via commit hooks), and `pytest tests` in `src/api` — 2870 passed, the same 5 `test_admin_course_detail.py` failures that fail on `main` (sqlite has no `concat()`).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 267d45aad11d09f6db3b87d945b2b8719fd34b60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->