### PR TITLE
test: enforce ruff PT011 (narrow pytest.raises assertions)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -228,6 +228,7 @@ select = [
     "S108",  # hardcoded /tmp path instead of tempfile.gettempdir()
     "A001",  # local variable shadowing a builtin
     "D401",  # docstring first line not in imperative mood
+    "PT011",  # pytest.raises without match/specific exception
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -66,7 +66,7 @@ class TestEnvVarInitialization:
 
     def test_invalid_required_with_default(self):
         """Test that required=True with default raises ValueError."""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="marked as required") as exc_info:
             EnvVar(
                 name="INVALID_VAR",
                 required=True,
@@ -263,7 +263,10 @@ class TestLLMModelMaxOutputTokensConfig:
         env_var = ENV_VARS["LLM_MODEL_MAX_OUTPUT_TOKENS"]
 
         assert env_var.validate_value(value) is False
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match=r"must be a JSON object|model ids must|maximum output token values",
+        ):
             parse_llm_model_max_output_tokens(value)
 
 

--- a/src/api/tests/common/test_config_integration.py
+++ b/src/api/tests/common/test_config_integration.py
@@ -396,7 +396,7 @@ class TestBackwardCompatibility:
 
     def test_required_means_no_default(self):
         """Test that required=True prevents having defaults."""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="marked as required") as exc_info:
             EnvVar(name="TEST", required=True, default="should-fail")
 
         assert "marked as required" in str(exc_info.value)

--- a/src/api/tests/common/test_config_trim.py
+++ b/src/api/tests/common/test_config_trim.py
@@ -1,7 +1,11 @@
 """Unit tests for environment variable trimming functionality."""
 
 import pytest
-from flaskr.common.config import EnhancedConfig, EnvVar
+from flaskr.common.config import (
+    EnhancedConfig,
+    EnvironmentConfigError,
+    EnvVar,
+)
 
 
 class TestEnvironmentVariableTrimming:
@@ -193,7 +197,9 @@ class TestEnvironmentVariableTrimming:
         config = EnhancedConfig(env_vars)
 
         # Should fail validation because whitespace-only is treated as empty
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(
+            EnvironmentConfigError, match="Missing required environment variables"
+        ) as exc_info:
             config.validate_environment()
 
         assert "Missing required environment variables" in str(exc_info.value)

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -182,7 +182,7 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
         lambda *, source, session=None: invalidations.append(source) or True,
     )
 
-    with pytest.raises(ValueError), app.app_context():
+    with pytest.raises(ValueError, match="business"), app.app_context():
         raise ValueError("business")
 
     assert invalidations == []

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -225,7 +225,7 @@ class TestElementType:
     def test_invalid_value_raises(self):
         from flaskr.service.learn.learn_dtos import ElementType
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="nonexistent"):
             ElementType("nonexistent")
 
     def test_element_type_codes_complete(self):

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -90,7 +90,7 @@ def test_sse_business_error_does_not_invalidate(app, invalidations):
         )
         stream = iter(response.response)
         next(stream)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="business"):
             next(stream)
 
     assert invalidations == []

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -158,7 +158,7 @@ def test_ordinary_error_still_rolls_back_pooled_connection(app, monkeypatch):
 
     with app.app_context():
         generator = _start_stream(app)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="business failure"):
             next(generator)
 
     assert session.invalidations == 0

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -148,7 +148,7 @@ def test_native_snapshot_upsert_preserves_zero_amount_and_requires_identifier(
             == 0
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="requires a stable identifier"):
             upsert_native_snapshot(
                 biz_domain="order",
                 payment_provider="alipay",

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -7,7 +7,7 @@ import pytest
 from flaskr.dao import db
 from flaskr.service.billing.consts import BILLING_PRODUCT_TYPE_PLAN
 from flaskr.service.billing.models import BillingProduct
-from flaskr.service.common.models import ERROR_CODE
+from flaskr.service.common.models import ERROR_CODE, AppException
 from flaskr.service.referral.admin import (
     list_operator_referral_campaign_invitations,
     list_operator_referrals,
@@ -555,7 +555,7 @@ def test_operator_referral_filters_accept_user_identifier(referral_app):
 def test_operator_referral_campaign_rejects_invalid_payload(referral_app, payload):
     with referral_app.app_context():
         _seed_plan_product()
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(AppException) as exc_info:
             create_operator_referral_campaign(
                 referral_app,
                 operator_user_bid="operator-1",
@@ -580,7 +580,7 @@ def test_operator_referral_campaign_rejects_enabling_ended_campaign(referral_app
             ),
         )
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(AppException) as exc_info:
             update_operator_referral_campaign_status(
                 referral_app,
                 operator_user_bid="operator-1",
@@ -601,7 +601,7 @@ def test_operator_referral_campaign_duplicate_code_is_rejected(referral_app):
             operator_user_bid="operator-1",
             payload=_payload(),
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(AppException) as exc_info:
             create_operator_referral_campaign(
                 referral_app,
                 operator_user_bid="operator-1",

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -163,7 +163,7 @@ def test_repair_shifu_outline_structure_requires_user_bid_before_processing(app)
         _mk_outline("shifu-user-bid-check", "child-b", "0101", parent_bid="root-1")
         db.session.commit()
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="user_bid is required") as exc_info:
         repair_shifu_outline_structure(
             app,
             user_bid=None,

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -239,7 +239,7 @@ def test_synthesize_raises_on_api_error_with_code(monkeypatch):
     )
 
     provider = module.TencentTextToVoiceProvider()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="InvalidParameterValue") as exc_info:
         provider.synthesize(
             "你好",
             voice_settings=module.VoiceSettings(voice_id="101001"),
@@ -261,7 +261,9 @@ def test_synthesize_raises_on_empty_audio(monkeypatch):
     )
 
     provider = module.TencentTextToVoiceProvider()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError, match="No audio data received from Tencent TextToVoice"
+    ) as exc_info:
         provider.synthesize(
             "你好",
             voice_settings=module.VoiceSettings(voice_id="101001"),
@@ -274,7 +276,9 @@ def test_synthesize_rejects_non_numeric_voice_id(monkeypatch):
 
     _patch_credentials(monkeypatch)
     provider = module.TencentTextToVoiceProvider()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError, match="Invalid Tencent TextToVoice voice id"
+    ) as exc_info:
         provider.synthesize(
             "你好",
             voice_settings=module.VoiceSettings(voice_id="v-female-R2s4N9qJ"),

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -48,7 +48,10 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     events.clear()
 
     # Ordinary error: savepoint rollback then classified session cleanup.
-    with pytest.raises(ValueError), repo_module.transactional_session():
+    with (
+        pytest.raises(ValueError, match="business"),
+        repo_module.transactional_session(),
+    ):
         raise ValueError("business")
     assert events == [("cleanup", "transactional_session")]
     assert nested.rollbacks == 1

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1750,7 +1750,7 @@ def test_stream_non_retryable_error_raises_immediately(monkeypatch, app):
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(monkeypatch, [[ValueError("business error")]])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="business error"):
         _collect_retry_stream(app)
 
     assert calls["count"] == 1


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Broad `pytest.raises(Exception)` blocks now assert the exception they actually expect: `AppException` for referral admin tests, `EnvironmentConfigError` for config trimming tests, and `match=` patterns elsewhere. This means these tests no longer pass when an unrelated error is raised. Selects `PT011` in `ruff.toml`.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit abd758be119f7189797c7613bfe94c3e5c966b22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->