### PR TITLE
refactor: rename exception classes to the Error suffix convention

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -120,6 +120,7 @@ select = [
     "N802",    # function name that is not lowercase
     "N803",    # argument name that is not lowercase
     "N813",    # CamelCase imported under a lowercase alias
+    "N818",    # exception class name without an Error suffix
     "TD002",   # TODO without an author
     # S101 bans `assert` in shipped code (python -O strips it, so an assert is
     # not a runtime guard). Test suites and script self-tests are exempt via

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import HTTPException
 from flaskr.common.shifu_context import clear_shifu_context
 from flaskr.i18n import _, _translations, clear_language, set_language
 
-from ..service.common import AppException
+from ..service.common import AppError
 
 by_pass_login_func = [
     "flasgger.apispec_1",
@@ -70,8 +70,8 @@ def bypass_token_validation(func):
 
 
 def register_common_handler(app: Flask) -> Flask:
-    @app.errorhandler(AppException)
-    def handle_invalid_usage(error: AppException):
+    @app.errorhandler(AppError)
+    def handle_invalid_usage(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -17,7 +17,7 @@ from cryptography import x509
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import serialization
 from flask import Flask, current_app, has_app_context
-from flaskr.service.common.models import AppException, raise_error, raise_param_error
+from flaskr.service.common.models import AppError, raise_error, raise_param_error
 from flaskr.service.common.oss_utils import OSS_PROFILE_COURSES
 from flaskr.service.common.storage import upload_to_storage
 from flaskr.service.config.funcs import get_config
@@ -678,7 +678,7 @@ def _serialize_latest_management_integration(
         return _serialize_active_integration(app, creator_bid, provider)
     try:
         integration_bid = _latest_version_bid(app, creator_bid, provider)
-    except AppException:
+    except AppError:
         return _serialize_active_integration(app, creator_bid, provider)
     record = _load_integration_record(
         app,
@@ -739,7 +739,7 @@ def _load_latest_record_or_active(
         return None
     try:
         integration_bid = _latest_version_bid(app, creator_bid, provider)
-    except AppException:
+    except AppError:
         return _load_active_record(creator_bid, provider)
     return _load_integration_record(
         app,
@@ -1084,7 +1084,7 @@ def _normalize_home_url_lenient(value: Any) -> str:
     """
     try:
         return _normalize_home_url(value)
-    except AppException:
+    except AppError:
         return ""
 
 

--- a/src/api/flaskr/service/common/__init__.py
+++ b/src/api/flaskr/service/common/__init__.py
@@ -1,3 +1,9 @@
 """Shared service models, errors and dictionaries."""
 
+from flaskr.util.deprecation import deprecated_alias_getattr
+
 from .models import *  # noqa: F403
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"AppException": "AppError"}, globals()
+)

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from flaskr.i18n import _
 
 
-class AppException(Exception):
+class AppError(Exception):
     def __init__(self, message, status_code=None, payload=None):
         Exception.__init__(self)
         self.message = message
@@ -53,21 +53,21 @@ def register_error(error_name, error_code):
 
 
 def raise_param_error(param_message):
-    raise AppException(
+    raise AppError(
         _("server.common.paramsError").format(param_message=param_message),
         ERROR_CODE["server.common.paramsError"],
     )
 
 
 def raise_error(error_name):
-    raise AppException(
+    raise AppError(
         _(error_name),
         ERROR_CODE.get(error_name, ERROR_CODE["server.common.unknownError"]),
     )
 
 
 def raise_error_with_args(error_name, **kwargs):
-    raise AppException(
+    raise AppError(
         _(error_name).format(**kwargs),
         ERROR_CODE.get(error_name, ERROR_CODE["server.common.unknownError"]),
     )

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from flaskr.i18n import _
+from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class AppError(Exception):
@@ -71,3 +72,8 @@ def raise_error_with_args(error_name, **kwargs):
         _(error_name).format(**kwargs),
         ERROR_CODE.get(error_name, ERROR_CODE["server.common.unknownError"]),
     )
+
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"AppException": "AppError"}, globals()
+)

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -78,7 +78,7 @@ def is_oss_profile_configured(profile: str = OSS_PROFILE_DEFAULT) -> bool:
 
     Notes:
     - This is intentionally conservative and checks credentials + bucket.
-    - It avoids raising AppException so callers can implement fallbacks (e.g., local storage).
+    - It avoids raising AppError so callers can implement fallbacks (e.g., local storage).
 
     """
     resolved_profile = (profile or "").strip().lower() or OSS_PROFILE_DEFAULT

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -53,7 +53,7 @@ from flask import Flask
 from flaskr.i18n import _
 from flaskr.service.billing.consts import CREDIT_SOURCE_TYPE_USAGE
 from flaskr.service.billing.models import CreditLedgerEntry
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.permissions import get_user_shifu_permissions
 from sqlalchemy import and_, bindparam, func, select
@@ -450,7 +450,7 @@ def _raise(error_name: str, detail: str | None = None) -> None:
     if detail:
         message = f"{message} ({detail})"
     code = ERROR_CODE.get(error_name, ERROR_CODE.get("server.common.unknownError"))
-    raise AppException(message, code)
+    raise AppError(message, code)
 
 
 __all__ = ["ERR_INVALID_DSL", "ERR_INVALID_LIMIT", "ERR_NO_PERMISSION", "run"]

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -7,7 +7,7 @@ then consumed by :mod:`flaskr.service.creator_analytics.sql_builder`.
 
 Validation is intentionally strict — every shape, table, column, operator,
 aggregate, and limit is checked against an explicit allowlist before any SQL
-is composed. Errors are raised as :class:`AppException` with stable error
+is composed. Errors are raised as :class:`AppError` with stable error
 names registered in ``src/api/error_codes.json``.
 """
 
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from flaskr.i18n import _
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 
 from .whitelist import (
     ALLOWED_AGGREGATE_FUNCTIONS,
@@ -89,7 +89,7 @@ _LIKE_MIN_NON_WILDCARD_CHARS = 2
 
 
 def _raise(error_name: str, detail: str | None = None) -> None:
-    """Raise an :class:`AppException` with a stable error name.
+    """Raise an :class:`AppError` with a stable error name.
 
     ``detail`` is appended in parentheses so the client gets actionable
     feedback (e.g. which column failed validation) without leaking internals.
@@ -98,7 +98,7 @@ def _raise(error_name: str, detail: str | None = None) -> None:
     if detail:
         message = f"{message} ({detail})"
     code = ERROR_CODE.get(error_name, ERROR_CODE.get("server.common.unknownError"))
-    raise AppException(message, code)
+    raise AppError(message, code)
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/creator_analytics/funcs.py
+++ b/src/api/flaskr/service/creator_analytics/funcs.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from flask import Flask
 from flaskr.i18n import _
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.shifu.permissions import get_user_shifu_permissions
 
 from .dsl import parse_dsl
@@ -138,7 +138,7 @@ def _redact_user_users_rows(result: dict[str, Any]) -> None:
 def _raise(error_name: str) -> None:
     message = _(error_name)
     code = ERROR_CODE.get(error_name, ERROR_CODE.get("server.common.unknownError"))
-    raise AppException(message, code)
+    raise AppError(message, code)
 
 
 __all__ = ["ERR_NO_PERMISSION", "run_dsl"]

--- a/src/api/flaskr/service/learn/check_text.py
+++ b/src/api/flaskr/service/learn/check_text.py
@@ -22,10 +22,6 @@ from flaskr.service.shifu.consts import BLOCK_TYPE_MDINTERACTION_VALUE
 from flaskr.service.user.repository import UserAggregate
 
 
-class BreakException(Exception):
-    pass
-
-
 def check_text_with_llm_response(
     app: Flask,
     user_info: UserAggregate,

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -30,7 +30,7 @@ from flaskr.service.learn.const import (
     ROLE_STUDENT,
     ROLE_TEACHER,
 )
-from flaskr.service.learn.exceptions import PaidException
+from flaskr.service.learn.exceptions import PaidError
 from flaskr.service.learn.handle_input_ask import handle_input_ask
 from flaskr.service.learn.langfuse_naming import (
     build_langfuse_generation_name,
@@ -106,7 +106,7 @@ from flaskr.service.shifu.shifu_struct_manager import (
     get_shifu_struct,
 )
 from flaskr.service.shifu.struct_utils import find_node_with_parents
-from flaskr.service.user.exceptions import UserNotLoginException
+from flaskr.service.user.exceptions import UserNotLoginError
 from flaskr.service.user.repository import UserAggregate, load_user_aggregate
 from flaskr.util import generate_id
 from markdown_flow import (
@@ -1956,13 +1956,13 @@ class RunScriptContextV2:
                 raise_error("server.shifu.lessonNotFoundInCourse")
             if outline_item_info_db.type == UNIT_TYPE_VALUE_NORMAL:
                 if (not self._is_paid) and (not self._preview_mode):
-                    raise PaidException
+                    raise PaidError
             elif outline_item_info_db.type == UNIT_TYPE_VALUE_TRIAL and (
                 not self._preview_mode
                 and not self._user_info.mobile
                 and not self._user_info.email
             ):
-                raise UserNotLoginException
+                raise UserNotLoginError
             parent_path = _find_outline_path_or_raise(self._struct, outline_bid)
             attend_info = None
             new_records: list[LearnProgressRecord] = []
@@ -3562,15 +3562,15 @@ class RunScriptContextV2:
     def run(self, app: Flask) -> Generator[RunMarkdownFlowDTO, None, None]:
         try:
             yield from self.run_inner(app)
-        except PaidException:
-            app.logger.info("PaidException")
+        except PaidError:
+            app.logger.info("PaidError")
             self._can_continue = False
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.order.checkout')}//_sys_pay]"
             )
             yield from self._emit_feedback_after_exception_gate()
-        except UserNotLoginException:
-            app.logger.info("UserNotLoginException")
+        except UserNotLoginError:
+            app.logger.info("UserNotLoginError")
             self._can_continue = False
             yield from self._emit_current_progress_gate_interaction(
                 f"?[{_('server.user.login')}//_sys_login]"

--- a/src/api/flaskr/service/learn/exceptions.py
+++ b/src/api/flaskr/service/learn/exceptions.py
@@ -1,4 +1,5 @@
 from flaskr.service.common import ERROR_CODE, AppError
+from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class PaidError(AppError):
@@ -21,3 +22,8 @@ class BreakError(AppError):
                 ERROR_CODE["server.common.unknownError"],
             ),
         )
+
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"PaidException": "PaidError", "BreakException": "BreakError"}, globals()
+)

--- a/src/api/flaskr/service/learn/exceptions.py
+++ b/src/api/flaskr/service/learn/exceptions.py
@@ -1,7 +1,7 @@
-from flaskr.service.common import ERROR_CODE, AppException
+from flaskr.service.common import ERROR_CODE, AppError
 
 
-class PaidException(AppException):
+class PaidError(AppError):
     def __init__(self):
         super().__init__(
             "server.order.courseNotPaid",
@@ -12,7 +12,7 @@ class PaidException(AppException):
         )
 
 
-class BreakException(AppException):
+class BreakError(AppError):
     def __init__(self):
         super().__init__(
             "server.order.courseNotPaid",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -87,7 +87,7 @@ from flaskr.service.tts import (
     resolve_tts_billable_chars,
 )
 from flaskr.service.tts.api import (
-    TTSRpmQueueTimeout,
+    TTSRpmQueueTimeoutError,
     create_streaming_tts_processor,
     find_ready_cloned_voice,
     find_tracked_cloned_voice,
@@ -996,7 +996,7 @@ def _yield_with_tts_error_mapping(
         yield from body()
     except ValueError as exc:
         raise_error_with_args("server.common.paramsError", param_message=str(exc))
-    except TTSRpmQueueTimeout as exc:
+    except TTSRpmQueueTimeoutError as exc:
         # The TTS provider's RPM quota is saturated. This is expected
         # backpressure, not a crash: log at WARNING (so it does not page ops as
         # an ERROR) and surface a retryable message instead of a generic

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -15,7 +15,7 @@ from flaskr.i18n import get_current_language
 from flaskr.route.common import bypass_token_validation, make_common_response
 from flaskr.service.billing.admission import admit_creator_usage
 from flaskr.service.common import raise_error
-from flaskr.service.common.models import AppException, raise_param_error
+from flaskr.service.common.models import AppError, raise_param_error
 from flaskr.service.learn.context_v2 import RunScriptPreviewContextV2
 from flaskr.service.learn.learn_dtos import (
     PlaygroundPreviewRequest,
@@ -116,7 +116,7 @@ def _stream_sse_response(
             # ROLLBACK on a possibly desynced stream.
             invalidate_session(source="learn stream_sse_response close")
             raise
-        except AppException as exc:
+        except AppError as exc:
             app.logger.warning("%s: %s (code: %s)", error_log, exc, exc.code)
             if error_event_factory is None:
                 raise

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -24,10 +24,10 @@ from flaskr.dao import (
     is_protocol_interrupt_error,
 )
 from flaskr.i18n import _, get_current_language, set_language
-from flaskr.service.common.models import AppException, raise_error
+from flaskr.service.common.models import AppError, raise_error
 from flaskr.service.learn.const import INPUT_TYPE_ASK
 from flaskr.service.learn.context_v2 import RunScriptContextV2
-from flaskr.service.learn.exceptions import BreakException
+from flaskr.service.learn.exceptions import BreakError
 from flaskr.service.learn.learn_dtos import (
     AudioBackfillReadyDTO,
     GeneratedType,
@@ -492,13 +492,13 @@ def run_script_inner(
             yield from _iter_audio_backfill_ready_events(
                 ready_element_bids_by_block_bid
             )
-        except BreakException:
+        except BreakError:
             _finalize_langfuse_if_available(run_script_context)
             db.session.commit()
             yield from _iter_audio_backfill_ready_events(
                 ready_element_bids_by_block_bid
             )
-            app.logger.info("BreakException")
+            app.logger.info("BreakError")
         except GeneratorExit:
             # The close lands at an arbitrary yield point (client disconnect),
             # so the connection's protocol state is unknowable: this is the
@@ -541,10 +541,10 @@ def _to_sse_chunk(payload: object) -> str:
 
 
 def _log_run_script_stream_error(app: Flask, stream_error: Exception) -> None:
-    """Log a run-script stream error, keeping handled AppExceptions off ERROR.
+    """Log a run-script stream error, keeping handled AppErrors off ERROR.
 
     Unexpected errors are logged at ERROR for operational alerting, while a
-    handled, user-facing AppException is logged at INFO so it stays out of the
+    handled, user-facing AppError is logged at INFO so it stays out of the
     alert stream but remains diagnosable.
     """
     error_traceback = "".join(
@@ -560,8 +560,8 @@ def _log_run_script_stream_error(app: Flask, stream_error: Exception) -> None:
         "traceback": error_traceback,
     }
 
-    if isinstance(stream_error, AppException):
-        # AppException is already a handled, user-facing business error (for example,
+    if isinstance(stream_error, AppError):
+        # AppError is already a handled, user-facing business error (for example,
         # a stale lesson URL after a course republish). Keep it out of ERROR-level
         # operational alerts while preserving enough context for diagnostics.
         app.logger.info("run_script handled app exception")
@@ -969,7 +969,7 @@ def run_script(
                 and isinstance(stream_error, Exception)
             ):
                 _log_run_script_stream_error(app, stream_error)
-                if isinstance(stream_error, AppException):
+                if isinstance(stream_error, AppError):
                     error_content = str(stream_error)
                 elif _is_retryable_llm_stream_connection_error(stream_error):
                     error_content = str(_("server.learn.llmStreamInterrupted"))

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -12,7 +12,7 @@ from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.common.dtos import PageNationDTO
 from flaskr.service.common.models import (
-    AppException,
+    AppError,
     raise_error,
     raise_error_with_args,
     raise_param_error,
@@ -162,7 +162,7 @@ def _mask_contact_identifier(identifier: str) -> str:
     return f"hash:{digest}"
 
 
-def _log_error_code(exc: AppException) -> str:
+def _log_error_code(exc: AppError) -> str:
     """Return a safe error identifier for logs without leaking PII."""
     if getattr(exc, "code", None) is not None:
         return str(exc.code)
@@ -778,7 +778,7 @@ def import_activation_orders(
                 contact_type=contact_type,
             )
             results["success"].append({"mobile": normalized_mobile, **order})
-        except AppException as exc:
+        except AppError as exc:
             if hasattr(app, "logger"):
                 masked_identifier = _mask_contact_identifier(normalized_mobile)
                 app.logger.warning(
@@ -828,7 +828,7 @@ def import_activation_orders_from_entries(
                 allow_empty_nickname=True,
             )
             results["success"].append({"mobile": normalized_mobile, **order})
-        except AppException as exc:
+        except AppError as exc:
             if hasattr(app, "logger"):
                 masked_identifier = _mask_contact_identifier(normalized_mobile)
                 app.logger.warning(

--- a/src/api/flaskr/service/profile/learner_profile_optimizer.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer.py
@@ -11,7 +11,7 @@ from flaskr.api.langfuse import (
 )
 from flaskr.api.llm import invoke_llm
 from flaskr.common.i18n_utils import resolve_markdownflow_output_language
-from flaskr.service.common.models import AppException, raise_error, raise_param_error
+from flaskr.service.common.models import AppError, raise_error, raise_param_error
 from flaskr.service.metering.api import UsageContext
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD
 from flaskr.service.profile.learner_profile import (
@@ -25,13 +25,13 @@ LEARNER_PROFILE_OPTIMIZATION_MAX_TOKENS = 1200
 LEARNER_PROFILE_OPTIMIZATION_GENERATION_NAME = "learner_profile_optimize"
 
 
-class _EmptyOptimizationOutput(ValueError):
+class _EmptyOptimizationOutputError(ValueError):
     pass
 
 
 def _parse_optimized_profile(raw_response: str) -> str:
     if not raw_response.strip():
-        raise _EmptyOptimizationOutput
+        raise _EmptyOptimizationOutputError
     return raw_response
 
 
@@ -52,8 +52,7 @@ def _optimization_runtime_error_reason(exc: Exception) -> str:
     ):
         return "timeout"
     if any(
-        isinstance(item, AppException) and item.code in {8001, 8002, 8003}
-        for item in chain
+        isinstance(item, AppError) and item.code in {8001, 8002, 8003} for item in chain
     ):
         return "not_configured"
     return "failed"
@@ -146,7 +145,7 @@ def optimize_learner_profile(
         )
         raw_response = "".join(chunk.result for chunk in response)
         optimized_profile = _parse_optimized_profile(raw_response)
-    except _EmptyOptimizationOutput:
+    except _EmptyOptimizationOutputError:
         app.logger.warning(
             "Learner profile optimization returned an empty response | "
             "user_id=%s | input_chars=%s | output_chars=%s",

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -42,7 +42,7 @@ class _LocalLease:
     expires_at: float
 
 
-class _AdmissionDenied(Exception):
+class _AdmissionDeniedError(Exception):
     pass
 
 
@@ -84,7 +84,7 @@ def _acquire_redis_admission(*, key: str, token: str) -> _AdmissionLease | None:
         )
     )
     if not acquired:
-        raise _AdmissionDenied
+        raise _AdmissionDeniedError
     return _AdmissionLease(backend="redis", token=token, key=key)
 
 
@@ -93,7 +93,7 @@ def _acquire_local_admission(*, key: str, token: str) -> _AdmissionLease:
     with _local_lock:
         existing = _local_in_flight_state.get(key)
         if existing is not None and existing.expires_at > now:
-            raise _AdmissionDenied
+            raise _AdmissionDeniedError
         _local_in_flight_state[key] = _LocalLease(
             token=token,
             expires_at=now + IN_FLIGHT_TTL_SECONDS,
@@ -108,7 +108,7 @@ def _acquire_admission(app: Flask, *, user_id: str) -> _AdmissionLease:
         lease = _acquire_redis_admission(key=key, token=token)
         if lease is not None:
             return lease
-    except _AdmissionDenied:
+    except _AdmissionDeniedError:
         raise
     except Exception as exc:
         app.logger.warning(
@@ -116,7 +116,7 @@ def _acquire_admission(app: Flask, *, user_id: str) -> _AdmissionLease:
             "denying request | error_type=%s",
             type(exc).__name__,
         )
-        raise _AdmissionDenied from exc
+        raise _AdmissionDeniedError from exc
     return _acquire_local_admission(key=key, token=token)
 
 
@@ -157,7 +157,7 @@ def learner_profile_optimization_admission(
     """Allow only one in-flight optimization for each learner."""
     try:
         lease = _acquire_admission(app, user_id=user_id)
-    except _AdmissionDenied:
+    except _AdmissionDeniedError:
         app.logger.warning("Learner profile optimization already in flight")
         raise_error("server.profile.learnerProfileOptimizationRateLimited")
 

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -190,7 +190,7 @@ def assert_outline_items_publishable(
         outline_items: Draft outline items that would be published
 
     Raises:
-        AppException: server.shifu.outlineStructureBroken when positions collide
+        AppError: server.shifu.outlineStructureBroken when positions collide
 
     """
     positions: dict[str, list[str]] = {}

--- a/src/api/flaskr/service/tts/api.py
+++ b/src/api/flaskr/service/tts/api.py
@@ -18,7 +18,7 @@ from flaskr.service.tts.minimax_voice_clone import (
     submit_minimax_voice_clone,
 )
 from flaskr.service.tts.pipeline import build_av_segmentation_contract
-from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
@@ -36,7 +36,7 @@ def create_streaming_tts_processor(**kwargs):
 
 
 __all__ = [
-    "TTSRpmQueueTimeout",
+    "TTSRpmQueueTimeoutError",
     "append_subtitle_cue",
     "build_av_segmentation_contract",
     "build_minimax_clone_cost",

--- a/src/api/flaskr/service/tts/api.py
+++ b/src/api/flaskr/service/tts/api.py
@@ -27,6 +27,7 @@ from flaskr.service.tts.volcengine_voice_clone import (
     is_valid_volcengine_custom_voice_id,
     verify_volcengine_voice_id,
 )
+from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 def create_streaming_tts_processor(**kwargs):
@@ -57,3 +58,8 @@ __all__ = [
     "supports_cloned_voices",
     "verify_volcengine_voice_id",
 ]
+
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"TTSRpmQueueTimeout": "TTSRpmQueueTimeoutError"}, globals()
+)

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -20,7 +20,7 @@ _FALLBACK_WARNING_LOCK = threading.Lock()
 _FALLBACK_WARNING_KEYS: set[str] = set()
 
 
-class TTSRpmQueueTimeout(TimeoutError):
+class TTSRpmQueueTimeoutError(TimeoutError):
     """Raised when a TTS request cannot enter the RPM queue fast enough."""
 
 
@@ -71,7 +71,7 @@ def acquire_tts_rpm_slot(
             max_wait_seconds=wait_cap,
             now_fn=now_fn,
         )
-    except TTSRpmQueueTimeout:
+    except TTSRpmQueueTimeoutError:
         raise
     except Exception as exc:
         _warn_redis_fallback_once(provider=provider, scope_key=scope_key, exc=exc)
@@ -111,7 +111,7 @@ def _acquire_redis_slot(
     )
     acquired = lock.acquire(blocking=True, blocking_timeout=max_wait_seconds)
     if not acquired:
-        raise TTSRpmQueueTimeout(
+        raise TTSRpmQueueTimeoutError(
             f"TTS RPM queue lock timed out after {max_wait_seconds:.2f}s"
         )
 
@@ -121,7 +121,7 @@ def _acquire_redis_slot(
         next_available_at = _parse_timestamp(raw_next, default=now)
         scheduled_at = max(now, next_available_at)
         if scheduled_at > deadline:
-            raise TTSRpmQueueTimeout(
+            raise TTSRpmQueueTimeoutError(
                 f"TTS RPM queue wait exceeded {max_wait_seconds:.2f}s"
             )
 
@@ -149,7 +149,7 @@ def _acquire_local_slot(
         now = now_fn()
         scheduled_at = max(now, _LOCAL_STATE.get(scope_key, now))
         if scheduled_at > deadline:
-            raise TTSRpmQueueTimeout("TTS RPM local queue wait exceeded limit")
+            raise TTSRpmQueueTimeoutError("TTS RPM local queue wait exceeded limit")
 
         _LOCAL_STATE[scope_key] = scheduled_at + interval
         return TTSRpmGateResult(

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from flaskr.common.log import AppLoggerProxy
+from flaskr.util.deprecation import deprecated_alias_getattr
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
@@ -208,3 +209,8 @@ def _warn_redis_fallback_once(*, provider: str, scope_key: str, exc: Exception) 
         (provider or "default").strip().lower() or "default",
         exc,
     )
+
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"TTSRpmQueueTimeout": "TTSRpmQueueTimeoutError"}, globals()
+)

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -64,7 +64,7 @@ from flaskr.service.tts.pipeline import (
     _find_next_av_boundary,
     build_av_segmentation_contract,
 )
-from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 from flaskr.service.tts.subtitle_utils import (
     append_subtitle_cue,
     normalize_subtitle_cues,
@@ -664,7 +664,7 @@ class StreamingTTSProcessor:
                     f"TTS segment {segment.index} synthesized: "
                     f"text_len={len(segment.text)}, duration={segment.duration_ms}ms"
                 )
-            except TTSRpmQueueTimeout as e:
+            except TTSRpmQueueTimeoutError as e:
                 self._enabled = False
                 logger.warning(
                     "TTS segment %s skipped after RPM queue timeout: %s",

--- a/src/api/flaskr/service/user/exceptions.py
+++ b/src/api/flaskr/service/user/exceptions.py
@@ -1,8 +1,8 @@
 from flaskr.i18n import _
-from flaskr.service.common import ERROR_CODE, AppException
+from flaskr.service.common import ERROR_CODE, AppError
 
 
-class UserNotLoginException(AppException):
+class UserNotLoginError(AppError):
     def __init__(self):
         super().__init__(
             _("server.user.userNotLogin"),

--- a/src/api/flaskr/service/user/exceptions.py
+++ b/src/api/flaskr/service/user/exceptions.py
@@ -1,5 +1,6 @@
 from flaskr.i18n import _
 from flaskr.service.common import ERROR_CODE, AppError
+from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class UserNotLoginError(AppError):
@@ -11,3 +12,8 @@ class UserNotLoginError(AppError):
                 ERROR_CODE["server.common.unknownError"],
             ),
         )
+
+
+__getattr__ = deprecated_alias_getattr(
+    __name__, {"UserNotLoginException": "UserNotLoginError"}, globals()
+)

--- a/src/api/flaskr/util/deprecation.py
+++ b/src/api/flaskr/util/deprecation.py
@@ -1,0 +1,26 @@
+"""Helpers for keeping renamed public names importable during a transition."""
+
+import warnings
+from collections.abc import Callable
+
+
+def deprecated_alias_getattr(
+    module_name: str, aliases: dict[str, str], namespace: dict[str, object]
+) -> Callable[[str], object]:
+    """Build a module ``__getattr__`` that resolves renamed names with a warning.
+
+    ``aliases`` maps a removed name to its current name in ``namespace``.
+    """
+
+    def module_getattr(name: str) -> object:
+        current = aliases.get(name)
+        if current is None:
+            raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+        warnings.warn(
+            f"{module_name}.{name} is deprecated, use {current} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return namespace[current]
+
+    return module_getattr

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -76,7 +76,7 @@ from flaskr.service.billing.subscriptions import (
     repair_topup_grant_expiries,
     sync_subscription_lifecycle_events,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.order.models import PingxxOrder, StripeOrder
 from flaskr.service.order.payment_providers import (
     PaymentCreationResult,
@@ -524,8 +524,8 @@ def billing_write_client(monkeypatch):
         lambda: True,
     )
 
-    @app.errorhandler(AppException)
-    def _handle_app_exception(error: AppException):
+    @app.errorhandler(AppError)
+    def _handle_app_exception(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -69,7 +69,7 @@ from flaskr.service.billing.read_models import (
     build_admin_bill_subscriptions_page,
     build_admin_billing_focus_teachers_page,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.models import UserInfo
 from flaskr.service.user.repository import create_user_entity, upsert_credential
 from tests.common.fixtures.bill_products import build_bill_products
@@ -121,8 +121,8 @@ def admin_billing_client(monkeypatch):
     dao.db.init_app(app)
     load_translations(app)
 
-    @app.errorhandler(AppException)
-    def _handle_app_exception(error: AppException):
+    @app.errorhandler(AppError)
+    def _handle_app_exception(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_billing_admission.py
+++ b/src/api/tests/service/billing/test_billing_admission.py
@@ -27,7 +27,7 @@ from flaskr.service.billing.models import (
     CreditWalletBucket,
 )
 from flaskr.service.billing.subscriptions import repair_subscription_cycle_mismatches
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
@@ -175,7 +175,7 @@ def test_admit_creator_usage_rejects_topup_credits_without_active_subscription(
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-topup-no-sub-1",
@@ -269,7 +269,7 @@ def test_admit_creator_usage_rejects_missing_credits(
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-empty-1",
@@ -335,7 +335,7 @@ def test_admit_creator_usage_rejects_inactive_subscription_only_balance(
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-subscription-1",
@@ -428,7 +428,7 @@ def test_admit_creator_usage_rejects_expired_topup_bucket_even_if_wallet_snapsho
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-expired-topup-1",
@@ -460,7 +460,7 @@ def test_admit_creator_usage_rejects_future_bucket_before_effective_time(
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-future-bucket-1",
@@ -536,7 +536,7 @@ def test_repair_subscription_cycle_mismatches_restores_admission_for_current_buc
         )
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         admit_creator_usage(
             billing_admission_app,
             shifu_bid="shifu-repair-cycle-1",

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -22,7 +22,7 @@ from flaskr.service.billing.domains import (
     verify_domain_binding,
 )
 from flaskr.service.billing.models import BillingDomainBinding, BillingEntitlement
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from tests.service.billing.route_loader import (
     load_billing_routes_module,
     load_register_billing_routes,
@@ -48,8 +48,8 @@ def billing_domain_client(monkeypatch):
 
     dao.db.init_app(app)
 
-    @app.errorhandler(AppException)
-    def _handle_app_exception(error: AppException):
+    @app.errorhandler(AppError)
+    def _handle_app_exception(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -15,7 +15,7 @@ from flaskr.service.billing.manual_credit_grants import (
     grant_manual_credits_to_user,
 )
 from flaskr.service.billing.manual_plan_grants import grant_manual_plan_to_user
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 
 
 class _UnavailableLock:
@@ -37,7 +37,7 @@ def test_subscription_checkout_lock_conflict_returns_busy_error(app, monkeypatch
 
     with (
         app.app_context(),
-        pytest.raises(AppException) as exc_info,
+        pytest.raises(AppError) as exc_info,
         checkout_module._subscription_checkout_lock(app, "creator-busy"),
     ):
         raise AssertionError("lock body should not execute")
@@ -48,7 +48,7 @@ def test_subscription_checkout_lock_conflict_returns_busy_error(app, monkeypatch
 def test_manual_plan_grant_lock_conflict_returns_busy_error(app, monkeypatch):
     monkeypatch.setattr(manual_plan_grants_module.redis, "lock", _LockFactory().lock)
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         grant_manual_plan_to_user(
             app,
             user_bid="creator-busy",
@@ -72,7 +72,7 @@ def test_manual_credit_grant_failure_returns_specific_error(app, monkeypatch):
         ),
     )
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         grant_manual_credits_to_user(
             app,
             user_bid="creator-credit-failed",
@@ -94,7 +94,7 @@ def test_credit_notification_policy_save_failure_returns_specific_error(
         credit_notifications_module, "add_config", lambda *_, **__: False
     )
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         save_credit_notification_policy(
             app,
             {"enabled": False, "types": {}},

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -69,7 +69,7 @@ from flaskr.service.billing.read_models import (
     build_billing_overview,
     build_billing_wallet_buckets,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
@@ -147,8 +147,8 @@ def billing_test_client(monkeypatch):
 
     dao.db.init_app(app)
 
-    @app.errorhandler(AppException)
-    def _handle_app_exception(error: AppException):
+    @app.errorhandler(AppError)
+    def _handle_app_exception(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -30,7 +30,7 @@ from flaskr.service.billing.models import (
     CreditWalletBucket,
 )
 from flaskr.service.billing.trials import bootstrap_new_creator_trial_credits
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.user.consts import USER_STATE_REGISTERED
 from flaskr.service.user.repository import create_user_entity
 from tests.common.fixtures.bill_products import build_bill_products
@@ -72,8 +72,8 @@ def trial_billing_client(monkeypatch):
 
     dao.db.init_app(app)
 
-    @app.errorhandler(AppException)
-    def _handle_app_exception(error: AppException):
+    @app.errorhandler(AppError)
+    def _handle_app_exception(error: AppError):
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -12,7 +12,7 @@ from flaskr.service.billing.entitlements import (
     resolve_creator_entitlement_state,
 )
 from flaskr.service.billing.models import BillingEntitlement
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.user import user as user_service
 from flaskr.util.datetime import now_utc
 from PIL import Image
@@ -257,7 +257,7 @@ def test_expired_custom_payment_never_falls_back_to_platform(app, monkeypatch):
             customization.resolve_payment_integration_for_new_order(
                 app, "creator-expired-1", "stripe"
             )
-        except AppException:
+        except AppError:
             pass
         else:
             raise AssertionError("expired custom payment must block new checkout")
@@ -716,7 +716,7 @@ def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch):
             filename="fake.ico",
             content_type="image/x-icon",
         )
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             customization.upload_creator_brand_logo(
                 app,
                 "creator-favicon-1",
@@ -803,7 +803,7 @@ def test_creator_branding_home_url_roundtrip(app, monkeypatch):
         )
         assert cleared["home_url"] == ""
 
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             customization.save_creator_branding(
                 app,
                 "creator-home-url-1",
@@ -839,7 +839,7 @@ def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(app, monke
                     "creator-logo-invalid",
                     logo,
                 )
-            except AppException:
+            except AppError:
                 pass
             else:
                 raise AssertionError("invalid logo content must be rejected")

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -57,7 +57,7 @@ from flaskr.service.billing.tasks import (
     CreditNotificationRetryableError,
     send_credit_notification_task,
 )
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.config.models import Config
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
 from flaskr.service.user.repository import (
@@ -520,7 +520,7 @@ def test_credit_notification_policy_rejects_invalid_windows(
 ) -> None:
     app = credit_notifications_app
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         save_credit_notification_policy(
             app,
             {
@@ -924,7 +924,7 @@ def test_credit_notification_policy_revalidates_cached_template_with_provider(
         ),
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         save_credit_notification_policy(
             app,
             {
@@ -956,7 +956,7 @@ def test_credit_notification_policy_rejects_unknown_template_variables(
         placeholders=["credits", "bad_variable"],
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         save_credit_notification_policy(
             app,
             {
@@ -1047,7 +1047,7 @@ def test_credit_notification_policy_rejects_invalid_low_balance_thresholds(
 ) -> None:
     app = credit_notifications_app
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         save_credit_notification_policy(
             app,
             {
@@ -2432,5 +2432,5 @@ def test_softlimit_disables_debug_when_policy_threshold_is_reached(
 
     assert state["state"] == "softlimit"
     assert state["debug_allowed"] is False
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         assert_creator_debug_allowed(app, "creator-1")

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -26,7 +26,7 @@ from flaskr.service.billing.models import (
     CreditWallet,
     CreditWalletBucket,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PREVIEW,
     BILL_USAGE_TYPE_TTS,
@@ -285,7 +285,7 @@ def test_reserve_operation_credits_rejects_insufficient_balance(
         _seed_wallet("creator-insufficient", "1.0000000000")
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         reserve_operation_credits(
             operation_credit_app,
             creator_bid="creator-insufficient",
@@ -349,7 +349,7 @@ def test_reserve_operation_credits_freezes_topup_without_active_subscription(
         dao.db.session.add_all([wallet, bucket, subscription])
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         reserve_operation_credits(
             operation_credit_app,
             creator_bid=creator_bid,
@@ -459,7 +459,7 @@ def test_reserve_operation_credits_rejects_topup_after_consumption_window(
         dao.db.session.add_all([wallet, bucket, subscription])
         dao.db.session.commit()
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         reserve_operation_credits(
             operation_credit_app,
             creator_bid=creator_bid,

--- a/src/api/tests/service/common/test_deprecated_exception_aliases.py
+++ b/src/api/tests/service/common/test_deprecated_exception_aliases.py
@@ -1,0 +1,34 @@
+"""Renamed exception classes stay importable under their previous names."""
+
+import importlib
+
+import pytest
+
+ALIASES = [
+    ("flaskr.service.common", "AppException", "AppError"),
+    ("flaskr.service.common.models", "AppException", "AppError"),
+    ("flaskr.service.learn.exceptions", "PaidException", "PaidError"),
+    ("flaskr.service.learn.exceptions", "BreakException", "BreakError"),
+    ("flaskr.service.user.exceptions", "UserNotLoginException", "UserNotLoginError"),
+    ("flaskr.service.tts.rpm_gate", "TTSRpmQueueTimeout", "TTSRpmQueueTimeoutError"),
+    ("flaskr.service.tts.api", "TTSRpmQueueTimeout", "TTSRpmQueueTimeoutError"),
+]
+
+
+@pytest.mark.parametrize(("module_name", "old_name", "new_name"), ALIASES)
+def test_old_exception_name_resolves_to_the_renamed_class(
+    module_name: str, old_name: str, new_name: str
+) -> None:
+    module = importlib.import_module(module_name)
+
+    with pytest.deprecated_call():
+        alias = getattr(module, old_name)
+
+    assert alias is getattr(module, new_name)
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    module = importlib.import_module("flaskr.service.common.models")
+
+    with pytest.raises(AttributeError, match="NoSuchName"):
+        _ = module.NoSuchName

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -6,7 +6,7 @@ Pure in-memory tests — no DB, no Flask app context.
 from __future__ import annotations
 
 import pytest
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.creator_analytics.dsl import (
     ERR_INVALID_AGGREGATE,
     ERR_INVALID_COLUMN,
@@ -36,7 +36,7 @@ def _parse(payload):
 
 
 def _assert_error(payload, error_name: str) -> None:
-    with pytest.raises(AppException) as excinfo:
+    with pytest.raises(AppError) as excinfo:
         _parse(payload)
     # Match by error code so the assertion holds regardless of whether i18n
     # is initialized (the localized message differs by locale).

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -121,7 +121,7 @@ def test_user_cannot_query_a_shifu_they_do_not_own(mock_request_user, test_clien
         },
     )
 
-    # The error envelope is wrapped by AppException → make_common_response.
+    # The error envelope is wrapped by AppError → make_common_response.
     payload = response.get_json(force=True)
     assert payload["code"] == 11001  # server.creatorAnalytics.noPermission
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -108,7 +108,7 @@ from flaskr.service.learn.context_v2 import (
 )
 from flaskr.service.learn.context_v2 import (
     MdflowContextV2,
-    PaidException,
+    PaidError,
     RUNLLMProvider,
     RunScriptContextV2,
     RunScriptPreviewContextV2,
@@ -2385,7 +2385,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         ctx = _make_context()
 
         def _raise_paid(_app):
-            raise PaidException
+            raise PaidError
 
         ctx.run_inner = _raise_paid
         ctx._emit_feedback_after_exception_gate = lambda: iter(["feedback"])

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -1888,7 +1888,7 @@ class TestGeneratedBlockListenTtsElementFirst:
         self, monkeypatch
     ):
         from flaskr.dao import db
-        from flaskr.service.common.models import AppException
+        from flaskr.service.common.models import AppError
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
 
         user_bid = "user-finalize-no-complete-1"
@@ -1953,7 +1953,7 @@ class TestGeneratedBlockListenTtsElementFirst:
             lambda _parts: b"",
         )
 
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             list(
                 stream_generated_block_audio(
                     self.app,

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1799,7 +1799,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app):
 
     from flaskr.dao import db
     from flaskr.service.learn.context_v2 import RunScriptContextV2
-    from flaskr.service.learn.exceptions import PaidException
+    from flaskr.service.learn.exceptions import PaidError
     from flaskr.service.learn.listen_elements import ListenElementRunAdapter
     from flaskr.service.learn.models import (
         LearnGeneratedBlock,
@@ -1845,7 +1845,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app):
         )
 
         def _raise_paid(self, current_app):
-            raise PaidException
+            raise PaidError
             yield  # pragma: no cover
 
         ctx.run_inner = types.MethodType(_raise_paid, ctx)

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask, has_app_context
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.learn import runscript_v2
 from flaskr.service.learn.learn_dtos import (
     ElementDTO,
@@ -596,7 +596,7 @@ def test_log_run_script_stream_error_does_not_error_for_app_exception():
     app.logger.error = lambda *args, **kwargs: error_calls.append(args)
 
     runscript_v2._log_run_script_stream_error(
-        app, AppException("outline unit does not exist", status_code=1001)
+        app, AppError("outline unit does not exist", status_code=1001)
     )
 
     assert error_calls == []
@@ -646,7 +646,7 @@ def test_run_script_inner_rejects_missing_course_without_default(monkeypatch):
         ),
     )
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         list(
             runscript_v2.run_script_inner(
                 app=app,
@@ -1054,7 +1054,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
                 type=GeneratedType.CONTENT,
                 content="hello",
             )
-            raise runscript_v2.BreakException
+            raise runscript_v2.BreakError
 
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -200,7 +200,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(monkeypatc
 
 
 def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
-    from flaskr.service.common.models import AppException
+    from flaskr.service.common.models import AppError
     from flaskr.service.learn import routes
 
     app = Flask(__name__)
@@ -211,7 +211,7 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
     )
 
     def _messages():
-        raise AppException("TTS provider quota exceeded", 45000292)
+        raise AppError("TTS provider quota exceeded", 45000292)
         yield  # pragma: no cover
 
     with app.test_request_context("/api/learn/shifu/s/generated-blocks/g/tts"):
@@ -221,7 +221,7 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
             close_log="closed",
             error_log="synthesize generated block audio failed",
         )
-        with caplog.at_level(logging.WARNING), contextlib.suppress(AppException):
+        with caplog.at_level(logging.WARNING), contextlib.suppress(AppError):
             list(resp.response)
 
     assert (
@@ -262,7 +262,7 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog):
 def test_stream_sse_emits_error_event_for_business_error_with_factory(
     monkeypatch, caplog
 ):
-    from flaskr.service.common.models import AppException
+    from flaskr.service.common.models import AppError
     from flaskr.service.learn import routes
 
     app = Flask(__name__)
@@ -273,7 +273,7 @@ def test_stream_sse_emits_error_event_for_business_error_with_factory(
     )
 
     def _messages():
-        raise AppException("TTS provider quota exceeded", 45000292)
+        raise AppError("TTS provider quota exceeded", 45000292)
         yield  # pragma: no cover
 
     with app.test_request_context("/api/learn/shifu/s/generated-blocks/g/tts"):

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -1,20 +1,20 @@
 import logging
 
 import pytest
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.learn.learn_funcs import _yield_with_tts_error_mapping
-from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeout
+from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 
 
 def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
     def _body():
-        raise TTSRpmQueueTimeout("TTS RPM queue wait exceeded 10.00s")
+        raise TTSRpmQueueTimeoutError("TTS RPM queue wait exceeded 10.00s")
         yield  # pragma: no cover
 
     with (
         app.app_context(),
         caplog.at_level(logging.WARNING),
-        pytest.raises(AppException) as exc_info,
+        pytest.raises(AppError) as exc_info,
     ):
         list(
             _yield_with_tts_error_mapping(
@@ -39,7 +39,7 @@ def test_unexpected_error_still_maps_to_unknown_error(app, caplog):
     with (
         app.app_context(),
         caplog.at_level(logging.ERROR),
-        pytest.raises(AppException) as exc_info,
+        pytest.raises(AppError) as exc_info,
     ):
         list(
             _yield_with_tts_error_mapping(

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.order.admin import (
     import_activation_order,
     normalize_mobile,
@@ -73,7 +73,7 @@ def test_normalize_mobile_handles_valid_edge_cases(input_phone, expected):
 
 @pytest.mark.parametrize("input_phone", ["", None])
 def test_normalize_mobile_rejects_empty_values(input_phone):
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         normalize_mobile(input_phone)
 
 

--- a/src/api/tests/service/order/test_payment_channel_resolution.py
+++ b/src/api/tests/service/order/test_payment_channel_resolution.py
@@ -1,5 +1,5 @@
 import pytest
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.order.funs import _resolve_payment_channel
 
 
@@ -14,7 +14,7 @@ class TestResolvePaymentChannel:
         assert sub_channel == "wx_pub_qr"
 
     def test_pingxx_channel_missing_sub_channel_raises(self):
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             _resolve_payment_channel(
                 payment_channel_hint=None,
                 channel_hint="",
@@ -79,7 +79,7 @@ class TestResolvePaymentChannel:
             fake_get_config,
         )
 
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             _resolve_payment_channel(
                 payment_channel_hint="pingxx",
                 channel_hint="wx_pub_qr",
@@ -183,7 +183,7 @@ class TestResolvePaymentChannel:
             fake_get_config,
         )
 
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             _resolve_payment_channel(
                 payment_channel_hint="alipay",
                 channel_hint="wx_pub_qr",

--- a/src/api/tests/service/promo/test_promo_error_specificity.py
+++ b/src/api/tests/service/promo/test_promo_error_specificity.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import flaskr.service.promo.admin as promo_admin
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.promo.consts import COUPON_STATUS_ACTIVE, COUPON_TYPE_FIXED
 from flaskr.service.promo.models import Coupon, CouponUsage
 
@@ -45,7 +45,7 @@ def test_generate_unique_coupon_code_failure_returns_specific_error(app, monkeyp
         )
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             promo_admin._generate_unique_coupon_code()
 
     assert (
@@ -78,7 +78,7 @@ def test_generate_unique_coupon_codes_failure_returns_specific_error(app, monkey
         )
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             promo_admin._generate_unique_coupon_codes(1)
 
     assert (

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -7,7 +7,7 @@ import pytest
 from flaskr.dao import db
 from flaskr.service.billing.consts import BILLING_PRODUCT_TYPE_PLAN
 from flaskr.service.billing.models import BillingProduct
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.referral.admin import (
     list_operator_referral_campaign_invitations,
     list_operator_referrals,
@@ -555,7 +555,7 @@ def test_operator_referral_filters_accept_user_identifier(referral_app):
 def test_operator_referral_campaign_rejects_invalid_payload(referral_app, payload):
     with referral_app.app_context():
         _seed_plan_product()
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             create_operator_referral_campaign(
                 referral_app,
                 operator_user_bid="operator-1",
@@ -580,7 +580,7 @@ def test_operator_referral_campaign_rejects_enabling_ended_campaign(referral_app
             ),
         )
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             update_operator_referral_campaign_status(
                 referral_app,
                 operator_user_bid="operator-1",
@@ -601,7 +601,7 @@ def test_operator_referral_campaign_duplicate_code_is_rejected(referral_app):
             operator_user_bid="operator-1",
             payload=_payload(),
         )
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             create_operator_referral_campaign(
                 referral_app,
                 operator_user_bid="operator-1",

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -17,7 +17,7 @@ from flaskr.service.billing.consts import (
 )
 from flaskr.service.billing.models import CreditUsageRate
 from flaskr.service.common import credit_rate_references
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
     BILL_USAGE_TYPE_LLM,
@@ -448,7 +448,7 @@ def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app):
         db.session.query(CreditUsageRate).delete()
         _seed_default_llm_rates()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             config_rates.update_operator_rate_config(
                 app,
                 payload={
@@ -803,7 +803,7 @@ def test_create_only_rejects_duplicate_active_exact_identity(monkeypatch, app):
         )
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             config_rates.update_operator_rate_config(
                 app,
                 payload={
@@ -878,7 +878,7 @@ def test_create_only_rejects_invalid_identity_and_fixed_fields(
     }
     payload.update(overrides)
 
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         config_rates.update_operator_rate_config(
             app,
             payload=payload,

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -19,7 +19,7 @@ from flaskr.service.billing.consts import (
     CREDIT_USAGE_RATE_STATUS_ACTIVE,
 )
 from flaskr.service.billing.models import CreditLedgerEntry, CreditUsageRate
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.learn.const import (
     LEARN_STATUS_COMPLETED,
     LEARN_STATUS_IN_PROGRESS,
@@ -1768,7 +1768,7 @@ def test_admin_operation_course_chapter_detail_route_rejects_missing_outline_ite
 
 
 def test_get_operator_course_detail_rejects_blank_shifu_bid_with_params_error(app):
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         get_operator_course_detail(app, shifu_bid="   ")
 
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
@@ -1777,7 +1777,7 @@ def test_get_operator_course_detail_rejects_blank_shifu_bid_with_params_error(ap
 def test_get_operator_course_chapter_detail_rejects_blank_params_with_params_error(
     app,
 ):
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         get_operator_course_chapter_detail(
             app,
             shifu_bid="   ",

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from flask import Flask
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.learn.const import LEARN_STATUS_COMPLETED
 from flaskr.service.learn.models import LearnProgressRecord
 from flaskr.service.order.consts import ORDER_STATUS_INIT, ORDER_STATUS_SUCCESS
@@ -817,7 +817,7 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
         ) as overview_mock,
         patch("flaskr.service.shifu.admin._load_latest_shifu_seeds") as latest_mock,
     ):
-        with pytest.raises(AppException) as excinfo:
+        with pytest.raises(AppError) as excinfo:
             list_operator_courses(app, 1, 20, {"quick_filter": "invalid"})
         assert excinfo.value.code is not None
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -37,7 +37,7 @@ from flaskr.service.billing.models import (
     CreditWallet,
     CreditWalletBucket,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.learn.models import (
     LearnGeneratedBlock,
     LearnGeneratedElement,
@@ -2485,7 +2485,7 @@ def test_get_operator_user_credit_usage_detail_uses_ledger_owner_not_usage_user(
             user_bid="usage-detail-wallet-owner",
             usage_bid="usage-detail-owner-check",
         )
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             get_operator_user_credit_usage_detail(
                 app,
                 user_bid="usage-detail-other-owner",
@@ -3170,7 +3170,7 @@ def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app):
             providers=[("email", "referral-reward-invalid-amount@example.com")],
         )
 
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             grant_operator_user_credits(
                 app,
                 user_bid="referral-reward-invalid-amount",
@@ -3231,7 +3231,7 @@ def test_grant_operator_user_credits_rejects_unknown_grant_type(app):
             providers=[("email", "credits-grant-unknown-type@example.com")],
         )
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             grant_operator_user_credits(
                 app,
                 user_bid="credits-grant-unknown-type",
@@ -3323,7 +3323,7 @@ def test_grant_operator_user_credits_rejects_regular_user_targets(app):
             providers=[("email", "credits-grant-regular@example.com")],
         )
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             grant_operator_user_credits(
                 app,
                 user_bid="credits-grant-regular",
@@ -3612,7 +3612,7 @@ def test_grant_operator_user_package_rejects_active_stripe_subscription(app):
             current_period_end_at=now_utc() + timedelta(days=29),
         )
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             grant_operator_user_package(
                 app,
                 user_bid="package-grant-stripe-conflict",

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 from flaskr import dao
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 
 
 def _get_models():
@@ -360,7 +360,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
     )
 
     def fail_default_outlines(*_args, **_kwargs):
-        raise AppException("outline init failed")
+        raise AppError("outline init failed")
 
     monkeypatch.setattr(
         draft_module,
@@ -368,7 +368,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
         fail_default_outlines,
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         draft_module.create_shifu_draft(
             app,
             user_id=owner_bid,
@@ -388,7 +388,7 @@ def test_archive_requires_creator_permission(app):
     _seed_shifu(app, shifu_bid, creator)
     archive_shifu, _ = _get_archive_funcs()
 
-    with pytest.raises(AppException) as excinfo:
+    with pytest.raises(AppError) as excinfo:
         archive_shifu(app, "intruder", shifu_bid)
 
     assert "permission" in excinfo.value.message.lower()

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -11,7 +11,7 @@ import pytest
 from flaskr.common import config as config_module
 from flaskr.dao import db
 from flaskr.i18n import _
-from flaskr.service.common.models import ERROR_CODE, AppException, raise_error
+from flaskr.service.common.models import ERROR_CODE, AppError, raise_error
 from flaskr.service.profile.models import Variable
 from flaskr.service.shifu.admin import copy_operator_course
 from flaskr.service.shifu.models import AiCourseAuth, DraftOutlineItem, DraftShifu
@@ -565,7 +565,7 @@ def test_copy_course_rejects_builtin_demo_course(app):
         db.session.add(demo_draft)
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             copy_operator_course(
                 app,
                 shifu_bid=shifu_bid,
@@ -594,7 +594,7 @@ def test_copy_course_requires_operator_user_bid(app):
         )
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             copy_operator_course(
                 app,
                 shifu_bid=shifu_bid,
@@ -744,7 +744,7 @@ def test_copy_course_risk_rejection_does_not_create_target_user(app, monkeypatch
         _reject_risk,
     )
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         copy_operator_course(
             app,
             shifu_bid=shifu_bid,

--- a/src/api/tests/service/shifu/test_create_outlines_batch.py
+++ b/src/api/tests/service/shifu/test_create_outlines_batch.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.shifu import shifu_outline_funcs
 from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 from flaskr.service.shifu.shifu_outline_funcs import (
@@ -177,6 +177,6 @@ def test_batch_rejects_empty_payload(app):
     shifu_bid = "shifu_batch_empty"
     with app.app_context():
         _seed_shifu(shifu_bid)
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             create_outlines_batch(app, "creator-1", shifu_bid, [])
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]

--- a/src/api/tests/service/shifu/test_reorder_outline_conversion.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_conversion.py
@@ -1,5 +1,5 @@
 import pytest
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.shifu.shifu_outline_funcs import (
     convert_outline_to_reorder_outline_item_dto,
 )
@@ -36,11 +36,11 @@ def test_convert_accepts_empty_list():
 
 @pytest.mark.parametrize("bad_value", [None, {}, "outlines", 42])
 def test_convert_rejects_non_list_top_level(bad_value):
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         convert_outline_to_reorder_outline_item_dto(bad_value)
 
 
 @pytest.mark.parametrize("bad_item", ["not-a-dict", 1, ["nested"], None])
 def test_convert_rejects_non_dict_items(bad_item):
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         convert_outline_to_reorder_outline_item_dto([bad_item])

--- a/src/api/tests/service/shifu/test_shifu_outline_tree.py
+++ b/src/api/tests/service/shifu/test_shifu_outline_tree.py
@@ -9,7 +9,7 @@ blocked with a clear error instead of shipping a broken course.
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.shifu.models import DraftOutlineItem
 from flaskr.service.shifu.shifu_outline_funcs import (
     assert_outline_tree_publishable,
@@ -102,7 +102,7 @@ def test_assert_publishable_raises_on_position_collision(app):
         _mk_item(shifu_bid, "b", "0101", parent_bid="root1")  # collision
         db.session.commit()
 
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             assert_outline_tree_publishable(app, shifu_bid)
         # 4010 == server.shifu.outlineStructureBroken (see error_codes.json)
         assert exc_info.value.code == 4010

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 from flaskr.service.shifu.tts_preview import build_tts_preview_response
 
@@ -243,7 +243,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
                 "owner_user_bid": owner_user_bid,
             }
         )
-        raise AppException("voice unavailable", ERROR_CODE["server.common.paramsError"])
+        raise AppError("voice unavailable", ERROR_CODE["server.common.paramsError"])
 
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.assert_preview_cloned_voice_available",
@@ -253,7 +253,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
 
     with (
         app.test_request_context("/api/shifu/tts/preview", method="POST"),
-        pytest.raises(AppException) as exc_info,
+        pytest.raises(AppError) as exc_info,
     ):
         build_tts_preview_response(
             {

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_FAILED,
     TTS_MINIMAX_CLONE_STATUS_READY,
@@ -96,7 +96,7 @@ def test_ready_clone_owned_by_another_user_is_rejected(app):
         owner="other-creator",
         status=TTS_MINIMAX_CLONE_STATUS_READY,
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",
@@ -132,7 +132,7 @@ def test_isolation_when_same_voice_id_has_different_owners(app):
             owner_user_bid="creator-1",
         )
         # creator-3 owns none -> rejected even though the id exists for others.
-        with pytest.raises(AppException) as exc_info:
+        with pytest.raises(AppError) as exc_info:
             assert_preview_cloned_voice_available(
                 app,
                 provider="minimax",
@@ -151,7 +151,7 @@ def test_custom_voice_with_empty_owner_is_rejected(app):
         owner="creator-1",
         status=TTS_MINIMAX_CLONE_STATUS_READY,
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",
@@ -169,7 +169,7 @@ def test_failed_clone_is_rejected(app):
         owner="creator-1",
         status=TTS_MINIMAX_CLONE_STATUS_FAILED,
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",
@@ -191,7 +191,7 @@ def test_deleted_clone_is_rejected(app):
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         deleted=1,
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",
@@ -203,7 +203,7 @@ def test_deleted_clone_is_rejected(app):
 
 def test_unknown_custom_voice_is_rejected(app):
     _prepare_tables(app)
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",
@@ -215,7 +215,7 @@ def test_unknown_custom_voice_is_rejected(app):
 
 def test_empty_voice_id_is_rejected(app):
     _prepare_tables(app)
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app, provider="minimax", voice_id="   ", owner_user_bid="creator-1"
         )
@@ -249,7 +249,7 @@ def test_volcengine_ready_clone_of_another_owner_is_rejected(app):
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         provider="volcengine",
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="volcengine",
@@ -269,7 +269,7 @@ def test_volcengine_clone_row_does_not_leak_to_minimax_provider(app):
         status=TTS_MINIMAX_CLONE_STATUS_READY,
         provider="volcengine",
     )
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
             app,
             provider="minimax",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -19,7 +19,7 @@ from flaskr.service.billing.models import (
     CreditWallet,
     CreditWalletBucket,
 )
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW, BILL_USAGE_TYPE_TTS
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu
@@ -129,7 +129,7 @@ def test_validate_minimax_custom_voice_id_rules() -> None:
 
     assert settings.voice_id == "AiShifu_voice_123"
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         validate_tts_settings_strict(
             provider="baidu",
             model="",

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -5,7 +5,7 @@ import json
 import re
 
 import pytest
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 
 
 class _FakeSSEStreamingResponse:
@@ -171,7 +171,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     assert validated.provider == "tencent"
     assert validated.model == ""
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         validate_tts_settings_strict(
             provider="tencent",
             model="",

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -287,7 +287,7 @@ def test_synthesize_rejects_non_numeric_voice_id(monkeypatch):
 
 
 def test_validation_requires_model_and_tier_consistency():
-    from flaskr.service.common.models import AppException
+    from flaskr.service.common.models import AppError
     from flaskr.service.tts.validation import validate_tts_settings_strict
 
     # Valid: premium voice with premium tier.
@@ -313,7 +313,7 @@ def test_validation_requires_model_and_tier_consistency():
     assert settings.model == "large-model"
 
     # Missing model is rejected (provider requires model).
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         validate_tts_settings_strict(
             provider="tencent_texttovoice",
             model="",
@@ -324,7 +324,7 @@ def test_validation_requires_model_and_tier_consistency():
         )
 
     # Cross-tier combination is rejected (premium voice + large-model tier).
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         validate_tts_settings_strict(
             provider="tencent_texttovoice",
             model="large-model",
@@ -335,7 +335,7 @@ def test_validation_requires_model_and_tier_consistency():
         )
 
     # Emotion is not supported.
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         validate_tts_settings_strict(
             provider="tencent_texttovoice",
             model="premium",

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -178,7 +178,7 @@ def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch):
         sleep_fn=sleep_fn,
     )
 
-    with pytest.raises(rpm_gate.TTSRpmQueueTimeout):
+    with pytest.raises(rpm_gate.TTSRpmQueueTimeoutError):
         rpm_gate.acquire_tts_rpm_slot(
             provider="minimax",
             api_key="api-key-a",

--- a/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
+++ b/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.tts.models import (
     TTS_MINIMAX_CLONE_STATUS_READY,
     TTSMiniMaxClonedVoice,
@@ -94,21 +94,21 @@ def test_volcengine_registered_clone_keeps_teacher_selected_model(app):
 def test_volcengine_clone_with_unlisted_model_is_rejected(app):
     _prepare_tables(app)
     _seed_ready_clone(app, provider="volcengine", voice_id="S_xxxxxxxxxx")
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         _validate("volcengine", "seed-tts-9.9", "S_xxxxxxxxxx")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
 def test_volcengine_unregistered_clone_is_rejected(app):
     _prepare_tables(app)
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         _validate("volcengine", "seed-tts-2.0", "S_xxxxxxxxxxxx")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
 def test_volcengine_bad_shape_custom_voice_is_rejected(app):
     _prepare_tables(app)
-    with app.app_context(), pytest.raises(AppException) as exc_info:
+    with app.app_context(), pytest.raises(AppError) as exc_info:
         _validate("volcengine", "seed-tts-2.0", "AiShifu_not_a_speaker")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.tts import volcengine_voice_clone
 from flaskr.service.tts.volcengine_voice_clone import (
     VOLCENGINE_ICL_RESOURCE_ID,
@@ -82,13 +82,13 @@ def test_query_status_raises_on_base_resp_error(monkeypatch) -> None:
             {"BaseResp": {"StatusCode": 1001, "StatusMessage": "bad request"}}
         ),
     )
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
 def test_query_status_raises_without_credentials(monkeypatch) -> None:
     _patch_config(monkeypatch, config={})
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
@@ -104,7 +104,7 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
         raise requests_lib.exceptions.ConnectTimeout("connect timeout")
 
     monkeypatch.setattr(volcengine_voice_clone.requests, "post", _raise_transport_error)
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
@@ -123,7 +123,7 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
         "post",
         lambda *args, **kwargs: _BadJsonResponse(),
     )
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxx")
 
 
@@ -139,7 +139,7 @@ def test_query_status_converts_http_error_to_param_error(monkeypatch) -> None:
             {"message": "parameter license not found for appid"}, status_code=403
         ),
     )
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxxx")
 
 
@@ -166,7 +166,7 @@ def test_verify_rejects_not_ready_statuses(monkeypatch, status) -> None:
             {"BaseResp": {"StatusCode": 0}, "status": status}
         ),
     )
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         verify_volcengine_voice_id("S_xxxxxxxxxx")
 
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -8,7 +8,7 @@ import pytest
 from flaskr.api.check import CHECK_RESULT_UNKNOWN
 from flaskr.dao import db
 from flaskr.service.check_risk.models import RiskControlResult
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD
 from flaskr.service.profile import learner_profile_optimizer as optimizer
 from flaskr.service.user.models import UserInfo, UserOnboardingState
@@ -319,7 +319,7 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     with app.app_context():
         _create_profile_state(user_bid)
         before = _snapshot_profile_state(user_bid)
-        with pytest.raises(AppException) as raised:
+        with pytest.raises(AppError) as raised:
             optimizer.optimize_learner_profile(
                 app,
                 user_id=user_bid,
@@ -393,7 +393,7 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     with app.app_context():
         _create_profile_state(user_bid)
         before = _snapshot_profile_state(user_bid)
-        with pytest.raises(AppException) as raised:
+        with pytest.raises(AppError) as raised:
             optimizer.optimize_learner_profile(
                 app,
                 user_id=user_bid,
@@ -428,7 +428,7 @@ def test_optimize_rejects_empty_model_output_without_changing_state(
     with app.app_context():
         _create_profile_state(user_bid)
         before = _snapshot_profile_state(user_bid)
-        with pytest.raises(AppException) as raised:
+        with pytest.raises(AppError) as raised:
             optimizer.optimize_learner_profile(
                 app,
                 user_id=user_bid,
@@ -458,7 +458,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatc
     with app.app_context():
         _create_profile_state(user_bid)
         before = _snapshot_profile_state(user_bid)
-        with pytest.raises(AppException) as raised:
+        with pytest.raises(AppError) as raised:
             optimizer.optimize_learner_profile(
                 app,
                 user_id=user_bid,
@@ -481,12 +481,12 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
         try:
             raise TimeoutError("provider timeout")
         except TimeoutError as exc:
-            raise AppException("wrapped provider failure", 9999) from exc
+            raise AppError("wrapped provider failure", 9999) from exc
         yield  # pragma: no cover
 
     monkeypatch.setattr(optimizer, "invoke_llm", timeout_invoke)
 
-    with app.app_context(), pytest.raises(AppException) as raised:
+    with app.app_context(), pytest.raises(AppError) as raised:
         optimizer.optimize_learner_profile(
             app,
             user_id=user_bid,
@@ -502,7 +502,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
     [
         (RuntimeError("provider unavailable"), 1021, "encountered an error"),
         (
-            AppException("model route unavailable", 8002),
+            AppError("model route unavailable", 8002),
             1024,
             "No profile optimization model is configured",
         ),
@@ -525,7 +525,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
     with app.app_context():
         _create_profile_state(user_bid)
         before = _snapshot_profile_state(user_bid)
-        with pytest.raises(AppException) as raised:
+        with pytest.raises(AppError) as raised:
             optimizer.optimize_learner_profile(
                 app,
                 user_id=user_bid,
@@ -555,7 +555,7 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
     monkeypatch.setattr(optimizer, "check_text_content", failed_moderation)
     monkeypatch.setattr(optimizer, "invoke_llm", unexpected_invoke)
 
-    with app.app_context(), pytest.raises(AppException) as raised:
+    with app.app_context(), pytest.raises(AppError) as raised:
         optimizer.optimize_learner_profile(
             app,
             user_id="profile-optimize-moderation-error",
@@ -580,7 +580,7 @@ def test_optimize_rejects_invalid_input_before_moderation(
 
     monkeypatch.setattr(optimizer, "check_text_content", unexpected_moderation)
 
-    with app.app_context(), pytest.raises(AppException) as raised:
+    with app.app_context(), pytest.raises(AppError) as raised:
         optimizer.optimize_learner_profile(
             app,
             user_id="profile-optimize-invalid-input",

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.profile import learner_profile_optimizer_admission as admission
 
 
@@ -47,7 +47,7 @@ def reset_local_admission_state():
 
 def _assert_admission_denied(app, *, user_id: str) -> None:
     with (
-        pytest.raises(AppException) as raised,
+        pytest.raises(AppError) as raised,
         admission.learner_profile_optimization_admission(
             app,
             user_id=user_id,

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -10,7 +10,7 @@ from flaskr.api.check.dto import (
     CHECK_RESULT_UNKNOWN,
 )
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.profile.models import VariableValue
 from flaskr.service.user.models import UserInfo, UserOnboardingState
 from flaskr.service.user.repository import (
@@ -444,7 +444,7 @@ def test_replace_rejects_invalid_profile_without_overwriting(app, monkeypatch, v
     user_bid = f"profile-invalid-{type(value).__name__}-{len(str(value))}"
     with app.app_context():
         _create_user(user_bid, learner_profile="existing profile")
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             replace_learner_profile(
                 app,
                 user_id=user_bid,
@@ -561,7 +561,7 @@ def test_replace_rejects_invalid_nickname_without_overwriting(
     with app.app_context():
         user_bid = f"profile-invalid-nickname-{type(nickname).__name__}"
         _create_user(user_bid, learner_profile="existing profile")
-        with pytest.raises(AppException):
+        with pytest.raises(AppError):
             replace_learner_profile(
                 app,
                 user_id=user_bid,
@@ -586,7 +586,7 @@ def test_safety_rejection_preserves_existing_profile(app, monkeypatch):
     )
     with app.app_context():
         _create_user("profile-safety-reject", learner_profile="existing profile")
-        with pytest.raises(AppException) as caught_error:
+        with pytest.raises(AppError) as caught_error:
             replace_learner_profile(
                 app,
                 user_id="profile-safety-reject",
@@ -667,7 +667,7 @@ def test_profile_moderation_rejects_only_explicit_reject(app, monkeypatch):
     with app.app_context():
         user_bid = "profile-moderation-reject"
         _create_user(user_bid, learner_profile="existing profile")
-        with pytest.raises(AppException) as caught_error:
+        with pytest.raises(AppError) as caught_error:
             replace_learner_profile(
                 app,
                 user_id=user_bid,
@@ -704,7 +704,7 @@ def test_nickname_rejection_rolls_back_profile_nickname_and_state(app, monkeypat
     with app.app_context():
         user_bid = "profile-nickname-reject"
         _create_user(user_bid, learner_profile="existing profile")
-        with pytest.raises(AppException) as caught_error:
+        with pytest.raises(AppError) as caught_error:
             replace_learner_profile(
                 app,
                 user_id=user_bid,

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.profile.models import VariableValue
 from flaskr.service.user.repository import create_user_entity
 
@@ -72,7 +72,7 @@ def test_profile_onboarding_config_rejects_non_whitelisted_variable(app):
         update_profile_onboarding_config,
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         update_profile_onboarding_config(
             app,
             payload={

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -1,7 +1,7 @@
 import jwt
 import pytest
 from flask import Flask
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.common import validate_user
 
 
@@ -17,7 +17,7 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(monkeypatc
 
     monkeypatch.setattr(jwt, "decode", _raise_invalid_algorithm)
 
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         validate_user(app, "invalid-token")
 
     assert exc_info.value.code == ERROR_CODE["server.user.userNotFound"]

--- a/src/api/tests/service/user/test_verification_code_errors.py
+++ b/src/api/tests/service/user/test_verification_code_errors.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import pytest
-from flaskr.service.common.models import ERROR_CODE, AppException
+from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.verification_codes import consume_verification_code
 
 
 def test_consume_verification_code_rejects_missing_identifier_as_param_error(app):
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="", code="1234")
 
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
@@ -14,7 +14,7 @@ def test_consume_verification_code_rejects_missing_identifier_as_param_error(app
 
 
 def test_consume_verification_code_rejects_missing_code_as_param_error(app):
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="user@example.com", code="")
 
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
@@ -22,7 +22,7 @@ def test_consume_verification_code_rejects_missing_code_as_param_error(app):
 
 
 def test_consume_verification_code_rejects_empty_normalized_phone_as_param_error(app):
-    with pytest.raises(AppException) as exc_info:
+    with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="+86", code="1234")
 
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.order.coupon_funcs import use_coupon_code
 from flaskr.service.order.models import Order
 from flaskr.service.promo.consts import (
@@ -286,5 +286,5 @@ def test_use_coupon_code_rejects_coupon_not_yet_started_in_utc(app, monkeypatch)
         lambda *_args: None,
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         use_coupon_code(app, user_bid, coupon_code, order_bid)

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 from flaskr.dao import db
-from flaskr.service.common.models import AppException
+from flaskr.service.common.models import AppError
 from flaskr.service.shifu.models import DraftOutlineItem
 from flaskr.service.shifu.shifu_history_manager import (
     get_shifu_draft_meta,
@@ -156,7 +156,7 @@ def test_get_shifu_mdflow_history_version_detail_returns_content_and_user(app):
 
 
 def test_get_shifu_mdflow_history_version_detail_raises_not_found(app):
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         get_shifu_mdflow_history_version_detail(
             app,
             "shifu-mdflow-history-detail-2",
@@ -175,7 +175,7 @@ def test_save_shifu_mdflow_rejects_outline_from_other_shifu(app):
         0,
     )
 
-    with pytest.raises(AppException):
+    with pytest.raises(AppError):
         save_shifu_mdflow(
             app,
             "user-attacker",

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -6,14 +6,14 @@ from flaskr.dao import retry_on_deadlock
 from sqlalchemy.exc import OperationalError
 
 
-class _FakeOrig(Exception):
+class _FakeOrigError(Exception):
     def __init__(self, errno, message):
         super().__init__(errno, message)
         self.args = (errno, message)
 
 
 def _operational_error(errno):
-    return OperationalError("SELECT 1", {}, _FakeOrig(errno, "boom"))
+    return OperationalError("SELECT 1", {}, _FakeOrigError(errno, "boom"))
 
 
 def test_retries_deadlock_then_succeeds():


### PR DESCRIPTION
# Summary

Enables ruff `N818` and renames every exception class that did not end in `Error`:

- `AppException` → `AppError` (the backend error base, ~205 references across 58 files) and, once the base was renamed, its three subclasses: `PaidException` → `PaidError`, `BreakException` → `BreakError`, `UserNotLoginException` → `UserNotLoginError`.
- `TTSRpmQueueTimeout` → `TTSRpmQueueTimeoutError` (also in `flaskr/service/tts/api.py`'s `__all__`).
- Private/local ones: `_EmptyOptimizationOutput`, `_AdmissionDenied`, `_FakeOrigError`.

One non-rename: `flaskr/service/learn/check_text.py` defined a second `class BreakException(Exception)` that nothing imports — a dead duplicate shadowing the real `learn.exceptions.BreakException` by name. It is removed rather than renamed.

Pure rename otherwise, so no new tests: the existing suite references these names throughout and would fail on a missed site. `grep` over all tracked files shows no remaining references and no string/JSON/frontend references to the old names (only completed exec-plan docs, left as historical record).

Stacked on #2532 (ANN206).

Verified: `ruff check .` / `ruff format --check .` clean, full backend suite `2888 passed, 15 skipped` with the 5 pre-existing `test_admin_course_detail` failures that also fail on `main` (SQLite has no `concat`).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical identifier renames with no API contract or error-code changes; behavior should match the prior names if every reference was updated (verified by grep and existing tests).
> 
> **Overview**
> Turns on ruff **N818** and renames exception classes so names end with **`Error`**, without changing error codes or handler behavior.
> 
> The main rename is **`AppException` → `AppError`**, including Flask **`@app.errorhandler`**, **`raise_error` / `raise_param_error`**, and broad **`except`** / **`pytest.raises`** updates in services and tests. Learn-flow types become **`PaidError`**, **`BreakError`**, and **`UserNotLoginError`**; TTS backpressure is **`TTSRpmQueueTimeoutError`** (public **`__all__`** updated). Smaller private types (**`_EmptyOptimizationOutputError`**, **`_AdmissionDeniedError`**, test **`_FakeOrigError`**) follow the same rule.
> 
> **`check_text.py`** drops an unused local **`BreakException`** that duplicated **`learn.exceptions`** and was never imported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f131cac95519edc3dc7e223bb0cfae55f38f8b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->