### PR TITLE
style: enforce ruff S113 (requests call without timeout)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -222,6 +222,7 @@ select = [
     "PGH003", # blanket type ignore
     "PLW2901", # redefined loop name
     "A006", # lambda arg shadows builtin
+    "S113", # requests call without a timeout
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/api/wechat.py
+++ b/src/api/flaskr/api/wechat.py
@@ -11,7 +11,7 @@ def get_wechat_access_token(app: Flask, code: str):
         "WECHAT_APP_SECRET", ""
     )
     url = f"https://api.weixin.qq.com/sns/oauth2/access_token?appid={app_id}&secret={app_secret}&code={code}&grant_type=authorization_code"
-    response = requests.get(url)
+    response = requests.get(url, timeout=10)
     app.logger.info(f"get_wechat_access_token response: {response}")
     if response.status_code == 200:
         app.logger.info("get_wechat_access_token:" + str(response.json()))

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -357,7 +357,7 @@ def get_video_info(app, user_id: str, url: str) -> dict:
                     "Connection": "keep-alive",
                 }
 
-                response = requests.get(api_url, headers=headers)
+                response = requests.get(api_url, headers=headers, timeout=10)
                 if response.status_code == 200:
                     data = response.json()
                     if data["code"] == 0:


### PR DESCRIPTION
# Summary

First PR in a stack that enables 10 low-risk ruff rules found by the full-rule audit, one rule per PR.

Adds an explicit `timeout=10` to the two `requests` calls that had none (WeChat access token fetch and shifu URL fetch), then selects `S113` in `ruff.toml`. Without a timeout these calls can hang a worker indefinitely when the third party stalls.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 300ff49d6c1128863e763f4b221218ba61bf1929. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeouts to external requests when retrieving WeChat access tokens and video metadata.
  * Improved responsiveness by preventing requests from waiting indefinitely.
* **Quality Improvements**
  * Added checks to identify HTTP requests that are missing timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->