### PR TITLE
chore: drop a stale S603 noqa in the app entrypoint

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -14,7 +14,7 @@ from flaskr.framework.plugin.plugin_manager import enable_plugin_manager
 # fix windows platform
 if os.name == "nt":
     # tzutil ships with Windows and is resolved from PATH.
-    subprocess.run(["tzutil", "/s", "UTC"], check=False)  # noqa: S603, S607
+    subprocess.run(["tzutil", "/s", "UTC"], check=False)  # noqa: S607
 else:
     # Load environment variables first so we can use get_config
     if not os.getenv("SKIP_LOAD_DOTENV"):


### PR DESCRIPTION
# Summary

RUF100 with the repo's rule set reports 34 directives, but 33 of them are `# noqa: BLE001 / SLF001 / DTZ001 / S102` markers that only look unused because those rules are deliberately off — enabling RUF100 would delete documentation of intentional exceptions, which is why `ruff.toml` keeps it ignored and prunes stale directives by hand.

This is the one genuinely dead directive: `S603` on the Windows `tzutil` call in `src/api/app.py`. The rule is enabled and no longer fires there (static argument list), so only `S607` (partial executable path, resolved from PATH) remains.

Stacked on #2534 (S107). Verified with `ruff check --extend-select RUF100 .`: no `unused:` findings remain.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or security behavior impact.
> 
> **Overview**
> Removes the unused `# noqa: S603` on the Windows `subprocess.run(["tzutil", "/s", "UTC"], ...)` path in `app.py`, leaving only `# noqa: S607` for the partial executable path resolved from PATH.
> 
> No behavior change—this is lint-hygiene so RUF100 / manual cleanup does not flag a dead directive while `S603` no longer applies to that static command list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12327068ca2aa06ec994affd216d8503627fbade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->