### PR TITLE
style: enforce ruff TRY002 (no vanilla Exception raises)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -223,6 +223,7 @@ select = [
     "PLW2901", # redefined loop name
     "A006", # lambda arg shadows builtin
     "S113", # requests call without a timeout
+    "TRY002", # raising a vanilla Exception instead of a named class
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -27,6 +27,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+class MigrationBatchError(RuntimeError):
+    """Raised when a migration batch exceeds its tolerated error count."""
+
+
 @dataclass
 class MigrationConfig:
     """Migration configuration"""
@@ -450,7 +454,7 @@ class UnifiedMigrationTask:
                     if (
                         error_count > self.config.batch_size * 0.5
                     ):  # If more than 50% errors
-                        raise Exception(
+                        raise MigrationBatchError(
                             f"Too many errors in batch: {error_count}"
                         ) from e
 


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

The unified migration task raised a bare `Exception` when a batch exceeded its tolerated error count. Introduces `MigrationBatchError(RuntimeError)` and raises that instead, then selects `TRY002` in `ruff.toml`, so callers can catch the failure specifically.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule plus a named exception with identical control flow; no auth, security, or API surface changes.
> 
> **Overview**
> Enables **ruff `TRY002`** in `ruff.toml` so CI rejects bare `raise Exception(...)`.
> 
> In `unified_migration_task.py`, when more than half of records in a batch fail, the code now raises **`MigrationBatchError`** (subclass of `RuntimeError`) instead of a generic `Exception`, with the same message and `from e` chaining. Call paths that already catch `Exception` behave the same; the new type is available for targeted handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f24ced9706b535292a0d733472a137d4876ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->