### PR TITLE
test: enforce ruff S107 (no hardcoded credential defaults)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -127,6 +127,7 @@ select = [
     # per-file-ignores below.
     "S101",    # assert used outside tests
     "S104",    # binding a socket to all interfaces
+    "S107",    # hardcoded password as a function default
     "S108",    # hardcoded /tmp path instead of tempfile.gettempdir()
     "S113",    # requests call without a timeout
     "S310",    # urlopen without an audited URL scheme

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -4,6 +4,8 @@ from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.learn.ask_provider_adapters import AskProviderError
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 
+_PREVIEW_TOKEN = "preview-token"  # noqa: S105 - stub session token, `validate_user` is mocked
+
 
 class _FakeObservation:
     """Mimics a Langfuse SDK v3 span/generation object."""
@@ -87,7 +89,7 @@ def _mock_authenticated_user(
     return user
 
 
-def _auth_headers(token: str = "preview-token") -> dict[str, str]:
+def _auth_headers(token: str = _PREVIEW_TOKEN) -> dict[str, str]:
     return {"Token": token}
 
 


### PR DESCRIPTION
# Summary

Enables `S107` (hardcoded password as a function default). The repo had exactly one hit: `_auth_headers(token: str = "preview-token")` in the ask-preview route test. The literal moves to a module constant carrying an explicit marker that it is a stub (`validate_user` is monkeypatched in these tests), which keeps the intent visible instead of hiding it behind a bare `noqa` on the signature.

Stacked on #2533 (N818).

Verified: `ruff check .` / `ruff format --check .` clean, `tests/service/shifu/test_ask_preview_route.py` 10 passed.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and test-only changes with no production behavior impact.
> 
> **Overview**
> **Enables Ruff `S107`** in `ruff.toml`, banning hardcoded passwords in function default arguments repo-wide.
> 
> The only violation was in **`test_ask_preview_route.py`**: the default auth token on `_auth_headers` is moved to a module-level `_PREVIEW_TOKEN` with an explicit **`noqa: S105`** comment documenting that it is a stub token because `validate_user` is monkeypatched in these tests. `_auth_headers` now defaults to that constant instead of an inline string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ead1121febdb21e08c88c74935f399c42a46d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->