### PR TITLE
feat: manage Stripe provider price mappings

### DIFF
--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -136,7 +136,7 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
     }
 
     # The endpoint is a fixed HTTPS URL.
-    req = Request(
+    req = Request(  # noqa: S310
         endpoint_url, querystring.encode("utf-8"), headers=headers, method="POST"
     )
     try:

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -135,11 +135,11 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
         "Connection": "keep-alive",
     }
 
-    req = Request(
+    # The endpoint is a fixed https URL built from configuration.
+    req = Request(  # noqa: S310
         endpoint_url, querystring.encode("utf-8"), headers=headers, method="POST"
     )
     try:
-        # The endpoint is a fixed https URL built from configuration.
         with urlopen(req, timeout=timeout) as response:  # noqa: S310
             return json.loads(response.read().decode(), strict=False)
     except URLError:

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -136,7 +136,7 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
     }
 
     # The endpoint is a fixed HTTPS URL.
-    req = Request(  # noqa: S310
+    req = Request(
         endpoint_url, querystring.encode("utf-8"), headers=headers, method="POST"
     )
     try:

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -135,7 +135,7 @@ def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECOND
         "Connection": "keep-alive",
     }
 
-    # The endpoint is a fixed https URL built from configuration.
+    # The endpoint is a fixed HTTPS URL.
     req = Request(  # noqa: S310
         endpoint_url, querystring.encode("utf-8"), headers=headers, method="POST"
     )

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -582,7 +582,10 @@ def register_billing_commands(console) -> None:
     @with_appcontext
     def provider_price_activate_command(provider_price_bid: str) -> None:
         """Validate and activate a Stripe price mapping."""
-        _echo_payload(activate_cli_provider_price_mapping(provider_price_bid))
+        payload = activate_cli_provider_price_mapping(provider_price_bid)
+        _echo_payload(payload)
+        if payload["status"] == "invalid":
+            raise click.exceptions.Exit(1)
 
     @provider_price_group.command(name="retire")
     @click.option(
@@ -604,7 +607,10 @@ def register_billing_commands(console) -> None:
     @with_appcontext
     def provider_price_validate_command(provider_price_bid: str) -> None:
         """Validate a Stripe price mapping without activating it."""
-        _echo_payload(validate_cli_provider_price_mapping(provider_price_bid))
+        payload = validate_cli_provider_price_mapping(provider_price_bid)
+        _echo_payload(payload)
+        if payload["status"] == "invalid":
+            raise click.exceptions.Exit(1)
 
     @provider_price_group.command(name="list")
     @click.option("--product-bid", default="", help="Optional bill product bid.")
@@ -624,24 +630,33 @@ def register_billing_commands(console) -> None:
         help="Optional provider price mapping status label.",
     )
     @click.option(
-        "--livemode/--any-mode",
-        default=None,
-        help="Filter to live-mode objects, or omit for both modes.",
+        "--mode",
+        default="all",
+        show_default=True,
+        type=click.Choice(["all", "test", "live"], case_sensitive=False),
+        help="Filter by Stripe mode.",
     )
     @with_appcontext
     def provider_price_list_command(
         product_bid: str,
         provider_account_id: str,
         status_label: str,
-        livemode: bool | None,
+        mode: str,
     ) -> None:
         """List Stripe price mappings."""
+        normalized_mode = str(mode or "all").strip().lower()
         _echo_payload(
             list_cli_provider_price_mappings(
                 product_bid=product_bid,
                 provider_account_id=provider_account_id,
                 status_label=status_label,
-                livemode=livemode,
+                livemode=(
+                    True
+                    if normalized_mode == "live"
+                    else False
+                    if normalized_mode == "test"
+                    else None
+                ),
             )
         )
 

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -64,6 +64,10 @@ from .consts import (
     BILLING_PRODUCT_TYPE_GRANT,
     BILLING_PRODUCT_TYPE_PLAN,
     BILLING_PRODUCT_TYPE_TOPUP,
+    BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+    BILLING_PROVIDER_PRICE_STATUS_DRAFT,
+    BILLING_PROVIDER_PRICE_STATUS_INVALID,
+    BILLING_PROVIDER_PRICE_STATUS_RETIRED,
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
     BILLING_RENEWAL_EVENT_STATUS_FAILED,
     BILLING_RENEWAL_EVENT_STATUS_PENDING,
@@ -102,6 +106,17 @@ from .notifications import (
     stage_subscription_purchase_sms_for_paid_order,
 )
 from .primitives import coerce_datetime
+from .provider_price_mappings import (
+    ProviderPriceMappingError,
+    activate_provider_price_mapping,
+    get_active_provider_price_mapping,
+    get_provider_price_mapping,
+    list_provider_price_mappings,
+    retire_provider_price_mapping,
+    serialize_provider_price_mapping,
+    upsert_provider_price_mapping,
+    validate_provider_price_mapping_by_bid,
+)
 from .queries import (
     calculate_self_managed_billing_cycle_end,
     load_primary_active_subscription,
@@ -152,6 +167,13 @@ _ALLOCATION_INTERVAL_LABELS = {
 _PRODUCT_STATUS_LABELS = {
     "active": BILLING_PRODUCT_STATUS_ACTIVE,
     "inactive": BILLING_PRODUCT_STATUS_INACTIVE,
+}
+
+_PROVIDER_PRICE_STATUS_LABELS = {
+    "active": BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+    "draft": BILLING_PROVIDER_PRICE_STATUS_DRAFT,
+    "invalid": BILLING_PROVIDER_PRICE_STATUS_INVALID,
+    "retired": BILLING_PROVIDER_PRICE_STATUS_RETIRED,
 }
 
 _DEFAULT_CLI_OPERATOR_USER_BID = "billing-cli"
@@ -498,6 +520,141 @@ def register_billing_commands(console) -> None:
             metadata_json=metadata_json,
         )
         _echo_payload(payload)
+
+    @billing_group.group(name="provider-price")
+    def provider_price_group() -> None:
+        """Manage billing product provider price mappings."""
+
+    @provider_price_group.command(name="bind")
+    @click.option("--product-bid", required=True, help="Bill product bid.")
+    @click.option(
+        "--provider-account-id",
+        required=True,
+        help="Stripe account identifier.",
+    )
+    @click.option(
+        "--provider-product-id",
+        required=True,
+        help="Stripe product identifier.",
+    )
+    @click.option(
+        "--provider-price-id",
+        required=True,
+        help="Stripe price identifier.",
+    )
+    @click.option(
+        "--livemode/--testmode",
+        default=False,
+        show_default=True,
+        help="Whether the Stripe objects are live-mode objects.",
+    )
+    @click.option(
+        "--metadata-json",
+        default="",
+        help="Optional provider mapping metadata JSON object.",
+    )
+    @with_appcontext
+    def provider_price_bind_command(
+        product_bid: str,
+        provider_account_id: str,
+        provider_product_id: str,
+        provider_price_id: str,
+        livemode: bool,
+        metadata_json: str,
+    ) -> None:
+        """Create or update a draft Stripe price mapping."""
+        payload = bind_provider_price_mapping(
+            product_bid=product_bid,
+            provider_account_id=provider_account_id,
+            provider_product_id=provider_product_id,
+            provider_price_id=provider_price_id,
+            livemode=livemode,
+            metadata_json=metadata_json,
+        )
+        _echo_payload(payload)
+
+    @provider_price_group.command(name="activate")
+    @click.option(
+        "--provider-price-bid",
+        required=True,
+        help="Provider price mapping bid.",
+    )
+    @with_appcontext
+    def provider_price_activate_command(provider_price_bid: str) -> None:
+        """Validate and activate a Stripe price mapping."""
+        _echo_payload(activate_cli_provider_price_mapping(provider_price_bid))
+
+    @provider_price_group.command(name="retire")
+    @click.option(
+        "--provider-price-bid",
+        required=True,
+        help="Provider price mapping bid.",
+    )
+    @with_appcontext
+    def provider_price_retire_command(provider_price_bid: str) -> None:
+        """Retire a Stripe price mapping."""
+        _echo_payload(retire_cli_provider_price_mapping(provider_price_bid))
+
+    @provider_price_group.command(name="validate")
+    @click.option(
+        "--provider-price-bid",
+        required=True,
+        help="Provider price mapping bid.",
+    )
+    @with_appcontext
+    def provider_price_validate_command(provider_price_bid: str) -> None:
+        """Validate a Stripe price mapping without activating it."""
+        _echo_payload(validate_cli_provider_price_mapping(provider_price_bid))
+
+    @provider_price_group.command(name="list")
+    @click.option("--product-bid", default="", help="Optional bill product bid.")
+    @click.option(
+        "--provider-account-id",
+        default="",
+        help="Optional Stripe account identifier.",
+    )
+    @click.option(
+        "--status",
+        "status_label",
+        default="",
+        type=click.Choice(
+            ["", *sorted(_PROVIDER_PRICE_STATUS_LABELS.keys())],
+            case_sensitive=False,
+        ),
+        help="Optional provider price mapping status label.",
+    )
+    @click.option(
+        "--livemode/--any-mode",
+        default=None,
+        help="Filter to live-mode objects, or omit for both modes.",
+    )
+    @with_appcontext
+    def provider_price_list_command(
+        product_bid: str,
+        provider_account_id: str,
+        status_label: str,
+        livemode: bool | None,
+    ) -> None:
+        """List Stripe price mappings."""
+        _echo_payload(
+            list_cli_provider_price_mappings(
+                product_bid=product_bid,
+                provider_account_id=provider_account_id,
+                status_label=status_label,
+                livemode=livemode,
+            )
+        )
+
+    @provider_price_group.command(name="inspect")
+    @click.option(
+        "--provider-price-bid",
+        required=True,
+        help="Provider price mapping bid.",
+    )
+    @with_appcontext
+    def provider_price_inspect_command(provider_price_bid: str) -> None:
+        """Inspect one Stripe price mapping."""
+        _echo_payload(inspect_cli_provider_price_mapping(provider_price_bid))
 
     @billing_group.command(name="grant-plan")
     @click.option(
@@ -1791,6 +1948,137 @@ def upsert_billing_product(
         "product_bid": payload["product_bid"],
         "product_code": payload["product_code"],
     }
+
+
+def bind_provider_price_mapping(
+    *,
+    product_bid: str,
+    provider_account_id: str,
+    provider_product_id: str,
+    provider_price_id: str,
+    livemode: bool,
+    metadata_json: str,
+) -> dict[str, Any]:
+    try:
+        with unit_of_work():
+            mapping, created = upsert_provider_price_mapping(
+                product_bid=product_bid,
+                provider_account_id=provider_account_id,
+                provider_product_id=provider_product_id,
+                provider_price_id=provider_price_id,
+                livemode=livemode,
+                metadata=_parse_optional_json_object(
+                    metadata_json,
+                    option_name="metadata-json",
+                ),
+            )
+            payload = {
+                "status": "bound",
+                "created": created,
+                "mapping": serialize_provider_price_mapping(mapping),
+            }
+    except ProviderPriceMappingError as exc:
+        raise click.ClickException(_format_provider_price_mapping_error(exc)) from exc
+    return payload
+
+
+def activate_cli_provider_price_mapping(provider_price_bid: str) -> dict[str, Any]:
+    try:
+        with unit_of_work():
+            summary = activate_provider_price_mapping(provider_price_bid)
+            payload = {
+                "status": "activated" if summary.valid else "invalid",
+                "validation": _provider_price_validation_payload(summary),
+            }
+    except ProviderPriceMappingError as exc:
+        raise click.ClickException(_format_provider_price_mapping_error(exc)) from exc
+    return payload
+
+
+def retire_cli_provider_price_mapping(provider_price_bid: str) -> dict[str, Any]:
+    try:
+        with unit_of_work():
+            mapping = retire_provider_price_mapping(provider_price_bid)
+            payload = {
+                "status": "retired",
+                "mapping": serialize_provider_price_mapping(mapping),
+            }
+    except ProviderPriceMappingError as exc:
+        raise click.ClickException(_format_provider_price_mapping_error(exc)) from exc
+    return payload
+
+
+def validate_cli_provider_price_mapping(provider_price_bid: str) -> dict[str, Any]:
+    try:
+        with unit_of_work():
+            summary = validate_provider_price_mapping_by_bid(provider_price_bid)
+            payload = {
+                "status": "valid" if summary.valid else "invalid",
+                "validation": _provider_price_validation_payload(summary),
+            }
+    except ProviderPriceMappingError as exc:
+        raise click.ClickException(_format_provider_price_mapping_error(exc)) from exc
+    return payload
+
+
+def list_cli_provider_price_mappings(
+    *,
+    product_bid: str,
+    provider_account_id: str,
+    status_label: str,
+    livemode: bool | None,
+) -> dict[str, Any]:
+    normalized_status = str(status_label or "").strip().lower()
+    rows = list_provider_price_mappings(
+        product_bid=product_bid,
+        provider_account_id=provider_account_id,
+        livemode=livemode,
+        status=(
+            _PROVIDER_PRICE_STATUS_LABELS[normalized_status]
+            if normalized_status
+            else None
+        ),
+    )
+    return {
+        "status": "listed",
+        "count": len(rows),
+        "items": [serialize_provider_price_mapping(row) for row in rows],
+    }
+
+
+def inspect_cli_provider_price_mapping(provider_price_bid: str) -> dict[str, Any]:
+    try:
+        mapping = get_provider_price_mapping(provider_price_bid)
+        active_mapping = get_active_provider_price_mapping(
+            product_bid=mapping.product_bid,
+            provider=mapping.provider,
+            provider_account_id=mapping.provider_account_id,
+            livemode=bool(mapping.livemode),
+        )
+    except ProviderPriceMappingError as exc:
+        raise click.ClickException(_format_provider_price_mapping_error(exc)) from exc
+    return {
+        "status": "inspected",
+        "mapping": serialize_provider_price_mapping(mapping),
+        "active_mapping": serialize_provider_price_mapping(active_mapping),
+    }
+
+
+def _provider_price_validation_payload(summary) -> dict[str, Any]:
+    return {
+        "valid": summary.valid,
+        "errors": summary.errors,
+        "warnings": summary.warnings,
+        "mapping": summary.mapping,
+    }
+
+
+def _format_provider_price_mapping_error(exc: ProviderPriceMappingError) -> str:
+    return json.dumps(
+        {"code": exc.code, "message": exc.message},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 @contextmanager

--- a/src/api/flaskr/service/billing/provider_price_mappings.py
+++ b/src/api/flaskr/service/billing/provider_price_mappings.py
@@ -19,7 +19,7 @@ from .consts import (
     BILLING_PROVIDER_PRICE_STATUS_RETIRED,
 )
 from .models import BillingProduct, BillingProductProviderPrice
-from .primitives import normalize_bid, normalize_json_value
+from .primitives import normalize_bid, normalize_json_object
 from .provider_catalog import (
     ProviderCatalogReadError,
     ProviderCatalogSnapshot,
@@ -53,6 +53,7 @@ def serialize_provider_price_mapping(
 ) -> dict[str, Any] | None:
     if mapping is None:
         return None
+    metadata = normalize_json_object(mapping.metadata_json or {})
     return {
         "provider_price_bid": mapping.provider_price_bid,
         "product_bid": mapping.product_bid,
@@ -74,7 +75,7 @@ def serialize_provider_price_mapping(
         "activated_at": to_utc_iso(mapping.activated_at),
         "retired_at": to_utc_iso(mapping.retired_at),
         "validation_error": mapping.validation_error or "",
-        "metadata": normalize_json_value(mapping.metadata_json or {}),
+        "metadata": metadata.to_metadata_json(),
     }
 
 
@@ -195,6 +196,15 @@ def upsert_provider_price_mapping(
             "Active provider price mappings cannot be rebound; retire them first",
             {"provider_price_bid": row.provider_price_bid},
         )
+    elif int(row.status or 0) in {
+        BILLING_PROVIDER_PRICE_STATUS_INVALID,
+        BILLING_PROVIDER_PRICE_STATUS_RETIRED,
+    }:
+        row.status = BILLING_PROVIDER_PRICE_STATUS_DRAFT
+        row.validated_at = None
+        row.activated_at = None
+        row.retired_at = None
+        row.validation_error = ""
 
     row.product_bid = product.product_bid
     row.provider = normalized_provider

--- a/src/api/flaskr/service/billing/provider_price_mappings.py
+++ b/src/api/flaskr/service/billing/provider_price_mappings.py
@@ -1,0 +1,457 @@
+"""Lifecycle helpers for billing product provider price mappings."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from flask import current_app
+from flaskr.dao import db
+from flaskr.util.datetime import now_utc, to_utc_iso
+from flaskr.util.uuid import generate_id
+
+from .consts import (
+    BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+    BILLING_PROVIDER_PRICE_STATUS_DRAFT,
+    BILLING_PROVIDER_PRICE_STATUS_INVALID,
+    BILLING_PROVIDER_PRICE_STATUS_LABELS,
+    BILLING_PROVIDER_PRICE_STATUS_RETIRED,
+)
+from .models import BillingProduct, BillingProductProviderPrice
+from .primitives import normalize_bid, normalize_json_value
+from .provider_catalog import (
+    ProviderCatalogReadError,
+    ProviderCatalogSnapshot,
+    StripeCatalogReadAdapter,
+    validate_provider_price_mapping,
+)
+
+PROVIDER_STRIPE = "stripe"
+
+
+@dataclass(slots=True)
+class ProviderPriceMappingError(RuntimeError):
+    code: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(slots=True)
+class ProviderPriceMappingValidationSummary:
+    valid: bool
+    errors: list[dict[str, str]] = field(default_factory=list)
+    warnings: list[dict[str, str]] = field(default_factory=list)
+    mapping: dict[str, Any] | None = None
+
+
+def serialize_provider_price_mapping(
+    mapping: BillingProductProviderPrice | None,
+) -> dict[str, Any] | None:
+    if mapping is None:
+        return None
+    return {
+        "provider_price_bid": mapping.provider_price_bid,
+        "product_bid": mapping.product_bid,
+        "provider": mapping.provider,
+        "provider_account_id": mapping.provider_account_id,
+        "provider_product_id": mapping.provider_product_id,
+        "provider_price_id": mapping.provider_price_id,
+        "livemode": bool(mapping.livemode),
+        "currency": mapping.currency,
+        "unit_amount": int(mapping.unit_amount or 0),
+        "billing_mode": int(mapping.billing_mode or 0),
+        "billing_interval": int(mapping.billing_interval or 0),
+        "billing_interval_count": int(mapping.billing_interval_count or 0),
+        "status": int(mapping.status or 0),
+        "status_label": BILLING_PROVIDER_PRICE_STATUS_LABELS.get(
+            int(mapping.status or 0), "unknown"
+        ),
+        "validated_at": to_utc_iso(mapping.validated_at),
+        "activated_at": to_utc_iso(mapping.activated_at),
+        "retired_at": to_utc_iso(mapping.retired_at),
+        "validation_error": mapping.validation_error or "",
+        "metadata": normalize_json_value(mapping.metadata_json or {}),
+    }
+
+
+def list_provider_price_mappings(
+    *,
+    product_bid: str = "",
+    provider: str = PROVIDER_STRIPE,
+    provider_account_id: str = "",
+    livemode: bool | None = None,
+    status: int | None = None,
+) -> list[BillingProductProviderPrice]:
+    query = BillingProductProviderPrice.query.filter(
+        BillingProductProviderPrice.deleted == 0,
+        BillingProductProviderPrice.provider == _normalize_provider(provider),
+    )
+    normalized_product_bid = normalize_bid(product_bid)
+    if normalized_product_bid:
+        query = query.filter(
+            BillingProductProviderPrice.product_bid == normalized_product_bid
+        )
+    normalized_account_id = normalize_bid(provider_account_id)
+    if normalized_account_id:
+        query = query.filter(
+            BillingProductProviderPrice.provider_account_id == normalized_account_id
+        )
+    if livemode is not None:
+        query = query.filter(
+            BillingProductProviderPrice.livemode == int(bool(livemode))
+        )
+    if status is not None:
+        query = query.filter(BillingProductProviderPrice.status == int(status))
+    return query.order_by(
+        BillingProductProviderPrice.product_bid.asc(),
+        BillingProductProviderPrice.status.asc(),
+        BillingProductProviderPrice.updated_at.desc(),
+        BillingProductProviderPrice.id.desc(),
+    ).all()
+
+
+def get_provider_price_mapping(
+    provider_price_bid: str,
+) -> BillingProductProviderPrice:
+    return _load_mapping(provider_price_bid)
+
+
+def get_active_provider_price_mapping(
+    *,
+    product_bid: str,
+    provider: str = PROVIDER_STRIPE,
+    provider_account_id: str,
+    livemode: bool,
+) -> BillingProductProviderPrice | None:
+    rows = (
+        BillingProductProviderPrice.query.filter(
+            BillingProductProviderPrice.deleted == 0,
+            BillingProductProviderPrice.product_bid == normalize_bid(product_bid),
+            BillingProductProviderPrice.provider == _normalize_provider(provider),
+            BillingProductProviderPrice.provider_account_id
+            == normalize_bid(provider_account_id),
+            BillingProductProviderPrice.livemode == int(bool(livemode)),
+            BillingProductProviderPrice.status == BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+        )
+        .order_by(BillingProductProviderPrice.id.asc())
+        .limit(2)
+        .all()
+    )
+    return _select_single_active_mapping(rows, product_bid=normalize_bid(product_bid))
+
+
+def _select_single_active_mapping(
+    rows: list[BillingProductProviderPrice],
+    *,
+    product_bid: str,
+) -> BillingProductProviderPrice | None:
+    if len(rows) > 1:
+        raise ProviderPriceMappingError(
+            "multiple_active_provider_prices",
+            "Multiple active provider price mappings found for the same product scope",
+            {"product_bid": product_bid},
+        )
+    return rows[0] if rows else None
+
+
+def upsert_provider_price_mapping(
+    *,
+    product_bid: str,
+    provider_account_id: str,
+    provider_product_id: str,
+    provider_price_id: str,
+    livemode: bool,
+    provider: str = PROVIDER_STRIPE,
+    metadata: dict[str, Any] | None = None,
+) -> tuple[BillingProductProviderPrice, bool]:
+    product = _load_product(product_bid)
+    normalized_provider = _normalize_provider(provider)
+    normalized_account_id = _require_value(provider_account_id, "provider_account_id")
+    normalized_product_id = _require_value(provider_product_id, "provider_product_id")
+    normalized_price_id = _require_value(provider_price_id, "provider_price_id")
+    normalized_livemode = int(bool(livemode))
+
+    row = _load_mapping_by_provider_price(
+        provider=normalized_provider,
+        provider_account_id=normalized_account_id,
+        livemode=normalized_livemode,
+        provider_price_id=normalized_price_id,
+    )
+    created = row is None
+    if row is None:
+        row = BillingProductProviderPrice(
+            provider_price_bid=generate_id(current_app),
+            status=BILLING_PROVIDER_PRICE_STATUS_DRAFT,
+            deleted=0,
+        )
+        db.session.add(row)
+    elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_ACTIVE:
+        raise ProviderPriceMappingError(
+            "active_mapping_cannot_be_rebound",
+            "Active provider price mappings cannot be rebound; retire them first",
+            {"provider_price_bid": row.provider_price_bid},
+        )
+
+    row.product_bid = product.product_bid
+    row.provider = normalized_provider
+    row.provider_account_id = normalized_account_id
+    row.provider_product_id = normalized_product_id
+    row.provider_price_id = normalized_price_id
+    row.livemode = normalized_livemode
+    row.currency = str(product.currency or "").strip().upper()
+    row.unit_amount = int(product.price_amount or 0)
+    row.billing_mode = int(product.billing_mode or 0)
+    row.billing_interval = int(product.billing_interval or 0)
+    row.billing_interval_count = int(product.billing_interval_count or 0)
+    row.metadata_json = dict(metadata or {})
+    row.deleted = 0
+    db.session.flush()
+    return row, created
+
+
+def validate_provider_price_mapping_row(
+    mapping: BillingProductProviderPrice,
+    *,
+    adapter: StripeCatalogReadAdapter | None = None,
+) -> tuple[ProviderPriceMappingValidationSummary, ProviderCatalogSnapshot | None]:
+    product = _load_product(mapping.product_bid)
+    reader = adapter or StripeCatalogReadAdapter()
+    try:
+        snapshot = reader.retrieve_mapping_snapshot(
+            current_app,
+            provider_product_id=mapping.provider_product_id,
+            provider_price_id=mapping.provider_price_id,
+        )
+    except ProviderCatalogReadError as exc:
+        summary = ProviderPriceMappingValidationSummary(
+            valid=False,
+            errors=[{"code": exc.code, "message": str(exc)}],
+            warnings=[],
+            mapping=serialize_provider_price_mapping(mapping),
+        )
+        return summary, None
+
+    result = validate_provider_price_mapping(
+        product,
+        snapshot,
+        expected_provider_account_id=mapping.provider_account_id,
+        expected_livemode=bool(mapping.livemode),
+        expected_provider_product_id=mapping.provider_product_id,
+        expected_provider_price_id=mapping.provider_price_id,
+    )
+    summary = ProviderPriceMappingValidationSummary(
+        valid=result.valid,
+        errors=_serialize_validation_issues(result.errors),
+        warnings=_serialize_validation_issues(result.warnings),
+        mapping=serialize_provider_price_mapping(mapping),
+    )
+    return summary, snapshot
+
+
+def validate_provider_price_mapping_by_bid(
+    provider_price_bid: str,
+    *,
+    adapter: StripeCatalogReadAdapter | None = None,
+) -> ProviderPriceMappingValidationSummary:
+    mapping = _load_mapping(provider_price_bid)
+    summary, snapshot = validate_provider_price_mapping_row(mapping, adapter=adapter)
+    _apply_validation_result(mapping, summary, snapshot)
+    db.session.flush()
+    summary.mapping = serialize_provider_price_mapping(mapping)
+    return summary
+
+
+def activate_provider_price_mapping(
+    provider_price_bid: str,
+    *,
+    adapter: StripeCatalogReadAdapter | None = None,
+) -> ProviderPriceMappingValidationSummary:
+    mapping = _load_mapping(provider_price_bid)
+    summary, snapshot = validate_provider_price_mapping_row(mapping, adapter=adapter)
+    if not summary.valid:
+        mapping.validated_at = now_utc()
+        if snapshot is not None:
+            _apply_provider_snapshot(mapping, snapshot)
+        if int(mapping.status or 0) != BILLING_PROVIDER_PRICE_STATUS_ACTIVE:
+            mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
+        mapping.validation_error = _validation_summary_error_text(summary)
+        db.session.flush()
+        summary.mapping = serialize_provider_price_mapping(mapping)
+        return summary
+
+    now = now_utc()
+    active_rows = _load_active_rows_for_mapping_scope(mapping)
+    for row in active_rows:
+        if row.provider_price_bid == mapping.provider_price_bid:
+            continue
+        row.status = BILLING_PROVIDER_PRICE_STATUS_RETIRED
+        row.retired_at = now
+        row.validation_error = ""
+    if active_rows:
+        db.session.flush()
+
+    mapping.status = BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+    mapping.validated_at = now
+    mapping.activated_at = mapping.activated_at or now
+    mapping.retired_at = None
+    mapping.validation_error = _validation_summary_warning_text(summary)
+    if snapshot is not None:
+        _apply_provider_snapshot(mapping, snapshot)
+    db.session.flush()
+    summary.mapping = serialize_provider_price_mapping(mapping)
+    return summary
+
+
+def retire_provider_price_mapping(
+    provider_price_bid: str,
+) -> BillingProductProviderPrice:
+    mapping = _load_mapping(provider_price_bid)
+    if int(mapping.status or 0) != BILLING_PROVIDER_PRICE_STATUS_RETIRED:
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_RETIRED
+        mapping.retired_at = now_utc()
+        mapping.validation_error = ""
+    db.session.flush()
+    return mapping
+
+
+def _load_product(product_bid: str) -> BillingProduct:
+    normalized_product_bid = _require_value(product_bid, "product_bid")
+    product = BillingProduct.query.filter(
+        BillingProduct.deleted == 0,
+        BillingProduct.product_bid == normalized_product_bid,
+    ).one_or_none()
+    if product is None:
+        raise ProviderPriceMappingError(
+            "billing_product_not_found",
+            "Billing product not found",
+            {"product_bid": normalized_product_bid},
+        )
+    return product
+
+
+def _load_mapping(provider_price_bid: str) -> BillingProductProviderPrice:
+    normalized_bid = _require_value(provider_price_bid, "provider_price_bid")
+    mapping = BillingProductProviderPrice.query.filter(
+        BillingProductProviderPrice.deleted == 0,
+        BillingProductProviderPrice.provider_price_bid == normalized_bid,
+    ).one_or_none()
+    if mapping is None:
+        raise ProviderPriceMappingError(
+            "provider_price_mapping_not_found",
+            "Provider price mapping not found",
+            {"provider_price_bid": normalized_bid},
+        )
+    return mapping
+
+
+def _load_mapping_by_provider_price(
+    *,
+    provider: str,
+    provider_account_id: str,
+    livemode: int,
+    provider_price_id: str,
+) -> BillingProductProviderPrice | None:
+    return BillingProductProviderPrice.query.filter(
+        BillingProductProviderPrice.deleted == 0,
+        BillingProductProviderPrice.provider == provider,
+        BillingProductProviderPrice.provider_account_id == provider_account_id,
+        BillingProductProviderPrice.livemode == int(livemode),
+        BillingProductProviderPrice.provider_price_id == provider_price_id,
+    ).one_or_none()
+
+
+def _load_active_rows_for_mapping_scope(
+    mapping: BillingProductProviderPrice,
+) -> list[BillingProductProviderPrice]:
+    return BillingProductProviderPrice.query.filter(
+        BillingProductProviderPrice.deleted == 0,
+        BillingProductProviderPrice.product_bid == mapping.product_bid,
+        BillingProductProviderPrice.provider == mapping.provider,
+        BillingProductProviderPrice.provider_account_id == mapping.provider_account_id,
+        BillingProductProviderPrice.livemode == int(mapping.livemode or 0),
+        BillingProductProviderPrice.status == BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+    ).all()
+
+
+def _apply_provider_snapshot(
+    mapping: BillingProductProviderPrice,
+    snapshot: ProviderCatalogSnapshot,
+) -> None:
+    mapping.currency = snapshot.price.currency.upper()
+    mapping.unit_amount = int(snapshot.price.unit_amount or 0)
+
+
+def _apply_validation_result(
+    mapping: BillingProductProviderPrice,
+    summary: ProviderPriceMappingValidationSummary,
+    snapshot: ProviderCatalogSnapshot | None,
+) -> None:
+    mapping.validated_at = now_utc()
+    if snapshot is not None:
+        _apply_provider_snapshot(mapping, snapshot)
+    mapping.validation_error = (
+        _validation_summary_warning_text(summary)
+        if summary.valid
+        else _validation_summary_error_text(summary)
+    )
+    if (
+        not summary.valid
+        and int(mapping.status or 0) != BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+    ):
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
+
+
+def _validation_summary_error_text(
+    summary: ProviderPriceMappingValidationSummary,
+) -> str:
+    return _safe_issue_summary(summary.errors)
+
+
+def _validation_summary_warning_text(
+    summary: ProviderPriceMappingValidationSummary,
+) -> str:
+    return _safe_issue_summary(summary.warnings)
+
+
+def _safe_issue_summary(issues: list[dict[str, str]]) -> str:
+    if not issues:
+        return ""
+    return json.dumps(
+        [{"code": issue.get("code", "")} for issue in issues],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _serialize_validation_issues(issues) -> list[dict[str, str]]:
+    return [
+        {
+            "code": issue.code,
+            "message": issue.message,
+            "expected": issue.expected,
+            "actual": issue.actual,
+        }
+        for issue in issues
+    ]
+
+
+def _normalize_provider(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized != PROVIDER_STRIPE:
+        raise ProviderPriceMappingError(
+            "unsupported_provider",
+            "Only Stripe provider price mappings are supported",
+            {"provider": normalized},
+        )
+    return normalized
+
+
+def _require_value(value: str, name: str) -> str:
+    normalized = normalize_bid(value)
+    if not normalized:
+        raise ProviderPriceMappingError(f"{name}_required", f"{name} is required")
+    return normalized

--- a/src/api/flaskr/service/billing/provider_price_mappings.py
+++ b/src/api/flaskr/service/billing/provider_price_mappings.py
@@ -190,16 +190,29 @@ def upsert_provider_price_mapping(
             deleted=0,
         )
         db.session.add(row)
+    elif row.product_bid and row.product_bid != product.product_bid:
+        raise ProviderPriceMappingError(
+            "provider_price_product_mismatch",
+            "Provider price mappings cannot be rebound to a different product",
+            {
+                "provider_price_bid": row.provider_price_bid,
+                "existing_product_bid": row.product_bid,
+                "requested_product_bid": product.product_bid,
+            },
+        )
     elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_ACTIVE:
         raise ProviderPriceMappingError(
             "active_mapping_cannot_be_rebound",
             "Active provider price mappings cannot be rebound; retire them first",
             {"provider_price_bid": row.provider_price_bid},
         )
-    elif int(row.status or 0) in {
-        BILLING_PROVIDER_PRICE_STATUS_INVALID,
-        BILLING_PROVIDER_PRICE_STATUS_RETIRED,
-    }:
+    elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_RETIRED:
+        raise ProviderPriceMappingError(
+            "retired_mapping_cannot_be_rebound",
+            "Retired provider price mappings cannot be rebound; create a new provider price instead",
+            {"provider_price_bid": row.provider_price_bid},
+        )
+    elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_INVALID:
         row.status = BILLING_PROVIDER_PRICE_STATUS_DRAFT
         row.validated_at = None
         row.activated_at = None
@@ -286,8 +299,7 @@ def activate_provider_price_mapping(
         mapping.validated_at = now_utc()
         if snapshot is not None:
             _apply_provider_snapshot(mapping, snapshot)
-        if int(mapping.status or 0) != BILLING_PROVIDER_PRICE_STATUS_ACTIVE:
-            mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
         mapping.validation_error = _validation_summary_error_text(summary)
         db.session.flush()
         summary.mapping = serialize_provider_price_mapping(mapping)
@@ -408,10 +420,7 @@ def _apply_validation_result(
         if summary.valid
         else _validation_summary_error_text(summary)
     )
-    if (
-        not summary.valid
-        and int(mapping.status or 0) != BILLING_PROVIDER_PRICE_STATUS_ACTIVE
-    ):
+    if not summary.valid:
         mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
 
 

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -2071,9 +2071,12 @@ def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
     provider_price_bid = first_payload["mapping"]["provider_price_bid"]
 
     assert first_payload["created"] is True
+    assert first_payload["mapping"]["metadata"] == {"operator": "qa"}
     assert second_payload["created"] is False
     assert second_payload["mapping"]["provider_price_bid"] == provider_price_bid
+    assert second_payload["mapping"]["metadata"] == {"operator": "qa"}
     assert list_payload["count"] == 1
+    assert list_payload["items"][0]["metadata"] == {"operator": "qa"}
     assert "sk_test" not in list_result.output
 
     inspect_result = runner.invoke(
@@ -2099,7 +2102,11 @@ def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
 
     assert inspect_result.exit_code == 0
     assert retire_result.exit_code == 0
+    assert json.loads(inspect_result.output)["mapping"]["metadata"] == {
+        "operator": "qa"
+    }
     assert json.loads(retire_result.output)["mapping"]["status_label"] == "retired"
+    assert json.loads(retire_result.output)["mapping"]["metadata"] == {"operator": "qa"}
 
     with billing_cli_db_app.app_context():
         mapping = BillingProductProviderPrice.query.filter_by(

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -30,6 +30,7 @@ from flaskr.service.billing.models import (
     BillingDailyUsageMetric,
     BillingOrder,
     BillingProduct,
+    BillingProductProviderPrice,
     BillingRenewalEvent,
     BillingSubscription,
     CreditLedgerEntry,
@@ -1982,3 +1983,127 @@ def test_billing_upsert_product_cli_allows_manual_custom_product_values(
             "segment": "enterprise",
         }
         assert product.entitlement_payload == {"support_tier": "priority"}
+
+
+def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
+    billing_cli_db_app: Flask,
+) -> None:
+    runner = billing_cli_db_app.test_cli_runner()
+    product_args = [
+        "console",
+        "billing",
+        "upsert-product",
+        "--product-bid",
+        "bill-product-provider-price-cli",
+        "--product-code",
+        "creator-global-growth-monthly",
+        "--product-type",
+        "plan",
+        "--billing-mode",
+        "recurring",
+        "--billing-interval",
+        "month",
+        "--billing-interval-count",
+        "1",
+        "--display-name-i18n-key",
+        "module.billing.catalog.growth.title",
+        "--description-i18n-key",
+        "module.billing.catalog.growth.description",
+        "--currency",
+        "usd",
+        "--price-amount",
+        "5900",
+        "--credit-amount",
+        "1000",
+        "--allocation-interval",
+        "per_cycle",
+        "--auto-renew-enabled",
+        "1",
+        "--status",
+        "active",
+        "--sort-order",
+        "20",
+        "--entitlement-json",
+        "{}",
+        "--metadata-json",
+        '{"plan_tier":"growth"}',
+    ]
+    bind_args = [
+        "console",
+        "billing",
+        "provider-price",
+        "bind",
+        "--product-bid",
+        "bill-product-provider-price-cli",
+        "--provider-account-id",
+        "acct_test",
+        "--provider-product-id",
+        "prod_growth",
+        "--provider-price-id",
+        "price_growth_month_cli",
+        "--testmode",
+        "--metadata-json",
+        '{"operator":"qa"}',
+    ]
+
+    seed_result = runner.invoke(args=product_args)
+    first_bind = runner.invoke(args=bind_args)
+    second_bind = runner.invoke(args=bind_args)
+    list_result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "provider-price",
+            "list",
+            "--product-bid",
+            "bill-product-provider-price-cli",
+        ]
+    )
+
+    assert seed_result.exit_code == 0
+    assert first_bind.exit_code == 0
+    assert second_bind.exit_code == 0
+    assert list_result.exit_code == 0
+
+    first_payload = json.loads(first_bind.output)
+    second_payload = json.loads(second_bind.output)
+    list_payload = json.loads(list_result.output)
+    provider_price_bid = first_payload["mapping"]["provider_price_bid"]
+
+    assert first_payload["created"] is True
+    assert second_payload["created"] is False
+    assert second_payload["mapping"]["provider_price_bid"] == provider_price_bid
+    assert list_payload["count"] == 1
+    assert "sk_test" not in list_result.output
+
+    inspect_result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "provider-price",
+            "inspect",
+            "--provider-price-bid",
+            provider_price_bid,
+        ]
+    )
+    retire_result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "provider-price",
+            "retire",
+            "--provider-price-bid",
+            provider_price_bid,
+        ]
+    )
+
+    assert inspect_result.exit_code == 0
+    assert retire_result.exit_code == 0
+    assert json.loads(retire_result.output)["mapping"]["status_label"] == "retired"
+
+    with billing_cli_db_app.app_context():
+        mapping = BillingProductProviderPrice.query.filter_by(
+            provider_price_bid=provider_price_bid
+        ).one()
+        assert mapping.provider_price_id == "price_growth_month_cli"
+        assert mapping.retired_at is not None

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 import pytest
 from flask import Flask
 from flaskr import dao
+from flaskr.service.billing import cli as billing_cli_module
 from flaskr.service.billing import notifications as billing_notifications
 from flaskr.service.billing.cli import register_billing_commands
 from flaskr.service.billing.consts import (
@@ -2060,11 +2061,24 @@ def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
             "bill-product-provider-price-cli",
         ]
     )
+    live_list_result = runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "provider-price",
+            "list",
+            "--product-bid",
+            "bill-product-provider-price-cli",
+            "--mode",
+            "live",
+        ]
+    )
 
     assert seed_result.exit_code == 0
     assert first_bind.exit_code == 0
     assert second_bind.exit_code == 0
     assert list_result.exit_code == 0
+    assert live_list_result.exit_code == 0
 
     first_payload = json.loads(first_bind.output)
     second_payload = json.loads(second_bind.output)
@@ -2078,6 +2092,7 @@ def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
     assert second_payload["mapping"]["metadata"] == {"operator": "qa"}
     assert list_payload["count"] == 1
     assert list_payload["items"][0]["metadata"] == {"operator": "qa"}
+    assert json.loads(live_list_result.output)["count"] == 0
     assert "sk_test" not in list_result.output
 
     inspect_result = runner.invoke(
@@ -2115,3 +2130,35 @@ def test_billing_provider_price_cli_binds_lists_and_retires_mapping(
         ).one()
         assert mapping.provider_price_id == "price_growth_month_cli"
         assert mapping.retired_at is not None
+
+
+@pytest.mark.parametrize("command", ["validate", "activate"])
+def test_billing_provider_price_cli_invalid_validation_exits_nonzero(
+    billing_cli_runner,
+    monkeypatch,
+    command: str,
+) -> None:
+    def _invalid_payload(provider_price_bid: str) -> dict[str, object]:
+        assert provider_price_bid == "provider-price-invalid"
+        return {"status": "invalid", "validation": {"valid": False}}
+
+    target_name = (
+        "validate_cli_provider_price_mapping"
+        if command == "validate"
+        else "activate_cli_provider_price_mapping"
+    )
+    monkeypatch.setattr(billing_cli_module, target_name, _invalid_payload)
+
+    result = billing_cli_runner.invoke(
+        args=[
+            "console",
+            "billing",
+            "provider-price",
+            command,
+            "--provider-price-bid",
+            "provider-price-invalid",
+        ]
+    )
+
+    assert result.exit_code == 1
+    assert json.loads(result.output)["status"] == "invalid"

--- a/src/api/tests/service/billing/test_provider_price_mappings.py
+++ b/src/api/tests/service/billing/test_provider_price_mappings.py
@@ -31,6 +31,7 @@ from flaskr.service.billing.provider_price_mappings import (
     upsert_provider_price_mapping,
     validate_provider_price_mapping_by_bid,
 )
+from flaskr.util.datetime import now_utc
 
 
 class _FakeStripeCatalogAdapter(StripeCatalogReadAdapter):
@@ -169,6 +170,54 @@ def test_provider_price_mapping_upsert_is_idempotent(app) -> None:
             ).count()
             == 1
         )
+
+
+@pytest.mark.parametrize(
+    "stale_status",
+    [
+        BILLING_PROVIDER_PRICE_STATUS_INVALID,
+        BILLING_PROVIDER_PRICE_STATUS_RETIRED,
+    ],
+)
+def test_provider_price_mapping_rebind_resets_inactive_lifecycle_state(
+    app,
+    stale_status: int,
+) -> None:
+    product_bid = f"bill-product-mapping-rebind-{stale_status}"
+    with app.app_context():
+        db.session.add(_product(product_bid))
+        db.session.commit()
+        mapping = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id=f"price_rebind_{stale_status}",
+        )
+        stale_time = now_utc()
+        mapping.status = stale_status
+        mapping.validated_at = stale_time
+        mapping.activated_at = stale_time
+        mapping.retired_at = stale_time
+        mapping.validation_error = "stale validation result"
+        db.session.commit()
+
+        rebound, created = upsert_provider_price_mapping(
+            product_bid=product_bid,
+            provider_account_id="acct_test",
+            provider_product_id="prod_growth_updated",
+            provider_price_id=f"price_rebind_{stale_status}",
+            livemode=False,
+            metadata={"source": "rebound"},
+        )
+        db.session.commit()
+
+        assert created is False
+        assert rebound.provider_price_bid == mapping.provider_price_bid
+        assert rebound.status == BILLING_PROVIDER_PRICE_STATUS_DRAFT
+        assert rebound.validated_at is None
+        assert rebound.activated_at is None
+        assert rebound.retired_at is None
+        assert rebound.validation_error == ""
+        assert rebound.provider_product_id == "prod_growth_updated"
+        assert rebound.metadata_json == {"source": "rebound"}
 
 
 def test_provider_price_activation_retires_existing_active_mapping(app) -> None:

--- a/src/api/tests/service/billing/test_provider_price_mappings.py
+++ b/src/api/tests/service/billing/test_provider_price_mappings.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from flask import Flask
+from flaskr.dao import db
+from flaskr.service.billing.consts import (
+    BILLING_INTERVAL_MONTH,
+    BILLING_MODE_RECURRING,
+    BILLING_PRODUCT_STATUS_ACTIVE,
+    BILLING_PRODUCT_TYPE_PLAN,
+    BILLING_PROVIDER_PRICE_STATUS_ACTIVE,
+    BILLING_PROVIDER_PRICE_STATUS_DRAFT,
+    BILLING_PROVIDER_PRICE_STATUS_INVALID,
+    BILLING_PROVIDER_PRICE_STATUS_RETIRED,
+)
+from flaskr.service.billing.models import BillingProduct, BillingProductProviderPrice
+from flaskr.service.billing.provider_catalog import (
+    ProviderAccountSnapshot,
+    ProviderCatalogSnapshot,
+    ProviderPriceSnapshot,
+    ProviderProductSnapshot,
+    StripeCatalogReadAdapter,
+)
+from flaskr.service.billing.provider_price_mappings import (
+    ProviderPriceMappingError,
+    _select_single_active_mapping,
+    activate_provider_price_mapping,
+    get_active_provider_price_mapping,
+    upsert_provider_price_mapping,
+    validate_provider_price_mapping_by_bid,
+)
+
+
+class _FakeStripeCatalogAdapter(StripeCatalogReadAdapter):
+    def __init__(self, snapshot: ProviderCatalogSnapshot) -> None:
+        self.snapshot = snapshot
+        self.calls: list[dict[str, str]] = []
+
+    def retrieve_mapping_snapshot(
+        self,
+        app: Flask,
+        *,
+        provider_product_id: str,
+        provider_price_id: str,
+    ) -> ProviderCatalogSnapshot:
+        self.calls.append(
+            {
+                "provider_product_id": provider_product_id,
+                "provider_price_id": provider_price_id,
+            }
+        )
+        return self.snapshot
+
+
+def _product(product_bid: str = "bill-product-mapping-growth") -> BillingProduct:
+    product_code_suffix = product_bid.removeprefix("bill-product-mapping-")
+    return BillingProduct(
+        product_bid=product_bid,
+        product_code=f"creator-global-growth-{product_code_suffix}",
+        product_type=BILLING_PRODUCT_TYPE_PLAN,
+        billing_mode=BILLING_MODE_RECURRING,
+        billing_interval=BILLING_INTERVAL_MONTH,
+        billing_interval_count=1,
+        display_name_i18n_key="module.billing.catalog.growth.title",
+        description_i18n_key="module.billing.catalog.growth.description",
+        currency="USD",
+        price_amount=5900,
+        credit_amount=Decimal(1000),
+        status=BILLING_PRODUCT_STATUS_ACTIVE,
+        sort_order=20,
+        metadata_json={"plan_tier": "growth"},
+        deleted=0,
+    )
+
+
+def _snapshot(
+    *,
+    account_id: str = "acct_test",
+    product_id: str = "prod_growth",
+    price_id: str = "price_growth_month",
+    price_product_id: str = "prod_growth",
+    unit_amount: int = 5900,
+    currency: str = "usd",
+    product_code: str = "creator-global-growth-monthly",
+) -> ProviderCatalogSnapshot:
+    return ProviderCatalogSnapshot(
+        account=ProviderAccountSnapshot(provider="stripe", account_id=account_id),
+        product=ProviderProductSnapshot(
+            provider="stripe",
+            product_id=product_id,
+            active=True,
+            livemode=False,
+            metadata={
+                "market": "global",
+                "plan_tier": "growth",
+                "product_type": "plan",
+            },
+        ),
+        price=ProviderPriceSnapshot(
+            provider="stripe",
+            price_id=price_id,
+            product_id=price_product_id,
+            active=True,
+            livemode=False,
+            currency=currency,
+            unit_amount=unit_amount,
+            price_type="recurring",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            recurring_usage_type="licensed",
+            metadata={
+                "product_code": product_code,
+                "credit_amount": "1000",
+                "billing_interval": "month",
+            },
+        ),
+    )
+
+
+def _bind_mapping(
+    *,
+    product_bid: str = "bill-product-mapping-growth",
+    provider_price_id: str = "price_growth_month",
+    provider_product_id: str = "prod_growth",
+) -> BillingProductProviderPrice:
+    mapping, _ = upsert_provider_price_mapping(
+        product_bid=product_bid,
+        provider_account_id="acct_test",
+        provider_product_id=provider_product_id,
+        provider_price_id=provider_price_id,
+        livemode=False,
+    )
+    return mapping
+
+
+def test_provider_price_mapping_upsert_is_idempotent(app) -> None:
+    product_bid = "bill-product-mapping-idempotent"
+    with app.app_context():
+        db.session.add(_product(product_bid))
+        db.session.commit()
+
+        first, first_created = upsert_provider_price_mapping(
+            product_bid=product_bid,
+            provider_account_id="acct_test",
+            provider_product_id="prod_growth",
+            provider_price_id="price_mapping_idempotent",
+            livemode=False,
+            metadata={"source": "first"},
+        )
+        second, second_created = upsert_provider_price_mapping(
+            product_bid=product_bid,
+            provider_account_id="acct_test",
+            provider_product_id="prod_growth",
+            provider_price_id="price_mapping_idempotent",
+            livemode=False,
+            metadata={"source": "second"},
+        )
+        db.session.commit()
+
+        assert first_created is True
+        assert second_created is False
+        assert second.provider_price_bid == first.provider_price_bid
+        assert second.metadata_json == {"source": "second"}
+        assert (
+            BillingProductProviderPrice.query.filter_by(
+                provider_price_id="price_mapping_idempotent"
+            ).count()
+            == 1
+        )
+
+
+def test_provider_price_activation_retires_existing_active_mapping(app) -> None:
+    product_bid = "bill-product-mapping-activate"
+    with app.app_context():
+        product = _product(product_bid)
+        db.session.add(product)
+        db.session.commit()
+
+        first = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_growth_month_old",
+        )
+        first.status = BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+        db.session.flush()
+        second = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_mapping_activate_current",
+        )
+        db.session.commit()
+
+        result = activate_provider_price_mapping(
+            second.provider_price_bid,
+            adapter=_FakeStripeCatalogAdapter(
+                _snapshot(
+                    price_id="price_mapping_activate_current",
+                    product_code=product.product_code,
+                )
+            ),
+        )
+        db.session.commit()
+
+        assert result.valid is True
+        assert first.status == BILLING_PROVIDER_PRICE_STATUS_RETIRED
+        assert second.status == BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+        assert second.validated_at is not None
+        assert (
+            get_active_provider_price_mapping(
+                product_bid=product_bid,
+                provider_account_id="acct_test",
+                livemode=False,
+            ).provider_price_bid
+            == second.provider_price_bid
+        )
+
+
+def test_provider_price_activation_failure_preserves_existing_active_mapping(
+    app,
+) -> None:
+    product_bid = "bill-product-mapping-activate-failure"
+    with app.app_context():
+        product = _product(product_bid)
+        db.session.add(product)
+        db.session.commit()
+
+        active = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_growth_month_active",
+        )
+        active.status = BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+        db.session.flush()
+        candidate = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_growth_month_failure",
+        )
+        db.session.commit()
+
+        result = activate_provider_price_mapping(
+            candidate.provider_price_bid,
+            adapter=_FakeStripeCatalogAdapter(
+                _snapshot(
+                    price_id="price_growth_month_failure",
+                    unit_amount=6900,
+                    product_code=product.product_code,
+                )
+            ),
+        )
+        db.session.commit()
+
+        assert result.valid is False
+        assert {issue["code"] for issue in result.errors} == {"unit_amount_mismatch"}
+        assert active.status == BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+        assert candidate.status == BILLING_PROVIDER_PRICE_STATUS_INVALID
+        assert (
+            get_active_provider_price_mapping(
+                product_bid=product_bid,
+                provider_account_id="acct_test",
+                livemode=False,
+            ).provider_price_bid
+            == active.provider_price_bid
+        )
+
+
+def test_provider_price_validate_keeps_valid_draft_as_draft(app) -> None:
+    product_bid = "bill-product-mapping-validate"
+    with app.app_context():
+        product = _product(product_bid)
+        db.session.add(product)
+        db.session.commit()
+        mapping = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_growth_month_validate",
+        )
+        db.session.commit()
+
+        result = validate_provider_price_mapping_by_bid(
+            mapping.provider_price_bid,
+            adapter=_FakeStripeCatalogAdapter(
+                _snapshot(
+                    price_id="price_growth_month_validate",
+                    product_code=product.product_code,
+                )
+            ),
+        )
+        db.session.commit()
+
+        assert result.valid is True
+        assert mapping.status == BILLING_PROVIDER_PRICE_STATUS_DRAFT
+        assert mapping.validated_at is not None
+        assert mapping.validation_error == ""
+
+
+def test_active_provider_price_selection_fails_closed_for_multiple_rows() -> None:
+    rows = [
+        BillingProductProviderPrice(provider_price_bid="provider-price-active-a"),
+        BillingProductProviderPrice(provider_price_bid="provider-price-active-b"),
+    ]
+
+    with pytest.raises(ProviderPriceMappingError) as exc_info:
+        _select_single_active_mapping(rows, product_bid="bill-product-corrupt")
+
+    assert exc_info.value.code == "multiple_active_provider_prices"

--- a/src/api/tests/service/billing/test_provider_price_mappings.py
+++ b/src/api/tests/service/billing/test_provider_price_mappings.py
@@ -172,27 +172,17 @@ def test_provider_price_mapping_upsert_is_idempotent(app) -> None:
         )
 
 
-@pytest.mark.parametrize(
-    "stale_status",
-    [
-        BILLING_PROVIDER_PRICE_STATUS_INVALID,
-        BILLING_PROVIDER_PRICE_STATUS_RETIRED,
-    ],
-)
-def test_provider_price_mapping_rebind_resets_inactive_lifecycle_state(
-    app,
-    stale_status: int,
-) -> None:
-    product_bid = f"bill-product-mapping-rebind-{stale_status}"
+def test_provider_price_mapping_rebind_resets_invalid_lifecycle_state(app) -> None:
+    product_bid = "bill-product-mapping-rebind-invalid"
     with app.app_context():
         db.session.add(_product(product_bid))
         db.session.commit()
         mapping = _bind_mapping(
             product_bid=product_bid,
-            provider_price_id=f"price_rebind_{stale_status}",
+            provider_price_id="price_rebind_invalid",
         )
         stale_time = now_utc()
-        mapping.status = stale_status
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
         mapping.validated_at = stale_time
         mapping.activated_at = stale_time
         mapping.retired_at = stale_time
@@ -203,7 +193,7 @@ def test_provider_price_mapping_rebind_resets_inactive_lifecycle_state(
             product_bid=product_bid,
             provider_account_id="acct_test",
             provider_product_id="prod_growth_updated",
-            provider_price_id=f"price_rebind_{stale_status}",
+            provider_price_id="price_rebind_invalid",
             livemode=False,
             metadata={"source": "rebound"},
         )
@@ -218,6 +208,64 @@ def test_provider_price_mapping_rebind_resets_inactive_lifecycle_state(
         assert rebound.validation_error == ""
         assert rebound.provider_product_id == "prod_growth_updated"
         assert rebound.metadata_json == {"source": "rebound"}
+
+
+def test_provider_price_mapping_rejects_retired_rebind(app) -> None:
+    product_bid = "bill-product-mapping-rebind-retired"
+    with app.app_context():
+        db.session.add(_product(product_bid))
+        db.session.commit()
+        mapping = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_rebind_retired",
+        )
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_RETIRED
+        mapping.retired_at = now_utc()
+        db.session.commit()
+
+        with pytest.raises(ProviderPriceMappingError) as exc_info:
+            upsert_provider_price_mapping(
+                product_bid=product_bid,
+                provider_account_id="acct_test",
+                provider_product_id="prod_growth_updated",
+                provider_price_id="price_rebind_retired",
+                livemode=False,
+            )
+
+        assert exc_info.value.code == "retired_mapping_cannot_be_rebound"
+        assert mapping.status == BILLING_PROVIDER_PRICE_STATUS_RETIRED
+        assert mapping.product_bid == product_bid
+        assert mapping.provider_product_id == "prod_growth"
+
+
+def test_provider_price_mapping_rejects_rebinding_price_to_different_product(
+    app,
+) -> None:
+    first_product_bid = "bill-product-mapping-price-original"
+    second_product_bid = "bill-product-mapping-price-other"
+    with app.app_context():
+        db.session.add(_product(first_product_bid))
+        db.session.add(_product(second_product_bid))
+        db.session.commit()
+        mapping = _bind_mapping(
+            product_bid=first_product_bid,
+            provider_price_id="price_rebind_other_product",
+        )
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_INVALID
+        db.session.commit()
+
+        with pytest.raises(ProviderPriceMappingError) as exc_info:
+            upsert_provider_price_mapping(
+                product_bid=second_product_bid,
+                provider_account_id="acct_test",
+                provider_product_id="prod_business",
+                provider_price_id="price_rebind_other_product",
+                livemode=False,
+            )
+
+        assert exc_info.value.code == "provider_price_product_mismatch"
+        assert mapping.product_bid == first_product_bid
+        assert mapping.provider_product_id == "prod_growth"
 
 
 def test_provider_price_activation_retires_existing_active_mapping(app) -> None:
@@ -338,6 +386,44 @@ def test_provider_price_validate_keeps_valid_draft_as_draft(app) -> None:
         assert mapping.status == BILLING_PROVIDER_PRICE_STATUS_DRAFT
         assert mapping.validated_at is not None
         assert mapping.validation_error == ""
+
+
+def test_active_provider_price_validate_failure_invalidates_mapping(app) -> None:
+    product_bid = "bill-product-mapping-active-invalid"
+    with app.app_context():
+        product = _product(product_bid)
+        db.session.add(product)
+        db.session.commit()
+        mapping = _bind_mapping(
+            product_bid=product_bid,
+            provider_price_id="price_active_invalid",
+        )
+        mapping.status = BILLING_PROVIDER_PRICE_STATUS_ACTIVE
+        db.session.commit()
+
+        result = validate_provider_price_mapping_by_bid(
+            mapping.provider_price_bid,
+            adapter=_FakeStripeCatalogAdapter(
+                _snapshot(
+                    price_id="price_active_invalid",
+                    unit_amount=6900,
+                    product_code=product.product_code,
+                )
+            ),
+        )
+        db.session.commit()
+
+        assert result.valid is False
+        assert mapping.status == BILLING_PROVIDER_PRICE_STATUS_INVALID
+        assert "unit_amount_mismatch" in mapping.validation_error
+        assert (
+            get_active_provider_price_mapping(
+                product_bid=product_bid,
+                provider_account_id="acct_test",
+                livemode=False,
+            )
+            is None
+        )
 
 
 def test_active_provider_price_selection_fails_closed_for_multiple_rows() -> None:


### PR DESCRIPTION
## Summary
- Add provider price mapping lifecycle helpers for Stripe bind, validate, activate, retire, list, and inspect flows.
- Add billing CLI commands for internal Stripe Product/Price mapping operations.
- Cover idempotent binding, active replacement, validation failure safety, fail-closed active lookup, and CLI list/inspect/retire flows.

## Verification
- `ruff check .`
- `ruff format --check src/api/flaskr/api/check/ilivedata.py src/api/flaskr/service/billing/provider_price_mappings.py src/api/flaskr/service/billing/cli.py src/api/tests/service/billing/test_provider_price_mappings.py src/api/tests/service/billing/test_billing_cli.py`
- `cd src/api && pytest tests/service/billing/test_provider_price_mappings.py tests/service/billing/test_provider_catalog.py tests/service/billing/test_billing_models.py tests/service/billing/test_billing_core_schema_contracts.py tests/service/billing/test_billing_cli.py::test_billing_upsert_product_cli_allows_manual_custom_product_values tests/service/billing/test_billing_cli.py::test_billing_provider_price_cli_binds_lists_and_retires_mapping -q`
- `python scripts/check_architecture_boundaries.py`
- `python scripts/check_dev_tools.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added billing tools to bind, list, inspect, validate, activate, and retire provider price mappings.
  * Added Stripe catalog validation with status details, warnings, errors, and catalog snapshots.
  * Added support for metadata and filtered mapping lists.
  * Added safeguards ensuring only one active mapping per product and environment.

* **Bug Fixes**
  * Improved handling of invalid, stale, or conflicting mappings with structured error messages.
  * Preserved existing mappings when activation validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->