### PR TITLE
chore: preserve runtime dependency layers

### DIFF
--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -23,7 +23,7 @@ that branch.
   default GitHub Actions cache scope and import the same cache manifest.
 - [x] 2026-08-20 12:15 CST: Gave the API and Cook Web image builds independent
   cache scopes.
-- [ ] 2026-08-20 12:20 CST: Reorder the Cook Web development image so dependency
+- [x] 2026-08-20 12:20 CST: Reordered the Cook Web development image so dependency
   installation precedes source copying.
 - [ ] 2026-08-20 12:25 CST: Make each Backend Tests run save a new testmon cache
   and restore the newest compatible cache.

--- a/src/cook-web/Dockerfile_DEV
+++ b/src/cook-web/Dockerfile_DEV
@@ -9,10 +9,12 @@ WORKDIR /app
 # copy package.json and package-lock.json files
 COPY package*.json ./
 
-# copy project source code
-COPY . .
 # install dependencies
-RUN npm install --ignore-scripts
+RUN npm ci --ignore-scripts
+
+# copy project source code after dependencies so source-only changes reuse the
+# lockfile-keyed install layer
+COPY . .
 
 # expose port
 EXPOSE 3000


### PR DESCRIPTION
## Summary

Install Cook Web dependencies from package-lock.json before copying application source into the development image.

The previous Dockerfile copied the entire source tree before npm install, so any source edit invalidated the dependency layer.

## Benefit

Frontend source-only changes can reuse the lockfile-keyed dependency layer during Runtime Harness builds.

## Verification

- npm ci --ignore-scripts dry run passed against the current lockfile
- Repository harness passed
- Full lefthook pre-commit gate passed

## Stack

1. #2536 — isolate runtime image cache scopes
2. #2537 — this PR, based on the PR #2536 branch
3. #2538 — roll pytest-testmon caches forward

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Docker build ordering and install command; no production runtime or application logic changes.
> 
> **Overview**
> **Cook Web dev image** (`Dockerfile_DEV`) now installs Node dependencies **before** copying application source, so Runtime Harness builds can reuse the lockfile-keyed install layer when only frontend source changes.
> 
> The install step switches from `npm install` to **`npm ci --ignore-scripts`** after copying only `package*.json`, then **`COPY . .`** runs last. The CI speed stack exec plan marks the “reorder dependency install” milestone complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a8ea21f025e2351fe2b5a0d3fa8f91fe886f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->