### PR TITLE
style: enforce ruff FBT003 (name boolean flags at call sites)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -166,6 +166,15 @@ select = [
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
+
+    # --- Boolean arguments ------------------------------------------------
+    # flake8-boolean-trap is otherwise off: FBT001/FBT002 would rewrite the
+    # signatures of stable service helpers and DTO constructors, which is a
+    # separate project. FBT003 only asks the caller to name the flag, so
+    # `get_shifu_info(app, bid, preview_mode=False)` says which of the two
+    # code paths it takes. Third-party APIs that only accept the flag
+    # positionally (SQLAlchemy, the MySQL DBAPI `ping`) carry an inline noqa.
+    "FBT003",  # boolean positional value in a call
     # flake8-type-checking is enabled as a whole. TC002/TC003 are ignored below
     # (they would push third-party imports behind TYPE_CHECKING, where runtime
     # annotation resolution then fails); the rest have no violations and catch

--- a/ruff.toml
+++ b/ruff.toml
@@ -173,7 +173,8 @@ select = [
     # separate project. FBT003 only asks the caller to name the flag, so
     # `get_shifu_info(app, bid, preview_mode=False)` says which of the two
     # code paths it takes. Third-party APIs that only accept the flag
-    # positionally (SQLAlchemy, the MySQL DBAPI `ping`) carry an inline noqa.
+    # positionally (SQLAlchemy, the MySQL DBAPI `ping`, `socket.setblocking`,
+    # `monkeypatch.setitem`) carry an inline noqa.
     "FBT003",  # boolean positional value in a call
     # flake8-type-checking is enabled as a whole. TC002/TC003 are ignored below
     # (they would push third-party imports behind TYPE_CHECKING, where runtime

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -358,12 +358,12 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
     if not api_key:
         _log_warning(f"{config.api_key_env} not configured")
         return ProviderState(
-            False,
-            None,
-            [],
-            config.prefix,
-            config.wildcard_prefixes,
-            config.reload_params,
+            enabled=False,
+            params=None,
+            models=[],
+            prefix=config.prefix,
+            wildcard_prefixes=config.wildcard_prefixes,
+            reload_params=config.reload_params,
         )
     base_url = None
     if config.base_url_env:
@@ -399,12 +399,12 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
     if display_models:
         _log_info(f"{config.key} models: {display_models}")
     return ProviderState(
-        True,
-        params,
-        display_models,
-        config.prefix,
-        config.wildcard_prefixes,
-        config.reload_params,
+        enabled=True,
+        params=params,
+        models=display_models,
+        prefix=config.prefix,
+        wildcard_prefixes=config.wildcard_prefixes,
+        reload_params=config.reload_params,
     )
 
 
@@ -1083,10 +1083,10 @@ def invoke_llm(
                 yield LLMStreamResponse(
                     res.id,
                     bool(res.choices[0].finish_reason),
-                    False,
-                    res.choices[0].delta.content,
-                    res.choices[0].finish_reason,
-                    None,
+                    is_truncated=False,
+                    result=res.choices[0].delta.content,
+                    finish_reason=res.choices[0].finish_reason,
+                    usage=None,
                 )
             res_usage = getattr(res, "usage", None)
             if res_usage:
@@ -1258,10 +1258,10 @@ def chat_llm(
                     yield LLMStreamResponse(
                         res.id,
                         bool(res.choices[0].finish_reason),
-                        False,
-                        res.choices[0].delta.content,
-                        res.choices[0].finish_reason,
-                        None,
+                        is_truncated=False,
+                        result=res.choices[0].delta.content,
+                        finish_reason=res.choices[0].finish_reason,
+                        usage=None,
                     )
                 res_usage = getattr(res, "usage", None)
                 if res_usage:

--- a/src/api/flaskr/common/observability.py
+++ b/src/api/flaskr/common/observability.py
@@ -53,7 +53,7 @@ def init_observability(app: Flask) -> Flask:
     health_path = app.config.get(
         "INTERNAL_OBSERVABILITY_HEALTH_PATH", "/internal/observability/health"
     )
-    traces_enabled = _bool_config(app, "OBSERVABILITY_TRACES_ENABLED", False)
+    traces_enabled = _bool_config(app, "OBSERVABILITY_TRACES_ENABLED", default=False)
     sample_rate = _float_config(app, "OTEL_TRACE_SAMPLE_RATE", 1.0)
 
     if traces_enabled:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -179,7 +179,8 @@ def _reject_desynced_connection_on_checkout(
         _mark_checkout_boundary(connection_record)
         return
     try:
-        ping(False)
+        # MySQL's DBAPI ping() takes `reconnect` positionally.
+        ping(False)  # noqa: FBT003
     except BaseException as ping_exc:
         connection_record.invalidate(
             e=ping_exc if isinstance(ping_exc, Exception) else None

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -223,7 +223,9 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             stripeEnabled=(
                 "stripe" in custom_payment_channels
                 if custom_payment_enabled
-                else _to_bool(get_config("STRIPE_ENABLED", False), False)
+                else _to_bool(
+                    get_config("STRIPE_ENABLED", default=False), default=False
+                )
             ),
             paymentChannels=payment_channels,
             payOrderExpireSeconds=_to_int(
@@ -231,8 +233,8 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                 600,
             ),
             alwaysShowLessonTree=_to_bool(
-                get_config("UI_ALWAYS_SHOW_LESSON_TREE", False),
-                False,
+                get_config("UI_ALWAYS_SHOW_LESSON_TREE", default=False),
+                default=False,
             ),
             logoWideUrl=logo_wide_url,
             logoSquareUrl=logo_square_url,
@@ -246,8 +248,8 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
                 "",
             ),
             enableEruda=_to_bool(
-                get_config("DEBUG_ERUDA_ENABLED", False),
-                False,
+                get_config("DEBUG_ERUDA_ENABLED", default=False),
+                default=False,
             ),
             loginMethodsEnabled=_to_list(
                 get_config("LOGIN_METHODS_ENABLED", "phone"),

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -671,7 +671,7 @@ def register_order_handler(app: Flask, path_prefix: str):
                         entry["nickname"] = fallback_nickname
 
             # Validate course exists before iterating mobiles to avoid repeated errors
-            get_shifu_info(app, course_id, False)
+            get_shifu_info(app, course_id, preview_mode=False)
 
             return make_common_response(
                 import_activation_orders_from_entries(
@@ -690,7 +690,7 @@ def register_order_handler(app: Flask, path_prefix: str):
             raise_param_error(f"{contact_label} limit 50")
 
         # Validate course exists before iterating mobiles to avoid repeated errors
-        get_shifu_info(app, course_id, False)
+        get_shifu_info(app, course_id, preview_mode=False)
 
         return make_common_response(
             import_activation_orders(

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -156,7 +156,7 @@ class ProviderCredentialContext:
 
 
 def is_creator_customization_enabled() -> bool:
-    return _to_bool(get_config("CREATOR_CUSTOMIZATION_ENABLED", False))
+    return _to_bool(get_config("CREATOR_CUSTOMIZATION_ENABLED", default=False))
 
 
 def build_creator_customization(
@@ -424,8 +424,12 @@ def save_creator_integration(
             else entitlement.custom_payment_enabled,
             allow_when_customization_disabled=allow_when_customization_disabled,
         )
-        public_config = _normalize_config(provider, payload.get("public_config"), False)
-        secret_config = _normalize_config(provider, payload.get("secret_config"), True)
+        public_config = _normalize_config(
+            provider, payload.get("public_config"), secret=False
+        )
+        secret_config = _normalize_config(
+            provider, payload.get("secret_config"), secret=True
+        )
         previous_record = _load_latest_record_or_active(app, creator_bid, provider)
         if previous_record:
             previous_secret_config = dict(previous_record.get("secret_config") or {})
@@ -1452,10 +1456,10 @@ def _normalize_admin_creator_customization_draft(
             if isinstance(provider_payload, dict):
                 normalized_integrations[provider] = {
                     "public_config": _normalize_config(
-                        provider, provider_payload.get("public_config"), False
+                        provider, provider_payload.get("public_config"), secret=False
                     ),
                     "secret_config": _normalize_config(
-                        provider, provider_payload.get("secret_config"), True
+                        provider, provider_payload.get("secret_config"), secret=True
                     ),
                 }
             else:

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -804,7 +804,7 @@ class RunScriptPreviewContextV2:
         session_id: str,
     ) -> Generator[RunElementSSEMessageDTO, None, None]:
         outline = self._get_outline_record(shifu_bid, outline_bid)
-        shifu = self._get_shifu_record(shifu_bid, True)
+        shifu = self._get_shifu_record(shifu_bid, has_draft_outline=True)
         document_prompt = self._resolve_document_prompt(
             preview_request,
             outline,

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -164,9 +164,9 @@ class LearnShifuInfoDTO(BaseModel):
     keywords: list[str] = Field(..., description="shifu keywords", required=False)
     avatar: str = Field(..., description="shifu avatar", required=False)
     price: str = Field(..., description="shifu price", required=False)
-    tts_enabled: bool = Field(False, description="tts enabled", required=False)
+    tts_enabled: bool = Field(default=False, description="tts enabled", required=False)
     default_listen_mode_enabled: bool = Field(
-        False,
+        default=False,
         description="Default learner mode to listen when TTS is enabled",
         required=False,
     )

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -528,7 +528,7 @@ def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
             DraftShifu.title.like(like_value),
         )
         .yield_per(200)
-        .enable_eagerloads(False)
+        .enable_eagerloads(False)  # noqa: FBT003 -- SQLAlchemy takes the flag positionally
     ):
         shifu_bid = str(row.shifu_bid or "").strip()
         if shifu_bid:
@@ -540,7 +540,7 @@ def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
             PublishedShifu.title.like(like_value),
         )
         .yield_per(200)
-        .enable_eagerloads(False)
+        .enable_eagerloads(False)  # noqa: FBT003 -- SQLAlchemy takes the flag positionally
     ):
         shifu_bid = str(row.shifu_bid or "").strip()
         if shifu_bid:
@@ -606,7 +606,7 @@ def _apply_order_source_filter(query, order_source: str):
             )
         )
 
-    return query.filter(db.literal(False))
+    return query.filter(db.literal(False))  # noqa: FBT003 -- SQL literal value
 
 
 def _build_order_item(

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -187,7 +187,9 @@ def send_order_feishu(app: Flask, record_id: str):
             order_info.user_id,
         )
         return
-    shifu_info: LearnShifuInfoDTO = get_shifu_info(app, order_info.course_id, False)
+    shifu_info: LearnShifuInfoDTO = get_shifu_info(
+        app, order_info.course_id, preview_mode=False
+    )
     if not shifu_info:
         return
 
@@ -236,7 +238,9 @@ def send_revoke_feishu(app: Flask, order_bid: str, user_identify: str):
     order: Order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
         return
-    shifu_info: LearnShifuInfoDTO = get_shifu_info(app, order.shifu_bid, False)
+    shifu_info: LearnShifuInfoDTO = get_shifu_info(
+        app, order.shifu_bid, preview_mode=False
+    )
     title = "取消课程授权通知"
     msgs = [
         f"用户标识：{user_identify}",
@@ -372,7 +376,7 @@ def init_buy_record(
 ):
     creator_bid = get_shifu_creator_bid(app, course_id)
     set_shifu_context(course_id, creator_bid)
-    shifu_info: LearnShifuInfoDTO = get_shifu_info(app, course_id, False)
+    shifu_info: LearnShifuInfoDTO = get_shifu_info(app, course_id, preview_mode=False)
     app.logger.info(f"shifu_info: {shifu_info}")
     if not shifu_info:
         raise_error("server.shifu.courseNotFound")
@@ -448,8 +452,8 @@ def init_buy_record(
                 _("server.order.payItemProduct"),
                 _("server.order.payItemBasePrice"),
                 buy_record.payable_price,
-                False,
-                None,
+                is_discount=False,
+                discount_code=None,
             )
         )
         if campaign_applications:
@@ -458,8 +462,8 @@ def init_buy_record(
                     _("server.order.payItemPromotion"),
                     campaign_application.promo_name,
                     campaign_application.discount_amount,
-                    True,
-                    None,
+                    is_discount=True,
+                    discount_code=None,
                 )
                 for campaign_application in campaign_applications
             )
@@ -534,7 +538,9 @@ def generate_charge(
         creator_bid = get_shifu_creator_bid(app, buy_record.shifu_bid) or ""
         set_shifu_context(buy_record.shifu_bid, creator_bid)
         buy_record.creator_bid = creator_bid
-        shifu_info: LearnShifuInfoDTO = get_shifu_info(app, buy_record.shifu_bid, False)
+        shifu_info: LearnShifuInfoDTO = get_shifu_info(
+            app, buy_record.shifu_bid, preview_mode=False
+        )
         if not shifu_info:
             raise_error("server.shifu.shifuNotFound")
         app.logger.info(f"buy record found:{buy_record}")
@@ -2034,8 +2040,8 @@ def _supplement_promo_discount_items(
                 _("server.order.payItemPromotion"),
                 promo_name,
                 item_discount,
-                True,
-                None,
+                is_discount=True,
+                discount_code=None,
             )
         )
         current_discount_value += item_discount
@@ -2061,8 +2067,8 @@ def calculate_discount_value(
                     _("server.order.payItemPromotion"),
                     campaign_application.promo_name,
                     campaign_application.discount_amount,
-                    True,
-                    None,
+                    is_discount=True,
+                    discount_code=None,
                 )
             )
     if discount_records is not None and len(discount_records) > 0:
@@ -2083,8 +2089,8 @@ def calculate_discount_value(
                         _("server.order.payItemCoupon"),
                         _resolve_coupon_display_name(discount),
                         discount.value,
-                        True,
-                        discount.code,
+                        is_discount=True,
+                        discount_code=discount.code,
                     )
                 )
     discount_value = min(discount_value, price)
@@ -2104,13 +2110,13 @@ def query_buy_record(app: Flask, record_id: str) -> AICourseBuyRecordDTO:
                     _("server.order.payItemProduct"),
                     _("server.order.payItemBasePrice"),
                     buy_record.payable_price,
-                    False,
-                    None,
+                    is_discount=False,
+                    discount_code=None,
                 )
             )
             if buy_record.payable_price > 0:
                 campaign_applications = query_promo_campaign_applications(
-                    app, record_id, False
+                    app, record_id, recalc_discount=False
                 )
                 discount_records = CouponUsageModel.query.filter(
                     CouponUsageModel.order_bid == record_id

--- a/src/api/flaskr/service/profile/profile_manage.py
+++ b/src/api/flaskr/service/profile/profile_manage.py
@@ -259,7 +259,7 @@ def add_profile_item_quick_internal(app: Flask, parent_id: str, key: str, user_i
                 legacy_scope,
                 _(f"PROFILE.PROFILE_SCOPE_{legacy_scope}".upper()),
                 legacy_item["profile_id"],
-                False,
+                is_hidden=False,
             )
 
         profile_id = generate_id(app)
@@ -343,7 +343,7 @@ def add_profile_item_quick_internal(app: Flask, parent_id: str, key: str, user_i
             legacy_scope,
             _(f"PROFILE.PROFILE_SCOPE_{legacy_scope}".upper()),
             profile_id,
-            False,
+            is_hidden=False,
         )
 
     existing = (

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -38,10 +38,12 @@ class ShifuDto(BaseModel):
     is_favorite: bool = Field(..., description="is favorite", required=False)
     archived: bool = Field(..., description="is archived", required=False)
     can_manage_archive: bool = Field(
-        False, description="whether current user can archive/unarchive", required=False
+        default=False,
+        description="whether current user can archive/unarchive",
+        required=False,
     )
     can_manage_permissions: bool = Field(
-        False,
+        default=False,
         description="whether current user can manage shared permissions",
         required=False,
     )
@@ -49,7 +51,7 @@ class ShifuDto(BaseModel):
         "", description="owner user business id", required=False
     )
     is_guide_course: bool = Field(
-        False,
+        default=False,
         description="whether this course is the built-in guide course",
         required=False,
     )
@@ -117,16 +119,18 @@ class ShifuDetailDto(BaseModel):
     readonly: bool = Field(..., description="is shifu readonly", required=False)
     archived: bool = Field(..., description="is shifu archived", required=False)
     can_manage_archive: bool = Field(
-        False, description="whether current user can archive/unarchive", required=False
+        default=False,
+        description="whether current user can archive/unarchive",
+        required=False,
     )
     can_publish: bool = Field(
-        False, description="whether current user can publish", required=False
+        default=False, description="whether current user can publish", required=False
     )
     created_user_bid: str = Field(
         "", description="owner user business id", required=False
     )
     # TTS Configuration
-    tts_enabled: bool = Field(False, description="TTS enabled", required=False)
+    tts_enabled: bool = Field(default=False, description="TTS enabled", required=False)
     tts_provider: str = Field(
         "",
         description="TTS provider: minimax, volcengine, volcengine_http, baidu, aliyun",
@@ -144,12 +148,12 @@ class ShifuDetailDto(BaseModel):
     )
     tts_emotion: str = Field("", description="TTS emotion setting", required=False)
     default_listen_mode_enabled: bool = Field(
-        False,
+        default=False,
         description="Default learner mode to listen when TTS is enabled",
         required=False,
     )
     use_learner_language: bool = Field(
-        False,
+        default=False,
         description="Use learner language for AI output",
         required=False,
     )

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -925,8 +925,8 @@ def get_shifu_published_list(
                 shifu.description,
                 res_url_map.get(shifu.avatar_res_bid, ""),
                 STATUS_PUBLISHED,
-                False,
-                False,
+                is_favorite=False,
+                archived=False,
                 can_manage_archive=True,
                 can_manage_permissions=(shifu.created_user_bid == user_id),
                 created_user_bid=shifu.created_user_bid or "",
@@ -977,8 +977,8 @@ def _set_shifu_archive_state(app, user_id: str, shifu_id: str, archived: bool):
 
 
 def archive_shifu(app, user_id: str, shifu_id: str):
-    _set_shifu_archive_state(app, user_id, shifu_id, True)
+    _set_shifu_archive_state(app, user_id, shifu_id, archived=True)
 
 
 def unarchive_shifu(app, user_id: str, shifu_id: str):
-    _set_shifu_archive_state(app, user_id, shifu_id, False)
+    _set_shifu_archive_state(app, user_id, shifu_id, archived=False)

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -479,9 +479,9 @@ def create_default_outlines_for_new_shifu(
         normalized_chapter_name,
         UNIT_TYPE_GUEST,
         None,
-        False,
-        now_time,
-        chapter_bid,
+        is_hidden=False,
+        now_time=now_time,
+        outline_bid=chapter_bid,
         persist_history=False,
     )
     lesson = __insert_outline_locked(
@@ -492,9 +492,9 @@ def create_default_outlines_for_new_shifu(
         normalized_lesson_name,
         UNIT_TYPE_GUEST,
         None,
-        False,
-        now_time,
-        lesson_bid,
+        is_hidden=False,
+        now_time=now_time,
+        outline_bid=lesson_bid,
         persist_history=False,
     )
     outline_items = load_existing_outline_items(shifu_id)

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -68,7 +68,7 @@ class AuthResult(_BaseDTO):
         None, description="Persisted credential record when available"
     )
     is_new_user: bool = Field(
-        False, description="Indicates whether the auth flow created a new user"
+        default=False, description="Indicates whether the auth flow created a new user"
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict, description="Provider-specific auxiliary data"

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -150,7 +150,11 @@ def verify_email_code(
                     include_nickname=include_legacy_nickname,
                 )
                 update_user_profile_with_lable(
-                    app, target_aggregate.user_bid, new_profiles, False, course_id
+                    app,
+                    target_aggregate.user_bid,
+                    new_profiles,
+                    update_all=False,
+                    course_id=course_id,
                 )
             if origin_aggregate and course_id is not None:
                 migrate_user_study_record(

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -364,8 +364,8 @@ def verify_phone_code(
                     app,
                     target_aggregate.user_bid,
                     new_profiles,
-                    False,
-                    normalized_course_id,
+                    update_all=False,
+                    course_id=normalized_course_id,
                 )
                 migrate_user_study_record(
                     app,

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -142,8 +142,8 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("random") is False
 
         # Already boolean
-        assert env_var.convert_type(True) is True  # noqa: FBT003
-        assert env_var.convert_type(False) is False  # noqa: FBT003
+        assert env_var.convert_type(value=True) is True
+        assert env_var.convert_type(value=False) is False
 
         # Empty/None returns default
         assert env_var.convert_type("") is False

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -142,8 +142,8 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("random") is False
 
         # Already boolean
-        assert env_var.convert_type(True) is True
-        assert env_var.convert_type(False) is False
+        assert env_var.convert_type(True) is True  # noqa: FBT003
+        assert env_var.convert_type(False) is False  # noqa: FBT003
 
         # Empty/None returns default
         assert env_var.convert_type("") is False

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -32,7 +32,7 @@ class _FakePyMySQLConnection:
 @pytest.fixture
 def sock_pair():
     left, right = socket.socketpair()
-    left.setblocking(False)
+    left.setblocking(False)  # noqa: FBT003 -- stdlib socket API
     yield left, right
     left.close()
     right.close()

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -51,14 +51,16 @@ def test_pre_execute_probe_blocks_desynced_connection():
         conn = _FakeConn()
 
         # Clean socket: probe passes.
-        dao._intercept_desync_before_execute(conn, None, "SELECT 1", None, None, False)
+        dao._intercept_desync_before_execute(
+            conn, None, "SELECT 1", None, None, executemany=False
+        )
 
         # An unread response appears (interrupted previous exchange): the
         # next execute must be refused and the connection invalidated.
         right.sendall(b"\x07\x00\x00\x01\x00stale")
         with pytest.raises(DisconnectionError):
             dao._intercept_desync_before_execute(
-                conn, None, "SELECT id FROM t", None, None, False
+                conn, None, "SELECT id FROM t", None, None, executemany=False
             )
         assert _FakeConn.invalidated_count == 1
     finally:

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -704,7 +704,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch):
     monkeypatch.setattr(customization, "import_module", fake_import)
 
     with app.app_context():
-        monkeypatch.setitem(app.config, "SAAS_PLUGIN_ENABLED", False)
+        monkeypatch.setitem(app.config, "SAAS_PLUGIN_ENABLED", False)  # noqa: FBT003
         grant_creator_manual_entitlement(
             app,
             "creator-disabled-plugin",

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -147,7 +147,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -184,7 +184,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -204,7 +204,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert result.records == []
@@ -220,7 +220,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 1
@@ -238,7 +238,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -257,7 +257,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -276,7 +276,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -300,7 +300,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2
@@ -329,7 +329,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
                 progress.shifu_bid,
                 progress.outline_item_bid,
                 progress.user_bid,
-                False,
+                preview_mode=False,
             )
 
         assert len(result.records) == 2

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -83,19 +83,19 @@ def _patch_run_dependencies(monkeypatch, script):
     monkeypatch.setattr(
         runscript_v2,
         "get_outline_item_dto",
-        lambda _app, _bid, _preview: types.SimpleNamespace(
+        lambda _app, _bid, preview_mode: types.SimpleNamespace(
             bid="outline-1", shifu_bid="shifu-1", __json__=dict
         ),
     )
     monkeypatch.setattr(
         runscript_v2,
         "get_shifu_dto",
-        lambda _app, _bid, _preview: types.SimpleNamespace(bid="shifu-1", price=0),
+        lambda _app, _bid, preview_mode: types.SimpleNamespace(bid="shifu-1", price=0),
     )
     monkeypatch.setattr(
         runscript_v2,
         "get_shifu_struct",
-        lambda _app, _bid, _preview: types.SimpleNamespace(bid="shifu-1"),
+        lambda _app, _bid, preview_mode: types.SimpleNamespace(bid="shifu-1"),
     )
     _StubRunContext.script = list(script)
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", _StubRunContext)

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -93,7 +93,7 @@ def test_admin_import_activation_allows_owner(monkeypatch, test_client, app):
 
     monkeypatch.setattr(
         "flaskr.route.order.get_shifu_info",
-        lambda _app, _shifu_bid, _preview: SimpleNamespace(price=Decimal(0)),
+        lambda _app, _shifu_bid, preview_mode: SimpleNamespace(price=Decimal(0)),
         raising=False,
     )
     monkeypatch.setattr(

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -68,7 +68,7 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(
+        lambda _app, _bid, preview_mode: SimpleNamespace(
             price=Decimal("99.00"),
             title="Legacy course",
             description="Legacy checkout flow",
@@ -345,7 +345,7 @@ def test_creator_payment_config_smoke_supports_alipay_and_wechatpay_checkout(
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, bid, _preview: SimpleNamespace(
+        lambda _app, bid, preview_mode: SimpleNamespace(
             bid=bid,
             price=Decimal("99.00"),
             title="Paid course",

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -65,7 +65,7 @@ def stub_shifu(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(
+        lambda _app, _bid, preview_mode: SimpleNamespace(
             price=Decimal("100.00"),
             title="UOW course",
             description="UOW failure-path course",

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -22,7 +22,9 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
 
     monkeypatch.setattr(order_funs, "query_buy_record", lambda _app, _id: order_info)
     monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _id: aggregate)
-    monkeypatch.setattr(order_funs, "get_shifu_info", lambda _app, _cid, _p: shifu_info)
+    monkeypatch.setattr(
+        order_funs, "get_shifu_info", lambda _app, _cid, preview_mode: shifu_info
+    )
 
     class FakeQuery:
         def __init__(self, first_value=None, count_value=0) -> None:

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -31,7 +31,7 @@ def test_init_buy_record_creates_order(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("100.00")),
+        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("100.00")),
     )
     monkeypatch.setattr(
         order_funs, "apply_promo_campaigns", lambda *_args, **_kwargs: []
@@ -60,7 +60,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("100.00")),
+        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("100.00")),
     )
 
     promo_application = SimpleNamespace(
@@ -75,7 +75,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
             return []
         return [promo_application]
 
-    def fake_query_promo_campaign_applications(_app, _order_id, _recalc_discount):
+    def fake_query_promo_campaign_applications(_app, _order_id, recalc_discount):
         if apply_calls["count"] >= 2:
             return [promo_application]
         return []
@@ -118,7 +118,7 @@ def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("500.00")),
+        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
     )
 
     now = now_utc()
@@ -186,7 +186,7 @@ def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("500.00")),
+        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
     )
 
     now = now_utc()
@@ -279,7 +279,7 @@ def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(price=Decimal("500.00")),
+        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
     )
 
     promo_application = SimpleNamespace(
@@ -295,7 +295,7 @@ def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, _recalc_discount: [promo_application],
+        lambda _app, _order_id, recalc_discount: [promo_application],
     )
 
     with app.app_context():

--- a/src/api/tests/test_query_order.py
+++ b/src/api/tests/test_query_order.py
@@ -50,7 +50,7 @@ def test_query_buy_record_keeps_stored_discount_for_unpaid_order(app, monkeypatc
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, _recalc: [
+        lambda _app, _order_id, recalc_discount: [
             SimpleNamespace(
                 discount_amount=Decimal("123.45"),
                 promo_name="spring-promo",
@@ -108,7 +108,7 @@ def test_query_buy_record_uses_coupon_name_and_code_in_price_item(app, monkeypat
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, _recalc: [],
+        lambda _app, _order_id, recalc_discount: [],
     )
 
     result = query_buy_record(app, "order-query-coupon-1")
@@ -172,7 +172,7 @@ def test_query_buy_record_does_not_supplement_voided_campaign_redemption(
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, _recalc: [],
+        lambda _app, _order_id, recalc_discount: [],
     )
 
     result = query_buy_record(app, "order-query-voided-promo-1")

--- a/src/api/tests/test_study_record.py
+++ b/src/api/tests/test_study_record.py
@@ -41,6 +41,6 @@ def test_get_learn_record_returns_blocks(app):
         db.session.add(block)
         db.session.commit()
 
-    record = get_learn_record(app, "shifu-1", "outline-1", "user-1", False)
+    record = get_learn_record(app, "shifu-1", "outline-1", "user-1", preview_mode=False)
     assert len(record.records) == 1
     assert record.records[0].content == "hello"

--- a/src/api/tests/test_sudy.py
+++ b/src/api/tests/test_sudy.py
@@ -2,5 +2,7 @@ from flaskr.service.learn.learn_funcs import get_learn_record
 
 
 def test_get_learn_record_empty_when_no_progress(app):
-    record = get_learn_record(app, "shifu-empty", "outline-empty", "user-empty", False)
+    record = get_learn_record(
+        app, "shifu-empty", "outline-empty", "user-empty", preview_mode=False
+    )
     assert record.records == []

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -31,7 +31,7 @@ def test_generate_charge_uses_pingxx_channel(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, _preview: SimpleNamespace(
+        lambda _app, _bid, preview_mode: SimpleNamespace(
             title="Course", description="Desc"
         ),
     )


### PR DESCRIPTION
# Summary

Enables `FBT003` (boolean positional value in a call) and names the 72 boolean
arguments that were passed positionally. The rest of flake8-boolean-trap stays
off: `FBT001`/`FBT002` would rewrite the signatures of stable service helpers
and DTO constructors, which is a separate project. `FBT003` only touches
callers, so it is behavior-preserving.

What the rule buys, concretely:

```python
# before -- which of the two code paths does this take?
shifu_info = get_shifu_info(app, order_info.course_id, False)
public_config = _normalize_config(provider, payload.get("public_config"), False)
secret_config = _normalize_config(provider, payload.get("secret_config"), True)

# after
shifu_info = get_shifu_info(app, order_info.course_id, preview_mode=False)
public_config = _normalize_config(provider, payload.get("public_config"), secret=False)
secret_config = _normalize_config(provider, payload.get("secret_config"), secret=True)
```

Groups of call sites touched:

- Service helpers whose flag selects a data source or a write mode:
  `get_shifu_info(preview_mode=)`, `get_learn_record(preview_mode=)`,
  `_get_shifu_record(has_draft_outline=)`, `_normalize_config(secret=)`,
  `_set_shifu_archive_state(archived=)`, `__insert_outline_locked(is_hidden=)`,
  `query_promo_campaign_applications(recalc_discount=)`,
  `update_user_profile_with_lable(update_all=)`.
- Positional DTO constructors where the flag sat between unrelated strings:
  `PayItemDto(is_discount=, discount_code=)`, `ProfileItemDefinition(is_hidden=)`,
  `ShifuDto(is_favorite=, archived=)`, `ProviderState(enabled=)`,
  `LLMStreamResponse(is_truncated=)`.
- Config defaults, now named as defaults: `get_config(key, default=False)`,
  `_to_bool(value, default=False)`, `_bool_config(app, key, default=False)`.
- Pydantic `Field(False, ...)` -> `Field(default=False, ...)`. Same default,
  no schema change.
- Third-party APIs that only accept the flag positionally keep an inline
  `noqa` with the reason: SQLAlchemy `enable_eagerloads(False)` /
  `db.literal(False)`, the MySQL DBAPI `ping(False)`, `socket.setblocking`,
  `monkeypatch.setitem`, and the test that asserts `convert_type(True/False)`.

Test doubles that shadowed a renamed-in-call parameter were updated in the same
change (e.g. `lambda _app, _bid, _preview:` -> `lambda _app, _bid, preview_mode:`),
which is the failure mode the A002 review caught earlier in this series.

# Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`
- Backend suite: 2966 passed, 16 skipped. The 5 remaining failures in
  `tests/service/shifu/test_admin_course_detail.py` are the known SQLite
  baseline (`no such function: concat`) and fail on `main` too.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved clarity and consistency by using explicit names for boolean and optional settings.
  * Preserved existing behavior and configuration defaults across API, billing, learning, profile, and order workflows.

* **Tests**
  * Updated test cases and mocks to follow clearer argument conventions.
  * Confirmed safe handling of interrupted or desynchronized streams while preserving normal rollback behavior.

* **Chores**
  * Strengthened linting rules to encourage explicit boolean arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->