### PR TITLE
chore: enforce D407 with the tested Swagger exception

### DIFF
--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -38,8 +38,13 @@ plan's progress update for that rule.
   repository pre-commit hooks passed.
 - [ ] Merge foundation PR #2571, then merge or retarget D406 PR #2572 without
   combining its rule unit with its successor.
-- [ ] Remove the global D407 exception on top of D406 using the same Swagger
-  contract test.
+- [x] 2026-08-20 22:10 CST: Opened ready D407 PR
+  [#2573](https://github.com/ai-shifu/ai-shifu/pull/2573) from
+  `sunner/ruff-d407` to the D406 branch. Its one finding became the second code
+  on the same explained inline suppression; the inherited Flasgger schema test
+  and all repository pre-commit hooks passed.
+- [ ] Merge or retarget D407 PR #2573 after its predecessors without combining
+  it with the D405 rule unit.
 - [ ] Remove the global D405 exception by fixing ordinary docstrings and
   retaining only the narrow exceptions required by Swagger or immutable
   migration history.
@@ -115,6 +120,12 @@ unsuppressed findings. The focused captcha-route suite passes 10 tests after
 parsing the registered view's docstring and asserting its required request-body
 schema; the repository Ruff, format, harness, developer-tool, and full
 pre-commit gates also pass.
+
+The D407 stage removes one more global ignore and adds D407 to that same inline
+exception because its automatic dashed underline would also invalidate the
+Swagger YAML. `ruff check . --select D407` reports no unsuppressed findings,
+the inherited 10-test schema suite passes on the D407 tip, and the same full
+repository gates pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -228,9 +228,10 @@ ignore = [
     "D213",    # summary on the second line -- conflicts with D212
     # D405: route docstrings carry the flasgger/Swagger spec after a `---` line,
     # and this rule reads YAML keys such as `parameters:` as numpydoc section
-    # headers. Its fix capitalizes the key, turning the embedded spec into
-    # invalid YAML. D406 / D407 are enforced; their one Swagger conflict is
-    # justified inline and contract-tested.
+    # headers. Its fix capitalizes the key into valid YAML under `Parameters`,
+    # so Flasgger loses the lowercase OpenAPI `parameters` field. D406 / D407
+    # are enforced; their one Swagger conflict is justified inline and
+    # contract-tested.
     "D405",
     # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING
     # breaks anything that resolves annotations at runtime, which for this repo

--- a/ruff.toml
+++ b/ruff.toml
@@ -226,13 +226,12 @@ ignore = [
     "D203",    # blank line before a class docstring -- conflicts with D211
     "D205",    # summary wrapped over two lines -- 260 prose rewrites, deferred
     "D213",    # summary on the second line -- conflicts with D212
-    # D405 / D407: route docstrings carry the flasgger/Swagger spec after a
-    # `---` line, and these rules read YAML keys such as `parameters:` as
-    # numpydoc section headers. Their fixes capitalize keys or insert a dashed
-    # underline, turning the embedded spec into invalid YAML. D406 is enforced;
-    # its one Swagger conflict is justified inline and contract-tested.
+    # D405: route docstrings carry the flasgger/Swagger spec after a `---` line,
+    # and this rule reads YAML keys such as `parameters:` as numpydoc section
+    # headers. Its fix capitalizes the key, turning the embedded spec into
+    # invalid YAML. D406 / D407 are enforced; their one Swagger conflict is
+    # justified inline and contract-tested.
     "D405",
-    "D407",
     # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING
     # breaks anything that resolves annotations at runtime, which for this repo
     # means the SQLAlchemy mappers and pydantic models (~230 hits).

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -569,8 +569,9 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             raise_param_error("captcha_code")
         return make_common_response(verify_captcha_code(app, captcha_id, captcha_code))
 
-    # Flasgger parses `parameters:` below as a YAML key; D406's NumPy-docstring
-    # fix would remove the colon and invalidate the published API specification.
+    # Flasgger parses `parameters:` below as a YAML key. D406 would remove its
+    # colon, while D407 would insert a dashed section underline; either fix
+    # would invalidate the published API specification.
     @app.route(path_prefix + "/send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -619,7 +619,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             400:
                 description: parameter error
 
-        """  # noqa: D406
+        """  # noqa: D406, D407
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
         _apply_request_language(payload)


### PR DESCRIPTION
## Summary

- Remove D407 from the repository-wide Ruff ignore list.
- Extend the existing coded Flasgger suppression to D407 because Ruff would insert a dashed underline below the `parameters:` Swagger YAML key and invalidate the schema.
- Reuse the predecessor's focused regression test, which parses the registered route docstring and verifies the required request-body schema.

The initial one D407 finding is now one justified inline exception; D407 is enforced everywhere else. Runtime request behavior is unchanged.

## Stack

- Predecessor: #2572
- Base: `sunner/ruff-d406`
- Head: `sunner/ruff-d407`
- Next planned rule: D405

## Verification

- `ruff check . --select D407`
- `ruff check .`
- `ruff format --check .`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/user/test_captcha_routes.py -q` — 10 passed
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files --no-stage-fixed --no-tty`


## Review follow-up

- Documented the distinct D406 colon-removal and D407 underline-insertion failure modes at the shared Flasgger suppression.
- Corrected the D405 explanation: capitalization preserves YAML syntax but removes Flasgger's lowercase OpenAPI `parameters` field.

Latest verification: D406/D407 and full Ruff checks passed; formatting passed; captcha route suite passed 10 tests; commit hooks passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->