### PR TITLE
chore: enforce magic method documentation

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -381,6 +381,14 @@ real side effects or invariants. Do not copy the signature or write a generic
 "Initialize the object" sentence merely to satisfy the rule. Test doubles
 should name the state or collaborator they stand in for.
 
+For `D105`, document the observable protocol contract instead of restating the
+magic method name. A `__json__` docstring says whether it returns a scalar,
+JSON-compatible data, or a JSON string; mapping methods identify the keys or
+payload they proxy; representation and comparison methods describe their
+visible result. Keep a one-line contract when sufficient, and make test-double
+operators name the fake expression they build. Do not write filler such as
+"Implement `__json__`".
+
 Adopt or remove exceptions one rule unit at a time. A rule unit is normally
 one Ruff code; combine codes only when they report the same construct and have
 the same fix and exception boundary. Base each rule PR on the preceding rule

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -121,6 +121,17 @@ plan's progress update for that rule.
   reports 30,778 findings across 39 rules and no D107 findings.
 - [ ] Merge or retarget D107 PR #2582 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 01:09 CST: Opened ready D105 PR
+  [#2583](https://github.com/ai-shifu/ai-shifu/pull/2583) from
+  `sunner/ruff-d105` to the D107 branch. All 155 findings across 37 Python
+  files now document each magic method's observable protocol. A semantic AST
+  audit found no executable change after removing docstrings; 224 focused
+  tests, the full backend suite, and all pre-commit hooks pass.
+- [x] 2026-08-21 01:09 CST: Re-ran the stable `ALL` census on the D105 tip. It
+  reports 30,623 findings across 38 rules and no D105 findings. E501 remains at
+  613 findings, so the documentation cleanup transfers no line-length debt.
+- [ ] Merge or retarget D105 PR #2583 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -176,6 +187,10 @@ plan's progress update for that rule.
   `pass` statement redundant under the already-selected PIE790 rule. Removing
   that no-op preserves the configured baseline and runtime behavior; it does
   not adopt a second rule unit.
+- The first D105 pass introduced four E501 findings through long protocol
+  summaries. Shortening those summaries without weakening their observable
+  contracts restored E501 to 613, making the final census a pure 155-finding
+  reduction instead of moving debt between rules.
 - FIX002 and TD003 report the same two TODOs. One is a real password-login
   rate-limit feature and one is a compatibility-removal checkpoint. Renaming
   them to evade lint would hide work, and implementing either is larger than a
@@ -303,6 +318,17 @@ suites pass 166 tests with one skip, the full backend suite passes 3,010 tests
 with 17 skips, and the repository-wide pre-commit gate passes. The engineering
 baseline tells future agents to document the payload, state, dependency, setup,
 or real side effects instead of copying a signature or adding generic filler.
+
+The D105 stage removes the global missing-magic-method-docstring exception and
+documents all 155 affected methods in 37 files. The 106 `__json__` methods state
+whether they expose a scalar, JSON-compatible data, or a serialized string;
+mapping, representation, comparison, iteration, and delegation methods name
+their visible protocol result. No runtime path consumes these docstrings, and a
+semantic AST audit proves the Python sources are otherwise identical after
+docstrings are removed. The focused protocol suites pass 224 tests, the full
+backend suite passes 3,010 tests with 17 skips, and the repository-wide
+pre-commit gate passes. Future agents now have an explicit D105 repair contract
+that rejects filler summaries in favor of observable behavior.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -217,14 +217,13 @@ select = [
 ]
 ignore = [
     "E501",    # line length is owned by the formatter
-    # D1xx (except D104 and D107, which are enforced): ~4.6k undocumented
-    # modules, classes, methods, functions and magic methods. Writing them is a
-    # codebase project, not a lint config change.
+    # D1xx (except D104, D105 and D107, which are enforced): ~4.5k undocumented
+    # modules, classes, methods and functions. Writing them is a codebase
+    # project, not a lint config change.
     "D100",    # undocumented public module
     "D101",    # undocumented public class
     "D102",    # undocumented public method
     "D103",    # undocumented public function
-    "D105",    # undocumented magic method
     "D203",    # blank line before a class docstring -- conflicts with D211
     "D213",    # summary on the second line -- conflicts with D212
     # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -139,6 +139,7 @@ class IdentifierViolation:
     message: str
 
     def __str__(self) -> str:
+        """Return the violation in path-and-line form."""
         return f"{self.path}:{self.line}: {self.message}"
 
 

--- a/src/api/flaskr/api/check/dto.py
+++ b/src/api/flaskr/api/check/dto.py
@@ -27,6 +27,7 @@ class CheckResultDTO:
         self.raw_data = raw_data
 
     def __to_dict__(self) -> dict:
+        """Return the risk-check result as a dictionary."""
         return {
             "check_result": self.check_result,
             "risk_labels": self.risk_labels,
@@ -35,4 +36,5 @@ class CheckResultDTO:
         }
 
     def __json__(self) -> dict:
+        """Return the risk-check result as JSON-compatible data."""
         return self.__to_dict__()

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -57,6 +57,8 @@ class MockClient:
         """Initialize the no-op Langfuse client."""
 
     def __getattr__(self, name) -> Any:
+        """Return a no-op callable for any Langfuse operation."""
+
         def method(*args, **kwargs):
             return self
 

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -33,6 +33,7 @@ class AppLoggerProxy:
             return self._fallback
 
     def __getattr__(self, name: str) -> Any:
+        """Delegate attribute access to the active application logger."""
         return getattr(self._resolve(), name)
 
 

--- a/src/api/flaskr/service/billing/admission.py
+++ b/src/api/flaskr/service/billing/admission.py
@@ -47,6 +47,7 @@ class CreatorUsageAdmission:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a response field by key."""
         return self.to_response_dict()[key]
 
 

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -69,6 +69,7 @@ class UsageMetricCharge:
     consumed_credits: Decimal
 
     def __getitem__(self, key: str) -> Any:
+        """Return an attribute value by key."""
         return getattr(self, key)
 
 

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -199,6 +199,7 @@ class ProviderReferenceReconcileResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/consts.py
+++ b/src/api/flaskr/service/billing/consts.py
@@ -437,6 +437,7 @@ class CreditUsageRateSeed:
     status: int
 
     def __getitem__(self, key: str) -> Any:
+        """Return an attribute value by key."""
         return getattr(self, key)
 
 

--- a/src/api/flaskr/service/billing/daily_aggregates.py
+++ b/src/api/flaskr/service/billing/daily_aggregates.py
@@ -67,6 +67,7 @@ class DailyAggregateJobResult:
         return payload
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -111,6 +112,7 @@ class RebuildDailyAggregatesResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/domains.py
+++ b/src/api/flaskr/service/billing/domains.py
@@ -65,6 +65,7 @@ class DomainVerificationResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -17,12 +17,15 @@ class BillingBaseDTO(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     def __json__(self) -> dict[str, Any]:
+        """Return aliased model fields as JSON-compatible data."""
         return self.model_dump(mode="python", by_alias=True)
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized DTO field by key."""
         return self.__json__()[key]
 
     def __eq__(self, other: object) -> bool:
+        """Compare the DTO with a serialized mapping or model."""
         if isinstance(other, dict):
             return self.__json__() == other
         return super().__eq__(other)

--- a/src/api/flaskr/service/billing/entitlements.py
+++ b/src/api/flaskr/service/billing/entitlements.py
@@ -61,6 +61,7 @@ class CreatorEntitlementState:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized entitlement field by key."""
         if key == "feature_payload":
             return self.feature_payload.to_metadata_json()
         return getattr(self, key)

--- a/src/api/flaskr/service/billing/grant_results.py
+++ b/src/api/flaskr/service/billing/grant_results.py
@@ -39,6 +39,7 @@ class ManualCreditGrantResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/provider_price_mappings.py
+++ b/src/api/flaskr/service/billing/provider_price_mappings.py
@@ -37,6 +37,7 @@ class ProviderPriceMappingError(RuntimeError):
     details: dict[str, Any] = field(default_factory=dict)
 
     def __str__(self) -> str:
+        """Return the validation error message."""
         return self.message
 
 

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -92,6 +92,7 @@ class BillingOrderProviderUpdateResult:
     )
 
     def __bool__(self) -> bool:
+        """Return whether the provider update was applied."""
         return self.applied
 
     def stage_after_state_changes(

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -265,6 +265,7 @@ class RenewalEventSnapshot:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -306,6 +307,7 @@ class RenewalEventResult:
         return payload
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -87,6 +87,7 @@ class SettlementResult:
         return payload
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -108,6 +109,7 @@ class BackfillSettlementItem:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -137,6 +139,7 @@ class BackfillSettlementResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -216,6 +216,7 @@ class TopupExpiryRepairResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -267,6 +268,7 @@ class SubscriptionCycleRepairResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/value_objects.py
+++ b/src/api/flaskr/service/billing/value_objects.py
@@ -40,18 +40,23 @@ class JsonObjectMap(MutableMapping[str, Any]):
     values: dict[str, Any] = field(default_factory=dict)
 
     def __getitem__(self, key: str) -> Any:
+        """Return a stored JSON value by key."""
         return self.values[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
+        """Store a JSON value under the normalized string key."""
         self.values[str(key)] = value
 
     def __delitem__(self, key: str) -> None:
+        """Delete the stored JSON value for a key."""
         del self.values[key]
 
     def __iter__(self) -> Iterator[str]:
+        """Iterate over the stored JSON keys."""
         return iter(self.values)
 
     def __len__(self) -> int:
+        """Return the number of stored JSON keys."""
         return len(self.values)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -98,6 +98,7 @@ class WalletSnapshotRecord:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -123,6 +124,7 @@ class WalletSnapshotRebuildResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -146,6 +148,7 @@ class RefundReturnCreditsResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -165,6 +168,7 @@ class WalletExpirationResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -228,6 +232,7 @@ class ExpireLedgerBucketDriftRepairResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -293,6 +298,7 @@ class ExpiredCreditPackBucketRestoreResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 
@@ -320,6 +326,7 @@ class ManualCreditGrantResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -347,6 +354,7 @@ class ReservedGrantRepairRecord:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
 
@@ -404,6 +412,7 @@ class RenewalStateDriftRepairResult:
         }
 
     def __getitem__(self, key: str) -> Any:
+        """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
 

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -126,9 +126,11 @@ class BillingWebhookResult:
         return payload
 
     def __getitem__(self, key: str) -> Any:
+        """Return a response field by key."""
         return self.to_response_dict()[key]
 
     def __iter__(self) -> Iterator[Any]:
+        """Yield the response payload and status code for unpacking."""
         yield self.to_response_dict()
         yield self.status_code
 

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -10,6 +10,7 @@ class DictItem:
         self.value = value
 
     def __json__(self) -> dict:
+        """Return the dictionary item as JSON-compatible data."""
         return {"display": self.display, "value": self.value}
 
 
@@ -21,6 +22,7 @@ class Dict:
         self.items = items
 
     def __json__(self) -> dict:
+        """Return the dictionary definition as JSON-compatible data."""
         return {"name": self.name, "display": self.display, "items": self.items}
 
 

--- a/src/api/flaskr/service/common/dto_base.py
+++ b/src/api/flaskr/service/common/dto_base.py
@@ -61,6 +61,7 @@ class AutoJsonMixin:
     __json_exclude__: frozenset = frozenset()
 
     def __json__(self) -> dict:
+        """Derive JSON-compatible data from declared model fields."""
         payload = {}
         for name, field in type(self).model_fields.items():
             if name in self.__json_exclude__:

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -60,6 +60,7 @@ class UserInfo:
         self.is_operator = is_operator
 
     def __json__(self) -> dict:
+        """Return the user information as JSON-compatible data."""
         return {
             "user_id": self.user_id,
             "username": self.username,
@@ -75,6 +76,7 @@ class UserInfo:
         }
 
     def __html__(self) -> dict:
+        """Return the serialized user-information payload."""
         return self.__json__()
 
 
@@ -89,6 +91,7 @@ class UserToken:
         self.token = token
 
     def __json__(self) -> dict:
+        """Return the user token as JSON-compatible data."""
         return {
             "userInfo": self.userInfo,
             "token": self.token,
@@ -106,6 +109,7 @@ class OAuthStartDTO:
         self.state = state
 
     def __json__(self) -> dict:
+        """Return the OAuth start response as JSON-compatible data."""
         return {
             "authorization_url": self.authorization_url,
             "state": self.state,
@@ -136,6 +140,7 @@ class PageNationDTO(BaseModel):
         self.data = data
 
     def __json__(self) -> dict:
+        """Return the paginated response as JSON-compatible data."""
         return {
             "page": self.page,
             "page_size": self.page_size,

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -15,15 +15,18 @@ class AppError(Exception):
         self.payload = payload
 
     def __json__(self) -> dict:
+        """Return the application error as JSON-compatible data."""
         rv = dict(self.payload or ())
         rv["message"] = self.message
         rv["code"] = self.code
         return rv
 
     def __str__(self) -> str:
+        """Return the application error message."""
         return self.message
 
     def __html__(self) -> dict:
+        """Return the serialized application-error payload."""
         return self.__json__()
 
 

--- a/src/api/flaskr/service/learn/learn_dtos.py
+++ b/src/api/flaskr/service/learn/learn_dtos.py
@@ -15,6 +15,7 @@ class LearnStatus(Enum):
     LOCKED = "locked"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -25,6 +26,7 @@ class OutlineType(Enum):
     GUEST = "guest"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -44,6 +46,7 @@ class GeneratedType(Enum):
     ASK = "ask"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -71,6 +74,7 @@ class ElementType(Enum):
     _VIDEO = "video"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -80,6 +84,7 @@ class ElementChangeType(Enum):
     DIFF = "diff"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -90,6 +95,7 @@ class LikeStatus(Enum):
     NONE = "none"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -102,6 +108,7 @@ class BlockType(Enum):
     ANSWER = "answer"
 
     def __json__(self) -> str:
+        """Return the serialized enum value."""
         return self.value
 
 
@@ -119,6 +126,7 @@ class VariableUpdateDTO(BaseModel):
         super().__init__(variable_name=variable_name, variable_value=variable_value)
 
     def __json__(self) -> dict:
+        """Return the variable update as JSON-compatible data."""
         return {
             "variable_name": self.variable_name,
             "variable_value": self.variable_value,
@@ -150,6 +158,7 @@ class OutlineItemUpdateDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the outline item update as JSON-compatible data."""
         return {
             "outline_bid": self.outline_bid,
             "title": self.title,
@@ -197,6 +206,7 @@ class LearnShifuInfoDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return learner-facing course information as JSON-compatible data."""
         return {
             "bid": self.bid,
             "title": self.title,
@@ -240,6 +250,7 @@ class LearnBannerInfoDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the learner banner as JSON-compatible data."""
         return {
             "title": self.title,
             "pop_up_title": self.pop_up_title,
@@ -290,6 +301,7 @@ class LearnOutlineItemInfoDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the learner outline item as JSON-compatible data."""
         return {
             "bid": self.bid,
             "position": self.position,
@@ -323,6 +335,7 @@ class LearnOutlineItemsWithBannerInfoDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the learner banner and outline collection as JSON-compatible data."""
         return {
             "banner_info": None
             if self.banner_info is None
@@ -386,6 +399,7 @@ class AudioSegmentDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the audio segment as JSON-compatible data."""
         ret = {
             "position": self.position,
             "segment_index": self.segment_index,
@@ -454,6 +468,7 @@ class AudioCompleteDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return completed-audio metadata as JSON-compatible data."""
         ret = {
             "position": self.position,
             "audio_url": self.audio_url,
@@ -481,6 +496,7 @@ class ElementVisualDTO(BaseModel):
         super().__init__(visual_type=visual_type, content=content)
 
     def __json__(self) -> dict:
+        """Return the element visual as JSON-compatible data."""
         return {"visual_type": self.visual_type, "content": self.content}
 
 
@@ -514,6 +530,7 @@ class SubtitleCueDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the subtitle cue as JSON-compatible data."""
         return {
             "text": self.text or "",
             "start_ms": int(self.start_ms or 0),
@@ -555,6 +572,7 @@ class ElementAudioDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the element audio as JSON-compatible data."""
         ret = {
             "position": int(self.position or 0),
             "audio_url": self.audio_url,
@@ -616,6 +634,7 @@ class ElementPayloadDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the composite element payload as JSON-compatible data."""
         ret = {
             "audio": self.audio.__json__() if self.audio is not None else None,
             "previous_visuals": [
@@ -732,6 +751,7 @@ class ElementDTO(BaseModel):
         return segments
 
     def __json__(self) -> dict:
+        """Return the element as JSON-compatible data."""
         ret = {
             "event_type": self.event_type,
             "element_bid": self.element_bid,
@@ -774,6 +794,7 @@ class AudioBackfillReadyDTO(BaseModel):
     )
 
     def __json__(self) -> dict:
+        """Return audio-backfill readiness as JSON-compatible data."""
         return {
             "generated_block_bid": self.generated_block_bid,
             "element_bids": self.element_bids,
@@ -806,6 +827,7 @@ class RunElementSSEMessageDTO(BaseModel):
     ) = Field(..., description="Run event content")
 
     def __json__(self) -> dict:
+        """Return the run element SSE message as JSON-compatible data."""
         ret = {
             "type": self.type,
             "event_type": self.event_type,
@@ -890,6 +912,7 @@ class RunMarkdownFlowDTO(BaseModel):
         return list(self._mdflow_stream_parts)
 
     def __json__(self) -> dict:
+        """Return the MarkdownFlow execution payload as JSON-compatible data."""
         ret = {
             "outline_bid": self.outline_bid,
             "generated_block_bid": self.generated_block_bid,
@@ -972,6 +995,7 @@ class LearnElementRecordDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the learner element record as JSON-compatible data."""
         ret = {
             "elements": [
                 item.__json__() if isinstance(item, BaseModel) else item
@@ -1002,6 +1026,7 @@ class RunStatusDTO(BaseModel):
         super().__init__(is_running=is_running, running_time=running_time)
 
     def __json__(self) -> dict:
+        """Return the run status as JSON-compatible data."""
         return {
             "is_running": self.is_running,
             "running_time": self.running_time,
@@ -1030,6 +1055,7 @@ class GeneratedInfoDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return generated-outline metadata as JSON-compatible data."""
         return {
             "position": self.position,
             "outline_name": self.outline_name,

--- a/src/api/flaskr/service/learn/legacy_record_builder.py
+++ b/src/api/flaskr/service/learn/legacy_record_builder.py
@@ -29,6 +29,7 @@ class LegacyGeneratedBlockRecord:
     audios: list[AudioCompleteDTO] | None = None
 
     def __json__(self) -> dict:
+        """Return the legacy generated block record as JSON-compatible data."""
         ret = {
             "generated_block_bid": self.generated_block_bid,
             "content": self.content,
@@ -52,6 +53,7 @@ class LegacyLearnRecord:
     records: list[LegacyGeneratedBlockRecord]
 
     def __json__(self) -> dict:
+        """Return the legacy learn record as JSON-compatible data."""
         return {
             "records": self.records,
         }

--- a/src/api/flaskr/service/learn/llmsetting.py
+++ b/src/api/flaskr/service/learn/llmsetting.py
@@ -6,10 +6,13 @@ class LLMSettings(BaseModel):
     temperature: float
 
     def __str__(self) -> str:
+        """Return a concise model and temperature description."""
         return f"model: {self.model}, temperature: {self.temperature}"
 
     def __repr__(self) -> str:
+        """Return the same concise description as string conversion."""
         return self.__str__()
 
     def __json__(self) -> dict:
+        """Return the LLM settings as JSON-compatible data."""
         return {"model": self.model, "temperature": self.temperature}

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -47,6 +47,7 @@ class FollowUpInfo:
         self.ask_provider_config = ask_provider_config or {}
 
     def __json__(self) -> dict:
+        """Return the follow-up info as JSON-compatible data."""
         return {
             "ask_model": self.ask_model,
             "ask_prompt": self.ask_prompt,

--- a/src/api/flaskr/service/order/admin_dtos.py
+++ b/src/api/flaskr/service/order/admin_dtos.py
@@ -42,6 +42,7 @@ class OrderAdminOverviewDTO(BaseModel):
     )
 
     def __json__(self) -> dict:
+        """Return the operator order overview as JSON-compatible data."""
         return {
             "total_order_count": self.total_order_count,
             "paid_order_count": self.paid_order_count,
@@ -130,6 +131,7 @@ class OrderAdminSummaryDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator order summary as JSON-compatible data."""
         return {
             "order_bid": self.order_bid,
             "shifu_bid": self.shifu_bid,
@@ -187,6 +189,7 @@ class OrderAdminActivityDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator order activity as JSON-compatible data."""
         return {
             "active_id": self.active_id,
             "active_name": self.active_name,
@@ -243,6 +246,7 @@ class OrderAdminCouponDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator order coupon as JSON-compatible data."""
         return {
             "coupon_bid": self.coupon_bid,
             "code": self.code,
@@ -330,6 +334,7 @@ class OrderAdminPaymentDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator order payment as JSON-compatible data."""
         return {
             "payment_channel": self.payment_channel,
             "payment_channel_key": self.payment_channel_key,
@@ -383,6 +388,7 @@ class OrderAdminDetailDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator order detail as JSON-compatible data."""
         return {
             "order": self.order,
             "activities": self.activities,

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -111,6 +111,7 @@ class PayItemDto:
         self.discount_code = discount_code
 
     def __json__(self) -> dict:
+        """Return the pay item as JSON-compatible data."""
         return {
             "name": self.name,
             "price_name": self.price_name,
@@ -156,6 +157,8 @@ class AICourseBuyRecordDTO:
         self.payment_channel = payment_channel
 
     def __json__(self) -> dict:
+        """Return the AI course buy record as JSON-compatible data."""
+
         def format_decimal(value):
             # Convert to a string with two decimal places
             formatted_value = value if isinstance(value, str) else f"{value:.2f}"
@@ -508,6 +511,7 @@ class BuyRecordDTO:
         self.payment_payload = payment_payload or {}
 
     def __json__(self) -> dict:
+        """Return the buy record as JSON-compatible data."""
         return {
             "order_id": self.order_id,
             "user_id": self.user_id,

--- a/src/api/flaskr/service/profile/dtos.py
+++ b/src/api/flaskr/service/profile/dtos.py
@@ -14,9 +14,11 @@ class ColorSetting:
         self.text_color = text_color
 
     def __json__(self) -> dict:
+        """Return the color setting as JSON-compatible data."""
         return {"color": self.color, "text_color": self.text_color}
 
     def __str__(self) -> str:
+        """Return the color settings as JSON text."""
         return json.dumps(self.__json__(), ensure_ascii=True)
 
 
@@ -55,6 +57,7 @@ class ProfileItemDefinition:
         self.is_hidden = is_hidden
 
     def __json__(self) -> dict:
+        """Return the profile item definition as JSON-compatible data."""
         return {
             "profile_key": self.profile_key,
             "color_setting": self.color_setting,
@@ -68,6 +71,7 @@ class ProfileItemDefinition:
         }
 
     def __str__(self) -> str:
+        """Return the profile definition mapping as text."""
         return str(self.__json__())
 
 
@@ -98,6 +102,7 @@ class ProfileValueDto:
         self.value = value
 
     def __json__(self) -> dict:
+        """Return the profile value as JSON-compatible data."""
         return {"name": self.name, "value": self.value}
 
 
@@ -114,4 +119,5 @@ class ProfileToSave:
         self.bid = bid
 
     def __json__(self) -> dict:
+        """Return the pending profile value as JSON-compatible data."""
         return {"key": self.key, "value": self.value, "bid": self.bid}

--- a/src/api/flaskr/service/shifu/admin_dtos_courses.py
+++ b/src/api/flaskr/service/shifu/admin_dtos_courses.py
@@ -86,6 +86,7 @@ class AdminOperationCourseSummaryDTO(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the operator course summary as JSON-compatible data."""
         return {
             "shifu_bid": self.shifu_bid,
             "course_name": self.course_name,
@@ -143,6 +144,7 @@ class AdminOperationCourseOverviewDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course overview as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -161,6 +163,7 @@ class AdminOperationCourseListDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course list as JSON-compatible data."""
         return {
             "items": [item.__json__() for item in self.items],
             "page": self.page,
@@ -189,6 +192,7 @@ class AdminOperationCourseDetailBasicInfoDTO(BaseModel):
     updated_at: datetime | None = Field(..., description="Updated at", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return operator course basic information as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -239,6 +243,7 @@ class AdminOperationCourseDetailMetricsDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course detail metrics as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -259,6 +264,7 @@ class AdminOperationEstimatedCreditComponentDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator estimated credit component as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -279,6 +285,7 @@ class AdminOperationEstimatedCreditModeDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator estimated credit mode as JSON-compatible data."""
         payload = self.model_dump(exclude={"llm", "tts"})
         payload["llm"] = self.llm.__json__()
         payload["tts"] = self.tts.__json__() if self.tts is not None else None
@@ -303,6 +310,7 @@ class AdminOperationEstimatedCreditAssumptionsDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator estimated credit assumptions as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -324,6 +332,7 @@ class AdminOperationEstimatedCreditCostDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator estimated credit cost as JSON-compatible data."""
         return {
             "read": self.read.__json__(),
             "listen": self.listen.__json__(),
@@ -379,6 +388,7 @@ class AdminOperationCourseDetailChapterDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course detail chapter as JSON-compatible data."""
         payload = self.model_dump(exclude={"children"})
         payload["children"] = [child.__json__() for child in self.children]
         return payload
@@ -421,6 +431,7 @@ class AdminOperationCourseUserDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course user as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -433,6 +444,7 @@ class AdminOperationCoursePromptDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course prompt as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -453,6 +465,7 @@ class AdminOperationCourseChapterDetailDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course chapter detail as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -476,6 +489,7 @@ class AdminOperationCourseDetailDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course detail as JSON-compatible data."""
         return {
             "basic_info": self.basic_info.__json__(),
             "metrics": self.metrics.__json__(),
@@ -502,6 +516,7 @@ class AdminOperationCourseFollowUpSummaryDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course follow-up summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -547,6 +562,7 @@ class AdminOperationCourseFollowUpItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course follow-up item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -568,6 +584,7 @@ class AdminOperationCourseFollowUpListDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course follow-up list as JSON-compatible data."""
         return {
             "summary": self.summary.__json__(),
             "items": [item.__json__() for item in self.items],
@@ -596,6 +613,7 @@ class AdminOperationCourseRatingSummaryDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course rating summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -635,6 +653,7 @@ class AdminOperationCourseRatingItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course rating item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -656,6 +675,7 @@ class AdminOperationCourseRatingListDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course rating list as JSON-compatible data."""
         return {
             "summary": self.summary.__json__(),
             "items": [item.__json__() for item in self.items],
@@ -739,6 +759,7 @@ class AdminOperationCourseCreditUsageItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course credit usage item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -780,6 +801,7 @@ class AdminOperationCourseCreditUsageDetailItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return credit-usage detail as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -803,6 +825,7 @@ class AdminOperationCourseCreditUsageListDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course credit usage list as JSON-compatible data."""
         return {
             "view": self.view,
             "items": [item.__json__() for item in self.items],
@@ -828,6 +851,7 @@ class AdminOperationCourseCreditUsageDetailListDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return credit-usage details as JSON-compatible data."""
         return {
             "items": [item.__json__() for item in self.items],
             "page": self.page,
@@ -865,6 +889,7 @@ class AdminOperationCourseFollowUpDetailBasicInfoDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return basic follow-up information as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -905,6 +930,7 @@ class AdminOperationCourseFollowUpCurrentRecordDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the current follow-up record as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -924,6 +950,7 @@ class AdminOperationCourseFollowUpTimelineItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return a follow-up timeline item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -944,6 +971,7 @@ class AdminOperationCourseFollowUpDetailDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator course follow-up detail as JSON-compatible data."""
         return {
             "basic_info": self.basic_info.__json__(),
             "current_record": self.current_record.__json__(),

--- a/src/api/flaskr/service/shifu/admin_dtos_users.py
+++ b/src/api/flaskr/service/shifu/admin_dtos_users.py
@@ -35,6 +35,7 @@ class AdminOperationUserCourseSummaryDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user course summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -128,6 +129,7 @@ class AdminOperationUserSummaryDTO(BaseModel):
     updated_at: datetime | None = Field(..., description="Updated at", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -177,6 +179,7 @@ class AdminOperationUserOverviewDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user overview as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -210,6 +213,7 @@ class AdminOperationUserListDTO(BaseModel):
         )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user list as JSON-compatible data."""
         return {
             "page": self.page,
             "page_size": self.page_size,
@@ -250,6 +254,7 @@ class AdminOperationUserCreditSummaryDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -282,6 +287,7 @@ class AdminOperationUserCreditGrantRequestDTO(BaseModel):
     note: str = Field(default="", description="Optional operator note", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit grant request as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -327,6 +333,7 @@ class AdminOperationUserCreditGrantResultDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit grant result as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -356,6 +363,7 @@ class AdminOperationUserReferralRewardSummaryDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user referral reward summary as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -390,6 +398,7 @@ class AdminOperationUserGrantBootstrapDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user grant bootstrap as JSON-compatible data."""
         return {
             "plans": [item.__json__() for item in self.plans],
             "current_subscription_product_display_name_i18n_key": (
@@ -418,6 +427,7 @@ class AdminOperationUserPackageGrantRequestDTO(BaseModel):
     note: str = Field(default="", description="Optional operator note", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user package grant request as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -453,6 +463,7 @@ class AdminOperationUserPackageGrantResultDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user package grant result as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -529,6 +540,7 @@ class AdminOperationUserCreditLedgerItemDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit ledger item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -550,6 +562,7 @@ class AdminOperationUserCreditLedgerPageDTO(BaseModel):
     page_count: int = Field(..., description="Page count", required=False)
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit ledger page as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -569,6 +582,7 @@ class AdminOperationUserCreditUsageDetailItemDTO(BaseModel):
     segment_count: int = Field(default=0, description="TTS segment count")
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit usage detail item as JSON-compatible data."""
         return self.model_dump()
 
 
@@ -593,4 +607,5 @@ class AdminOperationUserCreditUsageDetailDTO(BaseModel):
     )
 
     def __json__(self) -> dict[str, Any]:
+        """Return the operator user credit usage detail as JSON-compatible data."""
         return self.model_dump()

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -87,6 +87,7 @@ class ShifuDto(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the shifu as JSON-compatible data."""
         return {
             "bid": self.bid,
             "name": self.name,
@@ -252,6 +253,7 @@ class ShifuDetailDto(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the shifu detail as JSON-compatible data."""
         return {
             "bid": self.bid,
             "name": self.name,
@@ -339,6 +341,7 @@ class SimpleOutlineDto(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the simple outline as JSON-compatible data."""
         return {
             "bid": self.bid,
             "position": self.position,
@@ -430,6 +433,7 @@ class OutlineDto(BaseModel):
         )
 
     def __json__(self) -> dict:
+        """Return the outline as JSON-compatible data."""
         return {
             "bid": self.bid,
             "position": self.position,
@@ -455,6 +459,7 @@ class ReorderOutlineItemDto:
         self.children = children
 
     def __json__(self) -> dict:
+        """Return the reorder outline item as JSON-compatible data."""
         return {
             "bid": self.bid,
             "children": self.children,
@@ -478,6 +483,7 @@ class MdflowDTOParseResult(BaseModel):
         super().__init__(variables=variables, blocks_count=blocks_count)
 
     def __json__(self) -> dict:
+        """Return parsed MarkdownFlow metadata as JSON-compatible data."""
         return {
             "variables": self.variables,
             "blocks_count": self.blocks_count,

--- a/src/api/flaskr/service/shifu/shifu_struct_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_struct_manager.py
@@ -39,6 +39,7 @@ class ShifuOutlineItemDto(BaseModel):
     children: list["ShifuOutlineItemDto"]
 
     def __json__(self) -> str:
+        """Return the shifu outline item as a JSON string."""
         return self.model_dump_json(exclude_none=True)
 
 
@@ -55,6 +56,7 @@ class ShifuInfoDto(BaseModel):
     use_learner_language: bool = False
 
     def __json__(self) -> str:
+        """Return the shifu info as a JSON string."""
         return self.model_dump_json(exclude_none=True)
 
 

--- a/src/api/flaskr/service/user/dtos.py
+++ b/src/api/flaskr/service/user/dtos.py
@@ -13,6 +13,7 @@ class UserProfileLabelItemDTO(BaseModel):
     items: list | None = Field(..., description="items", required=False)
 
     def __json__(self) -> dict:
+        """Return the user profile label item as JSON-compatible data."""
         return {
             "key": self.key,
             "label": self.label,
@@ -30,6 +31,7 @@ class UserProfileLabelDTO(BaseModel):
     language: str = Field(..., description="language")
 
     def __json__(self) -> dict:
+        """Return the user profile label as JSON-compatible data."""
         return {
             "profiles": [item.__json__() for item in self.profiles],
             "language": self.language,

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -1550,12 +1550,15 @@ class FakeColumn:
         self.name = name
 
     def __eq__(self, other) -> tuple:
+        """Build a fake equality expression."""
         return ("eq", self.name, other)
 
     def __ge__(self, other) -> tuple:
+        """Build a fake greater-than-or-equal expression."""
         return ("ge", self.name, other)
 
     def __le__(self, other) -> tuple:
+        """Build a fake less-than-or-equal expression."""
         return ("le", self.name, other)
 
     def ilike(self, value: str):


### PR DESCRIPTION
## Summary
- remove the global D105 exception from Ruff
- document 155 magic methods across 37 Python files using their observable serialization, mapping, representation, comparison, and delegation behavior
- record the preferred D105 remediation pattern for future contributors and coding agents

## Safety
- confirmed there are no runtime consumers of magic-method docstrings in the repository
- independently compared every touched Python AST after stripping docstrings; no executable syntax changed
- kept the existing E501 count at 613, so this rule cleanup transfers no debt to line-length enforcement

## Stack
- follows #2582
- base branch: sunner/ruff-d107

## Verification
- ruff check . --select D105
- ruff check .
- ruff format --check .
- python3 scripts/check_example_identifiers.py --self-test
- 224 focused backend tests passed
- full backend suite: 3010 passed, 17 skipped
- python3 scripts/check_repo_harness.py
- python3 scripts/check_dev_tools.py
- lefthook run pre-commit --all-files --no-stage-fixed --no-tty
- final Ruff census: 30,623 findings across 38 rules; D105 is 0 and E501 remains 613
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->