### PR TITLE
fix: build the study record migration query without string interpolation

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -137,6 +137,11 @@ select = [
     "S603",    # subprocess call with unvalidated input
     "S605",    # process started with a shell
     "S607",    # process started with a partial executable path
+    # S608 flags every SQL string built by interpolation. Values always use
+    # bound parameters; the remaining sites interpolate table or column names,
+    # which bound parameters cannot carry, and justify it inline. Applied
+    # Alembic revisions must not be edited, so they are exempt below.
+    "S608",    # SQL query built by string interpolation
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands
@@ -220,5 +225,8 @@ ignore = [
 "src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]
+# Applied Alembic revisions are immutable history: their backfill statements
+# interpolate table names and cannot be rewritten after deployment.
+"src/api/migrations/versions/**" = ["S608"]
 "scripts/**" = ["S603", "S607"]
 "src/api/scripts/**" = ["S603", "S607"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -225,8 +225,14 @@ ignore = [
 "src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]
-# Applied Alembic revisions are immutable history: their backfill statements
-# interpolate table names and cannot be rewritten after deployment.
-"src/api/migrations/versions/**" = ["S608"]
+# These applied Alembic revisions are immutable history: their backfill
+# statements interpolate table names and cannot be rewritten after deployment.
+# Listed one by one so new revisions stay covered by S608.
+"src/api/migrations/versions/4a1f6c8e9b2d_add_learn_generated_elements.py" = ["S608"]
+"src/api/migrations/versions/56b765541144_add_shifu_user_archives.py" = ["S608"]
+"src/api/migrations/versions/6b603528dac8_add_system_profile.py" = ["S608"]
+"src/api/migrations/versions/6b956399315e_backfill_profile_variable_tables.py" = ["S608"]
+"src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py" = ["S608"]
+"src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py" = ["S608"]
 "scripts/**" = ["S603", "S607"]
 "src/api/scripts/**" = ["S603", "S607"]

--- a/scripts/migrate_oss_domain.py
+++ b/scripts/migrate_oss_domain.py
@@ -137,7 +137,8 @@ def migrate(
             count: int = (
                 conn.execute(
                     sa.text(
-                        f"SELECT COUNT(*) FROM `{table}` WHERE `{column}` LIKE :pat"
+                        # Identifiers come from the whitelisted TARGETS constant
+                        f"SELECT COUNT(*) FROM `{table}` WHERE `{column}` LIKE :pat"  # noqa: S608
                     ),
                     {"pat": pat},
                 ).scalar()
@@ -163,7 +164,8 @@ def migrate(
                 while True:
                     result = conn.execute(
                         sa.text(
-                            f"UPDATE `{table}` SET `{column}` = "
+                            # Identifiers come from the whitelisted TARGETS constant
+                            f"UPDATE `{table}` SET `{column}` = "  # noqa: S608
                             f"REPLACE(`{column}`, :old, :new) "
                             f"WHERE `{column}` LIKE :pat "
                             f"LIMIT :lim"

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -753,12 +753,13 @@ class UnifiedMigrationTask:
         self, session, table_name: str, where_clause: str = ""
     ) -> int:
         """Get table record count using provided session."""
-        try:
-            # Identifier validated by _quote_identifier
-            query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
-            if where_clause:
-                query += f" WHERE {where_clause}"
+        # Validated outside the try so an unsafe identifier is not reported as
+        # an empty table.
+        query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
+        if where_clause:
+            query += f" WHERE {where_clause}"
 
+        try:
             count = session.execute(text(query)).scalar()
         except Exception:
             logger.exception(f"Error getting table count for {table_name}")
@@ -802,13 +803,14 @@ class UnifiedMigrationTask:
 
     def _get_table_count(self, table_name: str, where_clause: str = "") -> int:
         """Get table record count."""
+        # Validated before the session is opened so an unsafe identifier is not
+        # reported as an empty table.
+        query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
+        if where_clause:
+            query += f" WHERE {where_clause}"
+
         session = self.SessionClass()
         try:
-            # Identifier validated by _quote_identifier
-            query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
-            if where_clause:
-                query += f" WHERE {where_clause}"
-
             count = session.execute(text(query)).scalar()
         except Exception:
             logger.exception(f"Error getting table count for {table_name}")

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import os
+import re
 import sys
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -26,6 +27,21 @@ logging.basicConfig(
     ],
 )
 logger = logging.getLogger(__name__)
+
+
+_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _quote_identifier(name: str) -> str:
+    """Validate a table or column name and quote it for MySQL.
+
+    The migration statements below interpolate identifiers because bound
+    parameters cannot carry them. Every identifier passes through here so an
+    unexpected value fails loudly instead of reaching the database.
+    """
+    if not _IDENTIFIER_PATTERN.fullmatch(name or ""):
+        raise ValueError(f"Unsafe SQL identifier: {name!r}")
+    return f"`{name}`"
 
 
 class MigrationBatchError(RuntimeError):
@@ -362,11 +378,11 @@ class UnifiedMigrationTask:
                 # Incremental migration - get records with ID greater than last synced ID
                 query = text(
                     f"""
-                    SELECT * FROM {source_table}
+                    SELECT * FROM {_quote_identifier(source_table)}
                     WHERE id > :last_synced_id
                     ORDER BY id ASC
                     LIMIT :batch_size
-                """
+                """  # noqa: S608 - identifier validated by _quote_identifier
                 )
                 params = {
                     "last_synced_id": last_synced_id,
@@ -379,10 +395,10 @@ class UnifiedMigrationTask:
                 # Full migration - use OFFSET-based pagination
                 query = text(
                     f"""
-                    SELECT * FROM {source_table}
+                    SELECT * FROM {_quote_identifier(source_table)}
                     ORDER BY id ASC
                     LIMIT :batch_size OFFSET :offset
-                """
+                """  # noqa: S608 - identifier validated by _quote_identifier
                 )
                 params = {"batch_size": self.config.batch_size, "offset": offset}
                 logger.info(
@@ -400,9 +416,10 @@ class UnifiedMigrationTask:
                     # Check if record already exists in target table
                     existing_query = text(
                         f"""
-                        SELECT COUNT(*) FROM {target_table}
-                        WHERE {target_key} = :key_value AND deleted = 0
-                    """
+                        SELECT COUNT(*) FROM {_quote_identifier(target_table)}
+                        WHERE {_quote_identifier(target_key)} = :key_value
+                        AND deleted = 0
+                    """  # noqa: S608 - identifiers validated by _quote_identifier
                     )
 
                     existing_count = session.execute(
@@ -419,28 +436,34 @@ class UnifiedMigrationTask:
 
                         for field, value in mapped_data.items():
                             if field != target_key:  # Don't update the key field
-                                update_fields.append(f"{field} = :{field}")
+                                update_fields.append(
+                                    f"{_quote_identifier(field)} = :{field}"
+                                )
                                 update_params[field] = value
 
                         if update_fields:
                             update_query = text(
                                 f"""
-                                UPDATE {target_table}
+                                UPDATE {_quote_identifier(target_table)}
                                 SET {", ".join(update_fields)}
-                                WHERE {target_key} = :key_value
-                            """
+                                WHERE {_quote_identifier(target_key)} = :key_value
+                            """  # noqa: S608 - identifiers validated by _quote_identifier
                             )
                             session.execute(update_query, update_params)
                     else:
                         # Insert new record
                         field_names = list(mapped_data.keys())
+                        quoted_field_names = [
+                            _quote_identifier(field) for field in field_names
+                        ]
                         field_placeholders = [f":{field}" for field in field_names]
 
                         insert_query = text(
                             f"""
-                            INSERT INTO {target_table} ({", ".join(field_names)})
+                            INSERT INTO {_quote_identifier(target_table)}
+                            ({", ".join(quoted_field_names)})
                             VALUES ({", ".join(field_placeholders)})
-                        """
+                        """  # noqa: S608 - identifiers validated by _quote_identifier
                         )
                         session.execute(insert_query, mapped_data)
 
@@ -546,10 +569,10 @@ class UnifiedMigrationTask:
             # Get random sample from source table
             sample_query = text(
                 f"""
-                SELECT * FROM {source_table}
+                SELECT * FROM {_quote_identifier(source_table)}
                 ORDER BY RAND()
                 LIMIT :sample_size
-            """
+            """  # noqa: S608 - identifier validated by _quote_identifier
             )
 
             samples = session.execute(
@@ -564,10 +587,11 @@ class UnifiedMigrationTask:
                 # Find corresponding record in target table
                 target_query = text(
                     f"""
-                    SELECT * FROM {target_table}
-                    WHERE {target_key} = :key_value AND deleted = 0
+                    SELECT * FROM {_quote_identifier(target_table)}
+                    WHERE {_quote_identifier(target_key)} = :key_value
+                    AND deleted = 0
                     LIMIT 1
-                """
+                """  # noqa: S608 - identifiers validated by _quote_identifier
                 )
 
                 target_record = session.execute(
@@ -715,7 +739,7 @@ class UnifiedMigrationTask:
         session = self.SessionClass()
         try:
             result = session.execute(
-                text(f"SHOW TABLES LIKE '{table_name}'")
+                text("SHOW TABLES LIKE :table_name"), {"table_name": table_name}
             ).fetchone()
         except Exception:
             logger.exception(f"Error checking table existence {table_name}")
@@ -730,7 +754,8 @@ class UnifiedMigrationTask:
     ) -> int:
         """Get table record count using provided session."""
         try:
-            query = f"SELECT COUNT(*) FROM {table_name}"
+            # Identifier validated by _quote_identifier
+            query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
             if where_clause:
                 query += f" WHERE {where_clause}"
 
@@ -748,13 +773,14 @@ class UnifiedMigrationTask:
         try:
             result = session.execute(
                 text(
-                    f"""
+                    """
                 SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
                 WHERE TABLE_SCHEMA = DATABASE()
-                AND TABLE_NAME = '{table_name}'
-                AND COLUMN_NAME = '{column_name}'
+                AND TABLE_NAME = :table_name
+                AND COLUMN_NAME = :column_name
             """
-                )
+                ),
+                {"table_name": table_name, "column_name": column_name},
             ).scalar()
             # Compared inside the try: scalar() returns None when the
             # information_schema query matches nothing.
@@ -778,7 +804,8 @@ class UnifiedMigrationTask:
         """Get table record count."""
         session = self.SessionClass()
         try:
-            query = f"SELECT COUNT(*) FROM {table_name}"
+            # Identifier validated by _quote_identifier
+            query = f"SELECT COUNT(*) FROM {_quote_identifier(table_name)}"  # noqa: S608
             if where_clause:
                 query += f" WHERE {where_clause}"
 

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -185,7 +185,8 @@ def migrate_user_study_record(
         LearnProgressRecord.id.in_(record_ids)
     ).update({LearnProgressRecord.user_bid: to_user_id}, synchronize_session=False)
     db.session.query(LearnGeneratedBlock).filter(
-        LearnGeneratedBlock.progress_record_bid.in_(progress_record_bids)
+        LearnGeneratedBlock.user_bid == from_user_id,
+        LearnGeneratedBlock.progress_record_bid.in_(progress_record_bids),
     ).update({LearnGeneratedBlock.user_bid: to_user_id}, synchronize_session=False)
     db.session.flush()
     app.logger.info(

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -132,7 +132,7 @@ def _consume_latest_sms_code_from_db(app: Flask, phone: str, code: str) -> str:
 def migrate_user_study_record(
     app: Flask, from_user_id: str, to_user_id: str, course_id: str | None = None
 ) -> None:
-    from flaskr.service.learn.models import LearnProgressRecord
+    from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 
     normalized_course_id = str(course_id or "").strip()
     if not normalized_course_id:
@@ -179,24 +179,14 @@ def migrate_user_study_record(
         )
         return
 
-    db.session.execute(
-        text(
-            "update learn_progress_records set user_bid = '{}' where id in ({})".format(
-                to_user_id, ",".join(str(attend.id) for attend in migrate_attends)
-            )
-        )
-    )
-    db.session.execute(
-        text(
-            "update learn_generated_blocks set user_bid = '{}' where progress_record_bid in ({})".format(
-                to_user_id,
-                ",".join(
-                    "'" + str(attend.progress_record_bid) + "'"
-                    for attend in migrate_attends
-                ),
-            )
-        )
-    )
+    record_ids = [attend.id for attend in migrate_attends]
+    progress_record_bids = [attend.progress_record_bid for attend in migrate_attends]
+    db.session.query(LearnProgressRecord).filter(
+        LearnProgressRecord.id.in_(record_ids)
+    ).update({LearnProgressRecord.user_bid: to_user_id}, synchronize_session=False)
+    db.session.query(LearnGeneratedBlock).filter(
+        LearnGeneratedBlock.progress_record_bid.in_(progress_record_bids)
+    ).update({LearnGeneratedBlock.user_bid: to_user_id}, synchronize_session=False)
     db.session.flush()
     app.logger.info(
         "migrate_user_study_record done: migrated_records=%s course_id=%s",

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -1,5 +1,40 @@
 import pytest
-from flaskr.command.unified_migration_task import _quote_identifier
+from flaskr.command.unified_migration_task import (
+    UnifiedMigrationTask,
+    _quote_identifier,
+)
+
+
+class _FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+    def fetchone(self):
+        return self._value
+
+
+class _FakeSession:
+    """Session double that records the statements a migration step issues."""
+
+    def __init__(self, value=1):
+        self._value = value
+        self.calls = []
+
+    def execute(self, statement, params=None):
+        self.calls.append((str(statement), params))
+        return _FakeResult(self._value)
+
+    def close(self):
+        pass
+
+
+def _task_with_session(session):
+    task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
+    task.SessionClass = lambda: session
+    return task
 
 
 @pytest.mark.parametrize("name", ["learn_progress_records", "_bid", "Col1"])
@@ -13,3 +48,61 @@ def test_quote_identifier_quotes_valid_names(name):
 def test_quote_identifier_rejects_unsafe_names(name):
     with pytest.raises(ValueError, match="Unsafe SQL identifier"):
         _quote_identifier(name)
+
+
+def test_get_table_count_quotes_the_table_name():
+    session = _FakeSession(value=7)
+    task = _task_with_session(session)
+
+    assert (
+        task._get_table_count("learn_progress_records", where_clause="deleted = 0") == 7
+    )
+
+    statement, _ = session.calls[0]
+    assert "FROM `learn_progress_records`" in statement
+    assert statement.endswith("WHERE deleted = 0")
+
+
+@pytest.mark.parametrize(
+    "table_name", ["learn_progress_records; drop table users", "learn progress"]
+)
+def test_get_table_count_rejects_unsafe_table_names(table_name):
+    session = _FakeSession()
+    task = _task_with_session(session)
+
+    with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+        task._get_table_count(table_name)
+    with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+        task._get_table_count_with_session(session, table_name)
+    assert session.calls == []
+
+
+def test_table_exists_binds_the_table_name():
+    session = _FakeSession(value=("learn_progress_records",))
+    task = _task_with_session(session)
+
+    assert task._table_exists("learn_progress_records") is True
+
+    statement, params = session.calls[0]
+    assert statement == "SHOW TABLES LIKE :table_name"
+    assert params == {"table_name": "learn_progress_records"}
+
+
+def test_check_column_exists_binds_table_and_column():
+    session = _FakeSession(value=1)
+    task = _task_with_session(session)
+
+    assert (
+        task._check_column_exists_with_session(
+            session, "learn_progress_records", "user_bid"
+        )
+        is True
+    )
+
+    statement, params = session.calls[0]
+    assert "INFORMATION_SCHEMA.COLUMNS" in statement
+    assert "learn_progress_records" not in statement
+    assert params == {
+        "table_name": "learn_progress_records",
+        "column_name": "user_bid",
+    }

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -1,0 +1,15 @@
+import pytest
+from flaskr.command.unified_migration_task import _quote_identifier
+
+
+@pytest.mark.parametrize("name", ["learn_progress_records", "_bid", "Col1"])
+def test_quote_identifier_quotes_valid_names(name):
+    assert _quote_identifier(name) == f"`{name}`"
+
+
+@pytest.mark.parametrize(
+    "name", ["", "1table", "users; drop table users", "user`s", "learn progress"]
+)
+def test_quote_identifier_rejects_unsafe_names(name):
+    with pytest.raises(ValueError, match="Unsafe SQL identifier"):
+        _quote_identifier(name)

--- a/src/api/tests/service/user/test_migrate_user_study_record.py
+++ b/src/api/tests/service/user/test_migrate_user_study_record.py
@@ -1,0 +1,101 @@
+from flaskr.dao import db
+from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
+from flaskr.service.order.consts import LEARN_STATUS_IN_PROGRESS
+from flaskr.service.shifu.consts import BLOCK_TYPE_CONTENT_VALUE
+from flaskr.service.user.phone_flow import migrate_user_study_record
+
+
+def _add_progress_with_block(shifu_bid: str, user_bid: str, suffix: str) -> None:
+    db.session.add(
+        LearnProgressRecord(
+            progress_record_bid=f"progress-{suffix}",
+            shifu_bid=shifu_bid,
+            outline_item_bid=f"outline-{suffix}",
+            user_bid=user_bid,
+            status=LEARN_STATUS_IN_PROGRESS,
+            deleted=0,
+        )
+    )
+    db.session.add(
+        LearnGeneratedBlock(
+            generated_block_bid=f"block-{suffix}",
+            progress_record_bid=f"progress-{suffix}",
+            user_bid=user_bid,
+            block_bid=f"block-bid-{suffix}",
+            outline_item_bid=f"outline-{suffix}",
+            shifu_bid=shifu_bid,
+            type=BLOCK_TYPE_CONTENT_VALUE,
+            role=0,
+            generated_content="hello",
+            position=1,
+            status=1,
+            deleted=0,
+        )
+    )
+    db.session.commit()
+
+
+def test_migrate_user_study_record_moves_records_and_blocks(app):
+    shifu_bid = "shifu-migrate"
+    with app.app_context():
+        LearnGeneratedBlock.query.delete()
+        LearnProgressRecord.query.delete()
+        db.session.commit()
+
+        _add_progress_with_block(shifu_bid, "tmp-user", "migrate-1")
+        # An unrelated shifu must stay with the temporary user.
+        _add_progress_with_block("shifu-other", "tmp-user", "migrate-2")
+
+        migrate_user_study_record(app, "tmp-user", "real-user", shifu_bid)
+        db.session.commit()
+
+        moved = LearnProgressRecord.query.filter_by(
+            progress_record_bid="progress-migrate-1"
+        ).one()
+        assert moved.user_bid == "real-user"
+        moved_block = LearnGeneratedBlock.query.filter_by(
+            generated_block_bid="block-migrate-1"
+        ).one()
+        assert moved_block.user_bid == "real-user"
+
+        untouched = LearnProgressRecord.query.filter_by(
+            progress_record_bid="progress-migrate-2"
+        ).one()
+        assert untouched.user_bid == "tmp-user"
+        untouched_block = LearnGeneratedBlock.query.filter_by(
+            generated_block_bid="block-migrate-2"
+        ).one()
+        assert untouched_block.user_bid == "tmp-user"
+
+
+def test_migrate_user_study_record_skips_outlines_already_present(app):
+    shifu_bid = "shifu-migrate-dup"
+    with app.app_context():
+        LearnGeneratedBlock.query.delete()
+        LearnProgressRecord.query.delete()
+        db.session.commit()
+
+        _add_progress_with_block(shifu_bid, "tmp-user", "dup")
+        db.session.add(
+            LearnProgressRecord(
+                progress_record_bid="progress-dup-target",
+                shifu_bid=shifu_bid,
+                outline_item_bid="outline-dup",
+                user_bid="real-user",
+                status=LEARN_STATUS_IN_PROGRESS,
+                deleted=0,
+            )
+        )
+        db.session.commit()
+
+        migrate_user_study_record(app, "tmp-user", "real-user", shifu_bid)
+        db.session.commit()
+
+        kept = LearnProgressRecord.query.filter_by(
+            progress_record_bid="progress-dup"
+        ).one()
+        assert kept.user_bid == "tmp-user"
+        kept_block = LearnGeneratedBlock.query.filter_by(
+            generated_block_bid="block-dup"
+        ).one()
+        assert kept_block.user_bid == "tmp-user"

--- a/src/api/tests/service/user/test_migrate_user_study_record.py
+++ b/src/api/tests/service/user/test_migrate_user_study_record.py
@@ -45,6 +45,25 @@ def test_migrate_user_study_record_moves_records_and_blocks(app):
         _add_progress_with_block(shifu_bid, "tmp-user", "migrate-1")
         # An unrelated shifu must stay with the temporary user.
         _add_progress_with_block("shifu-other", "tmp-user", "migrate-2")
+        # progress_record_bid is not unique, so a block owned by someone else
+        # may share the identifier and must keep its owner.
+        db.session.add(
+            LearnGeneratedBlock(
+                generated_block_bid="block-other-owner",
+                progress_record_bid="progress-migrate-1",
+                user_bid="other-user",
+                block_bid="block-bid-other-owner",
+                outline_item_bid="outline-migrate-1",
+                shifu_bid=shifu_bid,
+                type=BLOCK_TYPE_CONTENT_VALUE,
+                role=0,
+                generated_content="hello",
+                position=1,
+                status=1,
+                deleted=0,
+            )
+        )
+        db.session.commit()
 
         migrate_user_study_record(app, "tmp-user", "real-user", shifu_bid)
         db.session.commit()
@@ -57,6 +76,11 @@ def test_migrate_user_study_record_moves_records_and_blocks(app):
             generated_block_bid="block-migrate-1"
         ).one()
         assert moved_block.user_bid == "real-user"
+
+        other_owner_block = LearnGeneratedBlock.query.filter_by(
+            generated_block_bid="block-other-owner"
+        ).one()
+        assert other_owner_block.user_bid == "other-user"
 
         untouched = LearnProgressRecord.query.filter_by(
             progress_record_bid="progress-migrate-2"


### PR DESCRIPTION
# Summary

Enables ruff `S608` (SQL built by string interpolation), the last of the lightweight rules in this series. 27 sites; one was a real injection vector, the rest interpolate identifiers only.

**Real fix — `migrate_user_study_record` (`user/phone_flow.py`)**: the temp-user → real-user merge built two `UPDATE` statements by formatting `to_user_id` and the id list straight into SQL. Now ORM bulk updates, with the block update scoped to the source user because `progress_record_bid` is neither unique nor foreign-keyed:

```python
db.session.query(LearnGeneratedBlock).filter(
    LearnGeneratedBlock.user_bid == from_user_id,
    LearnGeneratedBlock.progress_record_bid.in_(progress_record_bids),
).update({LearnGeneratedBlock.user_bid: to_user_id}, synchronize_session=False)
```

`migrate_user_study_record` had no test; added `tests/service/user/test_migrate_user_study_record.py` covering the move (records + generated blocks), the unrelated-shifu case, a block owned by a third user that shares a migrated `progress_record_bid`, and the "outline already exists for the target user" skip.

**`command/unified_migration_task.py` (11 sites)**: table/column names come from the module's `table_mappings` and the mapping functions, and bound parameters cannot carry identifiers. Added `_quote_identifier()`, which validates against `[A-Za-z_][A-Za-z0-9_]*` and backtick-quotes, and routed every interpolated identifier through it; each remaining f-string carries `# noqa: S608` naming that guarantee. Two statements that interpolated *values* (`SHOW TABLES LIKE '{table}'`, the `INFORMATION_SCHEMA.COLUMNS` lookup) now use bound parameters, so they need no suppression. Added a small test for `_quote_identifier`.

**`scripts/migrate_oss_domain.py` (2 sites)**: identifiers come from the `TARGETS` constant and are already whitelist-checked; values are bound. Inline `# noqa: S608` with that reason.

**`migrations/versions` (12 sites)**: applied Alembic revisions are immutable history, so the 6 affected files are exempted individually (not by glob) and future revisions stay covered by S608.

Verified: `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`, and the full backend suite (`2883 passed, 15 skipped`; the 5 `test_admin_course_detail.py` failures are the known preexisting SQLite-vs-MySQL `concat` ones, reproducible on `main`).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection against SQL injection by validating and safely quoting dynamic database identifiers.
  * Replaced dynamically constructed record updates with safer database operations.

* **Bug Fixes**
  * Improved user study-record migration reliability while preserving unrelated records, ownership boundaries, and existing outlines.

* **Tests**
  * Added coverage for identifier validation and user study-record migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->