### PR TITLE
style: enforce ruff D401 (imperative docstring first lines)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -227,6 +227,7 @@ select = [
     "S324",  # hashlib md5/sha1 without usedforsecurity=False
     "S108",  # hardcoded /tmp path instead of tempfile.gettempdir()
     "A001",  # local variable shadowing a builtin
+    "D401",  # docstring first line not in imperative mood
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -102,7 +102,7 @@ def _hooks_dir() -> Path | None:
 
 
 def _lefthook_hook_installed() -> bool:
-    """True when ``lefthook install`` has wired the pre-commit hook in."""
+    """Report whether ``lefthook install`` has wired the pre-commit hook in."""
     hooks_dir = _hooks_dir()
     if hooks_dir is None:
         return False
@@ -155,7 +155,7 @@ def _report(title: str, checks: list[Check]) -> None:
 
 
 def _fix_lines(missing: list[Check]) -> list[str]:
-    """Unique fix commands, preserving first-seen order."""
+    """Collect unique fix commands, preserving first-seen order."""
     seen: list[str] = []
     for check in missing:
         if check.fix not in seen:

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -18,7 +18,7 @@ from .update_shifu_demo import update_demo_shifu
 
 
 def setup_migration_logging():
-    """Setup logging for migration commands"""
+    """Set up logging for migration commands"""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1009,7 +1009,7 @@ class UnifiedMigrationTask:
 
 
 async def main():
-    """Main execution function"""
+    """Run the unified migration task"""
     import argparse
 
     parser = argparse.ArgumentParser(description="Unified Database Migration Task")

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -158,7 +158,7 @@ def _extract_request_host(request) -> str | None:
 def with_shifu_context(
     resolve_shifu_bid: Callable[..., str | None] | None = None,
 ) -> Callable:
-    """Decorator to automatically populate shifu context for a route handler.
+    """Populate shifu context for a route handler.
 
     By default it tries to resolve shifu_bid from:
       - path parameters: request.view_args["shifu_bid"]

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -60,7 +60,7 @@ def enable_plugins(app: Flask):
 
     @plugin.group(name="db")
     def plugin_db():
-        """The plugin database management commands"""
+        """Manage the plugin database"""
 
     def get_version_table_name(plugin_name: str) -> str:
         """Get version table name"""

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -503,7 +503,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/admin/orders/shifus", methods=["GET"])
     def admin_order_shifu_list():
-        """Created shifu list for order admin filters
+        """List created shifus for order admin filters
         ---
         tags:
             - 订单

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -294,7 +294,7 @@ def _join_conditions(params: _Params):
 
 
 def _where_clauses(params: _Params):
-    """Common WHERE predicates shared by detail + summary queries."""
+    """Build the WHERE predicates shared by detail + summary queries."""
     bu = BillUsageRecord.__table__
     clauses = [bu.c.shifu_bid == bindparam("__shifu_bid", value=params.shifu_bid)]
     if params.start_date is not None:

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -37,7 +37,7 @@ ERR_INVALID_LIMIT = "server.creatorAnalytics.invalidLimit"
 
 
 def _translation_keys_used() -> None:
-    """Static registry consumed by the translation-usage checker.
+    """Return the static registry consumed by the translation-usage checker.
 
     Never invoked at runtime — translation keys are referenced through the
     ERR_* constants above. Listing them as literal `_()` calls inside an

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -293,7 +293,7 @@ def handle_input_ask(
     anchor_element_bid: str = "",
     parent_observation: Any | None = None,
 ) -> Generator[str, None, None]:
-    """Main function to handle user Q&A input
+    """Handle user Q&A input
     Responsible for processing user questions in the shifu and returning AI tutor responses
     """
     # Get follow-up information (including Q&A prompts and model configuration)

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -53,5 +53,5 @@ def registered_providers() -> Iterable[str]:
 
 
 def clear_providers() -> None:
-    """Utility for tests to reset the provider registry."""
+    """Reset the provider registry (test helper)."""
     _REGISTRY.clear()

--- a/src/api/flaskr/util/datetime.py
+++ b/src/api/flaskr/util/datetime.py
@@ -5,7 +5,7 @@ from flask import Flask
 
 
 def now_utc() -> datetime:
-    """Current UTC time as a naive datetime.
+    """Return the current UTC time as a naive datetime.
 
     The database stores UTC. Returning a naive (tz-unaware) value keeps the
     same semantics as ``datetime.utcnow()`` used elsewhere, so it can be

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -7,7 +7,7 @@ import sys
 
 
 def _gevent_worker_requested(argv) -> bool:
-    """True when the command line selects the gevent worker class.
+    """Report whether the command line selects the gevent worker class.
 
     Monkey-patching must match the worker class. The production deployment
     runs ``-k gthread``; patching gevent onto gthread workers turns their

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -45,7 +45,7 @@ target_db = current_app.extensions["migrate"].db
 
 
 def include_object(object, name, type_, reflected, compare_to):
-    """The simplest mode to avoid separation"""
+    """Use the simplest mode to avoid separation"""
     # the system tables
     system_tables = [
         "alembic_version",

--- a/src/api/tests/common/fixtures/config_data.py
+++ b/src/api/tests/common/fixtures/config_data.py
@@ -13,7 +13,7 @@ def port_validator(value):
 
 
 def email_validator(value):
-    """Simple email validator for testing."""
+    """Validate an email address (test helper)."""
     import re
 
     pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"

--- a/src/api/tests/common/fixtures/mock_validators.py
+++ b/src/api/tests/common/fixtures/mock_validators.py
@@ -21,12 +21,12 @@ def mock_email_validator(value):
 
 
 def always_fail_validator(value):
-    """Validator that always fails (for testing)."""
+    """Fail validation always (test helper)."""
     return False
 
 
 def always_pass_validator(value):
-    """Validator that always passes (for testing)."""
+    """Pass validation always (test helper)."""
     return True
 
 

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -22,7 +22,7 @@ def mock_app():
 
 
 def create_test_processor(mock_app, **kwargs):
-    """Helper to create a StreamingTTSProcessor with test defaults."""
+    """Create a StreamingTTSProcessor with test defaults."""
     defaults = {
         "app": mock_app,
         "generated_block_bid": "test-block",


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Rewrites 18 docstring first lines into imperative mood (e.g. `Setup logging ...` -> `Set up logging ...`, `Current UTC time as a naive datetime.` -> `Return the current UTC time as a naive datetime.`) and selects `D401` in `ruff.toml`. Docstrings only; no code changes.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lint configuration only; no executable logic, APIs, or data paths are modified.
> 
> **Overview**
> Enables **ruff `D401`** in `ruff.toml` so docstring first lines must use imperative mood, as part of the low-risk ruff rule rollout.
> 
> **Docstring-only updates** (~18 first lines) across API, scripts, tests, and config helpers—e.g. `Setup logging` → `Set up logging`, `Current UTC time…` → `Return the current UTC time…`, and similar rewrites for decorators, CLI groups, migration helpers, and test fixtures. **No runtime or behavioral changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746466e19f43ace70ff29dbb213c8d40c451d33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->