### PR TITLE
style: enforce ruff DTZ901 (no bare datetime.min/max sentinels)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -78,10 +78,12 @@ select = [
     # --- Datetime / UTC contract -----------------------------------------
     # Partial on purpose. The repo's UTC contract (AGENTS.md) stores naive-UTC
     # datetimes and provides `now_utc()` as the sanctioned naive "now", so the
-    # rules demanding tz-aware values everywhere (DTZ001/DTZ007/DTZ901) fight
-    # the convention and are ignored below. What stays enabled are the calls
-    # whose result depends on the process time zone (now()/today()/utcnow()/
-    # fromtimestamp() without tz) -- exactly the drifts the contract forbids.
+    # rules demanding tz-aware values everywhere (DTZ001/DTZ007) fight the
+    # convention and are ignored below. What stays enabled are the calls whose
+    # result depends on the process time zone (now()/today()/utcnow()/
+    # fromtimestamp() without tz) -- exactly the drifts the contract forbids --
+    # plus DTZ901, whose two sanctioned sentinels now live in
+    # `flaskr/util/datetime.py`.
     "DTZ",
 
     # --- Logging ----------------------------------------------------------
@@ -237,7 +239,6 @@ ignore = [
     "TC003",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "DTZ007",  # naive strptime() -- naive UTC is the house convention
-    "DTZ901",  # datetime.min/max -- naive UTC is the house convention
     "G004",    # f-string logging -- house style, and rewriting it is churn
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -49,7 +49,7 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_TYPE_LLM,
     normalize_usage_scene,
 )
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 
 logger = logging.getLogger(__name__)
 
@@ -1452,7 +1452,7 @@ def _select_credit_usage_rate(
             row.provider == normalized_provider,
             row.model in candidate_set,
             model_priority.get(row.model, 0),
-            row.effective_from or datetime.min,
+            row.effective_from or NAIVE_DATETIME_MIN,
             int(row.id or 0),
         ),
         reverse=True,

--- a/src/api/flaskr/service/billing/bucket_categories.py
+++ b/src/api/flaskr/service/billing/bucket_categories.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
+from flaskr.util.datetime import NAIVE_DATETIME_MAX, NAIVE_DATETIME_MIN
+
 from .consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,
     BILLING_ORDER_TYPE_LABELS,
@@ -150,8 +152,8 @@ def build_wallet_bucket_runtime_sort_key(
     return (
         resolve_credit_bucket_priority(normalized_category),
         bucket.effective_to is None,
-        bucket.effective_to or datetime.max,
-        bucket.created_at or datetime.min,
+        bucket.effective_to or NAIVE_DATETIME_MAX,
+        bucket.created_at or NAIVE_DATETIME_MIN,
         int(bucket.id or 0),
     )
 

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -13,7 +13,7 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_TYPE_TTS,
 )
 from flaskr.service.metering.models import BillUsageRecord
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 
 from .consts import (
     BILLING_METRIC_LABELS,
@@ -341,7 +341,7 @@ def load_usage_rate(
             row.provider == provider,
             row.model in set(model_candidates),
             model_priority.get(row.model, 0),
-            row.effective_from or datetime.min,
+            row.effective_from or NAIVE_DATETIME_MIN,
             int(row.id or 0),
         ),
         reverse=True,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -25,7 +25,7 @@ from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MAX, NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, or_, select
 
 from .bucket_categories import (
@@ -753,8 +753,8 @@ def _wallet_bucket_view_sort_key(
     return (
         resolve_credit_bucket_priority(allocation_view.runtime_bucket_category),
         row.effective_to is None,
-        row.effective_to or datetime.max,
-        row.created_at or datetime.min,
+        row.effective_to or NAIVE_DATETIME_MAX,
+        row.created_at or NAIVE_DATETIME_MIN,
         int(row.id or 0),
     )
 

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -9,7 +9,7 @@ from typing import Any
 from flask import Flask
 from flaskr.dao import db, retry_on_deadlock, uow
 from flaskr.dao.uow import app_context_scope, unit_of_work
-from flaskr.util.datetime import now_utc, to_utc_iso
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc, to_utc_iso
 
 from .checkout import sync_billing_order
 from .consts import (
@@ -757,8 +757,8 @@ def _load_primary_paid_renewal_order_for_cycle(
             else 1,
             0 if _is_preorder_order(row) else 1,
             1 if _is_paid_referral_invitation_renewal(row) else 0,
-            row.paid_at or row.created_at or datetime.min,
-            row.created_at or datetime.min,
+            row.paid_at or row.created_at or NAIVE_DATETIME_MIN,
+            row.created_at or NAIVE_DATETIME_MIN,
             row.id,
         )
     )

--- a/src/api/flaskr/service/billing/reserved_renewal_activation.py
+++ b/src/api/flaskr/service/billing/reserved_renewal_activation.py
@@ -9,7 +9,7 @@ from typing import Protocol
 
 from flask import Flask
 from flaskr.dao import db
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 
 from .bucket_categories import resolve_credit_bucket_priority
 from .consts import (
@@ -85,7 +85,7 @@ def _normalize_utc_datetime(value: datetime) -> datetime:
 
 def _datetime_sort_value(value: datetime | None) -> datetime:
     if value is None:
-        return datetime.min
+        return NAIVE_DATETIME_MIN
     return _normalize_utc_datetime(value)
 
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -11,7 +11,7 @@ from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error
 from flaskr.service.order.payment_providers import get_payment_provider
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from flaskr.util.uuid import generate_id
 
 from .bucket_categories import (
@@ -344,9 +344,9 @@ def _load_topup_expiry_subscription_for_bucket(
         product_sort_order = int(product.sort_order) if product is not None else -1
         return (
             product_sort_order,
-            row.current_period_start_at or datetime.min,
-            row.current_period_end_at or datetime.min,
-            row.created_at or datetime.min,
+            row.current_period_start_at or NAIVE_DATETIME_MIN,
+            row.current_period_end_at or NAIVE_DATETIME_MIN,
+            row.created_at or NAIVE_DATETIME_MIN,
             int(row.id or 0),
         )
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -11,7 +11,7 @@ from flask import Flask
 from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
-from flaskr.util.datetime import now_utc, to_utc_iso
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 from sqlalchemy import case, func, or_
 from sqlalchemy.exc import IntegrityError
@@ -939,7 +939,7 @@ def load_primary_credit_bucket_by_category(
         return (
             status_rank,
             has_balance_rank,
-            row.created_at or datetime.min,
+            row.created_at or NAIVE_DATETIME_MIN,
             int(row.id or 0),
         )
 

--- a/src/api/flaskr/service/referral/reward_queue.py
+++ b/src/api/flaskr/service/referral/reward_queue.py
@@ -12,6 +12,7 @@ from flaskr.service.billing.models import (
     CreditLedgerEntry,
     CreditWalletBucket,
 )
+from flaskr.util.datetime import NAIVE_DATETIME_MAX
 
 from .consts import (
     REFERRAL_REWARD_STATUS_CANCELED,
@@ -267,8 +268,8 @@ def build_referral_reward_queue(
             ledger,
         )
         return (
-            effective_at or datetime.max,
-            reward.created_at or datetime.max,
+            effective_at or NAIVE_DATETIME_MAX,
+            reward.created_at or NAIVE_DATETIME_MAX,
             int(reward.id or 0),
         )
 

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -45,7 +45,7 @@ from flaskr.service.shifu.models import (
     PublishedShifu,
 )
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from markdown_flow import MarkdownFlow
 from sqlalchemy import and_, case, literal, not_
 from sqlalchemy.orm import defer
@@ -861,8 +861,8 @@ def _merge_courses(
         sorted(
             course_map.values(),
             key=lambda item: (
-                item.updated_at or datetime.min,
-                item.created_at or datetime.min,
+                item.updated_at or NAIVE_DATETIME_MIN,
+                item.created_at or NAIVE_DATETIME_MIN,
                 item.shifu_bid or "",
             ),
             reverse=True,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -58,7 +58,7 @@ from flaskr.service.shifu.models import (
     PublishedOutlineItem,
     PublishedShifu,
 )
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import and_, case, literal, not_, or_
 from sqlalchemy.orm import defer
 
@@ -1320,13 +1320,13 @@ def _list_operator_courses_legacy(
         merged_courses = [
             course
             for course in merged_courses
-            if (resolve_updated_at(course) or datetime.min) >= updated_start_time
+            if (resolve_updated_at(course) or NAIVE_DATETIME_MIN) >= updated_start_time
         ]
     if updated_end_time:
         merged_courses = [
             course
             for course in merged_courses
-            if (resolve_updated_at(course) or datetime.min) <= updated_end_time
+            if (resolve_updated_at(course) or NAIVE_DATETIME_MIN) <= updated_end_time
         ]
     if quick_filter:
         if quick_filter == COURSE_QUICK_FILTER_DRAFT:
@@ -1377,8 +1377,8 @@ def _list_operator_courses_legacy(
     merged_courses = sorted(
         merged_courses,
         key=lambda item: (
-            resolve_updated_at(item) or datetime.min,
-            item.created_at or datetime.min,
+            resolve_updated_at(item) or NAIVE_DATETIME_MIN,
+            item.created_at or NAIVE_DATETIME_MIN,
             item.shifu_bid or "",
         ),
         reverse=True,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -40,6 +40,7 @@ from flaskr.service.user.models import (
 from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
+from flaskr.util.datetime import NAIVE_DATETIME_MIN
 from sqlalchemy import case, or_
 
 COURSE_STATUS_PUBLISHED = "published"
@@ -609,8 +610,8 @@ def _merge_courses(
         sorted(
             course_map.values(),
             key=lambda item: (
-                item.updated_at or datetime.min,
-                item.created_at or datetime.min,
+                item.updated_at or NAIVE_DATETIME_MIN,
+                item.created_at or NAIVE_DATETIME_MIN,
                 item.shifu_bid or "",
             ),
             reverse=True,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -45,6 +45,7 @@ from flaskr.service.shifu.models import (
 from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
+from flaskr.util.datetime import NAIVE_DATETIME_MIN
 
 
 def _load_course_related_user_bids(
@@ -434,10 +435,10 @@ def get_operator_course_users(
             items_with_sort_keys.append(
                 (
                     (
-                        last_learning_at or datetime.min,
-                        joined_at or datetime.min,
-                        last_login_at or datetime.min,
-                        getattr(user, "created_at", None) or datetime.min,
+                        last_learning_at or NAIVE_DATETIME_MIN,
+                        joined_at or NAIVE_DATETIME_MIN,
+                        last_login_at or NAIVE_DATETIME_MIN,
+                        getattr(user, "created_at", None) or NAIVE_DATETIME_MIN,
                         user_bid,
                     ),
                     dto,

--- a/src/api/flaskr/service/shifu/admin_user_courses.py
+++ b/src/api/flaskr/service/shifu/admin_user_courses.py
@@ -6,7 +6,6 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import datetime
 
 from flaskr.dao import db
 from flaskr.service.learn.const import (
@@ -33,6 +32,7 @@ from flaskr.service.shifu.models import (
     PublishedOutlineItem,
     PublishedShifu,
 )
+from flaskr.util.datetime import NAIVE_DATETIME_MIN
 
 
 def _build_operator_user_course_summary(
@@ -357,7 +357,7 @@ def _load_operator_user_course_maps(
     sorted_learned_rows = sorted(
         learned_rows,
         key=lambda row: (
-            row.last_activity_at or datetime.min,
+            row.last_activity_at or NAIVE_DATETIME_MIN,
             str(row.shifu_bid or "").strip(),
         ),
         reverse=True,

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -126,7 +126,7 @@ from flaskr.service.shifu.models import (
 from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, not_, or_
 
 
@@ -891,7 +891,7 @@ def _load_active_subscription_end_map(
         sort_key = (
             row.product_sort_order if row.product_sort_order is not None else -1,
             row.current_period_end_at,
-            row.created_at or datetime.min,
+            row.created_at or NAIVE_DATETIME_MIN,
             row.id,
         )
         current = best_by_creator.get(row.creator_bid)

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -68,7 +68,7 @@ from flaskr.service.user.models import (
 from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, or_
 
 
@@ -514,7 +514,7 @@ def _load_operator_user_registration_source_map(
         if credential_rows is not None
         else _load_operator_user_auth_credentials(normalized_user_bids),
         key=lambda credential: (
-            getattr(credential, "created_at", None) or datetime.min,
+            getattr(credential, "created_at", None) or NAIVE_DATETIME_MIN,
             int(getattr(credential, "id", 0) or 0),
         ),
     )

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from flaskr.dao import db
+from flaskr.util.datetime import NAIVE_DATETIME_MIN
 from sqlalchemy import and_, or_
 
 from .models import DraftOutlineItem, DraftShifu, PublishedOutlineItem, PublishedShifu
@@ -21,11 +22,11 @@ def _record_course_activity(
     if not shifu_bid:
         return
     current = activity_map.get(shifu_bid)
-    candidate_time = updated_at or datetime.min
+    candidate_time = updated_at or NAIVE_DATETIME_MIN
     current_time = (
         current.get("updated_at")
         if current and current.get("updated_at")
-        else datetime.min
+        else NAIVE_DATETIME_MIN
     )
     should_replace = current is None or candidate_time > current_time
     if (

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -38,7 +38,7 @@ from flaskr.service.learn.ask_provider_adapters.consts import (  # noqa: F401
 )
 from flaskr.service.tts.validation import validate_tts_settings_strict
 from flaskr.util import generate_id
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 
 from .consts import (
     ASK_MODE_DEFAULT,
@@ -756,12 +756,12 @@ def get_shifu_draft_list(
 
         def resolve_updated_at(draft: DraftShifu) -> datetime:
             activity = activity_map.get(str(draft.shifu_bid or "").strip(), {})
-            return activity.get("updated_at") or draft.updated_at or datetime.min
+            return activity.get("updated_at") or draft.updated_at or NAIVE_DATETIME_MIN
 
         shifu_drafts.sort(
             key=lambda draft: (
                 resolve_updated_at(draft),
-                draft.updated_at or datetime.min,
+                draft.updated_at or NAIVE_DATETIME_MIN,
                 int(draft.id or 0),
             ),
             reverse=True,

--- a/src/api/flaskr/util/datetime.py
+++ b/src/api/flaskr/util/datetime.py
@@ -3,6 +3,13 @@ from datetime import UTC, datetime
 import pytz
 from flask import Flask
 
+# Sentinels for ordering and comparing the naive UTC timestamps stored in the
+# database, used where a nullable column takes part in a sort key or a range
+# check. They are naive on purpose: an aware sentinel raises `TypeError` as
+# soon as it meets a stored value.
+NAIVE_DATETIME_MIN = datetime.min  # noqa: DTZ901
+NAIVE_DATETIME_MAX = datetime.max  # noqa: DTZ901
+
 
 def now_utc() -> datetime:
     """Return the current UTC time as a naive datetime.


### PR DESCRIPTION
# Summary

`DTZ901` flags `datetime.min` / `datetime.max`. All 34 hits are the same
pattern: a nullable timestamp column taking part in a sort key or a range check,
e.g.

```python
key=lambda row: (row.effective_to or datetime.max, row.created_at or datetime.min)
```

Ruff's suggested fix (`datetime.max.replace(tzinfo=...)`) is wrong here — the
repo stores naive UTC (`AGENTS.md`), so an aware sentinel raises `TypeError` the
moment it meets a stored value. Instead the sentinel is declared once, next to
`now_utc()`:

```python
# Sentinels for ordering and comparing the naive UTC timestamps stored in the
# database, ... They are naive on purpose: an aware sentinel raises `TypeError`
# as soon as it meets a stored value.
NAIVE_DATETIME_MIN = datetime.min  # noqa: DTZ901
NAIVE_DATETIME_MAX = datetime.max  # noqa: DTZ901
```

and the 34 call sites in 18 modules (billing, shifu operator admin, referral,
llm rate selection) use it. `DTZ901` moves from `ignore` to enforced, so the
only place allowed to spell the sentinel is that one module, with the reason
attached. `DTZ001` / `DTZ007` stay ignored — those are the ones that genuinely
fight the naive-UTC convention.

No behavior change: `NAIVE_DATETIME_MIN is datetime.min`.

Verification:

- `ruff check .`, `ruff format --check .`, `lefthook` pre-commit (all hooks pass)
- Backend suite: 2963 passed, 16 skipped. The 5 failures in
  `tests/service/shifu/test_admin_course_detail.py` are the known SQLite
  baseline (`no such function: concat`) and fail on `main` too.

Stacked on #2567.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->