### PR TITLE
style: enforce ruff RUF012 (annotate mutable class attributes as ClassVar)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -169,7 +169,7 @@ select = [
     "UP",
 
     # --- Ruff-native rules ------------------------------------------------
-    # RUF001 (ambiguous unicode in a string), RUF012 and RUF100 are ignored
+    # RUF001 (ambiguous unicode in a string) and RUF100 are ignored
     # below.
     "RUF",
 ]
@@ -201,7 +201,6 @@ ignore = [
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
-    "RUF012",  # mutable class attribute without ClassVar -- annotation churn
     # RUF100: with a partial select list, ruff reports deliberate `# noqa:
     # BLE001 / DTZ001 / SLF001 / S102` markers as unused simply because those
     # rules are off here, so enforcing it would delete documentation of

--- a/src/api/flaskr/service/common/dto_base.py
+++ b/src/api/flaskr/service/common/dto_base.py
@@ -31,7 +31,7 @@ How per-class output is reproduced:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 
 def _json_field_value(value: Any, annotation: Any) -> Any:
@@ -57,7 +57,7 @@ class AutoJsonMixin:
     the per-class knobs ``__json_key_overrides__`` and ``__json_exclude__``.
     """
 
-    __json_key_overrides__: dict = {}
+    __json_key_overrides__: ClassVar[dict] = {}
     __json_exclude__: frozenset = frozenset()
 
     def __json__(self) -> dict:

--- a/src/api/flaskr/service/config/models.py
+++ b/src/api/flaskr/service/config/models.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -15,7 +17,7 @@ class Config(db.Model):
     """Config."""
 
     __tablename__ = "sys_configs"
-    __table_args__ = {"comment": "System configs"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "System configs"}
 
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     config_bid = Column(

--- a/src/api/flaskr/service/learn/models.py
+++ b/src/api/flaskr/service/learn/models.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from flaskr.service.order.consts import LEARN_STATUS_LOCKED
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
@@ -18,7 +20,7 @@ class LearnProgressRecord(db.Model):
     """Learn progress record."""
 
     __tablename__ = "learn_progress_records"
-    __table_args__ = {"comment": "Learn progress records"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Learn progress records"}
 
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     progress_record_bid = Column(
@@ -90,7 +92,7 @@ class LearnGeneratedBlock(db.Model):
     """Learn generated block."""
 
     __tablename__ = "learn_generated_blocks"
-    __table_args__ = {"comment": "Learn generated blocks"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Learn generated blocks"}
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     generated_block_bid = Column(
         String(36),
@@ -188,7 +190,9 @@ class LearnGeneratedElement(db.Model):
     """Listen-mode generated element snapshots and events."""
 
     __tablename__ = "learn_generated_elements"
-    __table_args__ = {"comment": "Listen-mode generated elements"}
+    __table_args__: ClassVar[dict[str, str]] = {
+        "comment": "Listen-mode generated elements"
+    }
 
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     element_bid = Column(

--- a/src/api/flaskr/service/order/models.py
+++ b/src/api/flaskr/service/order/models.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -21,7 +23,7 @@ class Order(db.Model):
     """Order."""
 
     __tablename__ = "order_orders"
-    __table_args__ = {"comment": "Order orders"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Order orders"}
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     order_bid = Column(
         String(36),
@@ -565,7 +567,7 @@ class WechatPayOrder(_NativeProviderOrderBase):
 
 class BannerInfo(db.Model):
     __tablename__ = "order_banner_info"
-    __table_args__ = {"comment": "Order banner info"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Order banner info"}
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     banner_id = Column(
         String(36), nullable=False, default="", index=True, comment="Banner identifier"

--- a/src/api/flaskr/service/profile/models.py
+++ b/src/api/flaskr/service/profile/models.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from flaskr.util.datetime import now_utc
 from sqlalchemy import Column, DateTime, SmallInteger, String, Text
 from sqlalchemy.dialects.mysql import BIGINT
@@ -51,7 +53,7 @@ class Variable(db.Model):
     """
 
     __tablename__ = "var_variables"
-    __table_args__ = {
+    __table_args__: ClassVar[dict[str, str]] = {
         "comment": (
             "Variable definition table for MarkdownFlow-based shifu. Defines variables "
             "referenced in course content (via MarkdownFlow markers) and used to collect "
@@ -138,7 +140,7 @@ class VariableValue(db.Model):
     """
 
     __tablename__ = "var_variable_values"
-    __table_args__ = {
+    __table_args__: ClassVar[dict[str, str]] = {
         "comment": (
             "User variable value table for variables. Stores the actual values entered "
             "during learning for variables defined in var_variables. Each record represents "

--- a/src/api/flaskr/service/promo/models.py
+++ b/src/api/flaskr/service/promo/models.py
@@ -1,3 +1,5 @@
+from typing import ClassVar
+
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -24,7 +26,7 @@ class Coupon(db.Model):
     """Coupon."""
 
     __tablename__ = "promo_coupons"
-    __table_args__ = {"comment": "Promo coupons"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Promo coupons"}
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     coupon_bid = Column(
         String(36),
@@ -123,7 +125,7 @@ class CouponUsage(db.Model):
     """
 
     __tablename__ = "promo_coupon_usages"
-    __table_args__ = {"comment": "Promo coupon usages"}
+    __table_args__: ClassVar[dict[str, str]] = {"comment": "Promo coupon usages"}
     id = Column(BIGINT, primary_key=True, autoincrement=True)
     coupon_usage_bid = Column(
         String(36),
@@ -205,7 +207,7 @@ class PromoCampaign(db.Model):
     """Promotion campaign definition."""
 
     __tablename__ = "promo_promos"
-    __table_args__ = {
+    __table_args__: ClassVar[dict[str, str]] = {
         "comment": (
             "Promotion campaign definition table. Defines a discount campaign for a specific "
             "Shifu (join/apply type, time window, discount configuration, channel, and targeting "
@@ -329,7 +331,7 @@ class PromoRedemption(db.Model):
     """Promotion campaign redemption ledger."""
 
     __tablename__ = "promo_redemptions"
-    __table_args__ = {
+    __table_args__: ClassVar[dict[str, str]] = {
         "comment": (
             "Promotion campaign redemption ledger. Records each time a user redeems/applies a "
             "promo campaign to an order, including snapshot fields (campaign name/discount "

--- a/src/api/flaskr/service/tts/models.py
+++ b/src/api/flaskr/service/tts/models.py
@@ -3,6 +3,8 @@
 This module defines the database models for storing TTS audio records.
 """
 
+from typing import ClassVar
+
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc, to_utc_iso
 from sqlalchemy import (
@@ -51,7 +53,9 @@ class LearnGeneratedAudio(db.Model):
     """
 
     __tablename__ = "learn_generated_audios"
-    __table_args__ = {"comment": "TTS audio for generated content blocks"}
+    __table_args__: ClassVar[dict[str, str]] = {
+        "comment": "TTS audio for generated content blocks"
+    }
 
     id = Column(BIGINT, primary_key=True, autoincrement=True)
 

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -9,6 +9,8 @@ off-by-one protocol desync. The worker_process_init hook must discard the
 inherited pool without touching the parent's file descriptors.
 """
 
+from typing import ClassVar
+
 from celery.signals import worker_process_init
 from flaskr.common.celery_app import dispose_inherited_db_pools, get_celery_app
 from flaskr.dao import db
@@ -57,7 +59,10 @@ def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
             disposed.append(close)
 
     class _FakeDB:
-        engines = {"broken": _BrokenEngine(), None: _GoodEngine()}
+        engines: ClassVar[dict[str | None, object]] = {
+            "broken": _BrokenEngine(),
+            None: _GoodEngine(),
+        }
 
     monkeypatch.setattr(dao, "db", _FakeDB())
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -8,6 +8,7 @@ statement via the per-connection journal.
 """
 
 import socket
+from typing import ClassVar
 
 import pytest
 from flaskr import dao
@@ -41,7 +42,7 @@ def test_pre_execute_probe_blocks_desynced_connection():
 
         class _FakeConn:
             connection = _FakeFairy()
-            info = {}
+            info: ClassVar[dict[str, object]] = {}
             invalidated_count = 0
 
             def invalidate(self):

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -12,6 +12,7 @@ rolling back on it.
 """
 
 import types
+from typing import ClassVar
 
 import pytest
 from flaskr.service.learn import runscript_v2
@@ -45,7 +46,7 @@ class _FakeSession:
 class _StubRunContext:
     """Yields scripted items (or raises) through run(); has_next() once."""
 
-    script: list = []
+    script: ClassVar[list] = []
 
     def __init__(self, **_kwargs):
         self._steps = iter([True, False])

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -1,5 +1,6 @@
 import json
 import time
+from typing import ClassVar
 from urllib.parse import parse_qs, unquote, urlparse
 
 import requests
@@ -126,7 +127,7 @@ def test_aliyun_provider_synthesize_uses_dynamic_token(monkeypatch):
 
     class DummyResponse:
         status_code = 200
-        headers = {"Content-Type": "audio/mpeg"}
+        headers: ClassVar[dict[str, str]] = {"Content-Type": "audio/mpeg"}
         content = b"audio-bytes"
 
     def fake_post(url, json=None, headers=None, timeout=None):

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -1,11 +1,12 @@
 import io
+from typing import ClassVar
 
 import pytest
 from flaskr.service.tts import audio_utils
 
 
 class _FakeSegment:
-    append_crossfades: list[int] = []
+    append_crossfades: ClassVar[list[int]] = []
 
     def __init__(self, duration_ms: int):
         self.duration_ms = duration_ms
@@ -56,7 +57,7 @@ class _PartiallyBrokenAudioSegment:
 
 
 class _RecordingAudioSegment:
-    from_file_formats: list[str] = []
+    from_file_formats: ClassVar[list[str]] = []
 
     @staticmethod
     def from_file(segment_io: io.BytesIO, format="mp3") -> "_FakeSegment":  # noqa: A002 - mirrors the pydub API

--- a/src/api/tests/service/tts/test_volcengine_http_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_http_provider.py
@@ -1,4 +1,5 @@
 import base64
+from typing import ClassVar
 
 import requests
 from flaskr.api.tts.base import AudioSettings, VoiceSettings
@@ -22,7 +23,7 @@ def test_volcengine_http_synthesize_success(monkeypatch):
     class DummyResponse:
         status_code = 200
         url = VOLCENGINE_HTTP_TTS_URL
-        headers = {"Content-Type": "application/json"}
+        headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
         def raise_for_status(self):
@@ -87,7 +88,7 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(monkeypatc
     class DummyResponse:
         status_code = 200
         url = VOLCENGINE_HTTP_TTS_URL
-        headers = {"Content-Type": "application/json"}
+        headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
         def raise_for_status(self):

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -7,12 +7,14 @@ crashes the hub (KeyError in AbstractLinkable._notify_links) and can
 interrupt unrelated in-flight DB exchanges.
 """
 
+from typing import ClassVar
+
 import flaskr.api.langfuse as langfuse_module
 from flaskr.api.langfuse import MockClient, init_langfuse
 
 
 class _RecordingLangfuse:
-    instances = []
+    instances: ClassVar[list[dict[str, object]]] = []
 
     def __init__(self, **kwargs):
         _RecordingLangfuse.instances.append(kwargs)


### PR DESCRIPTION
# Summary

Next rule in the per-rule ruff cleanup: RUF012 (`mutable-class-default`) had 23 hits. Each one is annotation-only — no value, no schema, no behavior changes:

```python
class Config(db.Model):
    __tablename__ = "sys_configs"
    __table_args__: ClassVar[dict[str, str]] = {"comment": "System configs"}
```

Breakdown:
- 13 SQLAlchemy `__table_args__` dicts across `config`, `learn`, `order`, `profile`, `promo`, `tts` models. `__table_args__` is a declarative dunder consumed by the mapper, so annotating it as `ClassVar` is inert for mapping (the models use the legacy `Column(...)` style, not annotated `Mapped[...]` columns).
- `AutoJsonMixin.__json_key_overrides__` in `service/common/dto_base.py`.
- 9 test stub classes whose class-level `dict`/`list` is deliberately shared per class (recording lists like `_RecordingAudioSegment.from_file_formats`, fake response `headers`, `_FakeDB.engines`, ...) — `ClassVar` documents exactly that intent.

`RUF012` is dropped from the `ignore` list in `ruff.toml`, so the whole `RUF` group is now enforced except `RUF001` and `RUF100`.

## Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`
- `pytest tests/service/{tts,learn,order,promo,config,profile,common} tests/common tests/test_langfuse_preload_deferral.py` — 1126 passed, 5 skipped (the suite creates the tables, so the annotated models are exercised).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only lint cleanup across models and tests; SQLAlchemy mapping and runtime behavior are unchanged.
> 
> **Overview**
> **Enables Ruff RUF012** by removing it from `ruff.toml` ignores and annotating every previously flagged mutable class default with `typing.ClassVar`.
> 
> Production SQLAlchemy models in config, learn, order, profile, promo, and TTS now declare dict-only `__table_args__` as `ClassVar[dict[str, str]]`. `AutoJsonMixin.__json_key_overrides__` gets the same treatment. Several test doubles (fake DB engines, HTTP response headers, shared recording lists) are updated so class-level dicts/lists are explicitly class variables, not mistaken for instance fields.
> 
> No values or mapper behavior change—types and lint compliance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54d36751160ed24c5b1ba6a24f723b5fc09f779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->