### PR TITLE
style: enforce ruff ERA001 (no commented-out code)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -233,6 +233,7 @@ select = [
     "PT011",  # pytest.raises without match/specific exception
     "D104",  # missing docstring in public package
     "G003",  # logging statement uses string concatenation
+    "ERA001",  # commented-out code
 ]
 ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -20,8 +20,6 @@ from .dto import (
     CheckResultDTO,
 )
 
-# pid = ""
-# secret_key = b""
 endpoint_host = "tsafe.ilivedata.com"
 endpoint_path = "/api/v1/text/check"
 endpoint_url = "https://tsafe.ilivedata.com/api/v1/text/check"

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -992,7 +992,7 @@ ALIYUN_VOICES = [
         "lang": "zh",
         "desc": "直播女声",
     },
-    # 臻品音色 (Ultra-HD)
+    # 臻品音色 group (Ultra-HD)
     {
         "id": "zhiqi",
         "name": "知琪",

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -41,7 +41,7 @@ BAIDU_AUDIO_FORMATS = {
 # Baidu voice IDs - Complete list
 # Reference: https://ai.baidu.com/ai-doc/SPEECH/Rluv3uq3d
 BAIDU_VOICES = [
-    # 基础音库 (Basic - Free)
+    # 基础音库 group (Basic - Free)
     {
         "id": "0",
         "name": "度小美",
@@ -74,7 +74,7 @@ BAIDU_VOICES = [
         "gender": "child",
         "desc": "童声",
     },
-    # 精品音库 (Premium)
+    # 精品音库 group (Premium)
     {
         "id": "5",
         "name": "度逍遥",

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -361,11 +361,6 @@ class RUNLLMProvider(LLMProvider):
         if not messages:
             raise ValueError("No messages provided")
 
-        # system_prompt = messages[0].get("content", "")
-        # Get the last message content
-        # last_message = messages[-1]
-        # prompt = last_message.get("content", "")
-
         # Use provided model/temperature or fall back to settings
         actual_model = model or self.llm_settings.model
         actual_temperature = (
@@ -2649,8 +2644,7 @@ class RunScriptContextV2:
                         return True
                 if button.get("value") == "_sys_login":
                     # Same logged-in definition as the emitter's
-                    # is_access_gate_blocking_interaction: email-only
-                    # accounts are logged in too.
+                    # access-gate check: email-only accounts are logged in too.
                     if bool(self._user_info.mobile or self._user_info.email):
                         self._can_continue = True
                         self._recorder.update_progress_pointer(

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -422,7 +422,6 @@ def init_buy_record(
                 active_id=None,
             )
             return query_buy_record(app, origin_record.order_bid)
-        # raise_error("server.order.orderNotFound")
         order_id = str(get_uuid(app))
         if order_timeout_make_new_order:
             buy_record = Order()
@@ -549,7 +548,6 @@ def generate_charge(
                 "",
                 payment_channel=buy_record.payment_channel,
             )
-            # raise_error("server.order.orderHasPaid")
         amount = int(buy_record.paid_price * 100)
         subject = shifu_info.title
         body = shifu_info.description

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -154,7 +154,6 @@ def check_text_content(
 
 
 def get_profile_labels():
-    # language = get_current_language()
     return {
         "sys_user_nickname": {
             "label": _("server.profile.nickname"),

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -343,7 +343,7 @@ class SimpleOutlineDto(BaseModel):
 
 
 # new outline tree node class, for handling DraftOutlineItem
-# author: yfge
+# written by yfge
 # date: 2025-07-13
 # version: 1.0.0
 # description: this class is used to handle DraftOutlineItem

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -263,7 +263,6 @@ def get_outline_tree(app, user_id: str, shifu_bid: str) -> list[SimpleOutlineDto
     app.logger.info(f"get outline tree, user_id: {user_id}, shifu_bid: {shifu_bid}")
     with app.app_context():
         outline_tree = build_outline_tree(app, shifu_bid, include_content=False)
-        # return result
         return get_outline_tree_dto(outline_tree)
 
 

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -1,5 +1,5 @@
 # user service
-# author: yfge
+# written by yfge
 #
 
 
@@ -41,7 +41,7 @@ from .repository import (
 from .utils import generate_token
 
 # generate temp user for anonymous user
-# author: yfge
+# written by yfge
 
 
 def _try_delete_local_file_by_url(app: Flask, url: str) -> None:

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -168,8 +168,6 @@ def send_sms_code(
         if ip:
             ip_ban_key = _redis_prefix(app, "REDIS_KEY_PREFIX_IP_BAN") + ip
             if redis.get(ip_ban_key):
-                # Development, debugging and use
-                # redis.delete(ip_ban_key)
                 raise_error("server.user.ipBanned")
 
             # Check IP sending frequency
@@ -242,8 +240,6 @@ def send_email_code(
         if ip:
             ip_ban_key = _redis_prefix(app, "REDIS_KEY_PREFIX_IP_BAN") + ip
             if redis.get(ip_ban_key):
-                # Development, debugging and use
-                # redis.delete(ip_ban_key)
                 raise_error("server.user.ipBanned")
 
             # Check IP sending frequency

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -31,17 +31,8 @@ def get_engine_url():
         return str(get_engine().url).replace("%", "%%")
 
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
 config.set_main_option("sqlalchemy.url", get_engine_url())
 target_db = current_app.extensions["migrate"].db
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
 
 
 def include_object(object, name, type_, reflected, compare_to):

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -143,7 +143,7 @@ def _build_cases(*, provider_name: str, matrix: str) -> list[dict[str, str]]:
                     add_case(model_value, _safe_str(voice.get("value")))
         return cases
 
-    # matrix == "coverage"
+    # Coverage matrix:
     # 1) Test each model with a representative voice.
     for model in models:
         model_value = _safe_str(model.get("value"))

--- a/src/api/tests/__init__.py
+++ b/src/api/tests/__init__.py
@@ -1,10 +1,5 @@
 """Backend test suite."""
 
-# import sys
-# import os
-
-# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import os
 from pathlib import Path
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -91,10 +91,6 @@ from tests.common.fixtures.fake_llm import (
 from tests.common.fixtures.fake_redis import FakeRedis
 
 
-# Path: test/test_flaskr.py
-# Compare this snippet from flaskr/plugin/test.py:
-# from ..service.schedule import *
-#
 @pytest.fixture(scope="session")
 def app():
     if os.getenv("SKIP_APP_FIXTURE"):

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -91,7 +91,8 @@ class TestFinalizeSegmentation:
         submitted_texts = []
 
         def mock_submit(*args, **kwargs):
-            # Args: (_synthesize_in_thread, segment, voice_settings, audio_settings, provider, model)
+            # Positional args are the thread target followed by segment,
+            # voice settings, audio settings, provider and model.
             # Capture the segment text from args[1]
             if len(args) > 1:
                 segment = args[1]
@@ -131,7 +132,8 @@ class TestFinalizeSegmentation:
         submitted_texts = []
 
         def mock_submit(*args, **kwargs):
-            # Args: (_synthesize_in_thread, segment, voice_settings, audio_settings, provider, model)
+            # Positional args are the thread target followed by segment,
+            # voice settings, audio settings, provider and model.
             if len(args) > 1:
                 segment = args[1]
                 if hasattr(segment, "text"):
@@ -162,7 +164,8 @@ class TestFinalizeSegmentation:
         submitted_texts = []
 
         def mock_submit(*args, **kwargs):
-            # Args: (_synthesize_in_thread, segment, voice_settings, audio_settings, provider, model)
+            # Positional args are the thread target followed by segment,
+            # voice settings, audio settings, provider and model.
             if len(args) > 1:
                 segment = args[1]
                 if hasattr(segment, "text"):

--- a/src/api/tests/test_app.py
+++ b/src/api/tests/test_app.py
@@ -1,16 +1,5 @@
 import pytest
 
-# Path: test/test_flaskr.py
-# Compare this snippet from flaskr/plugin/test.py:
-# from ..service.schedule import *
-#
-
-# print("test_flaskr.py")
-# @pytest.fixture(scope="session", autouse=True)
-# def app():
-#     app = create_app('test_sifu')
-#     yield app
-
 
 @pytest.fixture
 def test_client(app):

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -10,10 +10,6 @@ except Exception:  # pragma: no cover - fallback for test environment
         pp.pprint(data)
 
 
-# from .test_utils import dump
-# dump(data)
-
-
 # python -m pytest tests/test_xxx.py::xxx -v -s --disable-warnings
 def dump(data: Any) -> None:
     print("\n=== Test Result ===")


### PR DESCRIPTION
# Summary

Top PR in the stack enabling 10 low-risk ruff rules, one rule per PR.

Deletes dead commented-out statements (e.g. the commented ilivedata credentials, `# redis.delete(ip_ban_key)` debugging lines, the alembic boilerplate comments in `migrations/env.py`, and stale fixture stubs in the test package) and rewords a handful of descriptive comments that ERA001 parses as code (`# author: yfge`, voice-group section labels, `# Args: (...)`). Selects `ERA001` in `ruff.toml`.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and lint-only changes; removed snippets were dead code or unreachable after existing returns.
> 
> **Overview**
> Enables **ERA001** in `ruff.toml` so CI and local lint reject commented-out code.
> 
> The diff **removes** dead commented statements across the API and tests (e.g. placeholder ilivedata credential lines, debug `redis.delete` snippets, stale pytest/sys.path stubs, Alembic boilerplate in `migrations/env.py`, and unreachable `raise_error` lines in order flows that already return). A few **comments are reworded** where ERA001 treated prose as code (`# author:` → `# written by`, TTS section headers with `group`, test mock arg notes without `# Args:`).
> 
> No runtime behavior change—only lint policy and comment cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4804e8f3abcf4aee34b38d7078a0255e3169339c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->