### PR TITLE
docs: enforce ruff D104 (document public packages)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -229,6 +229,7 @@ select = [
     "A001",  # local variable shadowing a builtin
     "D401",  # docstring first line not in imperative mood
     "PT011",  # pytest.raises without match/specific exception
+    "D104",  # missing docstring in public package
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/__init__.py
+++ b/src/api/flaskr/__init__.py
@@ -1,0 +1,1 @@
+"""AI-Shifu Flask backend application package."""

--- a/src/api/flaskr/api/__init__.py
+++ b/src/api/flaskr/api/__init__.py
@@ -1,1 +1,3 @@
+"""Third-party API clients and observability integrations."""
+
 from .langfuse import init_langfuse  # noqa: F401

--- a/src/api/flaskr/api/check/__init__.py
+++ b/src/api/flaskr/api/check/__init__.py
@@ -1,3 +1,5 @@
+"""Content risk-check provider integrations."""
+
 from flask import Flask
 
 from .dto import (

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -1,3 +1,5 @@
+"""LLM invocation wrappers built on LiteLLM."""
+
 import asyncio
 import logging
 import os

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -1,3 +1,5 @@
+"""Flask CLI commands for migrations and maintenance tasks."""
+
 import asyncio
 import logging
 import tempfile

--- a/src/api/flaskr/common/__init__.py
+++ b/src/api/flaskr/common/__init__.py
@@ -1,3 +1,5 @@
+"""Shared configuration, logging and Swagger helpers."""
+
 from .config import *  # noqa: F403
 from .log import *  # noqa: F403
 from .swagger import *  # noqa: F403

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -1,3 +1,5 @@
+"""Database, cache and session infrastructure."""
+
 import collections
 import contextlib
 import functools

--- a/src/api/flaskr/framework/__init__.py
+++ b/src/api/flaskr/framework/__init__.py
@@ -1,3 +1,5 @@
+"""Extension and plugin framework primitives."""
+
 from .plugin.plugin_manager import (
     extensible,
     extensible_generic,

--- a/src/api/flaskr/framework/plugin/__init__.py
+++ b/src/api/flaskr/framework/plugin/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin discovery, registration and CLI support."""

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -1,3 +1,5 @@
+"""Backend translation loading and lookup."""
+
 import importlib.util
 import json
 import os

--- a/src/api/flaskr/service/check_risk/__init__.py
+++ b/src/api/flaskr/service/check_risk/__init__.py
@@ -1,1 +1,3 @@
+"""Risk-check service helpers."""
+
 from .funcs import *  # noqa: F403

--- a/src/api/flaskr/service/common/__init__.py
+++ b/src/api/flaskr/service/common/__init__.py
@@ -1,1 +1,3 @@
+"""Shared service models, errors and dictionaries."""
+
 from .models import *  # noqa: F403

--- a/src/api/flaskr/service/config/__init__.py
+++ b/src/api/flaskr/service/config/__init__.py
@@ -1,3 +1,5 @@
+"""Runtime configuration overrides for services."""
+
 from .funcs import (
     config_overrides,
     get_config,

--- a/src/api/flaskr/service/feedback/__init__.py
+++ b/src/api/flaskr/service/feedback/__init__.py
@@ -1,0 +1,1 @@
+"""User feedback service."""

--- a/src/api/flaskr/service/learn/__init__.py
+++ b/src/api/flaskr/service/learn/__init__.py
@@ -1,2 +1,4 @@
+"""Learning-session runtime service."""
+
 from ..common.dicts import register_dict  # noqa: F401
 from .models import *  # noqa: F403

--- a/src/api/flaskr/service/metering/__init__.py
+++ b/src/api/flaskr/service/metering/__init__.py
@@ -1,3 +1,5 @@
+"""Usage metering constants and helpers."""
+
 from flaskr.service.common.dicts import register_dict
 
 from .consts import (  # noqa: F401

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -1,3 +1,5 @@
+"""Order and payment service."""
+
 from __future__ import annotations
 
 from importlib import import_module

--- a/src/api/flaskr/service/order/payment_providers/__init__.py
+++ b/src/api/flaskr/service/order/payment_providers/__init__.py
@@ -1,3 +1,5 @@
+"""Payment provider adapters."""
+
 from .base import (
     PaymentCreationResult,
     PaymentNotificationResult,

--- a/src/api/flaskr/service/promo/__init__.py
+++ b/src/api/flaskr/service/promo/__init__.py
@@ -1,0 +1,1 @@
+"""Promotion and discount service."""

--- a/src/api/flaskr/service/resource/__init__.py
+++ b/src/api/flaskr/service/resource/__init__.py
@@ -1,0 +1,1 @@
+"""Uploaded resource service."""

--- a/src/api/flaskr/service/shifu/__init__.py
+++ b/src/api/flaskr/service/shifu/__init__.py
@@ -1,0 +1,1 @@
+"""Shifu authoring and publishing service."""

--- a/src/api/flaskr/service/shifu/admin_operations/__init__.py
+++ b/src/api/flaskr/service/shifu/admin_operations/__init__.py
@@ -1,0 +1,1 @@
+"""Operator-facing shifu admin operations."""

--- a/src/api/flaskr/util/__init__.py
+++ b/src/api/flaskr/util/__init__.py
@@ -1,2 +1,4 @@
+"""Small shared utilities."""
+
 from .datetime import get_now_time  # noqa: F401
 from .uuid import generate_id  # noqa: F401

--- a/src/api/tests/__init__.py
+++ b/src/api/tests/__init__.py
@@ -1,3 +1,5 @@
+"""Backend test suite."""
+
 # import sys
 # import os
 

--- a/src/api/tests/golden/__init__.py
+++ b/src/api/tests/golden/__init__.py
@@ -1,0 +1,1 @@
+"""Golden-file regression tests."""

--- a/src/api/tests/service/creator_analytics/__init__.py
+++ b/src/api/tests/service/creator_analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the creator analytics service."""

--- a/src/api/tests/service/profile/__init__.py
+++ b/src/api/tests/service/profile/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the profile service."""


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Adds a one-line docstring to 27 public `__init__.py` files (e.g. `"""Learning-session runtime service."""`) and selects `D104` in `ruff.toml`. Docstrings only; no imports or code moved.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstrings and lint configuration only; no application logic, APIs, or imports were modified.
> 
> **Overview**
> Enables **Ruff `D104`** (missing docstring on public packages) in `ruff.toml` and adds a **one-line package docstring** to **27** public `__init__.py` files under `src/api/flaskr` and `src/api/tests`.
> 
> The new strings briefly name each package’s role (e.g. Flask app root, LLM wrappers, order/payment, test suites). **Imports and runtime behavior are unchanged**—this is documentation plus lint policy only, as part of a series of low-risk Ruff rule rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ae4185dad04b8a2fa89c4ab266190e7b99f624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->