### PR TITLE
style: enforce ruff A001 (no local names shadowing builtins)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -226,6 +226,7 @@ select = [
     "TRY002", # raising a vanilla Exception instead of a named class
     "S324",  # hashlib md5/sha1 without usedforsecurity=False
     "S108",  # hardcoded /tmp path instead of tempfile.gettempdir()
+    "A001",  # local variable shadowing a builtin
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1999,16 +1999,16 @@ class EnhancedConfig:
             groups[env_var.group].append(env_var)
 
         # Generate output for each group
-        for group, vars in sorted(groups.items()):
+        for group, group_vars in sorted(groups.items()):
             # Skip empty groups
-            if not vars:
+            if not group_vars:
                 continue
 
             lines.append(f"\n#{'=' * 60}")
             lines.append(f"# {group.replace('_', ' ').title()}")
             lines.append(f"#{'=' * 60}\n")
 
-            for env_var in sorted(vars, key=lambda x: x.name):
+            for env_var in sorted(group_vars, key=lambda x: x.name):
                 example_value = (
                     env_var.example if env_var.example is not None else env_var.default
                 )

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -36,7 +36,7 @@ def enable_plugins(app: Flask):
         shutil.rmtree(dest_dir)
 
     @plugin.command(name="list")
-    def list():
+    def list_plugins():
         """List all plugins."""
         plugins_dir = str(Path("flaskr") / "plugins")
         plugins = [path.name for path in Path(plugins_dir).iterdir() if path.is_dir()]

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -86,14 +86,14 @@ def register_callback_handler(app: Flask, path_prefix: str):
     def pingxx_callback():
         body = request.get_json()
         app.logger.info("pingxx-callback: %s", body)
-        type = body.get("type", "")
-        if type == "charge.succeeded":
+        event_type = body.get("type", "")
+        if event_type == "charge.succeeded":
             order_no = body.get("data", {}).get("object", {}).get("order_no", "")
-            id = body.get("data", {}).get("object", {}).get("id", "")
+            charge_id = body.get("data", {}).get("object", {}).get("id", "")
             app.logger.info("pingxx-callback: charge.succeeded order_no: %s", order_no)
             billing_result = handle_billing_pingxx_webhook(app, body)
             if not billing_result.matched:
-                success_buy_record_from_pingxx(app, id, body)
+                success_buy_record_from_pingxx(app, charge_id, body)
             # 处理支付成功逻辑
             # do something
 

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1610,19 +1610,21 @@ def build_admin_billing_focus_teachers_page(
                 },
             )
 
-            credits = Decimal(str(credit_decimal_to_number(row.consumed_credits) or 0))
+            credit_amount = Decimal(
+                str(credit_decimal_to_number(row.consumed_credits) or 0)
+            )
             record_count = int(row.record_count or 0)
             # Use the start of the UTC stat window as the visible "latest
             # active" day. `window_ended_at` points at the next UTC day
             # boundary and can render as a future local date in the admin UI.
             latest_usage_at = row.window_started_at or row.window_ended_at
 
-            item["credits_30d"] += credits
-            item["total_credits_30d"] += credits
+            item["credits_30d"] += credit_amount
+            item["total_credits_30d"] += credit_amount
             if row.usage_scene == BILL_USAGE_SCENE_PROD:
-                item["production_credits_30d"] += credits
+                item["production_credits_30d"] += credit_amount
             elif row.usage_scene in (BILL_USAGE_SCENE_DEBUG, BILL_USAGE_SCENE_PREVIEW):
-                item["debug_preview_credits_30d"] += credits
+                item["debug_preview_credits_30d"] += credit_amount
 
             if latest_usage_at is not None and (
                 item["latest_usage_at"] is None
@@ -1631,12 +1633,12 @@ def build_admin_billing_focus_teachers_page(
                 item["latest_usage_at"] = latest_usage_at
 
             if current_7d_start <= stat_date <= today:
-                item["credits_7d"] += credits
+                item["credits_7d"] += credit_amount
                 item["record_count_7d"] += record_count
-                if credits > 0:
+                if credit_amount > 0:
                     item["active_days_7d"].add(stat_date.isoformat())
             elif previous_7d_start <= stat_date <= previous_7d_end:
-                item["credits_prev_7d"] += credits
+                item["credits_prev_7d"] += credit_amount
 
         focus_items: list[AdminBillingFocusTeacherDTO] = []
         for creator_bid, stats in aggregated.items():

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -3601,8 +3601,8 @@ class RunScriptContextV2:
             o.id: o for o in outline_item_info_db
         }
         course_prompt: str | None = None
-        for id in outline_ids:
-            outline_item_info = outline_item_info_map.get(id)
+        for outline_id in outline_ids:
+            outline_item_info = outline_item_info_map.get(outline_id)
             if (
                 outline_item_info
                 and outline_item_info.llm_system_prompt
@@ -3645,8 +3645,8 @@ class RunScriptContextV2:
             ).all()
         )
         outline_item_info_map = {o.id: o for o in outline_item_info_db}
-        for id in outline_ids:
-            outline_item_info = outline_item_info_map.get(id)
+        for outline_id in outline_ids:
+            outline_item_info = outline_item_info_map.get(outline_id)
             if outline_item_info and outline_item_info.llm:
                 return LLMSettings(
                     model=outline_item_info.llm,

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -326,7 +326,7 @@ def handle_input_ask(
     normalized_trace_input = normalize_langfuse_input_value(raw_input)
     if normalized_trace_input and not trace_args.get("input"):
         trace_args["input"] = normalized_trace_input
-    input = raw_input.replace("{", "{{").replace(
+    escaped_input = raw_input.replace("{", "{{").replace(
         "}", "}}"
     )  # Escape braces to avoid formatting conflicts
     use_learner_language = getattr(context._shifu_info, "use_learner_language", 0)
@@ -428,7 +428,7 @@ def handle_input_ask(
         "User question:\n"
     )
     # Append language instruction to user input if use_learner_language is enabled
-    user_content = format_constraint + input
+    user_content = format_constraint + escaped_input
     if use_learner_language:
         output_language = get_markdownflow_output_language()
         user_content += f"\n\n(IMPORTANT: You MUST respond in {output_language}.)"
@@ -448,7 +448,12 @@ def handle_input_ask(
 
     # Create ask block
     ask_block = _create_ask_block(
-        app, outline_item_info, attend_id, user_info.user_id, input, last_position
+        app,
+        outline_item_info,
+        attend_id,
+        user_info.user_id,
+        escaped_input,
+        last_position,
     )
 
     # Create answer block early (empty placeholder) so all teacher-side
@@ -463,7 +468,7 @@ def handle_input_ask(
         outline_bid=outline_item_info.bid,
         generated_block_bid=answer_block.generated_block_bid,
         type=GeneratedType.ASK,
-        content=input,
+        content=escaped_input,
         anchor_element_bid=anchor_element_bid,
     )
 
@@ -471,7 +476,7 @@ def handle_input_ask(
     span_parent = parent_observation or trace
     span = span_parent.span(
         name=build_langfuse_span_name(chapter_title, ask_scene, "user_follow_up"),
-        input=input,
+        input=escaped_input,
     )
 
     # Run guardrail check
@@ -479,7 +484,7 @@ def handle_input_ask(
         app,
         user_info,
         ask_block,
-        input,
+        escaped_input,
         span,
         outline_item_info,
         last_position,
@@ -510,7 +515,7 @@ def handle_input_ask(
             outline_bid=outline_item_info.bid,
             generated_block_bid=answer_block.generated_block_bid,
             type=GeneratedType.INTERACTION,
-            content=input,
+            content=escaped_input,
         )
         answer_block.generated_content = guardrail_text
         _finalize_ask_trace(

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -369,7 +369,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         """
         user_bid = request.user.user_id
         payload = request.get_json() or {}
-        input = payload.get("input", None)
+        user_input = payload.get("input", None)
         input_type = payload.get("input_type", None)
         reload_generated_block_bid = payload.get("reload_generated_block_bid", None)
         reload_element_bid = payload.get("reload_element_bid", None)
@@ -404,7 +404,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
                 shifu_bid=shifu_bid,
                 outline_bid=outline_bid,
                 user_bid=user_bid,
-                input=input,
+                input=user_input,
                 input_type=input_type,
                 reload_generated_block_bid=reload_generated_block_bid,
                 reload_element_bid=reload_element_bid,

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -54,9 +54,9 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
                         $ref: '#/components/schemas/ProfileItemDefinition'
         """
         parent_id = request.args.get("parent_id")
-        type = request.args.get("type", "all")
+        item_type = request.args.get("type", "all")
         return make_common_response(
-            get_profile_item_definition_list(app, parent_id=parent_id, type=type)
+            get_profile_item_definition_list(app, parent_id=parent_id, type=item_type)
         )
 
     @app.route(f"{path_prefix}/hide-unused-profile-items", methods=["POST"])

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1261,7 +1261,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         name = json_data.get("name")
         # No defaults: None is passed through to create_outline, which applies its
         # own fallback (a new outline still needs a concrete type/visibility).
-        type = json_data.get("type")
+        outline_type = json_data.get("type")
         system_prompt = json_data.get("system_prompt", None)
         is_hidden = json_data.get("is_hidden")
         if isinstance(is_hidden, str):
@@ -1273,7 +1273,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 shifu_bid,
                 parent_bid,
                 name,
-                type,
+                outline_type,
                 system_prompt,
                 is_hidden,
             )
@@ -1404,7 +1404,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         is_hidden = request.get_json().get("is_hidden")
         if isinstance(is_hidden, str):
             is_hidden = is_hidden.lower() == "true"
-        type = request.get_json().get("type")
+        outline_type = request.get_json().get("type")
         return make_common_response(
             modify_unit(
                 app,
@@ -1414,7 +1414,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
                 description,
                 system_prompt,
                 is_hidden,
-                type,
+                outline_type,
             )
         )
 

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -2546,7 +2546,7 @@ def test_admin_operation_course_credit_usage_model_labels_are_cached_per_request
             ("usage-tts-1", BILL_USAGE_TYPE_TTS, "volcengine", "seed-tts-2.0", "2"),
             ("usage-legacy-1", BILL_USAGE_TYPE_LLM, "legacy", "old-model-260101", "1"),
         ]
-        for index, (usage_bid, usage_type, provider, model, credits) in enumerate(
+        for index, (usage_bid, usage_type, provider, model, credit_amount) in enumerate(
             usage_specs
         ):
             _seed_credit_usage(
@@ -2558,7 +2558,7 @@ def test_admin_operation_course_credit_usage_model_labels_are_cached_per_request
                 usage_type=usage_type,
                 provider=provider,
                 model=model,
-                consumed_credits=Decimal(credits),
+                consumed_credits=Decimal(credit_amount),
                 created_at=datetime(2026, 4, 4, 10, index, 0),
                 extra={"generation_name": f"lesson_runtime/run_llm/{index}"},
             )


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Renames locals that shadowed builtins (`vars`, `type`, `id`, `input`, `credits`) to descriptive names such as `group_vars`, `event_type`, `charge_id`, `user_input`, `credit_amount`, and renames the click callback `list` to `list_plugins` while keeping `@plugin.command(name="list")` so the CLI name is unchanged. No request/response payload keys were touched. Selects `A001` in `ruff.toml`.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical identifier renames with no intentional behavior or external API changes; payment and learn flows still use the same payload keys and values.
> 
> **Overview**
> Enables **ruff `A001`** (locals must not shadow builtins) in `ruff.toml` and applies renames across the API so CI enforces the rule going forward.
> 
> Locals are renamed for clarity only—e.g. `vars` → `group_vars`, `type` → `event_type` / `outline_type` / `item_type`, `id` → `charge_id` / `outline_id`, `input` → `user_input` / `escaped_input`, `credits` → `credit_amount`. **JSON/query field names** (`"type"`, `"input"`, etc.) are unchanged.
> 
> The plugin CLI handler is renamed from `list` to `list_plugins` while **`@plugin.command(name="list")`** keeps the user-facing subcommand name the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 368dd6a335449b9aac76506f2274bf8ee83d5de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->