### PR TITLE
style: enforce ruff TRY300 (return after the try block, not inside it)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -88,6 +88,7 @@ select = [
     "TRY002",  # raising a vanilla Exception instead of a named class
     "TRY400",  # logging.error inside except that should be logging.exception
     "TRY401",  # exception object interpolated into a logging.exception message
+    "TRY300",  # return at the end of a try body that belongs in `else`
     "TRY004",  # type check raising something other than TypeError
 
     # --- Pylint subsets ---------------------------------------------------

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -555,7 +555,6 @@ def _iter_stream_with_precontent_retry(
                 else:
                     yield res
             yield from pending_reasoning_chunks
-            return
         except Exception as exc:
             attempts += 1
             retryable = _retryable_stream_error_types()
@@ -571,6 +570,8 @@ def _iter_stream_with_precontent_retry(
                 f"(attempt {attempts}/{_STREAM_PRECONTENT_RETRY_ATTEMPTS + 1}); "
                 f"reissuing request: {exc}"
             )
+        else:
+            return
 
 
 def _resolve_provider_for_model(model: str) -> tuple[str | None, str]:
@@ -599,9 +600,10 @@ def _load_gemini_models(
     if base_url and "generativelanguage.googleapis.com" not in base_url:
         try:
             models.extend(_fetch_provider_models(api_key, base_url))
-            return models
         except Exception as exc:
             _log_warning(f"load gemini models via custom base error: {exc}")
+        else:
+            return models
 
     # Default to Google Gemini ListModels endpoint (v1beta).
     google_base = base_url or "https://generativelanguage.googleapis.com"
@@ -1513,10 +1515,11 @@ def _attach_credit_multipliers(
                     "is_default": model == default_model,
                 }
             )
-        return enriched
     except Exception as exc:
         _log_warning(f"load LLM credit multipliers error: {exc}")
         return [{**option, "credit_multiplier": None} for option in options]
+    else:
+        return enriched
 
 
 def get_current_models(app: Flask) -> list[dict[str, Any]]:

--- a/src/api/flaskr/api/sms/aliyun.py
+++ b/src/api/flaskr/api/sms/aliyun.py
@@ -99,9 +99,10 @@ def send_sms_ali(
                 _body_value(res, "biz_id") or "<empty>",
             )
             return None
-        return res
     except Exception as error:
         _log_provider_error(app, error)
+    else:
+        return res
     return None
 
 

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -265,7 +265,6 @@ def get_aliyun_nls_token(
                 "Fetched Aliyun NLS token (expires_in=%ss)",
                 max(0, int(fresh.expire_time - time.time())),
             )
-            return fresh.token
         except Exception as exc:
             # If we still have a cached token that hasn't expired, use it as a fallback.
             if cached and not cached.is_expired(now=now):
@@ -275,6 +274,8 @@ def get_aliyun_nls_token(
                 )
                 return cached.token
             raise
+        else:
+            return fresh.token
     finally:
         if acquired:
             with contextlib.suppress(Exception):

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -697,11 +697,12 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
         _token_cache["expires_at"] = current_time + expires_in
 
         logger.info(f"Baidu access token obtained, expires in {expires_in} seconds")
-        return access_token
 
     except requests.RequestException as e:
         logger.exception("Failed to get Baidu access token")
         raise ValueError(f"Failed to get Baidu access token: {e}") from e
+    else:
+        return access_token
 
 
 # Frontend-formatted voice list

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -471,16 +471,16 @@ class UnifiedMigrationTask:
                     session, f"{source_table}_sync", latest_id
                 )
 
+        except Exception:
+            session.rollback()
+            logger.exception("Batch processing failed")
+            raise
+        else:
             return {
                 "synced": synced_count,
                 "errors": error_count,
                 "error_messages": error_messages,
             }
-
-        except Exception:
-            session.rollback()
-            logger.exception("Batch processing failed")
-            raise
         finally:
             session.close()
 
@@ -591,11 +591,11 @@ class UnifiedMigrationTask:
             )
             passed = success_rate >= 0.95  # 95% success rate required
 
-            return passed, mismatches
-
         except Exception as e:
             logger.exception("Sample integrity check failed")
             return False, [f"Integrity check error: {e!s}"]
+        else:
+            return passed, mismatches
         finally:
             session.close()
 
@@ -621,11 +621,12 @@ class UnifiedMigrationTask:
                     hasattr(target_record, "user_bid")
                     and target_record.user_bid is not None
                 )
-            return True  # Basic existence check for other tables
 
         except Exception:
             logger.exception("Record mapping verification failed")
             return False
+        else:
+            return True  # Basic existence check for other tables
 
     # Table mapping functions
     def _map_attendscript_to_progress_record(self, record) -> dict:
@@ -716,10 +717,11 @@ class UnifiedMigrationTask:
             result = session.execute(
                 text(f"SHOW TABLES LIKE '{table_name}'")
             ).fetchone()
-            return result is not None
         except Exception:
             logger.exception(f"Error checking table existence {table_name}")
             return False
+        else:
+            return result is not None
         finally:
             session.close()
 
@@ -733,10 +735,11 @@ class UnifiedMigrationTask:
                 query += f" WHERE {where_clause}"
 
             count = session.execute(text(query)).scalar()
-            return count or 0
         except Exception:
             logger.exception(f"Error getting table count for {table_name}")
             return 0
+        else:
+            return count or 0
 
     def _check_column_exists_with_session(
         self, session, table_name: str, column_name: str
@@ -753,7 +756,9 @@ class UnifiedMigrationTask:
             """
                 )
             ).scalar()
-            return result > 0
+            # Compared inside the try: scalar() returns None when the
+            # information_schema query matches nothing.
+            return result > 0  # noqa: TRY300
         except Exception:
             logger.exception(
                 f"Error checking column existence {table_name}.{column_name}"
@@ -778,10 +783,11 @@ class UnifiedMigrationTask:
                 query += f" WHERE {where_clause}"
 
             count = session.execute(text(query)).scalar()
-            return count or 0
         except Exception:
             logger.exception(f"Error getting table count for {table_name}")
             return 0
+        else:
+            return count or 0
         finally:
             session.close()
 

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -24,7 +24,9 @@ class AppLoggerProxy:
         try:
             from flask import current_app
 
-            return current_app.logger
+            # Resolved inside the try: attribute access on current_app raises
+            # outside an application context.
+            return current_app.logger  # noqa: TRY300
         except Exception:
             return self._fallback
 

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -122,7 +122,9 @@ def _pool_diagnostics_logger():
     try:
         from flask import current_app
 
-        return current_app.logger
+        # Resolved inside the try: attribute access on current_app raises
+        # outside an application context.
+        return current_app.logger  # noqa: TRY300
     except Exception:  # noqa: BLE001 - outside app context
         return logger
 
@@ -375,12 +377,13 @@ def invalidate_session(*, source: str, session=None) -> bool:
         if not hasattr(target, "invalidate") and callable(target):
             target = target()
         target.invalidate()
-        return True
     except Exception:  # noqa: BLE001 - termination cleanup must not raise
         _pool_diagnostics_logger().warning(
             "%s: session invalidate failed", source, exc_info=True
         )
         return False
+    else:
+        return True
 
 
 def cleanup_session_after(
@@ -403,7 +406,6 @@ def cleanup_session_after(
         return "noop"
     try:
         target.rollback()
-        return "rolled_back"
     except Exception:  # noqa: BLE001 - escalate, never raise from cleanup
         _pool_diagnostics_logger().warning(
             "%s: rollback failed; escalating to session invalidate",
@@ -412,6 +414,8 @@ def cleanup_session_after(
         )
         invalidate_session(source=source, session=session)
         return "invalidated"
+    else:
+        return "rolled_back"
 
 
 def release_session_classified(*, source: str) -> None:
@@ -448,7 +452,6 @@ def _rollback_quietly() -> bool:
         return True
     try:
         db.session.rollback()
-        return True
     except SQLAlchemyError as rollback_exc:
         # A database-layer rollback failure means the connection itself is
         # broken; escalate to invalidate and tell the caller to stop
@@ -463,6 +466,8 @@ def _rollback_quietly() -> bool:
         # Environmental failures (e.g. no app context in unit tests) keep the
         # legacy tolerant behavior: log and let the retry loop proceed.
         logger.warning("retry_on_deadlock rollback failed: %s", rollback_exc)
+        return True
+    else:
         return True
 
 

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -75,9 +75,10 @@ def register_order_handler(app: Flask, path_prefix: str):
                         parsed = parsed.replace(hour=23, minute=59, second=59)
                     else:
                         parsed = parsed.replace(hour=0, minute=0, second=0)
-                return parsed
             except ValueError:
                 continue
+            else:
+                return parsed
         try:
             parsed = datetime.fromisoformat(normalized)
         except ValueError:

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -2011,10 +2011,11 @@ def grant_billing_plan_by_identify(
             )
             payload["sms_enqueue_status"] = str(sms_payload.get("status") or "")
             payload["sms_enqueued"] = bool(sms_payload.get("enqueued"))
-        return payload
     except Exception:
         db.session.rollback()
         raise
+    else:
+        return payload
 
 
 def grant_operator_credits_by_cli(
@@ -2092,10 +2093,11 @@ def grant_operator_credits_by_cli(
                 "mobile": getattr(aggregate, "mobile", ""),
             }
         )
-        return payload
     except Exception:
         db.session.rollback()
         raise
+    else:
+        return payload
 
 
 def _build_cli_credit_grant_request_id(

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -2949,11 +2949,6 @@ def enqueue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
                 "enqueued": False,
             }
         task.apply_async(kwargs={"notification_bid": normalized_notification_bid})
-        return {
-            "status": "enqueued",
-            "notification_bid": normalized_notification_bid,
-            "enqueued": True,
-        }
     except Exception as exc:
         app.logger.exception(
             "Failed to enqueue %s for notification_bid=%s",
@@ -2965,6 +2960,12 @@ def enqueue_credit_notification(app: Flask, *, notification_bid: str) -> dict[st
             "notification_bid": normalized_notification_bid,
             "message": str(exc),
             "enqueued": False,
+        }
+    else:
+        return {
+            "status": "enqueued",
+            "notification_bid": normalized_notification_bid,
+            "enqueued": True,
         }
 
 

--- a/src/api/flaskr/service/billing/domains.py
+++ b/src/api/flaskr/service/billing/domains.py
@@ -660,9 +660,10 @@ def _is_invalid_host(host: str) -> bool:
         return True
     try:
         ipaddress.ip_address(host)
-        return True
     except ValueError:
         pass
+    else:
+        return True
     labels = host.split(".")
     if any(not label or len(label) > 63 for label in labels):
         return True

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -191,8 +191,6 @@ def warm_up_cdn(app: Any, url: str, config: OSSConfig) -> bool:
             if retry_count < max_retries:
                 time.sleep(1)
 
-        return False
-
     except Exception as exc:
         app.logger.warning("CDN preheating failed: %s", exc)
         app.logger.warning("Preheating URL: %s", url)
@@ -200,6 +198,8 @@ def warm_up_cdn(app: Any, url: str, config: OSSConfig) -> bool:
             "ObjectPath: %s",
             object_path if "object_path" in locals() else "Not set",
         )
+        return False
+    else:
         return False
 
 

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -203,10 +203,11 @@ def get_config(key: str, default: str | None = None) -> str:
                             "get_config lock for %s expired before release; ignoring",
                             key,
                         )
-            return default
         except (SQLAlchemyError, RuntimeError) as exc:
             app.logger.warning("Database not ready for get_config(%s): %s", key, exc)
             return get_config_from_common(key, default)
+        else:
+            return default
 
 
 def add_config(

--- a/src/api/flaskr/service/learn/ask_provider_adapters/common.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/common.py
@@ -176,7 +176,6 @@ def raise_for_provider_response(
 ) -> requests.Response:
     try:
         response.raise_for_status()
-        return response
     except requests.HTTPError as exc:
         detail = ""
         try:
@@ -187,3 +186,5 @@ def raise_for_provider_response(
         if detail:
             message += f" | {detail[:300]}"
         raise AskProviderError(message) from exc
+    else:
+        return response

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -614,10 +614,11 @@ def backfill_learn_generated_elements_for_progress(
             db.session.rollback()
         else:
             db.session.commit()
-        return stats
     except Exception:
         db.session.rollback()
         raise
+    else:
+        return stats
 
 
 def backfill_learn_generated_elements_batch(

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -166,7 +166,6 @@ class RunStateResolver:
                 ).get_all_blocks()
             )
             block_count_cache[outline_bid] = block_count
-            return block_count
         except Exception as exc:
             self.app.logger.warning(
                 "Load runtime block count failed for outline %s: %s",
@@ -175,6 +174,8 @@ class RunStateResolver:
                 exc_info=True,
             )
             return history_block_count
+        else:
+            return block_count
 
     # get the outline items to start or complete
     def get_next_outline_item(self) -> list[OutlineItemUpdateDTO]:

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -56,7 +56,6 @@ def _persist_usage_record(app: Flask, record: BillUsageRecord) -> bool:
         try:
             db.session.add(record)
             db.session.commit()
-            return True
         except Exception as exc:
             # Never mask the persistence failure with a logging failure.
             with contextlib.suppress(Exception):
@@ -74,6 +73,8 @@ def _persist_usage_record(app: Flask, record: BillUsageRecord) -> bool:
             # before the context teardown would roll back on it.
             invalidate_session(source="usage metering persist interrupt")
             raise
+        else:
+            return True
 
 
 def _should_enqueue_usage_settlement(

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -214,9 +214,10 @@ def _parse_datetime(value: str, is_end: bool = False) -> datetime | None:
                     parsed = parsed.replace(hour=23, minute=59, second=59)
                 else:
                     parsed = parsed.replace(hour=0, minute=0, second=0)
-            return parsed
         except ValueError:
             continue
+        else:
+            return parsed
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError:

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -46,10 +46,11 @@ def _get_pingpp_client() -> Any:
         import pingpp  # type: ignore[import-untyped]
 
         _PINGPP_CLIENT = pingpp
-        return pingpp
     except Exception as exc:  # pragma: no cover
         _PINGPP_IMPORT_ERROR = exc
         raise
+    else:
+        return pingpp
 
 
 class PingxxProvider(PaymentProvider):

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -268,7 +268,6 @@ def _create_invite_code_with_retry(
         db.session.add(invite_code)
         try:
             db.session.flush()
-            return invite_code
         except IntegrityError:
             db.session.rollback()
             existing = _load_active_invite_code(
@@ -277,6 +276,8 @@ def _create_invite_code_with_retry(
             )
             if existing is not None:
                 return existing
+        else:
+            return invite_code
     raise RuntimeError("unable to generate referral invite code")
 
 

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -154,9 +154,10 @@ def _parse_datetime_filter(
                     parsed = parsed.replace(hour=23, minute=59, second=59)
                 else:
                     parsed = parsed.replace(hour=0, minute=0, second=0)
-            return parsed
         except ValueError:
             continue
+        else:
+            return parsed
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError:

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -238,14 +238,14 @@ def upload_url(app, user_id: str, url: str) -> str:
             db.session.add(resource)
             db.session.commit()
 
-            return result.url
-
         except requests.RequestException:
             app.logger.exception(f"Failed to download image from URL: {url}")
             raise_error("server.file.fileDownloadFailed")
         except Exception:
             app.logger.exception(f"Failed to upload image to OSS: {url}")
             raise_error("server.file.fileUploadFailed")
+        else:
+            return result.url
 
 
 def shifu_permission_verification(
@@ -273,9 +273,10 @@ def shifu_permission_verification(
         if cache_result is not None:
             try:
                 cached_auth_types = json.loads(cache_result)
-                return auth_type in cached_auth_types
             except (json.JSONDecodeError, TypeError):
                 redis.delete(cache_key)
+            else:
+                return auth_type in cached_auth_types
         # If it is not in the cache, query the database
         creator_bid = get_shifu_creator_bid(app, shifu_id)
         if creator_bid and creator_bid == user_id:
@@ -311,9 +312,10 @@ def shifu_permission_verification(
                 permissions = permissions or set(normalized)
                 result = auth_type in permissions
                 redis.set(cache_key, json.dumps(list(permissions)), cache_key_expire)
-                return result
             except (json.JSONDecodeError, TypeError):
                 return False
+            else:
+                return result
         else:
             return False
 

--- a/src/api/tests/common/fixtures/config_data.py
+++ b/src/api/tests/common/fixtures/config_data.py
@@ -7,9 +7,10 @@ def port_validator(value):
     """Validate port number is in valid range."""
     try:
         port = int(value)
-        return 1 <= port <= 65535
     except (ValueError, TypeError):
         return False
+    else:
+        return 1 <= port <= 65535
 
 
 def email_validator(value):

--- a/src/api/tests/common/fixtures/mock_validators.py
+++ b/src/api/tests/common/fixtures/mock_validators.py
@@ -5,9 +5,10 @@ def mock_port_validator(value):
     """Mock port validator that accepts 1-65535."""
     try:
         port = int(value)
-        return 1 <= port <= 65535
     except (ValueError, TypeError):
         return False
+    else:
+        return 1 <= port <= 65535
 
 
 def mock_email_validator(value):
@@ -36,9 +37,10 @@ def range_validator(min_val, max_val):
     def validator(value):
         try:
             num = float(value)
-            return min_val <= num <= max_val
         except (ValueError, TypeError):
             return False
+        else:
+            return min_val <= num <= max_val
 
     return validator
 


### PR DESCRIPTION
# Summary

Stacked on #2522. Enables ruff `TRY300` and clears its 39 violations.

A `return` as the last statement of a `try` body runs *inside* the protected region, so an exception raised while evaluating the returned expression is caught by a handler written for the operation above it. Moving it to `else` keeps the handler scoped to what it was written for:

```diff
     try:
         db.session.flush()
-        return invite_code
     except IntegrityError:
         db.session.rollback()
         ...
+    else:
+        return invite_code
```

Three returns intentionally stay inside the `try` with `# noqa: TRY300` and a comment, because there the handler is the point:

- `AppLoggerProxy._resolve` and `_pool_diagnostics_logger` return `current_app.logger`; the attribute access raises outside an application context and must fall back to the module logger.
- `_check_column_exists_with_session` returns `result > 0` where `scalar()` yields `None` when the information_schema query matches nothing, which the handler turns into `False`.

## Verification

- `ruff check .`, `ruff format --check .`, `lefthook run pre-commit` (commit hook)
- `cd src/api && pytest -q` — 2870 passed, same 5 preexisting `test_admin_course_detail.py` MySQL-`concat` failures that also fail on `origin/main`.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 641487202d43c3b78891b966aace46e943ed0464. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->