### PR TITLE
chore: enforce the full flake8-type-checking rule group

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -161,12 +161,13 @@ select = [
     # frozen-clock `now()` doubles.
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
-    # flake8-type-checking is partial: TC002/TC003 would push third-party
-    # imports (SQLAlchemy, pydantic) behind TYPE_CHECKING, where any decorator
-    # or mapper that resolves annotations at runtime then fails. TC001 only
-    # covers first-party imports used solely in annotations, and every module
-    # it touches already has `from __future__ import annotations`.
-    "TC001",   # first-party import used only in annotations
+    # flake8-type-checking is enabled as a whole. TC002/TC003 are ignored below
+    # (they would push third-party imports behind TYPE_CHECKING, where runtime
+    # annotation resolution then fails); the rest have no violations and catch
+    # the mistakes a TYPE_CHECKING block invites: a name imported there but used
+    # at runtime (TC004), an empty or redundant block (TC005/TC010), a
+    # needlessly quoted annotation (TC006/TC007).
+    "TC",
 
     # --- Docstrings -------------------------------------------------------
     # pydocstyle is enabled as a whole; the members that would need thousands
@@ -207,6 +208,11 @@ ignore = [
     "D405",
     "D406",
     "D407",
+    # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING
+    # breaks anything that resolves annotations at runtime, which for this repo
+    # means the SQLAlchemy mappers and pydantic models (~230 hits).
+    "TC002",
+    "TC003",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "DTZ901",  # datetime.min/max -- naive UTC is the house convention


### PR DESCRIPTION
# Summary

Widens the `TC001`-only selection in `ruff.toml` to the whole `TC` prefix, keeping `TC002`/`TC003` in `ignore`.

The newly enforced members have **zero current violations** and catch the mistakes a `TYPE_CHECKING` block invites: a name imported there but used at runtime (`TC004`), an empty or redundant block (`TC005`/`TC010`), a needlessly quoted annotation (`TC006`/`TC007`).

`TC002`/`TC003` stay ignored for the reason already documented: pushing third-party or stdlib imports behind `TYPE_CHECKING` breaks anything that resolves annotations at runtime, which here means the SQLAlchemy mappers and pydantic models (~230 hits).

No source changes: `ruff check .` and `ruff format --check .` pass as-is.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->