### PR TITLE
style: enforce ruff N806 (lowercase local variable names)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -33,8 +33,7 @@
 #   callbacks, fixtures and test doubles.
 # - TD003 / FIX002: the remaining TODOs have no tracking issue to link, and
 #   inventing one (or downgrading the comment) would hide real pending work.
-# - N806 / N815: local CamelCase bindings and camelCase DTO attributes are
-#   still widespread; N815 in particular encodes serialized JSON field names.
+# - N815: camelCase DTO attributes encode serialized JSON field names.
 
 # Matches the Python pinned by src/api/Dockerfile and the CI workflows.
 target-version = "py311"
@@ -114,8 +113,9 @@ select = [
     "ARG004",  # unused staticmethod argument
     "A001",    # local variable shadowing a builtin
     "A006",    # lambda argument shadowing a builtin
-    # pep8-naming is partial: N806/N815 stay off (see the header above).
+    # pep8-naming is partial: N815 stays off (see the header above).
     "N801",    # class name that is not CapWords
+    "N806",    # local variable that is not lowercase
     "N802",    # function name that is not lowercase
     "N803",    # argument name that is not lowercase
     "N813",    # CamelCase imported under a lowercase alias
@@ -210,6 +210,12 @@ ignore = [
 # out to `git`, `node` and `python` with statically built argument lists, so the
 # subprocess audit rules only add noise there.
 "src/api/tests/**" = ["S101", "S603", "S607"]
+# These suites bind SQLAlchemy model classes and session factories to local
+# names, where the CapWords spelling is the point.
+"src/api/tests/service/shifu/test_archive.py" = ["N806"]
+"src/api/tests/service/shifu/test_mdflow_history_routes.py" = ["N806"]
+"src/api/tests/service/shifu/test_permissions.py" = ["N806"]
+"src/api/tests/service/billing/test_renewal_uow_failure_paths.py" = ["N806"]
 "src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -25,10 +25,10 @@ class Dict:
 def register_dict(name, desp, items: dict):
     if name in DICTS:
         return
-    dictItems = []
+    dict_items = []
     for key, value in items.items():
-        dictItems.append(DictItem(key, value))
-    DICTS[name] = Dict(name, desp, dictItems)
+        dict_items.append(DictItem(key, value))
+    DICTS[name] = Dict(name, desp, dict_items)
 
 
 def get_all_dicts(app: Flask) -> dict:

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -191,7 +191,7 @@ def send_order_feishu(app: Flask, record_id: str):
     if not shifu_info:
         return
 
-    _CHANNEL_LABEL = {
+    channel_labels = {
         "pingxx": "用户购买 (Pingxx)",
         "stripe": "用户购买 (Stripe)",
         "alipay": "用户购买 (支付宝)",
@@ -206,7 +206,7 @@ def send_order_feishu(app: Flask, record_id: str):
     msgs.append(f"课程名称：{shifu_info.title}")
     msgs.append(f"实付金额：{order_info.price}")
     channel = getattr(order_info, "payment_channel", "") or ""
-    source_label = _CHANNEL_LABEL.get(channel, channel or "未知")
+    source_label = channel_labels.get(channel, channel or "未知")
     msgs.append(f"订单来源：{source_label}")
     user_convertion = UserConversion.query.filter(
         UserConversion.user_id == order_info.user_id

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -208,7 +208,7 @@ def get_profile_labels():
 def save_user_profiles(
     app: Flask, user_id: str, course_id: str, profiles: list[ProfileToSave]
 ) -> bool:
-    PROFILES_LABLES = get_profile_labels()
+    profile_labels = get_profile_labels()
     app.logger.info("save user profiles:%s", profiles)
     aggregate = _ensure_user_aggregate(user_id)
     profiles_items = get_profile_item_definition_list(app, course_id)
@@ -238,7 +238,7 @@ def save_user_profiles(
         variable_bid = (profile.bid or "").strip() or (
             profile_item.profile_id if profile_item else ""
         )
-        target_shifu = "" if profile.key in PROFILES_LABLES else (course_id or "")
+        target_shifu = "" if profile.key in profile_labels else (course_id or "")
 
         latest_value = _get_latest_variable_value(
             user_values,
@@ -258,8 +258,8 @@ def save_user_profiles(
             db.session.add(user_value)
             user_values.insert(0, user_value)
 
-        if profile.key in PROFILES_LABLES:
-            profile_lable = PROFILES_LABLES[profile.key]
+        if profile.key in profile_labels:
+            profile_lable = profile_labels[profile.key]
             if profile_lable.get("mapping"):
                 if profile_lable.get("items_mapping"):
                     profile.value = profile_lable["items_mapping"].get(
@@ -286,7 +286,7 @@ def get_user_profiles(app: Flask, user_id: str, course_id: str) -> dict:
     from what the user sees in the personal settings page.
 
     """
-    PROFILES_LABLES = get_profile_labels()
+    profile_labels = get_profile_labels()
     profiles_items = get_profile_item_definition_list(app, course_id)
 
     candidate_shifus = [course_id or ""]
@@ -313,7 +313,7 @@ def get_user_profiles(app: Flask, user_id: str, course_id: str) -> dict:
     for profile_item in profiles_items:
         # Follow save_user_profiles routing: label keys are global, others per-course.
         target_shifu = (
-            "" if profile_item.profile_key in PROFILES_LABLES else (course_id or "")
+            "" if profile_item.profile_key in profile_labels else (course_id or "")
         )
 
         user_value = (
@@ -331,7 +331,7 @@ def get_user_profiles(app: Flask, user_id: str, course_id: str) -> dict:
     # Keep runtime variable resolution aligned with /api/user/get_profile:
     # mapped system fields should use the latest canonical user entity values.
     if aggregate:
-        for key, profile_label in PROFILES_LABLES.items():
+        for key, profile_label in profile_labels.items():
             mapping = profile_label.get("mapping")
             if not mapping:
                 continue
@@ -390,13 +390,13 @@ def get_user_profile_labels(
         app.logger.warning("Failed to load var_variable_values: %s", exc)
         user_values = []
     profiles_items = get_profile_item_definition_list(app, course_id)
-    PROFILES_LABLES = get_profile_labels()
+    profile_labels = get_profile_labels()
     aggregate = load_user_aggregate(user_id)
     language_value = aggregate.user_language if aggregate else "en-US"
     result = UserProfileLabelDTO(profiles=[], language=language_value)
     mapping_keys = []
     if aggregate:
-        for key, meta in PROFILES_LABLES.items():
+        for key, meta in profile_labels.items():
             mapping = meta.get("mapping")
             if not mapping:
                 continue
@@ -428,19 +428,19 @@ def get_user_profile_labels(
                     items=meta.get("items"),
                 )
             )
-    for key in PROFILES_LABLES:
+    for key in profile_labels:
         if key in mapping_keys:
             continue
         profile_key = key
         item = {
             "key": profile_key,
-            "label": PROFILES_LABLES[profile_key]["label"],
-            "type": PROFILES_LABLES[profile_key].get(
+            "label": profile_labels[profile_key]["label"],
+            "type": profile_labels[profile_key].get(
                 "type",
-                ("select" if "items" in PROFILES_LABLES[profile_key] else "text"),
+                ("select" if "items" in profile_labels[profile_key] else "text"),
             ),
             "value": "",
-            "items": PROFILES_LABLES[profile_key].get("items"),
+            "items": profile_labels[profile_key].get("items"),
         }
         user_value = None
         profile_item = next(
@@ -488,7 +488,7 @@ def update_user_profile_with_lable(
     course_id: str | None = None,
 ):
     app.logger.info(f"update user profile with lable:{course_id}")
-    PROFILES_LABLES = get_profile_labels()
+    profile_labels = get_profile_labels()
     if isinstance(profiles, UserProfileLabelDTO):
         profiles = profiles.profiles or []
     elif isinstance(profiles, UserProfileLabelItemDTO):
@@ -548,7 +548,7 @@ def update_user_profile_with_lable(
 
         app.logger.info("update user profile:%s-%s", key, profile_value)
 
-        profile_lable = PROFILES_LABLES.get(key, None)
+        profile_lable = profile_labels.get(key, None)
         default_value = profile_lable.get("default", None) if profile_lable else None
 
         if profile_lable and profile_lable.get("items_mapping"):
@@ -576,10 +576,10 @@ def update_user_profile_with_lable(
         elif not profile_lable:
             app.logger.info("profile_lable not found:%s", key)
 
-        # System variables (in PROFILES_LABLES) are global; custom variables
+        # System variables (in profile_labels) are global; custom variables
         # are scoped to the course.  This must match save_user_profiles() so
         # that the run interface reads the same value the settings page wrote.
-        target_shifu = "" if key in PROFILES_LABLES else (course_id or "")
+        target_shifu = "" if key in profile_labels else (course_id or "")
 
         should_persist_value = (
             profile_value not in (None, "") and profile_value != default_value

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -110,7 +110,7 @@ def upload_file(app, user_id: str, resource_id: str, file) -> str:
 
     """
     with app.app_context():
-        isUpdate = False
+        is_update = False
         if resource_id == "":
             file_id = str(uuid.uuid4()).replace("-", "")
             resource = None
@@ -118,7 +118,7 @@ def upload_file(app, user_id: str, resource_id: str, file) -> str:
             file_id = resource_id
             resource = Resource.query.filter_by(resource_id=file_id).first()
             if resource is not None:
-                isUpdate = True
+                is_update = True
             else:
                 app.logger.warning(
                     "upload_file received missing resource_id=%s; creating a new resource",
@@ -134,7 +134,7 @@ def upload_file(app, user_id: str, resource_id: str, file) -> str:
             profile=OSS_PROFILE_COURSES,
         )
 
-        if isUpdate:
+        if is_update:
             resource.name = file.filename
             resource.oss_bucket = result.bucket
             resource.oss_name = result.object_key

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -241,12 +241,13 @@ def init_first_course(app: Flask, user_id: str) -> bool:
         creator_granted_now = not bool(verified_users[0].is_creator)
         mark_user_roles(user_id, is_creator=True, is_operator=True)
 
-        ShifuModel: PublishedShifu | DraftShifu = PublishedShifu
+        # Holds a model class, so it keeps the CapWords spelling.
+        ShifuModel: PublishedShifu | DraftShifu = PublishedShifu  # noqa: N806
         # Assign demo shifu only when there is exactly one published course
         course_count = PublishedShifu.query.filter(PublishedShifu.deleted == 0).count()
         if course_count == 0:
             course_count = DraftShifu.query.filter(DraftShifu.deleted == 0).count()
-            ShifuModel = DraftShifu
+            ShifuModel = DraftShifu  # noqa: N806
         if course_count != 1:
             db.session.flush()
             return creator_granted_now

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -282,7 +282,7 @@ def _ensure_user_entity(user_bid: str) -> UserEntity:
             VariableValue,  # type: ignore[import-not-found]
         )
     except ImportError:  # pragma: no cover - defensive fallback
-        VariableValue = None  # type: ignore[assignment]
+        VariableValue = None  # type: ignore[assignment]  # noqa: N806 - keeps the imported class name
 
     rows = []
     if VariableValue is not None:


### PR DESCRIPTION
# Summary

Next rule in the lightweight ruff series (after #2521 / #2522 / #2523): 32 `N806` violations, then the rule is enabled.

Renamed the function-local names that were not snake_case:

- `dictItems` → `dict_items` (`service/common/dicts.py`)
- `isUpdate` → `is_update` (`service/shifu/funcs.py`)
- `_CHANNEL_LABEL` → `channel_labels` (`service/order/funs.py`, a local dict literal, not a module constant)
- `PROFILES_LABLES` → `profile_labels` (4 functions in `service/profile/funcs.py`)

All renames are local to a single function body, so no call site or public contract changes.

Kept CapWords where the local binds a class object, since lowercasing would make `shifu_model.query` read like an instance:

- `ShifuModel` in `service/user/phone_flow.py` and the `VariableValue = None` import fallback in `service/user/repository.py` carry a `# noqa: N806` with the reason.
- Four test modules unpack SQLAlchemy model classes / a `sessionmaker` into locals (`DraftShifu, AiCourseAuth = _get_models()`, `Session = sessionmaker(...)`); they get a per-file ignore instead of ~20 inline noqa comments.

`ruff.toml`: `N806` moved from the "intentionally off" header note into `select`.

## Verification

- `ruff check .` and `ruff format --check .` pass
- `python scripts/check_dev_tools.py`
- `cd src/api && pytest -q tests/service/profile tests/service/user tests/service/order tests/service/shifu tests/service/billing` → 1313 passed, 9 skipped, 5 failed; the 5 are the known preexisting `test_admin_course_detail.py` failures (SQLite lacks `concat`), reproducible on clean `main`.

Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic naming and lint config only; renames are local and exceptions are documented for intentional class aliases.
> 
> **Overview**
> Turns on **ruff N806** (lowercase local names) and clears the remaining violations with **function-scoped renames only**—no API or behavior changes.
> 
> **`ruff.toml`** adds `N806` to `select`, narrows the header note so only **N815** stays intentionally off, and adds **per-file `N806` ignores** for four test modules that bind SQLAlchemy model classes / session factories with CapWords locals.
> 
> **Production code** renames locals: `dict_items`, `is_update`, `channel_labels`, and `profile_labels` (replacing `PROFILES_LABLES`) across dict registration, file upload, order Feishu notify, and profile helpers. **CapWords locals that hold model classes** (`ShifuModel`, import-fallback `VariableValue`) keep their spelling with documented `# noqa: N806`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5e827f1fbdc75aac62b136d6a781a9995c22e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Code Quality**
  * Standardized internal variable naming to improve consistency and readability.
  * Updated linting rules and targeted exceptions for intentional naming patterns.
* **Bug Fixes**
  * Corrected a misspelled profile-label variable without changing application behavior.
* **Maintenance**
  * Preserved existing order, profile, resource, course, and user workflows while aligning code with naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->