### PR TITLE
fix: generate verification codes with a cryptographic random source

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,10 @@
 #   service and route modules exceed by design.
 # - ARG001 / ARG002 / ARG005: unused arguments are pervasive in framework
 #   callbacks, fixtures and test doubles.
+# - TD003 / FIX002: the remaining TODOs have no tracking issue to link, and
+#   inventing one (or downgrading the comment) would hide real pending work.
+# - N806 / N815: local CamelCase bindings and camelCase DTO attributes are
+#   still widespread; N815 in particular encodes serialized JSON field names.
 
 # Matches the Python pinned by src/api/Dockerfile and the CI workflows.
 target-version = "py311"
@@ -73,15 +77,16 @@ select = [
     "DTZ",
 
     # --- Logging ----------------------------------------------------------
-    # G001/G004 (f-string and .format logging) are the established house
-    # style and stay ignored below; the rest catch real defects: G003 `+`
-    # concatenation can raise TypeError on non-string values, and G201/G202
-    # are strictly equivalent rewrites to `.exception(...)`.
+    # G004 (f-string logging) is the established house style and stays ignored
+    # below; the rest catch real defects: G001/G003 format the message eagerly
+    # (and `+` can raise TypeError on non-string values), and G201/G202 are
+    # strictly equivalent rewrites to `.exception(...)`.
     "G",
     "LOG",     # flake8-logging (exc_info must name the exception outside except blocks)
     "TRY2",    # verbose re-raise / exception handler that only re-raises
     "TRY002",  # raising a vanilla Exception instead of a named class
     "TRY400",  # logging.error inside except that should be logging.exception
+    "TRY004",  # type check raising something other than TypeError
 
     # --- Pylint subsets ---------------------------------------------------
     "PLE",     # pylint errors (yield/return in __init__, invalid dunders, ...)
@@ -102,16 +107,32 @@ select = [
     # --- Paths, suppressions, shadowing, security -------------------------
     "PTH",     # os.path calls that should use pathlib
     "PGH",     # blanket noqa / type: ignore, invalid suppressions
+    "ARG003",  # unused classmethod argument
     "ARG004",  # unused staticmethod argument
     "A001",    # local variable shadowing a builtin
     "A006",    # lambda argument shadowing a builtin
+    # pep8-naming is partial: N806/N815 stay off (see the header above).
+    "N801",    # class name that is not CapWords
+    "N802",    # function name that is not lowercase
+    "N803",    # argument name that is not lowercase
+    "N813",    # CamelCase imported under a lowercase alias
+    "TD002",   # TODO without an author
     # S101 bans `assert` in shipped code (python -O strips it, so an assert is
     # not a runtime guard). Test suites and script self-tests are exempt via
     # per-file-ignores below.
     "S101",    # assert used outside tests
+    "S104",    # binding a socket to all interfaces
     "S108",    # hardcoded /tmp path instead of tempfile.gettempdir()
     "S113",    # requests call without a timeout
+    "S310",    # urlopen without an audited URL scheme
+    "S311",    # `random` where a cryptographic generator is required
     "S324",    # hashlib md5/sha1 without usedforsecurity=False
+    # S603/S605/S607 flag every subprocess and shell invocation. Application
+    # code justifies each one inline; developer tooling is exempt through
+    # per-file-ignores below.
+    "S603",    # subprocess call with unvalidated input
+    "S605",    # process started with a shell
+    "S607",    # process started with a partial executable path
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands
@@ -155,7 +176,6 @@ ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "DTZ901",  # datetime.min/max -- naive UTC is the house convention
-    "G001",    # str.format logging -- house style
     "G004",    # f-string logging -- house style, and rewriting it is churn
     "PERF401", # manual list comprehension -- rewrites obscure the loop bodies
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
@@ -183,7 +203,12 @@ ignore = [
 [lint.per-file-ignores]
 # `assert` is the point of a test, and both scripts below are test code: one is
 # a pytest module, the other keeps its regex fixtures in a `run_self_test()`.
-"src/api/tests/**" = ["S101"]
+# Developer tooling (repo scripts, backend scripts, test harnesses) also shells
+# out to `git`, `node` and `python` with statically built argument lists, so the
+# subprocess audit rules only add noise there.
+"src/api/tests/**" = ["S101", "S603", "S607"]
 "src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]
+"scripts/**" = ["S603", "S607"]
+"src/api/scripts/**" = ["S603", "S607"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -79,8 +79,9 @@ select = [
     # --- Logging ----------------------------------------------------------
     # G004 (f-string logging) is the established house style and stays ignored
     # below; the rest catch real defects: G001/G003 format the message eagerly
-    # (and `+` can raise TypeError on non-string values), and G201/G202 are
-    # strictly equivalent rewrites to `.exception(...)`.
+    # (and `+` can raise TypeError on non-string values), G201 replaces
+    # `.error(..., exc_info=True)` with the equivalent `.exception(...)`, and
+    # G202 drops `exc_info` arguments that already match the call's default.
     "G",
     "LOG",     # flake8-logging (exc_info must name the exception outside except blocks)
     "TRY2",    # verbose re-raise / exception handler that only re-raises

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -127,7 +127,7 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
         if isinstance(flat_section, dict):
             for key, value in flat_section.items():
                 if not isinstance(value, str):
-                    raise ValueError(f"Translation value for '{key}' must be a string")
+                    raise TypeError(f"Translation value for '{key}' must be a string")
                 composite_key = f"{namespace}.{key}" if namespace else key
                 items[composite_key] = value
         for key, value in data.items():
@@ -137,7 +137,7 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
             items.update(flatten_translation(value, next_namespace))
         return items
     if not isinstance(data, str):
-        raise ValueError(f"Translation value for '{namespace}' must be a string")
+        raise TypeError(f"Translation value for '{namespace}' must be a string")
     return {namespace: data}
 
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import time
 from pathlib import Path
 
@@ -12,7 +13,8 @@ from flaskr.framework.plugin.plugin_manager import enable_plugin_manager
 # set timezone to UTC
 # fix windows platform
 if os.name == "nt":
-    os.system('tzutil /s "UTC"')
+    # tzutil ships with Windows and is resolved from PATH.
+    subprocess.run(["tzutil", "/s", "UTC"], check=False)  # noqa: S603, S607
 else:
     # Load environment variables first so we can use get_config
     if not os.getenv("SKIP_LOAD_DOTENV"):
@@ -117,7 +119,8 @@ def create_app() -> Flask:
 if __name__ == "__main__":
     app = create_app()
     # Only enable debug mode if explicitly running in development environment
-    app.run(host="0.0.0.0", port=5800, debug=app.config.get("ENV") == "development")
+    # Binding to all interfaces is required for the containerized dev server.
+    app.run(host="0.0.0.0", port=5800, debug=app.config.get("ENV") == "development")  # noqa: S104
 elif not os.getenv("SKIP_APP_AUTOCREATE"):
     app = create_app()
     from flaskr.framework.plugin.enable_plugin import enable_plugins

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -139,7 +139,9 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
         endpoint_url, querystring.encode("utf-8"), headers=headers, method="POST"
     )
     try:
-        return json.loads(urlopen(req, timeout=timeout).read().decode(), strict=False)
+        # The endpoint is a fixed https URL built from configuration.
+        response = urlopen(req, timeout=timeout)  # noqa: S310
+        return json.loads(response.read().decode(), strict=False)
     except URLError:
         raise
     except OSError as err:

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -140,8 +140,8 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
     )
     try:
         # The endpoint is a fixed https URL built from configuration.
-        response = urlopen(req, timeout=timeout)  # noqa: S310
-        return json.loads(response.read().decode(), strict=False)
+        with urlopen(req, timeout=timeout) as response:  # noqa: S310
+            return json.loads(response.read().decode(), strict=False)
     except URLError:
         raise
     except OSError as err:

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -3,7 +3,7 @@
 
 
 import hashlib
-import random
+import secrets
 import time
 from urllib.parse import urlencode
 
@@ -95,7 +95,7 @@ def yidun_check(
     params["businessId"] = YIDUN_BUSINESS_ID
     params["version"] = VERSION
     params["timestamp"] = int(time.time() * 1000)
-    params["nonce"] = int(random.random() * 100000000)
+    params["nonce"] = secrets.randbelow(100000000)
     if user_id:
         params["account"] = user_id
     params["signature"] = gen_signature(params)

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -116,7 +116,8 @@ def parse_llm_model_max_output_tokens(value: Any) -> dict[str, int]:
         except (TypeError, ValueError) as exc:
             raise ValueError("must be a JSON object") from exc
     if not isinstance(candidate, dict):
-        raise ValueError("must be a JSON object")
+        # ValueError is part of this parser's contract: callers only catch it.
+        raise ValueError("must be a JSON object")  # noqa: TRY004
 
     parsed: dict[str, int] = {}
     for model, max_output_tokens in candidate.items():

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -33,7 +33,7 @@ class AppLoggerProxy:
 
 
 class RequestFormatter(logging.Formatter):
-    def formatTime(self, record, datefmt=None):
+    def formatTime(self, record, datefmt=None):  # noqa: N802 - logging.Formatter hook name
         # create time zone info
         bj_time = pytz.timezone("Asia/Shanghai")
         # convert record.created (a float timestamp) to beijing time

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -508,7 +508,7 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
                     # Exponential backoff with jitter to avoid re-colliding with
                     # the peer transaction under sustained lock contention.
                     delay = backoff_seconds * (2 ** (attempt - 1))
-                    time.sleep(delay + random.uniform(0, backoff_seconds))
+                    time.sleep(delay + random.uniform(0, backoff_seconds))  # noqa: S311 - retry jitter
 
         return wrapper
 
@@ -649,9 +649,10 @@ def init_redis(app: Flask):
         return
 
     app.logger.info(
-        "init redis {} {} {}".format(
-            app.config["REDIS_HOST"], app.config["REDIS_PORT"], app.config["REDIS_DB"]
-        )
+        "init redis %s %s %s",
+        app.config["REDIS_HOST"],
+        app.config["REDIS_PORT"],
+        app.config["REDIS_DB"],
     )
 
     if (

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -24,7 +24,12 @@ def enable_plugins(app: Flask):
         dest_dir = str(Path("flaskr") / "plugins" / repo_name)
         if Path(dest_dir).exists():
             return
-        subprocess.run(["git", "clone", repo_url, dest_dir], check=False)
+        git_executable = shutil.which("git")
+        if git_executable is None:
+            click.echo("git is not available on PATH")
+            return
+        # The repository URL is supplied by the operator running this CLI command.
+        subprocess.run([git_executable, "clone", repo_url, dest_dir], check=False)  # noqa: S603
 
     @plugin.command(name="delete")
     @click.argument("repo_name")

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -26,8 +26,7 @@ def enable_plugins(app: Flask):
             return
         git_executable = shutil.which("git")
         if git_executable is None:
-            click.echo("git is not available on PATH")
-            return
+            raise click.ClickException("git is not available on PATH")
         # The repository URL is supplied by the operator running this CLI command.
         subprocess.run([git_executable, "clone", repo_url, dest_dir], check=False)  # noqa: S603
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1052,7 +1052,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             raise_param_error("password")
         provider = get_provider("password")
         vr = VerificationRequest(identifier=identifier, code=password)
-        # TODO: Add rate-limiting and failed login attempt tracking
+        # TODO(geyunfei): Add rate-limiting and failed login attempt tracking
         # (record identifier, request.remote_addr, timestamp on failure)
         auth_result = provider.verify(app, vr)
         current_user = _best_effort_password_login_user(app)

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -83,7 +83,7 @@ class UserToken:
     userInfo: UserInfo
     token: str
 
-    def __init__(self, userInfo: UserInfo, token):
+    def __init__(self, userInfo: UserInfo, token):  # noqa: N803 - mirrors the serialized field name
         self.userInfo = userInfo
         self.token = token
 

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -190,7 +190,7 @@ def get_config(key: str, default: str | None = None) -> str:
                             is_encrypted=bool(config.is_encrypted),
                             value=raw_value,
                         ).model_dump_json(),
-                        ex=86400 + random.randint(0, 3600),
+                        ex=86400 + random.randint(0, 3600),  # noqa: S311 - cache TTL jitter
                     )
                     return value
                 finally:
@@ -244,7 +244,7 @@ def add_config(
             redis.set(
                 cache_key,
                 ConfigCache(is_encrypted=is_secret, value=value).model_dump_json(),
-                ex=86400 + random.randint(0, 3600),
+                ex=86400 + random.randint(0, 3600),  # noqa: S311 - cache TTL jitter
             )
             return True
         # Config doesn't exist, add new one
@@ -266,7 +266,7 @@ def add_config(
             redis.set(
                 cache_key,
                 ConfigCache(is_encrypted=is_secret, value=value).model_dump_json(),
-                ex=86400 + random.randint(0, 3600),
+                ex=86400 + random.randint(0, 3600),  # noqa: S311 - cache TTL jitter
             )
             return True
         return False
@@ -317,7 +317,7 @@ def update_config(
             redis.set(
                 cache_key,
                 ConfigCache(is_encrypted=is_secret, value=value).model_dump_json(),
-                ex=86400 + random.randint(0, 3600),
+                ex=86400 + random.randint(0, 3600),  # noqa: S311 - cache TTL jitter
             )
             return True
         return False

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -217,10 +217,14 @@ def _run_guardrail(
     check_text_func = globals().get("check_text_with_llm_response")
     llm_settings_cls = globals().get("LLMSettings")
     if check_text_func is None or llm_settings_cls is None:
+        # Lowercase aliases keep the lazily imported names consistent with the
+        # module-level lookups above.
         from flaskr.service.learn.check_text import (
             check_text_with_llm_response as check_text_func,
         )
-        from flaskr.service.learn.llmsetting import LLMSettings as llm_settings_cls
+        from flaskr.service.learn.llmsetting import (  # noqa: N813
+            LLMSettings as llm_settings_cls,
+        )
 
     res = check_text_func(
         app,
@@ -561,13 +565,15 @@ def handle_input_ask(
         or ask_provider_error_cls is None
         or ask_provider_timeout_error_cls is None
     ):
-        from flaskr.service.learn.ask_provider_adapters import (
+        # Lowercase aliases keep the lazily imported names consistent with the
+        # module-level lookups above.
+        from flaskr.service.learn.ask_provider_adapters import (  # noqa: N813
             AskProviderError as ask_provider_error_cls,
         )
-        from flaskr.service.learn.ask_provider_adapters import (
+        from flaskr.service.learn.ask_provider_adapters import (  # noqa: N813
             AskProviderRuntime as ask_provider_runtime_cls,
         )
-        from flaskr.service.learn.ask_provider_adapters import (
+        from flaskr.service.learn.ask_provider_adapters import (  # noqa: N813
             AskProviderTimeoutError as ask_provider_timeout_error_cls,
         )
         from flaskr.service.learn.ask_provider_adapters import (

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -266,7 +266,8 @@ def _parse_alipay_response(raw_response: Any, response_key: str) -> dict[str, An
     if isinstance(raw_response, str):
         raw_response = json.loads(raw_response)
     if not isinstance(raw_response, dict):
-        raise RuntimeError("Invalid Alipay response")
+        # RuntimeError is this provider's uniform failure type.
+        raise RuntimeError("Invalid Alipay response")  # noqa: TRY004
     nested = raw_response.get(response_key)
     if isinstance(nested, dict):
         return nested

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -373,7 +373,7 @@ def submit_minimax_voice_clone(
 
         estimate = estimate_voice_clone_operation_credits(app)
         billing_enabled = is_billing_enabled()
-        should_bill = billing_enabled and estimate.consumed_credits > _ZERO()
+        should_bill = billing_enabled and estimate.consumed_credits > _zero()
         if should_bill:
             admit_creator_usage(
                 app,
@@ -635,7 +635,7 @@ def build_minimax_clone_cost(
     billing_enabled = is_billing_enabled()
     can_submit = (
         not billing_enabled
-        or estimate.consumed_credits <= _ZERO()
+        or estimate.consumed_credits <= _zero()
         or available >= estimate.consumed_credits
     )
     return {
@@ -793,7 +793,7 @@ def _execute_clone_processing(
                 )
         else:
             row.billing_status = TTS_MINIMAX_CLONE_BILLING_NOT_REQUIRED
-            row.charged_credits = _ZERO()
+            row.charged_credits = _zero()
         row.status = TTS_MINIMAX_CLONE_STATUS_READY
         row.ready_at = now_utc()
         db.session.commit()
@@ -868,13 +868,13 @@ def _mark_clone_failed(
 def _prepare_retry_billing(app: Flask, row: TTSMiniMaxClonedVoice) -> None:
     estimate = estimate_voice_clone_operation_credits(app)
     billing_enabled = is_billing_enabled()
-    should_bill = billing_enabled and estimate.consumed_credits > _ZERO()
+    should_bill = billing_enabled and estimate.consumed_credits > _zero()
     if not should_bill:
         row.billing_status = TTS_MINIMAX_CLONE_BILLING_NOT_REQUIRED
         row.estimated_credits = estimate.consumed_credits
         row.billing_reservation_bid = ""
         row.billing_ledger_bid = ""
-        row.charged_credits = _ZERO()
+        row.charged_credits = _zero()
         return
 
     if (
@@ -909,7 +909,7 @@ def _prepare_retry_billing(app: Flask, row: TTSMiniMaxClonedVoice) -> None:
     )
     row.billing_status = TTS_MINIMAX_CLONE_BILLING_RESERVED
     row.estimated_credits = estimate.consumed_credits
-    row.charged_credits = _ZERO()
+    row.charged_credits = _zero()
     row.billing_reservation_bid = reservation.reservation_bid
     row.billing_ledger_bid = reservation.ledger_bid
 
@@ -1080,7 +1080,7 @@ def _available_wallet_credits(app: Flask, creator_bid: str):
             .first()
         )
         if wallet is None:
-            return _ZERO()
+            return _zero()
         return quantize_credit_amount(wallet.available_credits)
 
 
@@ -1142,5 +1142,5 @@ def _normalize_required(value: str, field_name: str) -> str:
     return normalized
 
 
-def _ZERO() -> Any:
+def _zero() -> Any:
     return quantize_credit_amount(0)

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -1,5 +1,5 @@
 import json
-import random
+import secrets
 import smtplib
 import string
 import time
@@ -200,7 +200,7 @@ def send_sms_code(
 
         characters = string.digits
         # Generate a random string of length 4
-        random_string = "".join(random.choices(characters, k=4))
+        random_string = "".join(secrets.choice(characters) for _ in range(4))
         # 发送短信验证码
         redis.set(
             _redis_prefix(app, "REDIS_KEY_PREFIX_PHONE_CODE") + phone,
@@ -276,7 +276,7 @@ def send_email_code(
         msg["To"] = email
         msg["Subject"] = _("server.user.emailVerificationSubject")
         characters = string.digits
-        random_string = "".join(random.choices(characters, k=4))
+        random_string = "".join(secrets.choice(characters) for _ in range(4))
         # to set redis
         redis.set(
             _redis_prefix(app, "REDIS_KEY_PREFIX_MAIL_CODE") + email,

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -231,7 +231,7 @@ def test_desync_forensics_capture_fingerprints_the_stale_response():
             return 555001
 
     class _FakeConnection:
-        class connection:
+        class connection:  # noqa: N801 - mimics the SQLAlchemy attribute name
             dbapi_connection = _FakeRaw()
 
     described = _describe_desynced_connection(_FakeResult(), _FakeConnection())
@@ -280,7 +280,7 @@ def test_desync_forensics_logs_only_packet_header_not_payload():
                 return 1
 
         class _FakeConnection:
-            class connection:
+            class connection:  # noqa: N801 - mimics the SQLAlchemy attribute name
                 dbapi_connection = None
 
         _FakeConnection.connection.dbapi_connection = _FakeRaw()

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -696,7 +696,7 @@ def test_list_operator_courses_filters_by_course_status():
 def test_list_operator_courses_applies_quick_filters(monkeypatch):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None):  # noqa: ARG003 - matches datetime.now signature
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
@@ -828,7 +828,7 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
 def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None):  # noqa: ARG003 - matches datetime.now signature
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -204,7 +204,8 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
     fake_redis = FakeRedis()
     monkeypatch.setattr(user_utils, "redis", fake_redis, raising=False)
     monkeypatch.setattr(user_utils.smtplib, "SMTP", _FakeSMTP, raising=False)
-    monkeypatch.setattr(user_utils.random, "choices", lambda _chars, k: list("1234"))
+    fixed_digits = iter("1234")
+    monkeypatch.setattr(user_utils.secrets, "choice", lambda _chars: next(fixed_digits))
 
     with app.app_context():
         app.config.update(

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -64,6 +64,12 @@ def test_ilivedata_check_uses_configured_timeout(app, monkeypatch):
     captured = {}
 
     class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            captured["closed"] = True
+
         def read(self):
             return b'{"errorCode":0,"textSpam":{"result":0,"tags":[]}}'
 
@@ -83,3 +89,4 @@ def test_ilivedata_check_uses_configured_timeout(app, monkeypatch):
     assert result.provider == "ilivedata"
     assert captured["host"] == ilivedata_module.endpoint_url
     assert captured["timeout"] == 4
+    assert captured["closed"] is True


### PR DESCRIPTION
# Summary

Clears the last 16 ruff rules that had fewer than ten violations each, and enables them. The interesting part is the two real defects the audit surfaced:

- SMS and email verification codes were drawn from the `random` module, i.e. from the Mersenne Twister the whole process shares. They are now `"".join(secrets.choice(string.digits) for _ in range(4))`, so a code cannot be derived from observing other `random` output.
- The Yidun moderation request nonce moves from `int(random.random() * 100000000)` to `secrets.randbelow(100000000)`.

The remaining `random` uses (retry jitter, Redis TTL jitter) are timing-only and carry `# noqa: S311` with the reason inline.

Mechanical fixes elsewhere:

- `app.py` Windows path: `os.system('tzutil /s "UTC"')` → `subprocess.run(["tzutil", "/s", "UTC"], check=False)` (S605).
- Plugin CLI: `git` is resolved via `shutil.which` and the command aborts with a message when git is absent, instead of relying on PATH lookup inside `subprocess` (S607).
- `init_redis` logs with lazy `%s` arguments instead of `str.format` (G001).
- The two translation-script `isinstance` guards raise `TypeError` (TRY004). `config.py` and the Alipay response parser keep `ValueError` / `RuntimeError` with a documented `# noqa`, because callers and tests catch those exact types.
- Renamed `_ZERO()` → `_zero()` in the MiniMax voice-clone module (N802) and named the author of the password-login TODO (TD002).
- `formatTime`, the `userInfo` DTO argument, the fake `connection` classes in tests, the `tz` argument of the `datetime.now` stubs and the lowercase lazy-import aliases keep their names with a `# noqa` and a reason — each one is dictated by an external API.

Rules enabled: `TRY004`, `N801`, `N802`, `N803`, `N813`, `ARG003`, `TD002`, `G001`, `S104`, `S310`, `S311`, `S603`, `S605`, `S607`. `S603`/`S607` are exempted for `scripts/**`, `src/api/scripts/**` and `src/api/tests/**`, where every invocation is a static `git`/`node`/`python` argument list. `TD003`/`FIX002` stay off: the two remaining TODOs have no tracking issue to link, and inventing one would hide real pending work.

Follow-ups from review: `flask plugin add` raises `click.ClickException` when `git` is missing (non-zero exit instead of a printed notice), and the ilivedata request wraps `urlopen` in a context manager so the socket closes if decoding fails.

## Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`, `python scripts/check_translation_usage.py --fail-on-unused`
- `pytest tests/service/user tests/service/common tests/common tests/service/order tests/service/tts tests/service/shifu/test_admin_courses.py tests/service/learn/test_listen_element_run_persistence.py` — 824 passed. `test_send_email_code_stores_lowercase_identifier` patched `random.choices`; it now patches `secrets.choice` with the same fixed digits.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch authentication verification code generation (security-sensitive) but the switch to `secrets` reduces predictability risk; remaining edits are mostly lint compliance and low-behavior refactors.
> 
> **Overview**
> Expands **ruff** with a batch of low-violation rules (naming, logging **G001**, security **S***, **TRY004**, **TD002**, etc.) and documents intentional ignores for TODO tracking and JSON field naming. Scripts and tests get **S603/S607** exemptions where subprocess calls use static argument lists.
> 
> **Security-relevant behavior changes:** SMS and email verification codes now use **`secrets.choice`** instead of **`random`**, and the Yidun moderation nonce uses **`secrets.randbelow`**. Remaining **`random`** uses (retry/TTL jitter) stay with inline **`# noqa: S311`**.
> 
> Other fixes: Windows timezone setup moves from **`os.system`** to **`subprocess.run`**; plugin **`git clone`** resolves **`git`** via **`shutil.which`**; Redis init logging uses lazy **`%s`** formatting; translation flattening raises **`TypeError`** on bad types; assorted **`# noqa`** for API-shaped names and documented exception contracts; MiniMax helper **`_ZERO()`** renamed to **`_zero()`**; email test mocks **`secrets.choice`** instead of **`random.choices`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bed26ef9fe05373b1880252ea026460d9ccfa64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved randomness for verification codes and security nonces.
  * Added safer handling for system commands and plugin installation when Git is unavailable.

* **Bug Fixes**
  * Invalid translation value types now raise the appropriate `TypeError`.
  * Improved resource cleanup when processing external responses.

* **Maintenance**
  * Updated validation, logging, and linting rules to improve code quality and consistency without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->