### PR TITLE
style: enforce ruff DTZ007 (parse timestamps through the shared UTC helper)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -76,14 +76,15 @@ select = [
     "ERA001",  # commented-out code
 
     # --- Datetime / UTC contract -----------------------------------------
-    # Partial on purpose. The repo's UTC contract (AGENTS.md) stores naive-UTC
-    # datetimes and provides `now_utc()` as the sanctioned naive "now", so the
-    # rules demanding tz-aware values everywhere (DTZ001/DTZ007) fight the
-    # convention and are ignored below. What stays enabled are the calls whose
-    # result depends on the process time zone (now()/today()/utcnow()/
-    # fromtimestamp() without tz) -- exactly the drifts the contract forbids --
-    # plus DTZ901, whose two sanctioned sentinels now live in
-    # `flaskr/util/datetime.py`.
+    # Almost complete. The repo's UTC contract (AGENTS.md) stores naive-UTC
+    # datetimes, so the sanctioned naive constructors are centralized in
+    # `flaskr/util/datetime.py` -- `now_utc()` for "now", `parse_naive_utc()`
+    # for inbound strings, `NAIVE_DATETIME_MIN/MAX` for sort sentinels -- and
+    # everything else is enforced: the calls whose result depends on the
+    # process time zone (now()/today()/utcnow()/fromtimestamp() without tz)
+    # plus DTZ007/DTZ901, which now only pass through that one module. DTZ001
+    # stays ignored below: naive `datetime(...)` literals are the storage
+    # format itself.
     "DTZ",
 
     # --- Logging ----------------------------------------------------------
@@ -238,7 +239,6 @@ ignore = [
     "TC002",
     "TC003",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
-    "DTZ007",  # naive strptime() -- naive UTC is the house convention
     "G004",    # f-string logging -- house style, and rewriting it is churn
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     "PLW0603", # global statement -- used by module-level singletons/caches

--- a/scripts/run_harness_gardening.py
+++ b/scripts/run_harness_gardening.py
@@ -57,7 +57,11 @@ def stale_review_docs() -> list[str]:
                 stale.append(f"{path.relative_to(ROOT)} (missing last_reviewed)")
                 continue
             try:
-                reviewed_date = datetime.strptime(reviewed, "%Y-%m-%d").date()
+                # Repo scripts cannot import `flaskr.util.datetime`; the doc
+                # metadata carries a bare calendar date, so naive is correct.
+                reviewed_date = datetime.strptime(  # noqa: DTZ007
+                    reviewed, "%Y-%m-%d"
+                ).date()
             except ValueError:
                 stale.append(
                     f"{path.relative_to(ROOT)} (invalid last_reviewed={reviewed})"

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -37,6 +37,7 @@ from flaskr.service.shifu.shifu_draft_funcs import (
     get_shifu_published_list,
 )
 from flaskr.service.shifu.utils import get_shifu_creator_bid
+from flaskr.util.datetime import parse_naive_utc
 
 
 def register_order_handler(app: Flask, path_prefix: str):
@@ -69,7 +70,7 @@ def register_order_handler(app: Flask, path_prefix: str):
             "%Y-%m-%dT%H:%M:%S",
         ):
             try:
-                parsed = datetime.strptime(normalized, datetime_format)
+                parsed = parse_naive_utc(normalized, datetime_format)
                 if datetime_format == "%Y-%m-%d":
                     if is_end:
                         parsed = parsed.replace(hour=23, minute=59, second=59)

--- a/src/api/flaskr/service/billing/daily_aggregates.py
+++ b/src/api/flaskr/service/billing/daily_aggregates.py
@@ -11,7 +11,7 @@ from typing import Any
 from flask import Flask
 from flaskr.dao import db
 from flaskr.service.metering.models import BillUsageRecord
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, parse_naive_utc
 from flaskr.util.uuid import generate_id
 from sqlalchemy import select
 
@@ -607,7 +607,7 @@ def _resolve_stat_window(
 ) -> tuple[datetime, datetime, str]:
     anchor = now or now_utc()
     normalized_stat_date = str(stat_date or "").strip() or anchor.strftime("%Y-%m-%d")
-    day_start = datetime.strptime(normalized_stat_date, "%Y-%m-%d")
+    day_start = parse_naive_utc(normalized_stat_date, "%Y-%m-%d")
     day_end = day_start + timedelta(days=1)
     if finalize:
         return day_start, day_end, normalized_stat_date
@@ -629,8 +629,8 @@ def _resolve_stat_date_range(
     end_value = (
         normalized_date_to or normalized_date_from or anchor.strftime("%Y-%m-%d")
     )
-    start_date = datetime.strptime(start_value, "%Y-%m-%d")
-    end_date = datetime.strptime(end_value, "%Y-%m-%d")
+    start_date = parse_naive_utc(start_value, "%Y-%m-%d")
+    end_date = parse_naive_utc(end_value, "%Y-%m-%d")
     if end_date < start_date:
         raise ValueError("date_to must be greater than or equal to date_from")
     return start_date, end_date

--- a/src/api/flaskr/service/billing/queries.py
+++ b/src/api/flaskr/service/billing/queries.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, parse_naive_utc
 from sqlalchemy import case
 
 from .consts import (
@@ -78,7 +78,7 @@ def normalize_stat_date_filter(value: Any, *, parameter_name: str) -> str:
     if not normalized_value:
         return ""
     try:
-        datetime.strptime(normalized_value, "%Y-%m-%d")
+        parse_naive_utc(normalized_value, "%Y-%m-%d")
     except ValueError:
         raise_param_error(parameter_name)
     return normalized_value

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -25,7 +25,12 @@ from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
-from flaskr.util.datetime import NAIVE_DATETIME_MAX, NAIVE_DATETIME_MIN, now_utc
+from flaskr.util.datetime import (
+    NAIVE_DATETIME_MAX,
+    NAIVE_DATETIME_MIN,
+    now_utc,
+    parse_naive_utc,
+)
 from sqlalchemy import case, or_, select
 
 from .bucket_categories import (
@@ -198,7 +203,7 @@ def _parse_stat_date(value: str) -> datetime.date | None:
     if not normalized_value:
         return None
     try:
-        return datetime.strptime(normalized_value, "%Y-%m-%d").date()
+        return parse_naive_utc(normalized_value, "%Y-%m-%d").date()
     except ValueError:
         return None
 

--- a/src/api/flaskr/service/metering/routes.py
+++ b/src/api/flaskr/service/metering/routes.py
@@ -10,12 +10,13 @@ from flaskr.service.metering.consts import (
     normalize_usage_scene,
 )
 from flaskr.service.metering.models import BillUsageRecord
+from flaskr.util.datetime import parse_naive_utc
 from sqlalchemy import func
 
 
 def _parse_date(value: str, *, field_name: str) -> datetime.datetime:
     try:
-        return datetime.datetime.strptime(value, "%Y-%m-%d")
+        return parse_naive_utc(value, "%Y-%m-%d")
     except (TypeError, ValueError):
         raise_param_error(f"Invalid {field_name} format, expected YYYY-MM-DD")
 

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -70,6 +70,7 @@ from flaskr.service.user.repository import (
     upsert_credential,
 )
 from flaskr.service.user.utils import ensure_demo_course_permissions
+from flaskr.util.datetime import parse_naive_utc
 from sqlalchemy import case
 
 ORDER_STATUS_KEY_MAP = {
@@ -208,7 +209,7 @@ def _parse_datetime(value: str, is_end: bool = False) -> datetime | None:
         return None
     for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"):
         try:
-            parsed = datetime.strptime(normalized, fmt)
+            parsed = parse_naive_utc(normalized, fmt)
             if fmt == "%Y-%m-%d":
                 if is_end:
                     parsed = parsed.replace(hour=23, minute=59, second=59)

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -63,7 +63,7 @@ from flaskr.service.promo.models import (
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, parse_naive_utc
 from flaskr.util.uuid import generate_id
 from sqlalchemy import and_, case, func, not_, or_
 
@@ -111,7 +111,7 @@ def _parse_datetime(value: str, field_name: str, *, is_end: bool = False) -> dat
         raise_param_error(field_name)
     # Date-only filters fill the day bounds (UTC wall-clock day).
     try:
-        date_only = datetime.strptime(normalized, "%Y-%m-%d")
+        date_only = parse_naive_utc(normalized, "%Y-%m-%d")
     except ValueError:
         date_only = None
     if date_only is not None:
@@ -128,7 +128,7 @@ def _parse_datetime(value: str, field_name: str, *, is_end: bool = False) -> dat
     except ValueError:
         for fmt in ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S"):
             try:
-                parsed = datetime.strptime(candidate, fmt)
+                parsed = parse_naive_utc(candidate, fmt)
                 break
             except ValueError:
                 continue

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -17,7 +17,7 @@ from flaskr.service.billing.consts import (
 from flaskr.service.billing.models import BillingProduct
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.pagination import normalize_pagination
-from flaskr.util.datetime import now_utc, to_utc_iso
+from flaskr.util.datetime import now_utc, parse_naive_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 from sqlalchemy import or_
 
@@ -353,7 +353,7 @@ def _parse_datetime(value: object, field_name: str) -> datetime | None:
         return None
     for datetime_format in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
         try:
-            return datetime.strptime(normalized, datetime_format)
+            return parse_naive_utc(normalized, datetime_format)
         except ValueError:
             continue
     try:

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -103,6 +103,7 @@ from flaskr.service.shifu.admin_operations.voice_clones import (
     list_operator_voice_clones,
     register_operator_voice_clone,
 )
+from flaskr.util.datetime import parse_naive_utc
 from pydantic import ValidationError
 
 MAX_CONTACT_LENGTH = 320
@@ -148,7 +149,7 @@ def _parse_datetime_filter(
         return None
     for datetime_format in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
         try:
-            parsed = datetime.strptime(normalized, datetime_format)
+            parsed = parse_naive_utc(normalized, datetime_format)
             if datetime_format == "%Y-%m-%d":
                 if is_end:
                     parsed = parsed.replace(hour=23, minute=59, second=59)

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -11,7 +11,7 @@ from flaskr.service.config.funcs import get_config as get_dynamic_config
 from flaskr.service.shifu.dtos import resolve_demo_course_for_language
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, parse_naive_utc
 from sqlalchemy.exc import IntegrityError
 
 ONBOARDING_VERSION = "v1"
@@ -71,7 +71,7 @@ def _parse_rollout_threshold(value: Any) -> datetime | None:
             continue
     for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
         try:
-            return datetime.strptime(text, fmt)
+            return parse_naive_utc(text, fmt)
         except ValueError:
             continue
     return None

--- a/src/api/flaskr/util/datetime.py
+++ b/src/api/flaskr/util/datetime.py
@@ -22,6 +22,18 @@ def now_utc() -> datetime:
     return datetime.now(UTC).replace(tzinfo=None)
 
 
+def parse_naive_utc(value: str, fmt: str) -> datetime:
+    """Parse a timestamp string as UTC and return it as a naive datetime.
+
+    The inbound counterpart of ``now_utc()``: API filters, CLI arguments and
+    admin payloads carry no offset, and the stored timestamps they are compared
+    with are naive UTC, so the parsed value has to stay naive as well.
+    Propagates ``ValueError`` from ``datetime.strptime`` when the value does
+    not match the format.
+    """
+    return datetime.strptime(value, fmt)  # noqa: DTZ007
+
+
 def to_utc_iso(value: datetime | None) -> str | None:
     """Serialize a datetime to a UTC ISO 8601 string with a ``Z`` suffix.
 

--- a/src/api/tests/common/test_now_utc.py
+++ b/src/api/tests/common/test_now_utc.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta, timezone
 
-from flaskr.util.datetime import now_utc, to_utc_iso
+import pytest
+from flaskr.util.datetime import now_utc, parse_naive_utc, to_utc_iso
 
 
 def test_now_utc_returns_naive_utc() -> None:
@@ -26,6 +27,22 @@ def test_model_timestamp_default_writes_utc(app) -> None:
         assert created.tzinfo is None
         reference = datetime.now(UTC).replace(tzinfo=None)
         assert abs((reference - created).total_seconds()) < 60
+
+
+def test_parse_naive_utc_returns_naive_value() -> None:
+    value = parse_naive_utc("2026-08-14 03:04:05", "%Y-%m-%d %H:%M:%S")
+    # Naive so it stays comparable with the naive UTC timestamps in the database.
+    assert value.tzinfo is None
+    assert value == datetime(2026, 8, 14, 3, 4, 5)
+
+
+def test_parse_naive_utc_keeps_a_date_only_value_at_midnight() -> None:
+    assert parse_naive_utc("2026-08-14", "%Y-%m-%d") == datetime(2026, 8, 14)
+
+
+def test_parse_naive_utc_rejects_mismatched_format() -> None:
+    with pytest.raises(ValueError, match="does not match format"):
+        parse_naive_utc("14/08/2026", "%Y-%m-%d")
 
 
 def test_to_utc_iso_marks_naive_utc_with_z_suffix() -> None:

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -37,7 +37,7 @@ from flaskr.service.promo.models import (
 from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
-from flaskr.util.datetime import now_utc
+from flaskr.util.datetime import now_utc, parse_naive_utc
 
 
 @pytest.fixture(autouse=True)
@@ -1924,8 +1924,8 @@ def test_admin_promotions_campaign_route_rejects_overlap_with_legacy_enabled_cam
                 description="Legacy overlap campaign",
                 apply_type=PROMO_CAMPAIGN_JOIN_TYPE_AUTO,
                 status=0,
-                start_at=datetime.strptime("2026-04-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
-                end_at=datetime.strptime("2026-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
+                start_at=parse_naive_utc("2026-04-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
+                end_at=parse_naive_utc("2026-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"),
                 discount_type=COUPON_TYPE_FIXED,
                 value=Decimal(10),
                 channel="app",
@@ -2296,12 +2296,10 @@ def test_admin_promotions_coupon_update_allows_changing_only_end_time(
     with app.app_context():
         coupon = Coupon.query.filter(Coupon.coupon_bid == coupon_bid).first()
         assert coupon is not None
-        assert coupon.start == datetime.strptime(
+        assert coupon.start == parse_naive_utc(
             "2026-04-24 10:00:00", "%Y-%m-%d %H:%M:%S"
         )
-        assert coupon.end == datetime.strptime(
-            "2026-05-30 23:59:00", "%Y-%m-%d %H:%M:%S"
-        )
+        assert coupon.end == parse_naive_utc("2026-05-30 23:59:00", "%Y-%m-%d %H:%M:%S")
 
 
 def test_admin_promotions_coupon_update_ignores_empty_start_time(
@@ -2356,12 +2354,10 @@ def test_admin_promotions_coupon_update_ignores_empty_start_time(
     with app.app_context():
         coupon = Coupon.query.filter(Coupon.coupon_bid == coupon_bid).first()
         assert coupon is not None
-        assert coupon.start == datetime.strptime(
+        assert coupon.start == parse_naive_utc(
             "2026-04-24 10:00:00", "%Y-%m-%d %H:%M:%S"
         )
-        assert coupon.end == datetime.strptime(
-            "2026-05-30 23:59:00", "%Y-%m-%d %H:%M:%S"
-        )
+        assert coupon.end == parse_naive_utc("2026-05-30 23:59:00", "%Y-%m-%d %H:%M:%S")
 
 
 def test_admin_promotions_coupon_status_rejects_enabling_expired_coupon(
@@ -2560,10 +2556,10 @@ def test_admin_promotions_campaign_update_allows_changing_only_start_time(
             PromoCampaign.promo_bid == promo_bid
         ).first()
         assert campaign is not None
-        assert campaign.start_at == datetime.strptime(
+        assert campaign.start_at == parse_naive_utc(
             "2099-04-25 10:30:00", "%Y-%m-%d %H:%M:%S"
         )
-        assert campaign.end_at == datetime.strptime(
+        assert campaign.end_at == parse_naive_utc(
             "2099-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"
         )
 
@@ -2620,10 +2616,10 @@ def test_admin_promotions_campaign_update_ignores_null_end_time(
             PromoCampaign.promo_bid == promo_bid
         ).first()
         assert campaign is not None
-        assert campaign.start_at == datetime.strptime(
+        assert campaign.start_at == parse_naive_utc(
             "2099-04-25 10:30:00", "%Y-%m-%d %H:%M:%S"
         )
-        assert campaign.end_at == datetime.strptime(
+        assert campaign.end_at == parse_naive_utc(
             "2099-05-24 10:00:00", "%Y-%m-%d %H:%M:%S"
         )
 


### PR DESCRIPTION
# Summary

`DTZ007` flags `datetime.strptime()` without `%z`. All 24 hits parse an inbound
string that carries no offset — admin/API date filters (`%Y-%m-%d`,
`%Y-%m-%d %H:%M:%S`, `%Y-%m-%dT%H:%M[:%S]`), an onboarding value and promo test
fixtures — and compare the result with the naive-UTC timestamps in the database.
Making them aware is the wrong fix, so the sanctioned naive constructor gets a
name next to `now_utc()`:

```python
def parse_naive_utc(value: str, fmt: str) -> datetime:
    """Parse a timestamp string as UTC and return it as a naive datetime.
    ...
    """
    return datetime.strptime(value, fmt)  # noqa: DTZ007
```

23 call sites now go through it; `ValueError` still propagates, so the existing
`try/except ValueError` fallback loops (which try several formats in order) are
unchanged. The one remaining site, `scripts/run_harness_gardening.py`, cannot
import `flaskr` and keeps an inline `noqa` with the reason.

`DTZ007` moves from `ignore` to enforced. With this and #2568, the whole DTZ
group is on except `DTZ001` — a naive `datetime(...)` literal is the storage
format itself, so that one stays ignored, and the `ruff.toml` comment now says
so.

Tests: `parse_naive_utc` gets its own cases in `tests/common/test_now_utc.py`
(naive result, date-only midnight, `ValueError` on a mismatched format) — the
helper is new API, and nothing else asserted the naive-UTC parse contract.

Verification:

- `ruff check .`, `ruff format --check .`, `lefthook` pre-commit (all hooks pass)
- Backend suite: 2966 passed, 16 skipped. The 5 failures in
  `tests/service/shifu/test_admin_course_detail.py` are the known SQLite
  baseline (`no such function: concat`) and fail on `main` too.

Stacked on #2568.


Link to Devin session: https://app.devin.ai/sessions/591f149265704faaa4da8e4208e77c27
Requested by: @sunner
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->