### PR TITLE
style: enforce ruff ANN205 (staticmethod return types)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -15,9 +15,9 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN / SLF001 / PLC0415 / PLR2004 (and D1xx, see the ignore block):
-#   thousands of violations each; enforcing them is a codebase-wide project,
-#   not a lint config change.
+# - ANN (except ANN205, see `select`) / SLF001 / PLC0415 / PLR2004 (and D1xx,
+#   see the ignore block): thousands of violations each; enforcing them is a
+#   codebase-wide project, not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
 #   tuples/lists, not a missed comma. ISC001/ISC002 also conflict with the
 #   formatter.
@@ -142,6 +142,13 @@ select = [
     # which bound parameters cannot carry, and justify it inline. Applied
     # Alembic revisions must not be edited, so they are exempt below.
     "S608",    # SQL query built by string interpolation
+
+    # --- Type annotations -------------------------------------------------
+    # flake8-annotations is otherwise off (see the header): annotating every
+    # argument and return in the repo is a separate project. ANN205 is small
+    # enough to keep enforced, and a staticmethod is where a missing return
+    # type hides the most, since there is no `self`/`cls` to infer from.
+    "ANN205",  # missing return type on a staticmethod
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - exercised only when pydub is missing.
 
     class AudioSegment:  # type: ignore[no-redef]
         @staticmethod
-        def from_file(*_args, **_kwargs):
+        def from_file(*_args, **_kwargs) -> None:
             raise RuntimeError("audio decoder is not available")
 
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -1819,11 +1819,11 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 _ = args, kwargs
 
             @staticmethod
-            def normalize_context_messages(_value):
+            def normalize_context_messages(_value) -> None:
                 return None
 
             @staticmethod
-            def filter_context_by_output_language(context, _output_language):
+            def filter_context_by_output_language(context, _output_language) -> object:
                 return context
 
             def get_block(self, _block_index):

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -139,13 +139,13 @@ def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempot
 
     class FakeCoupon:
         @staticmethod
-        def create(**kwargs):
+        def create(**kwargs) -> dict[str, str]:
             captured_coupon.update(kwargs)
             return {"id": "coupon-1"}
 
     class FakeSession:
         @staticmethod
-        def create(**kwargs):
+        def create(**kwargs) -> object:
             captured_session.update(kwargs)
             return type(
                 "SessionResponse",
@@ -218,16 +218,16 @@ def test_stripe_subscription_discount_coupon_is_cleaned_up_on_session_failure(
 
     class FakeCoupon:
         @staticmethod
-        def create(**_kwargs):
+        def create(**_kwargs) -> dict[str, str]:
             return {"id": "coupon-cleanup-1"}
 
         @staticmethod
-        def delete(coupon_id, **_kwargs):
+        def delete(coupon_id, **_kwargs) -> None:
             deleted.append(coupon_id)
 
     class FakeSession:
         @staticmethod
-        def create(**_kwargs):
+        def create(**_kwargs) -> None:
             raise RuntimeError("session failed")
 
     class FakeCheckout:

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -1651,7 +1651,7 @@ class FakeSession:
 
 class FakeFunc:
     @staticmethod
-    def max(column: FakeColumn):
+    def max(column: FakeColumn) -> FakeMaxExpression:
         return FakeMaxExpression(column)
 
 

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -41,14 +41,14 @@ class _FakeSegment:
 
 class _FakeAudioSegment:
     @staticmethod
-    def from_mp3(segment_io: io.BytesIO):
+    def from_mp3(segment_io: io.BytesIO) -> "_FakeSegment":
         duration = int(segment_io.getvalue().decode("utf-8"))
         return _FakeSegment(duration)
 
 
 class _PartiallyBrokenAudioSegment:
     @staticmethod
-    def from_mp3(segment_io: io.BytesIO):
+    def from_mp3(segment_io: io.BytesIO) -> "_FakeSegment":
         payload = segment_io.getvalue()
         if payload == b"BAD":
             raise ValueError("Decoding failed")
@@ -59,7 +59,7 @@ class _RecordingAudioSegment:
     from_file_formats: list[str] = []
 
     @staticmethod
-    def from_file(segment_io: io.BytesIO, format="mp3"):  # noqa: A002 - mirrors the pydub API
+    def from_file(segment_io: io.BytesIO, format="mp3") -> "_FakeSegment":  # noqa: A002 - mirrors the pydub API
         _RecordingAudioSegment.from_file_formats.append(format)
         return _FakeSegment(int(segment_io.getvalue().decode("utf-8")))
 


### PR DESCRIPTION
# Summary

Annotates the return type of the 12 `@staticmethod` definitions that lacked one and enables `ANN205` in `ruff.toml`. The rest of flake8-annotations stays off (thousands of violations); ANN205 is small enough to enforce now, and it is the annotation rule where a missing return type hides the most, because there is no `self`/`cls` for a reader or type checker to infer from.

Annotations only — no runtime behavior changes, so no new tests. One production site (`minimax_voice_clone.AudioSegment.from_file`, the stub that raises when the audio decoder is absent) plus test doubles for stripe/pydub/sqlalchemy/mdflow.

Stacked on #2529 (RUF002/RUF003).

Verified: `ruff check .` clean, `ruff format --check .` clean, focused tests for the four touched test modules pass.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only lint and typing changes with no logic or API behavior changes.
> 
> **Overview**
> Turns on **Ruff `ANN205`** (missing return type on `@staticmethod`) in `ruff.toml` while keeping the rest of flake8-annotations off; the config header documents that exception.
> 
> Adds explicit return annotations on the **12** `@staticmethod` definitions that lacked them—one production stub (`minimax_voice_clone`’s fallback `AudioSegment.from_file`) and test doubles (Stripe, pydub/audio utils, SQLAlchemy admin fakes, preview mdflow fakes). **No runtime behavior changes**—types only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0716110093caf5fb2c9b9ffaf791227ebcd4c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->