### PR TITLE
ci: push lint auto-fixes from a trusted workflow

### DIFF
--- a/.github/workflows/lint-autofix-push.yml
+++ b/.github/workflows/lint-autofix-push.yml
@@ -1,0 +1,74 @@
+name: Lint Auto-fix Push
+
+# Trusted half of the lint auto-fix flow. The Lint workflow installs and runs
+# pull-request-controlled tooling, so it stays read-only and only uploads the
+# auto-fix diff as an artifact. This workflow always runs the version on the
+# default branch, never executes pull request code, and treats the downloaded
+# patch as untrusted data: it is applied with `git apply` onto the exact head
+# commit the patch was produced from, and nothing else in the PR is executed.
+
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-autofix-push-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  push:
+    # Fork pull requests cannot be pushed to; the Lint run fails them instead.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Needed to download the patch artifact from the triggering Lint run.
+      actions: read
+    steps:
+      - name: Download auto-fix patch
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: lint-autofix
+          path: autofix
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Check out the branch that was linted
+        if: steps.download.outcome == 'success'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          persist-credentials: false
+          path: repo
+
+      - name: Apply the patch and push
+        if: steps.download.outcome == 'success'
+        working-directory: repo
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          expected=$(cat ../autofix/head_sha)
+          current=$(git rev-parse HEAD)
+          if [ "$expected" != "$current" ]; then
+            echo "::notice::Branch moved from ${expected} to ${current} since the lint run; skipping stale auto-fix."
+            exit 0
+          fi
+          git apply --index --whitespace=nowarn ../autofix/autofix.patch
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "style: auto-fix from lint hooks"
+          # Token supplied only here (branch name via env, never expanded in shell).
+          # git-over-HTTPS on GitHub only accepts basic auth; a bearer header is
+          # answered with 401 and git then falls back to prompting.
+          auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
+            push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
           [ -n "$cwlint" ] && { (cd src/cook-web && npm run lint-file -- $cwlint) || true; }
           true
 
-      - name: Export auto-fixes as a patch (fail forks that need fixes)
+      - name: Export auto-fixes as a patch (fail what CI cannot push)
         id: patch
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -109,6 +109,12 @@ jobs:
           echo "Auto-fixable changes detected:"; git --no-pager diff --stat
           if [ "$SAME_REPO" != "true" ]; then
             echo "::error::Auto-fixable lint issues found on a fork PR (cannot push fixes). Run 'lefthook run pre-commit --all-files' locally and push the result."
+            exit 1
+          fi
+          # GITHUB_TOKEN may not create or update workflow files, so those fixes
+          # can never be pushed back.
+          if [ -n "$(git status --porcelain -- .github/workflows)" ]; then
+            echo "::error::Auto-fixable lint issues under .github/workflows/ cannot be pushed by CI. Run 'lefthook run pre-commit --all-files' locally and push the result."
             exit 1
           fi
           mkdir -p /tmp/autofix

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,13 @@
 name: Lint
 
 # Replaces the pre-commit.ci PR check, mirroring its behaviour:
-#   - auto-fixable issues are fixed and pushed back to the PR branch as a commit
+#   - auto-fixable issues are fixed and exported as a patch artifact, which the
+#     trusted lint-autofix-push.yml workflow commits back to the PR branch
 #   - issues that cannot be auto-fixed (ruff E722, invalid YAML/JSON, merge
 #     markers, hardcoded CJK in backend) fail the run.
+#
+# This job runs pull-request-controlled tooling (npm ci, linters), so it never
+# holds a write-capable token; see lint-autofix-push.yml.
 #
 # Scope: only the checks NOT already enforced by another workflow. Prettier has
 # prettier-check.yml, the repo-harness scripts have repo-harness.yml, and the
@@ -30,9 +34,10 @@ concurrency:
 jobs:
   autofix:
     runs-on: ubuntu-latest
-    # Only this job pushes the auto-fix commit back to the PR branch.
+    # This job installs and runs pull-request-controlled tooling, so it stays
+    # read-only. The patch it produces is pushed by lint-autofix-push.yml.
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Check out PR branch
         uses: actions/checkout@v6
@@ -42,10 +47,8 @@ jobs:
           # the default PR merge ref (read-only; fork fixes are never pushed).
           ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
           fetch-depth: 0
-          # Do not leave the write-capable token in .git/config while
-          # PR-controlled tooling (npm ci, linters) runs. The push step
-          # supplies it explicitly. The repo is public, so the base fetch
-          # below needs no credentials.
+          # Nothing here needs credentials: the repo is public and the auto-fix
+          # commit is pushed by a separate trusted workflow.
           persist-credentials: false
 
       - name: Set up Python
@@ -93,10 +96,10 @@ jobs:
           [ -n "$cwlint" ] && { (cd src/cook-web && npm run lint-file -- $cwlint) || true; }
           true
 
-      - name: Apply auto-fixes (push on same-repo PRs; fail forks that need fixes)
+      - name: Export auto-fixes as a patch (fail forks that need fixes)
+        id: patch
         env:
-          HEAD_REF: ${{ github.head_ref }}
-          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
@@ -104,21 +107,23 @@ jobs:
             exit 0
           fi
           echo "Auto-fixable changes detected:"; git --no-pager diff --stat
-          if [ "$SAME_REPO" = "true" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "style: auto-fix from lint hooks"
-            # Token supplied only here (branch name via env, never expanded in shell).
-            # git-over-HTTPS on GitHub only accepts basic auth; a bearer header
-            # is answered with 401 and git then falls back to prompting.
-            auth=$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)
-            git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth}" \
-              push origin "HEAD:${HEAD_REF}"
-          else
+          if [ "$SAME_REPO" != "true" ]; then
             echo "::error::Auto-fixable lint issues found on a fork PR (cannot push fixes). Run 'lefthook run pre-commit --all-files' locally and push the result."
             exit 1
           fi
+          mkdir -p /tmp/autofix
+          git add -A
+          git diff --cached --binary > /tmp/autofix/autofix.patch
+          printf '%s\n' "$HEAD_SHA" > /tmp/autofix/head_sha
+          echo "has-patch=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload auto-fix patch
+        if: steps.patch.outputs.has-patch == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-autofix
+          path: /tmp/autofix
+          retention-days: 1
 
       - name: Hard-fail checks (on the now-fixed tree)
         run: |


### PR DESCRIPTION
# Summary

Follow-up to #2503 (stacked on it; merge #2503 first). Addresses the CodeRabbit finding that the `autofix` job holds `contents: write` while it installs and runs pull-request-controlled code (`npm ci` postinstall scripts, eslint, prettier from the PR's `node_modules`).

Split into an untrusted producer and a trusted pusher:

- `lint.yml` / `autofix` → `permissions: contents: read`. Instead of committing and pushing, it exports the fixes as an artifact:

  ```bash
  git add -A
  git diff --cached --binary > /tmp/autofix/autofix.patch
  printf '%s\n' "$HEAD_SHA" > /tmp/autofix/head_sha   # upload-artifact: lint-autofix
  ```

  Fork PRs still hard-fail in this step (unchanged). Fixes touching `.github/workflows/**` also hard-fail with "run the hooks locally", because `GITHUB_TOKEN` may not push workflow files. The hard-fail checks still run on the fixed working tree.
- New `lint-autofix-push.yml`, triggered by `workflow_run` of `Lint` (so it always runs the default-branch version and never executes PR code), holds `contents: write` + `actions: read`, downloads the patch, checks out the linted branch, and applies it as untrusted data:

  ```bash
  [ "$(cat ../autofix/head_sha)" = "$(git rev-parse HEAD)" ] || exit 0   # branch moved -> skip stale patch
  git apply --index --whitespace=nowarn ../autofix/autofix.patch
  git commit -m "style: auto-fix from lint hooks" && git push origin "HEAD:${HEAD_REF}"
  ```

  `continue-on-error` on the download makes the "no fixes needed" case (no artifact) a no-op.

For contributors the outcome is unchanged, except auto-fixes land one Lint run later as the same `style: auto-fix from lint hooks` commit on same-repo PR branches.


Link to Devin session: https://app.devin.ai/sessions/f02defa8950b442bbad329128213fa7d
Requested by: @sunner