### PR TITLE
feat: share one Google OAuth callback across all domains

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -200,6 +200,10 @@ GOOGLE_OAUTH_CLIENT_ID=""
 # Secret value
 GOOGLE_OAUTH_CLIENT_SECRET=""
 
+# Shared Google OAuth callback URL for every domain this deployment serves. Google does not accept wildcards in a client's authorized redirect URIs, so pinning one callback here keeps white-label domains from each needing their own entry; the browser is handed back to the domain it started from afterwards. Leave empty to derive the callback from the requested origin.
+# (Optional - default: )
+GOOGLE_OAUTH_REDIRECT_URI=""
+
 # Google OAuth token endpoint URL used by the backend to exchange auth codes.
 # (Optional - default: https://oauth2.googleapis.com/token)
 GOOGLE_OAUTH_TOKEN_ENDPOINT="https://oauth2.googleapis.com/token"

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -903,6 +903,19 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         secret=True,
         group="auth",
     ),
+    "GOOGLE_OAUTH_REDIRECT_URI": EnvVar(
+        name="GOOGLE_OAUTH_REDIRECT_URI",
+        default="",
+        description=(
+            "Shared Google OAuth callback URL for every domain this deployment "
+            "serves. Google does not accept wildcards in a client's authorized "
+            "redirect URIs, so pinning one callback here keeps white-label "
+            "domains from each needing their own entry; the browser is handed "
+            "back to the domain it started from afterwards. Leave empty to "
+            "derive the callback from the requested origin."
+        ),
+        group="auth",
+    ),
     "GOOGLE_OAUTH_TOKEN_ENDPOINT": EnvVar(
         name="GOOGLE_OAUTH_TOKEN_ENDPOINT",
         default="https://oauth2.googleapis.com/token",

--- a/src/api/flaskr/common/public_urls.py
+++ b/src/api/flaskr/common/public_urls.py
@@ -12,7 +12,38 @@ STRIPE_BILLING_RESULT_PATH = "/payment/stripe/billing-result"
 
 
 def build_google_oauth_callback_url() -> str:
+    """Resolve the redirect_uri handed to Google.
+
+    Google does not accept wildcards in a client's authorized redirect URIs, so
+    letting this follow the requested origin means every white-label domain
+    needs its own entry in the Google console. When GOOGLE_OAUTH_REDIRECT_URI is
+    set, all domains share that one callback instead, and the browser is sent
+    back to its originating domain afterwards. Leaving it unset keeps the
+    historical per-origin behavior.
+    """
+    configured = _normalize_callback_url(
+        str(get_config("GOOGLE_OAUTH_REDIRECT_URI", "") or "")
+    )
+    if configured:
+        return configured
     return build_public_url(GOOGLE_OAUTH_CALLBACK_PATH)
+
+
+def _normalize_callback_url(value: str) -> str:
+    raw_value = str(value or "").strip()
+    if not raw_value:
+        return ""
+    parsed = urlsplit(raw_value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RuntimeError(
+            "GOOGLE_OAUTH_REDIRECT_URI must include http(s) scheme and host"
+        )
+    if parsed.query or parsed.fragment:
+        raise RuntimeError(
+            "GOOGLE_OAUTH_REDIRECT_URI must not carry a query or fragment"
+        )
+    path = parsed.path.rstrip("/") or GOOGLE_OAUTH_CALLBACK_PATH
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
 def build_alipay_notify_url() -> str:

--- a/src/api/flaskr/common/public_urls.py
+++ b/src/api/flaskr/common/public_urls.py
@@ -88,6 +88,16 @@ def _api_path(path: str) -> str:
     return f"{prefix}{_normalize_path(path)}"
 
 
+def resolve_request_origin() -> str:
+    """Return the origin this request actually arrived on.
+
+    Reads the Origin header and the proxy's X-Forwarded-* headers, which the
+    browser and ingress control, so a caller cannot nominate someone else's
+    domain.
+    """
+    return _request_origin()
+
+
 def _request_origin() -> str:
     if not has_request_context():
         return ""

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -977,6 +977,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/oauth/google", methods=["GET"])
     @bypass_token_validation
+    @optional_token_validation
     def google_oauth_start():
         provider = get_provider("google")
         metadata = {}
@@ -989,10 +990,16 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         ui_language = request.args.get("language")
         if ui_language:
             metadata["language"] = ui_language
-        # Derived from the request, never from a caller-supplied parameter: a
-        # query value would let one login nominate a different customer's
-        # verified domain as the place to hand the authorization code back to.
+        # Every header here is attacker-controllable — the edge nginx passes
+        # inbound X-Forwarded-* through, and Origin is forwarded unchanged — so
+        # the origin alone cannot decide where the authorization code is sent.
+        # It is paired with the session that started the flow, and the callback
+        # refuses to hand the code back unless the same session presents it.
         metadata["origin"] = resolve_request_origin()
+        initiator = getattr(request, "user", None)
+        metadata["initiator_user_id"] = str(
+            getattr(initiator, "user_id", "") or ""
+        ).strip()
         result = provider.begin_oauth(app, metadata)
         dto = OAuthStartDTO(
             authorization_url=result["authorization_url"],

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 from flask import Flask, current_app, make_response, request
 
+from flaskr.common.public_urls import resolve_request_origin
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.dao import db
 from flaskr.i18n import _translations, set_language
@@ -988,9 +989,10 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         ui_language = request.args.get("language")
         if ui_language:
             metadata["language"] = ui_language
-        origin = request.args.get("origin") or request.headers.get("Origin")
-        if origin:
-            metadata["origin"] = origin
+        # Derived from the request, never from a caller-supplied parameter: a
+        # query value would let one login nominate a different customer's
+        # verified domain as the place to hand the authorization code back to.
+        metadata["origin"] = resolve_request_origin()
         result = provider.begin_oauth(app, metadata)
         dto = OAuthStartDTO(
             authorization_url=result["authorization_url"],

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -31,6 +31,9 @@ from flaskr.service.profile.onboarding import (
 from flaskr.service.referral.service import extract_referral_post_auth_fields
 from flaskr.service.user.auth import get_provider
 from flaskr.service.user.auth.base import OAuthCallbackRequest, VerificationRequest
+from flaskr.service.user.auth.providers.google import (
+    resolve_state_return_origin,
+)
 from flaskr.service.user.captcha import (
     create_captcha_challenge,
     verify_captcha_code,
@@ -985,12 +988,31 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         ui_language = request.args.get("language")
         if ui_language:
             metadata["language"] = ui_language
+        origin = request.args.get("origin") or request.headers.get("Origin")
+        if origin:
+            metadata["origin"] = origin
         result = provider.begin_oauth(app, metadata)
         dto = OAuthStartDTO(
             authorization_url=result["authorization_url"],
             state=result["state"],
         )
         return make_common_response(dto)
+
+    @app.route(path_prefix + "/oauth/google/callback-origin", methods=["GET"])
+    @bypass_token_validation
+    def google_oauth_callback_origin():
+        """Resolve which domain a pending Google login should return to.
+
+        Every domain shares one Google callback, so the page that receives it
+        asks here whether the code belongs to a different domain and should be
+        forwarded there. Returns an empty origin when the login started on this
+        domain or when the recorded origin is no longer allowed.
+        ---
+        tags:
+            - user
+        """
+        origin = resolve_state_return_origin(app, request.args.get("state"))
+        return make_common_response({"origin": origin})
 
     @app.route(path_prefix + "/oauth/google/callback", methods=["GET"])
     @bypass_token_validation

--- a/src/api/flaskr/service/user/auth/oauth_origins.py
+++ b/src/api/flaskr/service/user/auth/oauth_origins.py
@@ -1,0 +1,98 @@
+"""Validation for the origin an OAuth flow returns the browser to.
+
+Google rejects wildcards in a client's authorized redirect URIs, so every
+white-label domain would otherwise need its own entry in the Google console.
+Instead all domains share one callback and the browser is sent back to the
+domain it started from. That hand-back is an open redirect unless the origin is
+checked against domains we actually serve, which is what this module does.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from flask import Flask
+from flaskr.common.public_urls import (
+    build_google_oauth_callback_url,
+    resolve_public_origin,
+)
+
+
+def normalize_origin(value: Any) -> str:
+    """Reduce a URL to a bare ``scheme://host[:port]`` origin, or "" if unusable."""
+    raw_value = str(value or "").strip().rstrip("/")
+    if not raw_value:
+        return ""
+    parsed = urlsplit(raw_value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def is_allowed_oauth_origin(app: Flask, origin: Any) -> bool:
+    """Return whether the browser may be handed back to this origin.
+
+    Allowed are the deployment's own origin, the origin of the configured
+    shared callback, and any custom domain that is verified, TLS-active, and
+    still entitled to custom domains.
+    """
+    normalized_origin = normalize_origin(origin)
+    if not normalized_origin:
+        return False
+
+    if normalized_origin in _platform_origins():
+        return True
+
+    host = urlsplit(normalized_origin).hostname or ""
+    if not host:
+        return False
+
+    # Only https custom domains are served, so refuse an http look-alike.
+    if urlsplit(normalized_origin).scheme != "https":
+        return False
+
+    try:
+        return _resolve_creator_bid_by_host(app, host) is not None
+    except Exception:  # noqa: BLE001 - a lookup failure must never allow an origin
+        return False
+
+
+def resolve_oauth_return_origin(app: Flask, origin: Any) -> str:
+    """Return the origin to hand back to, or "" when it is not allowed."""
+    normalized_origin = normalize_origin(origin)
+    if not normalized_origin:
+        return ""
+    if not is_allowed_oauth_origin(app, normalized_origin):
+        return ""
+    return normalized_origin
+
+
+def _platform_origins() -> set[str]:
+    origins: set[str] = set()
+    for candidate in (_configured_callback_origin(), _deployment_origin()):
+        if candidate:
+            origins.add(candidate)
+    return origins
+
+
+def _configured_callback_origin() -> str:
+    try:
+        return normalize_origin(build_google_oauth_callback_url())
+    except RuntimeError:
+        return ""
+
+
+def _deployment_origin() -> str:
+    try:
+        return normalize_origin(resolve_public_origin())
+    except RuntimeError:
+        return ""
+
+
+def _resolve_creator_bid_by_host(app: Flask, host: str) -> str | None:
+    # Imported lazily: the user service must not take a hard dependency on
+    # billing, which already reaches into user the same way.
+    domains = import_module("flaskr.service.billing.domains")
+    return domains.resolve_creator_bid_by_host(app, host)

--- a/src/api/flaskr/service/user/auth/oauth_origins.py
+++ b/src/api/flaskr/service/user/auth/oauth_origins.py
@@ -19,16 +19,39 @@ from flaskr.common.public_urls import (
     resolve_public_origin,
 )
 
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
 
 def normalize_origin(value: Any) -> str:
-    """Reduce a URL to a bare ``scheme://host[:port]`` origin, or "" if unusable."""
+    """Reduce a URL to a bare ``scheme://host`` origin, or "" if unusable.
+
+    Credentials and non-default ports are refused rather than carried through:
+    only the hostname is checked against our custom domains, so keeping either
+    would let ``https://someone@customer.example:8443`` pass that check and then
+    be handed the authorization code. An explicit default port is dropped so the
+    result compares equal to the browser's own ``window.location.origin``.
+    """
     raw_value = str(value or "").strip().rstrip("/")
     if not raw_value:
         return ""
-    parsed = urlsplit(raw_value)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    try:
+        parsed = urlsplit(raw_value)
+    except ValueError:
         return ""
-    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+    if parsed.scheme not in {"http", "https"}:
+        return ""
+    if parsed.username or parsed.password:
+        return ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
+    if port is not None and port != DEFAULT_PORTS[parsed.scheme]:
+        return ""
+    hostname = parsed.hostname
+    if not hostname:
+        return ""
+    return urlunsplit((parsed.scheme, hostname, "", "", ""))
 
 
 def is_allowed_oauth_origin(app: Flask, origin: Any) -> bool:

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -109,6 +109,28 @@ def _resolve_redirect_uri(app, explicit_uri: str | None = None) -> str:
     return build_google_oauth_callback_url()
 
 
+def _require_matching_initiator(
+    state_payload: dict[str, Any], current_user_id: str | None
+) -> None:
+    """Refuse a code meant for a different browser session.
+
+    Only applies to flows that recorded a return origin, i.e. the ones whose
+    code gets handed to another domain. The origin comes from headers a caller
+    can forge, so without this an attacker could name their own verified custom
+    domain and have someone else's authorization code delivered there.
+    """
+    expected_initiator = str(state_payload.get("initiator_user_id") or "").strip()
+    if not state_payload.get("origin"):
+        return
+    if not expected_initiator:
+        raise_error("server.user.googleOAuthStateInvalid")
+    if str(current_user_id or "").strip() != expected_initiator:
+        current_app.logger.warning(
+            "Google OAuth callback presented by a different session than started it"
+        )
+        raise_error("server.user.googleOAuthStateInvalid")
+
+
 def resolve_state_return_origin(app, state: str | None) -> str:
     """Return the validated origin recorded in an OAuth state, or "".
 
@@ -174,11 +196,16 @@ class GoogleAuthProvider(AuthProvider):
             "login_context": login_context,
         }
         # All domains share one Google callback, so remember where the browser
-        # came from to hand it back afterwards. Validated on the way in so a
-        # rejected origin never reaches the state, and again on the way out.
+        # came from to hand it back afterwards. The origin is derived from
+        # headers an attacker can set, so it is only honored together with the
+        # session that started the flow: the callback requires the same session
+        # to present the code. Without a session there is nothing to pair it
+        # with, so the login simply finishes on the shared callback domain.
         return_origin = resolve_oauth_return_origin(app, metadata.get("origin"))
-        if return_origin:
+        initiator_user_id = str(metadata.get("initiator_user_id") or "").strip()
+        if return_origin and initiator_user_id:
             state_payload["origin"] = return_origin
+            state_payload["initiator_user_id"] = initiator_user_id
         # Persist the interface language so we can use it
         # when creating or updating the user record.
         if ui_language_from_frontend:
@@ -218,6 +245,8 @@ class GoogleAuthProvider(AuthProvider):
             language = state_payload.get("language")
         except Exception:  # noqa: BLE001 - defensive fallback
             current_app.logger.warning("Failed to parse Google OAuth state payload")
+
+        _require_matching_initiator(state_payload, request.current_user_id)
 
         redirect_uri = _resolve_redirect_uri(app, redirect_uri)
         session = self._create_session(app, redirect_uri)

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -19,6 +19,9 @@ from flaskr.service.user.auth.base import (
     OAuthCallbackRequest,
 )
 from flaskr.service.user.auth.factory import has_provider, register_provider
+from flaskr.service.user.auth.oauth_origins import (
+    resolve_oauth_return_origin,
+)
 from flaskr.service.user.consts import USER_STATE_REGISTERED, USER_STATE_UNREGISTERED
 from flaskr.service.user.repository import (
     build_user_info_from_aggregate,
@@ -106,6 +109,22 @@ def _resolve_redirect_uri(app, explicit_uri: str | None = None) -> str:
     return build_google_oauth_callback_url()
 
 
+def resolve_state_return_origin(app, state: str | None) -> str:
+    """Return the validated origin recorded in an OAuth state, or "".
+
+    The shared callback page calls this to learn whether it should forward the
+    authorization code to the domain the login started from. Re-validated here
+    rather than trusted from the state, so revoking a custom domain takes effect
+    on in-flight logins too.
+    """
+    if not state:
+        return ""
+    payload = _decode_state(app, state)
+    if not payload:
+        return ""
+    return resolve_oauth_return_origin(app, payload.get("origin"))
+
+
 class GoogleAuthProvider(AuthProvider):
     provider_name = "google"
     supports_oauth = True
@@ -154,6 +173,12 @@ class GoogleAuthProvider(AuthProvider):
             "redirect_uri": redirect_uri,
             "login_context": login_context,
         }
+        # All domains share one Google callback, so remember where the browser
+        # came from to hand it back afterwards. Validated on the way in so a
+        # rejected origin never reaches the state, and again on the way out.
+        return_origin = resolve_oauth_return_origin(app, metadata.get("origin"))
+        if return_origin:
+            state_payload["origin"] = return_origin
         # Persist the interface language so we can use it
         # when creating or updating the user record.
         if ui_language_from_frontend:

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -9,6 +9,7 @@ from flaskr.common.public_urls import (
     build_stripe_billing_result_url,
     build_stripe_learner_result_url,
     build_wechatpay_notify_url,
+    resolve_request_origin,
 )
 
 
@@ -249,3 +250,29 @@ def test_malformed_pinned_google_callback_is_rejected(
 
     with pytest.raises(RuntimeError):
         build_google_oauth_callback_url()
+
+
+class TestResolveRequestOrigin:
+    """The OAuth return origin comes from here, so it must not be caller-driven."""
+
+    def test_a_query_parameter_cannot_nominate_another_domain(self):
+        # The attack this guards: starting a login on one domain while naming
+        # another customer's verified domain as where to hand the code back.
+        app = Flask(__name__)
+        with app.test_request_context(
+            "/api/user/oauth/google?origin=https://other-customer.example",
+            headers={"Origin": "https://learn.customer.example"},
+        ):
+            assert resolve_request_origin() == "https://learn.customer.example"
+
+    def test_falls_back_to_the_forwarded_host(self):
+        # Same-origin calls send no Origin header; the ingress sets these.
+        app = Flask(__name__)
+        with app.test_request_context(
+            "/api/user/oauth/google?origin=https://other-customer.example",
+            headers={
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "learn.customer.example",
+            },
+        ):
+            assert resolve_request_origin() == "https://learn.customer.example"

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -24,6 +24,7 @@ def clear_public_url_config_cache():
         "PATH_PREFIX",
         "WECHATPAY_APP_ID",
         "WECHATPAY_MCH_ID",
+        "GOOGLE_OAUTH_REDIRECT_URI",
     )
     _reset_config_cache(*keys)
     yield
@@ -183,3 +184,68 @@ def test_public_urls_omit_standard_port_from_forwarded_port(
             build_google_oauth_callback_url()
             == "https://app.example.com/login/google-callback"
         )
+
+
+def test_google_callback_can_be_pinned_to_one_shared_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """One callback for every domain, so Google needs no per-domain entry."""
+    monkeypatch.setenv("HOST_URL", "https://app.example.com")
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI", "https://app.example.com/login/google-callback"
+    )
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+
+    assert (
+        build_google_oauth_callback_url()
+        == "https://app.example.com/login/google-callback"
+    )
+
+
+def test_pinned_google_callback_wins_over_the_request_origin(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A white-label domain must still send Google the shared callback."""
+    monkeypatch.delenv("HOST_URL", raising=False)
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_REDIRECT_URI", "https://app.example.com/login/google-callback"
+    )
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/", headers={"Origin": "https://learn.customer.example"}
+    ):
+        assert (
+            build_google_oauth_callback_url()
+            == "https://app.example.com/login/google-callback"
+        )
+
+
+def test_google_callback_falls_back_to_the_request_origin_when_unpinned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Without the setting the historical per-origin behavior is kept."""
+    monkeypatch.delenv("HOST_URL", raising=False)
+    monkeypatch.delenv("GOOGLE_OAUTH_REDIRECT_URI", raising=False)
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/", headers={"Origin": "https://learn.customer.example"}
+    ):
+        assert (
+            build_google_oauth_callback_url()
+            == "https://learn.customer.example/login/google-callback"
+        )
+
+
+def test_malformed_pinned_google_callback_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("HOST_URL", "https://app.example.com")
+    monkeypatch.setenv("GOOGLE_OAUTH_REDIRECT_URI", "app.example.com/callback")
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+
+    with pytest.raises(RuntimeError):
+        build_google_oauth_callback_url()

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import flaskr.common.config as common_config
 import pytest
+from flaskr.service.common.models import AppError
 from flaskr.service.user.auth import oauth_origins
 from flaskr.service.user.auth.providers.google import (
     _encode_state,
+    _require_matching_initiator,
     resolve_state_return_origin,
 )
 
@@ -180,3 +182,43 @@ class TestResolveStateReturnOrigin:
 
     def test_missing_state_returns_empty(self, app) -> None:
         assert resolve_state_return_origin(app, None) == ""
+
+
+class TestInitiatorPairing:
+    """The return origin comes from forgeable headers, so it is only honored
+    together with the session that started the flow.
+
+    Without this, an attacker who owns a verified custom domain could start a
+    login with a forged Origin naming their own domain, get a victim to
+    authorize, and have the authorization code delivered to them.
+    """
+
+    def test_the_starting_session_may_complete_the_flow(self) -> None:
+        payload = {"origin": CUSTOM_ORIGIN, "initiator_user_id": "user-1"}
+        _require_matching_initiator(payload, "user-1")
+
+    def test_another_session_cannot_complete_the_flow(self, app) -> None:
+        # The attack: the code is handed to a domain the victim's session did
+        # not start the login from.
+        payload = {"origin": CUSTOM_ORIGIN, "initiator_user_id": "attacker"}
+        with app.app_context(), pytest.raises(AppError):
+            _require_matching_initiator(payload, "victim")
+
+    def test_an_anonymous_callback_cannot_complete_a_forwarded_flow(self, app) -> None:
+        payload = {"origin": CUSTOM_ORIGIN, "initiator_user_id": "user-1"}
+        for anonymous in (None, "", "   "):
+            with app.app_context(), pytest.raises(AppError):
+                _require_matching_initiator(payload, anonymous)
+
+    def test_an_origin_without_an_initiator_is_refused(self, app) -> None:
+        # A state carrying an origin but no initiator cannot be paired, so it
+        # must not be usable rather than falling through unchecked.
+        payload = {"origin": CUSTOM_ORIGIN}
+        with app.app_context(), pytest.raises(AppError):
+            _require_matching_initiator(payload, "user-1")
+
+    def test_same_domain_flows_are_unaffected(self) -> None:
+        # No origin means no forwarding, which is the pre-existing behavior and
+        # must keep working for anonymous sign-in.
+        _require_matching_initiator({}, None)
+        _require_matching_initiator({"initiator_user_id": "user-1"}, None)

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -104,6 +104,59 @@ class TestIsAllowedOAuthOrigin:
         )
 
 
+class TestNormalizeOrigin:
+    """Only the hostname is checked downstream, so nothing else may survive."""
+
+    def test_bare_origin_is_kept(self) -> None:
+        assert oauth_origins.normalize_origin(CUSTOM_ORIGIN) == CUSTOM_ORIGIN
+
+    def test_explicit_default_port_is_dropped(self) -> None:
+        # Must equal the browser's window.location.origin, or the callback page
+        # would forward to a URL it considers different and loop.
+        assert oauth_origins.normalize_origin(f"{CUSTOM_ORIGIN}:443") == CUSTOM_ORIGIN
+        assert (
+            oauth_origins.normalize_origin(f"http://{CUSTOM_DOMAIN}:80")
+            == f"http://{CUSTOM_DOMAIN}"
+        )
+
+    def test_non_default_port_is_refused(self) -> None:
+        assert oauth_origins.normalize_origin(f"{CUSTOM_ORIGIN}:8443") == ""
+
+    def test_userinfo_is_refused(self) -> None:
+        assert oauth_origins.normalize_origin(f"https://evil@{CUSTOM_DOMAIN}") == ""
+        assert (
+            oauth_origins.normalize_origin(f"https://user:pass@{CUSTOM_DOMAIN}:8443")
+            == ""
+        )
+
+    def test_malformed_port_is_refused(self) -> None:
+        assert oauth_origins.normalize_origin(f"{CUSTOM_ORIGIN}:notaport") == ""
+
+
+class TestPortAndUserinfoAreNotServedDomains:
+    """The hostname check must not be reachable with a decorated origin."""
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_non_default_port_on_a_verified_domain_is_refused(self, app) -> None:
+        assert (
+            oauth_origins.is_allowed_oauth_origin(app, f"{CUSTOM_ORIGIN}:8443") is False
+        )
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_userinfo_on_a_verified_domain_is_refused(self, app) -> None:
+        assert (
+            oauth_origins.is_allowed_oauth_origin(app, f"https://evil@{CUSTOM_DOMAIN}")
+            is False
+        )
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_explicit_default_port_still_resolves(self, app) -> None:
+        assert (
+            oauth_origins.resolve_oauth_return_origin(app, f"{CUSTOM_ORIGIN}:443")
+            == CUSTOM_ORIGIN
+        )
+
+
 class TestResolveStateReturnOrigin:
     @pytest.mark.usefixtures("_verified_custom_domain")
     def test_returns_the_recorded_origin(self, app) -> None:

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -1,0 +1,129 @@
+"""Origin validation for the shared Google OAuth callback.
+
+All domains share one Google callback because Google rejects wildcards in a
+client's authorized redirect URIs. Handing the browser back to the domain it
+started from is an open redirect unless the origin is checked, so these tests
+pin that check down.
+"""
+
+from __future__ import annotations
+
+import flaskr.common.config as common_config
+import pytest
+from flaskr.service.user.auth import oauth_origins
+from flaskr.service.user.auth.providers.google import (
+    _encode_state,
+    resolve_state_return_origin,
+)
+
+PLATFORM_CALLBACK = "https://app.example.com/login/google-callback"
+PLATFORM_ORIGIN = "https://app.example.com"
+CUSTOM_DOMAIN = "learn.customer.example"
+CUSTOM_ORIGIN = f"https://{CUSTOM_DOMAIN}"
+
+
+def _reset_config_cache(*keys: str) -> None:
+    for key in keys:
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+
+
+@pytest.fixture(autouse=True)
+def _shared_callback(monkeypatch):
+    """Pin the deployment to one shared callback URL."""
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+    monkeypatch.setattr(
+        oauth_origins,
+        "build_google_oauth_callback_url",
+        lambda: PLATFORM_CALLBACK,
+    )
+    monkeypatch.setattr(oauth_origins, "resolve_public_origin", lambda: PLATFORM_ORIGIN)
+    yield
+    _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
+
+
+@pytest.fixture
+def _verified_custom_domain(monkeypatch):
+    """Treat exactly one host as a verified, TLS-active custom domain."""
+    monkeypatch.setattr(
+        oauth_origins,
+        "_resolve_creator_bid_by_host",
+        lambda app, host: "creator-1" if host == CUSTOM_DOMAIN else None,
+    )
+
+
+class TestIsAllowedOAuthOrigin:
+    def test_platform_origin_is_allowed(self, app) -> None:
+        assert oauth_origins.is_allowed_oauth_origin(app, PLATFORM_ORIGIN) is True
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_verified_custom_domain_is_allowed(self, app) -> None:
+        assert oauth_origins.is_allowed_oauth_origin(app, CUSTOM_ORIGIN) is True
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_unknown_domain_is_refused(self, app) -> None:
+        # The open-redirect case: an attacker-controlled origin in the state.
+        assert (
+            oauth_origins.is_allowed_oauth_origin(app, "https://evil.example") is False
+        )
+
+    def test_unverified_custom_domain_is_refused(self, app, monkeypatch) -> None:
+        # Not yet verified, or entitlement revoked -> no hand-back.
+        monkeypatch.setattr(
+            oauth_origins, "_resolve_creator_bid_by_host", lambda app, host: None
+        )
+        assert oauth_origins.is_allowed_oauth_origin(app, CUSTOM_ORIGIN) is False
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_http_custom_domain_is_refused(self, app) -> None:
+        # Only https custom domains are served; refuse a plaintext look-alike.
+        assert (
+            oauth_origins.is_allowed_oauth_origin(app, f"http://{CUSTOM_DOMAIN}")
+            is False
+        )
+
+    def test_lookup_failure_refuses_rather_than_allows(self, app, monkeypatch) -> None:
+        def _boom(app, host):
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(oauth_origins, "_resolve_creator_bid_by_host", _boom)
+        assert oauth_origins.is_allowed_oauth_origin(app, CUSTOM_ORIGIN) is False
+
+    @pytest.mark.parametrize(
+        "value", ["", None, "not-a-url", "javascript:alert(1)", "//evil.example"]
+    )
+    def test_malformed_origins_are_refused(self, app, value) -> None:
+        assert oauth_origins.is_allowed_oauth_origin(app, value) is False
+
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_path_and_query_are_stripped(self, app) -> None:
+        assert (
+            oauth_origins.resolve_oauth_return_origin(
+                app, f"{CUSTOM_ORIGIN}/login/google-callback?next=/x"
+            )
+            == CUSTOM_ORIGIN
+        )
+
+
+class TestResolveStateReturnOrigin:
+    @pytest.mark.usefixtures("_verified_custom_domain")
+    def test_returns_the_recorded_origin(self, app) -> None:
+        state = _encode_state(app, {"origin": CUSTOM_ORIGIN})
+        assert resolve_state_return_origin(app, state) == CUSTOM_ORIGIN
+
+    def test_revoked_domain_is_refused_mid_flight(self, app, monkeypatch) -> None:
+        # State was minted while the domain was valid; it no longer is.
+        state = _encode_state(app, {"origin": CUSTOM_ORIGIN})
+        monkeypatch.setattr(
+            oauth_origins, "_resolve_creator_bid_by_host", lambda app, host: None
+        )
+        assert resolve_state_return_origin(app, state) == ""
+
+    def test_state_without_origin_returns_empty(self, app) -> None:
+        state = _encode_state(app, {"login_context": "default"})
+        assert resolve_state_return_origin(app, state) == ""
+
+    def test_tampered_state_returns_empty(self, app) -> None:
+        assert resolve_state_return_origin(app, "not-a-valid-jwt") == ""
+
+    def test_missing_state_returns_empty(self, app) -> None:
+        assert resolve_state_return_origin(app, None) == ""

--- a/src/cook-web/src/api/api.ts
+++ b/src/cook-web/src/api/api.ts
@@ -25,6 +25,7 @@ const api = {
   submitFeedback: 'POST /user/submit-feedback',
   googleOauthStart: 'GET /user/oauth/google',
   googleOauthCallback: 'GET /user/oauth/google/callback',
+  googleOauthCallbackOrigin: 'GET /user/oauth/google/callback-origin',
   ensureAdminCreator: 'POST /user/ensure_admin_creator',
   getCreatorOnboardingStatus: 'GET /user/onboarding/status',
   completeCreatorOnboarding: 'POST /user/onboarding/complete',

--- a/src/cook-web/src/app/login/google-callback/page.tsx
+++ b/src/cook-web/src/app/login/google-callback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2, AlertCircle } from 'lucide-react';
 import { useGoogleAuth } from '@/hooks/useGoogleAuth';
+import { resolveGoogleCallbackOrigin } from '@/lib/google-oauth-callback-origin';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
 import { useTranslation } from 'react-i18next';
 
@@ -28,6 +29,25 @@ export default function GoogleCallbackPage() {
     const run = async () => {
       console.info('[Google OAuth] running');
       try {
+        // Every domain shares one Google callback so that a white-label domain
+        // needs no entry of its own in the Google console. If this login began
+        // on another domain, hand the code back to it: the token exchange must
+        // happen there, where the state was stored and the session belongs.
+        if (code && state) {
+          const forwardOrigin = await resolveGoogleCallbackOrigin(state);
+          if (forwardOrigin && forwardOrigin !== window.location.origin) {
+            const forwardUrl = new URL('/login/google-callback', forwardOrigin);
+            forwardUrl.searchParams.set('code', code);
+            forwardUrl.searchParams.set('state', state);
+            if (redirect) {
+              forwardUrl.searchParams.set('redirect', redirect);
+            }
+            console.info('[Google OAuth] forwarding to', forwardUrl.toString());
+            window.location.replace(forwardUrl.toString());
+            return;
+          }
+        }
+
         const fallbackRedirect =
           redirect && redirect.startsWith('/') ? redirect : undefined;
         console.info('[Google OAuth] exchanging token');

--- a/src/cook-web/src/app/login/google-callback/page.tsx
+++ b/src/cook-web/src/app/login/google-callback/page.tsx
@@ -42,7 +42,9 @@ export default function GoogleCallbackPage() {
             if (redirect) {
               forwardUrl.searchParams.set('redirect', redirect);
             }
-            console.info('[Google OAuth] forwarding to', forwardUrl.toString());
+            // Log the origin only: the URL carries the authorization code
+            // and the signed state.
+            console.info('[Google OAuth] forwarding to', forwardOrigin);
             window.location.replace(forwardUrl.toString());
             return;
           }

--- a/src/cook-web/src/hooks/useGoogleAuth.ts
+++ b/src/cook-web/src/hooks/useGoogleAuth.ts
@@ -122,9 +122,6 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
             redirect_uri: redirectUri,
             login_context: loginContext,
             language,
-            // All domains share one Google callback, so tell the backend where
-            // to send the browser back to once Google returns.
-            origin: window.location.origin,
           }),
         );
         const payload = extractData<OAuthStartPayload>(response);

--- a/src/cook-web/src/hooks/useGoogleAuth.ts
+++ b/src/cook-web/src/hooks/useGoogleAuth.ts
@@ -122,6 +122,9 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
             redirect_uri: redirectUri,
             login_context: loginContext,
             language,
+            // All domains share one Google callback, so tell the backend where
+            // to send the browser back to once Google returns.
+            origin: window.location.origin,
           }),
         );
         const payload = extractData<OAuthStartPayload>(response);

--- a/src/cook-web/src/hooks/useGoogleAuth.ts
+++ b/src/cook-web/src/hooks/useGoogleAuth.ts
@@ -163,8 +163,11 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
       }
 
       try {
+        // Defence in depth alongside the backend's session pairing: a state
+        // this browser never issued means the flow started somewhere else, so
+        // a missing stored value must fail rather than skip the comparison.
         const expectedState = getGoogleOAuthState();
-        if (expectedState && state && expectedState !== state) {
+        if (!expectedState || !state || expectedState !== state) {
           throw new Error(t('module.auth.googleStateMismatch'));
         }
 

--- a/src/cook-web/src/lib/google-oauth-callback-origin.test.ts
+++ b/src/cook-web/src/lib/google-oauth-callback-origin.test.ts
@@ -1,0 +1,66 @@
+import { resolveGoogleCallbackOrigin } from './google-oauth-callback-origin';
+
+const mockCallbackOrigin = jest.fn();
+
+jest.mock('@/api', () => ({
+  __esModule: true,
+  default: {
+    googleOauthCallbackOrigin: (...args: unknown[]) =>
+      mockCallbackOrigin(...args),
+  },
+}));
+
+describe('resolveGoogleCallbackOrigin', () => {
+  beforeEach(() => {
+    mockCallbackOrigin.mockReset();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('returns the origin the backend validated', async () => {
+    mockCallbackOrigin.mockResolvedValue({
+      code: 0,
+      data: { origin: 'https://learn.customer.example' },
+    });
+
+    await expect(resolveGoogleCallbackOrigin('state-1')).resolves.toBe(
+      'https://learn.customer.example',
+    );
+  });
+
+  it('accepts an unwrapped payload', async () => {
+    mockCallbackOrigin.mockResolvedValue({
+      origin: 'https://learn.customer.example',
+    });
+
+    await expect(resolveGoogleCallbackOrigin('state-1')).resolves.toBe(
+      'https://learn.customer.example',
+    );
+  });
+
+  it('returns empty when the backend refuses the origin', async () => {
+    mockCallbackOrigin.mockResolvedValue({ code: 0, data: { origin: '' } });
+
+    await expect(resolveGoogleCallbackOrigin('state-1')).resolves.toBe('');
+  });
+
+  it('never blocks the login when the lookup fails', async () => {
+    mockCallbackOrigin.mockRejectedValue(new Error('network down'));
+
+    await expect(resolveGoogleCallbackOrigin('state-1')).resolves.toBe('');
+  });
+
+  it('never blocks the login when the lookup hangs', async () => {
+    jest.useFakeTimers();
+    mockCallbackOrigin.mockReturnValue(new Promise(() => {}));
+
+    const pending = resolveGoogleCallbackOrigin('state-1');
+    jest.advanceTimersByTime(5000);
+
+    await expect(pending).resolves.toBe('');
+  });
+});

--- a/src/cook-web/src/lib/google-oauth-callback-origin.ts
+++ b/src/cook-web/src/lib/google-oauth-callback-origin.ts
@@ -1,0 +1,60 @@
+import apiService from '@/api';
+
+/**
+ * Ask the backend which domain a pending Google login should return to.
+ *
+ * All domains share one Google callback, because Google does not accept
+ * wildcards in a client's authorized redirect URIs. The backend validates the
+ * origin recorded in the signed state against the domains we actually serve, so
+ * the answer is safe to redirect to; an empty string means "stay here". Never
+ * blocks the login: a slow or failing lookup falls back to finishing here.
+ */
+const RESOLVE_TIMEOUT_MS = 5000;
+
+function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return new Promise<T>(resolve => {
+    const timer = setTimeout(() => resolve(fallback), RESOLVE_TIMEOUT_MS);
+    promise
+      .then(value => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        resolve(fallback);
+      });
+  });
+}
+
+export async function resolveGoogleCallbackOrigin(
+  state: string,
+): Promise<string> {
+  try {
+    const response = (await withTimeout(
+      Promise.resolve(apiService.googleOauthCallbackOrigin({ state })),
+      null,
+    )) as
+      | { code?: number; data?: { origin?: string } }
+      | { origin?: string }
+      | null;
+
+    if (!response) {
+      // Timed out. Completing the login on this domain is the safe default:
+      // the user is signed in, just not handed back to the custom domain.
+      console.warn('[Google OAuth] return-origin lookup timed out');
+      return '';
+    }
+
+    const payload =
+      response && typeof response === 'object' && 'data' in response
+        ? (response as { data?: { origin?: string } }).data
+        : (response as { origin?: string });
+
+    return String(payload?.origin || '').trim();
+  } catch (error) {
+    // Staying on this domain still completes the login for the common case,
+    // so a failed lookup must not abort the flow.
+    console.warn('[Google OAuth] could not resolve return origin', error);
+    return '';
+  }
+}


### PR DESCRIPTION
## Problem

Google login is broken on every white-label domain. `learn.essentialpersonalfinance.com`
returns `Error 400: redirect_uri_mismatch`.

The redirect_uri follows whichever domain the browser is on, because
`resolve_public_origin()` falls back to the request origin when `HOST_URL` is
unset (it is unset in the US). So a white-label domain sends Google
`https://learn.customer.example/login/google-callback`, which is not in the OAuth
client's authorized redirect URIs.

Google does not accept wildcards there, so the only fix under the current design
is to add one entry per customer, by hand, forever — and Google caps a client at
100 redirect URIs.

Worth noting: `GOOGLE_OAUTH_REDIRECT_URI` was already set in the US deployment to
`https://app.ai-shifu.com/login/google-callback`, and nothing ever read it —
`_resolve_redirect_uri` opened with `del app, explicit_uri`. It was not declared
in the `ENV_VARS` registry either; this PR registers it (thanks @devin-ai-integration).

## Approach

Every domain shares one callback, and the browser is handed back to the domain
it started from.

1. `build_google_oauth_callback_url()` honors `GOOGLE_OAUTH_REDIRECT_URI` when set.
   One entry in the Google console covers all domains. Unset keeps the old
   per-origin behavior, so China is untouched.
2. `begin_oauth` records the originating origin in the OAuth `state`, which is
   already a signed JWT (HS256, `exp`, `nonce`), so it cannot be tampered with.
3. The shared callback page asks the new `GET /user/oauth/google/callback-origin`
   which domain the login belongs to, and forwards `code` + `state` there when it
   is not itself.

The token exchange deliberately still happens on the originating domain:
`finalizeGoogleLogin` compares the returned state against one held in that
domain's `sessionStorage`, and the session belongs there. The shared callback
only relays; it never mints a token, so no token ever travels in a URL.

## Security

Handing the browser back is an open redirect unless the origin is checked. A
forged `state` carrying `origin=https://evil.example` would otherwise deliver a
live authorization code to an attacker.

The origin is never trusted on its own. Request headers are not authoritative
here — `docker/nginx.conf` passes inbound `X-Forwarded-*` through and forwards
`Origin` unchanged — so an origin is recorded only together with the session
that started the flow, and the callback refuses a code whose state names an
origin unless that same session presents it. A state carrying an origin with no
initiator is refused outright. Same-domain flows, which are never forwarded,
keep working without a session.

`is_allowed_oauth_origin` then permits only the deployment's own origin, the
configured shared callback's origin, and custom domains that are verified,
TLS-active, and still entitled — reusing `resolve_creator_bid_by_host`, the same
predicate that decides whether a custom domain is served at all. It is
**re-validated at callback time, not trusted from the state**, so revoking a
domain also kills logins already in flight. Any lookup failure refuses the
origin rather than allowing it; a test pins that down by making the lookup raise.

## Tests

- `tests/service/user/test_oauth_origins.py` (17): platform origin allowed;
  verified custom domain allowed; unknown domain refused; unverified/revoked
  refused; `http://` look-alike refused; lookup failure fails closed; malformed
  values (`javascript:`, `//evil.example`) refused; revocation mid-flight
  refused; tampered and missing state refused.
- `tests/common/test_public_urls.py` (+6): the pinned callback wins over the
  request origin; unpinned still follows the origin; a malformed value is
  rejected; and `?origin=` cannot override either the Origin header or the
  forwarded host.
- Origin normalization: `:8443`, explicit `:443` and `:80`, userinfo with and
  without a password, and a non-numeric port — plus proof that a decorated
  origin cannot reach the hostname check.
- `TestInitiatorPairing`: the starting session completes the flow; a different
  session is refused; an anonymous callback is refused; an origin without an
  initiator is refused; same-domain flows still pass with no session.
- `src/lib/google-oauth-callback-origin.test.ts` (5): wrapped and unwrapped
  payloads; a refused origin; and login is never blocked when the lookup fails
  or hangs.

Backend: 1132 passed, 10 skipped across `tests/service/user`, `tests/route`,
`tests/common`, `tests/service/billing`. `tsc --noEmit` clean.
`lefthook run pre-commit` green, including the architecture-boundary check —
the billing lookup is a lazy import, mirroring how billing already reaches into
user.

Note: `src/app/login/page.test.tsx` crashes the Jest worker with a v8 heap OOM
rather than merely running long. It mocks `GoogleLoginButton` and never loads
`useGoogleAuth`, so it cannot be reached by this change; it is tracked
separately. It was not used as a signal here.

## Deployment

No config change needed. The US already sets `GOOGLE_OAUTH_REDIRECT_URI` via
`shifu-google-auth-config`, so this takes effect on rollout. China has no
`GOOGLE_OAUTH` config at all and keeps its current behavior.

After this ships, onboarding a white-label domain is DNS + ingress only — the
Google console is no longer part of it.

## Follow-up spotted while here

`runtime-config` publishes `googleOauthRedirect`, and nothing in the frontend
reads it. Left alone in case something external consumes it, but it looks like
another dead field of the same kind as the env var this PR revived.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for shared Google OAuth callback URLs.
  * OAuth callbacks now securely validate and preserve approved return origins across domains.
  * Added fallback handling for unavailable or invalid callback-origin lookups, allowing sign-in to continue.
  * Added optional configuration for a shared Google OAuth redirect URL.

* **Bug Fixes**
  * Prevented untrusted origins, malformed URLs, and unsafe redirects from being used during OAuth sign-in.
  * Improved callback URL normalization and proxy-aware origin detection.

* **Tests**
  * Added comprehensive coverage for callback configuration, origin validation, redirect handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Known limitation

An attacker can still start a flow, get someone to authorize it, and redeem the
code themselves. That is authorization-code injection; it predates this PR and
closing it needs PKCE or an equivalent, which does not belong in this change.
What this PR does close is the shortcut it briefly opened: having that code
delivered automatically to a domain of the attacker's choosing.
