### PR TITLE
chore: document the Ruff rule adoption workflow

### DIFF
--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -46,6 +46,11 @@ alwaysApply: true
   `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
   from duplicating the detailed commit-message policy.
 
+- Treat Ruff findings as code or contract signals: fix code with focused tests
+  first, use only narrow coded suppressions for intentional constructs, and
+  change global Ruff policy only in a dedicated rule PR tracked by the active
+  Ruff ExecPlan.
+
 - Keep generated knowledge artifacts in sync by running
   `python scripts/build_repo_knowledge_index.py` after docs structure or
   metadata changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,11 @@
   `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
   from duplicating the detailed commit-message policy.
 
+- Treat Ruff findings as code or contract signals: fix code with focused tests
+  first, use only narrow coded suppressions for intentional constructs, and
+  change global Ruff policy only in a dedicated rule PR tracked by the active
+  Ruff ExecPlan.
+
 - Regenerate repository knowledge indexes with
   `python scripts/build_repo_knowledge_index.py` after moving docs or changing
   required metadata.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ to.
 - Before committing, run `python scripts/check_dev_tools.py` to confirm
   lefthook and its underlying tools are installed; the local checks are
   silently skipped if lefthook was never installed.
+- Treat a Ruff finding as a code or contract signal. Prefer an established
+  project pattern plus focused regression coverage; if the flagged construct
+  is intentional, use the narrowest coded suppression with a plain-English
+  reason. Change global Ruff selection or ignores only in a dedicated rule PR
+  tracked by the active Ruff ExecPlan.
 - For git commit message title, body, and classification requirements, use
   [Git Commit Message Requirements](#git-commit-message-requirements); keep
   agent-specific rule files pointing there instead of duplicating the policy.
@@ -88,6 +93,9 @@ to.
   vs offset-aware, or string vs string) — normalize both to UTC before
   comparing. These are exactly the drifts that reappear when new code lands in
   modules the UTC sweep has not yet reached.
+- Do not weaken `ruff.toml`, add a blanket `noqa`, or create a broad per-file
+  exception merely to make new code pass. Fix the code first; reserve global
+  ignores for documented repository-wide contract conflicts.
 
 ## Git Commit Message Requirements
 
@@ -186,6 +194,9 @@ Pin release versions of both before merging.
   widen only when the change crosses a shared contract or multiple surfaces.
 - When a task touches only docs or instruction files, at minimum run
   `python scripts/check_repo_harness.py`.
+- When a Ruff-driven rewrite changes runtime behavior or a public/internal
+  contract, add or identify a focused regression test; a clean lint result is
+  not behavior coverage.
 - When a task changes shared boundaries or introduces new app/service
   dependencies, run `python scripts/check_architecture_boundaries.py`.
 - When a task touches the browser harness, run `cd src/cook-web && npm run test:e2e`.

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -337,6 +337,46 @@ src/api/tests/
 - Critical paths should target 100 percent coverage
 - Coverage command: `pytest --cov=flaskr --cov-report=html`
 
+### Ruff Findings And Rule Adoption
+
+Treat Ruff findings as code or contract signals, not as requests to make the
+configuration quieter. For a finding in new or changed code:
+
+1. Read `ruff rule <CODE>`, the nearest `AGENTS.md`, the implementation, its
+   call sites, and the closest tests.
+2. Prefer the existing project abstraction or a direct code fix. Add focused
+   regression coverage whenever the rewrite can change behavior, error paths,
+   serialization, persistence, timing, or a public/internal contract.
+3. If a framework or protocol requires the flagged construct, use an inline
+   `# noqa: CODE` for that construct and explain the reason in nearby English
+   prose. Do not use a blanket `# noqa`.
+4. Use `per-file-ignores` only when the purpose of a file or file class
+   intrinsically conflicts with the rule, such as a lint fixture or immutable
+   migration history. A single ordinary call site belongs inline, not in
+   `ruff.toml`.
+5. Use a global ignore only when a documented repository-wide contract
+   fundamentally conflicts with the rule. Do not weaken `select` or `ignore`
+   to make an unrelated PR pass.
+
+Adopt or remove exceptions one rule unit at a time. A rule unit is normally
+one Ruff code; combine codes only when they report the same construct and have
+the same fix and exception boundary. Base each rule PR on the preceding rule
+branch, and keep unrelated cleanup out of the diff. Track the stack and rule
+census in `docs/exec-plans/active/ruff-rule-minimization.md`.
+
+For each rule unit, run the focused check first and then the repository gates:
+
+```bash
+ruff check . --select CODE
+ruff check .
+ruff format --check .
+python scripts/check_repo_harness.py
+```
+
+Run the nearest behavior tests for every touched runtime surface. Lint passing
+does not replace test coverage. Before committing, also run
+`python scripts/check_dev_tools.py` and `lefthook run pre-commit --all-files`.
+
 ## Development Workflow
 
 ### Branch Naming

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -240,8 +240,10 @@ earliest unmerged branch first, then replay successors in order.
 ## Interfaces and Dependencies
 
 - Ruff is pinned at 0.16.3 in `lefthook.yml`,
-  `.github/workflows/lint.yml`, and `docs/engineering-baseline.md`. Upgrade work
-  is separate because changing the rule inventory while shrinking policy would
+  `.github/workflows/lint.yml`, `docs/engineering-baseline.md`, and
+  `scripts/check_dev_tools.py`. The doctor verifies the binary on `PATH`, so a
+  Ruff upgrade must update all four locations together. Upgrade work is
+  separate because changing the rule inventory while shrinking policy would
   make the census non-reproducible.
 - `ruff.toml` is a shared contract for local hooks and CI. A rule is not adopted
   until both paths use the same checked-in configuration.

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -1,0 +1,248 @@
+# Minimize the Explicit Ruff Policy
+
+## Purpose / Big Picture
+
+Make the repository's Ruff policy broad in enforcement and small in
+configuration. The end state should express the accepted stable Ruff rule set
+with the fewest possible `select`, `ignore`, and `per-file-ignores` entries,
+without deleting checks merely to make the file shorter. Code should satisfy a
+rule whenever the rule improves or safely constrains the project; exceptions
+should be narrow, documented, and intrinsic to the affected surface.
+
+The work lands as stacked pull requests. One pull request owns one Ruff rule
+unit: normally one rule code, or an inseparable pair that reports the same
+construct and requires the same change. Each rule pull request contains only
+the implementation changes, regression coverage, Ruff policy change, and this
+plan's progress update for that rule.
+
+## Progress
+
+- [x] 2026-08-20 21:13 CST: Fast-forwarded a clean detached worktree to
+  `origin/main` at `8bced2e70` and confirmed Ruff 0.16.3 is installed.
+- [x] 2026-08-20 21:13 CST: Confirmed the configured baseline passes
+  `ruff check .` and all 1,013 Python files pass `ruff format --check .`.
+- [x] 2026-08-20 21:13 CST: Measured the stable `ALL`-rule gap and recorded the
+  pull-request, testing, and exception policy in repository guidance.
+- [x] 2026-08-20 21:25 CST: Generated the Cursor/Copilot mirrors and knowledge
+  indexes; repository harness, Ruff, format, architecture, translation, JSON,
+  YAML, frontend lint/format, and all other pre-commit hooks passed.
+- [ ] Create and merge the policy-only foundation pull request.
+- [ ] Remove the global D406 exception while preserving the embedded Swagger
+  YAML contract with a narrow suppression and regression test.
+- [ ] Remove the global D407 exception on top of D406 using the same Swagger
+  contract test.
+- [ ] Remove the global D405 exception by fixing ordinary docstrings and
+  retaining only the narrow exceptions required by Swagger or immutable
+  migration history.
+- [ ] Re-run the census after each merged rule unit and choose the next smallest
+  behaviorally safe unit.
+- [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
+  rule is either clean or represented by a necessary, documented exception.
+- [ ] Move this plan to `docs/exec-plans/completed/` after the final stacked PR
+  is merged and the full acceptance suite passes.
+
+## Surprises & Discoveries
+
+- Ruff's built-in default does not mean "all rules." Removing `[lint].select`
+  today would discard most of the checks the repository deliberately adopted.
+  Configuration size must not be reduced by silently reducing enforcement.
+- `main` already contains a long sequence of one-rule pull requests through
+  PR #2569. The current file selects broad prefixes when they are clean and
+  spells out individual codes only when a broader prefix would expose debt.
+- Running `ruff check . --select ALL --statistics` against the current tree
+  reports 31,224 findings. Command-line selection supersedes global ignores,
+  while configured per-file exceptions still apply. Running the same census
+  with `--isolated` reports 42,444 findings because test, script, migration,
+  and fixture exceptions are removed too.
+- The largest stable-rule debts are COM812 (6,113), ANN001 (4,651), D103
+  (2,836), ANN201 (2,277), DTZ001 (1,584), ANN202 (1,501), PLC0415 (1,234),
+  PLR2004 (1,182), and SLF001 (830). These are not appropriate first stack
+  items because they mix broad contract decisions with mechanical churn.
+- D406 and D407 each have one finding: the `parameters:` key inside the
+  `/api/user/send_sms_code` Flasgger YAML docstring. Rewriting it as a NumPy
+  docstring section would corrupt the API specification, so the correct end
+  state is global enforcement plus a narrow, explained suppression.
+- FIX002 and TD003 report the same two TODOs. One is a real password-login
+  rate-limit feature and one is a compatibility-removal checkpoint. Renaming
+  them to evade lint would hide work, and implementing either is larger than a
+  lint cleanup, so they are deliberately not the first rule unit.
+
+## Decision Log
+
+- 2026-08-20: Interpret "minimal Ruff rules" as minimal explicit policy while
+  preserving the broadest useful enforcement. The target is `select = ["ALL"]`
+  with necessary exceptions, not an unconfigured Ruff invocation that checks
+  only Ruff's smaller built-in default set.
+- 2026-08-20: Use a policy-only foundation PR based on `main`. Every rule PR is
+  based on the preceding rule branch and names that predecessor in its body.
+  As a predecessor merges, retarget or rebase the next PR without combining
+  its rule unit with another.
+- 2026-08-20: A rule unit defaults to one Ruff code. Multiple codes may share a
+  PR only when they flag exactly the same construct, have the same fix and
+  exception boundary, and separating them would create a configuration-only
+  intermediate state with no independently meaningful behavior.
+- 2026-08-20: Lint passing is not behavior coverage. Any semantic rewrite must
+  add or identify a focused regression test that fails for the risky behavior.
+  Purely structural or suppression-narrowing changes still need the closest
+  contract test plus the repository Ruff, format, and harness gates.
+- 2026-08-20: Use inline `# noqa: CODE` only for one intentional construct and
+  accompany it with a plain-English reason. Use `per-file-ignores` only when a
+  file or file class exists specifically to exercise a conflicting pattern or
+  is immutable history. A global ignore is the last resort for a repository-
+  wide contract that fundamentally conflicts with a rule.
+- 2026-08-20: Do not edit applied Alembic migrations to satisfy style rules.
+
+## Outcomes & Retrospective
+
+The foundation stage changes no runtime code and does not change Ruff's active
+rule set. It establishes the continuation contract, baseline evidence, stacked
+PR model, and AI-facing decision process. Record cumulative rule counts,
+exception reductions, test results, and any revised prioritization here as the
+stack progresses.
+
+## Context and Orientation
+
+Start with these files:
+
+- `ruff.toml` is the repository-wide Ruff configuration consumed by
+  `lefthook.yml` and `.github/workflows/lint.yml`.
+- `AGENTS.md` owns repository-wide coding-agent rules.
+- `docs/engineering-baseline.md` owns the detailed Ruff finding and rule-
+  adoption workflow.
+- `scripts/generate_ai_collab_docs.py` owns generated Cursor and Copilot
+  mirrors; run it whenever shared AI guidance changes.
+- `scripts/check_repo_harness.py` verifies instruction and generated knowledge
+  surfaces.
+- `src/api/AGENTS.md` and the nearest service `AGENTS.md` files constrain
+  backend changes. Read the nearest file before editing each Ruff finding.
+- `lefthook.yml` and `.github/workflows/lint.yml` pin Ruff 0.16.3 and run both
+  check and format gates.
+
+The baseline command for currently enforced rules is:
+
+    ruff check .
+    ruff format --check .
+
+The reproducible stable-rule debt census is:
+
+    ruff check . --select ALL --statistics
+    ruff check . --isolated --select ALL --target-version py311 --statistics
+
+The first command preserves configured per-file exceptions but intentionally
+forces globally ignored and unselected rules into the report. The second
+removes all repository configuration and exposes whether an exception can be
+narrowed further.
+
+## Plan of Work
+
+1. Land a policy-only foundation PR containing this plan and the shared
+   AI-facing Ruff workflow. Do not modify `ruff.toml` in that PR.
+2. Re-run the `ALL` census on the foundation head and record drift from `main`.
+3. Choose the smallest rule unit whose correct fix is clear. Prefer removing a
+   global ignore, then enabling a currently unselected rule with few findings,
+   before undertaking high-count architectural rules.
+4. Inspect every finding, its nearest `AGENTS.md`, owning code, call sites, and
+   tests. Classify each finding as code defect, safe modernization, intentional
+   protocol/framework shape, fixture, or immutable history.
+5. Add or strengthen focused tests before the risky implementation rewrite.
+   Confirm the test protects behavior rather than merely restating source text.
+6. Apply the narrowest implementation fix. Use suppressions only according to
+   the hierarchy in the Decision Log.
+7. Change `ruff.toml` for exactly that rule unit, run the rule-specific command,
+   then the configured Ruff and format baselines, targeted tests, and the
+   relevant wider gates.
+8. Update this plan and create a ready PR whose base is the previous stack
+   branch. Keep the PR title, body, base branch, and verification readback
+   accurate after every push.
+9. Repeat until all stable rules are clean or necessarily excepted, then replace
+   the explicit selection list with `select = ["ALL"]` in its own final policy
+   PR and run the full repository gate.
+
+## Concrete Steps
+
+For each rule unit `CODE`:
+
+1. Create `sunner/ruff-<code-lowercase>` from the current stack tip.
+2. Run `ruff rule CODE` and `ruff check . --select CODE`.
+3. List every finding and map it to owning tests before editing.
+4. Add or identify the behavior/contract regression tests.
+5. Make the implementation and exception changes with no unrelated cleanup.
+6. Run:
+
+       ruff check . --select CODE
+       ruff check .
+       ruff format --check .
+       python scripts/check_repo_harness.py
+
+7. Run targeted tests for every touched runtime surface. Run the full backend
+   suite for shared helpers, cross-service changes, or broad mechanical edits.
+8. Run `python scripts/check_dev_tools.py`, then
+   `lefthook run pre-commit --all-files` before committing.
+9. Inspect staged and unstaged diffs, commit with the exact `Changed:` and
+   `Benefit:` body required by `AGENTS.md`, push, and create a ready PR based on
+   the preceding stack branch.
+10. Record the PR URL, base/head, findings removed, remaining exceptions, and
+    test results in this plan.
+
+The initial rule stack after the foundation is D406, D407, then D405. These
+three remove global pydocstyle exceptions while retaining the one Swagger YAML
+contract and immutable migration boundary explicitly.
+
+## Validation and Acceptance
+
+Every rule PR must satisfy all of the following:
+
+- Its diff against the immediate stack base contains one rule unit only.
+- `ruff check . --select CODE` passes, accounting only for documented narrow
+  exceptions that the PR deliberately retains.
+- `ruff check .` and `ruff format --check .` pass repository-wide.
+- Focused tests cover the behavior or contract at risk; lint output alone does
+  not count as test coverage.
+- `python scripts/check_repo_harness.py` passes whenever instructions, plans,
+  scripts, or generated knowledge files change.
+- `python scripts/check_dev_tools.py` confirms the local gate exists, and
+  `lefthook run pre-commit --all-files` passes before commit.
+- The ready PR clearly names its predecessor, rule code, behavior changes,
+  exceptions, targeted tests, and broader verification.
+- GitHub CI is green or any baseline/external failure is reproduced and
+  documented without weakening Ruff policy.
+
+The overall goal is accepted when:
+
+- all stable Ruff rules are enforced through `select = ["ALL"]` except for a
+  minimal, documented set of intrinsic conflicts;
+- global ignores have no single-call-site or single-file exceptions;
+- per-file and inline suppressions are narrow, coded, and justified;
+- the full backend and repository harness suites pass on the final stack tip;
+- repository AI guidance tells future agents how to resolve findings without
+  weakening the policy; and
+- every rule unit remains independently reviewable in the GitHub stack.
+
+## Idempotence and Recovery
+
+All census and validation commands are read-only and safe to rerun. Ruff fixes
+must not be run repository-wide without first limiting the rule and reviewing
+the proposed diff. If a formatter or hook rewrites unrelated files, restore
+only that generated churn and preserve user-owned changes.
+
+Each stack branch is independently recoverable. If a rule PR is rejected,
+retarget its successor to the last accepted predecessor and rebase or cherry-
+pick only the successor's own rule commit. Never squash distinct rule units
+together. If `main` advances, fetch it and update only the foundation or the
+earliest unmerged branch first, then replay successors in order.
+
+## Interfaces and Dependencies
+
+- Ruff is pinned at 0.16.3 in `lefthook.yml`,
+  `.github/workflows/lint.yml`, and `docs/engineering-baseline.md`. Upgrade work
+  is separate because changing the rule inventory while shrinking policy would
+  make the census non-reproducible.
+- `ruff.toml` is a shared contract for local hooks and CI. A rule is not adopted
+  until both paths use the same checked-in configuration.
+- Flasgger consumes route docstrings as YAML after the `---` marker; pydocstyle
+  fixes must not rewrite YAML keys as prose sections.
+- Applied Alembic revisions are immutable even when a style rule flags them.
+- Generated Cursor and Copilot instruction files depend on
+  `scripts/generate_ai_collab_docs.py`; do not edit generated mirrors by hand.
+- Stacked PR bases are GitHub branch dependencies. Keep each base branch alive
+  until its direct successor is retargeted after merge.

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -241,8 +241,9 @@ earliest unmerged branch first, then replay successors in order.
 
 - Ruff is pinned at 0.16.3 in `lefthook.yml`,
   `.github/workflows/lint.yml`, `docs/engineering-baseline.md`, and
-  `scripts/check_dev_tools.py`. The doctor verifies the binary on `PATH`, so a
-  Ruff upgrade must update all four locations together. Upgrade work is
+  `scripts/check_dev_tools.py`, with the contributor install command mirrored
+  in `INSTALL_MANUAL.md`. The doctor verifies the binary on `PATH`, so a Ruff
+  upgrade must update all five locations together. Upgrade work is
   separate because changing the rule inventory while shrinking policy would
   make the census non-reproducible.
 - `ruff.toml` is a shared contract for local hooks and CI. A rule is not adopted

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -20,7 +20,9 @@ plan's progress update for that rule.
 - [x] 2026-08-20 21:13 CST: Fast-forwarded a clean detached worktree to
   `origin/main` at `8bced2e70` and confirmed Ruff 0.16.3 is installed.
 - [x] 2026-08-20 21:13 CST: Confirmed the configured baseline passes
-  `ruff check .` and all 1,013 Python files pass `ruff format --check .`.
+  `ruff check .` and all 799 Python files pass `ruff format --check .`; the
+  formatter reported this total directly for `.py`, `.pyi`, and `.ipynb`
+  inputs at `8bced2e70`.
 - [x] 2026-08-20 21:13 CST: Measured the stable `ALL`-rule gap and recorded the
   pull-request, testing, and exception policy in repository guidance.
 - [x] 2026-08-20 21:25 CST: Generated the Cursor/Copilot mirrors and knowledge

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -222,10 +222,14 @@ The overall goal is accepted when:
 
 ## Idempotence and Recovery
 
-All census and validation commands are read-only and safe to rerun. Ruff fixes
-must not be run repository-wide without first limiting the rule and reviewing
-the proposed diff. If a formatter or hook rewrites unrelated files, restore
-only that generated churn and preserve user-owned changes.
+Census commands and checks that explicitly use check-only modes are read-only
+and safe to rerun. Tests can change external state, and
+`lefthook run pre-commit --all-files` runs formatters and fixers that can rewrite
+the worktree; safeguard unrelated changes and review the resulting diff before
+running either. Ruff fixes must not be run repository-wide without first
+limiting the rule and reviewing the proposed diff. If a formatter or hook
+rewrites unrelated files, restore only that generated churn and preserve
+user-owned changes.
 
 Each stack branch is independently recoverable. If a rule PR is rejected,
 retarget its successor to the last accepted predecessor and rebase or cherry-

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -25,6 +25,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [ExecPlan: Operator Promotion Ops State Rules](./active/operator-promotion-ops-state-rules.md)
 - [ExecPlan: Package Campaigns](./active/package-campaigns.md)
 - [老带新邀请奖励实施计划](./active/referral-invitation-rewards.md)
+- [Minimize the Explicit Ruff Policy](./active/ruff-rule-minimization.md)
 
 ## Completed
 

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -41,6 +41,7 @@
 | `docs/exec-plans/active/operator-promotion-ops-state-rules.md` | ExecPlan: Operator Promotion Ops State Rules | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/package-campaigns.md` | ExecPlan: Package Campaigns | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/referral-invitation-rewards.md` | 老带新邀请奖励实施计划 | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/ruff-rule-minimization.md` | Minimize the Explicit Ruff Policy | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/admin-orders-page-slimming.md` | Admin Orders Page Slimming | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/admin-rate-management-create.md` | Add arbitrary rate entries to Rate Management | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/agent-first-harness-migration.md` | Agent-First Harness Migration | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `12`
 - Product specs: `10`
 - References: `3`
-- Active ExecPlans: `19`
+- Active ExecPlans: `20`
 - Completed ExecPlans: `11`
 
 ## Boundary Baseline

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -42,6 +42,7 @@ else:
         "npm install -g @evilmartians/lefthook  # (or use your package manager)"
     )
 PIP_INSTALL = "pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0"
+RUFF_VERSION = "0.16.3"
 NPM_INSTALL = "cd src/cook-web && npm ci"
 LEFTHOOK_INSTALL = "lefthook install"
 NODE_INSTALL = "install Node.js (see INSTALL_MANUAL.md for the supported version)"
@@ -115,6 +116,24 @@ def _lefthook_hook_installed() -> bool:
         return False
 
 
+def _ruff_version_matches() -> bool:
+    """Report whether the Ruff binary on PATH matches the repository pin."""
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        return False
+    try:
+        result = subprocess.run(
+            [ruff, "--version"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return False
+    return result.stdout.strip() == f"ruff {RUFF_VERSION}"
+
+
 def collect_checks() -> tuple[list[Check], list[Check]]:
     """Return (core_checks, frontend_checks)."""
     lefthook_present = shutil.which("lefthook") is not None
@@ -128,7 +147,7 @@ def collect_checks() -> tuple[list[Check], list[Check]]:
             lefthook_present and _lefthook_hook_installed(),
             LEFTHOOK_INSTALL,
         ),
-        Check("ruff", shutil.which("ruff") is not None, PIP_INSTALL),
+        Check(f"ruff {RUFF_VERSION}", _ruff_version_matches(), PIP_INSTALL),
         Check("cz (commitizen)", shutil.which("cz") is not None, PIP_INSTALL),
     ]
     core.extend(

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1610,6 +1610,10 @@ def build_documents() -> dict[Path, str]:
                 "`AGENTS.md#git-commit-message-requirements`; keep "
                 "agent-specific rule files from duplicating the detailed "
                 "commit-message policy.",
+                "Treat Ruff findings as code or contract signals: fix code with "
+                "focused tests first, use only narrow coded suppressions for "
+                "intentional constructs, and change global Ruff policy only in "
+                "a dedicated rule PR tracked by the active Ruff ExecPlan.",
                 "Keep generated knowledge artifacts in sync by running "
                 "`python scripts/build_repo_knowledge_index.py` after docs "
                 "structure or metadata changes.",
@@ -1796,6 +1800,10 @@ def build_documents() -> dict[Path, str]:
                 "`AGENTS.md#git-commit-message-requirements`; keep "
                 "agent-specific rule files from duplicating the detailed "
                 "commit-message policy.",
+                "Treat Ruff findings as code or contract signals: fix code with "
+                "focused tests first, use only narrow coded suppressions for "
+                "intentional constructs, and change global Ruff policy only in "
+                "a dedicated rule PR tracked by the active Ruff ExecPlan.",
                 "Regenerate repository knowledge indexes with "
                 "`python scripts/build_repo_knowledge_index.py` after moving docs "
                 "or changing required metadata.",


### PR DESCRIPTION
## Summary

- Add a self-contained ExecPlan for minimizing explicit Ruff configuration toward `select = ["ALL"]` without weakening useful enforcement.
- Teach coding agents the decision hierarchy: fix code with focused tests first, use narrow coded suppressions only for real protocol conflicts, and reserve configuration ignores for intrinsic repository boundaries.
- Regenerate the Cursor, Copilot, and repository knowledge surfaces so the policy is discoverable to future AI-written code.

This foundation PR does not change runtime behavior or `ruff.toml`. Each rule removal will follow in its own stacked PR.

## Verification

- `python3 scripts/check_repo_harness.py`
- `ruff check .`
- `ruff format --check .`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files --no-stage-fixed --no-tty`

## Stack

Foundation layer for the Ruff rule-minimization stack. The first rule PR will remove the global D406 ignore while preserving Flasgger schema behavior with a focused regression test.


## Review follow-up

- Corrected the formatter baseline to 799 measured inputs.
- Scoped read-only guidance to check-only commands.
- Made `check_dev_tools.py` enforce Ruff 0.16.3.
- Added `INSTALL_MANUAL.md` to the five-location coordinated Ruff upgrade contract.

Latest verification: repository harness passed after each documentation change; Ruff check/format passed for the tooling change; the development-tool doctor passed core tooling checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for investigating and resolving Ruff code-quality findings.
  - Documented targeted exceptions, focused testing, validation steps, and incremental linting rule adoption.
  - Added an execution plan for simplifying linting configuration while preserving broad coverage.
  - Linked the active plan from the engineering documentation index.

- **Chores**
  - Updated contributor and AI-assisted development guidance to discourage broad linting suppressions.
  - Added validation that the expected Ruff version is installed and used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->