### PR TITLE
style: enforce ruff PERF401 (build lists with comprehensions)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -52,7 +52,7 @@ select = [
     "RSE",     # unnecessary parentheses on a raised exception
     "C4",      # comprehension and collection-literal simplifications
     "FLY",     # static str.join that should be an f-string
-    "PERF",    # performance anti-patterns (PERF401 ignored below)
+    "PERF",    # performance anti-patterns
     "FURB",    # refurb modernizations
     "PYI",     # flake8-pyi (Any in __eq__, int | float unions, ...)
     "Q",       # quote style, matching the formatter
@@ -198,7 +198,6 @@ ignore = [
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "DTZ901",  # datetime.min/max -- naive UTC is the house convention
     "G004",    # f-string logging -- house style, and rewriting it is churn
-    "PERF401", # manual list comprehension -- rewrites obscure the loop bodies
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended

--- a/scripts/build_repo_knowledge_index.py
+++ b/scripts/build_repo_knowledge_index.py
@@ -121,19 +121,18 @@ def build_reference_records() -> list[DocRecord]:
 
 def build_execplan_records(subdir: str, status: str) -> list[DocRecord]:
     plan_dir = DOCS_ROOT / "exec-plans" / subdir
-    records: list[DocRecord] = []
-    for path in sorted(plan_dir.glob("*.md")):
-        records.append(
-            DocRecord(
-                path=path,
-                title=extract_title(path),
-                category=f"exec-plan-{subdir}",
-                status=status,
-                owner_surface="repo",
-                last_reviewed="",
-                canonical="true",
-            )
+    records: list[DocRecord] = [
+        DocRecord(
+            path=path,
+            title=extract_title(path),
+            category=f"exec-plan-{subdir}",
+            status=status,
+            owner_surface="repo",
+            last_reviewed="",
+            canonical="true",
         )
+        for path in sorted(plan_dir.glob("*.md"))
+    ]
     return records
 
 
@@ -175,14 +174,17 @@ def render_execplan_index(
         "",
     ]
     if active:
-        for record in active:
-            lines.append(f"- [{record.title}](./active/{record.path.name})")
+        lines.extend(
+            f"- [{record.title}](./active/{record.path.name})" for record in active
+        )
     else:
         lines.append("- No active ExecPlans.")
     lines.extend(["", "## Completed", ""])
     if completed:
-        for record in completed:
-            lines.append(f"- [{record.title}](./completed/{record.path.name})")
+        lines.extend(
+            f"- [{record.title}](./completed/{record.path.name})"
+            for record in completed
+        )
     else:
         lines.append("- No completed ExecPlans.")
     lines.extend(
@@ -206,22 +208,22 @@ def render_inventory(records: list[DocRecord]) -> str:
         "| Path | Title | Category | Status | Owner | Last Reviewed | Canonical |",
         "| --- | --- | --- | --- | --- | --- | --- |",
     ]
-    for record in records:
-        lines.append(
-            "| "
-            + " | ".join(
-                [
-                    f"`{rel_doc(record.path)}`",
-                    record.title.replace("|", "\\|"),
-                    f"`{record.category}`",
-                    f"`{record.status or '-'}`",
-                    f"`{record.owner_surface or '-'}`",
-                    f"`{record.last_reviewed or '-'}`",
-                    f"`{record.canonical or '-'}`",
-                ]
-            )
-            + " |"
+    lines.extend(
+        "| "
+        + " | ".join(
+            [
+                f"`{rel_doc(record.path)}`",
+                record.title.replace("|", "\\|"),
+                f"`{record.category}`",
+                f"`{record.status or '-'}`",
+                f"`{record.owner_surface or '-'}`",
+                f"`{record.last_reviewed or '-'}`",
+                f"`{record.canonical or '-'}`",
+            ]
         )
+        + " |"
+        for record in records
+    )
     lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/scripts/check_architecture_boundaries.py
+++ b/scripts/check_architecture_boundaries.py
@@ -60,13 +60,13 @@ def read_text(path: Path) -> str:
 
 
 def collect_frontend_imports(path: Path, frontend_root: Path) -> list[str]:
-    imports: list[str] = []
     text = read_text(path)
-    for match in IMPORT_FROM_PATTERN.findall(text):
-        imports.append(match.strip())
+    imports: list[str] = [match.strip() for match in IMPORT_FROM_PATTERN.findall(text)]
     # Support dynamic imports without `from`.
-    for dynamic in re.findall(r"""import\(\s*["']([^"']+)["']\s*\)""", text):
-        imports.append(dynamic.strip())
+    imports.extend(
+        dynamic.strip()
+        for dynamic in re.findall(r"""import\(\s*["']([^"']+)["']\s*\)""", text)
+    )
     return imports
 
 
@@ -245,8 +245,7 @@ def iter_python_imports(path: Path, backend_root: Path) -> list[str]:
     tree = ast.parse(read_text(path), filename=str(path))
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            for alias in node.names:
-                imports.append(alias.name)
+            imports.extend(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
             if node.level:

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -131,8 +131,10 @@ def collect_checks() -> tuple[list[Check], list[Check]]:
         Check("ruff", shutil.which("ruff") is not None, PIP_INSTALL),
         Check("cz (commitizen)", shutil.which("cz") is not None, PIP_INSTALL),
     ]
-    for script in PRE_COMMIT_HOOKS_SCRIPTS:
-        core.append(Check(script, shutil.which(script) is not None, PIP_INSTALL))
+    core.extend(
+        Check(script, shutil.which(script) is not None, PIP_INSTALL)
+        for script in PRE_COMMIT_HOOKS_SCRIPTS
+    )
 
     frontend: list[Check] = [
         Check("node", shutil.which("node") is not None, NODE_INSTALL, required=False),

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -162,9 +162,11 @@ def check_manual_agents(errors: list[str]) -> None:
         if DOC_COMMENT in text:
             errors.append(f"Manual AGENTS file should not be generated: {path}")
         check_ordered_headings(path, text, errors)
-        for marker in markers:
-            if marker not in text:
-                errors.append(f"Missing marker '{marker}' in {path}")
+        errors.extend(
+            f"Missing marker '{marker}' in {path}"
+            for marker in markers
+            if marker not in text
+        )
 
 
 def check_manual_rules(errors: list[str]) -> None:
@@ -175,28 +177,38 @@ def check_manual_rules(errors: list[str]) -> None:
         text = path.read_text(encoding="utf-8")
         if DOC_COMMENT in text:
             errors.append(f"Manual Claude rule should not be generated: {path}")
-        for marker in markers:
-            if marker not in text:
-                errors.append(f"Missing marker '{marker}' in {path}")
+        errors.extend(
+            f"Missing marker '{marker}' in {path}"
+            for marker in markers
+            if marker not in text
+        )
 
 
 def check_root_docs(errors: list[str]) -> None:
-    for path in REQUIRED_ROOT_DOCS:
-        if not path.exists():
-            errors.append(f"Missing required root knowledge doc: {path}")
-    for path in REQUIRED_DIRS:
-        if not path.exists():
-            errors.append(f"Missing required docs directory: {path}")
-    for path in REQUIRED_WORKFLOWS:
-        if not path.exists():
-            errors.append(f"Missing required harness workflow: {path}")
+    errors.extend(
+        f"Missing required root knowledge doc: {path}"
+        for path in REQUIRED_ROOT_DOCS
+        if not path.exists()
+    )
+    errors.extend(
+        f"Missing required docs directory: {path}"
+        for path in REQUIRED_DIRS
+        if not path.exists()
+    )
+    errors.extend(
+        f"Missing required harness workflow: {path}"
+        for path in REQUIRED_WORKFLOWS
+        if not path.exists()
+    )
 
     readme = DOCS_ROOT / "README.md"
     if readme.exists():
         text = readme.read_text(encoding="utf-8")
-        for marker in README_MARKERS:
-            if marker not in text:
-                errors.append(f"Missing marker '{marker}' in {readme}")
+        errors.extend(
+            f"Missing marker '{marker}' in {readme}"
+            for marker in README_MARKERS
+            if marker not in text
+        )
 
     if (ROOT / "tasks.md").exists():
         errors.append("Repository-root tasks.md is retired and must not exist")
@@ -221,14 +233,15 @@ def check_frontmatter_docs(errors: list[str]) -> None:
             if path.name == "index.md":
                 continue
             metadata = parse_frontmatter(path)
-            for field in FRONTMATTER_FIELDS:
-                if not metadata.get(field):
-                    errors.append(f"Missing frontmatter field '{field}' in {path}")
+            errors.extend(
+                f"Missing frontmatter field '{field}' in {path}"
+                for field in FRONTMATTER_FIELDS
+                if not metadata.get(field)
+            )
 
 
 def check_example_identifiers(errors: list[str]) -> None:
-    for violation in find_identifier_violations():
-        errors.append(str(violation))
+    errors.extend(str(violation) for violation in find_identifier_violations())
 
 
 def main() -> int:

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1513,8 +1513,7 @@ def render_cursor_rule(
         f"description: {description}",
         "globs:",
     ]
-    for glob in globs:
-        lines.append(f"  - {glob}")
+    lines.extend(f"  - {glob}" for glob in globs)
     lines.extend(
         [
             f"alwaysApply: {'true' if always_apply else 'false'}",

--- a/scripts/run_harness_gardening.py
+++ b/scripts/run_harness_gardening.py
@@ -82,12 +82,11 @@ def retired_term_hits() -> list[str]:
         for line_number, line in enumerate(text.splitlines(), start=1):
             if any(pattern.search(line) for pattern in allowed_patterns):
                 continue
-            for term in RETIRED_TERM_PATTERNS:
-                if term in line:
-                    hits.append(
-                        f"{path.relative_to(ROOT)}:{line_number} contains retired "
-                        f"term `{term}`"
-                    )
+            hits.extend(
+                f"{path.relative_to(ROOT)}:{line_number} contains retired term `{term}`"
+                for term in RETIRED_TERM_PATTERNS
+                if term in line
+            )
     return hits
 
 

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -64,9 +64,10 @@ def _percent_encode(value: Any) -> str:
 
 def _canonicalized_query(params: dict[str, Any]) -> str:
     """Build canonicalized query string from params (excluding Signature)."""
-    parts: list[str] = []
-    for key in sorted(params.keys()):
-        parts.append(f"{_percent_encode(key)}={_percent_encode(params[key])}")
+    parts: list[str] = [
+        f"{_percent_encode(key)}={_percent_encode(params[key])}"
+        for key in sorted(params.keys())
+    ]
     return "&".join(parts)
 
 

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1031,8 +1031,10 @@ class UnifiedMigrationTask:
             report.append("RECOMMENDATIONS")
             report.append("-" * 40)
             report.append("The following tables failed consistency checks:")
-            for table in failed_consistency:
-                report.append(f"  - {table}: Review data mapping and re-run migration")
+            report.extend(
+                f"  - {table}: Review data mapping and re-run migration"
+                for table in failed_consistency
+            )
             report.append("")
 
         return "\n".join(report)

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -1292,10 +1292,11 @@ def _missing_template_params(
     template_params: dict[str, Any] | None,
 ) -> list[str]:
     params = template_params or {}
-    missing: list[str] = []
-    for placeholder in _template_placeholders(template_code):
-        if not str(params.get(placeholder) or "").strip():
-            missing.append(placeholder)
+    missing: list[str] = [
+        placeholder
+        for placeholder in _template_placeholders(template_code)
+        if not str(params.get(placeholder) or "").strip()
+    ]
     return missing
 
 

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -53,11 +53,10 @@ def build_statement(
     """
     table = dsl.spec.model.__table__
 
-    select_items: list[ColumnElement[Any]] = []
-    for col_name in dsl.select:
-        select_items.append(table.c[col_name].label(col_name))
-    for agg in dsl.aggregates:
-        select_items.append(_compile_aggregate(table, agg))
+    select_items: list[ColumnElement[Any]] = [
+        table.c[col_name].label(col_name) for col_name in dsl.select
+    ]
+    select_items.extend(_compile_aggregate(table, agg) for agg in dsl.aggregates)
 
     stmt = select(*select_items).select_from(table)
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -339,10 +339,7 @@ class RUNLLMProvider(LLMProvider):
             usage_scene=self.usage_scene,
         )
         # Collect all stream responses and concatenate the results
-        content_parts = []
-        for response in res:
-            if response.result:
-                content_parts.append(response.result)
+        content_parts = [response.result for response in res if response.result]
         output = "".join(content_parts)
         self._log_preview_output(
             model=actual_model,

--- a/src/api/flaskr/service/learn/listen_element_payloads.py
+++ b/src/api/flaskr/service/learn/listen_element_payloads.py
@@ -231,20 +231,19 @@ def _sanitize_audio_segments_for_storage(
     *,
     is_final: bool,
 ) -> list[dict[str, Any]]:
-    sanitized: list[dict[str, Any]] = []
-    for item in _prepare_audio_segments_for_element(
-        audio_segments,
-        is_final=is_final,
-    ):
-        sanitized.append(
-            {
-                "position": int(item.get("position", 0) or 0),
-                "segment_index": int(item.get("segment_index", 0) or 0),
-                "audio_data": "",
-                "duration_ms": int(item.get("duration_ms", 0) or 0),
-                "is_final": bool(item.get("is_final", False)),
-            }
+    sanitized: list[dict[str, Any]] = [
+        {
+            "position": int(item.get("position", 0) or 0),
+            "segment_index": int(item.get("segment_index", 0) or 0),
+            "audio_data": "",
+            "duration_ms": int(item.get("duration_ms", 0) or 0),
+            "is_final": bool(item.get("is_final", False)),
+        }
+        for item in _prepare_audio_segments_for_element(
+            audio_segments,
+            is_final=is_final,
         )
+    ]
     return sanitized
 
 

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -1092,21 +1092,20 @@ def _load_order_activities(order_bid: str) -> list[OrderAdminActivityDTO]:
         PromoRedemption.order_bid == order_bid,
         PromoRedemption.deleted == 0,
     ).all()
-    activities: list[OrderAdminActivityDTO] = []
-    for record in records:
-        activities.append(
-            OrderAdminActivityDTO(
-                active_id=record.promo_bid,
-                active_name=record.promo_name,
-                price=_format_decimal(record.discount_amount),
-                status=record.status,
-                status_key=ACTIVE_STATUS_KEY_MAP.get(
-                    record.status, "module.order.activeStatus.unknown"
-                ),
-                created_at=record.created_at,
-                updated_at=record.updated_at,
-            )
+    activities: list[OrderAdminActivityDTO] = [
+        OrderAdminActivityDTO(
+            active_id=record.promo_bid,
+            active_name=record.promo_name,
+            price=_format_decimal(record.discount_amount),
+            status=record.status,
+            status_key=ACTIVE_STATUS_KEY_MAP.get(
+                record.status, "module.order.activeStatus.unknown"
+            ),
+            created_at=record.created_at,
+            updated_at=record.updated_at,
         )
+        for record in records
+    ]
     return activities
 
 
@@ -1116,26 +1115,25 @@ def _load_order_coupons(order_bid: str) -> list[OrderAdminCouponDTO]:
         CouponUsage.order_bid == order_bid,
         CouponUsage.deleted == 0,
     ).all()
-    coupons: list[OrderAdminCouponDTO] = []
-    for record in records:
-        coupons.append(
-            OrderAdminCouponDTO(
-                coupon_bid=record.coupon_bid,
-                code=record.code,
-                name=record.name,
-                discount_type=record.discount_type,
-                discount_type_key=COUPON_TYPE_KEY_MAP.get(
-                    record.discount_type, "module.order.couponType.unknown"
-                ),
-                value=_format_decimal(record.value),
-                status=record.status,
-                status_key=COUPON_STATUS_KEY_MAP.get(
-                    record.status, "module.order.couponStatus.unknown"
-                ),
-                created_at=record.created_at,
-                updated_at=record.updated_at,
-            )
+    coupons: list[OrderAdminCouponDTO] = [
+        OrderAdminCouponDTO(
+            coupon_bid=record.coupon_bid,
+            code=record.code,
+            name=record.name,
+            discount_type=record.discount_type,
+            discount_type_key=COUPON_TYPE_KEY_MAP.get(
+                record.discount_type, "module.order.couponType.unknown"
+            ),
+            value=_format_decimal(record.value),
+            status=record.status,
+            status_key=COUPON_STATUS_KEY_MAP.get(
+                record.status, "module.order.couponStatus.unknown"
+            ),
+            created_at=record.created_at,
+            updated_at=record.updated_at,
         )
+        for record in records
+    ]
     return coupons
 
 

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -453,16 +453,16 @@ def init_buy_record(
             )
         )
         if campaign_applications:
-            for campaign_application in campaign_applications:
-                price_items.append(
-                    PayItemDto(
-                        _("server.order.payItemPromotion"),
-                        campaign_application.promo_name,
-                        campaign_application.discount_amount,
-                        True,
-                        None,
-                    )
+            price_items.extend(
+                PayItemDto(
+                    _("server.order.payItemPromotion"),
+                    campaign_application.promo_name,
+                    campaign_application.discount_amount,
+                    True,
+                    None,
                 )
+                for campaign_application in campaign_applications
+            )
         return AICourseBuyRecordDTO(
             buy_record.order_bid,
             buy_record.user_bid,

--- a/src/api/flaskr/service/profile/profile_manage.py
+++ b/src/api/flaskr/service/profile/profile_manage.py
@@ -107,14 +107,13 @@ def get_unused_profile_keys(app: Flask, shifu_bid: str) -> list[str]:
     """Determine custom profile keys that are not referenced in any outline content."""
     definitions = get_profile_item_definition_list(app, parent_id=shifu_bid)
     used_variables = _collect_used_variables(app, shifu_bid)
-    unused_keys: list[str] = []
-    for definition in definitions:
-        if (
-            definition.profile_scope == CONST_PROFILE_SCOPE_USER
-            and definition.profile_key
-            and definition.profile_key not in used_variables
-        ):
-            unused_keys.append(definition.profile_key)
+    unused_keys: list[str] = [
+        definition.profile_key
+        for definition in definitions
+        if definition.profile_scope == CONST_PROFILE_SCOPE_USER
+        and definition.profile_key
+        and definition.profile_key not in used_variables
+    ]
     return unused_keys
 
 

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -823,17 +823,16 @@ def _build_outline_history_tree(
     def _build(parent_bid: str) -> list[HistoryItem]:
         children = outline_children_map.get(parent_bid, [])
         children.sort(key=lambda item: (item.position or "", item.id))
-        history_items: list[HistoryItem] = []
-        for child in children:
-            history_items.append(
-                HistoryItem(
-                    bid=str(child.outline_item_bid or "").strip(),
-                    id=int(child.id),
-                    type="outline",
-                    children=_build(str(child.outline_item_bid or "").strip()),
-                    child_count=_count_blocks(child.content or ""),
-                )
+        history_items: list[HistoryItem] = [
+            HistoryItem(
+                bid=str(child.outline_item_bid or "").strip(),
+                id=int(child.id),
+                type="outline",
+                children=_build(str(child.outline_item_bid or "").strip()),
+                child_count=_count_blocks(child.content or ""),
             )
+            for child in children
+        ]
         return history_items
 
     return _build("")

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -151,17 +151,16 @@ def _build_outline_history_tree(
     def _build(parent_bid: str) -> list[HistoryItem]:
         children = outline_children_map.get(parent_bid, [])
         children.sort(key=lambda item: (item.position or "", item.id))
-        history_items: list[HistoryItem] = []
-        for child in children:
-            history_items.append(
-                HistoryItem(
-                    bid=str(child.outline_item_bid or "").strip(),
-                    id=int(child.id),
-                    type="outline",
-                    children=_build(str(child.outline_item_bid or "").strip()),
-                    child_count=_count_blocks(child.content or ""),
-                )
+        history_items: list[HistoryItem] = [
+            HistoryItem(
+                bid=str(child.outline_item_bid or "").strip(),
+                id=int(child.id),
+                type="outline",
+                children=_build(str(child.outline_item_bid or "").strip()),
+                child_count=_count_blocks(child.content or ""),
             )
+            for child in children
+        ]
         return history_items
 
     return _build("")

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -563,8 +563,9 @@ def _split_text_by_max_chars(units: Sequence[str], max_chars: int) -> list[str]:
                 current = unit
                 continue
             # Unit itself is too long; hard-split.
-            for i in range(0, len(unit), max_chars):
-                segments.append(unit[i : i + max_chars])
+            segments.extend(
+                unit[i : i + max_chars] for i in range(0, len(unit), max_chars)
+            )
             current = ""
             continue
 
@@ -576,8 +577,9 @@ def _split_text_by_max_chars(units: Sequence[str], max_chars: int) -> list[str]:
             if len(unit) <= max_chars:
                 current = unit
             else:
-                for i in range(0, len(unit), max_chars):
-                    segments.append(unit[i : i + max_chars])
+                segments.extend(
+                    unit[i : i + max_chars] for i in range(0, len(unit), max_chars)
+                )
                 current = ""
 
     if current:

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -216,19 +216,18 @@ def _normalize_identifier(provider: str, identifier: str | None) -> str:
 def _summarize_credentials(
     credentials: list[AuthCredential],
 ) -> list[CredentialSummary]:
-    summaries: list[CredentialSummary] = []
-    for credential in credentials:
-        summaries.append(
-            CredentialSummary(
-                credential_bid=credential.credential_bid,
-                provider=credential.provider_name,
-                identifier=credential.identifier,
-                subject_id=credential.subject_id,
-                subject_format=credential.subject_format,
-                state=credential.state,
-                metadata=deserialize_raw_profile(credential),
-            )
+    summaries: list[CredentialSummary] = [
+        CredentialSummary(
+            credential_bid=credential.credential_bid,
+            provider=credential.provider_name,
+            identifier=credential.identifier,
+            subject_id=credential.subject_id,
+            subject_format=credential.subject_format,
+            state=credential.state,
+            metadata=deserialize_raw_profile(credential),
         )
+        for credential in credentials
+    ]
     return summaries
 
 

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -228,12 +228,14 @@ def _format_stream_parts(
     parts: list[tuple[str, str, int]] = []
 
     for chunk in _iter_chunks(content, chunk_sizes):
-        for item in formatter.process(chunk):
-            parts.append(
-                (str(item.content or ""), str(item.type or ""), int(item.number))
-            )
-    for item in formatter.flush():
-        parts.append((str(item.content or ""), str(item.type or ""), int(item.number)))
+        parts.extend(
+            (str(item.content or ""), str(item.type or ""), int(item.number))
+            for item in formatter.process(chunk)
+        )
+    parts.extend(
+        (str(item.content or ""), str(item.type or ""), int(item.number))
+        for item in formatter.flush()
+    )
     return parts
 
 

--- a/src/api/scripts/harness_diagnostics.py
+++ b/src/api/scripts/harness_diagnostics.py
@@ -79,9 +79,11 @@ def detect_langfuse_mode() -> str:
 def collect_matches(log_files: list[Path], request_id: str) -> list[tuple[Path, str]]:
     matches: list[tuple[Path, str]] = []
     for path in log_files:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            if request_id in line:
-                matches.append((path, line))
+        matches.extend(
+            (path, line)
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+            if request_id in line
+        )
     return matches
 
 

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -111,8 +111,9 @@ def collect_routes(scope_body, env, rel):
                                 methods = ast.literal_eval(kw.value)
                             except Exception:
                                 methods = ["<dyn>"]
-                    for m in methods:
-                        results.append((m, path, rel, node.lineno, node.name))
+                    results.extend(
+                        (m, path, rel, node.lineno, node.name) for m in methods
+                    )
             # recurse into nested scopes (rare but cheap)
             collect_routes(node.body, dict(env), rel)
         elif isinstance(node, (ast.If, ast.With, ast.Try, ast.For, ast.While)):
@@ -181,8 +182,9 @@ for rel in sorted(route_files):
                                 methods = ast.literal_eval(kw.value)
                             except Exception:
                                 methods = ["<dyn>"]
-                    for m in methods:
-                        results.append((m, path, rel, node.lineno, node.name))
+                    results.extend(
+                        (m, path, rel, node.lineno, node.name) for m in methods
+                    )
 
 seen = set()
 unresolved = 0

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -188,22 +188,21 @@ def _render_html(rows: list[ReportRow], *, output_path: str) -> str:
     success = sum(1 for row in rows if row.audio_url and not row.error)
     failed = len(rows) - success
 
-    tr_rows = []
-    for row in rows:
-        tr_rows.append(
-            "<tr>"
-            f"<td>{html.escape(row.provider)}</td>"
-            f"<td>{html.escape(row.model)}</td>"
-            f"<td>{html.escape(row.voice_id)}</td>"
-            f"<td>{html.escape(row.voice_label)}</td>"
-            f"<td>{html.escape(row.language)}</td>"
-            f"<td>{row.segment_count}</td>"
-            f"<td>{row.duration_ms}</td>"
-            f"<td>{row.elapsed_seconds:.3f}</td>"
-            f"<td>{row.to_html_audio()}</td>"
-            f"<td style='color:#b91c1c'>{html.escape(row.error)}</td>"
-            "</tr>"
-        )
+    tr_rows = [
+        "<tr>"
+        f"<td>{html.escape(row.provider)}</td>"
+        f"<td>{html.escape(row.model)}</td>"
+        f"<td>{html.escape(row.voice_id)}</td>"
+        f"<td>{html.escape(row.voice_label)}</td>"
+        f"<td>{html.escape(row.language)}</td>"
+        f"<td>{row.segment_count}</td>"
+        f"<td>{row.duration_ms}</td>"
+        f"<td>{row.elapsed_seconds:.3f}</td>"
+        f"<td>{row.to_html_audio()}</td>"
+        f"<td style='color:#b91c1c'>{html.escape(row.error)}</td>"
+        "</tr>"
+        for row in rows
+    ]
 
     html_body = f"""<!doctype html>
 <html lang="en">
@@ -278,25 +277,25 @@ def _render_markdown(rows: list[ReportRow], *, output_path: str) -> str:
     )
     lines.append("|---|---|---|---|---|---:|---:|---:|---|---|")
 
-    for row in rows:
-        lines.append(
-            "| "
-            + " | ".join(
-                [
-                    _escape_markdown_cell(row.provider),
-                    _escape_markdown_cell(row.model),
-                    _escape_markdown_cell(row.voice_id),
-                    _escape_markdown_cell(row.voice_label),
-                    _escape_markdown_cell(row.language),
-                    str(int(row.segment_count)),
-                    str(int(row.duration_ms)),
-                    f"{row.elapsed_seconds:.3f}",
-                    row.to_html_audio() or "",
-                    _escape_markdown_cell(row.error),
-                ]
-            )
-            + " |"
+    lines.extend(
+        "| "
+        + " | ".join(
+            [
+                _escape_markdown_cell(row.provider),
+                _escape_markdown_cell(row.model),
+                _escape_markdown_cell(row.voice_id),
+                _escape_markdown_cell(row.voice_label),
+                _escape_markdown_cell(row.language),
+                str(int(row.segment_count)),
+                str(int(row.duration_ms)),
+                f"{row.elapsed_seconds:.3f}",
+                row.to_html_audio() or "",
+                _escape_markdown_cell(row.error),
+            ]
         )
+        + " |"
+        for row in rows
+    )
 
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -381,25 +380,25 @@ def main():
             # Still produce rows (as failures) so the report is complete.
             cfg = provider.get_provider_config()
             if cfg.models:
-                for model in cfg.models:
-                    cases.append(
-                        {
-                            "provider": provider_name,
-                            "model": _safe_str(model.get("value")),
-                            "voice_id": provider.get_default_voice_settings().voice_id,
-                            "voice_label": "",
-                        }
-                    )
+                cases.extend(
+                    {
+                        "provider": provider_name,
+                        "model": _safe_str(model.get("value")),
+                        "voice_id": provider.get_default_voice_settings().voice_id,
+                        "voice_label": "",
+                    }
+                    for model in cfg.models
+                )
             else:
-                for voice in cfg.voices:
-                    cases.append(
-                        {
-                            "provider": provider_name,
-                            "model": "",
-                            "voice_id": _safe_str(voice.get("value")),
-                            "voice_label": _safe_str(voice.get("label")),
-                        }
-                    )
+                cases.extend(
+                    {
+                        "provider": provider_name,
+                        "model": "",
+                        "voice_id": _safe_str(voice.get("value")),
+                        "voice_label": _safe_str(voice.get("label")),
+                    }
+                    for voice in cfg.voices
+                )
             continue
 
         cases.extend(_build_cases(provider_name=provider_name, matrix=args.matrix))

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -70,22 +70,20 @@ def _fetch_blocks_raw(app, limit=100):
             .all()
         )
         # Detach from session so we can use outside app context
-        result = []
-        for r in rows:
-            result.append(
-                {
-                    "generated_block_bid": r.generated_block_bid,
-                    "shifu_bid": r.shifu_bid,
-                    "outline_item_bid": r.outline_item_bid,
-                    "user_bid": r.user_bid,
-                    "progress_record_bid": r.progress_record_bid,
-                    "role": int(r.role or 0),
-                    "type": int(r.type or 0),
-                    "position": int(r.position or 0),
-                    "generated_content": r.generated_content or "",
-                }
-            )
-        return result
+        return [
+            {
+                "generated_block_bid": r.generated_block_bid,
+                "shifu_bid": r.shifu_bid,
+                "outline_item_bid": r.outline_item_bid,
+                "user_bid": r.user_bid,
+                "progress_record_bid": r.progress_record_bid,
+                "role": int(r.role or 0),
+                "type": int(r.type or 0),
+                "position": int(r.position or 0),
+                "generated_content": r.generated_content or "",
+            }
+            for r in rows
+        ]
 
 
 def _role_str(role_int):
@@ -387,9 +385,11 @@ class TestSSEElementSplitFromDB:
                         "is_final",
                         "content",
                     ]
-                    for field in required_fields:
-                        if field not in content:
-                            failures.append(f"Block {bid}: element missing '{field}'")
+                    failures.extend(
+                        f"Block {bid}: element missing '{field}'"
+                        for field in required_fields
+                        if field not in content
+                    )
 
         print(f"\n  SSE serialization tested on {len(sample_blocks)} blocks")
 

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -17,18 +17,17 @@ OUTLINE = "outline-history-pg"
 
 
 def _seed_versions(count: int) -> list[int]:
-    rows = []
-    for index in range(count):
-        rows.append(
-            DraftOutlineItem(
-                outline_item_bid=OUTLINE,
-                shifu_bid=SHIFU,
-                title=f"v{index}",
-                content=f"content-{index}",
-                position="01",
-                deleted=0,
-            )
+    rows = [
+        DraftOutlineItem(
+            outline_item_bid=OUTLINE,
+            shifu_bid=SHIFU,
+            title=f"v{index}",
+            content=f"content-{index}",
+            position="01",
+            deleted=0,
         )
+        for index in range(count)
+    ]
     db.session.add_all(rows)
     db.session.commit()
     return sorted((int(row.id) for row in rows), reverse=True)


### PR DESCRIPTION
# Summary

Continues the per-rule ruff cleanup: PERF401 (`manual-list-comprehension`) had 46 hits, all of them a bare `append` inside a loop. Each site becomes a comprehension when the loop is the whole list construction, or `list.extend(<generator>)` when the loop appends into a list built elsewhere or lives inside surrounding control flow:

```python
# before
summaries: list[CredentialSummary] = []
for credential in credentials:
    summaries.append(CredentialSummary(...))

# after
summaries: list[CredentialSummary] = [CredentialSummary(...) for credential in credentials]
```

```python
# before (append into an existing list, inside an `if`)
for campaign_application in campaign_applications:
    price_items.append(PayItemDto(...))

# after
price_items.extend(PayItemDto(...) for campaign_application in campaign_applications)
```

Element order and loop bodies are unchanged everywhere; no behavior change. `PERF401` is dropped from the `ignore` list in `ruff.toml`, so the whole `PERF` group is now enforced.

Notable non-trivial conversions:
- `creator_analytics/sql_builder.py`: two sequential append loops become one comprehension for `dsl.select` plus an `extend` for `dsl.aggregates`, preserving the select-item order.
- `tts/pipeline.py`: both hard-split branches become `segments.extend(unit[i : i + max_chars] for i in range(...))`.
- The repo-harness / knowledge-index / AI-doc generators changed too; re-running `build_repo_knowledge_index.py` and `generate_ai_collab_docs.py` produces byte-identical output.

## Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`
- `python scripts/check_repo_harness.py`, `python scripts/check_architecture_boundaries.py --run-fixture-tests`
- `pytest tests/service/{order,tts,user,profile,learn,billing,creator_analytics}` — 1857 passed, 14 skipped
- `pytest tests/service/{shifu,common}` — 418 passed; the 5 `test_admin_course_detail.py` failures are the pre-existing SQLite `concat(...)` failures also present on `main`.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactors with equivalent iteration semantics; risk is limited to rare edge cases if any loop had side effects beyond append (the PR targets the simple PERF401 pattern only).
> 
> **Overview**
> **Enforces Ruff PERF401** by removing it from `ruff.toml`’s ignore list and updating the `PERF` comment so manual list-comprehension rewrites are no longer suppressed repo-wide.
> 
> Across **~30 files**, loops that only `append` into a new list become list comprehensions; cases that append into an **existing** list (or sit inside other control flow) use **`list.extend(<generator>)`** instead. Order and loop bodies stay the same—this is stylistic/performance lint cleanup, not a feature change.
> 
> Touches **repo harness scripts** (`build_repo_knowledge_index`, `check_repo_harness`, `generate_ai_collab_docs`, etc.), **backend services** (order admin DTO mapping, TTS segmentation, learn streaming aggregation, billing template checks, creator analytics SQL builder), and **tests/scripts** that build report rows or seed data the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a056d7f75cad0dcae898c5be16659b05a75ac0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal collection and report-generation logic across application services, administrative tools, diagnostics, and validation utilities.
  - Preserved existing outputs, ordering, error handling, data processing, and report formatting.
  - Improved code consistency by adopting more concise collection-building patterns.

- **Chores**
  - Updated linting configuration to enforce an additional performance rule.
  - No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->