### PR TITLE
docs: enforce the pydocstyle rule group for docstrings

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -15,9 +15,9 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN / D1xx (except D104) / SLF001 / PLC0415 / PLR2004: thousands of
-#   violations each; enforcing them is a codebase-wide project, not a lint
-#   config change.
+# - ANN / SLF001 / PLC0415 / PLR2004 (and D1xx, see the ignore block):
+#   thousands of violations each; enforcing them is a codebase-wide project,
+#   not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
 #   tuples/lists, not a missed comma. ISC001/ISC002 also conflict with the
 #   formatter.
@@ -31,12 +31,6 @@
 #   service and route modules exceed by design.
 # - ARG001 / ARG002 / ARG005: unused arguments are pervasive in framework
 #   callbacks, fixtures and test doubles.
-# - D405 / D406 / D407: route docstrings carry the flasgger/Swagger spec after
-#   a `---` line, and these rules read YAML keys such as `parameters:` as
-#   numpydoc section headers. Their fixes strip the colon and insert a dashed
-#   underline, which turns the embedded spec into invalid YAML and breaks the
-#   generated API docs. The D2xx/D4xx rules that are selected never rewrite a
-#   line inside the YAML block.
 
 # Matches the Python pinned by src/api/Dockerfile and the CI workflows.
 target-version = "py311"
@@ -120,20 +114,10 @@ select = [
     "S324",    # hashlib md5/sha1 without usedforsecurity=False
 
     # --- Docstrings -------------------------------------------------------
-    # Partial: D1xx (missing docstrings) has ~4.6k violations, and D203/D205/
-    # D213/D400/D415 are formatting rewrites of existing prose. Only the
-    # mechanical members are enforced.
-    "D104",    # missing docstring in public package
-    "D202",    # blank line after a function docstring
-    "D209",    # closing quotes of a multi-line docstring not on their own line
-    # D212 stays explicit: the D21 prefix also enables the mutually exclusive
-    # D213, which ruff then warns about and ignores.
-    "D212",    # multi-line docstring summary not on the first line
-    "D3",      # docstring quote style (D300) and non-raw backslashes (D301)
-    "D401",    # docstring first line not in imperative mood
-    "D403",    # first word of a docstring not capitalized
-    "D411",    # missing blank line before section
-    "D413",    # missing blank line after the last docstring section
+    # pydocstyle is enabled as a whole; the members that would need thousands
+    # of new docstrings, conflict with a selected sibling rule, or rewrite
+    # embedded Swagger YAML are ignored below.
+    "D",
 
     # --- Modernization ----------------------------------------------------
     # UP040/UP046/UP047 (PEP 695 type parameters) are ignored below.
@@ -149,6 +133,25 @@ select = [
 ]
 ignore = [
     "E501",    # line length is owned by the formatter
+    # D1xx (except D104, which is enforced): ~4.6k undocumented modules,
+    # classes, methods, functions and __init__s. Writing them is a codebase
+    # project, not a lint config change.
+    "D100",    # undocumented public module
+    "D101",    # undocumented public class
+    "D102",    # undocumented public method
+    "D103",    # undocumented public function
+    "D105",    # undocumented magic method
+    "D107",    # undocumented __init__
+    "D203",    # blank line before a class docstring -- conflicts with D211
+    "D205",    # summary wrapped over two lines -- 260 prose rewrites, deferred
+    "D213",    # summary on the second line -- conflicts with D212
+    # D405 / D406 / D407: route docstrings carry the flasgger/Swagger spec
+    # after a `---` line, and these rules read YAML keys such as `parameters:`
+    # as numpydoc section headers. Their fixes strip the colon and insert a
+    # dashed underline, turning the embedded spec into invalid YAML.
+    "D405",
+    "D406",
+    "D407",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "DTZ901",  # datetime.min/max -- naive UTC is the house convention

--- a/scripts/generate_languages.py
+++ b/scripts/generate_languages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate/refresh src/i18n/locales.json
+"""Generate/refresh src/i18n/locales.json.
 
 - Updates locale labels from common/language.json
 - Rebuilds the namespaces list by scanning JSON and honoring __namespace__

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -62,7 +62,7 @@ CHECK_RESULT_MAP = {
 
 
 def gen_signature(params=None):
-    """Generate signature for yidun check"""
+    """Generate signature for yidun check."""
     buff = ""
     for k in sorted(params.keys()):
         buff += str(k) + str(params[k])

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -167,6 +167,8 @@ class VolcengineProtocol:
             volume: Volume rate (-50 to 100, 0 is normal)
             emotion: Emotion setting
             model: Model version (e.g., seed-tts-1.1)
+            enable_timestamp: Ask the provider for word-level timestamps
+            enable_subtitle: Ask the provider for subtitle events
 
         Returns:
             Encoded binary frame

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -433,6 +433,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
             text: Text to synthesize
             voice_settings: Voice settings (optional)
             audio_settings: Audio settings (optional)
+            model: Model version override (optional)
 
         Returns:
             TTSResult with audio data and metadata

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -20,7 +20,7 @@ from .update_shifu_demo import update_demo_shifu
 
 
 def setup_migration_logging():
-    """Set up logging for migration commands"""
+    """Set up logging for migration commands."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
@@ -45,7 +45,7 @@ def enable_commands(app: Flask):
     @click.argument("discount_code")
     @click.argument("user_nick_name")
     def import_user_command(mobile, course_id, discount_code, user_nick_name):
-        """Import user and enable course"""
+        """Import user and enable course."""
         import_user(app, mobile, course_id, discount_code, user_nick_name)
 
     @console.command(name="migrate")
@@ -61,7 +61,7 @@ def enable_commands(app: Flask):
         help="Show what would be migrated without actually doing it",
     )
     def migrate_command(batch_size, max_workers, force_full, output_file, dry_run):
-        """Run unified legacy data migration"""
+        """Run unified legacy data migration."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
 
@@ -172,7 +172,7 @@ def enable_commands(app: Flask):
 
     @console.command(name="verify")
     def verify_command():
-        """Verify data consistency between old and new tables"""
+        """Verify data consistency between old and new tables."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
 
@@ -227,7 +227,7 @@ def enable_commands(app: Flask):
 
     @console.command(name="status")
     def status_command():
-        """Show migration status and table counts"""
+        """Show migration status and table counts."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
 
@@ -313,7 +313,7 @@ def enable_commands(app: Flask):
     @click.argument("shifu_id")
     @click.argument("file_path")
     def export_shifu_command(shifu_id, file_path):
-        """Export a shifu to a JSON file
+        """Export a shifu to a JSON file.
 
         Args:
             shifu_id: Shifu business identifier
@@ -350,7 +350,7 @@ def enable_commands(app: Flask):
         "--user-id", required=True, help="User ID for creating/updating the shifu"
     )
     def import_shifu_command(file_path, shifu_id, user_id):
-        """Import a shifu from a JSON file
+        """Import a shifu from a JSON file.
 
         Args:
             file_path: Path to the JSON file to import
@@ -403,6 +403,6 @@ def enable_commands(app: Flask):
 
     @console.command(name="update_demo_shifu")
     def update_demo_shifu_command():
-        """Update demo shifu"""
+        """Update demo shifu."""
         app.logger.info("Updating demo shifu...")
         update_demo_shifu(app)

--- a/src/api/flaskr/command/import_user.py
+++ b/src/api/flaskr/command/import_user.py
@@ -16,7 +16,7 @@ from flaskr.service.user.repository import (
 def import_user(
     app: Flask, mobile, course_id, discount_code="web", user_nick_name=None
 ):
-    """Import user and enable course"""
+    """Import user and enable course."""
     app.logger.info(f"import_user: {mobile}, {course_id}")
     with app.app_context():
         normalized_mobile = normalize_phone_identifier(mobile)

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unified Database Migration Task"""
+"""Unified Database Migration Task."""
 
 import asyncio
 import logging
@@ -34,7 +34,7 @@ class MigrationBatchError(RuntimeError):
 
 @dataclass
 class MigrationConfig:
-    """Migration configuration"""
+    """Migration configuration."""
 
     batch_size: int = 1000
     max_workers: int = 4
@@ -45,7 +45,7 @@ class MigrationConfig:
 
 @dataclass
 class MigrationResult:
-    """Migration result for a single table"""
+    """Migration result for a single table."""
 
     table_name: str
     total_records: int
@@ -57,12 +57,12 @@ class MigrationResult:
 
     @property
     def duration(self) -> float:
-        """Get migration duration in seconds"""
+        """Get migration duration in seconds."""
         return (self.end_time - self.start_time).total_seconds()
 
     @property
     def success_rate(self) -> float:
-        """Get success rate as percentage"""
+        """Get success rate as percentage."""
         if self.total_records == 0:
             return 100.0
         return (self.synced_records / self.total_records) * 100
@@ -70,7 +70,7 @@ class MigrationResult:
 
 @dataclass
 class ConsistencyCheckResult:
-    """Consistency check result"""
+    """Consistency check result."""
 
     table_pair: str
     old_count: int
@@ -105,7 +105,7 @@ def _resolve_default_database_url() -> str:
 
 
 class UnifiedMigrationTask:
-    """Unified migration task for study, order, and coupon tables"""
+    """Unified migration task for study, order, and coupon tables."""
 
     def __init__(
         self,
@@ -165,7 +165,7 @@ class UnifiedMigrationTask:
         logger.info(f"Initialized unified migration task with database: {database_url}")
 
     async def migrate_all_tables(self) -> dict[str, MigrationResult]:
-        """Migrate all configured tables asynchronously"""
+        """Migrate all configured tables asynchronously."""
         logger.info("Starting unified migration for all tables...")
 
         results = {}
@@ -201,7 +201,7 @@ class UnifiedMigrationTask:
     async def _migrate_table_async(
         self, source_table: str, table_config: dict
     ) -> MigrationResult:
-        """Migrate a single table asynchronously"""
+        """Migrate a single table asynchronously."""
         logger.info(f"Starting migration for table: {source_table}")
         start_time = now_utc()
 
@@ -311,7 +311,7 @@ class UnifiedMigrationTask:
         target_key: str,
         offset: int,
     ) -> dict:
-        """Process a batch of records asynchronously"""
+        """Process a batch of records asynchronously."""
         loop = asyncio.get_event_loop()
 
         with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
@@ -335,7 +335,7 @@ class UnifiedMigrationTask:
         target_key: str,
         offset: int,
     ) -> dict:
-        """Process a batch of records synchronously"""
+        """Process a batch of records synchronously."""
         # Create a new session for this batch to avoid concurrency issues
         session = self.SessionClass()
         try:
@@ -485,7 +485,7 @@ class UnifiedMigrationTask:
             session.close()
 
     async def verify_data_consistency(self) -> dict[str, ConsistencyCheckResult]:
-        """Verify data consistency between old and new tables"""
+        """Verify data consistency between old and new tables."""
         logger.info("Starting comprehensive data consistency verification...")
 
         results = {}
@@ -540,7 +540,7 @@ class UnifiedMigrationTask:
     async def _verify_sample_integrity_async(
         self, source_table: str, target_table: str, key_field: str, target_key: str
     ) -> tuple[bool, list[str]]:
-        """Verify data integrity using random sampling"""
+        """Verify data integrity using random sampling."""
         session = self.SessionClass()
         try:
             # Get random sample from source table
@@ -602,7 +602,7 @@ class UnifiedMigrationTask:
     def _verify_record_mapping(
         self, source_table: str, source_record, target_record
     ) -> bool:
-        """Verify specific field mappings for a record"""
+        """Verify specific field mappings for a record."""
         try:
             if source_table == "discount":
                 return (
@@ -629,7 +629,7 @@ class UnifiedMigrationTask:
 
     # Table mapping functions
     def _map_attendscript_to_progress_record(self, record) -> dict:
-        """Map ai_course_lesson_attend to learn_progress_records"""
+        """Map ai_course_lesson_attend to learn_progress_records."""
         return {
             "progress_record_bid": getattr(record, "attend_id", ""),
             "shifu_bid": getattr(record, "course_id", ""),
@@ -644,7 +644,7 @@ class UnifiedMigrationTask:
         }
 
     def _map_log_script_to_generated_block(self, record) -> dict:
-        """Map ai_course_lesson_attendscript to learn_generated_blocks"""
+        """Map ai_course_lesson_attendscript to learn_generated_blocks."""
         return {
             "generated_block_bid": getattr(record, "log_id", ""),
             "progress_record_bid": getattr(record, "attend_id", ""),
@@ -665,7 +665,7 @@ class UnifiedMigrationTask:
         }
 
     def _map_discount_to_coupon(self, record) -> dict:
-        """Map discount to promo_coupons"""
+        """Map discount to promo_coupons."""
         return {
             "coupon_bid": record.discount_id,
             "code": record.discount_code,
@@ -686,7 +686,7 @@ class UnifiedMigrationTask:
         }
 
     def _map_discount_log_to_usage(self, record) -> dict:
-        """Map discount_use_log to promo_coupon_usages"""
+        """Map discount_use_log to promo_coupon_usages."""
         return {
             "coupon_usage_bid": record.record_id,
             "coupon_bid": record.discount_id,
@@ -705,12 +705,12 @@ class UnifiedMigrationTask:
 
     # Helper methods
     async def _table_exists_async(self, table_name: str) -> bool:
-        """Check if table exists asynchronously"""
+        """Check if table exists asynchronously."""
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, self._table_exists, table_name)
 
     def _table_exists(self, table_name: str) -> bool:
-        """Check if table exists"""
+        """Check if table exists."""
         session = self.SessionClass()
         try:
             result = session.execute(
@@ -726,7 +726,7 @@ class UnifiedMigrationTask:
     def _get_table_count_with_session(
         self, session, table_name: str, where_clause: str = ""
     ) -> int:
-        """Get table record count using provided session"""
+        """Get table record count using provided session."""
         try:
             query = f"SELECT COUNT(*) FROM {table_name}"
             if where_clause:
@@ -741,7 +741,7 @@ class UnifiedMigrationTask:
     def _check_column_exists_with_session(
         self, session, table_name: str, column_name: str
     ) -> bool:
-        """Check if column exists in table"""
+        """Check if column exists in table."""
         try:
             result = session.execute(
                 text(
@@ -763,14 +763,14 @@ class UnifiedMigrationTask:
     async def _get_table_count_async(
         self, table_name: str, where_clause: str = ""
     ) -> int:
-        """Get table record count asynchronously"""
+        """Get table record count asynchronously."""
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             None, self._get_table_count, table_name, where_clause
         )
 
     def _get_table_count(self, table_name: str, where_clause: str = "") -> int:
-        """Get table record count"""
+        """Get table record count."""
         session = self.SessionClass()
         try:
             query = f"SELECT COUNT(*) FROM {table_name}"
@@ -786,7 +786,7 @@ class UnifiedMigrationTask:
             session.close()
 
     def _get_last_sync_time(self, sync_type: str) -> datetime:
-        """Get last sync time from log table"""
+        """Get last sync time from log table."""
         session = self.SessionClass()
         try:
             return self._get_last_sync_time_with_session(session, sync_type)
@@ -794,7 +794,7 @@ class UnifiedMigrationTask:
             session.close()
 
     def _get_last_sync_time_with_session(self, session, sync_type: str) -> datetime:
-        """Get last sync time from log table using provided session"""
+        """Get last sync time from log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
 
@@ -811,7 +811,7 @@ class UnifiedMigrationTask:
             return datetime(2020, 1, 1)
 
     def _get_last_synced_id_with_session(self, session, sync_type: str) -> int:
-        """Get last synced ID from log table using provided session"""
+        """Get last synced ID from log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
 
@@ -828,7 +828,7 @@ class UnifiedMigrationTask:
             return 0
 
     def _update_sync_time(self, sync_type: str, sync_time: datetime):
-        """Update sync time in log table"""
+        """Update sync time in log table."""
         session = self.SessionClass()
         try:
             self._update_sync_time_with_session(session, sync_type, sync_time)
@@ -838,7 +838,7 @@ class UnifiedMigrationTask:
     def _update_sync_time_with_session(
         self, session, sync_type: str, sync_time: datetime
     ):
-        """Update sync time in log table using provided session"""
+        """Update sync time in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
 
@@ -855,7 +855,7 @@ class UnifiedMigrationTask:
     def _update_last_synced_id_with_session(
         self, session, sync_type: str, last_synced_id: int
     ):
-        """Update last synced ID in log table using provided session"""
+        """Update last synced ID in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
 
@@ -870,7 +870,7 @@ class UnifiedMigrationTask:
             logger.warning(f"Error updating last synced ID: {e}")
 
     def _ensure_sync_log_table(self):
-        """Ensure sync log table exists"""
+        """Ensure sync log table exists."""
         session = self.SessionClass()
         try:
             self._ensure_sync_log_table_with_session(session)
@@ -878,7 +878,7 @@ class UnifiedMigrationTask:
             session.close()
 
     def _ensure_sync_log_table_with_session(self, session):
-        """Ensure sync log table exists using provided session"""
+        """Ensure sync log table exists using provided session."""
         try:
             session.execute(
                 text(
@@ -936,7 +936,7 @@ class UnifiedMigrationTask:
         migration_results: dict[str, MigrationResult],
         consistency_results: dict[str, ConsistencyCheckResult],
     ) -> str:
-        """Generate comprehensive migration report"""
+        """Generate comprehensive migration report."""
         report = []
         report.append("=" * 80)
         report.append("UNIFIED DATABASE MIGRATION REPORT")
@@ -1003,13 +1003,13 @@ class UnifiedMigrationTask:
         return "\n".join(report)
 
     def close(self):
-        """Close database connections"""
+        """Close database connections."""
         if self.engine:
             self.engine.dispose()
 
 
 async def main():
-    """Run the unified migration task"""
+    """Run the unified migration task."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Unified Database Migration Task")

--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -127,7 +127,7 @@ def _ensure_creator_permissions(app: Flask, shifu_bid: str):
 
 
 def update_demo_shifu(app: Flask):
-    """Update demo shifu for both Chinese and English versions"""
+    """Update demo shifu for both Chinese and English versions."""
     if get_env_config("SKIP_DEMO_SHIFU_IMPORT"):
         app.logger.info("Skip demo shifu import due to SKIP_DEMO_SHIFU_IMPORT")
         return

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -10,7 +10,7 @@ class BasePlugin:
             self._run_migrations()
 
     def _run_migrations(self):
-        """执行插件的migrations"""
+        """执行插件的migrations."""
         from alembic import command
         from alembic.config import Config
 
@@ -23,7 +23,7 @@ class BasePlugin:
         command.upgrade(alembic_cfg, "head")
 
     def on_unload(self):
-        """插件卸载时调用"""
+        """插件卸载时调用."""
 
     def on_reload(self):
-        """插件重载时调用"""
+        """插件重载时调用."""

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -10,7 +10,7 @@ class BasePlugin:
             self._run_migrations()
 
     def _run_migrations(self):
-        """执行插件的migrations."""
+        """Run the plugin migrations."""
         from alembic import command
         from alembic.config import Config
 
@@ -23,7 +23,7 @@ class BasePlugin:
         command.upgrade(alembic_cfg, "head")
 
     def on_unload(self):
-        """插件卸载时调用."""
+        """Handle the plugin being unloaded."""
 
     def on_reload(self):
-        """插件重载时调用."""
+        """Handle the plugin being reloaded."""

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -45,7 +45,7 @@ def enable_plugins(app: Flask):
                 continue
 
     def get_plugin_migrations():
-        """Get plugin migrations"""
+        """Get plugin migrations."""
         plugins = []
         app.logger.info(
             f"plugin_manager.plugins: {len(plugin_manager.plugins.values())}"
@@ -60,14 +60,14 @@ def enable_plugins(app: Flask):
 
     @plugin.group(name="db")
     def plugin_db():
-        """Manage the plugin database"""
+        """Manage the plugin database."""
 
     def get_version_table_name(plugin_name: str) -> str:
-        """Get version table name"""
+        """Get version table name."""
         return f"alembic_version_plugin_{plugin_name.replace('-', '_')}"
 
     def get_alembic_config(plugin, version_table: str | None = None) -> Config:
-        """Get alembic config"""
+        """Get alembic config."""
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", plugin.migration_dir)
         alembic_cfg.set_main_option(
@@ -82,7 +82,7 @@ def enable_plugins(app: Flask):
         return alembic_cfg
 
     def get_plugin_include_object(plugin_name: str):
-        """Generate plugin model filter function"""
+        """Generate plugin model filter function."""
 
         def include_object(object, name, type_, reflected, compare_to):
             if type_ == "table":
@@ -95,7 +95,7 @@ def enable_plugins(app: Flask):
     @click.argument("plugin_name", required=False)
     @with_appcontext
     def upgrade(plugin_name):
-        """Upgrade the plugin database to the latest version"""
+        """Upgrade the plugin database to the latest version."""
         plugins = get_plugin_migrations()
 
         for plugin in plugins:
@@ -112,7 +112,7 @@ def enable_plugins(app: Flask):
     @click.argument("plugin_name")
     @with_appcontext
     def history(plugin_name):
-        """View the migration history of the plugin"""
+        """View the migration history of the plugin."""
         plugins = get_plugin_migrations()
         for plugin in plugins:
             if plugin.name == plugin_name:
@@ -128,7 +128,7 @@ def enable_plugins(app: Flask):
     @click.argument("plugin_name")
     @with_appcontext
     def migrate(plugin_name):
-        """Migrate the plugin database to the latest version"""
+        """Migrate the plugin database to the latest version."""
         plugins = get_plugin_migrations()
         for plugin in plugins:
             app.logger.info(f"plugin: {plugin.name}")

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -14,19 +14,19 @@ class PluginHotReloader:
         self.observer = Observer()
 
     def start(self):
-        """1111111"""
+        """1111111."""
         event_handler = PluginFileHandler(self)
         self.observer.schedule(event_handler, self.plugin_dir, recursive=True)
         self.observer.start()
         self.app.logger.info("Plugin hot reload started")
 
     def stop(self):
-        """停止热加载监听"""
+        """停止热加载监听."""
         self.observer.stop()
         self.observer.join()
 
     def reload_plugin(self, plugin_path: str):
-        """重新加载单个插件"""
+        """重新加载单个插件."""
         try:
             # 1. unload plugin
             self._unload_plugin(plugin_path)
@@ -46,7 +46,7 @@ class PluginHotReloader:
             )
 
     def _unload_plugin(self, plugin_path: str):
-        """Unload a plugin and clean up its resources
+        """Unload a plugin and clean up its resources.
 
         Args:
             plugin_path: Path to the plugin file
@@ -88,7 +88,7 @@ class PluginHotReloader:
             self.app.logger.exception(f"Failed to unload plugin {plugin_path}: {e!s}")
 
     def _register_plugin(self, module):
-        """Register a newly loaded plugin
+        """Register a newly loaded plugin.
 
         Args:
             module: The reloaded module object

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -21,12 +21,12 @@ class PluginHotReloader:
         self.app.logger.info("Plugin hot reload started")
 
     def stop(self):
-        """停止热加载监听."""
+        """Stop watching for hot reloads."""
         self.observer.stop()
         self.observer.join()
 
     def reload_plugin(self, plugin_path: str):
-        """重新加载单个插件."""
+        """Reload a single plugin."""
         try:
             # 1. unload plugin
             self._unload_plugin(plugin_path)

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -18,7 +18,7 @@ class PluginManager:
         self.is_enabled = True
 
     def enable_hot_reload(self):
-        """Enable the hot reload"""
+        """Enable the hot reload."""
         if not self.is_enabled:
             return
         if not self.hot_reloader:
@@ -26,13 +26,13 @@ class PluginManager:
             self.hot_reloader.start()
 
     def disable_hot_reload(self):
-        """Disable the hot reload"""
+        """Disable the hot reload."""
         if self.hot_reloader:
             self.hot_reloader.stop()
             self.hot_reloader = None
 
     def clear_extension(self, target_func_name):
-        """Clear all registered functions for the specified extension point"""
+        """Clear all registered functions for the specified extension point."""
         if target_func_name in self.extension_functions:
             del self.extension_functions[target_func_name]
 

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -10,20 +10,20 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/dicts", methods=["GET"])
     @bypass_token_validation
     def get_dicts():
-        """获取所有字典.
+        """Get all dictionaries.
         ---
         tags:
-          - 字典
+          - dict
         """
         return make_common_response(get_all_dicts(app))
 
     @app.route(path_prefix + "/models", methods=["GET"])
     @bypass_token_validation
     def get_models():
-        """获取所有模型.
+        """Get all models.
         ---
         tags:
-          - 字典
+          - dict
         """
         return make_common_response(get_current_models(app))
 

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -10,7 +10,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/dicts", methods=["GET"])
     @bypass_token_validation
     def get_dicts():
-        """获取所有字典
+        """获取所有字典.
         ---
         tags:
           - 字典
@@ -20,7 +20,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/models", methods=["GET"])
     @bypass_token_validation
     def get_models():
-        """获取所有模型
+        """获取所有模型.
         ---
         tags:
           - 字典

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -123,10 +123,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/reqiure-to-pay", methods=["POST"])
     def reqiure_to_pay():
-        """请求支付.
+        """Request payment.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -136,26 +136,26 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
                     channel:
                         type: string
-                        description: 支付渠道。国内通道请输入wx_pub_qr、wx_pub、alipay_qr等；Stripe通道请输入stripe或stripe:checkout_session等格式
+                        description: Payment channel. Domestic channels accept wx_pub_qr, wx_pub, alipay_qr and so on; the Stripe channel accepts stripe or stripe:checkout_session
                     payment_channel:
                         type: string
-                        description: 目标支付提供方，可选值为pingxx、stripe、alipay、wechatpay（不填则按配置解析）
+                        description: Target payment provider, one of pingxx, stripe, alipay or wechatpay (resolved from configuration when omitted)
         responses:
             200:
-                description: 请求支付成功
+                description: Payment requested
                 content:
                     application/json:
                         schema:
                             properties:
                                 code:
                                     type: integer
-                                    description: 返回码
+                                    description: Response code
                                 message:
                                     type: string
-                                    description: 返回信息
+                                    description: Response message
                                 data:
                                     $ref: "#/components/schemas/BuyRecordDTO"
 
@@ -178,11 +178,11 @@ def register_order_handler(app: Flask, path_prefix: str):
     @app.route(path_prefix + "/init-order", methods=["POST"])
     @with_shifu_context()
     def init_order():
-        """初始化订单.
+        """Initialize an order.
         ---
         tags:
 
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -192,20 +192,20 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     course_id:
                         type: string
-                        description: 课程id
+                        description: Course id
         responses:
             200:
-                description: 初始化订单成功
+                description: Order initialized
                 content:
                     application/json:
                         schema:
                             properties:
                                 code:
                                     type: integer
-                                    description: 返回码
+                                    description: Response code
                                 message:
                                     type: string
-                                    description: 返回信息
+                                    description: Response message
                                 data:
                                     $ref: "#/components/schemas/AICourseBuyRecordDTO"
 
@@ -216,10 +216,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/query-order", methods=["POST"])
     def query_order():
-        """查询订单.
+        """Query an order.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -229,21 +229,21 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
         responses:
 
             200:
-                description: 查询订单成功
+                description: Order queried
                 content:
                     application/json:
                         schema:
                             properties:
                                 code:
                                     type: integer
-                                    description: 返回码
+                                    description: Response code
                                 message:
                                     type: string
-                                    description: 返回信息
+                                    description: Response message
                                 data:
                                     $ref: "#/components/schemas/AICourseBuyRecordDTO"
 
@@ -253,10 +253,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/apply-discount", methods=["POST"])
     def apply_discount():
-        """使用折扣码.
+        """Apply a discount code.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -266,23 +266,23 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     discount_code:
                         type: string
-                        description: 折扣码
+                        description: Discount code
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
         responses:
             200:
-                description: 使用折扣码成功
+                description: Discount code applied
                 content:
                     application/json:
                         schema:
                             properties:
                                 code:
                                     type: integer
-                                    description: 返回码
+                                    description: Response code
                                 message:
                                     type: string
-                                    description: 返回信息
+                                    description: Response message
                                 data:
                                     $ref: "#/components/schemas/AICourseBuyRecordDTO"
 
@@ -300,10 +300,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/payment-detail", methods=["POST"])
     def payment_detail():
-        """查询支付详情.
+        """Query payment details.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -313,10 +313,10 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
         responses:
             200:
-                description: 查询支付详情成功
+                description: Payment details queried
                 content:
                     application/json:
                         schema:
@@ -335,10 +335,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/stripe/sync", methods=["POST"])
     def stripe_sync():
-        """同步 Stripe 支付状态.
+        """Sync the Stripe payment status.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -348,13 +348,13 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
                     session_id:
                         type: string
                         description: Stripe checkout session id
         responses:
             200:
-                description: 同步成功
+                description: Synced
         """
         payload = request.get_json() or {}
         order_id = payload.get("order_id", "")
@@ -373,10 +373,10 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/payment/sync", methods=["POST"])
     def payment_sync():
-        """同步支付状态.
+        """Sync the payment status.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -386,13 +386,13 @@ def register_order_handler(app: Flask, path_prefix: str):
                 properties:
                     order_id:
                         type: string
-                        description: 订单id
+                        description: Order id
                     payment_channel:
                         type: string
-                        description: 支付提供方，可选值为alipay、wechatpay、stripe
+                        description: Payment provider, one of alipay, wechatpay or stripe
         responses:
             200:
-                description: 同步成功
+                description: Synced
         """
         payload = request.get_json() or {}
         order_id = payload.get("order_id", "")
@@ -410,13 +410,13 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/stripe/webhook", methods=["POST"])
     def stripe_webhook():
-        """Stripe webhook接入占位.
+        """Stripe webhook placeholder.
         ---
         tags:
-            - 订单
+            - order
         responses:
             202:
-                description: Webhook已接收，具体逻辑待实现
+                description: Webhook received; handling is not implemented yet
         """
         sig_header = request.headers.get("Stripe-Signature", "")
         raw_body = request.get_data() or b""
@@ -429,7 +429,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         """Admin order list.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - name: page_index
               type: integer
@@ -506,7 +506,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         """List created shifus for order admin filters.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - name: page_index
               type: integer
@@ -585,7 +585,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         """Admin import activation order.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - in: body
               name: body
@@ -823,7 +823,7 @@ def register_order_handler(app: Flask, path_prefix: str):
         """Admin order detail.
         ---
         tags:
-            - 订单
+            - order
         parameters:
             - name: order_bid
               type: string

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -123,7 +123,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/reqiure-to-pay", methods=["POST"])
     def reqiure_to_pay():
-        """请求支付
+        """请求支付.
         ---
         tags:
             - 订单
@@ -178,7 +178,7 @@ def register_order_handler(app: Flask, path_prefix: str):
     @app.route(path_prefix + "/init-order", methods=["POST"])
     @with_shifu_context()
     def init_order():
-        """初始化订单
+        """初始化订单.
         ---
         tags:
 
@@ -216,7 +216,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/query-order", methods=["POST"])
     def query_order():
-        """查询订单
+        """查询订单.
         ---
         tags:
             - 订单
@@ -253,7 +253,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/apply-discount", methods=["POST"])
     def apply_discount():
-        """使用折扣码
+        """使用折扣码.
         ---
         tags:
             - 订单
@@ -300,7 +300,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/payment-detail", methods=["POST"])
     def payment_detail():
-        """查询支付详情
+        """查询支付详情.
         ---
         tags:
             - 订单
@@ -335,7 +335,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/stripe/sync", methods=["POST"])
     def stripe_sync():
-        """同步 Stripe 支付状态
+        """同步 Stripe 支付状态.
         ---
         tags:
             - 订单
@@ -373,7 +373,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/payment/sync", methods=["POST"])
     def payment_sync():
-        """同步支付状态
+        """同步支付状态.
         ---
         tags:
             - 订单
@@ -410,7 +410,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/stripe/webhook", methods=["POST"])
     def stripe_webhook():
-        """Stripe webhook接入占位
+        """Stripe webhook接入占位.
         ---
         tags:
             - 订单
@@ -426,7 +426,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/admin/orders", methods=["GET"])
     def admin_order_list():
-        """Admin order list
+        """Admin order list.
         ---
         tags:
             - 订单
@@ -503,7 +503,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/admin/orders/shifus", methods=["GET"])
     def admin_order_shifu_list():
-        """List created shifus for order admin filters
+        """List created shifus for order admin filters.
         ---
         tags:
             - 订单
@@ -582,7 +582,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/admin/orders/import-activation", methods=["POST"])
     def admin_import_activation():
-        """Admin import activation order
+        """Admin import activation order.
         ---
         tags:
             - 订单
@@ -820,7 +820,7 @@ def register_order_handler(app: Flask, path_prefix: str):
 
     @app.route(path_prefix + "/admin/orders/<order_bid>", methods=["GET"])
     def admin_order_detail(order_bid: str):
-        """Admin order detail
+        """Admin order detail.
         ---
         tags:
             - 订单

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -244,7 +244,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/info", methods=["GET"])
     def info():
-        """Get user information
+        """Get user information.
         ---
         tags:
             - user
@@ -325,7 +325,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/update_info", methods=["POST"])
     def update_info():
-        """Update user information
+        """Update user information.
         ---
         tags:
             - user
@@ -474,7 +474,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @with_shifu_context()
     def require_tmp():
-        """Temp login user
+        """Temp login user.
         ---
         tags:
             - user
@@ -538,7 +538,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/captcha", methods=["GET"])
     @bypass_token_validation
     def captcha_api():
-        """Create image captcha
+        """Create image captcha.
         ---
         tags:
            - user
@@ -549,7 +549,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/captcha/verify", methods=["POST"])
     @bypass_token_validation
     def captcha_verify_api():
-        """Verify image captcha and return one-time ticket
+        """Verify image captcha and return one-time ticket.
         ---
         tags:
            - user
@@ -569,7 +569,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @optional_token_validation
     def send_sms_code_api():
-        """Send SMS Captcha
+        """Send SMS Captcha.
         ---
         tags:
            - user
@@ -633,7 +633,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @optional_token_validation
     def console_send_sms_code_api():
-        """Send SMS verification code for console clients without image captcha
+        """Send SMS verification code for console clients without image captcha.
         ---
         tags:
            - user
@@ -656,7 +656,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @optional_token_validation
     def send_email_code_api():
-        """Send email verification code
+        """Send email verification code.
         ---
         tags:
            - user
@@ -738,7 +738,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @optional_token_validation
     def login_sms_api():
-        """Login through SMS verification code for web clients
+        """Login through SMS verification code for web clients.
         ---
         tags:
            - user
@@ -747,7 +747,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/get_profile", methods=["GET"])
     def get_profile():
-        """Get user profile
+        """Get user profile.
         ---
         tags:
             - user
@@ -784,7 +784,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/update_profile", methods=["POST"])
     def update_profile():
-        """Update user profile
+        """Update user profile.
         ---
         tags:
             - user
@@ -845,7 +845,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/upload_avatar", methods=["POST"])
     def upload_avatar():
-        """Upload avatar
+        """Upload avatar.
         ---
         tags:
             - user
@@ -882,7 +882,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/update_openid", methods=["POST"])
     @with_shifu_context()
     def update_wechat_openid():
-        """Update Wechat OpenID
+        """Update Wechat OpenID.
         ---
         summary: update wechat openid
         tags:
@@ -926,7 +926,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @bypass_token_validation
     @optional_token_validation
     def sumbit_feedback_api():
-        """Submit feedback
+        """Submit feedback.
         ---
         tags:
             - user
@@ -1035,7 +1035,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/login_password", methods=["POST"])
     @bypass_token_validation
     def login_password():
-        """Login with password
+        """Login with password.
         ---
         tags:
             - user
@@ -1091,7 +1091,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/set_password", methods=["POST"])
     def set_password():
-        """Set password for logged-in user (first time only)
+        """Set password for logged-in user (first time only).
         ---
         tags:
             - user
@@ -1173,7 +1173,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/change_password", methods=["POST"])
     def change_password():
-        """Change password for logged-in user (requires old password)
+        """Change password for logged-in user (requires old password).
         ---
         tags:
             - user
@@ -1207,7 +1207,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/reset_password", methods=["POST"])
     @bypass_token_validation
     def reset_password():
-        """Reset password via verification code
+        """Reset password via verification code.
         ---
         tags:
             - user

--- a/src/api/flaskr/service/config/models.py
+++ b/src/api/flaskr/service/config/models.py
@@ -12,7 +12,7 @@ from ...dao import db
 
 
 class Config(db.Model):
-    """Config"""
+    """Config."""
 
     __tablename__ = "sys_configs"
     __table_args__ = {"comment": "System configs"}

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -294,7 +294,7 @@ def handle_input_ask(
     parent_observation: Any | None = None,
 ) -> Generator[str, None, None]:
     """Handle user Q&A input
-    Responsible for processing user questions in the shifu and returning AI tutor responses
+    Responsible for processing user questions in the shifu and returning AI tutor responses.
     """
     # Get follow-up information (including Q&A prompts and model configuration)
     follow_up_info = get_follow_up_info_v2(

--- a/src/api/flaskr/service/learn/models.py
+++ b/src/api/flaskr/service/learn/models.py
@@ -15,7 +15,7 @@ from ...dao import db
 
 
 class LearnProgressRecord(db.Model):
-    """Learn progress record"""
+    """Learn progress record."""
 
     __tablename__ = "learn_progress_records"
     __table_args__ = {"comment": "Learn progress records"}
@@ -87,7 +87,7 @@ class LearnProgressRecord(db.Model):
 
 
 class LearnGeneratedBlock(db.Model):
-    """Learn generated block"""
+    """Learn generated block."""
 
     __tablename__ = "learn_generated_blocks"
     __table_args__ = {"comment": "Learn generated blocks"}

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -184,7 +184,7 @@ def _stream_passthrough_response(
 
 @inject
 def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
-    """Register learn routes"""
+    """Register learn routes."""
     app.logger.info(f"register learn routes {path_prefix}")
     preview_service = RunScriptPreviewContextV2(app)
 
@@ -237,7 +237,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @bypass_token_validation
     @with_shifu_context()
     def get_shifu_api(shifu_bid: str):
-        """Get shifu
+        """Get shifu.
         ---
         tags:
             - learn
@@ -279,7 +279,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>/outline-item-tree", methods=["GET"])
     @with_shifu_context()
     def get_outline_item_tree_api(shifu_bid: str):
-        """Get outline item tree
+        """Get outline item tree.
         ---
         tags:
             - learn
@@ -321,7 +321,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>/run/<outline_bid>", methods=["PUT"])
     @with_shifu_context()
     def run_outline_item_api(shifu_bid: str, outline_bid: str):
-        """Run the MarkdownFlow of the outline
+        """Run the MarkdownFlow of the outline.
         ---
         tags:
             - learn
@@ -423,7 +423,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def preview_outline_block_api(shifu_bid: str, outline_bid: str):
-        """Preview a specific outline block
+        """Preview a specific outline block.
         ---
         tags:
             - learn
@@ -578,7 +578,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def get_run_status_api(shifu_bid: str, outline_bid: str):
-        """Get run status
+        """Get run status.
         ---
         tags:
             - learn
@@ -616,7 +616,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def get_record_api(shifu_bid: str, outline_bid: str):
-        """Get learn records of the outline
+        """Get learn records of the outline.
         ---
         tags:
             - learn
@@ -677,7 +677,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def delete_record_api(shifu_bid: str, outline_bid: str):
-        """Reset the record of the outline
+        """Reset the record of the outline.
         ---
         tags:
             - learn
@@ -714,7 +714,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str):
-        """Submit lesson feedback
+        """Submit lesson feedback.
         ---
         tags:
             - learn
@@ -775,7 +775,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>/lesson-feedbacks", methods=["GET"])
     @with_shifu_context()
     def list_lesson_feedbacks_api(shifu_bid: str):
-        """List lesson feedbacks for a course (teacher/authoring side)
+        """List lesson feedbacks for a course (teacher/authoring side).
         ---
         tags:
             - learn
@@ -828,7 +828,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def generate_content_api(shifu_bid: str, generated_block_bid: str, action: str):
-        """Generate the content of the generated block
+        """Generate the content of the generated block.
         ---
         tags:
             - learn
@@ -869,7 +869,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def get_generated_content_api(shifu_bid: str, generated_block_bid: str):
-        """Get the content of the generated block
+        """Get the content of the generated block.
         ---
         tags:
             - learn
@@ -916,7 +916,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     )
     @with_shifu_context()
     def synthesize_generated_block_audio_api(shifu_bid: str, generated_block_bid: str):
-        """Synthesize audio for a generated block (C-end, persisted)
+        """Synthesize audio for a generated block (C-end, persisted).
         ---
         tags:
             - learn
@@ -983,7 +983,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>/tts/preview", methods=["POST"])
     @with_shifu_context()
     def synthesize_preview_tts_audio_api(shifu_bid: str):
-        """Synthesize audio for an arbitrary text (editor preview, not persisted)
+        """Synthesize audio for an arbitrary text (editor preview, not persisted).
         ---
         tags:
             - learn

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -328,7 +328,7 @@ def run_script_inner(
     element_adapter: ListenElementRunAdapter | None = None,
     manage_app_context: bool = True,
 ) -> Generator[RunMarkdownFlowDTO | RunElementSSEMessageDTO, None, None]:
-    """Core function for running course scripts"""
+    """Core function for running course scripts."""
 
     def _finalize_langfuse_if_available(
         context: RunScriptContextV2 | None,

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -18,7 +18,7 @@ from ...service.profile.funcs import get_user_profiles
 
 
 class FollowUpInfo:
-    """Follow up info"""
+    """Follow up info."""
 
     ask_model: str
     ask_prompt: str
@@ -72,7 +72,7 @@ def extract_variables(template: str) -> list:
 
 
 def safe_format_template(template: str, variables: dict) -> str:
-    """Safe format template"""
+    """Safe format template."""
     # Replace {xxx} or {{xxx}} with values from variables dict, keep original if not found
     pattern = re.compile(r"(\{{1,2})([^{}]+)(\}{1,2})")
 
@@ -131,7 +131,7 @@ def get_fmt_prompt(
         input: Input
         profile_overrides: Request-local profile values that take precedence
     Returns:
-        str: Fmt prompt
+        str: Fmt prompt.
     """
     app.logger.info("raw prompt: %s", profile_tmplate)
     propmpt_keys = []

--- a/src/api/flaskr/service/llm/route.py
+++ b/src/api/flaskr/service/llm/route.py
@@ -10,7 +10,7 @@ def register_llm_routes(app: Flask, path_prefix="/api/llm"):
 
     @app.route(path_prefix + "/model-list", methods=["GET"])
     def model_list_api():
-        """Get model list
+        """Get model list.
         ---
         tags:
             - llm

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -145,7 +145,7 @@ def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
     Returns:
         Order object
     Raises:
-        raise_error: If the coupon code is not found or the coupon is already used
+        raise_error: If the coupon code is not found or the coupon is already used.
     """
     with app.app_context():
         now = now_utc()

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -94,7 +94,7 @@ from flaskr.util.uuid import generate_id as get_uuid
 
 @register_schema_to_swagger
 class PayItemDto:
-    """PayItemDto"""
+    """PayItemDto."""
 
     name: str
     price_name: str
@@ -120,7 +120,7 @@ class PayItemDto:
 
 @register_schema_to_swagger
 class AICourseBuyRecordDTO:
-    """AICourseBuyRecordDTO"""
+    """AICourseBuyRecordDTO."""
 
     order_id: str
     user_id: str
@@ -476,7 +476,7 @@ def init_buy_record(
 
 @register_schema_to_swagger
 class BuyRecordDTO:
-    """BuyRecordDTO"""
+    """BuyRecordDTO."""
 
     order_id: str
     user_id: str  # 用户id
@@ -521,7 +521,7 @@ def generate_charge(
     client_ip: str,
     payment_channel: str | None = None,
 ) -> BuyRecordDTO:
-    """Generate charge"""
+    """Generate charge."""
     with _app_context_scope(app), unit_of_work():
         app.logger.info(f"generate charge for record:{record_id} channel:{channel}")
 
@@ -1857,7 +1857,7 @@ def success_buy_record_from_native(
 
 
 def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
-    """Success buy record from pingxx"""
+    """Success buy record from pingxx."""
     with _app_context_scope(app):
         pingxx_order = (
             legacy_pingxx_snapshot_query()
@@ -1921,7 +1921,7 @@ def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
 
 
 def success_buy_record(app: Flask, record_id: str):
-    """Success buy record
+    """Success buy record.
 
     Owns a unit of work so legacy callers (coupon_funcs, order admin) keep
     their self-committing behavior; when invoked inside another unit of work
@@ -2050,7 +2050,7 @@ def calculate_discount_value(
     campaign_applications: list,
     discount_records: list[CouponUsageModel],
 ) -> DiscountInfo:
-    """Calculate discount value"""
+    """Calculate discount value."""
     discount_value = 0
     items = []
     if campaign_applications is not None and len(campaign_applications) > 0:

--- a/src/api/flaskr/service/order/models.py
+++ b/src/api/flaskr/service/order/models.py
@@ -18,7 +18,7 @@ from .consts import (
 
 
 class Order(db.Model):
-    """Order"""
+    """Order."""
 
     __tablename__ = "order_orders"
     __table_args__ = {"comment": "Order orders"}
@@ -99,7 +99,7 @@ class Order(db.Model):
 
 
 class PingxxOrder(db.Model):
-    """Pingxx Order"""
+    """Pingxx Order."""
 
     __tablename__ = "order_pingxx_orders"
     __table_args__ = (
@@ -234,7 +234,7 @@ class PingxxOrder(db.Model):
 
 
 class StripeOrder(db.Model):
-    """Stripe Order"""
+    """Stripe Order."""
 
     __tablename__ = "order_stripe_orders"
     __table_args__ = (

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -369,7 +369,7 @@ def get_user_profile_labels(
         user_id: User id
         course_id: Course id
     Returns:
-        list: User profile labels
+        list: User profile labels.
     """
     app.logger.info(f"get user profile labels:{course_id}")
     candidate_shifus = [course_id or ""]

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -283,7 +283,7 @@ def get_user_profiles(app: Flask, user_id: str, course_id: str) -> dict:
 
     This function must follow the same shifu_bid routing rules as
     :func:`save_user_profiles`, otherwise the run context may see values different
-    from what the user sees in "个人设置".
+    from what the user sees in the personal settings page.
 
     """
     PROFILES_LABLES = get_profile_labels()

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -17,7 +17,7 @@ from flaskr.service.profile.profile_manage import (
 def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
     @app.route(f"{path_prefix}/get-profile-item-definitions", methods=["GET"])
     def get_profile_item_defination_api():
-        """Get profile item defination
+        """Get profile item defination.
         ---
         tags:
           - profiles
@@ -156,7 +156,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
 
     @app.route(f"{path_prefix}/add-profile-item-quick", methods=["POST"])
     def add_profile_item_quick_api():
-        """Add profile item
+        """Add profile item.
         ---
         tags:
           - profiles
@@ -199,7 +199,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
 
     @app.route(f"{path_prefix}/save-profile-item", methods=["POST"])
     def save_profile_item_api():
-        """Save profile item
+        """Save profile item.
         ---
         tags:
           - profiles
@@ -269,7 +269,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
 
     @app.route(f"{path_prefix}/delete-profile-item", methods=["POST"])
     def delete_profile_item_api():
-        """Delete profile item
+        """Delete profile item.
         ---
         tags:
           - profiles
@@ -311,6 +311,6 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
 
     @app.route(f"{path_prefix}/get-profile-item", methods=["POST"])
     def get_profile_item_api():
-        """Get profile item"""
+        """Get profile item."""
 
     return app

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -1,4 +1,4 @@
-"""Promo functions"""
+"""Promo functions."""
 
 import decimal
 from contextlib import nullcontext
@@ -92,7 +92,7 @@ def timeout_coupon_code_rollback(app: Flask, user_bid, order_bid):
     Args:
         app: Flask app
         user_bid: User bid
-        order_bid: Order bid
+        order_bid: Order bid.
     """
     with app.app_context():
         usage = CouponUsageModel.query.filter(

--- a/src/api/flaskr/service/promo/models.py
+++ b/src/api/flaskr/service/promo/models.py
@@ -21,7 +21,7 @@ from .consts import (
 
 
 class Coupon(db.Model):
-    """Coupon"""
+    """Coupon."""
 
     __tablename__ = "promo_coupons"
     __table_args__ = {"comment": "Promo coupons"}
@@ -114,7 +114,8 @@ class Coupon(db.Model):
 
 
 class CouponUsage(db.Model):
-    """Coupon Usage Record
+    """Coupon usage record.
+
     Generated:
 
     1. Generated one when user use a coupon code that could be used multiple times

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -308,7 +308,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/courses", methods=["GET"])
     def admin_operations_courses():
-        """Operator course list
+        """Operator course list.
         ---
         tags:
             - Course
@@ -433,7 +433,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/courses/overview", methods=["GET"])
     def admin_operations_course_overview():
-        """Operator course overview
+        """Operator course overview.
         ---
         tags:
             - Course
@@ -456,7 +456,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/users", methods=["GET"])
     def admin_operations_users():
-        """Operator user list
+        """Operator user list.
         ---
         tags:
             - User
@@ -570,7 +570,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/users/overview", methods=["GET"])
     def admin_operations_user_overview():
-        """Operator user overview
+        """Operator user overview.
         ---
         tags:
             - User
@@ -593,7 +593,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["GET"])
     def admin_operations_voice_clones():
-        """Operator MiniMax cloned voice list
+        """Operator MiniMax cloned voice list.
         ---
         tags:
             - TTS
@@ -713,7 +713,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["POST"])
     def admin_operations_register_voice_clone():
-        """Register a voice cloned on a provider console and assign it to a teacher
+        """Register a voice cloned on a provider console and assign it to a teacher.
         ---
         tags:
             - TTS
@@ -754,7 +754,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/orders", methods=["GET"])
     def admin_operations_orders():
-        """Operator global order list
+        """Operator global order list.
         ---
         tags:
             - Order
@@ -855,7 +855,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/orders/overview", methods=["GET"])
     def admin_operations_order_overview():
-        """Operator learning order overview
+        """Operator learning order overview.
         ---
         tags:
             - Order
@@ -1118,7 +1118,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_order_detail(order_bid: str):
-        """Get operator order detail
+        """Get operator order detail.
         ---
         tags:
             - Order
@@ -1139,7 +1139,7 @@ def register_admin_operations_routes(
 
     @app.route(path_prefix + "/admin/operations/orders/credits", methods=["GET"])
     def admin_operations_credit_orders():
-        """Operator global credit order list
+        """Operator global credit order list.
         ---
         tags:
             - Order
@@ -1243,7 +1243,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operations_credit_order_overview():
-        """Operator credit order overview
+        """Operator credit order overview.
         ---
         tags:
             - Order
@@ -1682,7 +1682,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_credit_order_detail(bill_order_bid: str):
-        """Get operator credit order detail
+        """Get operator credit order detail.
         ---
         tags:
             - Order
@@ -1929,7 +1929,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/detail", methods=["GET"]
     )
     def admin_operation_user_detail(user_bid: str):
-        """Get operator user detail
+        """Get operator user detail.
         ---
         tags:
             - User
@@ -1950,7 +1950,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credits", methods=["GET"]
     )
     def admin_operation_user_credits(user_bid: str):
-        """Get operator user credits detail
+        """Get operator user credits detail.
         ---
         tags:
             - User
@@ -2056,7 +2056,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str):
-        """Get operator user credit usage content detail
+        """Get operator user credit usage content detail.
         ---
         tags:
             - User
@@ -2089,7 +2089,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_user_credit_grant_bootstrap(user_bid: str):
-        """Get operator user grant bootstrap
+        """Get operator user grant bootstrap.
         ---
         tags:
             - User
@@ -2116,7 +2116,7 @@ def register_admin_operations_routes(
         methods=["POST"],
     )
     def admin_operation_user_credit_grant(user_bid: str):
-        """Grant operator user credits
+        """Grant operator user credits.
         ---
         tags:
             - User
@@ -2158,7 +2158,7 @@ def register_admin_operations_routes(
         methods=["POST"],
     )
     def admin_operation_user_package_grant(user_bid: str):
-        """Grant operator user package
+        """Grant operator user package.
         ---
         tags:
             - User
@@ -2210,7 +2210,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/detail", methods=["GET"]
     )
     def admin_operation_course_detail(shifu_bid: str):
-        """Get operator course detail
+        """Get operator course detail.
         ---
         tags:
             - Shifu
@@ -2248,7 +2248,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_course_chapter_detail(shifu_bid: str, outline_item_bid: str):
-        """Get operator course chapter detail
+        """Get operator course chapter detail.
         ---
         tags:
             - Shifu
@@ -2290,7 +2290,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/users", methods=["GET"]
     )
     def admin_operation_course_users(shifu_bid: str):
-        """Get operator course users
+        """Get operator course users.
         ---
         tags:
             - Shifu
@@ -2366,7 +2366,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_course_credit_usages(shifu_bid: str):
-        """Get operator course credit usage list
+        """Get operator course credit usage list.
         ---
         tags:
             - Shifu
@@ -2467,7 +2467,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_course_credit_usage_details(shifu_bid: str):
-        """Get operator course credit usage detail list
+        """Get operator course credit usage detail list.
         ---
         tags:
             - Shifu
@@ -2503,7 +2503,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_course_ratings(shifu_bid: str):
-        """Get operator course rating list
+        """Get operator course rating list.
         ---
         tags:
             - Shifu
@@ -2627,7 +2627,7 @@ def register_admin_operations_routes(
         methods=["GET"],
     )
     def admin_operation_course_follow_ups(shifu_bid: str):
-        """Get operator course follow-up list
+        """Get operator course follow-up list.
         ---
         tags:
             - Shifu
@@ -2737,7 +2737,7 @@ def register_admin_operations_routes(
         shifu_bid: str,
         generated_block_bid: str,
     ):
-        """Get operator course follow-up detail
+        """Get operator course follow-up detail.
         ---
         tags:
             - Shifu

--- a/src/api/flaskr/service/shifu/consts.py
+++ b/src/api/flaskr/service/shifu/consts.py
@@ -1,4 +1,4 @@
-"""Shifu consts
+"""Shifu consts.
 
 This module contains constants for shifu.
 

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -1,4 +1,4 @@
-"""Shifu dtos
+"""Shifu dtos.
 
 This module contains dtos for shifu.
 
@@ -28,7 +28,7 @@ def resolve_demo_course_for_language(
 
 @register_schema_to_swagger
 class ShifuDto(BaseModel):
-    """Shifu dto"""
+    """Shifu dto."""
 
     bid: str = Field(..., description="shifu id", required=False)
     name: str = Field(..., description="shifu name", required=False)
@@ -101,7 +101,7 @@ class ShifuDto(BaseModel):
 
 @register_schema_to_swagger
 class ShifuDetailDto(BaseModel):
-    """Shifu detail dto"""
+    """Shifu detail dto."""
 
     bid: str = Field(..., description="shifu id", required=False)
     name: str = Field(..., description="shifu name", required=False)
@@ -282,7 +282,7 @@ class ShifuDetailDto(BaseModel):
 
 @register_schema_to_swagger
 class SimpleOutlineDto(BaseModel):
-    """Simple outline dto"""
+    """Simple outline dto."""
 
     bid: str = Field(..., description="outline id", required=False)
     position: str = Field(..., description="outline position", required=False)
@@ -352,7 +352,7 @@ class SimpleOutlineDto(BaseModel):
 # 2. add a child to the node
 # 3. remove a child from the node
 class ShifuOutlineTreeNode:
-    """Shifu outline tree node"""
+    """Shifu outline tree node."""
 
     def __init__(self, outline_item: DraftOutlineItem):
         self.outline = outline_item
@@ -366,17 +366,17 @@ class ShifuOutlineTreeNode:
         self.parent_node = None
 
     def add_child(self, child: "ShifuOutlineTreeNode"):
-        """Add a child to the node"""
+        """Add a child to the node."""
         self.children.append(child)
         child.parent_node = self
 
     def remove_child(self, child: "ShifuOutlineTreeNode"):
-        """Remove a child from the node"""
+        """Remove a child from the node."""
         child.parent_node = None
         self.children.remove(child)
 
     def get_new_position(self):
-        """Get the new position of the node"""
+        """Get the new position of the node."""
         if not self.parent_node:
             return self.position
         return (
@@ -387,7 +387,7 @@ class ShifuOutlineTreeNode:
 
 @register_schema_to_swagger
 class OutlineDto(BaseModel):
-    """Outline dto"""
+    """Outline dto."""
 
     bid: str = Field(..., description="outline id", required=False)
     position: str = Field(..., description="outline no", required=False)
@@ -435,13 +435,13 @@ class OutlineDto(BaseModel):
 
 @register_schema_to_swagger
 class ReorderOutlineItemDto:
-    """Reorder outline item dto"""
+    """Reorder outline item dto."""
 
     bid: str
     children: list["ReorderOutlineItemDto"]
 
     def __init__(self, bid: str, children: list["ReorderOutlineItemDto"]):
-        """Init reorder outline item dto"""
+        """Init reorder outline item dto."""
         self.bid = bid
         self.children = children
 
@@ -454,7 +454,7 @@ class ReorderOutlineItemDto:
 
 @register_schema_to_swagger
 class ReorderOutlineDto:
-    """Reorder outline dto"""
+    """Reorder outline dto."""
 
     outlines: list[ReorderOutlineItemDto]
 

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -1,4 +1,4 @@
-"""common shifu funcs
+"""common shifu funcs.
 
 This module contains functions for shifu.
 

--- a/src/api/flaskr/service/shifu/models.py
+++ b/src/api/flaskr/service/shifu/models.py
@@ -1,4 +1,4 @@
-"""Shifu models
+"""Shifu models.
 
 This module contains models for shifu.
 
@@ -33,7 +33,7 @@ class ResourceType:
 
 
 class FavoriteScenario(db.Model):
-    """Favorite scenario"""
+    """Favorite scenario."""
 
     __tablename__ = "scenario_favorite"
     id = Column(BIGINT, primary_key=True, autoincrement=True)
@@ -55,7 +55,7 @@ class FavoriteScenario(db.Model):
 
 
 class ScenarioResource(db.Model):
-    """Scenario resource"""
+    """Scenario resource."""
 
     __tablename__ = "scenario_resource"
     id = Column(BIGINT, primary_key=True, autoincrement=True)
@@ -79,7 +79,7 @@ class ScenarioResource(db.Model):
 
 
 class AiCourseAuth(db.Model):
-    """Ai course auth"""
+    """Ai course auth."""
 
     __tablename__ = "ai_course_auth"
     id = Column(BIGINT, primary_key=True, autoincrement=True)
@@ -109,7 +109,7 @@ class AiCourseAuth(db.Model):
 
 # per-user archive status for a shifu
 class ShifuUserArchive(db.Model):
-    """Per-user archive state for a shifu"""
+    """Per-user archive state for a shifu."""
 
     __tablename__ = "shifu_user_archives"
     __table_args__ = (
@@ -160,7 +160,7 @@ class ShifuUserArchive(db.Model):
 
 # draft shifu's model
 class DraftShifu(db.Model):
-    """Shifu draft shifu"""
+    """Shifu draft shifu."""
 
     __tablename__ = "shifu_draft_shifus"
     id = Column(BIGINT, primary_key=True, autoincrement=True)

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1,4 +1,4 @@
-"""Shifu route
+"""Shifu route.
 
 This module contains route functions for shifu.
 use restful api to manage shifu.
@@ -161,7 +161,7 @@ EMAIL_PATTERN = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
 
 class ShifuTokenValidation:
     """Shifu token validation decorator
-    if is_creator is true, only verify creator permission and skip shifu-specific verification
+    if is_creator is true, only verify creator permission and skip shifu-specific verification.
     """
 
     def __init__(
@@ -282,7 +282,7 @@ def _resolve_publish_base_url(app: Flask) -> str:
 
 @inject
 def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
-    """Register shifu routes"""
+    """Register shifu routes."""
     app.logger.info(f"register shifu routes {path_prefix}")
 
     def _get_login_methods_enabled() -> set[str]:
@@ -425,7 +425,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @app.route(path_prefix + "/shifus", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     def get_shifu_list_api():
-        """Get shifu list
+        """Get shifu list.
         ---
         tags:
             - shifu
@@ -740,7 +740,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @app.route(path_prefix + "/shifus", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     def create_shifu_api():
-        """Create shifu
+        """Create shifu.
         ---
         tags:
             - shifu
@@ -793,7 +793,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def get_shifu_detail_api(shifu_bid: str):
-        """Get shifu detail
+        """Get shifu detail.
         ---
         tags:
             - shifu
@@ -829,7 +829,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def save_shifu_detail_api(shifu_bid: str):
-        """Save shifu detail
+        """Save shifu detail.
         ---
         tags:
             - shifu
@@ -1019,7 +1019,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     @with_shifu_context()
     def mark_favorite_shifu_api():
-        """Mark favorite shifu
+        """Mark favorite shifu.
         ---
         tags:
             - shifu
@@ -1068,7 +1068,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.PUBLISH)
     @with_shifu_context()
     def publish_shifu_api(shifu_bid: str):
-        """Publish shifu
+        """Publish shifu.
         ---
         tags:
             - shifu
@@ -1103,7 +1103,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def preview_shifu_api(shifu_bid: str):
-        """Preview shifu
+        """Preview shifu.
         ---
         tags:
             - shifu
@@ -1150,7 +1150,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @with_shifu_context()
     def update_chapter_order_api(shifu_bid: str):
         """Update chapter order
-        reset the chapter order to the order of the chapter ids
+        reset the chapter order to the order of the chapter ids.
         ---
         tags:
             - shifu
@@ -1201,7 +1201,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def create_outline_api(shifu_bid: str):
-        """Create unit
+        """Create unit.
         ---
         tags:
             - shifu
@@ -1283,7 +1283,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def create_outlines_batch_api(shifu_bid: str):
-        """Create multiple outlines atomically
+        """Create multiple outlines atomically.
         ---
         tags:
             - shifu
@@ -1349,7 +1349,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     def modify_outline_api(shifu_bid: str, outline_bid: str):
-        """Modify outline
+        """Modify outline.
         ---
         tags:
             - shifu
@@ -1424,7 +1424,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def get_unit_info_api(shifu_bid: str, outline_bid: str):
-        """Get unit info
+        """Get unit info.
         ---
         tags:
             - shifu
@@ -1459,7 +1459,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def delete_unit_api(shifu_bid: str, outline_bid: str):
-        """Delete unit
+        """Delete unit.
         ---
         tags:
             - shifu
@@ -1497,7 +1497,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def get_mdflow_api(shifu_bid: str, outline_bid: str):
-        """Get mdflow
+        """Get mdflow.
         ---
         tags:
             - shifu
@@ -1533,7 +1533,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     def get_draft_meta_api(shifu_bid: str):
-        """Get draft meta
+        """Get draft meta.
         ---
         tags:
             - shifu
@@ -1587,7 +1587,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def save_mdflow_api(shifu_bid: str, outline_bid: str):
-        """Save mdflow
+        """Save mdflow.
         ---
         tags:
             - shifu
@@ -1664,7 +1664,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def parse_mdflow_api(shifu_bid: str, outline_bid: str):
-        """Parse mdflow
+        """Parse mdflow.
         ---
         tags:
             - shifu
@@ -1710,7 +1710,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def get_mdflow_history_api(shifu_bid: str, outline_bid: str):
-        """Get mdflow history
+        """Get mdflow history.
         ---
         tags:
             - shifu
@@ -1786,7 +1786,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     def get_mdflow_history_version_detail_api(
         shifu_bid: str, outline_bid: str, version_id: str
     ):
-        """Get mdflow history version detail
+        """Get mdflow history version detail.
         ---
         tags:
             - shifu
@@ -1833,7 +1833,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
     def restore_mdflow_history_api(shifu_bid: str, outline_bid: str):
-        """Restore mdflow history version
+        """Restore mdflow history version.
         ---
         tags:
             - shifu
@@ -1919,7 +1919,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     def run_mdflow_api(shifu_bid: str, outline_bid: str):
-        """Run mdflow
+        """Run mdflow.
 
         Raises:
             NotImplementedError: This API endpoint is not yet implemented
@@ -1931,7 +1931,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
     def get_outline_tree_api(shifu_bid: str):
-        """Get outline tree
+        """Get outline tree.
         ---
         tags:
             - shifu
@@ -1962,7 +1962,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     @app.route(path_prefix + "/upfile", methods=["POST"])
     def upfile_api():
-        """Upfile to oss
+        """Upfile to oss.
         ---
         tags:
             - shifu
@@ -2000,7 +2000,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     @app.route(path_prefix + "/url-upfile", methods=["POST"])
     def upload_url_api():
-        """Upload url to oss
+        """Upload url to oss.
         ---
         tags:
             - shifu
@@ -2039,7 +2039,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     @app.route(path_prefix + "/get-video-info", methods=["POST"])
     def get_video_info_api():
-        """Get video info
+        """Get video info.
         ---
         tags:
             - shifu
@@ -2079,7 +2079,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @app.route(path_prefix + "/shifus/<shifu_bid>/export", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     def export_shifu_api(shifu_bid: str):
-        """Export shifu
+        """Export shifu.
         ---
         tags:
             - shifu
@@ -2121,7 +2121,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @app.route(path_prefix + "/ask/config", methods=["GET"])
     @bypass_token_validation
     def ask_config_api():
-        """Get ask provider configuration metadata
+        """Get ask provider configuration metadata.
         ---
         tags:
             - ask
@@ -2163,7 +2163,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     @app.route(path_prefix + "/ask/preview", methods=["POST"])
     def ask_preview_api():
-        """Preview ask provider output with current settings
+        """Preview ask provider output with current settings.
         ---
         tags:
             - ask
@@ -2570,7 +2570,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
     @app.route(path_prefix + "/tts/config", methods=["GET"])
     @bypass_token_validation
     def tts_config_api():
-        """Get TTS provider configuration
+        """Get TTS provider configuration.
         ---
         tags:
             - tts
@@ -2593,7 +2593,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
 
     @app.route(path_prefix + "/tts/preview", methods=["POST"])
     def tts_preview_api():
-        """Preview TTS with specified settings
+        """Preview TTS with specified settings.
         ---
         tags:
             - tts

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -1,4 +1,4 @@
-"""Shifu draft functions
+"""Shifu draft functions.
 
 This module contains functions for managing shifu draft.
 
@@ -114,7 +114,7 @@ def get_latest_shifu_draft(shifu_id: str) -> DraftShifu:
     Args:
         shifu_id: Shifu ID
     Returns:
-        DraftShifu: Shifu draft
+        DraftShifu: Shifu draft.
     """
     shifu_draft: DraftShifu = (
         DraftShifu.query.filter(
@@ -140,7 +140,7 @@ def return_shifu_draft_dto(
         shifu_draft: Shifu draft
         base_url: Base URL to build shifu links
         readonly: Whether the current user has read-only permission
-        archived_override: Optional override for archived state (per-user)
+        archived_override: Optional override for archived state (per-user).
 
     Returns:
         ShifuDetailDto: Shifu detail dto
@@ -235,7 +235,7 @@ def create_shifu_draft(
         shifu_temperature: Shifu temperature
         shifu_price: Shifu price
     Returns:
-        ShifuDto: Shifu dto
+        ShifuDto: Shifu dto.
     """
     with app.app_context():
         total_started_at = perf_counter()
@@ -344,7 +344,7 @@ def get_shifu_draft_info(
         shifu_id: Shifu ID
         base_url: Base URL to build shifu links
     Returns:
-        ShifuDetailDto: Shifu detail dto
+        ShifuDetailDto: Shifu detail dto.
     """
     with app.app_context():
         shifu_draft = get_latest_shifu_draft(shifu_id)
@@ -431,7 +431,7 @@ def save_shifu_draft_info(
         ask_system_prompt: Ask model system prompt
         ask_provider_config: Ask provider config object or JSON string
     Returns:
-        ShifuDetailDto: Shifu detail dto
+        ShifuDetailDto: Shifu detail dto.
     """
     with app.app_context():
         total_started_at = perf_counter()
@@ -719,7 +719,7 @@ def get_shifu_draft_list(
         archived: Filter archived (True) or active (False) shifus
         creator_only: Only include shifus created by the user
     Returns:
-        PageNationDTO: Page nation dto
+        PageNationDTO: Page nation dto.
     """
     with app.app_context():
         page_index = max(page_index, 1)

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -1,4 +1,4 @@
-"""Shifu history manager
+"""Shifu history manager.
 
 This module contains functions for managing shifu history.
 
@@ -54,7 +54,7 @@ OUTLINE_CONTENT_LOOKBACK_LIMIT = 1000
 
 class HistoryItem(BaseModel, Generic[T]):
     """History item
-    will be saved to database as json
+    will be saved to database as json.
     """
 
     bid: str
@@ -64,12 +64,12 @@ class HistoryItem(BaseModel, Generic[T]):
     child_count: int = 0
 
     def to_json(self):
-        """To json"""
+        """To json."""
         return self.model_dump_json()
 
     @classmethod
     def from_json(cls, json: str):
-        """From json to history item"""
+        """From json to history item."""
         return cls.model_validate_json(json)
 
 
@@ -257,7 +257,7 @@ def get_shifu_history(app, shifu_bid: str) -> HistoryItem:
         app: Flask application instance
         shifu_bid: Shifu bid
     Returns:
-        HistoryItem: History item
+        HistoryItem: History item.
     """
     with app.app_context():
         shifu_history = (
@@ -282,7 +282,7 @@ def __save_shifu_history(
         shifu_bid: Shifu bid
         history: History item
     Returns:
-        None
+        None.
     """
     now = now_utc()
     shifu_history = LogDraftStruct(
@@ -307,7 +307,7 @@ def save_shifu_history(app: Flask, user_id: str, shifu_bid: str, id: int):
         shifu_bid: Shifu bid
         id: Shifu id
     Returns:
-        None
+        None.
     """
     history = get_shifu_history(app, shifu_bid)
     history.id = id
@@ -336,7 +336,7 @@ def __save_new_item_history(
         type: Item type
         index: Item index
     Returns:
-        None
+        None.
     """
     history = get_shifu_history(app, shifu_bid)
     if not parent_bid or parent_bid == "":
@@ -387,7 +387,7 @@ def __delete_item_history(app: Flask, user_id: str, shifu_bid: str, item_bid: st
         shifu_bid: Shifu bid
         item_bid: Item bid
     Returns:
-        None
+        None.
     """
     history = get_shifu_history(app, shifu_bid)
     q = queue.Queue()
@@ -421,7 +421,7 @@ def save_new_outline_history(
         outline_bid: Outline bid
         id: Outline id
         parent_bid: Parent bid
-        index: Outline index
+        index: Outline index.
     """
     __save_new_item_history(
         app, user_id, shifu_bid, outline_bid, id, parent_bid, "outline", index
@@ -444,7 +444,7 @@ def save_outline_history(
         outline_bid: Outline bid
         id: Outline id
     Returns:
-        None
+        None.
     """
     history = get_shifu_history(app, shifu_bid)
     q = queue.Queue()
@@ -470,7 +470,7 @@ def delete_outline_history(app: Flask, user_id: str, shifu_bid: str, outline_bid
         shifu_bid: Shifu bid
         outline_bid: Outline bid
     Returns:
-        None
+        None.
     """
     __delete_item_history(app, user_id, shifu_bid, outline_bid)
 
@@ -490,7 +490,7 @@ def save_outline_tree_history(
         outline_tree: Outline tree
         shifu_id: Optional shifu database id to ensure root node id is correct
     Returns:
-        None
+        None.
     """
     history = get_shifu_history(app, shifu_bid)
     if shifu_id is not None:

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -149,6 +149,7 @@ def import_shifu(
                   If not provided or doesn't exist, will create a new shifu.
         file: FileStorage object containing the JSON file
         user_id: User ID for creating/updating the shifu
+        commit: Commit the transaction before returning
 
     Returns:
         str: The shifu_bid of the imported shifu

--- a/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_mdflow_funcs.py
@@ -26,7 +26,7 @@ from markdown_flow import MarkdownFlow
 
 
 def get_shifu_mdflow(app: Flask, shifu_bid: str, outline_bid: str) -> str:
-    """Get shifu mdflow"""
+    """Get shifu mdflow."""
     with app.app_context():
         outline_item = (
             DraftOutlineItem.query.filter(
@@ -145,7 +145,7 @@ def save_shifu_mdflow(
     content: str,
     base_revision: int | None = None,
 ) -> DraftSaveResponse:
-    """Save shifu mdflow"""
+    """Save shifu mdflow."""
     content = content or ""
     with app.app_context():
         lock_latest = isinstance(base_revision, int) and base_revision >= 0
@@ -265,7 +265,7 @@ def save_shifu_mdflow(
 def parse_shifu_mdflow(
     app: Flask, shifu_bid: str, outline_bid: str, data: str | None = None
 ) -> MdflowDTOParseResult:
-    """Parse shifu mdflow"""
+    """Parse shifu mdflow."""
     with app.app_context():
         outline_item = (
             DraftOutlineItem.query.filter(

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -1,4 +1,4 @@
-"""Shifu outline funcs
+"""Shifu outline funcs.
 
 This module contains functions for managing shifu outline.
 
@@ -49,7 +49,7 @@ def convert_outline_to_reorder_outline_item_dto(
     Args:
         json_array: The json array to convert
     Returns:
-        The reorder outline item dto
+        The reorder outline item dto.
     """
     if not isinstance(json_array, list):
         raise_param_error("outlines")
@@ -77,7 +77,7 @@ def load_existing_outline_items(
     Args:
         shifu_bid: Shifu bid
     Returns:
-        list[DraftOutlineItem]: Outline items
+        list[DraftOutlineItem]: Outline items.
     """
     sub_query = (
         db.session.query(db.func.max(DraftOutlineItem.id))
@@ -165,7 +165,7 @@ def build_outline_tree(
         app: Flask application instance
         shifu_bid: Shifu bid
     Returns:
-        list[ShifuOutlineTreeNode]: Outline tree
+        list[ShifuOutlineTreeNode]: Outline tree.
     """
     outline_items = load_existing_outline_items(
         shifu_bid, include_content=include_content
@@ -187,6 +187,7 @@ def assert_outline_items_publishable(
     Args:
         app: Flask application instance
         shifu_bid: Shifu bid
+        outline_items: Draft outline items that would be published
 
     Raises:
         AppException: server.shifu.outlineStructureBroken when positions collide
@@ -219,7 +220,7 @@ def get_outline_tree_dto(
     Args:
         outline_tree: Outline tree
     Returns:
-        list[SimpleOutlineDto]: Outline tree dto
+        list[SimpleOutlineDto]: Outline tree dto.
     """
     result = []
     for node in outline_tree:
@@ -258,7 +259,7 @@ def get_outline_tree(app, user_id: str, shifu_bid: str) -> list[SimpleOutlineDto
         user_id: User ID
         shifu_bid: Shifu bid
     Returns:
-        list[SimpleOutlineDto]: Outline tree
+        list[SimpleOutlineDto]: Outline tree.
     """
     app.logger.info(f"get outline tree, user_id: {user_id}, shifu_bid: {shifu_bid}")
     with app.app_context():
@@ -421,7 +422,7 @@ def create_outline(
         system_prompt: System prompt
         is_hidden: Is hidden
     Returns:
-        SimpleOutlineDto: Outline dto
+        SimpleOutlineDto: Outline dto.
     """
     with app.app_context():
         now_time = now_utc()
@@ -562,6 +563,9 @@ def create_outlines_batch(
     on position allocation and can leave a shifu unpublishable.
 
     Args:
+        app: Flask application instance
+        shifu_id: Shifu bid the outlines belong to
+        user_id: User bid performing the batch create
         outlines: nested nodes, each a dict with keys ``name`` (required),
             ``type``, ``system_prompt``, ``is_hidden``, and ``children`` (a list
             of the same shape).
@@ -638,7 +642,7 @@ def reorder_outline_tree(
 ):
     """Reorder outline tree
     usage:
-    1. reorder outline tree
+    1. reorder outline tree.
 
     Args:
         app: Flask application instance
@@ -736,7 +740,7 @@ def get_unit_by_id(app, user_id: str, unit_id: str):
         unit_id: Unit ID
     Returns:
         OutlineDto: Outline dto
-        None: If unit not found
+        None: If unit not found.
     """
     with app.app_context():
         unit: DraftOutlineItem = (
@@ -788,7 +792,7 @@ def modify_unit(
         unit_is_hidden: Unit is hidden
         unit_type: Unit type
     Returns:
-        OutlineDto: Outline dto
+        OutlineDto: Outline dto.
     """
     with app.app_context():
         app.logger.info(f"modify unit: {unit_id}, name: {unit_name}")
@@ -860,7 +864,7 @@ def modify_unit(
 
 
 def delete_unit(app, user_id: str, unit_id: str):
-    """Delete unit
+    """Delete unit.
 
     Args:
         app: Flask application instance

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -1,4 +1,4 @@
-"""Shifu publish funcs
+"""Shifu publish funcs.
 
 This module contains functions for publishing shifu.
 
@@ -70,7 +70,7 @@ def preview_shifu_draft(
         user_id: User ID
         shifu_id: Shifu ID
         variables: Variables
-        base_url: Base URL to build preview link
+        base_url: Base URL to build preview link.
     """
     with app.app_context():
         shifu_draft = get_latest_shifu_draft(shifu_id)
@@ -230,7 +230,7 @@ def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None)
     """Run shifu summary generation with error handling
     Args:
         app: Flask application instance
-        shifu_id: Shifu ID
+        shifu_id: Shifu ID.
     """
     try:
         apply_shifu_context_snapshot(shifu_context_snapshot)
@@ -258,7 +258,7 @@ def get_shifu_summary(app, shifu_id: str):
     """Obtain the shifu summary information
     Args:
         app: Flask application instance
-        shifu_id: Shifu ID
+        shifu_id: Shifu ID.
     """
     with app.app_context():
         shifu: PublishedShifu = (
@@ -313,7 +313,7 @@ def _generate_ask_prompts(
         outline_item_map: Outline item mapping
         ask_prompt_template: Ask template
     Returns:
-        None
+        None.
     """
     for chapter in shifu_info.outline_items:
         for section in chapter.children:
@@ -362,7 +362,7 @@ def _generate_summaries(
         summary_prompt_template: Summary template
         shifu: Course information
     Returns:
-        Summary mapping
+        Summary mapping.
     """
     outline_summary_map = {}
 
@@ -431,7 +431,7 @@ def _get_shifu_data(
         app: Flask application instance
         shifu_id: shifu ID
     Returns:
-        (outline_tree, outline_ids, outline_item_map)
+        (outline_tree, outline_ids, outline_item_map).
     """
     outline_ids = []
 
@@ -473,7 +473,7 @@ def _make_ask_prompt(
         learned_text: Learned text
         unlearned_text: Unlearned text
     Returns:
-        Ask prompt
+        Ask prompt.
     """
     return ask_prompt.format(
         learned=("\n" + learned_text) if learned_text else "",
@@ -497,7 +497,7 @@ def _get_summary(app, prompt, model_name, user_id=None, temperature=0.8):
         user_id: Optional, user ID
         temperature: Optional, sampling temperature
     Returns:
-        Summary text
+        Summary text.
     """
     # Create langfuse trace/span
     trace, span = create_trace_with_root_span(
@@ -548,7 +548,7 @@ def _build_summary_text(summaries: list[dict]) -> str:
     Args:
         summaries: List of summary dictionaries
     Returns:
-        Built summary text
+        Built summary text.
     """
     if not summaries:
         return ""

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -1,4 +1,4 @@
-"""Shifu struct manager
+"""Shifu struct manager.
 
 This module contains functions for managing shifu struct.
 
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 
 
 class ShifuOutlineItemDto(BaseModel):
-    """Shifu outline item dto"""
+    """Shifu outline item dto."""
 
     bid: str
     position: str
@@ -43,7 +43,7 @@ class ShifuOutlineItemDto(BaseModel):
 
 
 class ShifuInfoDto(BaseModel):
-    """Shifu info dto"""
+    """Shifu info dto."""
 
     bid: str
     title: str
@@ -67,7 +67,7 @@ def get_shifu_struct(
         shifu_bid: Shifu bid
         is_preview: Is preview
     Returns:
-        HistoryItem: Shifu struct
+        HistoryItem: Shifu struct.
     """
     with app.app_context():
         app.logger.info(f"get_shifu_struct:{shifu_bid},{is_preview}")
@@ -177,7 +177,7 @@ def get_shifu_dto(app: Flask, shifu_bid: str, is_preview: bool = False) -> Shifu
         shifu_bid: Shifu bid
         is_preview: Is preview
     Returns:
-        ShifuInfoDto: Shifu dto
+        ShifuInfoDto: Shifu dto.
     """
     shifu_model = DraftShifu if is_preview else PublishedShifu
     shifu: DraftShifu | PublishedShifu = (
@@ -215,7 +215,7 @@ def get_outline_item_dto(
         outline_item_bid: Outline item bid
         is_preview: Is preview
     Returns:
-        ShifuOutlineItemDto: Outline item dto
+        ShifuOutlineItemDto: Outline item dto.
     """
     app.logger.info(f"get_outline_item_dto: {outline_item_bid},{is_preview}")
 
@@ -243,7 +243,7 @@ def get_outline_item_dto(
 
 
 class OutlineItemDtoWithMdflow(BaseModel):
-    """Outline item dto with mdflow"""
+    """Outline item dto with mdflow."""
 
     mdflow: str
     outline_bid: str
@@ -256,7 +256,7 @@ def get_outline_item_dto_with_mdflow(
     is_preview: bool = False,
     outline_item_id: int | None = None,
 ) -> OutlineItemDtoWithMdflow:
-    """Get outline item dto with mdflow"""
+    """Get outline item dto with mdflow."""
     outline_item_model = DraftOutlineItem if is_preview else PublishedOutlineItem
     outline_item: DraftOutlineItem | PublishedOutlineItem | None = None
     if outline_item_id:

--- a/src/api/flaskr/service/shifu/struct_utils.py
+++ b/src/api/flaskr/service/shifu/struct_utils.py
@@ -1,4 +1,4 @@
-"""Shifu struct utils
+"""Shifu struct utils.
 
 This module contains utils for shifu struct.
 
@@ -18,7 +18,7 @@ def find_node_with_parents(
         target_bid: Target bid
         current_path: Current path
     Returns:
-        Optional[list[HistoryItem]]: Path to target node
+        Optional[list[HistoryItem]]: Path to target node.
     """
     if current_path is None:
         current_path = []

--- a/src/api/flaskr/service/shifu/utils.py
+++ b/src/api/flaskr/service/shifu/utils.py
@@ -1,4 +1,4 @@
-"""Shifu utils
+"""Shifu utils.
 
 This module contains utility functions for shifu.
 

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 def load_prompt_template(template_name: str) -> str:
-    """Load the specified prompt template file
+    """Load the specified prompt template file.
 
     Args:
         template_name: Template file name (without .md extension)

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -36,7 +36,7 @@ target_db = current_app.extensions["migrate"].db
 
 
 def include_object(object, name, type_, reflected, compare_to):
-    """Use the simplest mode to avoid separation"""
+    """Use the simplest mode to avoid separation."""
     # the system tables
     system_tables = [
         "alembic_version",
@@ -175,7 +175,7 @@ def run_migrations_online() -> None:
                         merge_related_changes(script)
 
     def is_meaningful_operation(op):
-        """Judge if an operation is meaningful (not meaningless type conversion)"""
+        """Judge if an operation is meaningful (not meaningless type conversion)."""
         op_type = type(op).__name__
 
         # for the ALTER COLUMN operation, check if it is meaningless type conversion
@@ -227,7 +227,7 @@ def run_migrations_online() -> None:
         return True
 
     def filter_unnecessary_operations(script):
-        """Filter out the unnecessary or duplicate operations"""
+        """Filter out the unnecessary or duplicate operations."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
 
@@ -261,7 +261,7 @@ def run_migrations_online() -> None:
             )
 
     def get_operation_signature(op):
-        """Generate the unique signature of the operation to detect duplication"""
+        """Generate the unique signature of the operation to detect duplication."""
         op_type = type(op).__name__
 
         if hasattr(op, "table_name"):
@@ -289,12 +289,12 @@ def run_migrations_online() -> None:
         return f"{op_type}:unknown"
 
     def should_skip_operation(op):
-        """Judge if it should skip the operation"""
+        """Judge if it should skip the operation."""
         op_type = type(op).__name__
 
         # dynamically get the application table prefixes, based on the actual defined models
         def get_app_table_prefixes():
-            """Dynamically get the table prefixes from the actual models"""
+            """Dynamically get the table prefixes from the actual models."""
             prefixes = set()
 
             # traverse all the registered models
@@ -325,7 +325,7 @@ def run_migrations_online() -> None:
 
         # get all registered application table names
         def get_app_table_names():
-            """Get all registered application table names"""
+            """Get all registered application table names."""
             table_names = set()
             for mapper in db.Model.registry.mappers:
                 model_class = mapper.class_
@@ -477,7 +477,7 @@ def run_migrations_online() -> None:
         return False
 
     def merge_related_changes(script):
-        """Merge the related changes into the same migration"""
+        """Merge the related changes into the same migration."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
 
@@ -568,7 +568,7 @@ def run_migrations_online() -> None:
         metadata_default,
         rendered_metadata_default,
     ):
-        """自定义 server_default 比较，减少误报"""
+        """自定义 server_default 比较，减少误报."""
 
         # 标准化默认值的表示
         def normalize_default(default):
@@ -596,7 +596,7 @@ def run_migrations_online() -> None:
     def compare_comment(
         context, inspected_column, metadata_column, inspected_comment, metadata_comment
     ):
-        """自定义 comment 比较，减少误报但允许真正的注释变更"""
+        """自定义 comment 比较，减少误报但允许真正的注释变更."""
 
         # 标准化注释
         def normalize_comment(comment):
@@ -640,7 +640,7 @@ def run_migrations_online() -> None:
     def compare_type(
         context, inspected_column, metadata_column, inspected_type, metadata_type
     ):
-        """自定义类型比较，减少误报"""
+        """自定义类型比较，减少误报."""
         # 对于某些类型的小差异，认为相同
         inspected_str = str(inspected_type).upper()
         metadata_str = str(metadata_type).upper()

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -568,7 +568,7 @@ def run_migrations_online() -> None:
         metadata_default,
         rendered_metadata_default,
     ):
-        """自定义 server_default 比较，减少误报."""
+        """Compare server defaults leniently to reduce false positives."""
 
         # 标准化默认值的表示
         def normalize_default(default):
@@ -596,7 +596,7 @@ def run_migrations_online() -> None:
     def compare_comment(
         context, inspected_column, metadata_column, inspected_comment, metadata_comment
     ):
-        """自定义 comment 比较，减少误报但允许真正的注释变更."""
+        """Compare comments leniently, still reporting real comment changes."""
 
         # 标准化注释
         def normalize_comment(comment):
@@ -640,7 +640,7 @@ def run_migrations_online() -> None:
     def compare_type(
         context, inspected_column, metadata_column, inspected_type, metadata_type
     ):
-        """自定义类型比较，减少误报."""
+        """Compare column types leniently to reduce false positives."""
         # 对于某些类型的小差异，认为相同
         inspected_str = str(inspected_type).upper()
         metadata_str = str(metadata_type).upper()

--- a/src/api/migrations/versions/0a7c4d8e9f12_backfill_billing_product_plan_tier.py
+++ b/src/api/migrations/versions/0a7c4d8e9f12_backfill_billing_product_plan_tier.py
@@ -1,4 +1,4 @@
-"""backfill billing product plan tier metadata
+"""backfill billing product plan tier metadata.
 
 Revision ID: 0a7c4d8e9f12
 Revises: f4a6b8c2d9e1

--- a/src/api/migrations/versions/0e9b8c7d6a5f_add_bid_to_learn_lesson_feedbacks.py
+++ b/src/api/migrations/versions/0e9b8c7d6a5f_add_bid_to_learn_lesson_feedbacks.py
@@ -1,4 +1,4 @@
-"""add learn lesson feedback table
+"""add learn lesson feedback table.
 
 Revision ID: 0e9b8c7d6a5f
 Revises: f0c1e2d3a4b5

--- a/src/api/migrations/versions/185e37df3252_initial_migration.py
+++ b/src/api/migrations/versions/185e37df3252_initial_migration.py
@@ -1,4 +1,4 @@
-"""Initial migration
+"""Initial migration.
 
 Revision ID: 185e37df3252
 Revises:

--- a/src/api/migrations/versions/1c8f4b7a9d2e_add_subtitle_cues_to_learn_generated_audios.py
+++ b/src/api/migrations/versions/1c8f4b7a9d2e_add_subtitle_cues_to_learn_generated_audios.py
@@ -1,4 +1,4 @@
-"""add subtitle cues to learn_generated_audios
+"""add subtitle cues to learn_generated_audios.
 
 Revision ID: 1c8f4b7a9d2e
 Revises: 2b7c9d1e4f6a

--- a/src/api/migrations/versions/1d8c4e7f9a2b_add_billing_campaign_tables.py
+++ b/src/api/migrations/versions/1d8c4e7f9a2b_add_billing_campaign_tables.py
@@ -1,4 +1,4 @@
-"""add billing campaign tables
+"""add billing campaign tables.
 
 Revision ID: 1d8c4e7f9a2b
 Revises: d2f4a7c9b8e1

--- a/src/api/migrations/versions/1f2e3d4c5b6a_add_is_operator_to_user_users.py
+++ b/src/api/migrations/versions/1f2e3d4c5b6a_add_is_operator_to_user_users.py
@@ -1,4 +1,4 @@
-"""add is_operator to user_users
+"""add is_operator to user_users.
 
 Revision ID: 1f2e3d4c5b6a
 Revises: 7b3c5d9e1a2f

--- a/src/api/migrations/versions/21a3e778ef01_add_sys_configs.py
+++ b/src/api/migrations/versions/21a3e778ef01_add_sys_configs.py
@@ -1,4 +1,4 @@
-"""add sys configs
+"""add sys configs.
 
 Revision ID: 21a3e778ef01
 Revises: 6b603528dac8

--- a/src/api/migrations/versions/2b7c9d1e4f6a_backfill_operator_for_first_verified_user.py
+++ b/src/api/migrations/versions/2b7c9d1e4f6a_backfill_operator_for_first_verified_user.py
@@ -1,4 +1,4 @@
-"""backfill operator for first verified user
+"""backfill operator for first verified user.
 
 Revision ID: 2b7c9d1e4f6a
 Revises: 1f2e3d4c5b6a

--- a/src/api/migrations/versions/2f8c9a1d7e6b_add_minimax_cloned_voices.py
+++ b/src/api/migrations/versions/2f8c9a1d7e6b_add_minimax_cloned_voices.py
@@ -1,4 +1,4 @@
-"""add minimax cloned voices
+"""add minimax cloned voices.
 
 Revision ID: 2f8c9a1d7e6b
 Revises: 5a6b7c8d9e10

--- a/src/api/migrations/versions/3ef04a9b5d37_add_position_to_learn_generated_audios.py
+++ b/src/api/migrations/versions/3ef04a9b5d37_add_position_to_learn_generated_audios.py
@@ -1,4 +1,4 @@
-"""add position to learn_generated_audios
+"""add position to learn_generated_audios.
 
 Revision ID: 3ef04a9b5d37
 Revises: 8f4c1a2b7d9e

--- a/src/api/migrations/versions/4a1f6c8e9b2d_add_learn_generated_elements.py
+++ b/src/api/migrations/versions/4a1f6c8e9b2d_add_learn_generated_elements.py
@@ -1,4 +1,4 @@
-"""add learn_generated_elements with element protocol fields
+"""add learn_generated_elements with element protocol fields.
 
 Revision ID: 4a1f6c8e9b2d
 Revises: b596b767bde5

--- a/src/api/migrations/versions/4d9f6c7b8a1e_add_coupon_admin_fields.py
+++ b/src/api/migrations/versions/4d9f6c7b8a1e_add_coupon_admin_fields.py
@@ -1,4 +1,4 @@
-"""add coupon admin fields
+"""add coupon admin fields.
 
 Revision ID: 4d9f6c7b8a1e
 Revises: b114d7f5e2c1

--- a/src/api/migrations/versions/4f2b7d8e9c1a_add_billing_campaign_product_rule_columns.py
+++ b/src/api/migrations/versions/4f2b7d8e9c1a_add_billing_campaign_product_rule_columns.py
@@ -1,4 +1,4 @@
-"""add billing campaign product rule columns
+"""add billing campaign product rule columns.
 
 Revision ID: 4f2b7d8e9c1a
 Revises: 1d8c4e7f9a2b

--- a/src/api/migrations/versions/56b765541144_add_shifu_user_archives.py
+++ b/src/api/migrations/versions/56b765541144_add_shifu_user_archives.py
@@ -1,4 +1,4 @@
-"""add shifu_user_archives and drop legacy archive columns
+"""add shifu_user_archives and drop legacy archive columns.
 
 Revision ID: 56b765541144
 Revises: b5f2d3a9c1e4

--- a/src/api/migrations/versions/5a6b7c8d9e10_add_referral_invitation_tables.py
+++ b/src/api/migrations/versions/5a6b7c8d9e10_add_referral_invitation_tables.py
@@ -1,4 +1,4 @@
-"""add referral invitation tables
+"""add referral invitation tables.
 
 Revision ID: 5a6b7c8d9e10
 Revises: c5d8e1f2a3b4

--- a/src/api/migrations/versions/6b603528dac8_add_system_profile.py
+++ b/src/api/migrations/versions/6b603528dac8_add_system_profile.py
@@ -1,4 +1,4 @@
-"""add system profile
+"""add system profile.
 
 Revision ID: 6b603528dac8
 Revises: 185e37df3252

--- a/src/api/migrations/versions/6b956399315e_backfill_profile_variable_tables.py
+++ b/src/api/migrations/versions/6b956399315e_backfill_profile_variable_tables.py
@@ -1,4 +1,4 @@
-"""backfill variable tables
+"""backfill variable tables.
 
 Revision ID: 6b956399315e
 Revises: 716efaaeb662

--- a/src/api/migrations/versions/716efaaeb662_create_profile_variable_tables.py
+++ b/src/api/migrations/versions/716efaaeb662_create_profile_variable_tables.py
@@ -1,4 +1,4 @@
-"""create variable tables
+"""create variable tables.
 
 Revision ID: 716efaaeb662
 Revises: ef7dbc5a8be3

--- a/src/api/migrations/versions/7b3c5d9e1a2f_add_learn_generated_element_active_lookup_indexes.py
+++ b/src/api/migrations/versions/7b3c5d9e1a2f_add_learn_generated_element_active_lookup_indexes.py
@@ -1,4 +1,4 @@
-"""add learn generated element active lookup indexes
+"""add learn generated element active lookup indexes.
 
 Revision ID: 7b3c5d9e1a2f
 Revises: 4a1f6c8e9b2d

--- a/src/api/migrations/versions/8c2d4e6f1a9b_drop_minimax_voice_id_unique_constraint.py
+++ b/src/api/migrations/versions/8c2d4e6f1a9b_drop_minimax_voice_id_unique_constraint.py
@@ -1,4 +1,4 @@
-"""drop minimax cloned voice_id unique constraint
+"""drop minimax cloned voice_id unique constraint.
 
 Revision ID: 8c2d4e6f1a9b
 Revises: 2f8c9a1d7e6b

--- a/src/api/migrations/versions/8f4c1a2b7d9e_drop_legacy_order_variable_active_tables.py
+++ b/src/api/migrations/versions/8f4c1a2b7d9e_drop_legacy_order_variable_active_tables.py
@@ -1,4 +1,4 @@
-"""drop legacy order, variable, and active tables
+"""drop legacy order, variable, and active tables.
 
 Revision ID: 8f4c1a2b7d9e
 Revises: 6b956399315e

--- a/src/api/migrations/versions/9a7c6d5e4f3b_merge_billing_campaign_and_notification_heads.py
+++ b/src/api/migrations/versions/9a7c6d5e4f3b_merge_billing_campaign_and_notification_heads.py
@@ -1,4 +1,4 @@
-"""merge billing campaign and notification migration heads
+"""merge billing campaign and notification migration heads.
 
 Revision ID: 9a7c6d5e4f3b
 Revises: 4f2b7d8e9c1a, f4a6b8c2d9e1

--- a/src/api/migrations/versions/9f3a0c3aebe0_add_hidden_profile_item.py
+++ b/src/api/migrations/versions/9f3a0c3aebe0_add_hidden_profile_item.py
@@ -1,4 +1,4 @@
-"""add hidden to profile item
+"""add hidden to profile item.
 
 Revision ID: 9f3a0c3aebe0
 Revises: d7a8e2f1b3c9

--- a/src/api/migrations/versions/a4d68cce5ce6_add_demo_shifu.py
+++ b/src/api/migrations/versions/a4d68cce5ce6_add_demo_shifu.py
@@ -1,4 +1,4 @@
-"""add demo shifu json file
+"""add demo shifu json file.
 
 Revision ID: a4d68cce5ce6
 Revises: 21a3e778ef01

--- a/src/api/migrations/versions/a7c4e9f1b2d3_snapshot_creator_payment_config.py
+++ b/src/api/migrations/versions/a7c4e9f1b2d3_snapshot_creator_payment_config.py
@@ -1,4 +1,4 @@
-"""snapshot creator payment config on learner orders
+"""snapshot creator payment config on learner orders.
 
 Revision ID: a7c4e9f1b2d3
 Revises: f6b2a4d8c9e0

--- a/src/api/migrations/versions/a9c3d5e7f1b2_add_default_listen_mode_setting.py
+++ b/src/api/migrations/versions/a9c3d5e7f1b2_add_default_listen_mode_setting.py
@@ -1,4 +1,4 @@
-"""add default listen mode setting
+"""add default listen mode setting.
 
 Revision ID: a9c3d5e7f1b2
 Revises: f9a2b3c4d5e6

--- a/src/api/migrations/versions/b114d7f5e2c1_add_billing_core_phase.py
+++ b/src/api/migrations/versions/b114d7f5e2c1_add_billing_core_phase.py
@@ -1,4 +1,4 @@
-"""add billing core phase
+"""add billing core phase.
 
 Revision ID: b114d7f5e2c1
 Revises: 1c8f4b7a9d2e

--- a/src/api/migrations/versions/b2793bb43f97_add_bill_usage.py
+++ b/src/api/migrations/versions/b2793bb43f97_add_bill_usage.py
@@ -1,4 +1,4 @@
-"""add bill usage table
+"""add bill usage table.
 
 Revision ID: b2793bb43f97
 Revises: 9f3a0c3aebe0

--- a/src/api/migrations/versions/b596b767bde5_add_api_key_field_to_user_users_table.py
+++ b/src/api/migrations/versions/b596b767bde5_add_api_key_field_to_user_users_table.py
@@ -1,4 +1,4 @@
-"""add api_key field to user_users table
+"""add api_key field to user_users table.
 
 Revision ID: b596b767bde5
 Revises: e1b2c3d4e5f6

--- a/src/api/migrations/versions/b5f2d3a9c1e4_update_tts_ranges_and_provider_defaults.py
+++ b/src/api/migrations/versions/b5f2d3a9c1e4_update_tts_ranges_and_provider_defaults.py
@@ -1,4 +1,4 @@
-"""add tts audio records and shifu tts config
+"""add tts audio records and shifu tts config.
 
 Revision ID: b5f2d3a9c1e4
 Revises: c9c92880fc67

--- a/src/api/migrations/versions/b8c1d2e3f4a5_merge_billing_campaign_and_plan_tier_heads.py
+++ b/src/api/migrations/versions/b8c1d2e3f4a5_merge_billing_campaign_and_plan_tier_heads.py
@@ -1,4 +1,4 @@
-"""merge billing campaign and plan tier heads
+"""merge billing campaign and plan tier heads.
 
 Revision ID: b8c1d2e3f4a5
 Revises: 9a7c6d5e4f3b, 0a7c4d8e9f12

--- a/src/api/migrations/versions/b8d5f0a2c3e4_add_generation_prompt_to_generated_blocks.py
+++ b/src/api/migrations/versions/b8d5f0a2c3e4_add_generation_prompt_to_generated_blocks.py
@@ -1,4 +1,4 @@
-"""add generation_prompt to learn_generated_blocks
+"""add generation_prompt to learn_generated_blocks.
 
 Revision ID: b8d5f0a2c3e4
 Revises: a7c4e9f1b2d3

--- a/src/api/migrations/versions/c221d355ffb7_add_promo_campaign_tables.py
+++ b/src/api/migrations/versions/c221d355ffb7_add_promo_campaign_tables.py
@@ -1,4 +1,4 @@
-"""add promo tables
+"""add promo tables.
 
 Revision ID: c221d355ffb7
 Revises: b2793bb43f97

--- a/src/api/migrations/versions/c3f101bbb462_add_active_table.py
+++ b/src/api/migrations/versions/c3f101bbb462_add_active_table.py
@@ -1,4 +1,4 @@
-"""add active table
+"""add active table.
 
 Revision ID: c3f101bbb462
 Revises: a4d68cce5ce6

--- a/src/api/migrations/versions/c5d8e1f2a3b4_add_billing_order_expires_at.py
+++ b/src/api/migrations/versions/c5d8e1f2a3b4_add_billing_order_expires_at.py
@@ -1,4 +1,4 @@
-"""add billing order expires_at
+"""add billing order expires_at.
 
 Revision ID: c5d8e1f2a3b4
 Revises: b8c1d2e3f4a5

--- a/src/api/migrations/versions/c6a4f8d9b2e1_add_user_onboarding_states.py
+++ b/src/api/migrations/versions/c6a4f8d9b2e1_add_user_onboarding_states.py
@@ -1,4 +1,4 @@
-"""add user onboarding states
+"""add user onboarding states.
 
 Revision ID: c6a4f8d9b2e1
 Revises: 8c2d4e6f1a9b

--- a/src/api/migrations/versions/c8f1a2d3e4b5_add_learner_profile_to_users.py
+++ b/src/api/migrations/versions/c8f1a2d3e4b5_add_learner_profile_to_users.py
@@ -1,4 +1,4 @@
-"""add canonical learning profile to users
+"""add canonical learning profile to users.
 
 Revision ID: c8f1a2d3e4b5
 Revises: b8d5f0a2c3e4

--- a/src/api/migrations/versions/c9c92880fc67_add_stripe_payment_channel.py
+++ b/src/api/migrations/versions/c9c92880fc67_add_stripe_payment_channel.py
@@ -1,4 +1,4 @@
-"""add stripe payment channel
+"""add stripe payment channel.
 
 Revision ID: c9c92880fc67
 Revises: c3f101bbb462

--- a/src/api/migrations/versions/d2f4a7c9b8e1_add_native_payment_snapshots.py
+++ b/src/api/migrations/versions/d2f4a7c9b8e1_add_native_payment_snapshots.py
@@ -1,4 +1,4 @@
-"""add native payment snapshots
+"""add native payment snapshots.
 
 Revision ID: d2f4a7c9b8e1
 Revises: 4d9f6c7b8a1e

--- a/src/api/migrations/versions/d4e5f6a7b8c9_add_creator_activated_at.py
+++ b/src/api/migrations/versions/d4e5f6a7b8c9_add_creator_activated_at.py
@@ -1,4 +1,4 @@
-"""add creator activated at
+"""add creator activated at.
 
 Revision ID: d4e5f6a7b8c9
 Revises: c6a4f8d9b2e1

--- a/src/api/migrations/versions/d7a8e2f1b3c9_add_use_learner_language.py
+++ b/src/api/migrations/versions/d7a8e2f1b3c9_add_use_learner_language.py
@@ -1,4 +1,4 @@
-"""add use_learner_language to shifu tables
+"""add use_learner_language to shifu tables.
 
 Revision ID: d7a8e2f1b3c9
 Revises: 56b765541144

--- a/src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py
+++ b/src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py
@@ -1,4 +1,4 @@
-"""add ask_provider_config to shifu draft/published tables
+"""add ask_provider_config to shifu draft/published tables.
 
 Revision ID: e1b2c3d4e5f6
 Revises: 0e9b8c7d6a5f

--- a/src/api/migrations/versions/e3b1c2d4f5a6_add_notification_records.py
+++ b/src/api/migrations/versions/e3b1c2d4f5a6_add_notification_records.py
@@ -1,4 +1,4 @@
-"""add notification records
+"""add notification records.
 
 Revision ID: e3b1c2d4f5a6
 Revises: d2f4a7c9b8e1

--- a/src/api/migrations/versions/e7b3c9d1f5a2_add_provider_to_tts_cloned_voices.py
+++ b/src/api/migrations/versions/e7b3c9d1f5a2_add_provider_to_tts_cloned_voices.py
@@ -1,4 +1,4 @@
-"""add provider to tts cloned voices
+"""add provider to tts cloned voices.
 
 Revision ID: e7b3c9d1f5a2
 Revises: b8d5f0a2c3e4

--- a/src/api/migrations/versions/e7f1a2b3c4d5_add_outline_shifu_outline_id_index.py
+++ b/src/api/migrations/versions/e7f1a2b3c4d5_add_outline_shifu_outline_id_index.py
@@ -1,4 +1,4 @@
-"""add (shifu_bid, outline_item_bid, id) index for draft outline
+"""add (shifu_bid, outline_item_bid, id) index for draft outline.
 
 Revision ID: e7f1a2b3c4d5
 Revises: d4e5f6a7b8c9

--- a/src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py
+++ b/src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py
@@ -1,4 +1,4 @@
-"""backfill promo tables from active tables
+"""backfill promo tables from active tables.
 
 Revision ID: ef7dbc5a8be3
 Revises: c221d355ffb7

--- a/src/api/migrations/versions/f0c1e2d3a4b5_add_outline_lookup_composite_index.py
+++ b/src/api/migrations/versions/f0c1e2d3a4b5_add_outline_lookup_composite_index.py
@@ -1,4 +1,4 @@
-"""add composite index for draft outline lookup
+"""add composite index for draft outline lookup.
 
 Revision ID: f0c1e2d3a4b5
 Revises: 3ef04a9b5d37

--- a/src/api/migrations/versions/f4a6b8c2d9e1_add_notification_record_operator_indexes.py
+++ b/src/api/migrations/versions/f4a6b8c2d9e1_add_notification_record_operator_indexes.py
@@ -1,4 +1,4 @@
-"""add notification record operator indexes
+"""add notification record operator indexes.
 
 Revision ID: f4a6b8c2d9e1
 Revises: e3b1c2d4f5a6

--- a/src/api/migrations/versions/f6b2a4d8c9e0_remove_legacy_timestamp_server_defaults.py
+++ b/src/api/migrations/versions/f6b2a4d8c9e0_remove_legacy_timestamp_server_defaults.py
@@ -1,4 +1,4 @@
-"""remove legacy timestamp server defaults
+"""remove legacy timestamp server defaults.
 
 Revision ID: f6b2a4d8c9e0
 Revises: e7f1a2b3c4d5

--- a/src/api/migrations/versions/f9a2b3c4d5e6_merge_learner_profile_and_tts_provider_heads.py
+++ b/src/api/migrations/versions/f9a2b3c4d5e6_merge_learner_profile_and_tts_provider_heads.py
@@ -1,4 +1,4 @@
-"""merge learner profile and tts provider heads
+"""merge learner profile and tts provider heads.
 
 Revision ID: f9a2b3c4d5e6
 Revises: c8f1a2d3e4b5, e7b3c9d1f5a2

--- a/src/api/scripts/inventory/filter_vulture.py
+++ b/src/api/scripts/inventory/filter_vulture.py
@@ -5,7 +5,7 @@
 - __json__ methods
 - celery @shared_task functions
 - anything under migrations/
-Usage: filter_vulture.py <vulture-raw.txt> <src_api_root>
+Usage: filter_vulture.py <vulture-raw.txt> <src_api_root>.
 """
 
 import re

--- a/src/api/tests/test_utils.py
+++ b/src/api/tests/test_utils.py
@@ -42,7 +42,7 @@ def dump(data: Any) -> None:
 
 
 def _dump_object_details(obj: Any, max_depth: int = 3, current_depth: int = 0) -> None:
-    """Recursively display detailed information of objects"""
+    """Recursively display detailed information of objects."""
     if current_depth >= max_depth:
         print("  " * current_depth + "... (reached max depth)")
         return
@@ -71,7 +71,7 @@ def _dump_object_details(obj: Any, max_depth: int = 3, current_depth: int = 0) -
 
 
 def dump_detailed(data: Any, include_methods: bool = False) -> None:
-    """More detailed dump function, can choose whether to display methods"""
+    """More detailed dump function, can choose whether to display methods."""
     print("\n=== Detailed Test Result ===")
 
     if isinstance(data, dict):
@@ -96,7 +96,7 @@ def dump_detailed(data: Any, include_methods: bool = False) -> None:
 
 
 def _dump_object_attributes(obj: Any, include_methods: bool = False) -> None:
-    """Display all attributes and optional methods of an object"""
+    """Display all attributes and optional methods of an object."""
     print("Attributes:")
     for attr_name in dir(obj):
         if not attr_name.startswith("_"):


### PR DESCRIPTION
# Summary

Enables the whole pydocstyle (`D`) group in `ruff.toml`, fixes everything it reports except the members that cannot be enforced without either authoring thousands of docstrings or breaking embedded Swagger specs, and rewrites the docstrings that were still Chinese in English.

Ruff fixes:
- `D400`/`D415` (684 sites, `ruff check --fix --unsafe-fixes`): missing terminal punctuation on docstring summaries. Route docstrings only gained a period on the summary line above the flasgger `---` block, so the embedded YAML is untouched.
- `D417` (4 sites): documented `enable_timestamp`/`enable_subtitle` (`volcengine_protocol.encode_start_session`), `model` (`volcengine_provider.synthesize`), `commit` (`import_shifu`), `outline_items` (`assert_outline_items_publishable`) and `app`/`shifu_id`/`user_id` (`create_outlines_batch`).
- `CouponUsage` docstring reshaped into summary + description.

English docstrings: the 23 remaining Chinese docstrings are now English — the `order` and `dicts` route summaries with their embedded Swagger tags, parameter and response descriptions, the alembic `env.py` comparison helpers, and the plugin base / hot-reload hooks. The Swagger tags `订单` and `字典` become `order` and `dict`, matching the English tags the other route modules already use; every rewritten spec was re-parsed with `yaml.safe_load` to confirm it is still valid YAML. Chinese kept on purpose: quoted external values that only exist in Chinese (the Ping++/WeChat rejection message, the Volcengine/Tencent voice-tier display names, the `简体中文` language-name example) and the docstrings of applied migrations under `migrations/versions/`, which this repo does not edit.

Ignored, with the reason recorded in `ruff.toml`:
- `D100`/`D101`/`D102`/`D103`/`D105`/`D107`: ~4.6k undocumented modules/classes/methods/functions/`__init__`s. `D104` stays enforced.
- `D203` and `D213`: mutually exclusive with the already-selected `D211`/`D212`.
- `D205`: 262 summaries wrapped over two lines; 244 of them do not fit on one line, so clearing it is prose rewriting of existing (accurate) docs rather than a mechanical fix. Deferred.
- `D405`/`D406`/`D407`: they read flasgger YAML keys such as `parameters:` as numpydoc section headers and their fixes would emit invalid YAML.

Net effect: the previous nine individually selected `D` rules become `select = ["D"]` plus explicit ignores, and 24 more docstring rules (D2xx/D4xx) are now enforced.

Verification: `ruff check .` and `ruff format --check .` clean; `pytest -q` in `src/api` → 2811 passed, 15 skipped (excluding the known SQLite `concat()` failures in `tests/service/shifu/test_admin_course_detail.py`, which also fail on `main`), plus `tests/service/order` and `tests/route` re-run after the translation. Rebased on `main` after #2520 merged.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner