### PR TITLE
chore: enforce standard library type-only imports

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -389,6 +389,22 @@ visible result. Keep a one-line contract when sufficient, and make test-double
 operators name the fake expression they build. Do not write filler such as
 "Implement `__json__`".
 
+For `TC003`, move a standard-library import into an `if TYPE_CHECKING:` block
+only after confirming every use is an annotation that Python does not need to
+resolve at runtime. Postponed annotations are the normal proof; a local
+variable annotation that is never evaluated is also safe. Keep imports that a
+framework, decorator, function signature without postponed evaluation, or
+explicit runtime reflection resolves while importing the module. Pydantic
+`BaseModel` fields are declared as runtime-evaluated in `ruff.toml`, so their
+field types stay imported normally; do not replace that contract with
+scattered `noqa` comments. When another shared runtime-evaluated base class or
+decorator is introduced, model it centrally in Ruff and add an import or
+schema smoke test. Use a narrow explained suppression only for a one-off
+runtime consumer that Ruff cannot model. Search tests for `monkeypatch`,
+`getattr`, and module-attribute assertions before moving an import: preserve a
+real injection seam, but remove an obsolete patch that never influences the
+code under test instead of keeping a fake runtime dependency.
+
 Adopt or remove exceptions one rule unit at a time. A rule unit is normally
 one Ruff code; combine codes only when they report the same construct and have
 the same fix and exception boundary. Base each rule PR on the preceding rule

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -132,6 +132,20 @@ plan's progress update for that rule.
   613 findings, so the documentation cleanup transfers no line-length debt.
 - [ ] Merge or retarget D105 PR #2583 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 01:40 CST: Opened ready TC003 PR
+  [#2584](https://github.com/ai-shifu/ai-shifu/pull/2584) from
+  `sunner/ruff-tc003` to the D105 branch. Of 100 findings across 86 files, 95
+  genuinely annotation-only imports in 81 files moved behind `TYPE_CHECKING`;
+  five Pydantic DTO modules retain runtime `datetime` imports through a shared
+  Ruff runtime-evaluation contract. The import AST audit, 261 focused tests,
+  full backend suite, script entry points, and all pre-commit hooks pass.
+- [x] 2026-08-21 01:40 CST: Re-ran the stable `ALL` census on the TC003 tip. It
+  reports 30,518 findings across 37 rules and no TC003 findings. The Pydantic
+  runtime model also removes four TC002 false positives while TC002 remains a
+  separate global exception; deleting one unused fake clock removes one
+  ANN001 finding, and every other rule count is unchanged.
+- [ ] Merge or retarget TC003 PR #2584 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -191,6 +205,16 @@ plan's progress update for that rule.
   summaries. Shortening those summaries without weakening their observable
   contracts restored E501 to 613, making the final census a pure 155-finding
   reduction instead of moving debt between rules.
+- TC003's unsafe fixer correctly identified annotation-only imports but could
+  not see four obsolete tests monkeypatching module-level `datetime` names that
+  production never read. The focused suites exposed the fake seams; removing
+  those patches while retaining their real `now_utc` injection made the tests
+  describe the actual clock contract.
+- The next numerically smaller candidate, PLR0911, spans 72 complex control-flow
+  functions across authentication, billing, payment, permissions, and Alembic
+  infrastructure. It is not a safe mechanical unit: adopting it requires
+  behavior-specific decomposition rather than result-variable or threshold
+  workarounds, so TC003 was the smaller reviewable exception-removal stage.
 - FIX002 and TD003 report the same two TODOs. One is a real password-login
   rate-limit feature and one is a compatibility-removal checkpoint. Renaming
   them to evade lint would hide work, and implementing either is larger than a
@@ -220,6 +244,10 @@ plan's progress update for that rule.
   is immutable history. A global ignore is the last resort for a repository-
   wide contract that fundamentally conflicts with a rule.
 - 2026-08-20: Do not edit applied Alembic migrations to satisfy style rules.
+- 2026-08-21: A shared Ruff semantic setting required by one rule may also
+  remove false positives from another still-ignored rule. Record that census
+  effect explicitly, but do not treat the second rule as adopted until its own
+  independent rule PR removes its exception and passes its acceptance suite.
 
 ## Outcomes & Retrospective
 
@@ -329,6 +357,19 @@ docstrings are removed. The focused protocol suites pass 224 tests, the full
 backend suite passes 3,010 tests with 17 skips, and the repository-wide
 pre-commit gate passes. Future agents now have an explicit D105 repair contract
 that rejects filler summaries in favor of observable behavior.
+
+The TC003 stage removes the global standard-library type-only import exception.
+Ninety-five imports across 81 Python files now load only under `TYPE_CHECKING`;
+an AST normalization audit proves those modules have no other executable syntax
+changes. Five Pydantic DTO modules keep `datetime` available while their model
+classes resolve field annotations, modeled once through Ruff's runtime-
+evaluated base-class setting and protected by five parameterized assertions.
+Focused testing also removed four ineffective `datetime` monkeypatch calls
+while preserving the real `now_utc` clock injection. The cross-service suite
+passes 261 tests, the full backend suite passes 3,015 tests with 17 skips, both
+diagnostic script entry points import, and the repository-wide pre-commit gate
+passes. Future agents now distinguish postponed and local annotations from
+Pydantic fields, runtime reflection, and genuine module-attribute test seams.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -226,11 +226,9 @@ ignore = [
     "D103",    # undocumented public function
     "D203",    # blank line before a class docstring -- conflicts with D211
     "D213",    # summary on the second line -- conflicts with D212
-    # TC002 / TC003: moving a third-party or stdlib import into TYPE_CHECKING
-    # breaks anything that resolves annotations at runtime, which for this repo
-    # means the SQLAlchemy mappers and pydantic models (~230 hits).
+    # TC002: moving a third-party import into TYPE_CHECKING breaks anything
+    # that resolves annotations at runtime, including SQLAlchemy mappers.
     "TC002",
-    "TC003",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     # INP001 is enforced; see per-file-ignores for the entrypoints, Alembic
@@ -238,6 +236,12 @@ ignore = [
     # than imported.
     "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
 ]
+
+[lint.flake8-type-checking]
+# Pydantic resolves model field annotations while creating each class. Keep
+# their standard-library field types imported at runtime; TC003 moves only
+# genuinely annotation-only imports behind TYPE_CHECKING.
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
 [lint.per-file-ignores]
 # `assert` is the point of a test, and both scripts below are test code: one is

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -8,8 +8,11 @@ import contextlib
 import json
 import re
 import sys
-from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 import json
 import re
 import sys
-from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
 I18N_DIR = ROOT / "src" / "i18n"

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -4,12 +4,14 @@ import json
 import logging
 import os
 import re
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Config as FlaskConfig
 from flask import Flask
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class EnvironmentConfigError(Exception):

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import contextlib
 import threading
-from collections.abc import Callable
 from functools import wraps
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _context_local = threading.local()
 

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -5,12 +5,15 @@ import json
 import os
 import threading
 from collections import defaultdict
-from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from flask import Flask
 
 from flaskr.common.config import get_config
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 TRANSLATIONS_DEFAULT_NAME = "i18n"
 

--- a/src/api/flaskr/route/storage.py
+++ b/src/api/flaskr/route/storage.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import mimetypes
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from flask import Flask, Response, send_file
 
 from flaskr.route.common import bypass_token_validation
 from flaskr.service.common.storage import get_local_storage_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _guess_mimetype(path: Path) -> str:

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator
 from contextlib import contextmanager, suppress
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.config.funcs import get_config, update_config
 
 from .primitives import normalize_bid
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _ADMIN_OPS_OWNER_BID = "billing-admin-ops"
 _CONFIG_STATUS_KEY = "ADMIN_BILLING.CONFIG_STATUS"

--- a/src/api/flaskr/service/billing/bucket_categories.py
+++ b/src/api/flaskr/service/billing/bucket_categories.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.util.datetime import NAIVE_DATETIME_MAX, NAIVE_DATETIME_MIN
 
@@ -27,6 +26,9 @@ from .consts import (
 from .models import BillingOrder, CreditWalletBucket
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 OrderTypeLoader = Callable[[str], int | None]
 

--- a/src/api/flaskr/service/billing/campaigns.py
+++ b/src/api/flaskr/service/billing/campaigns.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -59,6 +58,9 @@ from .serializers import (
     serialize_admin_campaign_detail,
     serialize_admin_campaign_product_option,
 )
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from decimal import ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP, Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_PROD,
@@ -36,6 +35,9 @@ from .primitives import (
     to_decimal,
 )
 from .rate_references import resolve_llm_rate_identity
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _ZERO = Decimal(0)
 _ROUNDING_LABELS = {

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from flask import Flask
@@ -149,6 +147,10 @@ from .subscriptions import (
     sync_subscription_lifecycle_events as _sync_subscription_lifecycle_events,
 )
 from .wallets import grant_refund_return_credits
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from datetime import datetime
 
 _SELF_MANAGED_PREORDER_PROVIDERS = {"pingxx", "alipay", "wechatpay"}
 

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 from flask import current_app
@@ -137,6 +136,9 @@ from .wallets import (
     repair_renewal_state_drift,
     restore_wrongly_expired_credit_pack_buckets,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _PRODUCT_TYPE_LABELS = {
     "custom": BILLING_PRODUCT_TYPE_CUSTOM,

--- a/src/api/flaskr/service/billing/credit_audit.py
+++ b/src/api/flaskr/service/billing/credit_audit.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc, to_utc_iso
@@ -36,6 +35,9 @@ from .primitives import (
 )
 from .queries import load_primary_active_subscription
 from .wallets import calculate_credit_wallet_snapshot_values
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _ZERO = Decimal(0)
 

--- a/src/api/flaskr/service/billing/credit_grant_allocation_views.py
+++ b/src/api/flaskr/service/billing/credit_grant_allocation_views.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from decimal import Decimal
 from typing import TYPE_CHECKING, Literal
 
 from flask import has_app_context
@@ -35,6 +33,9 @@ from .consts import (
 from .primitives import normalize_json_object, to_decimal
 
 if TYPE_CHECKING:
+    from datetime import datetime
+    from decimal import Decimal
+
     from .models import CreditLedgerEntry, CreditWalletBucket
 
 CreditAssetKind = Literal[

--- a/src/api/flaskr/service/billing/credit_mutations.py
+++ b/src/api/flaskr/service/billing/credit_mutations.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
@@ -15,6 +14,8 @@ from .primitives import normalize_json_object, quantize_credit_amount, to_decima
 from .wallets import sync_credit_bucket_status
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from .models import CreditLedgerEntry, CreditWalletBucket
 
 

--- a/src/api/flaskr/service/billing/cycle_state_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_state_transitions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc
@@ -22,6 +22,9 @@ from .consts import (
 )
 from .models import BillingSubscription, CreditLedgerEntry, CreditWalletBucket
 from .primitives import normalize_bid as _normalize_bid
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/billing/cycle_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_transitions.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .consts import (
     BILLING_INTERVAL_DAY,
@@ -18,6 +17,9 @@ from .queries import (
     extract_resolved_order_cycle_end_at,
     extract_resolved_order_cycle_start_at,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def resolve_order_effective_from(

--- a/src/api/flaskr/service/billing/grant_results.py
+++ b/src/api/flaskr/service/billing/grant_results.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/billing/manual_plan_grants.py
+++ b/src/api/flaskr/service/billing/manual_plan_grants.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -36,6 +35,9 @@ from .queries import (
     load_primary_active_subscription as _load_primary_active_subscription,
 )
 from .subscriptions import grant_paid_order_credits, is_self_managed_billing_provider
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _NOTIFICATION_EXTENSION_KEY = "admin_manual_plan_grant"
 _NOTIFICATION_STATUS_TEMPLATE_PENDING = "template_pending"

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.api.doc.feishu import send_notify
@@ -38,6 +37,9 @@ from .queries import (
 from .queries import (
     load_subscription_by_bid as _load_subscription_by_bid,
 )
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 TASK_NAME = "billing.send_subscription_purchase_sms"
 BILLING_PAID_FEISHU_TASK_NAME = "billing.send_billing_paid_feishu"

--- a/src/api/flaskr/service/billing/operation_credits.py
+++ b/src/api/flaskr/service/billing/operation_credits.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -35,6 +34,9 @@ from .consts import (
 from .models import CreditLedgerEntry, CreditWallet, CreditWalletBucket
 from .subscriptions import load_effective_topup_subscription
 from .wallets import persist_credit_wallet_snapshot, sync_credit_bucket_status
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _ZERO = Decimal(0)
 

--- a/src/api/flaskr/service/billing/preorders.py
+++ b/src/api/flaskr/service/billing/preorders.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.util.datetime import now_utc, to_utc_iso
 
@@ -14,6 +13,9 @@ from .consts import (
 from .models import BillingOrder, BillingProduct, BillingSubscription
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 CHECKOUT_ACTION_PREORDER = "preorder"
 CHECKOUT_ACTION_UPGRADE_IMMEDIATE = "upgrade_immediate"

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from flask import Flask
@@ -52,6 +51,8 @@ from .subscriptions import (
 from .value_objects import JsonObjectMap
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from .models import BillingOrder, BillingSubscription
 
 _STRIPE_SUCCESS_EVENT_TYPES = {

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask, has_app_context
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _MANUAL_PROVIDER_NAME = "manual"
 _CHECKOUT_TYPE = "referral_invitation_reward"

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -46,6 +45,9 @@ from .wallets import (
     refresh_credit_wallet_snapshot,
     sync_credit_bucket_status,
 )
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 REFERRAL_REWARD_GRANT_TYPE = "referral_reward"
 REFERRAL_REWARD_SCENE = "referral"

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db, retry_on_deadlock, uow
@@ -98,6 +97,9 @@ from .subscriptions import (
     sync_subscription_lifecycle_events as _sync_subscription_lifecycle_events,
 )
 from .wallets import _expire_credit_wallet_buckets_in_session
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _CLAIMABLE_EVENT_STATUSES = (
     BILLING_RENEWAL_EVENT_STATUS_PENDING,

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -28,6 +27,9 @@ from .models import BillingRenewalEvent, BillingSubscription
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import normalize_json_object as _normalize_json_object
 from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 MANAGED_RENEWAL_EVENT_TYPES = (
     BILLING_RENEWAL_EVENT_TYPE_RENEWAL,

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as cache_provider
@@ -45,6 +44,9 @@ from .wallets import (
     refresh_credit_wallet_snapshot,
     sync_credit_bucket_status,
 )
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _ZERO = Decimal(0)
 _SETTLEMENT_LOCK_TIMEOUT_SECONDS = 60

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.service.config import get_config
@@ -63,6 +62,9 @@ from .primitives import normalize_bid as _normalize_bid
 from .renewal import retry_billing_renewal_event, run_billing_renewal_event
 from .settlement import replay_bill_usage_settlement, settle_bill_usage
 from .wallets import expire_credit_wallet_buckets
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -6,8 +6,7 @@ import uuid
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask, has_app_context
 from flaskr.dao import db
@@ -49,6 +48,9 @@ from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import safe_to_positive_int as _safe_to_positive_int
 from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 _ACTIVE_SUBSCRIPTION_STATUSES = (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -85,6 +84,9 @@ from .provider_state import (
 from .queries import (
     load_latest_billing_order_by_subscription as _load_latest_billing_order_by_subscription,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _STRIPE_SUBSCRIPTION_EVENT_TYPES = {
     "customer.subscription.created",

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -15,6 +14,9 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from flaskr.service.common.models import raise_error, raise_error_with_args
 from flaskr.service.config import get_config
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 OSS_PROFILE_DEFAULT = "default"
 OSS_PROFILE_COURSES = "courses"

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -45,9 +45,8 @@ result so the summary is stable.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.i18n import _
@@ -60,6 +59,9 @@ from sqlalchemy import and_, bindparam, func, select
 from sqlalchemy.sql import Select
 
 from .engine import get_analytics_engine
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
 # Reuse the DSL-path error names so the HTTP wrapper maps them consistently
 # (the error name → HTTP code mapping lives in error_codes.json).

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -24,7 +24,6 @@ target dialect is MySQL — under SQLite (tests) the hint would not parse.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
@@ -38,6 +37,8 @@ from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import ColumnElement
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from .dsl import Aggregate, Filter, OrderBy, QueryDSL
 
 

--- a/src/api/flaskr/service/creator_analytics/whitelist.py
+++ b/src/api/flaskr/service/creator_analytics/whitelist.py
@@ -18,8 +18,8 @@ builder, driven by :class:`TableSpec` flags:
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flaskr.service.billing.models import BillingDailyUsageMetric
 from flaskr.service.learn.models import (
@@ -31,6 +31,9 @@ from flaskr.service.order.models import Order
 from flaskr.service.profile.models import VariableValue
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu, ShifuUserArchive
 from flaskr.service.user.models import UserInfo
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 ALLOWED_AGGREGATE_FUNCTIONS: frozenset[str] = frozenset(
     {"count", "count_distinct", "sum", "avg", "min", "max"}

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -64,6 +63,9 @@ from flaskr.util.datetime import now_utc
 from flaskr.util.timezone import _coerce_datetime
 from sqlalchemy import and_, case, false, or_
 from sqlalchemy.orm import aliased
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/learn/listen_element_history.py
+++ b/src/api/flaskr/service/learn/listen_element_history.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (
@@ -33,6 +32,9 @@ from flaskr.service.tts.models import AUDIO_STATUS_COMPLETED, LearnGeneratedAudi
 from flaskr.service.tts.subtitle_utils import normalize_subtitle_cues
 from flaskr.util.datetime import to_utc_iso
 from sqlalchemy import and_, or_
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _load_interaction_user_input_by_block_bid(

--- a/src/api/flaskr/service/learn/listen_element_matching.py
+++ b/src/api/flaskr/service/learn/listen_element_matching.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from flaskr.service.learn.learn_dtos import ElementDTO, ElementType
 from flaskr.service.learn.listen_element_types import _default_is_speakable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def get_speakable_text_elements(

--- a/src/api/flaskr/service/learn/listen_element_run_sidecar.py
+++ b/src/api/flaskr/service/learn/listen_element_run_sidecar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from flaskr.service.learn.learn_dtos import (
     ElementChangeType,
@@ -20,6 +20,9 @@ from flaskr.service.learn.listen_element_types import (
     _element_type_code,
     _new_element_bid,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class ListenElementRunSidecarMixin:

--- a/src/api/flaskr/service/learn/listen_element_run_stream.py
+++ b/src/api/flaskr/service/learn/listen_element_run_stream.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.service.learn.learn_dtos import (
@@ -59,6 +58,9 @@ from flaskr.service.learn.listen_source_span_utils import (
 from flaskr.service.learn.models import LearnGeneratedElement
 from flaskr.service.learn.type_state_machine import TypeInput
 from flaskr.service.tts.api import normalize_subtitle_cues
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class ListenElementRunStreamMixin:

--- a/src/api/flaskr/service/learn/listen_elements.py
+++ b/src/api/flaskr/service/learn/listen_elements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (
@@ -38,6 +38,9 @@ from flaskr.service.learn.type_state_machine import (
     TypeInput,
     TypeStateMachine,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 __all__ = [
     "ListenElementRunAdapter",

--- a/src/api/flaskr/service/learn/preview_elements.py
+++ b/src/api/flaskr/service/learn/preview_elements.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.service.learn.learn_dtos import (
@@ -13,6 +13,9 @@ from flaskr.service.learn.learn_dtos import (
 )
 from flaskr.service.learn.listen_element_run_state import BlockMeta
 from flaskr.service.learn.listen_elements import ListenElementRunAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class PreviewElementRunAdapter(ListenElementRunAdapter):

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import queue
 import threading
-from collections.abc import Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.common.shifu_context import (
     apply_shifu_context_snapshot,
@@ -12,6 +11,9 @@ from flaskr.common.shifu_context import (
 from flaskr.dao import cleanup_session_after, invalidate_session
 from flaskr.i18n import get_current_language, set_language
 from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class _StreamTTSFinalizeJob:

--- a/src/api/flaskr/service/order/payment_channel_resolution.py
+++ b/src/api/flaskr/service/order/payment_channel_resolution.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from flaskr.service.common.models import raise_error
 from flaskr.service.config import get_config
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def resolve_payment_channel(

--- a/src/api/flaskr/service/profile/learner_profile.py
+++ b/src/api/flaskr/service/profile/learner_profile.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from flask import Flask
 from flaskr.api.check import (
@@ -36,6 +35,9 @@ from flaskr.service.user.models import (
 from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 LEARNER_PROFILE_MAX_LENGTH = 1000
 LEARNER_PROFILE_NICKNAME_MAX_LENGTH = 64

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -4,12 +4,15 @@ import hashlib
 import threading
 import time
 import uuid
-from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.service.common.models import raise_error
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 IN_FLIGHT_TTL_SECONDS = 360
 

--- a/src/api/flaskr/service/referral/admin.py
+++ b/src/api/flaskr/service/referral/admin.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -37,6 +36,9 @@ from .models import (
     ReferralInviteReward,
 )
 from .reward_queue import build_referral_reward_queue
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 ABNORMAL_STATUS_BY_LABEL = {
     "normal": REFERRAL_ABNORMAL_STATUS_NORMAL,

--- a/src/api/flaskr/service/referral/dtos.py
+++ b/src/api/flaskr/service/referral/dtos.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -6,9 +6,8 @@ import hashlib
 import secrets
 import string
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 from flask import Flask, has_app_context, has_request_context, request
@@ -52,6 +51,9 @@ from .models import (
     ReferralInviteReward,
 )
 from .reward_queue import build_referral_reward_queue
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _INVITE_CODE_ALPHABET = string.ascii_uppercase + string.digits
 _INVITE_CODE_LENGTH = 8

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -5,11 +5,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.common.i18n_utils import get_markdownflow_output_language
 from flaskr.dao import db
@@ -49,6 +47,10 @@ from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from markdown_flow import MarkdownFlow
 from sqlalchemy import and_, case, literal, not_
 from sqlalchemy.orm import defer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from decimal import Decimal
 
 
 def _format_average_score(value: Decimal | None) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_estimate.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_estimate.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import contextlib
 import re
 from dataclasses import dataclass
-from datetime import datetime
 from decimal import ROUND_CEILING, Decimal
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.api.llm import get_current_models
@@ -37,6 +37,9 @@ from flaskr.service.shifu.admin_dtos_courses import (
 )
 from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 from flaskr.util.datetime import now_utc
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 _ZERO = Decimal(0)
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 
 import math
 import re
-from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.api.llm import PROVIDER_STATES, get_current_models
@@ -76,6 +75,9 @@ from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
 from sqlalchemy import and_, case, false, literal, not_, or_
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -5,8 +5,8 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.common.umami_client import get_course_visit_count_30d
@@ -63,6 +63,9 @@ from flaskr.service.shifu.models import (
     DraftOutlineItem,
     PublishedOutlineItem,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _resolve_learning_permission(item_type: int | None) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -6,9 +6,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -54,6 +52,10 @@ from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
 from sqlalchemy import and_, or_
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
 
 
 def _build_course_follow_up_base_subquery(shifu_bid: str):

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -5,10 +5,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask, current_app
 from flaskr.dao import db
@@ -61,6 +60,9 @@ from flaskr.service.shifu.models import (
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import and_, case, literal, not_, or_
 from sqlalchemy.orm import defer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
 
 @dataclass

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 
 import re
 import sys
-from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import current_app
 from flaskr.dao import db
@@ -181,6 +179,10 @@ from flaskr.service.shifu.admin_shared import (  # noqa: E402, F401
     COURSE_RATING_LIST_MAX_PAGE_SIZE,
     _normalize_identifier,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from decimal import Decimal
 
 COURSE_CREDIT_USAGE_VIEW_GROUPED = "grouped"
 

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -5,9 +5,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask, current_app
 from flaskr.common.cache_provider import cache as redis
@@ -65,6 +63,10 @@ from flaskr.service.user.utils import (
 from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc
 from markdown_flow import MarkdownFlow
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
 
 
 def _load_latest_course_for_transfer(shifu_bid: str):

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -5,10 +5,8 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.dao import db
@@ -46,6 +44,10 @@ from flaskr.service.user.models import (
     UserInfo as UserEntity,
 )
 from flaskr.util.datetime import NAIVE_DATETIME_MIN
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
 
 
 def _load_course_related_user_bids(

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import current_app
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.timezone import serialize_with_app_timezone
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def coerce_operator_datetime(value: Any) -> datetime | None:

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.api.tts import get_default_voice_settings, synthesize_text
@@ -31,6 +30,9 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
 from sqlalchemy import or_
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 OPERATOR_VOICE_CLONE_SOURCE_METHOD = "operator_register"
 # Short text/model used only to validate a registered voice_id against the

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime
-from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import current_app
 from flaskr.service.user.consts import (
@@ -17,6 +16,9 @@ from flaskr.service.user.consts import (
     USER_STATE_TRAIL,
     USER_STATE_UNREGISTERED,
 )
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 COURSE_STATUS_PUBLISHED = "published"
 

--- a/src/api/flaskr/service/shifu/admin_user_courses.py
+++ b/src/api/flaskr/service/shifu/admin_user_courses.py
@@ -5,7 +5,7 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.service.learn.const import (
@@ -33,6 +33,9 @@ from flaskr.service.shifu.models import (
     PublishedShifu,
 )
 from flaskr.util.datetime import NAIVE_DATETIME_MIN
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _build_operator_user_course_summary(

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -6,11 +6,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
-from datetime import datetime
 from decimal import Decimal
 from json import JSONDecodeError
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import current_app
 from flaskr.dao import db
@@ -128,6 +126,10 @@ from flaskr.service.user.models import (
 )
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, not_, or_
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -5,10 +5,9 @@ Split mechanically out of the former giant module (backend overhaul B5).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.service.common.models import (
@@ -70,6 +69,9 @@ from flaskr.service.user.models import (
 )
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, or_
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _load_course_user_contact_map(

--- a/src/api/flaskr/service/shifu/course_activity.py
+++ b/src/api/flaskr/service/shifu/course_activity.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.util.datetime import NAIVE_DATETIME_MIN
 from sqlalchemy import and_, or_
 
 from .models import DraftOutlineItem, DraftShifu, PublishedOutlineItem, PublishedShifu
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import datetime
 
 
 def _record_course_activity(

--- a/src/api/flaskr/service/tts/cloned_voice_registry.py
+++ b/src/api/flaskr/service/tts/cloned_voice_registry.py
@@ -13,8 +13,8 @@ write path (``admin_operations/voice_clones.py``).
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flaskr.service.tts.minimax_voice_clone import is_valid_minimax_custom_voice_id
 from flaskr.service.tts.models import (
@@ -26,6 +26,9 @@ from flaskr.service.tts.models import (
 from flaskr.service.tts.volcengine_voice_clone import (
     is_valid_volcengine_custom_voice_id,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -20,9 +20,9 @@ import logging
 import re
 import time
 import uuid
-from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flask import Flask
 from flaskr.api.tts import (
@@ -63,6 +63,9 @@ from flaskr.service.tts.patterns import (
 )
 from flaskr.service.tts.tts_handler import upload_audio_to_oss
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _AV_LATEX_BLOCK = AV_LATEX_BLOCK
 

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -7,11 +7,14 @@ import logging
 import math
 import threading
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from flaskr.common.log import AppLoggerProxy
 from flaskr.util.deprecation import deprecated_alias_getattr
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .base import AuthProvider
 
 

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -31,6 +30,9 @@ from flaskr.service.user.repository import (
 )
 from flaskr.service.user.utils import generate_token
 from flaskr.util.datetime import now_utc
+
+if TYPE_CHECKING:
+    import datetime
 
 
 def _is_within_seconds(value: datetime.datetime, *, seconds: int) -> bool:

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -44,6 +43,9 @@ from flaskr.service.user.utils import (
 )
 from flaskr.util.datetime import now_utc
 from sqlalchemy import text
+
+if TYPE_CHECKING:
+    import datetime
 
 BOOTSTRAP_LOCK_NAME = "user_first_verified_bootstrap"
 

--- a/src/api/flaskr/service/user/verification_codes.py
+++ b/src/api/flaskr/service/user/verification_codes.py
@@ -8,8 +8,7 @@ resetting passwords where we only want to validate ownership of an identifier.
 from __future__ import annotations
 
 import contextlib
-import datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as redis
@@ -19,6 +18,9 @@ from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
 from flaskr.service.user.models import UserVerifyCode
 from flaskr.util.datetime import now_utc
+
+if TYPE_CHECKING:
+    import datetime
 
 CodeKind = Literal["sms", "email"]
 

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -25,7 +25,6 @@ import shutil
 import sys
 import tempfile
 from collections import Counter, OrderedDict
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -33,10 +32,15 @@ os.environ.setdefault("SKIP_LOAD_DOTENV", "1")
 os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
 os.environ.setdefault("SKIP_DB_MIGRATIONS_FOR_TESTS", "1")
 
+from typing import TYPE_CHECKING
+
 from flask import Flask
 from flaskr import dao
 from sqlalchemy.dialects.mysql import BIGINT, LONGTEXT
 from sqlalchemy.ext.compiler import compiles
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @compiles(LONGTEXT, "sqlite")

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -20,7 +20,6 @@ import json
 import os
 import re
 import tempfile
-from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -29,8 +28,13 @@ os.environ.setdefault("SKIP_LOAD_DOTENV", "1")
 os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
 os.environ.setdefault("SKIP_DB_MIGRATIONS_FOR_TESTS", "1")
 
+from typing import TYPE_CHECKING
+
 from flaskr.service.tts import streaming_tts as streaming_tts_module
 from flaskr.service.tts.pipeline import split_av_speakable_segments
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 DEFAULT_CHUNK_SIZES = (1, 2, 3, 5, 8, 13)
 VISUAL_LEAK_PATTERN = re.compile(

--- a/src/api/tests/common/fixtures/billing_products.py
+++ b/src/api/tests/common/fixtures/billing_products.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flaskr.service.billing.consts import (
     ALLOCATION_INTERVAL_MANUAL,
@@ -25,6 +24,9 @@ from flaskr.service.billing.consts import (
     BILLING_TRIAL_PRODUCT_METADATA_VALID_DAYS,
 )
 from flaskr.service.billing.models import BillingProduct
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 _TEST_BILLING_PRODUCT_ROWS: tuple[dict[str, Any], ...] = (
     {

--- a/src/api/tests/service/billing/renewal_execution_app_fixture.py
+++ b/src/api/tests/service/billing/renewal_execution_app_fixture.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
 from flaskr import dao
 
 from tests.common.fixtures.bill_products import build_bill_products
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.fixture

--- a/src/api/tests/service/billing/route_loader.py
+++ b/src/api/tests/service/billing/route_loader.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import importlib
 import sys
-from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 _ROUTE_PACKAGE = "flaskr.route"
 _ROUTE_COMMON = f"{_ROUTE_PACKAGE}.common"

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -115,7 +115,6 @@ def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(billing_queries_module, "now_utc", lambda: _frozen_now)
     monkeypatch.setattr(billing_wallets_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(billing_wallets_module, "now_utc", lambda: _frozen_now)
-    monkeypatch.setattr(billing_campaigns_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(billing_campaigns_module, "now_utc", lambda: _frozen_now)
     monkeypatch.setattr(billing_serializers_module, "now_utc", lambda: _frozen_now)
 

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -107,7 +107,6 @@ def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(billing_queries_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(billing_queries_module, "now_utc", lambda: _frozen_now)
     monkeypatch.setattr(billing_read_models_module, "now_utc", lambda: _frozen_now)
-    monkeypatch.setattr(billing_campaigns_module, "datetime", _FixedDateTime)
     monkeypatch.setattr(billing_campaigns_module, "now_utc", lambda: _frozen_now)
     monkeypatch.setattr(billing_serializers_module, "now_utc", lambda: _frozen_now)
 

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -22,8 +22,8 @@ These tests pin the new semantics:
 from __future__ import annotations
 
 from datetime import timedelta
-from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -61,6 +61,9 @@ from flaskr.util.datetime import now_utc
 from sqlalchemy.orm import sessionmaker
 
 from tests.common.fixtures.bill_products import build_bill_products
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 CREATOR_BID = "creator-uow-renewal"
 

--- a/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
+++ b/src/api/tests/service/billing/wallet_lifecycle_app_fixture.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
 from flaskr import dao
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.fixture

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -1,9 +1,12 @@
 """Tests for the AutoJsonMixin DTO serialization base."""
 
+import importlib
 import json
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from typing import get_args
 
+import pytest
 from flaskr.route.common import fmt
 from flaskr.service.common.dto_base import AutoJsonMixin
 from pydantic import BaseModel, Field
@@ -120,3 +123,47 @@ def test_key_overrides_and_exclusions():
     assert payload == {"page": 2, "items": ["a", "b"]}
     assert list(payload.keys()) == ["page", "items"]
     assert "internal_state" not in payload
+
+
+@pytest.mark.parametrize(
+    ("module_name", "model_name", "field_name"),
+    [
+        (
+            "flaskr.service.billing.dtos",
+            "BillingSubscriptionDTO",
+            "current_period_end_at",
+        ),
+        (
+            "flaskr.service.dashboard.dtos",
+            "DashboardEntryCourseItemDTO",
+            "last_active_at",
+        ),
+        (
+            "flaskr.service.order.admin_dtos",
+            "OrderAdminSummaryDTO",
+            "created_at",
+        ),
+        (
+            "flaskr.service.shifu.admin_dtos_courses",
+            "AdminOperationCourseSummaryDTO",
+            "created_at",
+        ),
+        (
+            "flaskr.service.shifu.admin_dtos_users",
+            "AdminOperationUserSummaryDTO",
+            "created_at",
+        ),
+    ],
+)
+def test_pydantic_datetime_fields_keep_runtime_imports(
+    module_name: str,
+    model_name: str,
+    field_name: str,
+) -> None:
+    """Keep Pydantic field types available while each model class is built."""
+    module = importlib.import_module(module_name)
+    model = getattr(module, model_name)
+
+    assert module.datetime is datetime
+    annotation = model.model_fields[field_name].annotation
+    assert annotation is datetime or datetime in get_args(annotation)

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.dao import db
@@ -26,6 +26,9 @@ from flaskr.service.shifu.models import (
 )
 from flaskr.service.user.models import UserInfo
 from flaskr.util.datetime import now_utc
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 def _clear_tables() -> None:

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -2926,7 +2926,6 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
         def now(cls, tz=None) -> datetime:
             return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
 
-    monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
     monkeypatch.setattr(
         referral_reward_grants_module,
         "now_utc",
@@ -3019,12 +3018,6 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
 def test_grant_operator_user_referral_reward_extends_empty_active_bucket(
     app, monkeypatch
 ):
-    class FixedDateTime(datetime):
-        @classmethod
-        def now(cls, tz=None) -> datetime:
-            return cls(2026, 4, 21, 0, 0, 0, tzinfo=tz)
-
-    monkeypatch.setattr(referral_reward_grants_module, "datetime", FixedDateTime)
     monkeypatch.setattr(
         referral_reward_grants_module,
         "now_utc",


### PR DESCRIPTION
## Summary
- remove the global TC003 exception from Ruff
- move 95 genuinely annotation-only standard-library imports in 81 Python files behind TYPE_CHECKING
- model Pydantic BaseModel as runtime-evaluated so five DTO modules keep datetime available while their classes are built
- document the project decision process for postponed annotations, local annotations, runtime reflection, and test injection seams

## Runtime safety
- an AST audit confirms the 81 existing Python modules have no executable syntax changes after normalizing the 95 import moves
- five parameterized assertions verify representative Pydantic datetime fields remain resolved at import time
- removed four obsolete datetime monkeypatch calls that never influenced the code under test; the real now_utc clock seams remain covered
- the centralized Pydantic model also removes four TC002 false positives, but TC002 remains a separate globally ignored rule and is not enabled here

## Stack
- follows #2583
- base branch: sunner/ruff-d105

## Verification
- ruff check . --select TC003
- ruff check .
- ruff format --check .
- 261 cross-service focused tests passed
- full backend suite: 3015 passed, 17 skipped
- translation parity and usage checks
- both backend diagnostic script module entry points imported successfully
- python3 scripts/check_repo_harness.py
- python3 scripts/check_dev_tools.py
- lefthook run pre-commit --all-files --no-stage-fixed --no-tty
- final Ruff census: 30,518 findings across 37 rules; TC003 is 0, TC002 is 134, ANN001 is 4,662, and all other rule counts are unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->