### PR TITLE
test: scope the shared-provider-product assertion to its own test

### DIFF
--- a/src/api/tests/service/billing/test_billing_models.py
+++ b/src/api/tests/service/billing/test_billing_models.py
@@ -206,18 +206,23 @@ def test_provider_price_constraints_allow_shared_product_with_distinct_prices(
                     provider_price_bid="provider-price-growth-month",
                     product_bid="bill-product-growth-month",
                     provider_price_id="price_growth_month",
+                    provider_product_id="prod_growth_shared",
                 ),
                 _provider_price(
                     provider_price_bid="provider-price-growth-year",
                     product_bid="bill-product-growth-year",
                     provider_price_id="price_growth_year",
+                    provider_product_id="prod_growth_shared",
                 ),
             ]
         )
         db.session.commit()
 
+        # Scoped to this test's own provider product: the shared default is
+        # also written by the other tests here, so querying it would make this
+        # assertion depend on which of them ran first.
         rows = BillingProductProviderPrice.query.filter(
-            BillingProductProviderPrice.provider_product_id == "prod_shared"
+            BillingProductProviderPrice.provider_product_id == "prod_growth_shared"
         ).all()
         assert {row.provider_price_id for row in rows} == {
             "price_growth_month",


### PR DESCRIPTION
## Problem

`Backend Tests` fails on main-based PRs with:

```
FAILED tests/service/billing/test_billing_models.py::test_provider_price_constraints_allow_shared_product_with_distinct_prices
  AssertionError: assert {'price_draft_1', 'price_draft_2', 'price_duplicate',
                          'price_growth_month', 'price_growth_year'}
                      == {'price_growth_month', 'price_growth_year'}
```

The test queries `provider_product_id == "prod_shared"` and asserts an exact
set. `"prod_shared"` is the default in the `_provider_price` helper, so
`test_provider_price_constraints_reject_duplicate_provider_price` and
`test_provider_price_constraints_allow_multiple_drafts_for_sku` write rows that
match the same filter. Whether the assertion holds depends on which test ran
first.

Running the whole file top to bottom happens to pass, because the assertion sits
above the tests that pollute it. CI runs `pytest --testmon`, which selects a
subset (`467 deselected` in the failing run), and the order no longer protects
it.

Reproduces on unmodified `origin/main`:

```bash
cd src/api && python -m pytest \
  "tests/service/billing/test_billing_models.py::test_provider_price_constraints_allow_multiple_drafts_for_sku" \
  "tests/service/billing/test_billing_models.py::test_provider_price_constraints_allow_shared_product_with_distinct_prices"
# 1 failed, 1 passed
```

Introduced by #2547.

## Fix

The test writes and reads its own `provider_product_id` (`prod_growth_shared`)
instead of the shared default. It still proves what it is named for — two
distinct prices coexisting under one provider product — but no longer sees rows
it did not create. The exact-set assertion is kept rather than loosened to a
subset check, since the strictness is the point.

## Verification

Both orders now pass, as does the whole file and a randomized run:

```bash
python -m pytest tests/service/billing/test_billing_models.py            # 19 passed
python -m pytest <polluting test> <this test>                            # 2 passed
python -m pytest <duplicate test> <this test>                            # 2 passed
```

Unblocks CI on #2556, which does not touch billing at all.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->