### PR TITLE
style: enforce ruff G003 (lazy logging arguments)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -33,8 +33,10 @@
 #   reflow with no correctness value.
 # - BLE001 / S110 / S112: blind/except-pass handlers are deliberate fail-open
 #   patterns here (moderation, logging, notification side channels).
-# - G001 / G003 / G004: f-string logging is the established house style; the
-#   lazy-%-formatting argument does not outweigh the churn. G201 IS enabled --
+# - G001 / G004: f-string logging is the established house style; the
+#   lazy-%-formatting argument does not outweigh the churn. G003 IS enabled --
+#   `+` concatenation in a log call only appeared a handful of times and can
+#   raise TypeError on non-string values. G201 IS enabled --
 #   `.exception(...)` is strictly equivalent to `.error(..., exc_info=True)`.
 # - RUF012 / UP* as whole groups: style or modernization churn with no
 #   bug-catching value for this codebase today. Individual members that are

--- a/ruff.toml
+++ b/ruff.toml
@@ -230,6 +230,7 @@ select = [
     "D401",  # docstring first line not in imperative mood
     "PT011",  # pytest.raises without match/specific exception
     "D104",  # missing docstring in public package
+    "G003",  # logging statement uses string concatenation
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/api/wechat.py
+++ b/src/api/flaskr/api/wechat.py
@@ -14,6 +14,6 @@ def get_wechat_access_token(app: Flask, code: str):
     response = requests.get(url, timeout=10)
     app.logger.info(f"get_wechat_access_token response: {response}")
     if response.status_code == 200:
-        app.logger.info("get_wechat_access_token:" + str(response.json()))
+        app.logger.info("get_wechat_access_token: %s", response.json())
         return response.json()
     return None

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -32,5 +32,5 @@ def register_dict(name, desp, items: dict):
 
 
 def get_all_dicts(app: Flask) -> dict:
-    app.logger.info("get_all_dicts is called" + str(DICTS))
+    app.logger.info("get_all_dicts is called %s", DICTS)
     return DICTS

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -133,7 +133,7 @@ def get_fmt_prompt(
     Returns:
         str: Fmt prompt
     """
-    app.logger.info("raw prompt:" + profile_tmplate)
+    app.logger.info("raw prompt: %s", profile_tmplate)
     propmpt_keys = []
     profiles = {}
 
@@ -152,7 +152,7 @@ def get_fmt_prompt(
         if key in profiles:
             fmt_keys[key] = profiles[key]
         else:
-            app.logger.info("key not found:" + key + " ,user_id:" + user_id)
+            app.logger.info("key not found: %s ,user_id: %s", key, user_id)
     app.logger.info(fmt_keys)
     if not keys:
         prompt = profile_tmplate or input

--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -37,9 +37,7 @@ def validate_user(app: Flask, token: str) -> UserInfo:
             user_id = jwt.decode(token, app.config["SECRET_KEY"], algorithms=["HS256"])[
                 "user_id"
             ]
-            app.logger.info("user_id:" + user_id)
-
-            app.logger.info("user_id:" + user_id)
+            app.logger.info("user_id: %s", user_id)
             ttl_seconds = app.config.get("TOKEN_EXPIRE_TIME", 60 * 60 * 24 * 7)
             lookup = token_store.get_and_refresh(
                 app,


### PR DESCRIPTION
# Summary

Part of the stack enabling 10 low-risk ruff rules, one rule per PR.

Converts the logging calls that built their message with `+` into `%s` lazy arguments, e.g.

```python
app.logger.info("key not found: " + key + " ,user_id: " + user_id)
# ->
app.logger.info("key not found: %s ,user_id: %s", key, user_id)
```

Also drops a duplicated `user_id` log line in the user service and selects `G003` in `ruff.toml`. Formatting is now skipped when the level is disabled, and non-string values can no longer raise `TypeError` inside a log call.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2dc5ea15aa0e685ce7c83938262173839eebbe52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->