### PR TITLE
chore: roll backend test caches forward

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -38,16 +38,36 @@ jobs:
           cache: pip
           cache-dependency-path: src/api/requirements.txt
 
+      - name: Resolve testmon cache lineage
+        id: testmon-cache
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            current_sha="$PR_HEAD_SHA"
+          else
+            current_sha="$GITHUB_SHA"
+          fi
+          previous_sha="$(git rev-parse "${current_sha}^" 2>/dev/null || true)"
+          if [[ -z "$previous_sha" ]]; then
+            previous_sha="$current_sha"
+          fi
+          echo "current-sha=$current_sha" >> "$GITHUB_OUTPUT"
+          echo "previous-sha=$previous_sha" >> "$GITHUB_OUTPUT"
+
       - name: Restore testmon cache
         uses: actions/cache@v4
         with:
           path: |
             src/api/.testmondata
             src/api/.pytest_cache
-          # A unique exact key lets each successful commit publish updated
-          # testmon state; the prefixes below restore the newest compatible run.
-          key: testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ github.sha }}
+          # A unique exact key lets each successful commit publish updated state.
+          # Prefer the exact parent commit before broader branch/main fallbacks.
+          key: testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ steps.testmon-cache.outputs.current-sha }}
           restore-keys: |
+            testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ steps.testmon-cache.outputs.previous-sha }}
             testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}
             testmon-${{ runner.os }}-py311-main-main-${{ hashFiles('src/api/requirements.txt') }}
             testmon-${{ runner.os }}-py311-main-

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -68,8 +68,8 @@ jobs:
           key: testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ steps.testmon-cache.outputs.current-sha }}
           restore-keys: |
             testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ steps.testmon-cache.outputs.previous-sha }}
-            testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}
-            testmon-${{ runner.os }}-py311-main-main-${{ hashFiles('src/api/requirements.txt') }}
+            testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-
+            testmon-${{ runner.os }}-py311-main-main-${{ hashFiles('src/api/requirements.txt') }}-
             testmon-${{ runner.os }}-py311-main-
             testmon-${{ runner.os }}-py311-
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -44,8 +44,12 @@ jobs:
           path: |
             src/api/.testmondata
             src/api/.pytest_cache
-          key: testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}
+          # A unique exact key lets each successful commit publish updated
+          # testmon state; the prefixes below restore the newest compatible run.
+          key: testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}-${{ github.sha }}
           restore-keys: |
+            testmon-${{ runner.os }}-py311-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt') }}
+            testmon-${{ runner.os }}-py311-main-main-${{ hashFiles('src/api/requirements.txt') }}
             testmon-${{ runner.os }}-py311-main-
             testmon-${{ runner.os }}-py311-
 

--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -29,6 +29,8 @@ that branch.
   and restore the newest compatible cache.
 - [x] 2026-08-20 12:30 CST: Validated and published the three-PR stack as
   PRs #2536, #2537, and #2538.
+- [x] 2026-08-20 12:35 CST: Verified the corrected Backend Tests workflow saved
+  a cache under the pull request head SHA for an exact next-commit restore.
 
 ## Surprises & Discoveries
 
@@ -85,7 +87,9 @@ Runtime Harness times were measured in GitHub Actions:
 - PR #2538's first two Backend Tests runs passed in 1m20s and saved SHA-specific
   caches. The second run exposed that a current-PR prefix still fell through to
   main, so the final implementation resolves and restores the direct parent head
-  SHA exactly before using branch or main fallbacks.
+  SHA exactly before using branch or main fallbacks. The first corrected run
+  passed in 1m31s and saved its cache under head SHA `11cacd5f`; the next commit
+  provides the live exact-parent restore check.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -67,8 +67,16 @@ The implementation is published as three ready pull requests:
 Workflow parsing, repository harness validation, architecture boundaries, npm
 lockfile installation, and the full lefthook pre-commit gate passed locally.
 Docker is unavailable in the worktree, so actual cache-hit rates and elapsed
-Runtime Harness time remain live-CI acceptance measurements rather than local
-claims.
+Runtime Harness times were measured in GitHub Actions:
+
+- PR #2536 completed in 7m42s cold and 6m10s warm. Its image-build step fell
+  from 3m51s to 1m47s.
+- PR #2537 completed in 7m44s cold and 5m15s warm. Its image-build step fell
+  from 3m49s to 1m19s, and the logs reported cache hits for both the API pip
+  layer and the Cook Web `npm ci` layer.
+- PR #2538's first Backend Tests run passed in 1m20s and saved the SHA-specific
+  testmon cache. This measurement update provides the next commit that can
+  restore that newly written state by prefix.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -25,7 +25,7 @@ that branch.
   cache scopes.
 - [x] 2026-08-20 12:20 CST: Reordered the Cook Web development image so dependency
   installation precedes source copying.
-- [ ] 2026-08-20 12:25 CST: Make each Backend Tests run save a new testmon cache
+- [x] 2026-08-20 12:25 CST: Made each Backend Tests commit save a new testmon cache
   and restore the newest compatible cache.
 - [ ] 2026-08-20 12:30 CST: Validate and publish the three-PR stack.
 

--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -27,7 +27,8 @@ that branch.
   installation precedes source copying.
 - [x] 2026-08-20 12:25 CST: Made each Backend Tests commit save a new testmon cache
   and restore the newest compatible cache.
-- [ ] 2026-08-20 12:30 CST: Validate and publish the three-PR stack.
+- [x] 2026-08-20 12:30 CST: Validated and published the three-PR stack as
+  PRs #2536, #2537, and #2538.
 
 ## Surprises & Discoveries
 
@@ -57,8 +58,17 @@ that branch.
 
 ## Outcomes & Retrospective
 
-Implementation is in progress. Record measured CI outcomes here after each pull
-request runs.
+The implementation is published as three ready pull requests:
+
+- PR #2536 isolates the API and Cook Web Docker cache scopes.
+- PR #2537 preserves the Cook Web dependency layer across source-only changes.
+- PR #2538 rolls pytest-testmon state forward after each successful commit.
+
+Workflow parsing, repository harness validation, architecture boundaries, npm
+lockfile installation, and the full lefthook pre-commit gate passed locally.
+Docker is unavailable in the worktree, so actual cache-hit rates and elapsed
+Runtime Harness time remain live-CI acceptance measurements rather than local
+claims.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ci-backend-speed-stack.md
+++ b/docs/exec-plans/active/ci-backend-speed-stack.md
@@ -43,6 +43,10 @@ that branch.
 - The local worktree does not have a Docker CLI, so the bake definition cannot be
   expanded locally. Workflow parsing and repository checks are the local gate;
   the first pull request's Runtime Harness run is the live cache-scope gate.
+- A SHA-less restore prefix did not select the previous cache written under the
+  same pull request merge ref, even though both entries had the same cache
+  version. The workflow now uses the pull request head SHA as the saved key and
+  resolves its direct parent for an exact lineage restore before broad fallbacks.
 
 ## Decision Log
 
@@ -55,6 +59,10 @@ that branch.
 - Decision: keep `mode=min` for the Docker caches. Rationale: the confirmed defect
   is scope collision; changing cache breadth at the same time would make the
   result harder to attribute and may increase cache storage pressure.
+- Decision: restore the exact parent-head cache on pull request updates instead
+  of relying only on a SHA-less prefix. Rationale: live Actions runs proved exact
+  cache matches work across commits while the current-ref prefix fell through to
+  main; retaining the broad prefixes still covers rebases and multi-commit pushes.
 
 ## Outcomes & Retrospective
 
@@ -74,9 +82,10 @@ Runtime Harness times were measured in GitHub Actions:
 - PR #2537 completed in 7m44s cold and 5m15s warm. Its image-build step fell
   from 3m49s to 1m19s, and the logs reported cache hits for both the API pip
   layer and the Cook Web `npm ci` layer.
-- PR #2538's first Backend Tests run passed in 1m20s and saved the SHA-specific
-  testmon cache. This measurement update provides the next commit that can
-  restore that newly written state by prefix.
+- PR #2538's first two Backend Tests runs passed in 1m20s and saved SHA-specific
+  caches. The second run exposed that a current-PR prefix still fell through to
+  main, so the final implementation resolves and restores the direct parent head
+  SHA exactly before using branch or main fallbacks.
 
 ## Context and Orientation
 


### PR DESCRIPTION
## Summary

Save pytest-testmon state under the pull request head SHA and restore the exact direct-parent cache before broader branch and main fallbacks.

The previous branch-stable key became immutable after the first successful run. A SHA-less pull request prefix also fell through to main in live Actions runs, so this version uses explicit commit lineage.

## Benefit

Each later commit starts from the latest successful test state while rebases and multi-commit pushes retain safe branch and main fallbacks.

## Verification

- Workflow YAML parsed successfully
- Repository harness and architecture boundary checks passed
- Full lefthook pre-commit gate passed
- First corrected run passed in 1m31s and saved cache key `11cacd5f...`
- Next run passed in 1m26s, restored the exact `11cacd5f...` parent cache, and saved the current `411d61a7...` cache
- Live proof: https://github.com/ai-shifu/ai-shifu/actions/runs/32331784503

## Stack

1. #2536 — isolate runtime image cache scopes
2. #2537 — preserve the Cook Web dependency layer
3. #2538 — this PR, based on the PR #2537 branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and documentation only; test selection behavior is unchanged aside from fresher cache restores.
> 
> **Overview**
> **Backend Tests** now writes pytest-testmon state under a **per-commit cache key** and restores the **direct parent commit’s** cache before falling back to branch- or main-level prefixes.
> 
> A new workflow step resolves `current-sha` (PR head or push SHA) and `previous-sha` (`git rev-parse` of the parent) so each green run can publish fresh `.testmondata` / `.pytest_cache` instead of reusing the first immutable entry for a branch. **Restore order** is parent SHA → same PR/branch without SHA → `main` → generic `testmon-` prefixes, addressing live runs where a SHA-less PR prefix missed the prior commit and restored from `main`.
> 
> The **CI speed stack** exec plan is updated to mark the testmon item done, document the SHA-less restore surprise, and record measured Backend Tests timings and cache keys from Actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea445883cc45e4338756c9bb0e091d1feaa5e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->