### PR TITLE
chore: enforce D406 with a tested Swagger exception

### DIFF
--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -28,9 +28,16 @@ plan's progress update for that rule.
 - [x] 2026-08-20 21:25 CST: Generated the Cursor/Copilot mirrors and knowledge
   indexes; repository harness, Ruff, format, architecture, translation, JSON,
   YAML, frontend lint/format, and all other pre-commit hooks passed.
-- [ ] Create and merge the policy-only foundation pull request.
-- [ ] Remove the global D406 exception while preserving the embedded Swagger
-  YAML contract with a narrow suppression and regression test.
+- [x] 2026-08-20 21:56 CST: Opened ready foundation PR
+  [#2571](https://github.com/ai-shifu/ai-shifu/pull/2571) from
+  `sunner/ruff-rule-minimization-foundation` to `main`.
+- [x] 2026-08-20 22:04 CST: Opened ready D406 PR
+  [#2572](https://github.com/ai-shifu/ai-shifu/pull/2572) from
+  `sunner/ruff-d406` to the foundation branch. The global exception became one
+  explained inline suppression, and the focused Flasgger schema test plus all
+  repository pre-commit hooks passed.
+- [ ] Merge foundation PR #2571, then merge or retarget D406 PR #2572 without
+  combining its rule unit with its successor.
 - [ ] Remove the global D407 exception on top of D406 using the same Swagger
   contract test.
 - [ ] Remove the global D405 exception by fixing ordinary docstrings and
@@ -101,6 +108,13 @@ rule set. It establishes the continuation contract, baseline evidence, stacked
 PR model, and AI-facing decision process. Record cumulative rule counts,
 exception reductions, test results, and any revised prioritization here as the
 stack progresses.
+
+The D406 stage removes one global ignore and leaves one coded inline exception
+on the Flasgger YAML docstring. `ruff check . --select D406` reports no
+unsuppressed findings. The focused captcha-route suite passes 10 tests after
+parsing the registered view's docstring and asserting its required request-body
+schema; the repository Ruff, format, harness, developer-tool, and full
+pre-commit gates also pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -226,12 +226,12 @@ ignore = [
     "D203",    # blank line before a class docstring -- conflicts with D211
     "D205",    # summary wrapped over two lines -- 260 prose rewrites, deferred
     "D213",    # summary on the second line -- conflicts with D212
-    # D405 / D406 / D407: route docstrings carry the flasgger/Swagger spec
-    # after a `---` line, and these rules read YAML keys such as `parameters:`
-    # as numpydoc section headers. Their fixes strip the colon and insert a
-    # dashed underline, turning the embedded spec into invalid YAML.
+    # D405 / D407: route docstrings carry the flasgger/Swagger spec after a
+    # `---` line, and these rules read YAML keys such as `parameters:` as
+    # numpydoc section headers. Their fixes capitalize keys or insert a dashed
+    # underline, turning the embedded spec into invalid YAML. D406 is enforced;
+    # its one Swagger conflict is justified inline and contract-tested.
     "D405",
-    "D406",
     "D407",
     # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING
     # breaks anything that resolves annotations at runtime, which for this repo

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -569,6 +569,8 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             raise_param_error("captcha_code")
         return make_common_response(verify_captcha_code(app, captcha_id, captcha_code))
 
+    # Flasgger parses `parameters:` below as a YAML key; D406's NumPy-docstring
+    # fix would remove the colon and invalidate the published API specification.
     @app.route(path_prefix + "/send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
@@ -617,7 +619,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             400:
                 description: parameter error
 
-        """
+        """  # noqa: D406
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
         _apply_request_language(payload)

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -2,6 +2,7 @@ import base64
 import json
 from io import BytesIO
 
+from flasgger.utils import parse_docstring
 from PIL import Image
 
 
@@ -128,6 +129,22 @@ def test_send_sms_code_requires_captcha_ticket(test_client, app):
 
     assert response.status_code == 200
     assert body["code"] == 1009
+
+
+def test_send_sms_code_swagger_parameters_stay_valid_yaml(app):
+    view = app.view_functions["send_sms_code_api"]
+
+    _summary, _description, specification = parse_docstring(
+        view,
+        process_doc=lambda text: text,
+    )
+
+    assert specification["parameters"][0]["in"] == "body"
+    assert specification["parameters"][0]["required"] is True
+    assert specification["parameters"][0]["schema"]["required"] == [
+        "mobile",
+        "captcha_ticket",
+    ]
 
 
 def test_send_sms_code_localizes_missing_captcha_ticket_message(test_client, app):


### PR DESCRIPTION
## Summary

- Remove D406 from the repository-wide Ruff ignore list.
- Keep the single Flasgger conflict as an inline, coded suppression because Ruff would turn the `parameters:` Swagger YAML key into invalid YAML.
- Add a focused regression test that parses the live route docstring and verifies the required request-body schema.

D406 is now enforced everywhere else. Runtime request behavior is unchanged.

## Stack

- Predecessor: #2571
- Base: `sunner/ruff-rule-minimization-foundation`
- Head: `sunner/ruff-d406`
- Next planned rule: D407

## Verification

- `ruff check . --select D406`
- `ruff check .`
- `ruff format --check .`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/user/test_captcha_routes.py -q` — 10 passed
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files --no-stage-fixed --no-tty`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->