### PR TITLE
style: enforce ruff ANN204 (special method return types)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,7 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN205/ANN206, see `select`) / SLF001 / PLC0415 / PLR2004
+# - ANN (except ANN204/ANN205/ANN206, see `select`) / SLF001 / PLC0415 / PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
@@ -158,7 +158,12 @@ select = [
     # enough to keep enforced, and a staticmethod is where a missing return
     # type hides the most, since there is no `self` to infer from. ANN206
     # covers the classmethod counterpart, mostly alternative constructors and
-    # frozen-clock `now()` doubles.
+    # frozen-clock `now()` doubles. ANN204 is the same bet for special methods:
+    # `__init__`/`__exit__`/`__json__` and friends have a fixed contract, so the
+    # return type is never a judgement call and writing it down keeps the
+    # serialization dunders (`__json__` returning a dict vs an enum value's str)
+    # readable at a glance.
+    "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
     # flake8-type-checking is enabled as a whole. TC002/TC003 are ignored below

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -66,7 +66,7 @@ COOK_WEB_PRETTIER = ROOT / "src" / "cook-web" / "node_modules" / ".bin" / "prett
 class Check:
     """A single tool/state check and the command that fixes it."""
 
-    def __init__(self, name: str, ok: bool, fix: str, *, required: bool = True):
+    def __init__(self, name: str, ok: bool, fix: str, *, required: bool = True) -> None:
         self.name = name
         self.ok = ok
         self.fix = fix

--- a/src/api/flaskr/api/check/dto.py
+++ b/src/api/flaskr/api/check/dto.py
@@ -18,14 +18,14 @@ class CheckResultDTO:
         risk_label_ids: list[int],
         provider: str,
         raw_data: dict,
-    ):
+    ) -> None:
         self.check_result = check_result
         self.risk_labels = risk_labels
         self.risk_label_ids = risk_label_ids
         self.provider = provider
         self.raw_data = raw_data
 
-    def __to_dict__(self):
+    def __to_dict__(self) -> dict:
         return {
             "check_result": self.check_result,
             "risk_labels": self.risk_labels,
@@ -33,5 +33,5 @@ class CheckResultDTO:
             "provider": self.provider,
         }
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return self.__to_dict__()

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -52,10 +52,10 @@ _LINK_KEYS = {"trace_id", "parent_observation_id", "id"}
 
 
 class MockClient:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
-    def __getattr__(self, name):
+    def __getattr__(self, name) -> Any:
         def method(*args, **kwargs):
             return self
 
@@ -295,7 +295,7 @@ def _map_observation_kwargs(
 class LangfuseObservationHandle:
     """v2-style facade over a Langfuse SDK v3 span or generation."""
 
-    def __init__(self, delegate: Any, trace_id: str = ""):
+    def __init__(self, delegate: Any, trace_id: str = "") -> None:
         self._delegate = delegate
         delegate_trace_id = getattr(delegate, "trace_id", "")
         self.trace_id = trace_id or (

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -951,14 +951,16 @@ if not any_litellm_enabled:
 
 
 class LLMStreamaUsage:
-    def __init__(self, prompt_tokens, completion_tokens, total_tokens):
+    def __init__(self, prompt_tokens, completion_tokens, total_tokens) -> None:
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
         self.total_tokens = total_tokens
 
 
 class LLMStreamResponse:
-    def __init__(self, response_id, is_end, is_truncated, result, finish_reason, usage):
+    def __init__(
+        self, response_id, is_end, is_truncated, result, finish_reason, usage
+    ) -> None:
         self.id = response_id
 
         self.is_end = is_end

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -237,7 +237,7 @@ class TencentTTSError(ValueError):
         message: str = "",
         request_id: str = "",
         message_id: str = "",
-    ):
+    ) -> None:
         safe_message = str(message or "provider error").strip()
         detail = f"Tencent TTS error {code}: {safe_message}"
         if request_id:

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -115,7 +115,7 @@ class VolcengineProtocol:
     PROTOCOL_VERSION = 0b0001
     HEADER_SIZE = 0b0001  # 4 bytes (multiplied by 4)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.connection_id: str | None = None
         self.session_id: str | None = None
 

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -323,7 +323,7 @@ VOLCENGINE_EMOTIONS = [
 class VolcengineTTSProvider(BaseTTSProvider):
     """TTS provider using Volcengine bidirectional WebSocket API."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._protocol = VolcengineProtocol()
         self._lock = threading.Lock()
 

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -127,7 +127,7 @@ class UnifiedMigrationTask:
         self,
         database_url: str | None = None,
         config: MigrationConfig | None = None,
-    ):
+    ) -> None:
         if database_url is None:
             database_url = _resolve_default_database_url()
 

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -124,7 +124,7 @@ class _InMemoryEntry:
 
 
 class _InMemoryLock:
-    def __init__(self, lock: threading.Lock):
+    def __init__(self, lock: threading.Lock) -> None:
         self._lock = lock
         self._held = False
 
@@ -145,7 +145,7 @@ class _InMemoryLock:
 
 
 class InMemoryCacheProvider:
-    def __init__(self):
+    def __init__(self) -> None:
         self._store: dict[str, _InMemoryEntry] = {}
         self._locks: dict[str, threading.Lock] = {}
         self._mu = threading.RLock()
@@ -275,7 +275,7 @@ class FallbackCacheProvider:
     process-local in-memory cache when Redis is unavailable.
     """
 
-    def __init__(self, primary: CacheProvider, fallback: CacheProvider):
+    def __init__(self, primary: CacheProvider, fallback: CacheProvider) -> None:
         self._primary = primary
         self._fallback = fallback
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -29,7 +29,7 @@ class EnvVar:
     group: str = "general"
     depends_on: list[str] = field(default_factory=list)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate EnvVar configuration after initialization."""
         if self.required and self.default is not None:
             raise ValueError(
@@ -1785,7 +1785,7 @@ REDIS_KEY_SUFFIXES: dict[str, str] = {
 class EnhancedConfig:
     """Enhanced configuration management with validation and type safety."""
 
-    def __init__(self, env_vars: dict[str, EnvVar]):
+    def __init__(self, env_vars: dict[str, EnvVar]) -> None:
         self.env_vars = env_vars
         self._cache: dict[str, Any] = {}
         self._validated = False
@@ -2097,7 +2097,9 @@ __ENHANCED_CONFIG__ = EnhancedConfig(ENV_VARS)
 class Config(FlaskConfig):
     """Flask configuration wrapper with enhanced environment variable support."""
 
-    def __init__(self, parent: FlaskConfig, app: Flask, defaults: dict | None = None):
+    def __init__(
+        self, parent: FlaskConfig, app: Flask, defaults: dict | None = None
+    ) -> None:
         global __INSTANCE__
         self.parent = parent
         self.app = app

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
+from typing import Any
 
 import colorlog
 import pytz
@@ -17,7 +18,7 @@ from .request_context import thread_local
 
 
 class AppLoggerProxy:
-    def __init__(self, fallback: logging.Logger):
+    def __init__(self, fallback: logging.Logger) -> None:
         self._fallback = fallback
 
     def _resolve(self) -> logging.Logger:
@@ -30,7 +31,7 @@ class AppLoggerProxy:
         except Exception:
             return self._fallback
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._resolve(), name)
 
 
@@ -82,7 +83,7 @@ class RequestFormatter(logging.Formatter):
 class FeishuLogHandler(logging.Handler):
     MAX_TEXT_LENGTH = 18000
 
-    def __init__(self, webhook_url):
+    def __init__(self, webhook_url) -> None:
         super().__init__(level=logging.ERROR)
         self.webhook_url = webhook_url
         # This handler is attached to app.logger, so reporting a webhook
@@ -131,7 +132,7 @@ class FeishuLogHandler(logging.Handler):
 
 
 class ColoredRequestFormatter(RequestFormatter, colorlog.ColoredFormatter):
-    def __init__(self, fmt, **kwargs):
+    def __init__(self, fmt, **kwargs) -> None:
         super().__init__(fmt, **kwargs)
 
 

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -1,7 +1,7 @@
 class BasePlugin:
     name: str = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = self.__class__.__name__
         self.migration_dir = None  # plugin migration dir
 

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -7,7 +7,7 @@ from watchdog.observers import Observer
 
 
 class PluginHotReloader:
-    def __init__(self, app: Flask):
+    def __init__(self, app: Flask) -> None:
         self.app = app
         self.plugin_dir = "flaskr/plugins"  # plugin dir
         self.watched_files = {}
@@ -115,7 +115,7 @@ class PluginHotReloader:
 
 
 class PluginFileHandler(FileSystemEventHandler):
-    def __init__(self, reloader: PluginHotReloader):
+    def __init__(self, reloader: PluginHotReloader) -> None:
         self.reloader = reloader
         self.last_reload_time = {}  # Track last reload time per file
         self.min_reload_interval = 1.0  # Minimum seconds between reloads

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -8,7 +8,7 @@ plugin_manager = None
 
 
 class PluginManager:
-    def __init__(self, app: Flask):
+    def __init__(self, app: Flask) -> None:
         app.logger.info("PluginManager init")
         self.app = app
         self.extension_functions = {}

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -56,10 +56,10 @@ class ReferralPlanRewardResult:
 
 
 class _NullContext:
-    def __enter__(self):
+    def __enter__(self) -> None:
         return None
 
-    def __exit__(self, *_exc):
+    def __exit__(self, *_exc) -> bool | None:
         return False
 
 

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -127,7 +128,7 @@ class BillingWebhookResult:
     def __getitem__(self, key: str) -> Any:
         return self.to_response_dict()[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         yield self.to_response_dict()
         yield self.status_code
 

--- a/src/api/flaskr/service/check_risk/models.py
+++ b/src/api/flaskr/service/check_risk/models.py
@@ -47,7 +47,7 @@ class RiskControlResult(db.Model):
         check_resp,
         is_pass,
         check_strategy,
-    ):
+    ) -> None:
         self.chat_id = chat_id
         self.user_id = user_id
         self.text = text

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -4,21 +4,21 @@ DICTS = {}
 
 
 class DictItem:
-    def __init__(self, display, value):
+    def __init__(self, display, value) -> None:
         self.display = display
         self.value = value
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"display": self.display, "value": self.value}
 
 
 class Dict:
-    def __init__(self, name, display, items: list[DictItem]):
+    def __init__(self, name, display, items: list[DictItem]) -> None:
         self.name = name
         self.display = display
         self.items = items
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"name": self.name, "display": self.display, "items": self.items}
 
 

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -43,7 +43,7 @@ class UserInfo:
         user_avatar=None,
         is_creator=False,
         is_operator=False,
-    ):
+    ) -> None:
         self.user_id = user_id
         self.username = username
         self.name = name
@@ -58,7 +58,7 @@ class UserInfo:
         self.is_creator = is_creator
         self.is_operator = is_operator
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "user_id": self.user_id,
             "username": self.username,
@@ -73,7 +73,7 @@ class UserInfo:
             "is_operator": self.is_operator,
         }
 
-    def __html__(self):
+    def __html__(self) -> dict:
         return self.__json__()
 
 
@@ -82,11 +82,11 @@ class UserToken:
     userInfo: UserInfo
     token: str
 
-    def __init__(self, userInfo: UserInfo, token):  # noqa: N803 - mirrors the serialized field name
+    def __init__(self, userInfo: UserInfo, token) -> None:  # noqa: N803 - mirrors the serialized field name
         self.userInfo = userInfo
         self.token = token
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "userInfo": self.userInfo,
             "token": self.token,
@@ -98,11 +98,11 @@ class OAuthStartDTO:
     authorization_url: str
     state: str
 
-    def __init__(self, authorization_url: str, state: str):
+    def __init__(self, authorization_url: str, state: str) -> None:
         self.authorization_url = authorization_url
         self.state = state
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "authorization_url": self.authorization_url,
             "state": self.state,
@@ -131,7 +131,7 @@ class PageNationDTO(BaseModel):
         self.page_count = math.ceil(total / page_size if page_size > 0 else 0)
         self.data = data
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "page": self.page,
             "page_size": self.page_size,

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -7,22 +7,22 @@ from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class AppError(Exception):
-    def __init__(self, message, status_code=None, payload=None):
+    def __init__(self, message, status_code=None, payload=None) -> None:
         Exception.__init__(self)
         self.message = message
         self.code = status_code
         self.payload = payload
 
-    def __json__(self):
+    def __json__(self) -> dict:
         rv = dict(self.payload or ())
         rv["message"] = self.message
         rv["code"] = self.code
         return rv
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
-    def __html__(self):
+    def __html__(self) -> dict:
         return self.__json__()
 
 

--- a/src/api/flaskr/service/feedback/models.py
+++ b/src/api/flaskr/service/feedback/models.py
@@ -25,6 +25,6 @@ class FeedBack(db.Model):
         comment="Update time",
     )
 
-    def __init__(self, user_id, feedback):
+    def __init__(self, user_id, feedback) -> None:
         self.user_id = user_id
         self.feedback = feedback

--- a/src/api/flaskr/service/learn/ask_provider_adapters/base.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/base.py
@@ -35,7 +35,7 @@ class AskProviderError(Exception):
     description safe to surface in the UI; the raw message stays for logs.
     """
 
-    def __init__(self, message: str = "", user_message: str | None = None):
+    def __init__(self, message: str = "", user_message: str | None = None) -> None:
         super().__init__(message)
         self.user_message = user_message
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -214,7 +214,7 @@ class RunScriptInfo:
         outline_bid: str,
         block_position: int,
         mdflow: str,
-    ):
+    ) -> None:
         self.attend = attend
         self.outline_bid = outline_bid
         self.block_position = block_position
@@ -260,7 +260,7 @@ class RUNLLMProvider(LLMProvider):
         trace_args: dict,
         usage_context: UsageContext,
         usage_scene: int,
-    ):
+    ) -> None:
         self.app = app
         self.llm_settings = llm_settings
         self.trace = trace
@@ -410,7 +410,7 @@ class MdflowContextV2:
         use_learner_language: bool = False,
         visual_mode: bool = True,
         output_language: str | None = None,
-    ):
+    ) -> None:
         self._mdflow = MarkdownFlow(
             document=document,
             llm_provider=llm_provider,
@@ -621,7 +621,7 @@ class _PreviewContextStore:
         outline_bid: str,
         ttl_seconds: int | None = None,
         language: str | None = None,
-    ):
+    ) -> None:
         self._cache = cache_provider
         self._ttl_seconds = ttl_seconds or self._DEFAULT_TTL_SECONDS
         prefix = app.config.get("REDIS_KEY_PREFIX", "ai-shifu")
@@ -791,7 +791,7 @@ class _PreviewContextStore:
 class RunScriptPreviewContextV2:
     """MarkdownFlow preview using context v2 logic with optional Redis caching."""
 
-    def __init__(self, app: Flask):
+    def __init__(self, app: Flask) -> None:
         self.app = app
 
     def stream_preview(
@@ -1579,7 +1579,7 @@ class RunScriptContextV2:
         preview_mode: bool,
         listen: bool = False,
         stop_event: threading.Event | None = None,
-    ):
+    ) -> None:
         self._last_position = -1
         self.app = app
         self._struct = struct

--- a/src/api/flaskr/service/learn/exceptions.py
+++ b/src/api/flaskr/service/learn/exceptions.py
@@ -3,7 +3,7 @@ from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class PaidError(AppError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             "server.order.courseNotPaid",
             ERROR_CODE.get(
@@ -14,7 +14,7 @@ class PaidError(AppError):
 
 
 class BreakError(AppError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             "server.order.courseNotPaid",
             ERROR_CODE.get(

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -14,7 +14,7 @@ class LearnStatus(Enum):
     COMPLETED = "completed"
     LOCKED = "locked"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -24,7 +24,7 @@ class OutlineType(Enum):
     TRIAL = "trial"
     GUEST = "guest"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -43,7 +43,7 @@ class GeneratedType(Enum):
     # Internal ask event (listen adapter only, not exposed to non-listen consumers)
     ASK = "ask"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -70,7 +70,7 @@ class ElementType(Enum):
     _PICTURE = "picture"
     _VIDEO = "video"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -79,7 +79,7 @@ class ElementChangeType(Enum):
     RENDER = "render"
     DIFF = "diff"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -89,7 +89,7 @@ class LikeStatus(Enum):
     DISLIKE = "dislike"
     NONE = "none"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -101,7 +101,7 @@ class BlockType(Enum):
     ASK = "ask"
     ANSWER = "answer"
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.value
 
 
@@ -114,10 +114,10 @@ class VariableUpdateDTO(BaseModel):
         self,
         variable_name: str,
         variable_value: str,
-    ):
+    ) -> None:
         super().__init__(variable_name=variable_name, variable_value=variable_value)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "variable_name": self.variable_name,
             "variable_value": self.variable_value,
@@ -139,7 +139,7 @@ class OutlineItemUpdateDTO(BaseModel):
         title: str,
         status: LearnStatus,
         has_children: bool,
-    ):
+    ) -> None:
         super().__init__(
             outline_bid=outline_bid,
             title=title,
@@ -147,7 +147,7 @@ class OutlineItemUpdateDTO(BaseModel):
             has_children=has_children,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "outline_bid": self.outline_bid,
             "title": self.title,
@@ -181,7 +181,7 @@ class LearnShifuInfoDTO(BaseModel):
         price: str,
         tts_enabled: bool = False,
         default_listen_mode_enabled: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             bid=bid,
             title=title,
@@ -193,7 +193,7 @@ class LearnShifuInfoDTO(BaseModel):
             default_listen_mode_enabled=default_listen_mode_enabled,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "title": self.title,
@@ -226,7 +226,7 @@ class LearnBannerInfoDTO(BaseModel):
         pop_up_content: str,
         pop_up_confirm_text: str,
         pop_up_cancel_text: str,
-    ):
+    ) -> None:
         super().__init__(
             title=title,
             pop_up_title=pop_up_title,
@@ -235,7 +235,7 @@ class LearnBannerInfoDTO(BaseModel):
             pop_up_cancel_text=pop_up_cancel_text,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "title": self.title,
             "pop_up_title": self.pop_up_title,
@@ -272,7 +272,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         is_paid: bool,
         children: list[LearnOutlineItemInfoDTO],
         has_content_update_for_current_user: bool = False,
-    ):
+    ) -> None:
         super().__init__(
             bid=bid,
             position=position,
@@ -284,7 +284,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
             has_content_update_for_current_user=has_content_update_for_current_user,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "position": self.position,
@@ -310,13 +310,13 @@ class LearnOutlineItemsWithBannerInfoDTO(BaseModel):
         self,
         banner_info: LearnBannerInfoDTO | None,
         outline_items: list[LearnOutlineItemInfoDTO],
-    ):
+    ) -> None:
         super().__init__(
             banner_info=banner_info,
             outline_items=outline_items,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "banner_info": None
             if self.banner_info is None
@@ -365,7 +365,7 @@ class AudioSegmentDTO(BaseModel):
         stream_element_type: str | None = None,
         av_contract: dict[str, Any] | None = None,
         subtitle_cues: list[SubtitleCueDTO] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             position=position,
             stream_element_number=stream_element_number,
@@ -378,7 +378,7 @@ class AudioSegmentDTO(BaseModel):
             subtitle_cues=subtitle_cues or [],
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "position": self.position,
             "segment_index": self.segment_index,
@@ -433,7 +433,7 @@ class AudioCompleteDTO(BaseModel):
         stream_element_type: str | None = None,
         av_contract: dict[str, Any] | None = None,
         subtitle_cues: list[SubtitleCueDTO] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             position=position,
             stream_element_number=stream_element_number,
@@ -445,7 +445,7 @@ class AudioCompleteDTO(BaseModel):
             subtitle_cues=subtitle_cues or [],
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "position": self.position,
             "audio_url": self.audio_url,
@@ -468,10 +468,10 @@ class ElementVisualDTO(BaseModel):
     visual_type: str = Field(..., description="Visual payload type", required=False)
     content: str = Field(..., description="Visual payload content", required=False)
 
-    def __init__(self, visual_type: str, content: str):
+    def __init__(self, visual_type: str, content: str) -> None:
         super().__init__(visual_type=visual_type, content=content)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"visual_type": self.visual_type, "content": self.content}
 
 
@@ -494,7 +494,7 @@ class SubtitleCueDTO(BaseModel):
         end_ms: int,
         segment_index: int,
         position: int = 0,
-    ):
+    ) -> None:
         super().__init__(
             text=text or "",
             start_ms=int(start_ms or 0),
@@ -503,7 +503,7 @@ class SubtitleCueDTO(BaseModel):
             position=int(position or 0),
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "text": self.text or "",
             "start_ms": int(self.start_ms or 0),
@@ -534,7 +534,7 @@ class ElementAudioDTO(BaseModel):
         duration_ms: int,
         position: int = 0,
         subtitle_cues: list[SubtitleCueDTO] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             position=position,
             audio_url=audio_url,
@@ -543,7 +543,7 @@ class ElementAudioDTO(BaseModel):
             subtitle_cues=subtitle_cues or [],
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "position": int(self.position or 0),
             "audio_url": self.audio_url,
@@ -592,7 +592,7 @@ class ElementPayloadDTO(BaseModel):
         user_input: str | None = None,
         diff_payload: list[dict[str, Any]] | None = None,
         asks: list[dict[str, Any]] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             audio=audio,
             previous_visuals=previous_visuals or [],
@@ -603,7 +603,7 @@ class ElementPayloadDTO(BaseModel):
             asks=asks,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "audio": self.audio.__json__() if self.audio is not None else None,
             "previous_visuals": [
@@ -719,7 +719,7 @@ class ElementDTO(BaseModel):
             item["is_final"] = True
         return segments
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "event_type": self.event_type,
             "element_bid": self.element_bid,
@@ -761,7 +761,7 @@ class AudioBackfillReadyDTO(BaseModel):
         description="Persisted final element identifiers in this generated block",
     )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "generated_block_bid": self.generated_block_bid,
             "element_bids": self.element_bids,
@@ -793,7 +793,7 @@ class RunElementSSEMessageDTO(BaseModel):
         | AudioBackfillReadyDTO
     ) = Field(..., description="Run event content")
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "type": self.type,
             "event_type": self.event_type,
@@ -844,7 +844,7 @@ class RunMarkdownFlowDTO(BaseModel):
         | AudioSegmentDTO
         | AudioCompleteDTO,
         anchor_element_bid: str = "",
-    ):
+    ) -> None:
         super().__init__(
             outline_bid=outline_bid,
             generated_block_bid=generated_block_bid,
@@ -876,7 +876,7 @@ class RunMarkdownFlowDTO(BaseModel):
     def get_mdflow_stream_parts(self) -> list[tuple[str, str, int]]:
         return list(self._mdflow_stream_parts)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "outline_bid": self.outline_bid,
             "generated_block_bid": self.generated_block_bid,
@@ -950,14 +950,14 @@ class LearnElementRecordDTO(BaseModel):
         elements: list[ElementDTO] | None = None,
         events: list[RunElementSSEMessageDTO] | None = None,
         last_progress_updated_at: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             elements=elements or [],
             events=events,
             last_progress_updated_at=last_progress_updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "elements": [
                 item.__json__() if isinstance(item, BaseModel) else item
@@ -983,10 +983,10 @@ class RunStatusDTO(BaseModel):
         self,
         is_running: bool,
         running_time: int,
-    ):
+    ) -> None:
         super().__init__(is_running=is_running, running_time=running_time)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "is_running": self.is_running,
             "running_time": self.running_time,
@@ -1006,14 +1006,14 @@ class GeneratedInfoDTO(BaseModel):
         position: int,
         outline_name: str,
         is_trial_lesson: bool,
-    ):
+    ) -> None:
         super().__init__(
             position=position,
             outline_name=outline_name,
             is_trial_lesson=is_trial_lesson,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "position": self.position,
             "outline_name": self.outline_name,

--- a/src/api/flaskr/service/learn/legacy_record_builder.py
+++ b/src/api/flaskr/service/learn/legacy_record_builder.py
@@ -28,7 +28,7 @@ class LegacyGeneratedBlockRecord:
     audio_url: str | None = None
     audios: list[AudioCompleteDTO] | None = None
 
-    def __json__(self):
+    def __json__(self) -> dict:
         ret = {
             "generated_block_bid": self.generated_block_bid,
             "content": self.content,
@@ -51,7 +51,7 @@ class LegacyGeneratedBlockRecord:
 class LegacyLearnRecord:
     records: list[LegacyGeneratedBlockRecord]
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "records": self.records,
         }

--- a/src/api/flaskr/service/learn/listen_elements.py
+++ b/src/api/flaskr/service/learn/listen_elements.py
@@ -62,7 +62,7 @@ class ListenElementRunAdapter(
         outline_bid: str,
         user_bid: str,
         run_session_bid: str | None = None,
-    ):
+    ) -> None:
         self.app = app
         self.shifu_bid = shifu_bid
         self.outline_bid = outline_bid

--- a/src/api/flaskr/service/learn/llmsetting.py
+++ b/src/api/flaskr/service/learn/llmsetting.py
@@ -5,11 +5,11 @@ class LLMSettings(BaseModel):
     model: str
     temperature: float
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"model: {self.model}, temperature: {self.temperature}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"model": self.model, "temperature": self.temperature}

--- a/src/api/flaskr/service/learn/preview_elements.py
+++ b/src/api/flaskr/service/learn/preview_elements.py
@@ -26,7 +26,7 @@ class PreviewElementRunAdapter(ListenElementRunAdapter):
         outline_bid: str,
         user_bid: str,
         run_session_bid: str | None = None,
-    ):
+    ) -> None:
         super().__init__(
             app,
             shifu_bid=shifu_bid,

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -20,7 +20,7 @@ class _StreamTTSFinalizeJob:
         *,
         event_queue: queue.Queue,
         thread: threading.Thread,
-    ):
+    ) -> None:
         self.event_queue = event_queue
         self.thread = thread
         self.done = False
@@ -29,7 +29,7 @@ class _StreamTTSFinalizeJob:
 class StreamTTSFinalizeDrainer:
     """Finalize switched-out text TTS without blocking mdflow visual chunks."""
 
-    def __init__(self, run_context: Any, *, log_prefix: str):
+    def __init__(self, run_context: Any, *, log_prefix: str) -> None:
         self._run_context = run_context
         self._app = run_context.app
         self._log_prefix = log_prefix

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -36,7 +36,7 @@ class FollowUpInfo:
         model_args,
         ask_mode,
         ask_provider_config=None,
-    ):
+    ) -> None:
         self.ask_model = ask_model
         self.ask_prompt = ask_prompt
         self.ask_history_count = ask_history_count
@@ -45,7 +45,7 @@ class FollowUpInfo:
         self.ask_mode = ask_mode
         self.ask_provider_config = ask_provider_config or {}
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "ask_model": self.ask_model,
             "ask_prompt": self.ask_prompt,

--- a/src/api/flaskr/service/order/admin_dtos.py
+++ b/src/api/flaskr/service/order/admin_dtos.py
@@ -41,7 +41,7 @@ class OrderAdminOverviewDTO(BaseModel):
         required=False,
     )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "total_order_count": self.total_order_count,
             "paid_order_count": self.paid_order_count,
@@ -105,7 +105,7 @@ class OrderAdminSummaryDTO(BaseModel):
         order_source: str = "",
         order_source_key: str = "",
         coupon_codes: list[str] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             order_bid=order_bid,
             shifu_bid=shifu_bid,
@@ -128,7 +128,7 @@ class OrderAdminSummaryDTO(BaseModel):
             updated_at=updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "order_bid": self.order_bid,
             "shifu_bid": self.shifu_bid,
@@ -173,7 +173,7 @@ class OrderAdminActivityDTO(BaseModel):
         status_key: str,
         created_at: datetime | None,
         updated_at: datetime | None,
-    ):
+    ) -> None:
         super().__init__(
             active_id=active_id,
             active_name=active_name,
@@ -184,7 +184,7 @@ class OrderAdminActivityDTO(BaseModel):
             updated_at=updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "active_id": self.active_id,
             "active_name": self.active_name,
@@ -225,7 +225,7 @@ class OrderAdminCouponDTO(BaseModel):
         status_key: str,
         created_at: datetime | None,
         updated_at: datetime | None,
-    ):
+    ) -> None:
         super().__init__(
             coupon_bid=coupon_bid,
             code=code,
@@ -239,7 +239,7 @@ class OrderAdminCouponDTO(BaseModel):
             updated_at=updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "coupon_bid": self.coupon_bid,
             "code": self.code,
@@ -305,7 +305,7 @@ class OrderAdminPaymentDTO(BaseModel):
         channel: str = "",
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
-    ):
+    ) -> None:
         super().__init__(
             payment_channel=payment_channel,
             payment_channel_key=payment_channel_key,
@@ -325,7 +325,7 @@ class OrderAdminPaymentDTO(BaseModel):
             updated_at=updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "payment_channel": self.payment_channel,
             "payment_channel_key": self.payment_channel_key,
@@ -369,7 +369,7 @@ class OrderAdminDetailDTO(BaseModel):
         activities: list[OrderAdminActivityDTO],
         coupons: list[OrderAdminCouponDTO],
         payment: OrderAdminPaymentDTO,
-    ):
+    ) -> None:
         super().__init__(
             order=order,
             activities=activities,
@@ -377,7 +377,7 @@ class OrderAdminDetailDTO(BaseModel):
             payment=payment,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "order": self.order,
             "activities": self.activities,

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -102,14 +102,14 @@ class PayItemDto:
     is_discount: bool
     discount_code: str
 
-    def __init__(self, name, price_name, price, is_discount, discount_code):
+    def __init__(self, name, price_name, price, is_discount, discount_code) -> None:
         self.name = name
         self.price_name = price_name
         self.price = price
         self.is_discount = is_discount
         self.discount_code = discount_code
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "name": self.name,
             "price_name": self.price_name,
@@ -142,7 +142,7 @@ class AICourseBuyRecordDTO:
         discount,
         price_item,
         payment_channel="",
-    ):
+    ) -> None:
         self.order_id = record_id
         self.user_id = user_id
         self.course_id = course_id
@@ -153,7 +153,7 @@ class AICourseBuyRecordDTO:
         self.price_item = price_item
         self.payment_channel = payment_channel
 
-    def __json__(self):
+    def __json__(self) -> dict:
         def format_decimal(value):
             # Convert to a string with two decimal places
             formatted_value = value if isinstance(value, str) else f"{value:.2f}"
@@ -493,7 +493,7 @@ class BuyRecordDTO:
         qr_url,
         payment_channel: str = "",
         payment_payload: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         self.order_id = record_id
         self.user_id = user_id
         self.price = price
@@ -502,7 +502,7 @@ class BuyRecordDTO:
         self.payment_channel = payment_channel
         self.payment_payload = payment_payload or {}
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "order_id": self.order_id,
             "user_id": self.user_id,
@@ -1956,7 +1956,7 @@ class DiscountInfo:
     discount_value: str
     items: list[PayItemDto]
 
-    def __init__(self, discount_value, items):
+    def __init__(self, discount_value, items) -> None:
         self.discount_value = discount_value
         self.items = items
 

--- a/src/api/flaskr/service/profile/dtos.py
+++ b/src/api/flaskr/service/profile/dtos.py
@@ -8,14 +8,14 @@ class ColorSetting:
     color: str  # the background color of the profile item
     text_color: str  # the text color of the profile item
 
-    def __init__(self, color: str, text_color: str):
+    def __init__(self, color: str, text_color: str) -> None:
         self.color = color
         self.text_color = text_color
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"color": self.color, "text_color": self.text_color}
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.__json__(), ensure_ascii=True)
 
 
@@ -41,7 +41,7 @@ class ProfileItemDefinition:
         profile_scope_str: str,
         profile_id: str,
         is_hidden: bool = False,
-    ):
+    ) -> None:
         self.profile_key = profile_key
         self.color_setting = color_setting
         self.profile_type = profile_type
@@ -52,7 +52,7 @@ class ProfileItemDefinition:
         self.profile_id = profile_id
         self.is_hidden = is_hidden
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "profile_key": self.profile_key,
             "color_setting": self.color_setting,
@@ -65,7 +65,7 @@ class ProfileItemDefinition:
             "is_hidden": self.is_hidden,
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.__json__())
 
 
@@ -90,11 +90,11 @@ class ProfileValueDto:
     name: str
     value: str
 
-    def __init__(self, name: str, value: str):
+    def __init__(self, name: str, value: str) -> None:
         self.name = name
         self.value = value
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"name": self.name, "value": self.value}
 
 
@@ -104,10 +104,10 @@ class ProfileToSave:
     value: str
     bid: str
 
-    def __init__(self, key: str, value: str, bid: str):
+    def __init__(self, key: str, value: str, bid: str) -> None:
         self.key = key
         self.value = value
         self.bid = bid
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {"key": self.key, "value": self.value, "bid": self.bid}

--- a/src/api/flaskr/service/promo/admin_dtos.py
+++ b/src/api/flaskr/service/promo/admin_dtos.py
@@ -46,7 +46,7 @@ class _DTOBase(BaseModel):
             return None
         return value
 
-    def __json__(self):
+    def __json__(self) -> dict:
         if hasattr(self, "model_dump"):
             return self.model_dump()
         return self.dict()

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -114,10 +114,10 @@ def _with_app_context(app: Flask):
 
 
 class _NullContext:
-    def __enter__(self):
+    def __enter__(self) -> None:
         return None
 
-    def __exit__(self, *_exc):
+    def __exit__(self, *_exc) -> bool | None:
         return False
 
 

--- a/src/api/flaskr/service/shifu/admin.py
+++ b/src/api/flaskr/service/shifu/admin.py
@@ -642,7 +642,7 @@ _ADMIN_SPLIT_SUBMODULES = (
 
 
 class _AdminCompatibilityModule(type(sys)):
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
         super().__setattr__(name, value)
         for submodule in _ADMIN_SPLIT_SUBMODULES:
             if hasattr(submodule, name):

--- a/src/api/flaskr/service/shifu/admin_dtos_courses.py
+++ b/src/api/flaskr/service/shifu/admin_dtos_courses.py
@@ -63,7 +63,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
         updater_nickname: str,
         created_at: datetime | None,
         updated_at: datetime | None,
-    ):
+    ) -> None:
         super().__init__(
             shifu_bid=shifu_bid,
             course_name=course_name,
@@ -84,7 +84,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
             updated_at=updated_at,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "shifu_bid": self.shifu_bid,
             "course_name": self.course_name,

--- a/src/api/flaskr/service/shifu/admin_operations/courses.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses.py
@@ -418,7 +418,7 @@ _COURSES_SPLIT_SUBMODULES = (
 
 
 class _CoursesCompatibilityModule(type(sys)):
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
         super().__setattr__(name, value)
         for submodule in _COURSES_SPLIT_SUBMODULES:
             if hasattr(submodule, name):

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -189,7 +189,7 @@ def _format_course_credit_usage_model_label_fallback(value: str) -> str:
 
 
 class _CourseCreditUsageModelLabelResolver:
-    def __init__(self, app: Flask):
+    def __init__(self, app: Flask) -> None:
         self._app = app
         self._llm_label_map: dict[tuple[str, str], str] | None = None
         self._tts_label_map: dict[tuple[str, str], str] | None = None

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -68,7 +68,7 @@ class ShifuDto(BaseModel):
         created_user_bid: str = "",
         is_guide_course: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(
             bid=shifu_id,
             name=shifu_name,
@@ -83,7 +83,7 @@ class ShifuDto(BaseModel):
             is_guide_course=is_guide_course,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "name": self.name,
@@ -211,7 +211,7 @@ class ShifuDetailDto(BaseModel):
         ask_temperature: float = 0.0,
         ask_system_prompt: str = "",
         ask_provider_config: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             bid=shifu_id,
             name=shifu_name,
@@ -245,7 +245,7 @@ class ShifuDetailDto(BaseModel):
             ask_provider_config=ask_provider_config or {},
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "name": self.name,
@@ -305,7 +305,7 @@ class SimpleOutlineDto(BaseModel):
         children: list,
         type: str | None = None,  # noqa: A002 - serialized DTO field name
         is_hidden: bool | None = None,
-    ):
+    ) -> None:
         normalized_children: list[SimpleOutlineDto] = []
         if children:
             for child in children:
@@ -331,7 +331,7 @@ class SimpleOutlineDto(BaseModel):
             is_hidden=is_hidden,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "position": self.position,
@@ -354,7 +354,7 @@ class SimpleOutlineDto(BaseModel):
 class ShifuOutlineTreeNode:
     """Shifu outline tree node."""
 
-    def __init__(self, outline_item: DraftOutlineItem):
+    def __init__(self, outline_item: DraftOutlineItem) -> None:
         self.outline = outline_item
         self.children = []
         if outline_item:
@@ -408,7 +408,7 @@ class OutlineDto(BaseModel):
         index: int | None = None,
         system_prompt: str | None = None,
         is_hidden: bool | None = None,
-    ):
+    ) -> None:
         super().__init__(
             bid=bid,
             position=position,
@@ -420,7 +420,7 @@ class OutlineDto(BaseModel):
             is_hidden=is_hidden,
         )
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "position": self.position,
@@ -440,12 +440,12 @@ class ReorderOutlineItemDto:
     bid: str
     children: list["ReorderOutlineItemDto"]
 
-    def __init__(self, bid: str, children: list["ReorderOutlineItemDto"]):
+    def __init__(self, bid: str, children: list["ReorderOutlineItemDto"]) -> None:
         """Init reorder outline item dto."""
         self.bid = bid
         self.children = children
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "bid": self.bid,
             "children": self.children,
@@ -464,10 +464,10 @@ class MdflowDTOParseResult(BaseModel):
     variables: list[str] = Field(..., description="variables", required=True)
     blocks_count: int = Field(..., description="blocks count", required=True)
 
-    def __init__(self, variables: list[str], blocks_count: int):
+    def __init__(self, variables: list[str], blocks_count: int) -> None:
         super().__init__(variables=variables, blocks_count=blocks_count)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "variables": self.variables,
             "blocks_count": self.blocks_count,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -33,6 +33,7 @@ import json
 import re
 import tempfile
 import uuid
+from collections.abc import Callable
 from enum import Enum
 from functools import wraps
 from pathlib import Path
@@ -169,11 +170,11 @@ class ShifuTokenValidation:
         self,
         permission: ShifuPermission = ShifuPermission.VIEW,
         is_creator: bool = False,
-    ):
+    ) -> None:
         self.permission = permission
         self.is_creator = is_creator
 
-    def __call__(self, f):
+    def __call__(self, f) -> Callable:
         @wraps(f)
         def decorated_function(*args, **kwargs):
             token = request.cookies.get("token", None)

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -38,7 +38,7 @@ class ShifuOutlineItemDto(BaseModel):
     shifu_bid: str
     children: list["ShifuOutlineItemDto"]
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.model_dump_json(exclude_none=True)
 
 
@@ -54,7 +54,7 @@ class ShifuInfoDto(BaseModel):
     default_listen_mode_enabled: bool = False
     use_learner_language: bool = False
 
-    def __json__(self):
+    def __json__(self) -> str:
         return self.model_dump_json(exclude_none=True)
 
 

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -278,7 +278,7 @@ class StreamingTTSProcessor:
         stream_element_type: str | None = None,
         av_contract: dict[str, Any] | None = None,
         usage_scene: int = BILL_USAGE_SCENE_PROD,
-    ):
+    ) -> None:
         self.app = app
         self.generated_block_bid = generated_block_bid
         self.outline_bid = outline_bid
@@ -2090,7 +2090,7 @@ class AVStreamingTTSProcessor:
         tts_model: str = "",
         usage_scene: int = BILL_USAGE_SCENE_PROD,
         element_index_offset: int = 0,
-    ):
+    ) -> None:
         self.app = app
         self.generated_block_bid = generated_block_bid
         self.outline_bid = outline_bid

--- a/src/api/flaskr/service/user/dtos.py
+++ b/src/api/flaskr/service/user/dtos.py
@@ -12,7 +12,7 @@ class UserProfileLabelItemDTO(BaseModel):
     value: str | datetime.date | None = Field(..., description="value", required=False)
     items: list | None = Field(..., description="items", required=False)
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "key": self.key,
             "label": self.label,
@@ -29,7 +29,7 @@ class UserProfileLabelDTO(BaseModel):
     )
     language: str = Field(..., description="language")
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "profiles": [item.__json__() for item in self.profiles],
             "language": self.language,

--- a/src/api/flaskr/service/user/exceptions.py
+++ b/src/api/flaskr/service/user/exceptions.py
@@ -4,7 +4,7 @@ from flaskr.util.deprecation import deprecated_alias_getattr
 
 
 class UserNotLoginError(AppError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             _("server.user.userNotLogin"),
             ERROR_CODE.get(

--- a/src/api/flaskr/service/user/models.py
+++ b/src/api/flaskr/service/user/models.py
@@ -55,7 +55,7 @@ class UserConversion(db.Model):
         conversion_status,
         conversion_uuid="",
         conversion_third_platform="",
-    ):
+    ) -> None:
         self.user_id = user_id
         self.conversion_id = conversion_id
         self.conversion_source = conversion_source

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -24,7 +24,7 @@ class TokenStoreProvider:
       as an accelerator for token lookups and sliding expiration.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cache = cache
 
     def _cache_key(self, app: Flask, token: str) -> str:

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -139,7 +139,7 @@ def _simulate_observed_segments(
     captured_by_position: dict[int, list[str]] = {}
 
     class CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -3,7 +3,7 @@ from flaskr.api.doc import feishu
 
 
 class _Logger:
-    def __init__(self):
+    def __init__(self) -> None:
         self.infos = []
         self.warnings = []
         self.exceptions = []
@@ -19,12 +19,14 @@ class _Logger:
 
 
 class _App:
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = _Logger()
 
 
 class _Response:
-    def __init__(self, status_code=200, text="", json_value=None, json_exc=None):
+    def __init__(
+        self, status_code=200, text="", json_value=None, json_exc=None
+    ) -> None:
         self.status_code = status_code
         self.text = text
         self._json_value = json_value

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -6,7 +6,7 @@ from flaskr.command.unified_migration_task import (
 
 
 class _FakeResult:
-    def __init__(self, value):
+    def __init__(self, value) -> None:
         self._value = value
 
     def scalar(self):
@@ -19,7 +19,7 @@ class _FakeResult:
 class _FakeSession:
     """Session double that records the statements a migration step issues."""
 
-    def __init__(self, value=1):
+    def __init__(self, value=1) -> None:
         self._value = value
         self.calls = []
 

--- a/src/api/tests/common/fixtures/fake_llm.py
+++ b/src/api/tests/common/fixtures/fake_llm.py
@@ -12,7 +12,7 @@ class FakeLLMResponse:
         is_truncated: bool = False,
         finish_reason: str = "stop",
         usage=None,
-    ):
+    ) -> None:
         self.id = chunk_id
         self.is_end = is_end
         self.is_truncated = is_truncated

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -3,7 +3,7 @@ from typing import Any
 
 
 class FakeRedisLock:
-    def __init__(self, locks: dict[str, bool], key: str):
+    def __init__(self, locks: dict[str, bool], key: str) -> None:
         self._locks = locks
         self._key = key
         self._held = False
@@ -22,7 +22,7 @@ class FakeRedisLock:
 
 
 class FakeRedis:
-    def __init__(self):
+    def __init__(self) -> None:
         self._store: dict[str, Any] = {}
         self._expires: dict[str, float] = {}
         self._locks: dict[str, bool] = {}

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -12,7 +12,7 @@ from flaskr.common.gevent_hub_observer import install_hub_error_observer
 
 
 class _StubHub:
-    def __init__(self):
+    def __init__(self) -> None:
         self.calls = []
 
         def _original(context, exc_type, value, tb):
@@ -33,7 +33,7 @@ def test_observer_logs_and_delegates(caplog):
     assert install_hub_error_observer(logger, hub=hub) is True
 
     class _FakeSemaphore:
-        def __repr__(self):
+        def __repr__(self) -> str:
             return "<FakeSemaphore links=3>"
 
     context = _FakeSemaphore()
@@ -83,7 +83,7 @@ def test_unreprable_context_is_still_logged(caplog):
     install_hub_error_observer(logger, hub=hub)
 
     class _BadRepr:
-        def __repr__(self):
+        def __repr__(self) -> str:
             raise ValueError("no repr for you")
 
     with caplog.at_level(logging.ERROR, logger="test-hub-observer-badrepr"):

--- a/src/api/tests/common/test_i18n_utils.py
+++ b/src/api/tests/common/test_i18n_utils.py
@@ -14,7 +14,7 @@ def test_existing_english_and_chinese_names_are_unchanged():
 
 def test_french_native_name_reaches_content_and_interaction_prompts():
     class CapturingProvider:
-        def __init__(self):
+        def __init__(self) -> None:
             self.calls = []
 
         def complete(self, messages, **_kwargs):

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -16,7 +16,7 @@ from sqlalchemy.pool import QueuePool
 class _FakePyMySQLConnection:
     """Minimal stand-in exposing the pymysql `_sock` attribute."""
 
-    def __init__(self, sock):
+    def __init__(self, sock) -> None:
         self._sock = sock
         self.closed = False
 
@@ -172,7 +172,7 @@ def test_checkin_grace_window_is_a_short_positive_interval():
 class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
     """Fake with a healthy ping - the pymysql-shaped checkout path."""
 
-    def __init__(self, sock):
+    def __init__(self, sock) -> None:
         super().__init__(sock)
         self.pings = 0
 

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import DisconnectionError
 
 
 class _FakeRecord:
-    def __init__(self):
+    def __init__(self) -> None:
         self.invalidated_with = []
 
     def invalidate(self, e=None):

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -46,7 +46,7 @@ from sqlalchemy.ext.compiler import compiles
 
 
 class _TestPluginManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self.extension_functions = {}
         self.extensible_generic_functions = {}
         self.is_enabled = False

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -11,7 +11,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, config):
+        def __init__(self, config) -> None:
             captured["config"] = config
 
         def send_sms_with_options(self, request, runtime):
@@ -54,7 +54,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, config):
+        def __init__(self, config) -> None:
             captured["config"] = config
 
         def send_sms_with_options(self, request, runtime):
@@ -110,7 +110,7 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class DummyError(Exception):
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__("boom")
             self.message = "boom"
             self.data = {"Recommend": "retry"}
@@ -118,7 +118,7 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, config):
+        def __init__(self, config) -> None:
             captured["config"] = config
 
         def send_sms_with_options(self, request, runtime):
@@ -148,7 +148,7 @@ def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(monkeypatch)
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:
-        def __init__(self, _config):
+        def __init__(self, _config) -> None:
             pass
 
         def send_sms_with_options(self, request, runtime):
@@ -194,7 +194,7 @@ def test_send_sms_ali_logs_recipient_throttle_as_warning(
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:
-        def __init__(self, _config):
+        def __init__(self, _config) -> None:
             pass
 
         def send_sms_with_options(self, request, runtime):
@@ -239,7 +239,7 @@ def test_send_sms_ali_logs_illegal_recipient_number_as_warning(monkeypatch, capl
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:
-        def __init__(self, _config):
+        def __init__(self, _config) -> None:
             pass
 
         def send_sms_with_options(self, request, runtime):

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 
 class _Db:
-    def __init__(self, session):
+    def __init__(self, session) -> None:
         self.session = session
 
 

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -3,7 +3,7 @@ from flaskr.service.billing import admin_ops_state
 
 
 class _TrackingLock:
-    def __init__(self, events, key):
+    def __init__(self, events, key) -> None:
         self._events = events
         self._key = key
 
@@ -16,7 +16,7 @@ class _TrackingLock:
 
 
 class _TrackingRedis:
-    def __init__(self):
+    def __init__(self) -> None:
         self.events = []
 
     def lock(self, key, **_kwargs):

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -2,6 +2,7 @@ import hashlib
 from importlib import import_module
 from io import BytesIO
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from cryptography.fernet import Fernet
@@ -690,7 +691,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch):
     """
 
     class _ExplodingModule:
-        def __getattr__(self, name):
+        def __getattr__(self, name) -> Any:
             raise AssertionError(
                 "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
             )

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -184,7 +184,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
     )
 
     class CacheWrapper:
-        def __init__(self):
+        def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
         def get(self, key):
@@ -228,7 +228,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
     )
 
     class CacheWrapper:
-        def __init__(self):
+        def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
         def get(self, key):
@@ -358,7 +358,7 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(monkeypatch
     )
 
     class CacheWrapper:
-        def __init__(self):
+        def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
         def get(self, key):

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -27,7 +27,7 @@ def _make_context() -> RunScriptContextV2:
 class _RecordingEmitter:
     """Stand-in emitter recording every delegated call."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.calls = []
 
     def render_outline_updates(self, outline_updates, new_chapter=False):

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -22,7 +22,7 @@ class _FakeResponse:
         http_error=None,
         json_data=None,
         json_error=None,
-    ):
+    ) -> None:
         self._lines = lines or []
         self.status_code = status_code
         self.text = text

--- a/src/api/tests/service/learn/test_ask_provider_langfuse.py
+++ b/src/api/tests/service/learn/test_ask_provider_langfuse.py
@@ -6,7 +6,7 @@ from flaskr.service.learn.ask_provider_langfuse import stream_provider_with_lang
 
 
 class _DummyGeneration:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
@@ -15,7 +15,7 @@ class _DummyGeneration:
 
 
 class _DummySpan:
-    def __init__(self, trace_id="trace-1", span_id="span-1"):
+    def __init__(self, trace_id="trace-1", span_id="span-1") -> None:
         self.trace_id = trace_id
         self.id = span_id
         self.generations = []

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -158,7 +158,7 @@ def _make_context() -> RunScriptContextV2:
 
 
 class _FakeLangfuseSpan:
-    def __init__(self):
+    def __init__(self) -> None:
         self.updated = {}
         self.end_kwargs = {}
 
@@ -170,7 +170,7 @@ class _FakeLangfuseSpan:
 
 
 class _FakeLangfuseTrace:
-    def __init__(self):
+    def __init__(self) -> None:
         self.updated = {}
 
     def update(self, **kwargs):
@@ -460,7 +460,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             def in_(self, _values):
                 return self
 
-            def __eq__(self, _other):
+            def __eq__(self, _other) -> "_Column":
                 return self
 
         class _OutlineModel:
@@ -477,7 +477,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
                 return [("outline-1", False, "Outline 1")]
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -539,7 +539,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         attend = types.SimpleNamespace(outline_item_bid="outline-1", block_position=0)
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -753,16 +753,16 @@ class StreamTtsGateTests(unittest.TestCase):
         remove_calls: list[str] = []
 
         class ClosableStream:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.close_calls = 0
                 self._yielded_first = False
                 self.second_next_started = threading.Event()
                 self.release_second = threading.Event()
 
-            def __iter__(self):
+            def __iter__(self) -> "ClosableStream":
                 return self
 
-            def __next__(self):
+            def __next__(self) -> str:
                 if not self._yielded_first:
                     self._yielded_first = True
                     return "chunk-1"
@@ -1056,7 +1056,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
         class _FakeProcessor:
             next_element_index = 5
 
-            def __init__(self):
+            def __init__(self) -> None:
                 self.finalize_calls = []
 
             def finalize(self, *, commit=True):
@@ -1093,7 +1093,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
         class _FakeProcessor:
             next_element_index = 9
 
-            def __init__(self):
+            def __init__(self) -> None:
                 self.finalize_calls = 0
 
             def finalize(self, *, commit=True):
@@ -1126,7 +1126,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
 class MdflowContextCompatibilityTests(unittest.TestCase):
     def test_init_ignores_visual_mode_when_api_missing(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.args = args
                 self.kwargs = kwargs
 
@@ -1140,7 +1140,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_calls_visual_mode_when_api_exists(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.visual_mode = None
 
             def set_visual_mode(self, visual_mode):
@@ -1156,7 +1156,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_uses_explicit_output_language_when_enabled(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.output_language = None
 
             def set_output_language(self, language):
@@ -1805,7 +1805,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
         captured = {}
 
         class _FakePreviewContextStore:
-            def __init__(self, *_args, **_kwargs):
+            def __init__(self, *_args, **_kwargs) -> None:
                 pass
 
             def get_context(self, *_args, **_kwargs):
@@ -1815,7 +1815,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 return None
 
         class _FakePreviewMdflowContext:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 _ = args, kwargs
 
             @staticmethod
@@ -1844,7 +1844,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 )
 
         class _FakePreviewAdapter:
-            def __init__(self, *_args, **_kwargs):
+            def __init__(self, *_args, **_kwargs) -> None:
                 pass
 
             def process(self, events):
@@ -2144,7 +2144,7 @@ class PreviewElementizationTests(unittest.TestCase):
 
 
 class _InMemoryCache:
-    def __init__(self):
+    def __init__(self) -> None:
         self.store: dict[str, str] = {}
 
     def get(self, key: str):

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -41,7 +41,7 @@ def test_context_v2_tts_processor_uses_runtime_minimax_voice_fallback(monkeypatc
     captured_kwargs = {}
 
     class FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             captured_kwargs.update(kwargs)
 
     monkeypatch.setattr(

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -38,7 +38,7 @@ def adapter_app():
 
 
 class _FollowUpDummyGeneration:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
@@ -47,7 +47,7 @@ class _FollowUpDummyGeneration:
 
 
 class _FollowUpDummySpan:
-    def __init__(self):
+    def __init__(self) -> None:
         self.generations = []
         self.updated = {}
         self.output = ""
@@ -72,7 +72,7 @@ class _FollowUpDummySpan:
 
 
 class _FollowUpDummyTrace:
-    def __init__(self):
+    def __init__(self) -> None:
         self.updated = {}
 
     def span(self, **_kwargs):
@@ -83,7 +83,7 @@ class _FollowUpDummyTrace:
 
 
 class _FollowUpContext:
-    def __init__(self):
+    def __init__(self) -> None:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
@@ -95,13 +95,13 @@ class _FollowUpContext:
 
 
 class _FollowUpInfo:
-    def __init__(self, ask_provider_config):
+    def __init__(self, ask_provider_config) -> None:
         self.ask_prompt = "ASK_PROMPT::{shifu_system_message}"
         self.ask_model = "gpt-test"
         self.model_args = {"temperature": 0.2}
         self.ask_provider_config = ask_provider_config
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "ask_model": self.ask_model,
             "ask_provider_config": self.ask_provider_config,
@@ -118,12 +118,14 @@ def _setup_handle_input_ask_test_doubles(
     from flaskr.service.learn.ask_provider_adapters import AskProviderError
 
     class _DummyLLMSettings:
-        def __init__(self, model, temperature):
+        def __init__(self, model, temperature) -> None:
             self.model = model
             self.temperature = temperature
 
     class _DummyAskProviderRuntime:
-        def __init__(self, llm_stream_factory=None, llm_context_stream_factory=None):
+        def __init__(
+            self, llm_stream_factory=None, llm_context_stream_factory=None
+        ) -> None:
             self.llm_stream_factory = llm_stream_factory
             self.llm_context_stream_factory = llm_context_stream_factory
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -82,7 +82,7 @@ GeneratedType = importlib.import_module("flaskr.service.learn.learn_dtos").Gener
 class _DummyColumn:
     __hash__ = None
 
-    def __eq__(self, _other):
+    def __eq__(self, _other) -> bool:
         return True
 
 
@@ -129,13 +129,13 @@ class _DummyLearnGeneratedElementModel:
 
 
 class _DummyFollowUpInfo:
-    def __init__(self, ask_provider_config):
+    def __init__(self, ask_provider_config) -> None:
         self.ask_prompt = "ASK_PROMPT::{shifu_system_message}::{knowledge_section}"
         self.ask_model = "gpt-test"
         self.model_args = {"temperature": 0.2}
         self.ask_provider_config = ask_provider_config
 
-    def __json__(self):
+    def __json__(self) -> dict:
         return {
             "ask_model": self.ask_model,
             "ask_provider_config": self.ask_provider_config,
@@ -143,7 +143,7 @@ class _DummyFollowUpInfo:
 
 
 class _DummyGeneration:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
@@ -152,7 +152,7 @@ class _DummyGeneration:
 
 
 class _DummySpan:
-    def __init__(self):
+    def __init__(self) -> None:
         self.output = ""
         self.generations = []
         self.updated = {}
@@ -183,7 +183,7 @@ class _DummySpan:
 
 
 class _DummyTrace:
-    def __init__(self):
+    def __init__(self) -> None:
         self.span_output = None
         self.updated = {}
         self.last_span = None
@@ -197,12 +197,12 @@ class _DummyTrace:
 
 
 class _LLMChunk:
-    def __init__(self, result: str):
+    def __init__(self, result: str) -> None:
         self.result = result
 
 
 class _Context:
-    def __init__(self):
+    def __init__(self) -> None:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
@@ -215,12 +215,14 @@ class _Context:
 
 def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
     class _DummyLLMSettings:
-        def __init__(self, model, temperature):
+        def __init__(self, model, temperature) -> None:
             self.model = model
             self.temperature = temperature
 
     class _DummyAskProviderRuntime:
-        def __init__(self, llm_stream_factory=None, llm_context_stream_factory=None):
+        def __init__(
+            self, llm_stream_factory=None, llm_context_stream_factory=None
+        ) -> None:
             self.llm_stream_factory = llm_stream_factory
             self.llm_context_stream_factory = llm_context_stream_factory
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -248,19 +248,19 @@ class LearnRecordLoadTests(unittest.TestCase):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
 
         class DummyLLMResult:
-            def __init__(self, content: str):
+            def __init__(self, content: str) -> None:
                 self.content = content
 
         class FakeMarkdownFlow:
             last_context = None
 
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
             def set_visual_mode(self, *_args, **_kwargs):
@@ -367,17 +367,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
 
         class DummyLLMResult:
-            def __init__(self, content: str):
+            def __init__(self, content: str) -> None:
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "first content", 0),
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "second content", 1),
@@ -514,7 +514,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
@@ -522,7 +522,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
             def set_visual_mode(self, *_args, **_kwargs):
@@ -638,7 +638,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
@@ -646,7 +646,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
@@ -758,7 +758,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
@@ -766,7 +766,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -111,7 +111,7 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
             pass
 
     class _FakeConnection:
-        def __init__(self):
+        def __init__(self) -> None:
             self.invalidated = 0
 
         def execute(self, *_args, **_kwargs):
@@ -121,7 +121,7 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
             self.invalidated += 1
 
     class _FakeSession:
-        def __init__(self, connection):
+        def __init__(self, connection) -> None:
             self._connection = connection
 
         def connection(self):

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1397,17 +1397,17 @@ def test_listen_run_persists_content_block_before_element_rows(app):
         )
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
 
         class DummyLLMResult:
-            def __init__(self, content):
+            def __init__(self, content) -> None:
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [
                     DummyBlock(
                         MarkdownFlowBlockType.CONTENT,
@@ -1581,23 +1581,23 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
         ctx._should_stream_tts = types.MethodType(lambda self: True, ctx)
 
         class DummyBlock:
-            def __init__(self, block_type, content, index):
+            def __init__(self, block_type, content, index) -> None:
                 self.block_type = block_type
                 self.content = content
                 self.index = index
 
         class DummyFormattedElement:
-            def __init__(self, content, element_type, number):
+            def __init__(self, content, element_type, number) -> None:
                 self.content = content
                 self.type = element_type
                 self.number = number
 
         class DummyLLMResult:
-            def __init__(self, formatted_elements):
+            def __init__(self, formatted_elements) -> None:
                 self.formatted_elements = formatted_elements
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs):
+            def __init__(self, *args, **kwargs) -> None:
                 self.blocks = [
                     DummyBlock(
                         MarkdownFlowBlockType.CONTENT,
@@ -1647,7 +1647,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                 position,
                 stream_element_number,
                 stream_element_type,
-            ):
+            ) -> None:
                 self.generated_block_bid = generated_block_bid
                 self.position = position
                 self.stream_element_number = stream_element_number

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import OperationalError
 
 
 class _EchoResult:
-    def __init__(self, value):
+    def __init__(self, value) -> None:
         self._value = value
 
     def scalar(self):
@@ -13,7 +13,7 @@ class _EchoResult:
 
 
 class _FakeConnection:
-    def __init__(self):
+    def __init__(self) -> None:
         self.invalidated = 0
 
     def invalidate(self):
@@ -23,7 +23,7 @@ class _FakeConnection:
 class _FakeSession:
     """Scripted session: each execute() consumes the next behaviour."""
 
-    def __init__(self, behaviours):
+    def __init__(self, behaviours) -> None:
         # behaviours: list of "ok" | "raise" | any-fixed-echo-value
         self._behaviours = list(behaviours)
         self.executed = 0

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -26,7 +26,7 @@ def _skip_connection_probe(monkeypatch):
 
 
 class FakeLock:
-    def __init__(self, acquire_results: list[bool]):
+    def __init__(self, acquire_results: list[bool]) -> None:
         self._acquire_results = list(acquire_results)
         self.acquire_calls = 0
         self.release_calls = 0
@@ -42,7 +42,7 @@ class FakeLock:
 
 
 class FakeCacheProvider:
-    def __init__(self, lock: FakeLock):
+    def __init__(self, lock: FakeLock) -> None:
         self._lock = lock
         self.values: dict[str, bytes] = {}
 
@@ -67,7 +67,7 @@ class FakeCacheProvider:
 
 
 class FakeListenElementAdapter:
-    def __init__(self, *_args, **_kwargs):
+    def __init__(self, *_args, **_kwargs) -> None:
         self._seq = 0
         self._run_session_bid = "run-session-1"
 
@@ -515,7 +515,7 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs):
+        def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
         def set_input(self, *_args, **_kwargs):
@@ -556,7 +556,7 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
     class FakeElementAdapter:
-        def __init__(self):
+        def __init__(self) -> None:
             self.calls = []
 
         def process(self, events):
@@ -716,7 +716,7 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs):
+        def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
         def set_input(self, *_args, **_kwargs):
@@ -801,7 +801,7 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch):
     class FakeRunScriptContext:
         last_instance = None
 
-        def __init__(self, **_kwargs):
+        def __init__(self, **_kwargs) -> None:
             self._has_next = True
             self.finalize_calls = 0
             FakeRunScriptContext.last_instance = self
@@ -903,7 +903,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs):
+        def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
         def set_input(self, *_args, **_kwargs):
@@ -1032,7 +1032,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs):
+        def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
         def set_input(self, *_args, **_kwargs):

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import OperationalError, ResourceClosedError
 
 
 class _FakeSession:
-    def __init__(self):
+    def __init__(self) -> None:
         self.rollbacks = 0
         self.commits = 0
         self.invalidations = 0
@@ -48,7 +48,7 @@ class _StubRunContext:
 
     script: ClassVar[list] = []
 
-    def __init__(self, **_kwargs):
+    def __init__(self, **_kwargs) -> None:
         self._steps = iter([True, False])
 
     def set_input(self, *_args, **_kwargs):
@@ -192,7 +192,7 @@ def test_stop_event_cancellation_invalidates_instead_of_rollback(app, monkeypatc
     class _TwoRoundContext(_StubRunContext):
         # Two has_next rounds so the stop_event check at the loop boundary
         # fires between them.
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             super().__init__(**kwargs)
             # Each loop round consumes TWO steps: the while condition and the
             # has_next() call inside the log line.

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -12,7 +12,7 @@ class FakeRedis:
     Distinguishes acquire (key, max, ttl) from release (key) by arg count.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.counters: dict[str, int] = {}
 
     def eval(self, _script, _numkeys, *args):
@@ -34,7 +34,7 @@ class FakeRedis:
 class ExplodingRedis:
     """Redis stub whose .eval always raises, to exercise the fail-open path."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.calls = 0
 
     def eval(self, *_args, **_kwargs):

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql import column
 
 
 class DummyOrder:
-    def __init__(self):
+    def __init__(self) -> None:
         self.order_bid = "order-1"
         self.shifu_bid = "shifu-1"
         self.user_bid = "user-1"
@@ -46,7 +46,7 @@ class DummyOrder:
 
 
 class DummyShifu:
-    def __init__(self):
+    def __init__(self) -> None:
         self.title = "Demo Course"
 
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -2,7 +2,7 @@ import flaskr.service.order.funs as order_funs
 
 
 class DummyLock:
-    def __init__(self):
+    def __init__(self) -> None:
         self.acquired = 0
         self.released = 0
 
@@ -15,7 +15,7 @@ class DummyLock:
 
 
 class DummyRedis:
-    def __init__(self):
+    def __init__(self) -> None:
         self.last_key = None
         self.last_timeout = None
         self.last_blocking_timeout = None
@@ -29,7 +29,7 @@ class DummyRedis:
 
 
 class DummyApp:
-    def __init__(self, prefix="ai-shifu"):
+    def __init__(self, prefix="ai-shifu") -> None:
         self.config = {"REDIS_KEY_PREFIX": prefix}
 
 

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -40,7 +40,7 @@ def test_alipay_precreate_uses_host_url_notify_url(monkeypatch):
         pass
 
     class FakePrecreateRequest:
-        def __init__(self, *, biz_model):
+        def __init__(self, *, biz_model) -> None:
             self.biz_model = biz_model
 
     class FakeClient:

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -9,7 +9,7 @@ from flaskr.service.order.payment_providers.base import PaymentRefundResult
 
 
 class DummyStripeRefundProvider:
-    def __init__(self, result: PaymentRefundResult):
+    def __init__(self, result: PaymentRefundResult) -> None:
         self._result = result
 
     def refund_payment(self, *, request, app):  # pylint: disable=unused-argument

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -32,7 +32,7 @@ def _load_route_module(module_name: str):
 
 
 class DummyStripeProvider:
-    def __init__(self, notification: PaymentNotificationResult):
+    def __init__(self, notification: PaymentNotificationResult) -> None:
         self._notification = notification
 
     def verify_webhook(self, *, headers, raw_body, app):

--- a/src/api/tests/service/profile/test_variable_value_resolution.py
+++ b/src/api/tests/service/profile/test_variable_value_resolution.py
@@ -2,7 +2,7 @@ from flaskr.service.profile.funcs import _get_latest_variable_value
 
 
 class _DummyValue:
-    def __init__(self, *, key: str, shifu_bid: str, variable_bid: str):
+    def __init__(self, *, key: str, shifu_bid: str, variable_bid: str) -> None:
         self.key = key
         self.shifu_bid = shifu_bid
         self.variable_bid = variable_bid

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -55,7 +55,7 @@ class DummyCourse:
         updated_at: datetime,
         llm: str = "",
         llm_system_prompt: str = "",
-    ):
+    ) -> None:
         self.shifu_bid = shifu_bid
         self.title = title
         self.price = price
@@ -1544,16 +1544,16 @@ def test_merge_courses_checks_published_visibility_once():
 class FakeColumn:
     __hash__ = None
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> tuple:
         return ("eq", self.name, other)
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> tuple:
         return ("ge", self.name, other)
 
-    def __le__(self, other):
+    def __le__(self, other) -> tuple:
         return ("le", self.name, other)
 
     def ilike(self, value: str):
@@ -1570,7 +1570,7 @@ class FakeColumn:
 
 
 class FakeMaxExpression:
-    def __init__(self, column: FakeColumn):
+    def __init__(self, column: FakeColumn) -> None:
         self.column = column
 
     def label(self, alias: str):
@@ -1578,12 +1578,12 @@ class FakeMaxExpression:
 
 
 class FakeLatestSubquery:
-    def __init__(self):
+    def __init__(self) -> None:
         self.c = type("Columns", (), {"max_id": "latest-max-id"})()
 
 
 class FakeLatestQuery:
-    def __init__(self):
+    def __init__(self) -> None:
         self.filters = []
         self.grouped_by = []
         self.subquery_value = FakeLatestSubquery()
@@ -1601,12 +1601,12 @@ class FakeLatestQuery:
 
 
 class FakeIdQuery:
-    def __init__(self, target):
+    def __init__(self, target) -> None:
         self.target = target
 
 
 class FakeOuterQuery:
-    def __init__(self, result):
+    def __init__(self, result) -> None:
         self.filters = []
         self.ordering = []
         self.result = result
@@ -1634,7 +1634,9 @@ class FakeOuterQuery:
 
 
 class FakeSession:
-    def __init__(self, latest_query: FakeLatestQuery, outer_query: FakeOuterQuery):
+    def __init__(
+        self, latest_query: FakeLatestQuery, outer_query: FakeOuterQuery
+    ) -> None:
         self.latest_query = latest_query
         self.outer_query = outer_query
         self.id_queries = []
@@ -1656,7 +1658,9 @@ class FakeFunc:
 
 
 class FakeDB:
-    def __init__(self, latest_query: FakeLatestQuery, outer_query: FakeOuterQuery):
+    def __init__(
+        self, latest_query: FakeLatestQuery, outer_query: FakeOuterQuery
+    ) -> None:
         self.session = FakeSession(latest_query, outer_query)
         self.func = FakeFunc()
 

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -10,7 +10,7 @@ _PREVIEW_TOKEN = "preview-token"  # noqa: S105 - stub session token, `validate_u
 class _FakeObservation:
     """Mimics a Langfuse SDK v3 span/generation object."""
 
-    def __init__(self, kind: str = "span", **kwargs):
+    def __init__(self, kind: str = "span", **kwargs) -> None:
         self.kind = kind
         self.kwargs = kwargs
         self.updates = []
@@ -59,7 +59,7 @@ class _FakeObservation:
 
 
 class _FakeLangfuseClient:
-    def __init__(self):
+    def __init__(self) -> None:
         self.traces = []
 
     def start_span(self, trace_context=None, **kwargs):

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -86,7 +86,7 @@ _install_openai_responses_stub()
 class _FakeObservation:
     """Mimics a Langfuse SDK v3 span/generation object."""
 
-    def __init__(self, kind: str = "span", **kwargs):
+    def __init__(self, kind: str = "span", **kwargs) -> None:
         self.kind = kind
         self.kwargs = kwargs
         self.updates = []
@@ -130,7 +130,7 @@ class _FakeObservation:
 
 
 class _FakeLangfuseClient:
-    def __init__(self):
+    def __init__(self) -> None:
         self.traces = []
 
     def start_span(self, trace_context=None, **kwargs):

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -8,10 +8,10 @@ from flaskr.service.tts import audio_utils
 class _FakeSegment:
     append_crossfades: ClassVar[list[int]] = []
 
-    def __init__(self, duration_ms: int):
+    def __init__(self, duration_ms: int) -> None:
         self.duration_ms = duration_ms
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.duration_ms
 
     def append(self, other, crossfade=100):
@@ -28,7 +28,7 @@ class _FakeSegment:
             )
         return _FakeSegment(self.duration_ms + len(other) - crossfade)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> "_FakeSegment":
         if isinstance(key, slice):
             start = int(key.start or 0)
             stop = int(key.stop if key.stop is not None else self.duration_ms)

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -5,7 +5,7 @@ import pytest
 
 
 class _FakeResponse:
-    def __init__(self, lines=None, *, status_error=None, json_payload=None):
+    def __init__(self, lines=None, *, status_error=None, json_payload=None) -> None:
         self._lines = lines or []
         self._status_error = status_error
         self._json_payload = json_payload or {}

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Any, Self
 
 import pytest
 from flask import Flask
@@ -145,7 +146,7 @@ def test_normalize_audio_blob_validates_duration_and_exports_wav(monkeypatch) ->
     from flaskr.service.tts import minimax_voice_clone
 
     class FakeSegment:
-        def __len__(self):
+        def __len__(self) -> int:
             return 12_000
 
         def export(self, out, format="wav"):  # noqa: A002 - mirrors the pydub API
@@ -494,12 +495,12 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
     class FakeApp:
         def app_context(self):
             class Context:
-                def __enter__(self):
+                def __enter__(self) -> Self:
                     nonlocal in_context
                     in_context = True
                     return self
 
-                def __exit__(self, *_args):
+                def __exit__(self, *_args) -> bool | None:
                     nonlocal in_context
                     in_context = False
                     return False
@@ -507,7 +508,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
             return Context()
 
     class DetachedSensitiveRow:
-        def __init__(self):
+        def __init__(self) -> None:
             self.voice_bid = "voice-detached"
             self.voice_id = "AiShifu_detached_1"
             self.owner_user_bid = "creator-1"
@@ -519,7 +520,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
             self.billing_reservation_bid = ""
             self.estimated_credits = Decimal(0)
 
-        def __getattribute__(self, name):
+        def __getattribute__(self, name) -> Any:
             protected = {
                 "voice_bid",
                 "voice_id",

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -9,7 +9,7 @@ from flaskr.api.tts.baidu_provider import BaiduTTSProvider
 
 
 class _Response:
-    def __init__(self, payload, text):
+    def __init__(self, payload, text) -> None:
         self.headers = {"Content-Type": "application/json"}
         self.status_code = 200
         self._payload = payload

--- a/src/api/tests/service/tts/test_streaming_tts_av_contract.py
+++ b/src/api/tests/service/tts/test_streaming_tts_av_contract.py
@@ -18,7 +18,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(app, monkeypatch
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -96,7 +96,7 @@ def test_av_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatc
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -152,7 +152,7 @@ def test_av_streaming_tts_processor_skips_chunked_html_img_tag(app, monkeypatch)
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -209,7 +209,7 @@ def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
     captured_by_position: dict[int, list[str]] = {}
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
@@ -278,7 +278,7 @@ def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _LenGateStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -345,7 +345,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(app, monkeypatch
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -406,7 +406,7 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _NoopStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -464,7 +464,7 @@ def test_av_streaming_tts_processor_releases_sentence_before_long_list_tail(
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -9,7 +9,7 @@ from flaskr.service.common.models import AppError
 
 
 class _FakeSSEStreamingResponse:
-    def __init__(self, lines, *, headers=None):
+    def __init__(self, lines, *, headers=None) -> None:
         self._lines = list(lines)
         self.headers = headers or {"content-type": "text/event-stream"}
         self.closed = False

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -63,7 +63,7 @@ def _patch_credentials(monkeypatch):
 
 
 class _FakeResponse:
-    def __init__(self, body):
+    def __init__(self, body) -> None:
         self._body = body
 
     def json(self):

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -101,7 +101,7 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
 
 
 class _FakeRate:
-    def __init__(self, credits_per_unit, unit_size, provider, model):
+    def __init__(self, credits_per_unit, unit_size, provider, model) -> None:
         self.credits_per_unit = credits_per_unit
         self.unit_size = unit_size
         self.provider = provider

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -3,7 +3,7 @@ from flaskr.service.tts import rpm_gate
 
 
 class _FakeRedisLock:
-    def __init__(self):
+    def __init__(self) -> None:
         self.released = False
 
     def acquire(self, blocking=True, blocking_timeout=None):
@@ -15,7 +15,7 @@ class _FakeRedisLock:
 
 
 class _FakeRedis:
-    def __init__(self):
+    def __init__(self) -> None:
         self.values = {}
         self.locks = []
 

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -27,7 +27,7 @@ def _patch_config(monkeypatch, config=None):
 
 
 class _FakeResponse:
-    def __init__(self, payload, status_code=200):
+    def __init__(self, payload, status_code=200) -> None:
         self._payload = payload
         self.status_code = status_code
         self.text = ""

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -131,7 +131,9 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
             raise AssertionError(f"unexpected frame: {message!r}")
 
     class FakeWebSocketApp:
-        def __init__(self, url, header, on_message, on_error, on_close, on_open):
+        def __init__(
+            self, url, header, on_message, on_error, on_close, on_open
+        ) -> None:
             self.on_message = on_message
             self.on_close = on_close
             self.on_open = on_open

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -34,7 +34,7 @@ def clear_google_public_url_config_cache():
 
 
 class _FakeGoogleResponse:
-    def __init__(self, payload):
+    def __init__(self, payload) -> None:
         self._payload = payload
 
     def raise_for_status(self):
@@ -45,7 +45,7 @@ class _FakeGoogleResponse:
 
 
 class _FakeGoogleSession:
-    def __init__(self, profile, *, fetch_token_error=None):
+    def __init__(self, profile, *, fetch_token_error=None) -> None:
         self._profile = profile
         self._fetch_token_error = fetch_token_error
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -6,7 +6,7 @@ from flaskr.service.profile import learner_profile_optimizer_admission as admiss
 
 
 class FakeRedis:
-    def __init__(self):
+    def __init__(self) -> None:
         self.in_flight_tokens: dict[str, str] = {}
         self.acquire_ttls: list[int] = []
 

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -50,7 +50,7 @@ class _FakeRedis:
 
 
 class _FakeGoogleResponse:
-    def __init__(self, payload):
+    def __init__(self, payload) -> None:
         self._payload = payload
 
     def raise_for_status(self):
@@ -61,7 +61,7 @@ class _FakeGoogleResponse:
 
 
 class _FakeGoogleSession:
-    def __init__(self, profile):
+    def __init__(self, profile) -> None:
         self._profile = profile
 
     def fetch_token(self, *_args, **_kwargs):

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -2,7 +2,7 @@ import uuid
 
 
 class _FakeRedis:
-    def __init__(self, values=None):
+    def __init__(self, values=None) -> None:
         self.values = dict(values or {})
         self.deleted = []
 
@@ -186,7 +186,7 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
     from tests.common.fixtures.fake_redis import FakeRedis
 
     class _FakeSMTP:
-        def __init__(self, *_args, **_kwargs):
+        def __init__(self, *_args, **_kwargs) -> None:
             self.sent_to = None
 
         def starttls(self):

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -23,7 +23,7 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     )
 
     class _Nested:
-        def __init__(self):
+        def __init__(self) -> None:
             self.rollbacks = 0
             self.commits = 0
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import pytest
 
 
@@ -64,10 +66,10 @@ def test_ilivedata_check_uses_configured_timeout(app, monkeypatch):
     captured = {}
 
     class _Resp:
-        def __enter__(self):
+        def __enter__(self) -> Self:
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> bool | None:
             captured["closed"] = True
 
         def read(self):

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -25,7 +25,7 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
     monkeypatch.setattr(order_funs, "get_shifu_info", lambda _app, _cid, _p: shifu_info)
 
     class FakeQuery:
-        def __init__(self, first_value=None, count_value=0):
+        def __init__(self, first_value=None, count_value=0) -> None:
             self._first_value = first_value
             self._count_value = count_value
 
@@ -41,10 +41,10 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
     class FakeColumn:
         __hash__ = None
 
-        def __eq__(self, other):
+        def __eq__(self, other) -> bool:
             return True
 
-        def __ge__(self, other):
+        def __ge__(self, other) -> bool:
             return True
 
     class FakeUserConversion:

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -16,7 +16,7 @@ from flaskr.api.langfuse import MockClient, init_langfuse
 class _RecordingLangfuse:
     instances: ClassVar[list[dict[str, object]]] = []
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         _RecordingLangfuse.instances.append(kwargs)
 
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -110,7 +110,7 @@ pytestmark = pytest.mark.no_mock_llm
 
 
 class DummySpan:
-    def __init__(self, trace_id="trace-1", span_id="span-1"):
+    def __init__(self, trace_id="trace-1", span_id="span-1") -> None:
         self.generation_args = None
         self.end_args = None
         self.trace_id = trace_id
@@ -135,7 +135,7 @@ class FakeResponse:
         finish_reason=None,
         usage=None,
         reasoning_content=None,
-    ):
+    ) -> None:
         self.id = chunk_id
         delta = SimpleNamespace(
             content=content,
@@ -146,7 +146,7 @@ class FakeResponse:
 
 
 class FakeModelsResponse:
-    def __init__(self, payload):
+    def __init__(self, payload) -> None:
         self.payload = payload
 
     def raise_for_status(self):

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -82,7 +82,7 @@ pytestmark = pytest.mark.no_mock_llm
 
 
 class DummySpan:
-    def __init__(self, trace_id="trace-1", span_id="span-1"):
+    def __init__(self, trace_id="trace-1", span_id="span-1") -> None:
         self.generation_args = None
         self.end_args = None
         self.updated = None
@@ -101,7 +101,7 @@ class DummySpan:
 
 
 class FakeResponse:
-    def __init__(self, chunk_id, content=None, finish_reason=None, usage=None):
+    def __init__(self, chunk_id, content=None, finish_reason=None, usage=None) -> None:
         self.id = chunk_id
         delta = SimpleNamespace(content=content)
         self.choices = [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
@@ -109,7 +109,7 @@ class FakeResponse:
 
 
 class FakeUsage:
-    def __init__(self, prompt_tokens, completion_tokens, total_tokens):
+    def __init__(self, prompt_tokens, completion_tokens, total_tokens) -> None:
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
         self.total_tokens = total_tokens

--- a/src/api/tests/test_pingpp.py
+++ b/src/api/tests/test_pingpp.py
@@ -5,7 +5,7 @@ def test_init_pingxx_uses_provider(app, monkeypatch):
     from flaskr.service.order import pingxx_order
 
     class FakeProvider:
-        def __init__(self):
+        def __init__(self) -> None:
             self.called = False
 
         def ensure_client(self, _app):

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import OperationalError
 
 
 class _FakeOrigError(Exception):
-    def __init__(self, errno, message):
+    def __init__(self, errno, message) -> None:
         super().__init__(errno, message)
         self.args = (errno, message)
 

--- a/src/api/tests/test_sms_aliyun.py
+++ b/src/api/tests/test_sms_aliyun.py
@@ -8,7 +8,7 @@ def test_query_sms_template_list_caps_page_size_at_provider_limit(monkeypatch):
     captured = {}
 
     class FakeClient:
-        def __init__(self, _config):
+        def __init__(self, _config) -> None:
             pass
 
         def query_sms_template_list_with_options(self, request, _runtime):


### PR DESCRIPTION
# Summary

Annotates the return type of every special method in the repo (353 sites, 110 files) and selects `ANN204` in `ruff.toml`, next to the already-enforced `ANN205`/`ANN206`. The rest of `ANN` stays off — annotating every argument and return is a separate project — but a dunder's return type is never a judgement call, so it is cheap to write down and keeps the serialization dunders readable.

Breakdown of the added annotations:

- 254 `-> None`, almost all `__init__` (Ruff's own fix).
- 59 `-> dict` and 17 `-> str` on `__json__` / `__to_dict__` / `__html__`: the DTO serialization hook returns a dict for models, but a plain string for the `Enum` DTOs (`return self.value`) and for the two `model_dump_json(...)` call sites — a distinction that was previously invisible at the call site.
- The protocol dunders: `__enter__` (`None` / `Self`), `__exit__` (`bool | None`), `__iter__` (`Iterator[Any]`), `__next__`, `__getitem__`, `__getattr__`/`__getattribute__` (`Any`), `__call__` (`Callable`).
- The comparison doubles in tests, which deliberately return a recorded tuple rather than a bool (`-> tuple`), plus the always-true `__eq__` stubs (`-> bool`).

Imports added where a name was not in scope yet: `typing.Any` (log.py, two tests), `typing.Self` (two tests), `collections.abc.Iterator` (webhooks.py), `collections.abc.Callable` (shifu/route.py).

Annotations only — no runtime behavior changes. `ruff check .`, `ruff format --check .` and the backend suite pass (2963 passed; the 5 remaining failures are the pre-existing `sqlite3.OperationalError: no such function: concat` ones that also fail on `main`).


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->