### PR TITLE
style: enforce ruff S105 and S106 (no hardcoded credential literals)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -131,6 +131,8 @@ select = [
     "S101",    # assert used outside tests
     "S104",    # binding a socket to all interfaces
     "S107",    # hardcoded password as a function default
+    "S105",    # string literal that looks like a hardcoded password
+    "S106",    # hardcoded password passed as an argument
     "S108",    # hardcoded /tmp path instead of tempfile.gettempdir()
     # S110/S112 flag `except Exception: pass` / `continue`. A deliberate
     # best-effort block reads better as `contextlib.suppress(...)`, which the
@@ -237,7 +239,9 @@ ignore = [
 # Developer tooling (repo scripts, backend scripts, test harnesses) also shells
 # out to `git`, `node` and `python` with statically built argument lists, so the
 # subprocess audit rules only add noise there.
-"src/api/tests/**" = ["S101", "S603", "S607"]
+# Test suites are also full of literal fake passwords, tokens and secret keys
+# for fixtures and negative cases, which is what S105/S106 flag.
+"src/api/tests/**" = ["S101", "S105", "S106", "S603", "S607"]
 # These suites bind SQLAlchemy model classes and session factories to local
 # names, where the CapWords spelling is the point.
 "src/api/tests/service/shifu/test_archive.py" = ["N806"]

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -52,7 +52,7 @@ from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYP
 from flaskr.util.datetime import now_utc
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
-TTS_DEFAULT_MODEL_TOKEN = "default"
+TTS_DEFAULT_MODEL_TOKEN = "default"  # noqa: S105 - placeholder model id, not a secret
 
 # Provider registry (ordered by default selection priority)
 _PROVIDER_REGISTRY = {

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -33,9 +33,10 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 
 
 NLS_META_ENDPOINT = "https://nls-meta.cn-shanghai.aliyuncs.com/"
-NLS_CREATE_TOKEN_ACTION = "CreateToken"
-NLS_CREATE_TOKEN_VERSION = "2019-02-28"
-NLS_CREATE_TOKEN_REGION_ID = "cn-shanghai"
+# The token-issuing API coordinates below name the RPC, not a credential.
+NLS_CREATE_TOKEN_ACTION = "CreateToken"  # noqa: S105
+NLS_CREATE_TOKEN_VERSION = "2019-02-28"  # noqa: S105
+NLS_CREATE_TOKEN_REGION_ID = "cn-shanghai"  # noqa: S105
 
 # Refresh slightly early to avoid edge cases around clock skew.
 _DEFAULT_REFRESH_LEEWAY_SECONDS = 60

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -28,7 +28,7 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 
 # Baidu TTS API endpoints
 BAIDU_TTS_API_URL = "https://tsn.baidu.com/text2audio"
-BAIDU_TOKEN_URL = "https://aip.baidubce.com/oauth/2.0/token"
+BAIDU_TOKEN_URL = "https://aip.baidubce.com/oauth/2.0/token"  # noqa: S105 - endpoint URL
 
 # Baidu audio format mapping
 BAIDU_AUDIO_FORMATS = {

--- a/src/api/flaskr/common/umami_client.py
+++ b/src/api/flaskr/common/umami_client.py
@@ -13,7 +13,7 @@ from flaskr.common.cache_provider import cache
 from flaskr.common.config import get_config
 
 UMAMI_CLOUD_API_BASE_URL = "https://api.umami.is/v1"
-UMAMI_ACCESS_TOKEN_CACHE_SUFFIX = "analytics:umami:access-token"
+UMAMI_ACCESS_TOKEN_CACHE_SUFFIX = "analytics:umami:access-token"  # noqa: S105 - cache key suffix
 UMAMI_COURSE_VISIT_CACHE_PREFIX = "analytics:umami:course-visits:30d"
 UMAMI_METRICS_PAGE_SIZE = 500
 COURSE_VISIT_EVENT_PREFIX = "course_visit_"

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -38,7 +38,7 @@ from flaskr.service.user.utils import (
 )
 
 AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
-TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"  # noqa: S105 - endpoint URL
 USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
 # Lifetime (in seconds) for Google OAuth state.
 # Used for stateless signed state tokens (no Redis required).


### PR DESCRIPTION
# Summary

Enables `S105` (string literal that looks like a hardcoded password) and `S106` (hardcoded password passed as an argument), so a real credential literal in shipped backend code now fails lint.

Of the 77 hits, 70 are in `src/api/tests/**`, where literal fake passwords, tokens and secret keys are the fixtures and the negative cases — that directory gets a per-file ignore.

The 7 production hits are all name-triggered false positives, kept as-is with an inline justification:

| site | value | what it is |
| --- | --- | --- |
| `tts/__init__.py` `TTS_DEFAULT_MODEL_TOKEN` | `"default"` | placeholder model id |
| `tts/aliyun_nls_token.py` ×3 | `"CreateToken"` / `"2019-02-28"` / `"cn-shanghai"` | RPC action, version, region |
| `tts/baidu_provider.py` `BAIDU_TOKEN_URL` | OAuth endpoint URL | endpoint |
| `common/umami_client.py` `UMAMI_ACCESS_TOKEN_CACHE_SUFFIX` | `"analytics:umami:access-token"` | cache key suffix |
| `user/auth/providers/google.py` `TOKEN_ENDPOINT` | Google OAuth token URL | endpoint |

No behavior change. Verification: `ruff check .`, `ruff format --check .`.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->