### PR TITLE
chore: enforce the full flake8-bandit rule group

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -135,35 +135,24 @@ select = [
     "N815",    # mixedCase variable in class scope
     "N818",    # exception class name without an Error suffix
     "TD002",   # TODO without an author
-    # S101 bans `assert` in shipped code (python -O strips it, so an assert is
-    # not a runtime guard). Test suites and script self-tests are exempt via
-    # per-file-ignores below.
-    "S101",    # assert used outside tests
-    "S104",    # binding a socket to all interfaces
-    "S107",    # hardcoded password as a function default
-    "S105",    # string literal that looks like a hardcoded password
-    "S106",    # hardcoded password passed as an argument
-    "S108",    # hardcoded /tmp path instead of tempfile.gettempdir()
-    # S110/S112 flag `except Exception: pass` / `continue`. A deliberate
-    # best-effort block reads better as `contextlib.suppress(...)`, which the
-    # repo already uses; a narrower `except OSError:` is not flagged either.
-    "S110",    # try-except-pass that swallows every exception
-    "S112",    # try-except-continue that swallows every exception
-    "S113",    # requests call without a timeout
-    "S310",    # urlopen without an audited URL scheme
-    "S311",    # `random` where a cryptographic generator is required
-    "S324",    # hashlib md5/sha1 without usedforsecurity=False
-    # S603/S605/S607 flag every subprocess and shell invocation. Application
-    # code justifies each one inline; developer tooling is exempt through
-    # per-file-ignores below.
-    "S603",    # subprocess call with unvalidated input
-    "S605",    # process started with a shell
-    "S607",    # process started with a partial executable path
-    # S608 flags every SQL string built by interpolation. Values always use
-    # bound parameters; the remaining sites interpolate table or column names,
-    # which bound parameters cannot carry, and justify it inline. Applied
-    # Alembic revisions must not be edited, so they are exempt below.
-    "S608",    # SQL query built by string interpolation
+    # flake8-bandit is enabled as a whole. Every rule it adds beyond the ones
+    # this repo already satisfied is a security audit with zero current
+    # violations -- eval/exec, pickle and other unsafe deserializers,
+    # `shell=True`, disabled TLS verification, weak ciphers, XML parsers,
+    # Jinja autoescape -- so the group only guards against new ones. The
+    # members that do fire are documented individually:
+    # - S101: `assert` outside tests (python -O strips it, so it is not a
+    #   runtime guard); test suites and script self-tests are exempt below.
+    # - S110/S112: `except Exception: pass` / `continue`. A deliberate
+    #   best-effort block reads better as `contextlib.suppress(...)`, which the
+    #   repo already uses; a narrower `except OSError:` is not flagged either.
+    # - S603/S605/S607: every subprocess and shell invocation. Application code
+    #   justifies each one inline; developer tooling is exempt below.
+    # - S608: every SQL string built by interpolation. Values always use bound
+    #   parameters; the remaining sites interpolate table or column names, which
+    #   bound parameters cannot carry, and justify it inline. Applied Alembic
+    #   revisions must not be edited, so they are exempt below.
+    "S",
 
     # --- Type annotations -------------------------------------------------
     # flake8-annotations is otherwise off (see the header): annotating every

--- a/ruff.toml
+++ b/ruff.toml
@@ -217,7 +217,7 @@ ignore = [
     "PLW0603", # global statement -- used by module-level singletons/caches
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
     # RUF100: with a partial select list, ruff reports deliberate `# noqa:
-    # BLE001 / DTZ001 / SLF001 / S102` markers as unused simply because those
+    # BLE001 / DTZ001 / SLF001` markers as unused simply because those
     # rules are off here, so enforcing it would delete documentation of
     # intentional exceptions. Stale directives are pruned by hand instead.
     "RUF100",


### PR DESCRIPTION
# Summary

Replaces the hand-maintained list of individual `S1xx`/`S3xx`/`S6xx` selections in `ruff.toml` with the whole `S` prefix.

The 42 members this adds (`S102` `S103` `S201` `S202` `S3xx` deserializers/XML parsers, `S5xx` TLS and weak ciphers, `S6xx` shell invocations, `S7xx` Jinja autoescape, ...) all have **zero current violations**, verified by diffing `ruff check --show-settings` before and after. So this is purely a guard against new unsafe code, not a cleanup.

No source changes: `ruff check .` and `ruff format --check .` pass as-is. The members that do fire stay documented individually in the comment (S101 asserts, S110/S112 blanket handlers, S603/S605/S607 subprocess, S608 SQL interpolation), and every existing per-file ignore (tests, dev scripts, applied Alembic revisions) is untouched.

Also drops `S102` from the RUF100 rationale comment, since it is now enforced rather than an example of a rule that is not.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security linting configuration to consistently enable the full security rule set.
  * Added documentation clarifying the active security checks.
  * Removed an outdated suppression for a security rule no longer enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->