### PR TITLE
chore: stop preemptively ignoring UP046

### DIFF
--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -71,9 +71,17 @@ plan's progress update for that rule.
   passed.
 - [ ] Merge or retarget UP047 PR #2576 after its predecessors without combining
   it with the next rule unit.
-- [ ] Remove the target-gated UP046 global ignore. It has zero findings under
-  the configured Python 3.11 target and two explicit Python 3.12 findings that
-  should surface in the future runtime-upgrade PR instead of staying hidden.
+- [x] 2026-08-20 22:36 CST: Opened ready UP046 PR
+  [#2577](https://github.com/ai-shifu/ai-shifu/pull/2577) from
+  `sunner/ruff-up046` to the UP047 branch. The last target-gated PEP 695 ignore
+  was removed; the Python 3.11 check is clean, both Python 3.12 migration sites
+  are audited, 674 focused billing/history tests pass with 10 skips, and all
+  repository pre-commit hooks passed.
+- [ ] Merge or retarget UP046 PR #2577 after its predecessors without combining
+  it with the next rule unit.
+- [ ] Remove the PLW0603 global ignore by classifying and testing all 25 module-
+  state mutations, then refactoring safe cases and retaining only intrinsic
+  narrow exceptions.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -172,6 +180,12 @@ The UP047 stage removes another preemptive exception without introducing Python
 explicit Python 3.12 audit records the single generic-function migration in the
 learner-profile retry helper. Its 48-test service suite and the full repository
 gates pass.
+
+The UP046 stage removes the final preemptive PEP 695 exception without adding
+Python 3.12-only syntax. UP046 is clean under the configured Python 3.11 target;
+an explicit Python 3.12 audit records the `PageWindow` and `HistoryItem` class
+migrations. The billing suite passes 673 tests with 10 skips, the focused shifu
+history test passes, and the full repository gates pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -199,8 +199,7 @@ select = [
     "D",
 
     # --- Modernization ----------------------------------------------------
-    # UP046 (PEP 695 generic classes) is ignored below. UP047 is selected but
-    # target-gated until Python 3.12.
+    # UP046/UP047 stay selected but are target-gated until Python 3.12.
     # UP040 is enforced by an explicit Python 3.12 hook and CI check because
     # the repository-wide Python 3.11 target would otherwise leave it dormant.
     # UP035 is satisfied except in the two `admin` / `admin_operations.courses`
@@ -242,10 +241,6 @@ ignore = [
     # revisions and boundary-check fixtures that are loaded by path rather
     # than imported.
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
-    # UP046: PEP 695 generic-class syntax (`class T`). The py311 target
-    # currently suppresses it; moving to py312+ would expose unsafe generic
-    # rewrites that can change TypeVar variance. Defer until Python 3.12+.
-    "UP046",
 ]
 
 [lint.per-file-ignores]


### PR DESCRIPTION
## Summary

- Remove the final explicit PEP 695 global ignore while keeping the Python 3.11 runtime target unchanged.
- Keep all PEP 695 rules selected through the `UP` prefix and document that their diagnostics remain target-gated until Python 3.12.
- Leave runtime code unchanged; Python 3.12 class parameter syntax cannot land while the project supports Python 3.11.

An explicit Python 3.12 audit identifies two future migrations: billing `PageWindow` and shifu `HistoryItem`. Removing the ignore ensures a future target bump surfaces both instead of silently skipping them.

## Stack

- Predecessor: #2576
- Base: `sunner/ruff-up047`
- Head: `sunner/ruff-up046`
- Next planned rule: PLW0603, the smallest remaining actionable global ignore

## Verification

- `ruff check . --select UP046`
- `ruff check . --select UP046 --target-version py312` — expected two audited future-runtime diagnostics
- `ruff check .`
- `ruff format --check .`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/billing/ -q` — 673 passed, 10 skipped
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest tests/service/shifu/test_shifu_history_manager.py -q` — 1 passed
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files --no-stage-fixed --no-tty`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->