### PR TITLE
style: enforce ruff S108 (no hardcoded /tmp paths)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -225,6 +225,7 @@ select = [
     "S113", # requests call without a timeout
     "TRY002", # raising a vanilla Exception instead of a named class
     "S324",  # hashlib md5/sha1 without usedforsecurity=False
+    "S108",  # hardcoded /tmp path instead of tempfile.gettempdir()
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import tempfile
 from io import BytesIO
 from pathlib import Path
 
@@ -22,7 +23,7 @@ def setup_migration_logging():
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
         handlers=[
-            logging.FileHandler("/tmp/flask_migration.log"),
+            logging.FileHandler(Path(tempfile.gettempdir()) / "flask_migration.log"),
             logging.StreamHandler(),
         ],
     )

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import os
 import sys
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
@@ -20,7 +21,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
-        logging.FileHandler("/tmp/unified_migration.log"),
+        logging.FileHandler(Path(tempfile.gettempdir()) / "unified_migration.log"),
         logging.StreamHandler(),
     ],
 )

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -55,7 +55,7 @@ def _compile_bigint_sqlite(_type, _compiler, **_kw):
 
 
 DEFAULT_CHUNK_SIZES = (1, 2, 3, 5, 8, 13)
-DEFAULT_MDFLOW_ROOT = "/tmp/mdflow255"
+DEFAULT_MDFLOW_ROOT = str(Path(tempfile.gettempdir()) / "mdflow255")
 
 
 @dataclass
@@ -94,7 +94,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--input",
-        default="/tmp/latest_generate_blocks_b64.jsonl",
+        default=str(Path(tempfile.gettempdir()) / "latest_generate_blocks_b64.jsonl"),
         help="Path to JSONL exported from generated blocks",
     )
     parser.add_argument(

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -19,6 +19,7 @@ import base64
 import json
 import os
 import re
+import tempfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,7 +69,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--input",
-        default="/tmp/latest_generate_blocks_b64.jsonl",
+        default=str(Path(tempfile.gettempdir()) / "latest_generate_blocks_b64.jsonl"),
         help="Path to JSONL exported from MySQL",
     )
     parser.add_argument(


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Replaces hardcoded `/tmp/...` log/output paths in the migration command and two check scripts with `Path(tempfile.gettempdir()) / ...`, then selects `S108` in `ruff.toml`, so the platform-configured temp directory is respected.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical path resolution for logs and dev/check script defaults only; no auth, data, or production API behavior changes.
> 
> **Overview**
> **Enables ruff rule S108** in `ruff.toml` so hardcoded `/tmp` paths are flagged going forward.
> 
> **Replaces literal `/tmp/...` defaults** with `Path(tempfile.gettempdir()) / ...` in Flask migration CLI logging (`flask_migration.log`), unified migration task logging (`unified_migration.log`), and default input/work roots in `check_mdflow_listen_adapter.py` and `check_sse_segmentation.py`. Behavior is the same on typical Linux setups; non-default `TMPDIR` / platform temp dirs are respected instead of assuming `/tmp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cc5d70816fd013361bd8f8fd36a7fad662a151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->