### PR TITLE
style: enforce ruff RUF100 (no unused noqa directives)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -198,8 +198,10 @@ select = [
     "UP",
 
     # --- Ruff-native rules ------------------------------------------------
-    # RUF001 (ambiguous unicode in a string) and RUF100 are ignored
-    # below.
+    # RUF001 (ambiguous unicode in a string) is ignored below.
+    # RUF100 is enforced, so a `# noqa` may only name a rule this file
+    # selects: reasons for exceptions to non-selected rules (BLE001,
+    # DTZ001, SLF001) are written as plain comments instead.
     "RUF",
 ]
 ignore = [
@@ -235,11 +237,6 @@ ignore = [
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
-    # RUF100: with a partial select list, ruff reports deliberate `# noqa:
-    # BLE001 / DTZ001 / SLF001` markers as unused simply because those
-    # rules are off here, so enforcing it would delete documentation of
-    # intentional exceptions. Stale directives are pruned by hand instead.
-    "RUF100",
     # UP040 / UP046 / UP047: PEP 695 type-parameter syntax (`type`, `class T`,
     # `def T`). target-version is py311, which currently suppresses them; if
     # the target later moves to py312+, ruff would start reporting them and

--- a/scripts/generate_languages.py
+++ b/scripts/generate_languages.py
@@ -37,7 +37,7 @@ def main() -> int:
     if LOCALES_FILE.exists():
         try:
             locales_meta = read_json(LOCALES_FILE)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             print(f"Failed to parse {LOCALES_FILE}: {exc}")
             return 1
     else:

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -657,7 +657,7 @@ def _reload_openai_params(model_id: str, temperature: float) -> dict[str, Any]:
                 model=model_id,
                 custom_llm_provider="openai",
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             # Keep the existing prefix-based behavior for model aliases that
             # have not reached LiteLLM's bundled model map yet.
             logger.debug(

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -107,7 +107,7 @@ def _server_thread_id(dbapi_connection):
     """Best-effort MySQL server-side connection id for log correlation."""
     try:
         return dbapi_connection.thread_id()
-    except Exception:  # noqa: BLE001 - diagnostics only
+    except Exception:  # diagnostics only
         return None
 
 
@@ -125,7 +125,7 @@ def _pool_diagnostics_logger():
         # Resolved inside the try: attribute access on current_app raises
         # outside an application context.
         return current_app.logger  # noqa: TRY300
-    except Exception:  # noqa: BLE001 - outside app context
+    except Exception:  # outside app context
         return logger
 
 
@@ -378,7 +378,7 @@ def invalidate_session(*, source: str, session=None) -> bool:
         if not hasattr(target, "invalidate") and callable(target):
             target = target()
         target.invalidate()
-    except Exception:  # noqa: BLE001 - termination cleanup must not raise
+    except Exception:  # termination cleanup must not raise
         _pool_diagnostics_logger().warning(
             "%s: session invalidate failed", source, exc_info=True
         )
@@ -407,7 +407,7 @@ def cleanup_session_after(
         return "noop"
     try:
         target.rollback()
-    except Exception:  # noqa: BLE001 - escalate, never raise from cleanup
+    except Exception:  # escalate, never raise from cleanup
         _pool_diagnostics_logger().warning(
             "%s: rollback failed; escalating to session invalidate",
             source,
@@ -435,7 +435,7 @@ def release_session_classified(*, source: str) -> None:
         invalidate_session(source=source)
     try:
         db.session.remove()
-    except Exception:  # noqa: BLE001 - cleanup must not mask the original
+    except Exception:  # cleanup must not mask the original
         _pool_diagnostics_logger().warning(
             "%s db session cleanup failed", source, exc_info=True
         )
@@ -463,7 +463,7 @@ def _rollback_quietly() -> bool:
         )
         invalidate_session(source="retry_on_deadlock rollback failure")
         return False
-    except Exception as rollback_exc:  # noqa: BLE001 - best-effort cleanup
+    except Exception as rollback_exc:  # best-effort cleanup
         # Environmental failures (e.g. no app context in unit tests) keep the
         # legacy tolerant behavior: log and let the retry loop proceed.
         logger.warning("retry_on_deadlock rollback failed: %s", rollback_exc)

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -212,7 +212,7 @@ def _best_effort_password_login_user(app: Flask):
 
     try:
         return validate_user(app, str(token))
-    except Exception:  # noqa: BLE001 - stale login tokens must not block recovery
+    except Exception:  # stale login tokens must not block recovery
         return None
 
 

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -400,7 +400,7 @@ def _summary_row_to_dict(summary_row: Any) -> dict[str, Any]:
             "unique_wallets": 0,
             "time_range": [None, None],
         }
-    mapping = summary_row._mapping  # noqa: SLF001 — SQLAlchemy public-ish API
+    mapping = summary_row._mapping  # SQLAlchemy public-ish API
     total_records = int(mapping.get("total_records") or 0)
     total_credits = _coerce_value(mapping.get("total_credits") or 0)
     unique_users = int(mapping.get("unique_users") or 0)

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -1280,7 +1280,7 @@ class RunScriptPreviewContextV2:
     ) -> UserAggregate | None:
         try:
             return load_user_aggregate(user_bid, with_credentials=False)
-        except Exception as exc:  # noqa: BLE001 - preview must survive lookup failures
+        except Exception as exc:  # preview must survive lookup failures
             cleanup_session_after(
                 exc,
                 source="preview learner profile lookup",

--- a/src/api/flaskr/service/learn/listen_element_run_persistence.py
+++ b/src/api/flaskr/service/learn/listen_element_run_persistence.py
@@ -97,7 +97,7 @@ def _describe_desynced_connection(result, connection) -> str:
                 parts.append(f"socket_pending_header_hex={pending[:5].hex()}")
             else:
                 parts.append("socket_pending=none")
-        except Exception as probe_error:  # noqa: BLE001 - forensics only
+        except Exception as probe_error:  # forensics only
             parts.append(f"socket_probe_error={probe_error!r}")
     return " ".join(parts)
 

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -738,7 +738,7 @@ def retry_pending_referral_rewards(
                         "bill_order_bid": billing_artifacts.get("bill_order_bid", ""),
                     }
                 )
-            except Exception as exc:  # noqa: BLE001 - repair must continue per row.
+            except Exception as exc:  # repair must continue per row.
                 db.session.rollback()
                 _mark_reward_grant_failed(reward_bid=reward.reward_bid, error=exc)
                 results.append(
@@ -851,7 +851,7 @@ def process_referral_post_auth(
                 reward_bid=reward.reward_bid,
                 billing_artifacts=billing_artifacts,
             )
-        except Exception as exc:  # noqa: BLE001 - referral grant is best-effort.
+        except Exception as exc:  # referral grant is best-effort.
             db.session.rollback()
             _mark_reward_grant_failed(reward_bid=reward.reward_bid, error=exc)
             return ReferralPostAuthResult(

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -362,7 +362,7 @@ def _verify_minimax_voice_id(voice_id: str) -> None:
             provider_name="minimax",
             model=OPERATOR_VOICE_VERIFY_MODEL,
         )
-    except Exception as exc:  # noqa: BLE001 - surface the real reason to the operator
+    except Exception as exc:  # surface the real reason to the operator
         raise_param_error(f"voice_id verification failed: {exc}")
 
 

--- a/src/api/flaskr/service/user/auth/oauth_origins.py
+++ b/src/api/flaskr/service/user/auth/oauth_origins.py
@@ -78,7 +78,7 @@ def is_allowed_oauth_origin(app: Flask, origin: Any) -> bool:
 
     try:
         return _resolve_creator_bid_by_host(app, host) is not None
-    except Exception:  # noqa: BLE001 - a lookup failure must never allow an origin
+    except Exception:  # a lookup failure must never allow an origin
         return False
 
 

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -243,7 +243,7 @@ class GoogleAuthProvider(AuthProvider):
             redirect_uri = state_payload.get("redirect_uri")
             login_context = state_payload.get("login_context")
             language = state_payload.get("language")
-        except Exception:  # noqa: BLE001 - defensive fallback
+        except Exception:  # defensive fallback
             current_app.logger.warning("Failed to parse Google OAuth state payload")
 
         _require_matching_initiator(state_payload, request.current_user_id)

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -864,7 +864,7 @@ def transactional_session():
         else:
             try:
                 nested.rollback()
-            except Exception:  # noqa: BLE001 - savepoint already broken
+            except Exception:  # savepoint already broken
                 invalidate_session(source="transactional_session rollback failure")
             # Preserve the legacy contract: a failure rolls back the whole
             # session transaction, not only the savepoint.

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -15,7 +15,7 @@ from flaskr.common.public_urls import (
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -187,7 +187,7 @@ def self_managed_cycle_end_after_boundary(
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 def add_active_subscription(

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -12,7 +12,7 @@ from flaskr.service.tts.tts_handler import upload_audio_to_oss
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 def _make_storage_app(monkeypatch, tmp_path, provider: str) -> Flask:

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -25,7 +25,7 @@ from flaskr.service.order.payment_providers import PaymentCreationResult
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -13,7 +13,7 @@ from flaskr.service.order.payment_providers.wechatpay import WechatPayProvider
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -36,7 +36,7 @@ def _credit_rate(
     unit_size: int = 1,
     usage_type: int = BILL_USAGE_TYPE_LLM,
     provider: str = "qwen",
-    effective_from: datetime = datetime(2026, 1, 1, 0, 0, 0),  # noqa: DTZ001
+    effective_from: datetime = datetime(2026, 1, 1, 0, 0, 0),
     effective_to: datetime | None = None,
     status: int = CREDIT_USAGE_RATE_STATUS_ACTIVE,
     deleted: int = 0,
@@ -108,7 +108,7 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
             }
         ],
     )
-    fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates,
@@ -168,7 +168,7 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
             CreditUsageRate.status == CREDIT_USAGE_RATE_STATUS_ACTIVE,
             CreditUsageRate.provider == "qwen",
             CreditUsageRate.model == "deepseek-v4-flash",
-            CreditUsageRate.effective_from == datetime(2026, 1, 1, 0, 0, 0),  # noqa: DTZ001
+            CreditUsageRate.effective_from == datetime(2026, 1, 1, 0, 0, 0),
         ).all()
 
         assert result["rate_model"] == "deepseek-v4-flash"
@@ -235,7 +235,7 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
 
 
 def test_update_db_only_llm_alias_only_supersedes_explicit_alias(monkeypatch, app):
-    fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(3)
@@ -477,7 +477,7 @@ def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app):
 def test_operator_rate_config_appends_only_current_exact_db_identities(
     monkeypatch, app
 ):
-    fixed_now = datetime(2026, 7, 21, 12, 0, 0)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(1)
@@ -707,7 +707,7 @@ def test_operator_rate_config_appends_only_current_exact_db_identities(
 def test_create_only_llm_uses_raw_rate_model_without_superseding_alias(
     monkeypatch, app, credits_per_unit, expected_input, expected_cache
 ):
-    fixed_now = datetime(2026, 7, 21, 12, 0, 0)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(3)
@@ -779,7 +779,7 @@ def test_create_only_llm_uses_raw_rate_model_without_superseding_alias(
 
 
 def test_create_only_rejects_duplicate_active_exact_identity(monkeypatch, app):
-    fixed_now = datetime(2026, 7, 21, 12, 0, 0)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(3)
@@ -894,7 +894,7 @@ def test_create_only_rejects_invalid_identity_and_fixed_fields(
     ids=["regular", "numeric-max"],
 )
 def test_create_only_tts_allows_empty_default_model(monkeypatch, app, credits_per_unit):
-    fixed_now = datetime(2026, 7, 21, 12, 0, 0)  # noqa: DTZ001
+    fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(3)

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -4,7 +4,7 @@ from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.learn.ask_provider_adapters import AskProviderError
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG
 
-_PREVIEW_TOKEN = "preview-token"  # noqa: S105 - stub session token, `validate_user` is mocked
+_PREVIEW_TOKEN = "preview-token"  # stub session token, `validate_user` is mocked
 
 
 class _FakeObservation:

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -14,7 +14,7 @@ from flaskr.util.datetime import now_utc
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -23,7 +23,7 @@ from flaskr.service.user.models import (
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -26,7 +26,7 @@ CUSTOM_ORIGIN = f"https://{CUSTOM_DOMAIN}"
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
-        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)  # noqa: SLF001
+        common_config.__ENHANCED_CONFIG__._cache.pop(key, None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Summary

Enables `RUF100`, which reports a `# noqa` that suppresses nothing.

It was previously ignored because 35 directives named rules this config does
not select — `BLE001`, `DTZ001`, `SLF001`, `S105` in test code — so they were
documentation of an intentional exception rather than a suppression. That
documentation is kept, just as a plain comment:

```python
# before
except Exception:  # noqa: BLE001 - stale login tokens must not block recovery
# after
except Exception:  # stale login tokens must not block recovery
```

Directives with no reason attached (bare `# noqa: BLE001`, the `SLF001` on the
config-cache reset helper repeated across 8 test files, the `DTZ001` on fixed
test datetimes) are simply dropped. Comment-only change: no code, no
suppression of a rule this config actually enforces.

The rule matters going forward: with `RUF100` off, a directive left behind
after its violation is fixed — or misspelled — sits there forever. The
`ruff.toml` comment now states the resulting convention: a `# noqa` may only
name a selected rule.

# Verification

- `ruff check .`, `ruff format --check .`, `python scripts/check_dev_tools.py`
- `ruff check --extend-select ALL --select RUF100 .` reports no unused
  directives left, i.e. nothing stale hides behind the non-selected codes.
- Touched test files: 525 passed.

Stacked on #2564 (FBT003), which is the layer that edits `ruff.toml` before this one.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->