### PR TITLE
fix: keep a white-label domain on its owner's branding

### DIFF
--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -128,9 +128,19 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         # asking about a different creator made a custom domain look like none:
         # branding fell back to the platform default and the WeChat suppression
         # below stopped applying.
-        domain_owner_bid = str(
-            resolve_creator_bid_by_host(app, request_host) or ""
-        ).strip()
+        try:
+            domain_owner_bid = str(
+                resolve_creator_bid_by_host(app, request_host) or ""
+            ).strip()
+        except Exception:
+            # Runtime config is a public bootstrap dependency, so a failure to
+            # look the host up degrades to requester-scoped branding rather
+            # than taking the endpoint down.
+            app.logger.exception(
+                "Failed to resolve domain owner for runtime config; request_host=%s",
+                request_host or "-",
+            )
+            domain_owner_bid = ""
 
         owner_billing = None
         if domain_owner_bid and domain_owner_bid != creator_bid:
@@ -269,7 +279,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             currencySymbol=get_config("CURRENCY_SYMBOL", "¥"),
             legalUrls=legal_urls,
             entitlements=runtime_billing.entitlements,
-            branding=runtime_billing.branding,
+            branding=branding_source.branding,
             domain=domain_context,
             customizationCapabilities=customization_capabilities,
             paymentConfigurationReady=(

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -8,6 +8,7 @@ from flaskr.service.billing.customization import (
     is_creator_customization_enabled,
     resolve_creator_public_integrations,
 )
+from flaskr.service.billing.domains import resolve_creator_bid_by_host
 from flaskr.service.billing.dtos import (
     RuntimeConfigDTO,
     RuntimeLegalUrlsDTO,
@@ -122,17 +123,19 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                 request_host=request_host,
             )
 
+        # Who owns the host is a property of the host, not of whoever is asking.
+        # Reading it off a context built for the caller's creator_bid meant that
+        # asking about a different creator made a custom domain look like none:
+        # branding fell back to the platform default and the WeChat suppression
+        # below stopped applying.
         domain_owner_bid = str(
-            getattr(runtime_billing.domain, "creator_bid", None) or ""
+            resolve_creator_bid_by_host(app, request_host) or ""
         ).strip()
-        # Capture before the owner re-resolve below: its exception fallback
-        # rebuilds a default context that would drop the custom-domain flag.
-        is_custom_domain = bool(
-            getattr(runtime_billing.domain, "is_custom_domain", False)
-        )
-        if domain_owner_bid and is_custom_domain and domain_owner_bid != creator_bid:
+
+        owner_billing = None
+        if domain_owner_bid and domain_owner_bid != creator_bid:
             try:
-                runtime_billing = build_runtime_billing_context(
+                owner_billing = build_runtime_billing_context(
                     app,
                     creator_bid=domain_owner_bid,
                     request_host=request_host,
@@ -144,12 +147,17 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                     domain_owner_bid,
                     request_host or "-",
                 )
-                runtime_billing = build_default_runtime_billing_context(
-                    creator_bid=domain_owner_bid,
-                    request_host=request_host,
-                )
+                owner_billing = None
 
-        branding = runtime_billing.branding
+        # Branding and the domain verdict follow the host's owner: a white-label
+        # domain shows its owner's brand no matter who is signed in. Entitlements
+        # keep following the caller, so nobody inherits another creator's billing
+        # context just by visiting their domain.
+        branding_source = owner_billing or runtime_billing
+        domain_context = branding_source.domain
+        is_custom_domain = bool(getattr(domain_context, "is_custom_domain", False))
+
+        branding = branding_source.branding
         logo_wide_url = branding.logo_wide_url or get_config("LOGO_WIDE_URL", "")
         logo_square_url = branding.logo_square_url or get_config("LOGO_SQUARE_URL", "")
         favicon_url = branding.favicon_url or get_config("FAVICON_URL", "")
@@ -262,7 +270,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             legalUrls=legal_urls,
             entitlements=runtime_billing.entitlements,
             branding=runtime_billing.branding,
-            domain=runtime_billing.domain,
+            domain=domain_context,
             customizationCapabilities=customization_capabilities,
             paymentConfigurationReady=(
                 custom_payment_enabled and bool(custom_payment_channels)

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -240,9 +240,44 @@ def test_white_label_branding_survives_another_creators_bid(
     assert payload["faviconUrl"] == "https://cdn.example.com/creator-favicon.ico"
     assert payload["domain"]["is_custom_domain"] is True
     assert payload["domain"]["creator_bid"] == "creator-1"
+    # The nested block must agree with the flat fields above, or a client
+    # reading data.branding sees a different brand from one reading logoWideUrl.
+    assert payload["branding"]["logo_wide_url"] == (
+        "https://cdn.example.com/creator-wide.png"
+    )
+    assert payload["branding"]["home_url"] == "https://creator.example.com/home"
+    # Entitlements deliberately stay with the caller: visiting someone's domain
+    # must not hand over their billing context.
+    assert payload["entitlements"]["branding_enabled"] is False
+    assert payload["entitlements"]["custom_domain_enabled"] is False
     # The WeChat suppression keys off the same verdict, so it must hold too.
     assert payload["wechatAppId"] == ""
     assert payload["enableWechatCode"] is False
+
+
+def test_host_lookup_failure_degrades_instead_of_failing(
+    runtime_config_client,
+    monkeypatch,
+) -> None:
+    """Runtime config is a public bootstrap dependency and must still answer."""
+
+    def _boom(app, host):
+        raise RuntimeError("database is unavailable")
+
+    monkeypatch.setattr(config_route, "resolve_creator_bid_by_host", _boom)
+
+    response = runtime_config_client.get(
+        "/api/runtime-config",
+        headers={"Host": "creator.example.com"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json(force=True)["data"]
+    # Answers with a usable payload instead of a 500. The same-creator path
+    # still resolves the domain from the billing context it already built, so
+    # only the cross-creator re-resolve is lost.
+    assert "logoWideUrl" in payload
+    assert payload["domain"]["request_host"] == "creator.example.com"
 
 
 def test_non_custom_domain_still_follows_the_requested_creator(

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -220,6 +220,59 @@ def test_runtime_config_returns_billing_extensions_for_custom_domain(
     }
 
 
+def test_white_label_branding_survives_another_creators_bid(
+    runtime_config_client,
+) -> None:
+    """A white-label host keeps its owner's brand whoever is asking.
+
+    The creator console re-fetches this with the signed-in creator's bid to show
+    their own branding. On a custom domain that must not win, or the owner's
+    site briefly shows their logo and then flips to the platform default.
+    """
+    response = runtime_config_client.get(
+        "/api/runtime-config?creator_bid=creator-2",
+        headers={"Host": "creator.example.com"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["logoWideUrl"] == "https://cdn.example.com/creator-wide.png"
+    assert payload["logoSquareUrl"] == "https://cdn.example.com/creator-square.png"
+    assert payload["faviconUrl"] == "https://cdn.example.com/creator-favicon.ico"
+    assert payload["domain"]["is_custom_domain"] is True
+    assert payload["domain"]["creator_bid"] == "creator-1"
+    # The WeChat suppression keys off the same verdict, so it must hold too.
+    assert payload["wechatAppId"] == ""
+    assert payload["enableWechatCode"] is False
+
+
+def test_non_custom_domain_still_follows_the_requested_creator(
+    runtime_config_client,
+) -> None:
+    """Off a white-label host the caller's creator still decides the branding."""
+    response = runtime_config_client.get(
+        "/api/runtime-config?creator_bid=creator-1",
+        headers={"Host": "app.example.com"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["logoWideUrl"] == "https://cdn.example.com/creator-wide.png"
+    assert payload["domain"]["is_custom_domain"] is False
+
+
+def test_unverified_domain_does_not_borrow_its_owners_branding(
+    runtime_config_client,
+) -> None:
+    """inactive.example.com is bound but not entitled, so it is not white-label."""
+    response = runtime_config_client.get(
+        "/api/runtime-config",
+        headers={"Host": "inactive.example.com"},
+    )
+    payload = response.get_json(force=True)["data"]
+
+    assert payload["domain"]["is_custom_domain"] is False
+    assert payload["logoWideUrl"] != "https://cdn.example.com/creator-wide.png"
+
+
 def test_runtime_config_hides_creator_keys_without_matching_capability(
     runtime_config_client,
     monkeypatch,


### PR DESCRIPTION
## Problem

On a white-label domain the owner's logo appears for a moment and then flips to
the AI-Shifu default. Observed on `learn.essentialpersonalfinance.com/admin`.

The page fetches runtime config twice. The second call is deliberate —
`applyCreatorBranding()` re-reads it with the signed-in creator's bid so the
creator console shows that creator's brand. On a custom domain that call
returns the platform defaults and overwrites the owner's branding:

```
GET /api/runtime-config                              -> owner's logo
GET /api/runtime-config?creator_bid=<signed-in bid>  -> platform default logo
                                                        is_custom_domain: false
```

The backend already re-resolves branding for a domain's owner, but the guard
read ownership off a billing context built for whichever `creator_bid` the
caller asked about:

```python
domain_owner_bid = runtime_billing.domain.creator_bid
is_custom_domain = runtime_billing.domain.is_custom_domain
if domain_owner_bid and is_custom_domain and domain_owner_bid != creator_bid:
```

Asking about a creator who does not own the host makes that context report no
domain at all, so both values come back empty and the re-resolve never runs.
Ownership of a host does not depend on who is asking.

**This also silently disabled the WeChat fix from #2151.** The same
`is_custom_domain` decides whether to blank `wechatAppId`, so on a custom domain
any request carrying a `creator_bid` still received the WeChat app id — the
condition that #2151 added to avoid OAuth error 10003.

## Fix

Ownership now comes from the host via `resolve_creator_bid_by_host`, the same
predicate that decides whether a custom domain is served at all.

Branding and the domain verdict follow that owner — a white-label domain shows
its owner's brand regardless of who is signed in, which is the point of white
labelling. **Entitlements keep following the caller**, so a signed-in creator
does not inherit someone else's billing context merely by visiting their domain.
That split is deliberate; replacing the whole context would have changed billing
behaviour to fix a logo.

## Tests

Three cases in `test_runtime_config_billing.py`, using the fixture's existing
data (`creator-1` owns `creator.example.com`):

- Requesting `?creator_bid=creator-2` against `creator.example.com` keeps
  creator-1's logo, square logo and favicon, reports `is_custom_domain: true`,
  and still blanks `wechatAppId` — this one fails without the fix.
- Off a white-label host the caller's creator still decides the branding.
- A bound-but-unentitled host (`inactive.example.com`) does not borrow its
  owner's branding.

`pytest tests/service/billing tests/route tests/service/user` — 899 passed,
10 skipped. `lefthook run pre-commit` green.

## Scope note

Only the ownership lookup changed. `applyCreatorBranding()` on the frontend is
left as is: it is correct on the platform domain, and with this fix the backend
simply stops handing it defaults on a white-label host.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custom domains now consistently display the domain owner’s branding and domain-specific settings.
  - WeChat settings are suppressed when required by the active custom-domain configuration.
  - Non-custom domains continue to use the requested creator’s configuration and entitlements.
  - Unverified or inactive domains no longer apply their owner’s branding.
  - Configuration requests now return a usable response when domain ownership cannot be resolved.

- **Tests**
  - Added coverage for custom-domain branding, creator-specific configurations, inactive domains, and resolution failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->