### PR TITLE
style: enforce ruff T20 (no stray print in shipped code)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -62,6 +62,11 @@ select = [
     "YTT",     # sys.version checks that break on two-digit versions
     "EXE",     # shebang vs executable-bit consistency
     "ASYNC",   # blocking I/O / sleep / subprocess inside async functions
+    # T20 bans `print`/`pprint` in shipped code, where logging is the contract.
+    # Developer scripts, the inventory tooling and the test suites are console
+    # programs by design and are exempt below; the few remaining backend calls
+    # are CLI or debug output and say so inline.
+    "T20",     # print / pprint in shipped code
     "T1",      # leftover debugger calls
     "ERA001",  # commented-out code
 
@@ -241,7 +246,7 @@ ignore = [
 # subprocess audit rules only add noise there.
 # Test suites are also full of literal fake passwords, tokens and secret keys
 # for fixtures and negative cases, which is what S105/S106 flag.
-"src/api/tests/**" = ["S101", "S105", "S106", "S603", "S607"]
+"src/api/tests/**" = ["S101", "S105", "S106", "S603", "S607", "T20"]
 # These suites bind SQLAlchemy model classes and session factories to local
 # names, where the CapWords spelling is the point.
 "src/api/tests/service/shifu/test_archive.py" = ["N806"]
@@ -265,5 +270,7 @@ ignore = [
 # wire contract, not a naming slip.
 "src/api/flaskr/service/billing/dtos.py" = ["N815"]
 "src/api/flaskr/service/common/dtos.py" = ["N815"]
-"scripts/**" = ["S603", "S607"]
-"src/api/scripts/**" = ["S603", "S607"]
+# Developer scripts and the backend inventory/harness tooling are console
+# programs: printing to stdout is their interface.
+"scripts/**" = ["S603", "S607", "T20"]
+"src/api/scripts/**" = ["S603", "S607", "T20"]

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -284,7 +284,7 @@ class UnifiedMigrationTask:
                 )
 
                 # Also print for visibility during flask db upgrade
-                print(
+                print(  # noqa: T201
                     f"[MIGRATION] {source_table}: {progress:.1f}% ({synced_count}/{total_count})"
                 )
                 import sys
@@ -312,7 +312,8 @@ class UnifiedMigrationTask:
 
         completion_message = f"Migration completed for {source_table}: {synced_count}/{total_count} records, {error_count} errors"
         logger.info(completion_message)
-        print(f"[MIGRATION] ✅ {completion_message}")
+        # Printed so progress stays visible during `flask db upgrade`.
+        print(f"[MIGRATION] ✅ {completion_message}")  # noqa: T201
         import sys
 
         sys.stdout.flush()
@@ -1099,7 +1100,7 @@ async def main():
                 await asyncio.to_thread(_write_report)
                 logger.info(f"Report saved to: {args.output_file}")
             else:
-                print(report)
+                print(report)  # noqa: T201 - CLI report on stdout
 
         elif args.action == "verify":
             logger.info("Starting data consistency verification...")
@@ -1107,7 +1108,7 @@ async def main():
 
             for result in consistency_results.values():
                 status = "PASSED" if result.is_consistent else "FAILED"
-                print(f"{status}: {result.table_pair}")
+                print(f"{status}: {result.table_pair}")  # noqa: T201 - CLI output
                 if not result.is_consistent:
                     sys.exit(1)
 
@@ -1118,7 +1119,7 @@ async def main():
             report = migration_task.generate_migration_report(
                 migration_results, consistency_results
             )
-            print(report)
+            print(report)  # noqa: T201 - CLI report on stdout
 
     finally:
         migration_task.close()

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1934,7 +1934,7 @@ class EnhancedConfig:
 
     def debug_print(self) -> None:
         """Print all configuration values (excluding secrets) for debugging."""
-        print("\n=== Configuration Values ===")
+        print("\n=== Configuration Values ===")  # noqa: T201
         groups = {}
         for var_name, env_var in self.env_vars.items():
             if env_var.group not in groups:
@@ -1943,10 +1943,10 @@ class EnhancedConfig:
             display_value = "[REDACTED]" if env_var.secret and value else str(value)
             groups[env_var.group].append(f"  {var_name}: {display_value}")
         for group, items in sorted(groups.items()):
-            print(f"\n[{group.upper()}]")
+            print(f"\n[{group.upper()}]")  # noqa: T201
             for item in sorted(items):
-                print(item)
-        print("\n" + "=" * 30 + "\n")
+                print(item)  # noqa: T201
+        print("\n" + "=" * 30 + "\n")  # noqa: T201
 
     def export_env_example(self) -> str:
         """Export full environment variable definitions as .env.example format."""


### PR DESCRIPTION
# Summary

Enables the flake8-print group (`T201` print, `T203` pprint) so a debugging print left in request or service code fails lint instead of bypassing the logger in production.

Of the 233 hits, 224 are in code whose stdout *is* its interface — `scripts/**`, `src/api/scripts/**` (including the inventory tooling) and `src/api/tests/**` — which get per-file ignores rather than a rewrite that would break their CLI output.

The 9 remaining backend calls stay, each with an inline reason:

- `flaskr/common/config.py` `debug_print()` — a debug dump helper that prints by definition (4 calls).
- `flaskr/command/unified_migration_task.py` — 2 progress lines deliberately printed (with an explicit `stdout.flush()`) so migration progress is visible during `flask db upgrade`, and 3 report/status lines in the module's `main()` CLI.

No behavior change. Verification: `ruff check .`, `ruff format --check .`.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->