### PR TITLE
style: enforce ruff TRY401 (no exception object in exception logs)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -87,6 +87,7 @@ select = [
     "TRY2",    # verbose re-raise / exception handler that only re-raises
     "TRY002",  # raising a vanilla Exception instead of a named class
     "TRY400",  # logging.error inside except that should be logging.exception
+    "TRY401",  # exception object interpolated into a logging.exception message
     "TRY004",  # type check raising something other than TypeError
 
     # --- Pylint subsets ---------------------------------------------------

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -90,7 +90,7 @@ def ilivedata_check(
     try:
         ret = send(query_body, signature, now_date, pid, timeout=timeout_seconds)
     except URLError as err:
-        app.logger.exception("ilivedata request failed: %s", err)
+        app.logger.exception("ilivedata request failed")
         return CheckResultDTO(
             check_result=CHECK_RESULT_UNKNOWN,
             risk_labels=[],

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -151,8 +151,8 @@ def yidun_check(
             provider=PROVIDER,
             raw_data=response_json,
         )
-    except Exception as ex:
-        app.logger.exception("yidun check error: %r", ex)
+    except Exception:
+        app.logger.exception("yidun check error")
         return CheckResultDTO(
             check_result=CHECK_RESULT_UNKNOWN,
             risk_labels=[],

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1383,7 +1383,7 @@ class AliyunTTSProvider(BaseTTSProvider):
                 raise ValueError(f"Aliyun TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
-            logger.exception(f"Aliyun TTS request failed: {e}")
+            logger.exception("Aliyun TTS request failed")
             raise ValueError(f"Aliyun TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -700,7 +700,7 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
         return access_token
 
     except requests.RequestException as e:
-        logger.exception(f"Failed to get Baidu access token: {e}")
+        logger.exception("Failed to get Baidu access token")
         raise ValueError(f"Failed to get Baidu access token: {e}") from e
 
 
@@ -915,7 +915,7 @@ class BaiduTTSProvider(BaseTTSProvider):
                 raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
 
         except requests.RequestException as e:
-            logger.exception(f"Baidu TTS request failed: {e}")
+            logger.exception("Baidu TTS request failed")
             raise ValueError(f"Baidu TTS request failed: {e}") from e
 
     def get_provider_config(self) -> ProviderConfig:

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -356,7 +356,7 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             )
             body = response.json()
         except requests.RequestException as exc:
-            logger.exception("Tencent TextToVoice request failed: %s", exc)
+            logger.exception("Tencent TextToVoice request failed")
             raise ValueError(f"Tencent TextToVoice request failed: {exc}") from exc
         except ValueError as exc:
             raise ValueError(

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -241,7 +241,7 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
             )
         except requests.RequestException as exc:
             logger.exception(
-                "Volcengine HTTP TTS request error: url=%s reqid=%s cluster=%s voice=%s encoding=%s rate=%s text_len=%s err=%s",
+                "Volcengine HTTP TTS request error: url=%s reqid=%s cluster=%s voice=%s encoding=%s rate=%s text_len=%s",
                 VOLCENGINE_HTTP_TTS_URL,
                 req_id,
                 payload["app"]["cluster"],
@@ -249,7 +249,6 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
                 encoding,
                 sample_rate,
                 len(text),
-                exc,
             )
             raise ValueError(f"Volcengine HTTP TTS request failed: {exc}") from exc
 

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -391,8 +391,8 @@ class VolcengineProtocol:
                     if serialization == SerializationMethod.JSON:
                         try:
                             payload = json.loads(payload_data.decode("utf-8"))
-                        except json.JSONDecodeError as e:
-                            logger.exception(f"Failed to parse JSON payload: {e}")
+                        except json.JSONDecodeError:
+                            logger.exception("Failed to parse JSON payload")
                             payload = payload_data
                     else:
                         payload = payload_data

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -582,7 +582,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
                         session_finished.set()
 
             except Exception as e:
-                logger.exception(f"Error processing message: {e}")
+                logger.exception("Error processing message")
                 error_message = str(e)
                 session_started.set()
                 session_finished.set()

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -164,7 +164,7 @@ def enable_commands(app: Flask):
             )
 
         except Exception as e:
-            logger.exception(f"Migration failed: {e}")
+            logger.exception("Migration failed")
             raise click.ClickException(f"Migration failed: {e}") from e
         finally:
             if "migration_task" in locals():
@@ -219,7 +219,7 @@ def enable_commands(app: Flask):
                 click.echo("Consider re-running the migration for failed tables.")
 
         except Exception as e:
-            logger.exception(f"Verification failed: {e}")
+            logger.exception("Verification failed")
             raise click.ClickException(f"Verification failed: {e}") from e
         finally:
             if "migration_task" in locals():
@@ -303,7 +303,7 @@ def enable_commands(app: Flask):
                 click.echo(f"\nCould not read migration log: {e}")
 
         except Exception as e:
-            logger.exception(f"Status check failed: {e}")
+            logger.exception("Status check failed")
             raise click.ClickException(f"Status check failed: {e}") from e
         finally:
             if "migration_task" in locals():

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -277,7 +277,7 @@ class UnifiedMigrationTask:
 
             except Exception as e:
                 logger.exception(
-                    f"Batch processing failed for {source_table} at offset {offset}: {e}"
+                    f"Batch processing failed for {source_table} at offset {offset}"
                 )
                 errors.append(f"Batch error at offset {offset}: {e!s}")
                 error_count += self.config.batch_size
@@ -477,9 +477,9 @@ class UnifiedMigrationTask:
                 "error_messages": error_messages,
             }
 
-        except Exception as e:
+        except Exception:
             session.rollback()
-            logger.exception(f"Batch processing failed: {e}")
+            logger.exception("Batch processing failed")
             raise
         finally:
             session.close()
@@ -526,7 +526,7 @@ class UnifiedMigrationTask:
                 )
 
             except Exception as e:
-                logger.exception(f"Consistency check failed for {source_table}: {e}")
+                logger.exception(f"Consistency check failed for {source_table}")
                 results[source_table] = ConsistencyCheckResult(
                     table_pair=f"{source_table} -> {target_table}",
                     old_count=0,
@@ -594,7 +594,7 @@ class UnifiedMigrationTask:
             return passed, mismatches
 
         except Exception as e:
-            logger.exception(f"Sample integrity check failed: {e}")
+            logger.exception("Sample integrity check failed")
             return False, [f"Integrity check error: {e!s}"]
         finally:
             session.close()
@@ -623,8 +623,8 @@ class UnifiedMigrationTask:
                 )
             return True  # Basic existence check for other tables
 
-        except Exception as e:
-            logger.exception(f"Record mapping verification failed: {e}")
+        except Exception:
+            logger.exception("Record mapping verification failed")
             return False
 
     # Table mapping functions
@@ -717,8 +717,8 @@ class UnifiedMigrationTask:
                 text(f"SHOW TABLES LIKE '{table_name}'")
             ).fetchone()
             return result is not None
-        except Exception as e:
-            logger.exception(f"Error checking table existence {table_name}: {e}")
+        except Exception:
+            logger.exception(f"Error checking table existence {table_name}")
             return False
         finally:
             session.close()
@@ -734,8 +734,8 @@ class UnifiedMigrationTask:
 
             count = session.execute(text(query)).scalar()
             return count or 0
-        except Exception as e:
-            logger.exception(f"Error getting table count for {table_name}: {e}")
+        except Exception:
+            logger.exception(f"Error getting table count for {table_name}")
             return 0
 
     def _check_column_exists_with_session(
@@ -754,9 +754,9 @@ class UnifiedMigrationTask:
                 )
             ).scalar()
             return result > 0
-        except Exception as e:
+        except Exception:
             logger.exception(
-                f"Error checking column existence {table_name}.{column_name}: {e}"
+                f"Error checking column existence {table_name}.{column_name}"
             )
             return False
 
@@ -779,8 +779,8 @@ class UnifiedMigrationTask:
 
             count = session.execute(text(query)).scalar()
             return count or 0
-        except Exception as e:
-            logger.exception(f"Error getting table count for {table_name}: {e}")
+        except Exception:
+            logger.exception(f"Error getting table count for {table_name}")
             return 0
         finally:
             session.close()
@@ -928,8 +928,8 @@ class UnifiedMigrationTask:
                 logger.warning(f"Error checking/adding last_synced_id column: {e}")
 
             session.commit()
-        except Exception as e:
-            logger.exception(f"Error creating sync log table: {e}")
+        except Exception:
+            logger.exception("Error creating sync log table")
 
     def generate_migration_report(
         self,

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2097,8 +2097,8 @@ class Config(FlaskConfig):
         try:
             self.enhanced.validate_environment(allow_conversion_errors=True)
             app.logger.info("Environment configuration validated successfully")
-        except EnvironmentConfigError as e:
-            app.logger.exception(f"Environment configuration error: {e}")
+        except EnvironmentConfigError:
+            app.logger.exception("Environment configuration error")
             raise
         self._populate_redis_prefixes()
 

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -174,8 +174,8 @@ def init_log(app: Flask) -> Flask:
                 else:
                     request_body["Raw"] = request.get_data(as_text=True)
                 app.logger.info(f"Request body: {request_body}")
-            except Exception as e:
-                app.logger.exception(f"Failed to get request body: {e}")
+            except Exception:
+                app.logger.exception("Failed to get request body")
         else:
             app.logger.info(f"Request method: {request.method}")
 
@@ -198,8 +198,8 @@ def init_log(app: Flask) -> Flask:
                 return response
             response_data = response.get_data(as_text=True)
             app.logger.info(f"Response: {response_data}")
-        except Exception as e:
-            app.logger.exception(f"Error logging response: {e!s}")
+        except Exception:
+            app.logger.exception("Error logging response")
         return response
 
     host_name = socket.gethostname()

--- a/src/api/flaskr/dao/uow.py
+++ b/src/api/flaskr/dao/uow.py
@@ -85,8 +85,8 @@ def _run_post_commit(callbacks: list) -> None:
     for callback in callbacks:
         try:
             callback()
-        except Exception as exc:
-            logger.exception("unit_of_work post-commit callback failed: %s", exc)
+        except Exception:
+            logger.exception("unit_of_work post-commit callback failed")
 
 
 @contextmanager

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -40,10 +40,8 @@ class PluginHotReloader:
             self._register_plugin(module)
 
             self.app.logger.info(f"Hot reload plugin success: {plugin_path}")
-        except Exception as e:
-            self.app.logger.exception(
-                f"Hot reload plugin failed: {plugin_path}, error: {e!s}"
-            )
+        except Exception:
+            self.app.logger.exception(f"Hot reload plugin failed: {plugin_path}")
 
     def _unload_plugin(self, plugin_path: str):
         """Unload a plugin and clean up its resources.
@@ -84,8 +82,8 @@ class PluginHotReloader:
 
             self.app.logger.info(f"Plugin unloaded: {module_name}")
 
-        except Exception as e:
-            self.app.logger.exception(f"Failed to unload plugin {plugin_path}: {e!s}")
+        except Exception:
+            self.app.logger.exception(f"Failed to unload plugin {plugin_path}")
 
     def _register_plugin(self, module):
         """Register a newly loaded plugin.
@@ -112,10 +110,8 @@ class PluginHotReloader:
 
             self.app.logger.info(f"Plugin registered: {module.__name__}")
 
-        except Exception as e:
-            self.app.logger.exception(
-                f"Failed to register plugin {module.__name__}: {e!s}"
-            )
+        except Exception:
+            self.app.logger.exception(f"Failed to register plugin {module.__name__}")
 
 
 class PluginFileHandler(FileSystemEventHandler):

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -73,8 +73,8 @@ def load_plugins_from_dir(
                 try:
                     load_from_directory(str(Path(plugins_dir) / file), plugin_manager)
                     app.logger.info(f"load plugin: {file} success")
-                except Exception as e:
-                    app.logger.exception(f"load plugin: {file} error: {e}")
+                except Exception:
+                    app.logger.exception(f"load plugin: {file} error")
             else:
                 app.logger.warning(f"skip non-directory file: {file}")
     return plugins

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -75,9 +75,9 @@ def _load_json_translations(app: Flask, root: Path):
         try:
             metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
             language_codes = metadata.get("locales", {}).keys()
-        except Exception as exc:  # pragma: no cover - defensive log
+        except Exception:  # pragma: no cover - defensive log
             app.logger.exception(
-                "Failed to parse locales metadata at %s: %s", metadata_path, exc
+                "Failed to parse locales metadata at %s", metadata_path
             )
 
     if not language_codes:
@@ -108,10 +108,8 @@ def _load_json_translations(app: Flask, root: Path):
                 namespace = file_path.stem
             try:
                 content = json.loads(file_path.read_text(encoding="utf-8"))
-            except Exception as exc:  # pragma: no cover - IO errors are logged
-                app.logger.exception(
-                    "Failed to load translation file %s: %s", file_path, exc
-                )
+            except Exception:  # pragma: no cover - IO errors are logged
+                app.logger.exception("Failed to load translation file %s", file_path)
                 continue
 
             flat_entries = {}
@@ -259,8 +257,8 @@ def load_translations(app: Flask, translations_dir=None):
     shared_root = _shared_json_root()
     try:
         _validate_json_translations(app, shared_root)
-    except Exception as exc:
-        app.logger.exception("i18n validation failed: %s", exc)
+    except Exception:
+        app.logger.exception("i18n validation failed")
         raise
 
     _load_json_translations(app, shared_root)

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -74,8 +74,8 @@ def register_callback_handler(app: Flask, path_prefix: str):
                 if provider_name == "alipay":
                     return _plain_text_response("success")
                 return jsonify({"code": "SUCCESS", "message": "成功"})
-            except Exception as exc:
-                app.logger.exception("Scoped %s webhook failed: %s", provider_name, exc)
+            except Exception:
+                app.logger.exception("Scoped %s webhook failed", provider_name)
                 if provider_name == "alipay":
                     return _plain_text_response("failure")
                 return jsonify({"code": "FAIL", "message": "processing error"}), 400
@@ -133,8 +133,8 @@ def register_callback_handler(app: Flask, path_prefix: str):
                         "billing_and_order_not_matched",
                     )
                     return _plain_text_response("success")
-        except Exception as exc:
-            app.logger.exception("alipay-notify failed: %s", exc)
+        except Exception:
+            app.logger.exception("alipay-notify failed")
             return _plain_text_response("failure")
         return _plain_text_response("success")
 
@@ -171,8 +171,8 @@ def register_callback_handler(app: Flask, path_prefix: str):
                         "billing_and_order_not_matched",
                     )
                     return jsonify({"code": "SUCCESS", "message": "成功"})
-        except Exception as exc:
-            app.logger.exception("wechatpay-notify failed: %s", exc)
+        except Exception:
+            app.logger.exception("wechatpay-notify failed")
             return jsonify({"code": "FAIL", "message": "processing error"}), 400
         return jsonify({"code": "SUCCESS", "message": "成功"})
 

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -2956,10 +2956,9 @@ def enqueue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
         }
     except Exception as exc:
         app.logger.exception(
-            "Failed to enqueue %s for notification_bid=%s: %s",
+            "Failed to enqueue %s for notification_bid=%s",
             TASK_NAME,
             normalized_notification_bid,
-            exc,
         )
         return {
             "status": "enqueue_failed",

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -266,10 +266,9 @@ def enqueue_subscription_purchase_sms(
         )
     except Exception as exc:
         app.logger.exception(
-            "Failed to enqueue %s for bill_order_bid=%s: %s",
+            "Failed to enqueue %s for bill_order_bid=%s",
             TASK_NAME,
             normalized_bill_order_bid,
-            exc,
         )
         return _build_result(
             "enqueue_failed",
@@ -463,10 +462,9 @@ def enqueue_billing_paid_feishu(
         )
     except Exception as exc:
         app.logger.exception(
-            "Failed to enqueue %s for bill_order_bid=%s: %s",
+            "Failed to enqueue %s for bill_order_bid=%s",
             BILLING_PAID_FEISHU_TASK_NAME,
             normalized_bill_order_bid,
-            exc,
         )
         return _build_feishu_result(
             "enqueue_failed",
@@ -736,9 +734,8 @@ def deliver_billing_paid_feishu(
     except Exception as exc:
         provider_error_message = str(exc)
         app.logger.exception(
-            "Billing paid Feishu provider failed for bill_order_bid=%s: %s",
+            "Billing paid Feishu provider failed for bill_order_bid=%s",
             normalized_bill_order_bid,
-            exc,
         )
 
     with app.app_context():
@@ -881,9 +878,8 @@ def deliver_subscription_purchase_sms(
     except Exception as exc:  # pragma: no cover - guarded by send_sms_ali
         provider_error_message = str(exc)
         app.logger.exception(
-            "Subscription purchase SMS provider failed for bill_order_bid=%s: %s",
+            "Subscription purchase SMS provider failed for bill_order_bid=%s",
             normalized_bill_order_bid,
-            exc,
         )
 
     with app.app_context():

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -146,7 +146,7 @@ def handle_billing_stripe_webhook(
             app=app,
         )
     except Exception as exc:  # pragma: no cover - verified via route tests
-        app.logger.exception("Stripe billing webhook verification failed: %s", exc)
+        app.logger.exception("Stripe billing webhook verification failed")
         return BillingWebhookResult(
             status="error",
             message=str(exc),
@@ -406,7 +406,7 @@ def handle_billing_alipay_webhook(
     try:
         notification = provider.handle_notification(payload=payload, app=app)
     except Exception as exc:  # pragma: no cover - route-level verification path
-        app.logger.exception("Alipay billing webhook verification failed: %s", exc)
+        app.logger.exception("Alipay billing webhook verification failed")
         return BillingWebhookResult(status="error", message=str(exc), status_code=400)
     return apply_billing_native_notification(app, "alipay", notification)
 
@@ -425,7 +425,7 @@ def handle_billing_wechatpay_webhook(
             app=app,
         )
     except Exception as exc:  # pragma: no cover - route-level verification path
-        app.logger.exception("WeChat Pay billing webhook verification failed: %s", exc)
+        app.logger.exception("WeChat Pay billing webhook verification failed")
         return BillingWebhookResult(status="error", message=str(exc), status_code=400)
     return apply_billing_native_notification(app, "wechatpay", notification)
 

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -60,7 +60,7 @@ def _persist_usage_record(app: Flask, record: BillUsageRecord) -> bool:
         except Exception as exc:
             # Never mask the persistence failure with a logging failure.
             with contextlib.suppress(Exception):
-                app.logger.exception("Usage metering persist failed: %s", exc)
+                app.logger.exception("Usage metering persist failed")
             # Clean up INSIDE the pushed context so it targets the session
             # that actually failed - the previous cleanup ran after the
             # context pop and rolled back the CALLER's session instead.
@@ -105,12 +105,11 @@ def _enqueue_usage_settlement(app: Flask, *, usage_bid: str) -> None:
             )
             return
         task.apply_async(kwargs={"usage_bid": normalized_usage_bid})
-    except Exception as exc:
+    except Exception:
         with contextlib.suppress(Exception):
             app.logger.exception(
-                "Usage settlement enqueue failed for usage_bid=%s: %s",
+                "Usage settlement enqueue failed for usage_bid=%s",
                 normalized_usage_bid,
-                exc,
             )
 
 

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -1478,7 +1478,7 @@ def handle_stripe_webhook(
             app=app,
         )
     except Exception as exc:  # pragma: no cover - verified via tests for error path
-        app.logger.exception("Stripe webhook verification failed: %s", exc)
+        app.logger.exception("Stripe webhook verification failed")
         return {
             "status": "error",
             "message": str(exc),
@@ -1906,14 +1906,14 @@ def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
                     pingxx_order.charge_object = json.dumps(body)
                     try:
                         set_user_state(buy_record.user_bid, USER_STATE_PAID)
-                    except Exception as e:
-                        app.logger.exception("update user state error:%s", e)
+                    except Exception:
+                        app.logger.exception("update user state error")
                     buy_record.status = ORDER_STATUS_SUCCESS
                 send_order_feishu(app, buy_record.order_bid)
                 return query_buy_record(app, buy_record.order_bid)
-            except Exception as e:
+            except Exception:
                 app.logger.exception(
-                    f'success buy record from pingxx charge:"{charge_id}" error:{e}'
+                    f'success buy record from pingxx charge:"{charge_id}"'
                 )
             finally:
                 lock.release()
@@ -1938,8 +1938,8 @@ def success_buy_record(app: Flask, record_id: str):
             )
             try:
                 set_user_state(buy_record.user_bid, USER_STATE_PAID)
-            except Exception as e:
-                app.logger.exception("update user state error:%s", e)
+            except Exception:
+                app.logger.exception("update user state error")
             buy_record.status = ORDER_STATUS_SUCCESS
             # Notify only once the SUCCESS flip is durable: nested inside a
             # caller's unit of work this defers to the caller's commit (and

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -187,7 +187,7 @@ class AlipayProvider(PaymentProvider):
                 AlipayTradeQueryRequest,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
-            app.logger.exception("Alipay SDK is not available: %s", exc)
+            app.logger.exception("Alipay SDK is not available")
             raise RuntimeError("alipay-sdk-python is required for Alipay") from exc
 
         return {
@@ -211,7 +211,7 @@ class AlipayProvider(PaymentProvider):
                 verify_with_rsa,
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
-            app.logger.exception("Alipay signature utility is not available: %s", exc)
+            app.logger.exception("Alipay signature utility is not available")
             raise RuntimeError("Alipay signature utility is required") from exc
 
         public_key = _read_required_key("ALIPAY_PUBLIC_KEY_PATH", "ALIPAY_PUBLIC_KEY")

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -62,7 +62,7 @@ class PingxxProvider(PaymentProvider):
         try:
             client = _get_pingpp_client()
         except Exception as exc:  # pragma: no cover
-            app.logger.exception("Pingxx dependency is not available: %s", exc)
+            app.logger.exception("Pingxx dependency is not available")
             raise RuntimeError("Pingxx dependency is not available") from exc
 
         api_key = get_config("PINGXX_SECRET_KEY")

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -281,10 +281,8 @@ class StripeProvider(PaymentProvider):
             event = stripe.Webhook.construct_event(
                 raw_body_str, sig_header, webhook_secret
             )
-        except Exception as exc:  # pragma: no cover - handled in caller
-            app.logger.exception(
-                "Stripe webhook signature verification failed: %s", exc
-            )
+        except Exception:  # pragma: no cover - handled in caller
+            app.logger.exception("Stripe webhook signature verification failed")
             raise
 
         return self._build_notification_from_event(event)

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -240,13 +240,11 @@ def upload_url(app, user_id: str, url: str) -> str:
 
             return result.url
 
-        except requests.RequestException as e:
-            app.logger.exception(
-                f"Failed to download image from URL: {url}, error: {e!s}"
-            )
+        except requests.RequestException:
+            app.logger.exception(f"Failed to download image from URL: {url}")
             raise_error("server.file.fileDownloadFailed")
-        except Exception as e:
-            app.logger.exception(f"Failed to upload image to OSS: {url}, error: {e!s}")
+        except Exception:
+            app.logger.exception(f"Failed to upload image to OSS: {url}")
             raise_error("server.file.fileUploadFailed")
 
 
@@ -376,12 +374,12 @@ def get_video_info(app, user_id: str, url: str) -> dict:
             else:
                 raise_error("server.file.videoUnsupportedVideoSite")
 
-        except requests.RequestException as e:
-            app.logger.exception(f"Failed to fetch video info from {url}: {e!s}")
+        except requests.RequestException:
+            app.logger.exception(f"Failed to fetch video info from {url}")
             raise_error("server.file.videoNetworkError")
-        except KeyError as e:
-            app.logger.exception(f"Missing expected field in API response: {e!s}")
+        except KeyError:
+            app.logger.exception("Missing expected field in API response")
             raise_error("server.file.videoParseError")
-        except Exception as e:
-            app.logger.exception(f"Unexpected error getting video info: {e!s}")
+        except Exception:
+            app.logger.exception("Unexpected error getting video info")
             raise_error("server.file.videoGetInfoError")

--- a/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_import_export_funcs.py
@@ -162,8 +162,8 @@ def import_shifu(
             if isinstance(file_content, bytes):
                 file_content = file_content.decode("utf-8")
             import_data = json.loads(file_content)
-        except Exception as e:
-            app.logger.exception(f"Failed to parse JSON file: {e}")
+        except Exception:
+            app.logger.exception("Failed to parse JSON file")
             raise_error("server.shifu.importFileInvalid")
 
         # Validate import data

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -675,10 +675,9 @@ class StreamingTTSProcessor:
                 segment.is_ready = True
             except Exception as e:
                 logger.exception(
-                    "TTS segment %s failed: %s provider=%s model=%s "
+                    "TTS segment %s failed: provider=%s model=%s "
                     "text_len=%s text_preview=%r",
                     segment.index,
-                    e,
                     tts_provider or "(auto)",
                     tts_model or "(unset)",
                     len(segment.text or ""),
@@ -1450,7 +1449,7 @@ class StreamingTTSProcessor:
                 final_duration_ms,
             )
         except Exception as e:
-            logger.exception(f"Failed to finalize TTS: {e}")
+            logger.exception("Failed to finalize TTS")
             # The swallowed error may be a desync surfaced by the audio
             # record write; classify so an interrupted exchange discards the
             # connection instead of leaving it for the next statement.
@@ -2031,8 +2030,8 @@ class StreamingTTSProcessor:
         for future in self._pending_futures:
             try:
                 future.result(timeout=60)  # Max 60s per segment
-            except Exception as e:
-                logger.exception(f"TTS future failed: {e}")
+            except Exception:
+                logger.exception("TTS future failed")
 
         # Yield any remaining segments
         yield from self._yield_ready_segments()

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -313,8 +313,8 @@ def send_email_code(
             app.logger.info(f"Verification code sent to {email}")
             user_verify_code.verify_code_send = 1
             db.session.commit()
-        except Exception as e:
-            app.logger.exception(f"Failed to send verification code to {email}: {e!s}")
+        except Exception:
+            app.logger.exception(f"Failed to send verification code to {email}")
             raise_error("server.user.emailSendFailed")
         return {"expire_in": app.config["MAIL_CODE_EXPIRE_TIME"]}
 


### PR DESCRIPTION
# Summary

Stacked on #2521. Enables ruff `TRY401` and clears its 64 violations.

`logging.exception(...)` already appends the exception and its traceback, so interpolating the exception into the message printed it twice:

```
Failed to parse JSON file: Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  ...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Every such call drops the exception argument and the `%s` / `{e}` that consumed it, keeping all other context in the message:

```diff
-        app.logger.exception(f"Failed to fetch video info from {url}: {e!s}")
+        app.logger.exception(f"Failed to fetch video info from {url}")
-            "Usage settlement enqueue failed for usage_bid=%s: %s",
-            normalized_usage_bid,
-            exc,
+            "Usage settlement enqueue failed for usage_bid=%s",
+            normalized_usage_bid,
```

Handlers whose bound name existed only for that message become bare `except Exception:` (ruff `F841`); handlers that still use the exception elsewhere — `raise ... from exc`, `str(exc)` in a response payload, `segment.error = str(e)` — keep their binding untouched.

## Verification

- `ruff check .`, `ruff format --check .`, `lefthook run pre-commit` (via the commit hook), `python scripts/check_dev_tools.py`
- `cd src/api && pytest -q` — 2870 passed, 5 failed. The 5 failures are the `test_admin_course_detail.py` credit-usage tests that need MySQL `concat`; they fail identically on `origin/main` in a clean worktree.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d648145fa22ebd4e3f2b47f00fc295875c8a17e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->