### PR TITLE
refactor: import backend modules by absolute path instead of reaching into parent packages

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -124,6 +124,11 @@ select = [
     "N802",    # function name that is not lowercase
     "N803",    # argument name that is not lowercase
     "N813",    # CamelCase imported under a lowercase alias
+    # TID252 bans reaching into a parent package with `from ..x import y`, which
+    # hides which package a name really comes from; sibling-local `from .x`
+    # imports stay allowed. The boundary-checker fixture below must keep its
+    # parent-relative imports, since detecting them is what it tests.
+    "TID252",  # relative import from a parent module
     # N815 flags mixedCase class attributes. The two DTO modules whose fields
     # ARE the serialized JSON keys the frontend reads are exempt below, so the
     # rule still catches accidental camelCase everywhere else.
@@ -273,4 +278,7 @@ ignore = [
 # Developer scripts and the backend inventory/harness tooling are console
 # programs: printing to stdout is their interface.
 "scripts/**" = ["S603", "S607", "T20"]
+# This fixture exists so check_architecture_boundaries.py can prove it resolves
+# parent-relative imports; rewriting them would delete the test case.
+"scripts/testdata/architecture_boundaries/**" = ["TID252"]
 "src/api/scripts/**" = ["S603", "S607", "T20"]

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -11,9 +11,10 @@ from flask import Flask
 from sqlalchemy import create_engine, text
 from werkzeug.datastructures import FileStorage
 
-from ..service.billing.cli import register_billing_commands
-from ..service.shifu.cli import register_shifu_commands
-from ..service.shifu.shifu_import_export_funcs import export_shifu, import_shifu
+from flaskr.service.billing.cli import register_billing_commands
+from flaskr.service.shifu.cli import register_shifu_commands
+from flaskr.service.shifu.shifu_import_export_funcs import export_shifu, import_shifu
+
 from .import_user import import_user
 from .unified_migration_task import MigrationConfig, UnifiedMigrationTask
 from .update_shifu_demo import update_demo_shifu
@@ -184,7 +185,7 @@ def enable_commands(app: Flask):
 
         try:
             # Get database URL from Flask config
-            from ..common.config import get_config
+            from flaskr.common.config import get_config
 
             config = get_config()
             database_url = config.SQLALCHEMY_DATABASE_URI
@@ -239,7 +240,7 @@ def enable_commands(app: Flask):
 
         try:
             # Get database URL from Flask config
-            from ..common.config import get_config
+            from flaskr.common.config import get_config
 
             config = get_config()
             database_url = config.SQLALCHEMY_DATABASE_URI

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -9,15 +9,15 @@ from flaskr.service.billing.webhooks import (
     handle_billing_pingxx_webhook,
 )
 from flaskr.service.config import config_overrides
-from flaskr.service.order.models import Order, PingxxOrder
-from flaskr.service.order.payment_providers import get_payment_provider
-from flaskr.service.order.raw_snapshots import native_snapshot_model
-
-from ..service.order import (
+from flaskr.service.order import (
     handle_stripe_webhook,
     success_buy_record_from_native,
     success_buy_record_from_pingxx,
 )
+from flaskr.service.order.models import Order, PingxxOrder
+from flaskr.service.order.payment_providers import get_payment_provider
+from flaskr.service.order.raw_snapshots import native_snapshot_model
+
 from .common import bypass_token_validation
 
 

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -9,8 +9,7 @@ from werkzeug.exceptions import HTTPException
 
 from flaskr.common.shifu_context import clear_shifu_context
 from flaskr.i18n import _, _translations, clear_language, set_language
-
-from ..service.common import AppError
+from flaskr.service.common import AppError
 
 by_pass_login_func = [
     "flasgger.apispec_1",

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -1,8 +1,8 @@
 from flask import Flask
 
 from flaskr.api.llm import get_current_models
+from flaskr.service.common.dicts import get_all_dicts
 
-from ..service.common.dicts import get_all_dicts
 from .common import bypass_token_validation, make_common_response
 
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -6,8 +6,10 @@ from flask import Flask, current_app, make_response, request
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.dao import db
 from flaskr.i18n import _translations, set_language
+from flaskr.service.common.dtos import OAuthStartDTO, UserToken
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
+from flaskr.service.feedback.funs import submit_feedback
 from flaskr.service.profile.api import merge_learner_profile_for_sign_in
 from flaskr.service.profile.funcs import (
     get_user_profile_labels,
@@ -26,17 +28,27 @@ from flaskr.service.profile.onboarding import (
     complete_profile_onboarding,
     get_profile_onboarding_status,
 )
+from flaskr.service.referral.service import extract_referral_post_auth_fields
+from flaskr.service.user.auth import get_provider
+from flaskr.service.user.auth.base import OAuthCallbackRequest, VerificationRequest
 from flaskr.service.user.captcha import (
     create_captcha_challenge,
     verify_captcha_code,
 )
+from flaskr.service.user.common import update_user_info, validate_user
 from flaskr.service.user.consts import CREDENTIAL_STATE_VERIFIED
 from flaskr.service.user.models import AuthCredential
+from flaskr.service.user.onboarding import (
+    ONBOARDING_VERSION,
+    build_onboarding_status,
+    complete_onboarding_scene,
+)
 from flaskr.service.user.password_utils import (
     hash_password,
     validate_password_strength,
     verify_password,
 )
+from flaskr.service.user.post_auth import PostAuthContext, run_post_auth_extensions
 from flaskr.service.user.repository import (
     build_user_info_from_aggregate,
     find_credential,
@@ -46,31 +58,19 @@ from flaskr.service.user.repository import (
     load_user_aggregate_by_identifier,
     set_password_hash,
 )
-from flaskr.service.user.verification_codes import consume_verification_code
-from flaskr.util.uuid import generate_id
-
-from ..service.common.dtos import OAuthStartDTO, UserToken
-from ..service.feedback.funs import submit_feedback
-from ..service.referral.service import extract_referral_post_auth_fields
-from ..service.user.auth import get_provider
-from ..service.user.auth.base import OAuthCallbackRequest, VerificationRequest
-from ..service.user.common import update_user_info, validate_user
-from ..service.user.onboarding import (
-    ONBOARDING_VERSION,
-    build_onboarding_status,
-    complete_onboarding_scene,
-)
-from ..service.user.post_auth import PostAuthContext, run_post_auth_extensions
-from ..service.user.user import (
+from flaskr.service.user.user import (
     generate_temp_user,
     update_user_open_id,
     upload_user_avatar,
 )
-from ..service.user.utils import (
+from flaskr.service.user.utils import (
     ensure_admin_creator_and_demo_permissions,
     send_email_code,
     send_sms_code,
 )
+from flaskr.service.user.verification_codes import consume_verification_code
+from flaskr.util.uuid import generate_id
+
 from .common import by_pass_login_func, bypass_token_validation, make_common_response
 
 _DEFAULT_SUPPORTED_RUNTIME_LANGUAGES = ("zh-CN", "en-US", "fr-FR")

--- a/src/api/flaskr/service/check_risk/funcs.py
+++ b/src/api/flaskr/service/check_risk/funcs.py
@@ -1,10 +1,10 @@
 from flask import Flask
 from flaskr.api.check import CHECK_RESULT_PASS, CHECK_RESULT_REJECT, check_text
 from flaskr.api.check.dto import CheckResultDTO
+from flaskr.dao import db
 from flaskr.service.common.models import raise_error
 from flaskr.util.datetime import now_utc
 
-from ...dao import db
 from .models import RiskControlResult
 
 

--- a/src/api/flaskr/service/check_risk/models.py
+++ b/src/api/flaskr/service/check_risk/models.py
@@ -1,3 +1,4 @@
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     TIMESTAMP,
@@ -7,8 +8,6 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 
 class RiskControlResult(db.Model):

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -1,8 +1,7 @@
 import math
 
+from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import BaseModel, Field
-
-from ...common.swagger import register_schema_to_swagger
 
 USER_STATE_UNREGISTERED = 0
 USER_STATE_REGISTERED = 1

--- a/src/api/flaskr/service/config/models.py
+++ b/src/api/flaskr/service/config/models.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -9,8 +10,6 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 
 class Config(db.Model):

--- a/src/api/flaskr/service/feedback/funs.py
+++ b/src/api/flaskr/service/feedback/funs.py
@@ -1,8 +1,8 @@
 from flask import Flask
 from flaskr.api.doc.feishu import send_notify
+from flaskr.dao import db
 from flaskr.service.user.repository import load_user_aggregate
 
-from ...dao import db
 from .models import FeedBack
 
 

--- a/src/api/flaskr/service/feedback/models.py
+++ b/src/api/flaskr/service/feedback/models.py
@@ -1,3 +1,4 @@
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     TIMESTAMP,
@@ -5,8 +6,6 @@ from sqlalchemy import (
     String,
 )
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 
 class FeedBack(db.Model):

--- a/src/api/flaskr/service/learn/__init__.py
+++ b/src/api/flaskr/service/learn/__init__.py
@@ -1,4 +1,5 @@
 """Learning-session runtime service."""
 
-from ..common.dicts import register_dict  # noqa: F401
+from flaskr.service.common.dicts import register_dict  # noqa: F401
+
 from .models import *  # noqa: F403

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -11,6 +11,16 @@ from enum import Enum
 from typing import Any, Union
 
 from flask import Flask
+from flaskr.api.langfuse import (
+    LangfuseTraceHandle,
+    MockClient,
+    create_trace_with_root_span,
+    finalize_langfuse_trace,
+    get_langfuse_client,
+    get_request_trace_id,
+    normalize_langfuse_input_value,
+    normalize_langfuse_output_value,
+)
 from flaskr.api.llm import chat_llm, get_allowed_models, get_current_models
 from flaskr.common.cache_provider import cache as cache_provider
 from flaskr.common.i18n_utils import (
@@ -119,17 +129,6 @@ from markdown_flow import (
     replace_variables_in_text,
 )
 from markdown_flow.llm import LLMResult
-
-from ...api.langfuse import (
-    LangfuseTraceHandle,
-    MockClient,
-    create_trace_with_root_span,
-    finalize_langfuse_trace,
-    get_langfuse_client,
-    get_request_trace_id,
-    normalize_langfuse_input_value,
-    normalize_langfuse_output_value,
-)
 
 context_local = threading.local()
 

--- a/src/api/flaskr/service/learn/models.py
+++ b/src/api/flaskr/service/learn/models.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from flaskr.dao import db
 from flaskr.service.order.consts import LEARN_STATUS_LOCKED
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
@@ -12,8 +13,6 @@ from sqlalchemy import (
     Text,
 )
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 
 class LearnProgressRecord(db.Model):

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -2,6 +2,7 @@ import re
 
 from flask import Flask
 from flaskr.service.learn.models import LearnGeneratedBlock
+from flaskr.service.profile.funcs import get_user_profiles
 from flaskr.service.shifu.consts import ASK_MODE_DEFAULT, ASK_MODE_DISABLE
 from flaskr.service.shifu.models import (
     DraftOutlineItem,
@@ -13,8 +14,6 @@ from flaskr.service.shifu.shifu_draft_funcs import normalize_ask_provider_config
 from flaskr.service.shifu.shifu_struct_manager import HistoryItem, get_shifu_struct
 from flaskr.service.shifu.struct_utils import find_node_with_parents
 from flaskr.util.uuid import generate_id
-
-from ...service.profile.funcs import get_user_profiles
 
 
 class FollowUpInfo:

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any
 
-from ..common.dicts import register_dict
+from flaskr.service.common.dicts import register_dict
+
 from .consts import *  # noqa: F403
 
 register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa: F405

--- a/src/api/flaskr/service/order/models.py
+++ b/src/api/flaskr/service/order/models.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -13,7 +14,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.mysql import BIGINT
 
-from ...dao import db
 from .consts import (
     ORDER_STATUS_INIT,
 )

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -7,6 +7,9 @@ from flaskr.api.check import (
     CHECK_RESULT_REJECT,
     check_text,
 )
+from flaskr.dao import db
+from flaskr.i18n import _
+from flaskr.service.check_risk.funcs import add_risk_control_result
 from flaskr.service.common import raise_error
 from flaskr.service.profile.dtos import ProfileToSave
 from flaskr.service.profile.profile_manage import get_profile_item_definition_list
@@ -21,9 +24,6 @@ from flaskr.service.user.repository import (
 )
 from flaskr.util.uuid import generate_id
 
-from ...dao import db
-from ...i18n import _
-from ..check_risk.funcs import add_risk_control_result
 from .constants import SYS_USER_LANGUAGE, SYS_USER_NICKNAME
 from .models import VariableValue
 

--- a/src/api/flaskr/service/profile/models.py
+++ b/src/api/flaskr/service/profile/models.py
@@ -1,10 +1,9 @@
 from typing import ClassVar
 
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import Column, DateTime, SmallInteger, String, Text
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 PROFILE_TYPE_SYSTEM = 2801
 PROFILE_TYPE_USER = 2802

--- a/src/api/flaskr/service/profile/profile_manage.py
+++ b/src/api/flaskr/service/profile/profile_manage.py
@@ -2,6 +2,7 @@ import hashlib
 
 from flask import Flask
 from flaskr.common.i18n_utils import get_markdownflow_output_language
+from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.common import raise_error
 from flaskr.service.shifu.models import DraftOutlineItem
@@ -10,7 +11,6 @@ from flaskr.util.uuid import generate_id
 from markdown_flow import MarkdownFlow
 from sqlalchemy import func, inspect, text
 
-from ...dao import db
 from .dtos import (
     DEFAULT_COLOR_SETTINGS,
     ColorSetting,

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -4,11 +4,11 @@ import decimal
 from contextlib import nullcontext
 
 from flask import Flask, has_app_context
+from flaskr.dao import db
+from flaskr.util import generate_id
+from flaskr.util.datetime import now_utc
 from sqlalchemy import and_, func, or_
 
-from ...dao import db
-from ...util import generate_id
-from ...util.datetime import now_utc
 from .consts import (
     COUPON_BATCH_STATUS_ACTIVE,
     COUPON_BATCH_STATUS_INACTIVE,

--- a/src/api/flaskr/service/promo/models.py
+++ b/src/api/flaskr/service/promo/models.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     Column,
@@ -11,7 +12,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.mysql import BIGINT
 
-from ...dao import db
 from .consts import (
     COUPON_APPLY_TYPE_ALL,
     COUPON_STATUS_ACTIVE,

--- a/src/api/flaskr/service/resource/models.py
+++ b/src/api/flaskr/service/resource/models.py
@@ -1,8 +1,7 @@
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import TIMESTAMP, Column, Integer, String
 from sqlalchemy.dialects.mysql import BIGINT
-
-from ...dao import db
 
 
 class Resource(db.Model):

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -15,13 +15,13 @@ from urllib.parse import urlparse
 import requests
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_key_prefix
+from flaskr.dao import db
+from flaskr.service.common.models import raise_error
 from flaskr.service.common.oss_utils import OSS_PROFILE_COURSES, get_image_content_type
 from flaskr.service.common.storage import upload_to_storage
 from flaskr.service.config import get_config
+from flaskr.service.resource.models import Resource
 
-from ...dao import db
-from ...service.resource.models import Resource
-from ..common.models import raise_error
 from .models import AiCourseAuth, FavoriteScenario
 from .utils import get_shifu_creator_bid
 

--- a/src/api/flaskr/service/shifu/models.py
+++ b/src/api/flaskr/service/shifu/models.py
@@ -6,6 +6,7 @@ Author: yfge
 Date: 2025-08-07
 """
 
+from flaskr.dao import db
 from flaskr.util.compare import compare_decimal
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
@@ -22,7 +23,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.mysql import BIGINT, LONGTEXT
 
-from ...dao import db
 from .consts import ASK_MODE_DEFAULT
 
 

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -13,21 +13,18 @@ from time import perf_counter
 from typing import Any
 
 from flask import Flask
+from flaskr.dao import db
 from flaskr.i18n import _
-from flaskr.util.datetime import now_utc
-
-from ...dao import db
-from ...service.config import get_config
-from ...util import generate_id
-from ..check_risk.funcs import check_text_with_risk_control
-from ..common.dtos import PageNationDTO
-from ..common.models import raise_error, raise_error_with_args
+from flaskr.service.check_risk.funcs import check_text_with_risk_control
+from flaskr.service.common.dtos import PageNationDTO
+from flaskr.service.common.models import raise_error, raise_error_with_args
+from flaskr.service.config import get_config
 
 # Deprecation-window shim: the ask-provider constants moved to their canonical
 # home in flaskr/service/learn/ask_provider_adapters/consts.py. They are
 # re-exported here so existing importers keep working; import from the new
 # location in new code.
-from ..learn.ask_provider_adapters.consts import (  # noqa: F401
+from flaskr.service.learn.ask_provider_adapters.consts import (  # noqa: F401
     ASK_PROVIDER_COZE,
     ASK_PROVIDER_COZE_WORKFLOW,
     ASK_PROVIDER_DIFY,
@@ -39,7 +36,10 @@ from ..learn.ask_provider_adapters.consts import (  # noqa: F401
     SUPPORTED_ASK_PROVIDER_MODES,
     SUPPORTED_ASK_PROVIDERS,
 )
-from ..tts.validation import validate_tts_settings_strict
+from flaskr.service.tts.validation import validate_tts_settings_strict
+from flaskr.util import generate_id
+from flaskr.util.datetime import now_utc
+
 from .consts import (
     ASK_MODE_DEFAULT,
     ASK_MODE_DISABLE,

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -9,14 +9,14 @@ Date: 2025-08-07
 from decimal import Decimal
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
+from flaskr.dao import db
 from flaskr.service.check_risk.funcs import check_text_with_risk_control
+from flaskr.service.common.models import raise_error, raise_param_error
+from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc
 from markdown_flow import MarkdownFlow
 from sqlalchemy.orm import load_only
 
-from ...dao import db
-from ...util import generate_id
-from ..common.models import raise_error, raise_param_error
 from .consts import (
     UNIT_TYPE_GUEST,
     UNIT_TYPE_TRIAL,

--- a/src/api/flaskr/service/user/common.py
+++ b/src/api/flaskr/service/user/common.py
@@ -1,13 +1,13 @@
 import jwt
 from flask import Flask, has_app_context
+from flaskr.dao import db
 from flaskr.i18n import get_i18n_list
+from flaskr.service.common.dtos import UserInfo, UserToken
+from flaskr.service.common.models import raise_error
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
+from flaskr.service.profile.dtos import ProfileToSave
+from flaskr.service.profile.funcs import save_user_profiles
 
-from ...dao import db
-from ..common.dtos import UserInfo, UserToken
-from ..common.models import raise_error
-from ..profile.dtos import ProfileToSave
-from ..profile.funcs import save_user_profiles
 from .auth import get_provider
 from .auth.base import VerificationRequest
 from .repository import (

--- a/src/api/flaskr/service/user/dtos.py
+++ b/src/api/flaskr/service/user/dtos.py
@@ -1,8 +1,7 @@
 import datetime
 
+from flaskr.common.swagger import register_schema_to_swagger
 from pydantic import BaseModel, Field
-
-from ...common.swagger import register_schema_to_swagger
 
 
 @register_schema_to_swagger

--- a/src/api/flaskr/service/user/models.py
+++ b/src/api/flaskr/service/user/models.py
@@ -1,3 +1,4 @@
+from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from sqlalchemy import (
     TIMESTAMP,
@@ -12,7 +13,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.mysql import BIGINT
 
-from ...dao import db
 from .consts import CREDENTIAL_STATE_UNVERIFIED, USER_STATE_UNREGISTERED
 
 

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -7,8 +7,12 @@ import uuid
 from urllib.parse import urlsplit
 
 from flask import Flask
+from flaskr.api.wechat import get_wechat_access_token
 from flaskr.common.shifu_context import get_shifu_creator_bid as get_context_creator_bid
+from flaskr.dao import db
 from flaskr.service.billing.api import resolve_creator_public_integrations
+from flaskr.service.common.dtos import USER_STATE_UNREGISTERED, UserToken
+from flaskr.service.common.models import raise_error
 from flaskr.service.common.oss_utils import (
     OSS_PROFILE_DEFAULT,
     create_oss_bucket,
@@ -22,12 +26,8 @@ from flaskr.service.common.storage import (
     get_local_storage_path,
     upload_to_storage,
 )
+from flaskr.service.user.models import UserConversion
 
-from ...api.wechat import get_wechat_access_token
-from ...dao import db
-from ...service.common.dtos import USER_STATE_UNREGISTERED, UserToken
-from ...service.user.models import UserConversion
-from ..common.models import raise_error
 from .repository import (
     build_user_info_from_aggregate,
     create_user_entity,

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -11,7 +11,9 @@ from flask import Flask, has_app_context
 from flaskr.api.sms.aliyun import send_sms_code_ali
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_derived_prefix
+from flaskr.dao import db
 from flaskr.i18n import _
+from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.phone_numbers import (
     is_valid_sms_mobile,
     normalize_phone_identifier,
@@ -24,8 +26,6 @@ from flaskr.service.user.token_store import token_store
 from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc
 
-from ...dao import db
-from ..common.models import raise_error, raise_param_error
 from .models import UserVerifyCode
 
 


### PR DESCRIPTION
# Summary

Rewrites the 106 parent-relative imports under `src/api/flaskr` as absolute imports and enables `TID252` so new ones are rejected.

```diff
-from ...dao import db
-from ..common.dtos import UserInfo, UserToken
+from flaskr.dao import db
+from flaskr.service.common.dtos import UserInfo, UserToken
 from .auth import get_provider          # unchanged: sibling-local imports stay relative
```

`TID252` only bans `from ..`/`from ...` (its default `ban-relative-imports = "parents"`), so package-local `from .x import y` is untouched — 33 files changed, all import statements plus the isort regrouping they trigger. Absolute and relative forms resolve to the same module object, so import order and cycle behavior are unchanged.

`scripts/testdata/architecture_boundaries/**` keeps its parent-relative imports through a per-file ignore: that fixture exists so `check_architecture_boundaries.py` can prove it resolves them.

Verification: `ruff check .`, `ruff format --check .`, `python scripts/check_architecture_boundaries.py`, and the backend suite (2860 passed; the 5 `tests/service/shifu/test_admin_course_detail.py` failures are the pre-existing SQLite `no such function: concat` baseline, also failing on `main`).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->