### PR TITLE
fix: keep course card actions visible

### DIFF
--- a/src/cook-web/src/app/admin/components/ShifuCard.test.tsx
+++ b/src/cook-web/src/app/admin/components/ShifuCard.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ShifuCard from './ShifuCard';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('ShifuCard', () => {
+  test('keeps the course actions trigger visible without hover', () => {
+    render(
+      <ShifuCard
+        id='course-1'
+        image={undefined}
+        title='Course 1'
+        description='Course description'
+        isFavorite={false}
+        onImportActivationRequest={jest.fn()}
+      />,
+    );
+
+    const actionsTrigger = screen.getByRole('button', {
+      name: 'common.core.more',
+    });
+
+    expect(actionsTrigger).not.toHaveClass('opacity-0');
+    expect(actionsTrigger).toHaveClass('h-8', 'w-8', 'bg-transparent');
+    expect(actionsTrigger.closest('a')).toBeNull();
+  });
+});

--- a/src/cook-web/src/app/admin/components/ShifuCard.test.tsx
+++ b/src/cook-web/src/app/admin/components/ShifuCard.test.tsx
@@ -30,4 +30,25 @@ describe('ShifuCard', () => {
     expect(actionsTrigger).toHaveClass('h-8', 'w-8', 'bg-transparent');
     expect(actionsTrigger.closest('a')).toBeNull();
   });
+
+  test('marks the course cover image as decorative', () => {
+    const { container } = render(
+      <ShifuCard
+        id='course-1'
+        image='https://example.com/cover.png'
+        title='Course 1'
+        description='Course description'
+        isFavorite={false}
+      />,
+    );
+
+    expect(screen.queryByRole('img')).toBeNull();
+
+    const cover = container.querySelector(
+      'img[src="https://example.com/cover.png"]',
+    );
+    expect(cover).not.toBeNull();
+    expect(cover).toHaveAttribute('alt', '');
+    expect(cover).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/src/cook-web/src/app/admin/components/ShifuCard.tsx
+++ b/src/cook-web/src/app/admin/components/ShifuCard.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { StarIcon } from '@heroicons/react/24/solid';
+import { MoreHorizontal } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent } from '@/components/ui/Card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
+import { buildOnboardingTargetProps } from '@/lib/onboardingTargets';
+
+interface ShifuCardProps {
+  id: string;
+  image: string | undefined;
+  title: string;
+  description: string;
+  isFavorite: boolean;
+  archived?: boolean;
+  canManageArchive?: boolean;
+  canManagePermissions?: boolean;
+  onArchiveRequest?: () => void;
+  onPermissionRequest?: () => void;
+  onImportActivationRequest?: () => void;
+  onRedemptionCodeRequest?: () => void;
+  onboardingTargetId?: string;
+}
+
+const CARD_CONTAINER_CLASS =
+  'w-full h-full min-h-[118px] rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] transition-colors duration-200 ease-in-out hover:bg-primary/[0.04]';
+const CARD_CONTAINER_STYLE: React.CSSProperties = {
+  boxShadow:
+    'var(--shadow-sm-1-offset-x, 0) var(--shadow-sm-1-offset-y, 1px) var(--shadow-sm-1-blur-radius, 3px) var(--shadow-sm-1-spread-radius, 0) var(--shadow-sm-1-color, rgba(0, 0, 0, 0.10)), var(--shadow-sm-2-offset-x, 0) var(--shadow-sm-2-offset-y, 1px) var(--shadow-sm-2-blur-radius, 2px) var(--shadow-sm-2-spread-radius, -1px) var(--shadow-sm-2-color, rgba(0, 0, 0, 0.10))',
+};
+const CARD_CONTENT_CLASS = 'p-4 flex flex-col h-full cursor-pointer';
+const COURSE_AVATAR_CLASS =
+  'mr-3 flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px]';
+const COURSE_AVATAR_EMPTY_STYLE: React.CSSProperties = {
+  backgroundColor: '#CFCED4',
+};
+
+const ShifuCard = ({
+  id,
+  image,
+  title,
+  description,
+  isFavorite,
+  archived,
+  canManageArchive,
+  canManagePermissions,
+  onArchiveRequest,
+  onPermissionRequest,
+  onImportActivationRequest,
+  onRedemptionCodeRequest,
+  onboardingTargetId,
+}: ShifuCardProps) => {
+  const { t } = useTranslation();
+  const showMenu = Boolean(
+    onRedemptionCodeRequest ||
+    onImportActivationRequest ||
+    canManageArchive ||
+    canManagePermissions,
+  );
+
+  return (
+    <div
+      className='relative w-full h-full group'
+      {...(onboardingTargetId
+        ? buildOnboardingTargetProps(onboardingTargetId)
+        : {})}
+    >
+      <Link
+        href={`/shifu/${id}`}
+        className='block w-full h-full'
+      >
+        <Card
+          className={CARD_CONTAINER_CLASS}
+          style={CARD_CONTAINER_STYLE}
+        >
+          <CardContent className={CARD_CONTENT_CLASS}>
+            <div
+              className={`mb-4 flex flex-row items-center justify-between ${showMenu ? 'pr-8' : ''}`}
+            >
+              <div className='flex min-w-0 flex-row items-center w-full'>
+                <div
+                  className={COURSE_AVATAR_CLASS}
+                  style={!image ? COURSE_AVATAR_EMPTY_STYLE : undefined}
+                >
+                  {image ? (
+                    <img
+                      src={image}
+                      alt='recipe'
+                      className='h-full w-full rounded-[8px] object-cover'
+                    />
+                  ) : (
+                    <img
+                      src='/icons/logo.svg'
+                      alt=''
+                      aria-hidden='true'
+                      className='h-[19px] w-4 object-contain'
+                    />
+                  )}
+                </div>
+
+                <h3 className='overflow-hidden text-ellipsis whitespace-nowrap text-[16px] font-medium leading-5 text-black'>
+                  {title}
+                </h3>
+                {archived && (
+                  <Badge className='ml-2 rounded-full bg-muted text-muted-foreground px-2 py-0 text-xs whitespace-nowrap'>
+                    {t('common.core.archived')}
+                  </Badge>
+                )}
+              </div>
+              <div className='flex items-center gap-2'>
+                {isFavorite && <StarIcon className='w-5 h-5 text-yellow-400' />}
+              </div>
+            </div>
+            <p className='min-h-[1.25rem] break-words break-all text-sm font-normal leading-5 text-[color:rgba(10,10,10,0.65)] line-clamp-3'>
+              {description || ''}
+            </p>
+          </CardContent>
+        </Card>
+      </Link>
+      {showMenu && (
+        <DropdownMenu>
+          <div className='absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center'>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type='button'
+                variant='ghost'
+                size='icon'
+                className='h-8 w-8 bg-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted data-[state=open]:bg-muted data-[state=open]:text-foreground'
+                title={t('common.core.more')}
+                aria-label={t('common.core.more')}
+                onClick={event => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+              >
+                <MoreHorizontal className='h-5 w-5' />
+              </Button>
+            </DropdownMenuTrigger>
+          </div>
+          <DropdownMenuContent
+            align='end'
+            sideOffset={4}
+            className='min-w-[9rem]'
+          >
+            {onImportActivationRequest && (
+              <DropdownMenuItem
+                onSelect={event => {
+                  event.stopPropagation();
+                  onImportActivationRequest();
+                }}
+              >
+                {t('module.order.importActivation.action')}
+              </DropdownMenuItem>
+            )}
+            {onRedemptionCodeRequest && (
+              <DropdownMenuItem
+                onSelect={event => {
+                  event.stopPropagation();
+                  onRedemptionCodeRequest();
+                }}
+              >
+                {t('module.order.redemptionCodes.action')}
+              </DropdownMenuItem>
+            )}
+            {canManagePermissions && (
+              <DropdownMenuItem
+                onSelect={event => {
+                  event.stopPropagation();
+                  onPermissionRequest?.();
+                }}
+              >
+                {t('module.shifuSetting.permissionManage')}
+              </DropdownMenuItem>
+            )}
+            {canManageArchive && (
+              <DropdownMenuItem
+                onSelect={event => {
+                  event.stopPropagation();
+                  onArchiveRequest?.();
+                }}
+              >
+                {archived
+                  ? t('module.shifuSetting.unarchive')
+                  : t('module.shifuSetting.archive')}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+};
+
+export default ShifuCard;

--- a/src/cook-web/src/app/admin/components/ShifuCard.tsx
+++ b/src/cook-web/src/app/admin/components/ShifuCard.tsx
@@ -71,7 +71,7 @@ const ShifuCard = ({
 
   return (
     <div
-      className='relative w-full h-full group'
+      className='relative w-full h-full'
       {...(onboardingTargetId
         ? buildOnboardingTargetProps(onboardingTargetId)
         : {})}
@@ -96,7 +96,8 @@ const ShifuCard = ({
                   {image ? (
                     <img
                       src={image}
-                      alt='recipe'
+                      alt=''
+                      aria-hidden='true'
                       className='h-full w-full rounded-[8px] object-cover'
                     />
                   ) : (

--- a/src/cook-web/src/app/admin/page.test.tsx
+++ b/src/cook-web/src/app/admin/page.test.tsx
@@ -357,15 +357,11 @@ describe('AdminPage', () => {
       expect(screen.getByText('Course 1')).toBeInTheDocument();
     });
 
-    const courseActionsTrigger = screen.getByRole('button', {
-      name: 'common.core.more',
-    });
-
-    expect(courseActionsTrigger).not.toHaveClass('opacity-0');
-    expect(courseActionsTrigger).toHaveClass('h-8', 'w-8', 'bg-transparent');
-    expect(courseActionsTrigger.closest('a')).toBeNull();
-
-    fireEvent.click(courseActionsTrigger);
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.more',
+      }),
+    );
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -486,68 +482,5 @@ describe('AdminPage', () => {
         name: 'module.order.redemptionCodes.action',
       }),
     ).not.toBeInTheDocument();
-  });
-
-  test('opens import activation from the course card menu', async () => {
-    render(<AdminPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Course 1')).toBeInTheDocument();
-    });
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'common.core.more',
-      }),
-    );
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.order.importActivation.action',
-      }),
-    );
-
-    expect(screen.getByTestId('import-activation-dialog')).toHaveAttribute(
-      'data-open',
-      'true',
-    );
-    expect(screen.getByTestId('import-course-id')).toHaveTextContent(
-      'course-1',
-    );
-  });
-
-  test('shows the restore action for an archived course', async () => {
-    mockGetShifuList.mockResolvedValue({
-      items: [
-        {
-          bid: 'course-archived-1',
-          name: 'Archived Course',
-          description: 'Archived course description',
-          state: 1,
-          archived: true,
-          avatar: '',
-          is_favorite: false,
-          created_user_bid: 'user-1',
-          can_manage_permissions: true,
-        },
-      ],
-    });
-
-    render(<AdminPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Archived Course')).toBeInTheDocument();
-    });
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'common.core.more',
-      }),
-    );
-
-    expect(
-      screen.getByRole('button', {
-        name: 'module.shifuSetting.unarchive',
-      }),
-    ).toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/page.test.tsx
+++ b/src/cook-web/src/app/admin/page.test.tsx
@@ -357,11 +357,15 @@ describe('AdminPage', () => {
       expect(screen.getByText('Course 1')).toBeInTheDocument();
     });
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'common.core.more',
-      }),
-    );
+    const courseActionsTrigger = screen.getByRole('button', {
+      name: 'common.core.more',
+    });
+
+    expect(courseActionsTrigger).not.toHaveClass('opacity-0');
+    expect(courseActionsTrigger).toHaveClass('h-8', 'w-8', 'bg-transparent');
+    expect(courseActionsTrigger.closest('a')).toBeNull();
+
+    fireEvent.click(courseActionsTrigger);
 
     fireEvent.click(
       screen.getByRole('button', {
@@ -482,5 +486,68 @@ describe('AdminPage', () => {
         name: 'module.order.redemptionCodes.action',
       }),
     ).not.toBeInTheDocument();
+  });
+
+  test('opens import activation from the course card menu', async () => {
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Course 1')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.more',
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'module.order.importActivation.action',
+      }),
+    );
+
+    expect(screen.getByTestId('import-activation-dialog')).toHaveAttribute(
+      'data-open',
+      'true',
+    );
+    expect(screen.getByTestId('import-course-id')).toHaveTextContent(
+      'course-1',
+    );
+  });
+
+  test('shows the restore action for an archived course', async () => {
+    mockGetShifuList.mockResolvedValue({
+      items: [
+        {
+          bid: 'course-archived-1',
+          name: 'Archived Course',
+          description: 'Archived course description',
+          state: 1,
+          archived: true,
+          avatar: '',
+          is_favorite: false,
+          created_user_bid: 'user-1',
+          can_manage_permissions: true,
+        },
+      ],
+    });
+
+    render(<AdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Archived Course')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'common.core.more',
+      }),
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'module.shifuSetting.unarchive',
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -111,7 +111,6 @@ const ShifuCard = ({
     canManageArchive ||
     canManagePermissions,
   );
-
   return (
     <div
       className='relative w-full h-full group'
@@ -128,7 +127,9 @@ const ShifuCard = ({
           style={CARD_CONTAINER_STYLE}
         >
           <CardContent className={CARD_CONTENT_CLASS}>
-            <div className='mb-4 flex flex-row items-center justify-between'>
+            <div
+              className={`mb-4 flex flex-row items-center justify-between ${showMenu ? 'pr-8' : ''}`}
+            >
               <div className='flex min-w-0 flex-row items-center w-full'>
                 <div
                   className={COURSE_AVATAR_CLASS}
@@ -172,14 +173,13 @@ const ShifuCard = ({
       </Link>
       {showMenu && (
         <DropdownMenu>
-          {/* Reveal the menu when hovering the whole card, while keeping click behavior unchanged. */}
-          <div className='absolute top-0 right-0 h-10 w-10 flex items-center justify-center z-10 group'>
+          <div className='absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center'>
             <DropdownMenuTrigger asChild>
               <Button
                 type='button'
                 variant='ghost'
                 size='icon'
-                className='h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100'
+                className='h-8 w-8 bg-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted data-[state=open]:bg-muted data-[state=open]:text-foreground'
                 title={t('common.core.more')}
                 aria-label={t('common.core.more')}
                 onClick={event => {
@@ -187,14 +187,14 @@ const ShifuCard = ({
                   event.stopPropagation();
                 }}
               >
-                <MoreHorizontal className='h-4 w-4 text-muted-foreground' />
+                <MoreHorizontal className='h-5 w-5' />
               </Button>
             </DropdownMenuTrigger>
           </div>
           <DropdownMenuContent
             align='end'
-            sideOffset={0}
-            className='min-w-0'
+            sideOffset={4}
+            className='min-w-[9rem]'
           >
             {onImportActivationRequest && (
               <DropdownMenuItem

--- a/src/cook-web/src/app/admin/page.tsx
+++ b/src/cook-web/src/app/admin/page.tsx
@@ -1,21 +1,10 @@
 'use client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import Link from 'next/link';
-import { StarIcon } from '@heroicons/react/24/solid';
-import { MoreHorizontal } from 'lucide-react';
 import api from '@/api';
 import { Shifu } from '@/types/shifu';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { Button } from '@/components/ui/Button';
-import { Card, CardContent } from '@/components/ui/Card';
-import { Badge } from '@/components/ui/Badge';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/DropdownMenu';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -51,35 +40,8 @@ import {
   ONBOARDING_TARGET_IDS,
 } from '@/lib/onboardingTargets';
 import AdminTitle from './components/AdminTitle';
+import ShifuCard from './components/ShifuCard';
 
-interface ShifuCardProps {
-  id: string;
-  image: string | undefined;
-  title: string;
-  description: string;
-  isFavorite: boolean;
-  archived?: boolean;
-  canManageArchive?: boolean;
-  canManagePermissions?: boolean;
-  onArchiveRequest?: () => void;
-  onPermissionRequest?: () => void;
-  onImportActivationRequest?: () => void;
-  onRedemptionCodeRequest?: () => void;
-  onboardingTargetId?: string;
-}
-
-const CARD_CONTAINER_CLASS =
-  'w-full h-full min-h-[118px] rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] transition-colors duration-200 ease-in-out hover:bg-primary/[0.04]';
-const CARD_CONTAINER_STYLE: React.CSSProperties = {
-  boxShadow:
-    'var(--shadow-sm-1-offset-x, 0) var(--shadow-sm-1-offset-y, 1px) var(--shadow-sm-1-blur-radius, 3px) var(--shadow-sm-1-spread-radius, 0) var(--shadow-sm-1-color, rgba(0, 0, 0, 0.10)), var(--shadow-sm-2-offset-x, 0) var(--shadow-sm-2-offset-y, 1px) var(--shadow-sm-2-blur-radius, 2px) var(--shadow-sm-2-spread-radius, -1px) var(--shadow-sm-2-color, rgba(0, 0, 0, 0.10))',
-};
-const CARD_CONTENT_CLASS = 'p-4 flex flex-col h-full cursor-pointer';
-const COURSE_AVATAR_CLASS =
-  'mr-3 flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px]';
-const COURSE_AVATAR_EMPTY_STYLE: React.CSSProperties = {
-  backgroundColor: '#CFCED4',
-};
 const COURSE_TABS_LIST_CLASS =
   'h-auto rounded-[var(--border-radius-rounded-lg,10px)] bg-[var(--base-muted,#F5F5F5)] p-[3px]';
 const COURSE_TABS_TRIGGER_CLASS =
@@ -88,162 +50,6 @@ const CREATE_SUCCESS_TOAST_DURATION_MS = 2000;
 const CREATE_SUCCESS_REDIRECT_DELAY_MS = 600;
 const ACTION_DIALOG_RESET_DELAY_MS = 200;
 const SHIFU_STATE_PUBLISHED = 1;
-
-const ShifuCard = ({
-  id,
-  image,
-  title,
-  description,
-  isFavorite,
-  archived,
-  canManageArchive,
-  canManagePermissions,
-  onArchiveRequest,
-  onPermissionRequest,
-  onImportActivationRequest,
-  onRedemptionCodeRequest,
-  onboardingTargetId,
-}: ShifuCardProps) => {
-  const { t } = useTranslation();
-  const showMenu = Boolean(
-    onRedemptionCodeRequest ||
-    onImportActivationRequest ||
-    canManageArchive ||
-    canManagePermissions,
-  );
-  return (
-    <div
-      className='relative w-full h-full group'
-      {...(onboardingTargetId
-        ? buildOnboardingTargetProps(onboardingTargetId)
-        : {})}
-    >
-      <Link
-        href={`/shifu/${id}`}
-        className='block w-full h-full'
-      >
-        <Card
-          className={CARD_CONTAINER_CLASS}
-          style={CARD_CONTAINER_STYLE}
-        >
-          <CardContent className={CARD_CONTENT_CLASS}>
-            <div
-              className={`mb-4 flex flex-row items-center justify-between ${showMenu ? 'pr-8' : ''}`}
-            >
-              <div className='flex min-w-0 flex-row items-center w-full'>
-                <div
-                  className={COURSE_AVATAR_CLASS}
-                  style={!image ? COURSE_AVATAR_EMPTY_STYLE : undefined}
-                >
-                  {image && (
-                    <img
-                      src={image}
-                      alt='recipe'
-                      className='h-full w-full rounded-[8px] object-cover'
-                    />
-                  )}
-                  {!image && (
-                    <img
-                      src='/icons/logo.svg'
-                      alt=''
-                      aria-hidden='true'
-                      className='h-[19px] w-4 object-contain'
-                    />
-                  )}
-                </div>
-
-                <h3 className='overflow-hidden text-ellipsis whitespace-nowrap text-[16px] font-medium leading-5 text-black'>
-                  {title}
-                </h3>
-                {archived && (
-                  <Badge className='ml-2 rounded-full bg-muted text-muted-foreground px-2 py-0 text-xs whitespace-nowrap'>
-                    {t('common.core.archived')}
-                  </Badge>
-                )}
-              </div>
-              <div className='flex items-center gap-2'>
-                {isFavorite && <StarIcon className='w-5 h-5 text-yellow-400' />}
-              </div>
-            </div>
-            <p className='min-h-[1.25rem] break-words break-all text-sm font-normal leading-5 text-[color:rgba(10,10,10,0.65)] line-clamp-3'>
-              {description || ''}
-            </p>
-          </CardContent>
-        </Card>
-      </Link>
-      {showMenu && (
-        <DropdownMenu>
-          <div className='absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center'>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type='button'
-                variant='ghost'
-                size='icon'
-                className='h-8 w-8 bg-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted data-[state=open]:bg-muted data-[state=open]:text-foreground'
-                title={t('common.core.more')}
-                aria-label={t('common.core.more')}
-                onClick={event => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-              >
-                <MoreHorizontal className='h-5 w-5' />
-              </Button>
-            </DropdownMenuTrigger>
-          </div>
-          <DropdownMenuContent
-            align='end'
-            sideOffset={4}
-            className='min-w-[9rem]'
-          >
-            {onImportActivationRequest && (
-              <DropdownMenuItem
-                onSelect={event => {
-                  event.stopPropagation();
-                  onImportActivationRequest();
-                }}
-              >
-                {t('module.order.importActivation.action')}
-              </DropdownMenuItem>
-            )}
-            {onRedemptionCodeRequest && (
-              <DropdownMenuItem
-                onSelect={event => {
-                  event.stopPropagation();
-                  onRedemptionCodeRequest();
-                }}
-              >
-                {t('module.order.redemptionCodes.action')}
-              </DropdownMenuItem>
-            )}
-            {canManagePermissions && (
-              <DropdownMenuItem
-                onSelect={event => {
-                  event.stopPropagation();
-                  onPermissionRequest?.();
-                }}
-              >
-                {t('module.shifuSetting.permissionManage')}
-              </DropdownMenuItem>
-            )}
-            {canManageArchive && (
-              <DropdownMenuItem
-                onSelect={event => {
-                  event.stopPropagation();
-                  onArchiveRequest?.();
-                }}
-              >
-                {archived
-                  ? t('module.shifuSetting.unarchive')
-                  : t('module.shifuSetting.archive')}
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
-  );
-};
 
 const ScriptManagementPage = () => {
   const router = useRouter();


### PR DESCRIPTION
## Summary

## What changed
- Keep the course-card action trigger visible without requiring hover.
- Preserve the larger hit area and title spacing so the action does not overlap long course names.
- Move the reusable course-card UI out of the route entry into a focused component.
- Mark the course cover image as decorative so screen readers no longer announce it as `recipe`.
- Drop the stale `group` class left over from the hover-reveal trigger.
- Add focused component coverage for persistent action visibility and for the decorative cover image.

## Why
Teachers can now find course actions immediately on desktop and touch devices, while the admin route remains focused on page composition as required by `AGENTS.md`.

## Validation
- `npm test -- --runInBand src/app/admin/components/ShifuCard.test.tsx src/app/admin/page.test.tsx`
- `npm run type-check`
- `npm run lint` (passes with existing warnings)
- `python scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files`

## Dependencies
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added course cards with images, descriptions, favorites, archived status, and onboarding support.
  * Added card actions for importing activations, managing redemption codes and permissions, and archiving or unarchiving courses.
  * Card actions are available without hovering and do not trigger card navigation.
  * Decorative course cover images are hidden from assistive technologies.

* **Tests**
  * Added coverage for action visibility, styling, navigation behavior, and image accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->