### PR TITLE
style: enforce ruff RUF002 and RUF003 (unambiguous unicode in prose)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -157,8 +157,8 @@ select = [
     "UP",
 
     # --- Ruff-native rules ------------------------------------------------
-    # RUF001-RUF003 (ambiguous unicode) fire on intentional CJK punctuation in
-    # user-facing strings, RUF012 and RUF100 are ignored below.
+    # RUF001 (ambiguous unicode in a string), RUF012 and RUF100 are ignored
+    # below.
     "RUF",
 ]
 ignore = [
@@ -190,8 +190,6 @@ ignore = [
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
-    "RUF002",  # ambiguous unicode in a docstring -- same
-    "RUF003",  # ambiguous unicode in a comment -- same
     "RUF012",  # mutable class attribute without ClassVar -- annotation churn
     # RUF100: with a partial select list, ruff reports deliberate `# noqa:
     # BLE001 / DTZ001 / SLF001 / S102` markers as unused simply because those

--- a/scripts/migrate_oss_domain.py
+++ b/scripts/migrate_oss_domain.py
@@ -47,7 +47,7 @@ log = logging.getLogger(__name__)
 #   is_content=False -> column stores a bare URL
 # ---------------------------------------------------------------------------
 TARGETS: list[tuple[str, str, bool]] = [
-    # course outline content (MarkdownFlow – may embed multiple image URLs)
+    # course outline content (MarkdownFlow, may embed multiple image URLs)
     ("shifu_draft_outline_items", "content", True),
     ("shifu_published_outline_items", "content", True),
     # course resource references

--- a/src/api/flaskr/common/swagger.py
+++ b/src/api/flaskr/common/swagger.py
@@ -47,7 +47,8 @@ def parse_comments(cls):
                     else:  # ast.Assign
                         field_name = item.targets[0].id
 
-                    line_num = item.lineno - 1  # ast 行号从1开始，列表索引从0开始
+                    # ast line numbers are 1-based, list indexes are 0-based
+                    line_num = item.lineno - 1
                     line = source_lines[line_num].strip()
 
                     if "#" in line:

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -58,7 +58,7 @@ def _extract_request_language() -> str | None:
     return _resolve_supported_language(raw_language)
 
 
-# 装饰器函数，用于跳过Token校验
+# Decorator that exempts a route from token validation
 def bypass_token_validation(func):
     by_pass_login_func.append(func.__name__)
 

--- a/src/api/flaskr/service/learn/type_state_machine.py
+++ b/src/api/flaskr/service/learn/type_state_machine.py
@@ -6,10 +6,10 @@ produced by this module.
 
 State definitions
 -----------------
-- ``IDLE``       – no open element
-- ``BUILDING``   – accumulating a new element
-- ``PATCHING``   – applying incremental update to an existing element (``is_new=false``)
-- ``TERMINATED`` – final state after ``done`` / ``error``
+- ``IDLE``       - no open element
+- ``BUILDING``   - accumulating a new element
+- ``PATCHING``   - applying incremental update to an existing element (``is_new=false``)
+- ``TERMINATED`` - final state after ``done`` / ``error``
 
 See design doc §3.4 for the full transition table.
 """

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -53,7 +53,7 @@ class PasswordAuthProvider(AuthProvider):
         if not aggregate:
             raise_error("server.user.invalidCredentials")
 
-        # Find password credential – look up by user_bid only.
+        # Find password credential: look up by user_bid only.
         # The password credential's identifier may differ from the login
         # identifier (e.g. user registered with phone but logs in with
         # email, or vice-versa), so we must not filter by identifier here.

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -352,12 +352,14 @@ def run_migrations_online() -> None:
             if table_name in system_tables or table_name.startswith("information_"):
                 return True
 
-            # 对于删除操作，不应该基于当前模型来过滤，因为被删除的表在当前模型中已经不存在了
+            # Drops must not be filtered against the current models, because a
+            # dropped table no longer exists in them
             if op_type == "DropTableOp":
-                # 删除操作不应该被跳过，让include_object来决定
+                # Let include_object decide instead of skipping the drop here
                 return False
 
-            # skip the tables that do not belong to the application (只对非删除操作执行此检查)
+            # skip the tables that do not belong to the application (non-drop
+            # operations only)
             # Check both: if table name matches directly OR if it starts with a known prefix
             if table_name not in app_table_names and not any(
                 table_name.startswith(prefix) for prefix in app_table_prefixes
@@ -559,7 +561,7 @@ def run_migrations_online() -> None:
     conf_args["compare_name"] = False
     conf_args["compare_schema"] = False
 
-    # 添加自定义的比较函数来减少误报
+    # Custom comparison functions that reduce false positives
     def compare_server_default(
         context,
         inspected_column,
@@ -570,14 +572,14 @@ def run_migrations_online() -> None:
     ):
         """Compare server defaults leniently to reduce false positives."""
 
-        # 标准化默认值的表示
+        # Normalize how a default value is spelled
         def normalize_default(default):
             if default is None:
                 return None
             default_str = str(default).strip()
             if default_str == "" or default_str.lower() == "none":
                 return None
-            # MySQL TIMESTAMP 特殊处理
+            # MySQL TIMESTAMP special case
             if default_str.upper() in ["CURRENT_TIMESTAMP", "NOW()"]:
                 return "CURRENT_TIMESTAMP"
             if "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" in default_str.upper():
@@ -587,7 +589,7 @@ def run_migrations_online() -> None:
         norm_inspected = normalize_default(inspected_default)
         norm_metadata = normalize_default(rendered_metadata_default)
 
-        # 如果两个都是 None，认为相同
+        # Two missing defaults count as equal
         if norm_inspected is None and norm_metadata is None:
             return False
 
@@ -598,7 +600,7 @@ def run_migrations_online() -> None:
     ):
         """Compare comments leniently, still reporting real comment changes."""
 
-        # 标准化注释
+        # Normalize how a comment is spelled
         def normalize_comment(comment):
             if comment is None:
                 return None
@@ -610,19 +612,20 @@ def run_migrations_online() -> None:
         norm_inspected = normalize_comment(inspected_comment)
         norm_metadata = normalize_comment(metadata_comment)
 
-        # 如果两个都是 None 或空，认为相同
+        # Two missing or empty comments count as equal
         if norm_inspected is None and norm_metadata is None:
             return False
 
-        # 如果一个是 None 另一个不是，但内容是无意义的默认注释，跳过
+        # One side missing is still skipped when the other side only carries a
+        # meaningless boilerplate comment
         if norm_inspected != norm_metadata:
-            # 检查是否是从 None 到通用的"Update time"注释，这种情况跳过
+            # Skip a change that only adds or removes the generic "Update time"
             if (norm_inspected is None and norm_metadata == "Update time") or (
                 norm_metadata is None and norm_inspected == "Update time"
             ):
                 return False
 
-            # 检查是否已经有相同的注释变更在最近的迁移中
+            # Skip a comment change already reported during this run
             if hasattr(context, "_comment_change_signature"):
                 signature = f"{metadata_column.table.name}.{metadata_column.name}:{norm_inspected}->{norm_metadata}"
                 if signature in context._comment_change_signature:
@@ -641,27 +644,27 @@ def run_migrations_online() -> None:
         context, inspected_column, metadata_column, inspected_type, metadata_type
     ):
         """Compare column types leniently to reduce false positives."""
-        # 对于某些类型的小差异，认为相同
+        # Treat small type differences as equal
         inspected_str = str(inspected_type).upper()
         metadata_str = str(metadata_type).upper()
 
-        # MySQL TINYINT(1) 和 BOOLEAN 的处理 - 这些是等价的
+        # MySQL TINYINT(1) and BOOLEAN are equivalent
         if ("TINYINT(1)" in inspected_str and "BOOLEAN" in metadata_str) or (
             "BOOLEAN" in inspected_str and "TINYINT(1)" in metadata_str
         ):
             return False
 
-        # MySQL DECIMAL 和 SQLAlchemy Numeric 的处理 - 这些是等价的
+        # MySQL DECIMAL and SQLAlchemy Numeric are equivalent
         if ("DECIMAL" in inspected_str and "NUMERIC" in metadata_str) or (
             "NUMERIC" in inspected_str and "DECIMAL" in metadata_str
         ):
             return False
 
-        # BIGINT 自增字段的处理
+        # Autoincrement BIGINT columns
         if "BIGINT" in inspected_str and "BIGINT" in metadata_str:
             return False
 
-        # VARCHAR 长度差异的处理 - 只要长度相同就认为相同
+        # VARCHAR columns are equal as long as the length matches
         import re
 
         varchar_pattern = r"VARCHAR\((\d+)\)"
@@ -674,17 +677,18 @@ def run_migrations_online() -> None:
         ):
             return False
 
-        # TEXT 类型的处理 - MySQL 的 TEXT, LONGTEXT 等都映射到 SQLAlchemy 的 TEXT
+        # MySQL TEXT, LONGTEXT and friends all map to SQLAlchemy TEXT
         if "TEXT" in inspected_str and "TEXT" in metadata_str:
             return False
 
         return inspected_str != metadata_str
 
-    # 应用自定义比较函数
+    # Apply the custom comparison functions
     conf_args["compare_server_default"] = compare_server_default
-    # 重新启用注释比较但使用更智能的去重逻辑
+    # Comment comparison stays on, with the deduplication logic above
     conf_args["compare_comment"] = compare_comment
-    # 完全禁用类型比较以避免 DECIMAL<->NUMERIC 和 TINYINT<->BOOLEAN 的误报
+    # Type comparison is off entirely to avoid DECIMAL<->NUMERIC and
+    # TINYINT<->BOOLEAN false positives
     conf_args["compare_type"] = False
 
     connectable = get_engine()


### PR DESCRIPTION
# Summary

First PR of a stack that clears the remaining purely mechanical ruff rules, one rule per PR.

RUF002/RUF003 flag characters in docstrings and comments that look like ASCII but are not. 17 sites, two causes:

- Chinese comments containing `，` (FULLWIDTH COMMA) — in `migrations/env.py`, `common/swagger.py`, `route/common.py`. Rewritten in English, which the repo requires for code-facing text anyway. `env.py` had 21 Chinese comments in total; all were translated so the two comparison callbacks are not left half-translated.
- `–` (EN DASH) used as a separator — in the `type_state_machine` module docstring, the password provider comment, and a `migrate_oss_domain` target comment. Replaced with `-`, `:` or a comma.

`RUF001` (ambiguous unicode in a *string*) stays ignored: those 162 sites are intentional CJK punctuation inside user-facing text.

Comments and docstrings only, no code changes, so no tests were added. `ruff check` and `ruff format --check` are clean.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments, docstrings, and lint config only; no executable logic changes.
> 
> **Overview**
> Enables **RUF002** and **RUF003** by dropping them from `ruff.toml`’s ignore list and updating the RUF section comments so only **RUF001** (strings) stays exempt alongside RUF012/RUF100.
> 
> Comment and docstring fixes are mechanical: Chinese comments in `migrations/env.py`, `swagger.py`, and `route/common.py` are rewritten in English; EN DASH / fullwidth punctuation is replaced with ASCII separators in `type_state_machine.py`, `password.py`, and `migrate_oss_domain.py`. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f66a2888fa8da14bf111574cd812a384202ab42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal comments and migration guidance in English.
  * Improved descriptions for token validation, authentication, state handling, and API comment parsing.
  * Standardized punctuation and terminology in course and technical documentation.

* **Style**
  * Updated linting guidance for Unicode usage in comments and docstrings.
  * Removed outdated suppression rules while retaining the relevant exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->