### PR TITLE
style: enforce ruff ANN206 (classmethod return types)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -15,9 +15,9 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN205, see `select`) / SLF001 / PLC0415 / PLR2004 (and D1xx,
-#   see the ignore block): thousands of violations each; enforcing them is a
-#   codebase-wide project, not a lint config change.
+# - ANN (except ANN205/ANN206, see `select`) / SLF001 / PLC0415 / PLR2004
+#   (and D1xx, see the ignore block): thousands of violations each; enforcing
+#   them is a codebase-wide project, not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
 #   tuples/lists, not a missed comma. ISC001/ISC002 also conflict with the
 #   formatter.
@@ -147,8 +147,11 @@ select = [
     # flake8-annotations is otherwise off (see the header): annotating every
     # argument and return in the repo is a separate project. ANN205 is small
     # enough to keep enforced, and a staticmethod is where a missing return
-    # type hides the most, since there is no `self`/`cls` to infer from.
+    # type hides the most, since there is no `self` to infer from. ANN206
+    # covers the classmethod counterpart, mostly alternative constructors and
+    # frozen-clock `now()` doubles.
     "ANN205",  # missing return type on a staticmethod
+    "ANN206",  # missing return type on a classmethod
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands

--- a/src/api/flaskr/service/promo/admin_dtos.py
+++ b/src/api/flaskr/service/promo/admin_dtos.py
@@ -39,7 +39,7 @@ def _datetime_fields_for(cls) -> frozenset[str]:
 class _DTOBase(BaseModel):
     @field_validator("*", mode="before")
     @classmethod
-    def _coerce_empty_datetime(cls, value, info: ValidationInfo):
+    def _coerce_empty_datetime(cls, value, info: ValidationInfo) -> object:
         if not isinstance(value, str) or value.strip() not in _EMPTY_DATETIME_VALUES:
             return value
         if info.field_name in _datetime_fields_for(cls):

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -68,7 +68,7 @@ class HistoryItem(BaseModel, Generic[T]):
         return self.model_dump_json()
 
     @classmethod
-    def from_json(cls, json: str):
+    def from_json(cls, json: str) -> "HistoryItem":
         """From json to history item."""
         return cls.model_validate_json(json)
 

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -85,7 +85,7 @@ register_billing_routes = load_register_billing_routes()
 def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             current = cls(2026, 4, 6, 12, 0, 0)
             if tz is not None:
                 return current.replace(tzinfo=tz)

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -93,7 +93,7 @@ billing_routes_module = load_billing_routes_module()
 def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             current = cls(2026, 4, 6, 12, 0, 0)
             if tz is not None:
                 return current.replace(tzinfo=tz)
@@ -1154,7 +1154,7 @@ class TestBillingRoutes:
     ) -> None:
         class _FixedDateTime(datetime):
             @classmethod
-            def now(cls, tz=None):
+            def now(cls, tz=None) -> datetime:
                 current = cls(2026, 5, 1, 12, 0, 0)
                 if tz is not None:
                     return current.replace(tzinfo=tz)

--- a/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
@@ -917,7 +917,7 @@ class TestBillingWriteRoutesSubscriptionLifecycle:
 
         class FrozenDateTime(datetime):
             @classmethod
-            def now(cls, tz=None):
+            def now(cls, tz=None) -> datetime:
                 frozen_now = datetime(2026, 4, 24, 10, 0, 0)
                 if tz is not None:
                     return frozen_now.replace(tzinfo=tz)

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -227,7 +227,7 @@ class EmitterContextSeamTests(unittest.TestCase):
 
 class EmitterPayloadSmokeTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("run-emitter-payload-tests")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -289,7 +289,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
 
 class NextChapterInteractionTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("next-chapter-tests")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -567,7 +567,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
 
 class ExceptionGateFeedbackTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("exception-gate-feedback")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -649,7 +649,7 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
 
 class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("exception-gate-interaction-persistence")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -799,7 +799,7 @@ class StreamTtsGateTests(unittest.TestCase):
 
 class ReloadFromElementBidTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("reload-from-element-bid")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -2547,7 +2547,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("stream-prompt-capture-tests")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -130,7 +130,7 @@ def _patch_run_tts_processor(
 
 class TestGeneratedBlockListenTtsElementFirst:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.app = Flask("generated-block-listen-tts")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -56,7 +56,7 @@ from flaskr.service.shifu.consts import (
 
 class LearnRecordLoadTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("learn-record-tests")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -40,7 +40,7 @@ from flaskr.util import generate_id
 
 class LearnRecordFallbackTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("learn-record-fallback")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -21,7 +21,7 @@ from flaskr.service.shifu.consts import BLOCK_TYPE_MDINTERACTION_VALUE
 
 class LessonFeedbackTests(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.app = Flask("lesson-feedback-tests")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -18,7 +18,7 @@ if not hasattr(dao, "redis_client"):
 
 class TestListenElementHistorySubtitles:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.app = Flask("listen-element-history-subtitles")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -18,7 +18,7 @@ if not hasattr(dao, "redis_client"):
 
 class TestBuildListenElementsFromLegacyRecord:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.app = Flask("listen-elements-legacy-record")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -696,7 +696,7 @@ def test_list_operator_courses_filters_by_course_status():
 def test_list_operator_courses_applies_quick_filters(monkeypatch):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):  # noqa: ARG003 - matches datetime.now signature
+        def now(cls, tz=None) -> datetime:  # noqa: ARG003 - matches datetime.now signature
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
@@ -828,7 +828,7 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
 def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):  # noqa: ARG003 - matches datetime.now signature
+        def now(cls, tz=None) -> datetime:  # noqa: ARG003 - matches datetime.now signature
             return cls(2025, 5, 1, 12, 0, 0)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -868,7 +868,7 @@ def test_list_operator_users_returns_overview_summary_and_applies_quick_filters(
 ):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             return cls(2026, 5, 6, 12, 0, 0, tzinfo=tz)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
@@ -982,7 +982,7 @@ def test_list_operator_users_recent_windows_exclude_future_records_and_keep_micr
 ):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             return cls(2026, 5, 6, 23, 59, 59, 250000, tzinfo=tz)
 
     monkeypatch.setattr(admin_module, "datetime", FixedDateTime)
@@ -2922,7 +2922,7 @@ def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app):
 def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monkeypatch):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
 
     monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
@@ -3020,7 +3020,7 @@ def test_grant_operator_user_referral_reward_extends_empty_active_bucket(
 ):
     class FixedDateTime(datetime):
         @classmethod
-        def now(cls, tz=None):
+        def now(cls, tz=None) -> datetime:
             return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
 
     monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -18,7 +18,7 @@ if not hasattr(dao, "redis_client"):
 
 class TestStreamingTtsSubtitles:
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         cls.app = Flask("streaming-tts-subtitles")
         cls.app.config.update(
             SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -298,7 +298,7 @@ def test_onboarding_status_uses_conservative_fallback_when_new_creator_gate_miss
 
     class _MockDateTime(datetime):
         @classmethod
-        def utcnow(cls):
+        def utcnow(cls) -> datetime:
             return cls(2026, 6, 23, 10, 0, 0)
 
     monkeypatch.setattr("flaskr.service.user.onboarding.datetime", _MockDateTime)


### PR DESCRIPTION
# Summary

Annotates the return type of the 26 `@classmethod` definitions that lacked one and enables `ANN206` in `ruff.toml` (the rest of flake8-annotations stays off).

Two production sites: the promo DTO `field_validator` (`_coerce_empty_datetime -> object`, since it passes arbitrary values through) and `HistoryItem.from_json`. The remainder are test doubles — `setUpClass`/`setup_class` (`-> None`) and frozen-clock `datetime` subclasses whose `now()`/`utcnow()` return a `datetime`.

Annotations only — no runtime behavior changes, so no new tests.

Stacked on #2530 (ANN205).

Verified: `ruff check .` clean, `ruff format --check .` clean, and the touched backend test packages pass (1433 passed, 14 skipped).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint config plus type-only edits on classmethods; no logic, auth, or data-path changes.
> 
> **Overview**
> Turns on **Ruff `ANN206`** (missing return type on `@classmethod`) next to the existing **`ANN205`** rule and documents that pairing in `ruff.toml`.
> 
> **Production:** adds return types on two classmethods — promo DTO `_coerce_empty_datetime` → `object`, and `HistoryItem.from_json` → `"HistoryItem"`.
> 
> **Tests:** annotates the remaining classmethods (mostly `setUpClass` / `setup_class` → `None`, and frozen `datetime` subclasses’ `now()` / `utcnow()` → `datetime`) so `ruff check` stays clean.
> 
> Annotations only; no intended runtime or API behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8b771d4e92a991d1db998815a64afbb9af9b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->