### PR TITLE
style: enforce ruff TC001 (annotation-only imports in a type-checking block)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -154,6 +154,12 @@ select = [
     # frozen-clock `now()` doubles.
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
+    # flake8-type-checking is partial: TC002/TC003 would push third-party
+    # imports (SQLAlchemy, pydantic) behind TYPE_CHECKING, where any decorator
+    # or mapper that resolves annotations at runtime then fails. TC001 only
+    # covers first-party imports used solely in annotations, and every module
+    # it touches already has `from __future__ import annotations`.
+    "TC001",   # first-party import used only in annotations
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands

--- a/src/api/flaskr/service/billing/credit_grant_allocation_views.py
+++ b/src/api/flaskr/service/billing/credit_grant_allocation_views.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from flask import has_app_context
 from flaskr.dao import db
@@ -32,8 +32,10 @@ from .consts import (
     CREDIT_SOURCE_TYPE_SUBSCRIPTION,
     CREDIT_SOURCE_TYPE_TOPUP,
 )
-from .models import CreditLedgerEntry, CreditWalletBucket
 from .primitives import normalize_json_object, to_decimal
+
+if TYPE_CHECKING:
+    from .models import CreditLedgerEntry, CreditWalletBucket
 
 CreditAssetKind = Literal[
     "plan_credits",

--- a/src/api/flaskr/service/billing/credit_mutations.py
+++ b/src/api/flaskr/service/billing/credit_mutations.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 
 from .consts import CREDIT_BUCKET_STATUS_EXHAUSTED, CREDIT_BUCKET_STATUS_EXPIRED
-from .models import CreditLedgerEntry, CreditWalletBucket
 from .primitives import normalize_json_object, quantize_credit_amount, to_decimal
 from .wallets import sync_credit_bucket_status
+
+if TYPE_CHECKING:
+    from .models import CreditLedgerEntry, CreditWalletBucket
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flask import Flask
 
@@ -13,7 +14,6 @@ from .credit_notifications import (
 from .credit_notifications import (
     stage_credit_granted_notification_for_order as _stage_credit_granted_notification_for_order,
 )
-from .models import BillingOrder
 from .notifications import (
     enqueue_billing_paid_feishu as _enqueue_billing_paid_feishu,
 )
@@ -28,6 +28,9 @@ from .notifications import (
 )
 from .preorders import is_preorder_order as _is_preorder_order
 from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
+
+if TYPE_CHECKING:
+    from .models import BillingOrder
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.util.datetime import now_utc
@@ -24,7 +24,6 @@ from .consts import (
     BILLING_SUBSCRIPTION_STATUS_PAST_DUE,
     BILLING_SUBSCRIPTION_STATUS_PAUSED,
 )
-from .models import BillingOrder, BillingSubscription
 from .paid_side_effects import (
     BillingPaidOrderSideEffects,
 )
@@ -51,6 +50,9 @@ from .subscriptions import (
     sync_subscription_lifecycle_events as _sync_subscription_lifecycle_events,
 )
 from .value_objects import JsonObjectMap
+
+if TYPE_CHECKING:
+    from .models import BillingOrder, BillingSubscription
 
 _STRIPE_SUCCESS_EVENT_TYPES = {
     "payment_intent.succeeded",

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.service.metering.consts import (
@@ -73,19 +73,6 @@ from .dtos import (
     OperatorCreditOrderDTO,
     OperatorCreditOrderGrantDTO,
 )
-from .models import (
-    BillingCampaign,
-    BillingCampaignProduct,
-    BillingDailyLedgerSummary,
-    BillingDailyUsageMetric,
-    BillingOrder,
-    BillingProduct,
-    BillingRenewalEvent,
-    BillingSubscription,
-    CreditLedgerEntry,
-    CreditWallet,
-    CreditWalletBucket,
-)
 from .primitives import (
     credit_decimal_to_number,
     normalize_bid,
@@ -93,6 +80,21 @@ from .primitives import (
     to_decimal,
 )
 from .queries import load_product_code_map
+
+if TYPE_CHECKING:
+    from .models import (
+        BillingCampaign,
+        BillingCampaignProduct,
+        BillingDailyLedgerSummary,
+        BillingDailyUsageMetric,
+        BillingOrder,
+        BillingProduct,
+        BillingRenewalEvent,
+        BillingSubscription,
+        CreditLedgerEntry,
+        CreditWallet,
+        CreditWalletBucket,
+    )
 
 _USAGE_SCENE_LABELS = {
     BILL_USAGE_SCENE_DEBUG: "debug",

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -62,7 +62,6 @@ from .cycle_transitions import (
 from .cycle_transitions import (
     resolve_order_effective_to as _resolve_order_effective_to,
 )
-from .dtos import BillingSubscriptionDTO
 from .models import (
     BillingOrder,
     BillingProduct,
@@ -158,6 +157,9 @@ from .wallets import (
     resolve_bucket_source_type_for_category,
     sync_credit_bucket_status,
 )
+
+if TYPE_CHECKING:
+    from .dtos import BillingSubscriptionDTO
 
 SELF_MANAGED_BILLING_PROVIDERS = {"pingxx", "alipay", "wechatpay", "manual"}
 

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -25,7 +25,7 @@ target dialect is MySQL — under SQLite (tests) the hint would not parse.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     Column,
@@ -37,7 +37,8 @@ from sqlalchemy import (
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import ColumnElement
 
-from .dsl import Aggregate, Filter, OrderBy, QueryDSL
+if TYPE_CHECKING:
+    from .dsl import Aggregate, Filter, OrderBy, QueryDSL
 
 
 def build_statement(

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
-from .base import AuthProvider
+if TYPE_CHECKING:
+    from .base import AuthProvider
 
 
 class ProviderAlreadyRegisteredError(RuntimeError):


### PR DESCRIPTION
# Summary

Next rule in the per-rule ruff cleanup: TC001 (`typing-only-first-party-import`), 24 hits in 8 modules — billing (`serializers`, `subscriptions`, `provider_state`, `credit_mutations`, `credit_grant_allocation_views`, `paid_side_effects`), `creator_analytics/sql_builder`, `user/auth/factory`:

```python
-from .models import BillingOrder
+if TYPE_CHECKING:
+    from .models import BillingOrder
```

Safety of the move (checked per site, not just per rule):
- All 8 modules already have `from __future__ import annotations`, so every annotation referring to the moved names is a string at runtime.
- Nothing in these modules resolves annotations at runtime: the only `__annotations__` consumer in the backend is `register_schema_to_swagger` in `flaskr/common/swagger.py`, which is applied to `billing/dtos.py` only — untouched here. The dataclasses in these modules never call `get_type_hints`.
- No module re-exports the moved names (grepped every `from .serializers import` / `from .sql_builder import` / etc. call site), so removing the runtime binding cannot break an indirect import.

`TC001` is added to `ruff.toml`'s select list with a note on why TC002/TC003 stay off: pushing third-party imports (SQLAlchemy, pydantic) behind `TYPE_CHECKING` breaks the places that do resolve annotations at runtime.

## Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`
- `pytest tests/service/billing tests/service/creator_analytics tests/service/user` — 1109 passed, 9 skipped


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic changes; runtime model usage is unchanged where types are needed at execution time.
> 
> **Overview**
> Enables **Ruff TC001** and moves first-party imports that appear only in type hints into `if TYPE_CHECKING:` blocks across eight modules (billing serializers, subscriptions, provider state, credit helpers, creator analytics `sql_builder`, auth `factory`).
> 
> **`ruff.toml`** documents that only TC001 is turned on: TC002/TC003 stay off so third-party imports (SQLAlchemy, pydantic) are not deferred, avoiding runtime annotation resolution failures.
> 
> Affected modules already use `from __future__ import annotations`, so hints stay deferred strings at runtime; ORM models that are instantiated or queried at runtime (e.g. in `subscriptions.py`) remain normal imports. This is import-layout cleanup with no intended billing or auth behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e0f339aa9be7e411b951316c439b886067d24d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->