### PR TITLE
style: enforce ruff TRY301 (no raise inside a try that catches it)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -88,6 +88,7 @@ select = [
     "TRY400",  # logging.error inside except that should be logging.exception
     "TRY401",  # exception object interpolated into a logging.exception message
     "TRY300",  # return at the end of a try body that belongs in `else`
+    "TRY301",  # raise inside a try body that the same block then catches
     "TRY004",  # type check raising something other than TypeError
 
     # --- Pylint subsets ---------------------------------------------------

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -157,12 +157,17 @@ def validate_locale_files(locale_dirs: Iterable[Path]):
         raise TranslationError(message)
 
 
+def _require_locale_dirs() -> list[Path]:
+    """Return the locale directories, or fail when none exist."""
+    locale_dirs = list(iter_locale_dirs())
+    if not locale_dirs:
+        raise TranslationError(f"No locale directories found under {I18N_DIR}")
+    return locale_dirs
+
+
 def main() -> int:
     try:
-        locale_dirs = list(iter_locale_dirs())
-        if not locale_dirs:
-            raise TranslationError(f"No locale directories found under {I18N_DIR}")
-        validate_locale_files(locale_dirs)
+        validate_locale_files(_require_locale_dirs())
     except TranslationError as error:
         print(str(error), file=sys.stderr)
         return 1

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1371,16 +1371,14 @@ class AliyunTTSProvider(BaseTTSProvider):
             # Error response (JSON)
             try:
                 result = response.json()
-                status = result.get("status", "unknown")
-                message = result.get("message", "Unknown error")
-                task_id = result.get("task_id", "")
-                raise ValueError(
-                    f"Aliyun TTS API error {status}: {message} (task_id: {task_id})"
-                )
             except ValueError as e:
-                if "Aliyun TTS API error" in str(e):
-                    raise
                 raise ValueError(f"Aliyun TTS API error: {response.text[:200]}") from e
+            status = result.get("status", "unknown")
+            message = result.get("message", "Unknown error")
+            task_id = result.get("task_id", "")
+            raise ValueError(
+                f"Aliyun TTS API error {status}: {message} (task_id: {task_id})"
+            )
 
         except requests.RequestException as e:
             logger.exception("Aliyun TTS request failed")

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -909,11 +909,11 @@ class BaiduTTSProvider(BaseTTSProvider):
             # Error response (JSON)
             try:
                 result = response.json()
-                error_code = result.get("err_no", "unknown")
-                error_msg = result.get("err_msg", "Unknown error")
-                raise ValueError(f"Baidu TTS API error {error_code}: {error_msg}")
             except ValueError as e:
                 raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
+            error_code = result.get("err_no", "unknown")
+            error_msg = result.get("err_msg", "Unknown error")
+            raise ValueError(f"Baidu TTS API error {error_code}: {error_msg}")
 
         except requests.RequestException as e:
             logger.exception("Baidu TTS request failed")

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -68,6 +68,7 @@ def enable_commands(app: Flask):
         if dry_run:
             click.echo("DRY RUN MODE - No data will be actually migrated")
 
+        migration_failed = False
         try:
             database_url = app.config["SQLALCHEMY_DATABASE_URI"]
 
@@ -139,29 +140,31 @@ def enable_commands(app: Flask):
                         fg="red",
                     )
                 )
-                raise click.ClickException("Migration failed")
+                migration_failed = True
+            else:
+                if failed_consistency:
+                    click.echo(
+                        click.style(
+                            f"⚠️  Consistency check failed for: {', '.join(failed_consistency)}",
+                            fg="yellow",
+                        )
+                    )
 
-            if failed_consistency:
+                # Success summary
+                total_migrated = sum(
+                    r.synced_records for r in migration_results.values()
+                )
+                total_records = sum(r.total_records for r in migration_results.values())
+                overall_rate = (
+                    (total_migrated / total_records * 100) if total_records > 0 else 0
+                )
+
                 click.echo(
                     click.style(
-                        f"⚠️  Consistency check failed for: {', '.join(failed_consistency)}",
-                        fg="yellow",
+                        f"✅ Migration completed: {total_migrated}/{total_records} records ({overall_rate:.1f}%)",
+                        fg="green",
                     )
                 )
-
-            # Success summary
-            total_migrated = sum(r.synced_records for r in migration_results.values())
-            total_records = sum(r.total_records for r in migration_results.values())
-            overall_rate = (
-                (total_migrated / total_records * 100) if total_records > 0 else 0
-            )
-
-            click.echo(
-                click.style(
-                    f"✅ Migration completed: {total_migrated}/{total_records} records ({overall_rate:.1f}%)",
-                    fg="green",
-                )
-            )
 
         except Exception as e:
             logger.exception("Migration failed")
@@ -169,6 +172,9 @@ def enable_commands(app: Flask):
         finally:
             if "migration_task" in locals():
                 migration_task.close()
+
+        if migration_failed:
+            raise click.ClickException("Migration failed")
 
     @console.command(name="verify")
     def verify_command():
@@ -358,11 +364,10 @@ def enable_commands(app: Flask):
             user_id: User ID for creating/updating the shifu
 
         """
-        try:
-            # Check if file exists
-            if not Path(file_path).exists():
-                raise click.ClickException(f"File not found: {file_path}")
+        if not Path(file_path).exists():
+            raise click.ClickException(f"File not found: {file_path}")
 
+        try:
             click.echo(f"Importing shifu from {file_path}...")
             if shifu_id:
                 click.echo(f"Target shifu ID: {shifu_id} (will update if exists)")

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -54,17 +54,21 @@ def _admin_ops_lock(key: str) -> Iterator[None]:
         from flaskr import dao
 
         redis = getattr(dao, "redis_client", None)
-        if redis is None:
-            raise RuntimeError("Redis client is not configured")
-        lock = redis.lock(
-            f"billing:admin_ops_state:{key}",
-            timeout=10,
-            blocking_timeout=5,
+        lock = (
+            None
+            if redis is None
+            else redis.lock(
+                f"billing:admin_ops_state:{key}",
+                timeout=10,
+                blocking_timeout=5,
+            )
         )
     except Exception as exc:
         raise RuntimeError(
             "Admin billing operations state lock is unavailable"
         ) from exc
+    if lock is None:
+        raise RuntimeError("Admin billing operations state lock is unavailable")
 
     acquired = lock.acquire(blocking=True, blocking_timeout=5)
     if not acquired:

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -1791,6 +1793,16 @@ def upsert_billing_product(
     }
 
 
+@contextmanager
+def _rollback_on_error() -> Iterator[None]:
+    """Roll back the CLI transaction when the wrapped block raises."""
+    try:
+        yield
+    except Exception:
+        db.session.rollback()
+        raise
+
+
 def grant_billing_plan_by_identify(
     *,
     identify: str,
@@ -1815,7 +1827,7 @@ def grant_billing_plan_by_identify(
         )
     normalized_effective_to = str(effective_to or "").strip()
 
-    try:
+    with _rollback_on_error():
         aggregate = load_user_aggregate_by_identifier(normalized_identify)
         if aggregate is None:
             raise click.ClickException(
@@ -2011,11 +2023,7 @@ def grant_billing_plan_by_identify(
             )
             payload["sms_enqueue_status"] = str(sms_payload.get("status") or "")
             payload["sms_enqueued"] = bool(sms_payload.get("enqueued"))
-    except Exception:
-        db.session.rollback()
-        raise
-    else:
-        return payload
+    return payload
 
 
 def grant_operator_credits_by_cli(
@@ -2051,7 +2059,7 @@ def grant_operator_credits_by_cli(
         str(operator_user_bid or "").strip() or _DEFAULT_CLI_OPERATOR_USER_BID
     )
 
-    try:
+    with _rollback_on_error():
         aggregate = (
             load_user_aggregate(normalized_user_bid)
             if normalized_user_bid
@@ -2093,11 +2101,7 @@ def grant_operator_credits_by_cli(
                 "mobile": getattr(aggregate, "mobile", ""),
             }
         )
-    except Exception:
-        db.session.rollback()
-        raise
-    else:
-        return payload
+    return payload
 
 
 def _build_cli_credit_grant_request_id(

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1812,9 +1812,9 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
         """
         try:
             version_id_int = int(version_id)
-            if version_id_int <= 0:
-                raise ValueError
         except (TypeError, ValueError):
+            raise_param_error("version_id")
+        if version_id_int <= 0:
             raise_param_error("version_id")
 
         return make_common_response(

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -211,7 +211,7 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
 
     with app.app_context():
         try:
-            raise _Interrupt
+            raise _Interrupt  # noqa: TRY301 - the in-flight exception is the subject
         except _Interrupt:
             pass
         # No in-flight exception here: plain removal, no invalidate.

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -1,0 +1,87 @@
+"""Error-branch tests for the Baidu and Aliyun TTS HTTP responses."""
+
+import pytest
+import requests
+from flaskr.api.tts import aliyun_provider as aliyun_mod
+from flaskr.api.tts import baidu_provider as baidu_mod
+from flaskr.api.tts.aliyun_provider import AliyunTTSProvider
+from flaskr.api.tts.baidu_provider import BaiduTTSProvider
+
+
+class _Response:
+    def __init__(self, payload, text):
+        self.headers = {"Content-Type": "application/json"}
+        self.status_code = 200
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture
+def baidu(monkeypatch):
+    monkeypatch.setattr(baidu_mod, "_get_access_token", lambda *_args: "token")
+    provider = BaiduTTSProvider()
+    monkeypatch.setattr(provider, "_get_credentials", lambda: ("key", "secret"))
+    return provider
+
+
+@pytest.fixture
+def aliyun(monkeypatch):
+    monkeypatch.setattr(aliyun_mod, "get_aliyun_nls_token", lambda: "token")
+    provider = AliyunTTSProvider()
+    monkeypatch.setattr(provider, "_get_settings", lambda: ("appkey", "shanghai"))
+    return provider
+
+
+def test_baidu_reports_the_json_error_payload(baidu, monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response({"err_no": 502, "err_msg": "bad"}, "{}"),
+    )
+
+    with pytest.raises(ValueError, match=r"Baidu TTS API error 502: bad"):
+        baidu.synthesize("hello")
+
+
+def test_baidu_reports_the_raw_body_when_json_is_malformed(baidu, monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response(None, "<html>oops</html>"),
+    )
+
+    with pytest.raises(ValueError, match=r"Baidu TTS API error: <html>oops</html>"):
+        baidu.synthesize("hello")
+
+
+def test_aliyun_reports_the_json_error_payload(aliyun, monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response(
+            {"status": 40000000, "message": "denied", "task_id": "t-1"},
+            "{}",
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Aliyun TTS API error 40000000: denied \(task_id: t-1\)",
+    ):
+        aliyun.synthesize("hello")
+
+
+def test_aliyun_reports_the_raw_body_when_json_is_malformed(aliyun, monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *_args, **_kwargs: _Response(None, "<html>oops</html>"),
+    )
+
+    with pytest.raises(ValueError, match=r"Aliyun TTS API error: <html>oops</html>"):
+        aliyun.synthesize("hello")

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -479,7 +479,8 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
 
     def timeout_invoke(*_args, **_kwargs):
         try:
-            raise TimeoutError("provider timeout")
+            # The wrapped-timeout shape is exactly what this test asserts.
+            raise TimeoutError("provider timeout")  # noqa: TRY301
         except TimeoutError as exc:
             raise AppError("wrapped provider failure", 9999) from exc
         yield  # pragma: no cover


### PR DESCRIPTION
# Summary

Enables `TRY301` and reworks all 18 sites where a `raise` was thrown inside a `try` whose own handler catches it, so an error is no longer re-caught and rewrapped by the block that produced it. Each site was reviewed individually; nothing was rewritten mechanically.

**TTS providers** (`baidu_provider.py`, `aliyun_provider.py`) — only the JSON decode stays guarded; the provider-error raise moves after it:

```python
try:
    result = response.json()
except ValueError as e:
    raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
error_code = result.get("err_no", "unknown")
raise ValueError(f"Baidu TTS API error {error_code}: ...")
```

This also deletes the Aliyun `if "Aliyun TTS API error" in str(e): raise` string sniffing that existed only to tell its own raise apart from a decode failure. Messages for both branches are unchanged, and new tests in `tests/service/tts/test_provider_error_responses.py` pin the JSON-error and malformed-body messages for both providers (previously untested).

**`shifu/route.py`** — the `<= 0` check runs after the conversion `try` instead of as a bare `raise ValueError` inside it; same `raise_param_error("version_id")` contract.

**`command/__init__.py`** — `flask console migrate` sets a `migration_failed` flag and raises `ClickException("Migration failed")` after the `finally` that closes the task, instead of raising inside the handler that turned it into `Migration failed: Migration failed`; `import-shifu` checks file existence before entering the try, so a missing path reports `File not found: ...` rather than `Import failed: File not found: ...`. Both are message improvements; the failure exit path and the task cleanup are unchanged.

**`billing/admin_ops_state.py`** — the missing-Redis case is reported after the guarded lookup, with the same `Admin billing operations state lock is unavailable` message it already produced via the normalizing handler.

**`billing/cli.py`** — the two grant flows kept a `try/except: rollback; raise/else: return` wrapper around their whole transaction, which made every business-validation `ClickException` a TRY301 hit. The wrapper becomes an explicit boundary and the raises stay where they are decided:

```python
@contextmanager
def _rollback_on_error() -> Iterator[None]:
    try:
        yield
    except Exception:
        db.session.rollback()
        raise
```

Rollback still fires for every exception, and the commit/return points are untouched.

**`scripts/check_translations.py`** — the "no locale directories" check moves into `_require_locale_dirs()`, still raising `TranslationError` into `main()`'s handler.

Two deliberate `noqa: TRY301` remain in tests where the raise-inside-try shape *is* the fixture: the in-flight-interrupt DAO session test and the wrapped-provider-timeout optimizer test.

## Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`, `python scripts/check_translations.py`
- `pytest tests/service/billing tests/service/shifu tests/service/user tests/common tests/service/tts` → 1654 passed, 9 skipped. The 5 failures in `tests/service/shifu/test_admin_course_detail.py` are the pre-existing SQLite `no such function: concat` failures that also fail on `main`.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly control-flow refactors for lint compliance; billing CLI and migration paths were touched but preserve rollback, cleanup, and user-facing errors per added tests and the PR’s stated behavior.
> 
> **Overview**
> Enables **TRY301** in `ruff.toml` and refactors ~18 call sites so a `try`/`except` no longer raises an exception that the same block immediately catches and rewraps.
> 
> **TTS (Baidu/Aliyun):** JSON parsing stays in `try`/`except ValueError`; structured API error `ValueError`s are raised afterward, dropping Aliyun’s message-string sniff. New tests lock JSON vs malformed-body error messages.
> 
> **CLI / ops:** `flask console migrate` records failure via a flag and raises after `finally` cleanup; `import-shifu` validates the file path before the import `try`. Billing grant flows use a shared `_rollback_on_error()` context manager instead of wrapping the whole transaction in `try`/`except`/`else`.
> 
> **Smaller moves:** Shifu `version_id` positivity check after parse; billing admin Redis lock “unavailable” after lookup; translation script’s empty-locale check in `_require_locale_dirs()`. Two tests keep deliberate `noqa: TRY301` where raise-in-try is the scenario under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f2326585a7b9815c1034896f8fe08d6e5e8095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->