### PR TITLE
chore: enforce third-party type-only imports

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -389,21 +389,27 @@ visible result. Keep a one-line contract when sufficient, and make test-double
 operators name the fake expression they build. Do not write filler such as
 "Implement `__json__`".
 
-For `TC003`, move a standard-library import into an `if TYPE_CHECKING:` block
-only after confirming every use is an annotation that Python does not need to
-resolve at runtime. Postponed annotations are the normal proof; a local
-variable annotation that is never evaluated is also safe. Keep imports that a
-framework, decorator, function signature without postponed evaluation, or
-explicit runtime reflection resolves while importing the module. Pydantic
-`BaseModel` fields are declared as runtime-evaluated in `ruff.toml`, so their
-field types stay imported normally; do not replace that contract with
-scattered `noqa` comments. When another shared runtime-evaluated base class or
-decorator is introduced, model it centrally in Ruff and add an import or
-schema smoke test. Use a narrow explained suppression only for a one-off
-runtime consumer that Ruff cannot model. Search tests for `monkeypatch`,
-`getattr`, and module-attribute assertions before moving an import: preserve a
-real injection seam, but remove an obsolete patch that never influences the
-code under test instead of keeping a fake runtime dependency.
+For `TC002` and `TC003`, move a third-party or standard-library import into an
+`if TYPE_CHECKING:` block only after confirming every use is an annotation that
+Python does not need to resolve at runtime. Postponed annotations are the
+normal proof; a quoted annotation or a local variable annotation that is never
+evaluated is also safe. An import's source does not prove that it is safe to
+defer: keep imports that provide registration side effects or that a framework,
+decorator, function signature without postponed evaluation, or explicit
+runtime reflection resolves while importing the module. When one import
+statement mixes runtime values with annotation-only types, split the statement
+and move only the type-only names.
+
+Pydantic `BaseModel` fields are declared as runtime-evaluated in `ruff.toml`,
+so both their standard-library and third-party field types stay imported
+normally; do not replace that contract with scattered `noqa` comments. When
+another shared runtime-evaluated base class or decorator is introduced, model
+it centrally in Ruff and add an import or schema smoke test. Use a narrow
+explained suppression only for a one-off runtime consumer that Ruff cannot
+model. Search tests for `monkeypatch`, `getattr`, and module-attribute
+assertions before moving an import: preserve a real injection seam, but remove
+an obsolete patch that never influences the code under test instead of keeping
+a fake runtime dependency.
 
 Adopt or remove exceptions one rule unit at a time. A rule unit is normally
 one Ruff code; combine codes only when they report the same construct and have

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -146,6 +146,18 @@ plan's progress update for that rule.
   ANN001 finding, and every other rule count is unchanged.
 - [ ] Merge or retarget TC003 PR #2584 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 02:00 CST: Prepared the TC002 stage on
+  `sunner/ruff-tc002`, stacked on TC003. All 134 annotation-only third-party
+  imports across 113 files moved behind `TYPE_CHECKING`. An import AST audit
+  matched every removed runtime import to its type-only replacement and found
+  no other executable changes; 908 focused tests and the full backend suite
+  pass.
+- [x] 2026-08-21 02:00 CST: Re-ran the stable `ALL` census on the TC002 tip. It
+  reports 30,384 findings across 36 rules and no TC002 or TC003 findings. The
+  134-finding reduction is exact; ANN001, E501, and PLR0911 remain unchanged.
+- [ ] Open the ready TC002 PR against the TC003 branch after the repository
+  gates pass, then merge or retarget it after its predecessors without
+  combining it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -210,6 +222,11 @@ plan's progress update for that rule.
   production never read. The focused suites exposed the fake seams; removing
   those patches while retaining their real `now_utc` injection made the tests
   describe the actual clock contract.
+- TC002's unsafe fixer moved all 134 findings without exposing a hidden runtime
+  dependency. Two modules without postponed annotations used quoted or local
+  annotations, while SQLAlchemy model classes used for executable query
+  construction stayed available at runtime. The exact import-movement audit
+  makes that boundary explicit.
 - The next numerically smaller candidate, PLR0911, spans 72 complex control-flow
   functions across authentication, billing, payment, permissions, and Alembic
   infrastructure. It is not a safe mechanical unit: adopting it requires
@@ -370,6 +387,17 @@ passes 261 tests, the full backend suite passes 3,015 tests with 17 skips, both
 diagnostic script entry points import, and the repository-wide pre-commit gate
 passes. Future agents now distinguish postponed and local annotations from
 Pydantic fields, runtime reflection, and genuine module-attribute test seams.
+
+The TC002 stage removes the global third-party type-only import exception. All
+134 findings across 113 Python files are annotation-only uses and now load
+under `TYPE_CHECKING`; runtime SQLAlchemy models remain in normal imports, and
+Pydantic field types remain protected by the shared runtime-evaluated base-
+class setting. An AST audit proves a one-for-one movement of import aliases and
+no other executable changes. The focused cross-service suite passes 908 tests,
+the full backend suite passes 3,015 tests with 17 skips, and the stable `ALL`
+census falls exactly 134 findings to 30,384 across 36 rules. Future agents now
+apply the same runtime-resolution test to both third-party and standard-library
+annotation imports instead of treating import provenance as the safety proof.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -155,9 +155,12 @@ plan's progress update for that rule.
 - [x] 2026-08-21 02:00 CST: Re-ran the stable `ALL` census on the TC002 tip. It
   reports 30,384 findings across 36 rules and no TC002 or TC003 findings. The
   134-finding reduction is exact; ANN001, E501, and PLR0911 remain unchanged.
-- [ ] Open the ready TC002 PR against the TC003 branch after the repository
-  gates pass, then merge or retarget it after its predecessors without
-  combining it with the next rule unit.
+- [x] 2026-08-21 02:06 CST: Opened ready TC002 PR
+  [#2585](https://github.com/ai-shifu/ai-shifu/pull/2585) from
+  `sunner/ruff-tc002` to the TC003 branch after all repository pre-commit hooks
+  passed.
+- [ ] Merge or retarget TC002 PR #2585 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -185,12 +185,13 @@ select = [
     # positionally (SQLAlchemy, the MySQL DBAPI `ping`, `socket.setblocking`,
     # `monkeypatch.setitem`) carry an inline noqa.
     "FBT003",  # boolean positional value in a call
-    # flake8-type-checking is enabled as a whole. TC002/TC003 are ignored below
-    # (they would push third-party imports behind TYPE_CHECKING, where runtime
-    # annotation resolution then fails); the rest have no violations and catch
-    # the mistakes a TYPE_CHECKING block invites: a name imported there but used
-    # at runtime (TC004), an empty or redundant block (TC005/TC010), a
-    # needlessly quoted annotation (TC006/TC007).
+    # flake8-type-checking is enabled as a whole. Annotation-only standard-
+    # library and third-party imports live behind TYPE_CHECKING; the Pydantic
+    # runtime-evaluation contract below keeps model field types available while
+    # classes are created. The remaining rules catch the mistakes such a block
+    # invites: a name imported there but used at runtime (TC004), an empty or
+    # redundant block (TC005/TC010), or a needlessly quoted annotation
+    # (TC006/TC007).
     "TC",
 
     # --- Docstrings -------------------------------------------------------
@@ -226,9 +227,6 @@ ignore = [
     "D103",    # undocumented public function
     "D203",    # blank line before a class docstring -- conflicts with D211
     "D213",    # summary on the second line -- conflicts with D212
-    # TC002: moving a third-party import into TYPE_CHECKING breaks anything
-    # that resolves annotations at runtime, including SQLAlchemy mappers.
-    "TC002",
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
     # INP001 is enforced; see per-file-ignores for the entrypoints, Alembic
@@ -239,8 +237,8 @@ ignore = [
 
 [lint.flake8-type-checking]
 # Pydantic resolves model field annotations while creating each class. Keep
-# their standard-library field types imported at runtime; TC003 moves only
-# genuinely annotation-only imports behind TYPE_CHECKING.
+# their standard-library and third-party field types imported at runtime;
+# TC002/TC003 move only genuinely annotation-only imports behind TYPE_CHECKING.
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
 [lint.per-file-ignores]

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import importlib
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from celery import Celery, Task
 from celery.schedules import crontab
 from celery.signals import worker_process_init
-from flask import Flask
 
 from flaskr.common.config import get_explicit_env_override
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _DEFAULT_BROKER_URL = "redis://localhost:6379/0"
 _DEFAULT_BILLING_RENEWAL_CRON = "* * * * *"

--- a/src/api/flaskr/common/umami_client.py
+++ b/src/api/flaskr/common/umami_client.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import logging
 import time
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import requests
-from flask import Flask
 
 from flaskr.common.cache_provider import cache
 from flaskr.common.config import get_config
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 UMAMI_CLOUD_API_BASE_URL = "https://api.umami.is/v1"
 UMAMI_ACCESS_TOKEN_CACHE_SUFFIX = "analytics:umami:access-token"  # noqa: S105 - cache key suffix

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -4,7 +4,6 @@ import json
 from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.config.funcs import get_config, update_config
 
@@ -12,6 +11,8 @@ from .primitives import normalize_bid
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from flask import Flask
 
 _ADMIN_OPS_OWNER_BID = "billing-admin-ops"
 _CONFIG_STATUS_KEY = "ADMIN_BILLING.CONFIG_STATUS"

--- a/src/api/flaskr/service/billing/admin_target_users.py
+++ b/src/api/flaskr/service/billing/admin_target_users.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.contact_identifiers import (
     resolve_contact_lookup_providers,
     resolve_contact_type,
     validate_contact_identifier,
 )
 from flaskr.service.common.models import raise_error, raise_param_error
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def resolve_admin_entitlement_grant_target(

--- a/src/api/flaskr/service/billing/admission.py
+++ b/src/api/flaskr/service/billing/admission.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.models import raise_error
 from flaskr.util.datetime import now_utc
 
@@ -21,6 +20,9 @@ from .ownership import resolve_shifu_creator_bid
 from .primitives import is_billing_enabled
 from .primitives import to_decimal as _to_decimal
 from .subscriptions import load_effective_topup_subscription
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _ZERO_CREDITS = Decimal(0)
 

--- a/src/api/flaskr/service/billing/auth_hooks.py
+++ b/src/api/flaskr/service/billing/auth_hooks.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.framework.plugin.plugin_manager import extension
-from flaskr.service.user.post_auth import PostAuthContext
 
 from .trials import bootstrap_new_creator_trial_credits
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flaskr.service.user.post_auth import PostAuthContext
 
 
 @extension("run_post_auth_extensions")

--- a/src/api/flaskr/service/billing/campaigns.py
+++ b/src/api/flaskr/service/billing/campaigns.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.common.models import (
@@ -61,6 +60,8 @@ from .serializers import (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from flask import Flask
 from flaskr.common import cache_provider
 from flaskr.common.public_urls import build_stripe_billing_result_url
 from flaskr.dao import db
@@ -151,6 +150,8 @@ from .wallets import grant_refund_return_credits
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from datetime import datetime
+
+    from flask import Flask
 
 _SELF_MANAGED_PREORDER_PROVIDERS = {"pingxx", "alipay", "wechatpay"}
 

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -8,10 +8,9 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from flask import Flask
 from flaskr.api.sms.aliyun import (
     get_sms_template_ali,
     query_sms_template_list_ali,
@@ -65,6 +64,9 @@ from .primitives import is_billing_enabled
 from .primitives import normalize_bid as _normalize_bid
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 TASK_NAME = "billing.send_credit_notification"
 SOURCE_TYPE_LEDGER = "ledger"

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -10,7 +10,7 @@ import json
 from dataclasses import dataclass
 from importlib import import_module
 from io import BytesIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from cryptography import x509
@@ -29,7 +29,6 @@ from flaskr.service.config.funcs import get_config
 from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 from PIL import Image, ImageOps, UnidentifiedImageError
-from werkzeug.datastructures import FileStorage
 
 from .domains import build_creator_domain_bindings
 from .entitlements import (
@@ -38,6 +37,9 @@ from .entitlements import (
     serialize_creator_entitlements,
 )
 from .primitives import normalize_bid
+
+if TYPE_CHECKING:
+    from werkzeug.datastructures import FileStorage
 
 BRANDING_KEY = "CUSTOMIZATION.BRANDING"
 ADMIN_DRAFT_KEY = "CUSTOMIZATION.ADMIN_DRAFT"

--- a/src/api/flaskr/service/billing/daily_aggregates.py
+++ b/src/api/flaskr/service/billing/daily_aggregates.py
@@ -6,9 +6,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.util.datetime import now_utc, parse_naive_utc
@@ -25,6 +24,9 @@ from .models import (
 from .ownership import resolve_usage_creator_bid
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _ZERO = Decimal(0)
 

--- a/src/api/flaskr/service/billing/domains.py
+++ b/src/api/flaskr/service/billing/domains.py
@@ -7,11 +7,10 @@ import re
 import socket
 import ssl
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 import dns.resolver
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.config import get_config
@@ -41,6 +40,9 @@ from .entitlements import resolve_creator_entitlement_state
 from .models import BillingDomainBinding
 from .primitives import normalize_bid as _normalize_bid
 from .value_objects import JsonObjectMap
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _DOMAIN_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 

--- a/src/api/flaskr/service/billing/manual_credit_grants.py
+++ b/src/api/flaskr/service/billing/manual_credit_grants.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
@@ -26,6 +25,9 @@ from .queries import add_months as _add_months
 from .queries import add_years as _add_years
 from .queries import load_primary_active_subscription
 from .wallets import grant_manual_credit_wallet_balance
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 MANUAL_CREDIT_GRANT_SOURCE_REWARD = "reward"
 MANUAL_CREDIT_GRANT_SOURCE_COMPENSATION = "compensation"

--- a/src/api/flaskr/service/billing/manual_plan_grants.py
+++ b/src/api/flaskr/service/billing/manual_plan_grants.py
@@ -6,7 +6,6 @@ import contextlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as redis
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
@@ -38,6 +37,8 @@ from .subscriptions import grant_paid_order_credits, is_self_managed_billing_pro
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 _NOTIFICATION_EXTENSION_KEY = "admin_manual_plan_grant"
 _NOTIFICATION_STATUS_TEMPLATE_PENDING = "template_pending"

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.doc.feishu import send_notify
 from flaskr.api.sms.aliyun import send_sms_ali
 from flaskr.dao import db
@@ -40,6 +39,8 @@ from .queries import (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 TASK_NAME = "billing.send_subscription_purchase_sms"
 BILLING_PAID_FEISHU_TASK_NAME = "billing.send_billing_paid_feishu"

--- a/src/api/flaskr/service/billing/operation_credits.py
+++ b/src/api/flaskr/service/billing/operation_credits.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW, BILL_USAGE_TYPE_TTS
@@ -37,6 +36,8 @@ from .wallets import persist_credit_wallet_snapshot, sync_credit_bucket_status
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 _ZERO = Decimal(0)
 

--- a/src/api/flaskr/service/billing/ownership.py
+++ b/src/api/flaskr/service/billing/ownership.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG, normalize_usage_scene
 from flaskr.service.shifu.utils import get_shifu_creator_bid
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def resolve_shifu_creator_bid(app: Flask, shifu_bid: str) -> str | None:

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from flask import Flask
-
 from .consts import BILLING_ORDER_STATUS_PAID
 from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
@@ -30,6 +28,8 @@ from .preorders import is_preorder_order as _is_preorder_order
 from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
 
 if TYPE_CHECKING:
+    from flask import Flask
+
     from .models import BillingOrder
 
 

--- a/src/api/flaskr/service/billing/provider_catalog.py
+++ b/src/api/flaskr/service/billing/provider_catalog.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.stripe_client import get_stripe_client_options
 
 from .consts import (
@@ -24,6 +23,8 @@ from .consts import (
 from .primitives import normalize_bid, to_decimal
 
 if TYPE_CHECKING:
+    from flask import Flask
+
     from .models import BillingProduct
 
 _STRIPE_INTERVAL_BY_BILLING_INTERVAL = {

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.util.datetime import now_utc
 
 from .consts import (
@@ -52,6 +51,8 @@ from .value_objects import JsonObjectMap
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
     from .models import BillingOrder, BillingSubscription
 

--- a/src/api/flaskr/service/billing/rate_references.py
+++ b/src/api/flaskr/service/billing/rate_references.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING
 
-from flaskr.service.billing.models import CreditUsageRate
 from flaskr.service.common.credit_rate_references import (
     load_llm_credit_1x_unit_cost,
 )
+
+if TYPE_CHECKING:
+    from flaskr.service.billing.models import CreditUsageRate
 
 
 def rate_unit_cost(rate: CreditUsageRate | None) -> Decimal | None:

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.i18n import _ as translate
 from flaskr.i18n import get_current_language, set_language
@@ -174,6 +173,9 @@ from .wallets import (
     adjust_credit_wallet_balance,
     calculate_credit_wallet_snapshot_values,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _OPERATOR_PRODUCT_FILTER_LANGUAGES = ("zh-CN", "en-US", "fr-FR")
 _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
 from flaskr.util.datetime import now_utc
@@ -48,6 +47,8 @@ from .wallets import (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 REFERRAL_REWARD_GRANT_TYPE = "referral_reward"
 REFERRAL_REWARD_SCENE = "referral"

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db, retry_on_deadlock, uow
 from flaskr.dao.uow import app_context_scope, unit_of_work
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc, to_utc_iso
@@ -100,6 +99,8 @@ from .wallets import _expire_credit_wallet_buckets_in_session
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 _CLAIMABLE_EVENT_STATUSES = (
     BILLING_RENEWAL_EVENT_STATUS_PENDING,

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
@@ -30,6 +29,8 @@ from .primitives import normalize_mysql_datetime as _normalize_mysql_datetime
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 MANAGED_RENEWAL_EVENT_TYPES = (
     BILLING_RENEWAL_EVENT_TYPE_RENEWAL,

--- a/src/api/flaskr/service/billing/reserved_renewal_activation.py
+++ b/src/api/flaskr/service/billing/reserved_renewal_activation.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 
@@ -50,6 +49,9 @@ from .wallets import (
     refresh_credit_wallet_snapshot,
     resolve_bucket_source_type_for_category,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class ExpireBucketBalanceForTransition(Protocol):

--- a/src/api/flaskr/service/billing/runtime_config.py
+++ b/src/api/flaskr/service/billing/runtime_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
 
 from .consts import (
     BILLING_ENTITLEMENT_ANALYTICS_TIER_BASIC,
@@ -24,6 +24,9 @@ from .entitlements import (
     serialize_creator_entitlements,
 )
 from .primitives import normalize_bid
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def build_runtime_billing_context(

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
     BILL_USAGE_SCENE_PREVIEW,
@@ -82,6 +81,8 @@ from .primitives import (
 from .queries import load_product_code_map
 
 if TYPE_CHECKING:
+    from flask import Flask
+
     from .models import (
         BillingCampaign,
         BillingCampaignProduct,

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as cache_provider
 from flaskr.dao import db
 from flaskr.service.metering.models import BillUsageRecord
@@ -47,6 +46,8 @@ from .wallets import (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
 
 _ZERO = Decimal(0)
 _SETTLEMENT_LOCK_TIMEOUT_SECONDS = 60

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error
 from flaskr.service.order.payment_providers import get_payment_provider
@@ -159,6 +158,8 @@ from .wallets import (
 )
 
 if TYPE_CHECKING:
+    from flask import Flask
+
     from .dtos import BillingSubscriptionDTO
 
 SELF_MANAGED_BILLING_PROVIDERS = {"pingxx", "alipay", "wechatpay", "manual"}

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
@@ -60,6 +59,9 @@ from .primitives import credit_decimal_to_number as _credit_decimal_to_number
 from .primitives import quantize_credit_amount as _quantize_credit_amount
 from .primitives import to_decimal as _to_decimal
 from .queries import load_primary_active_subscription
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _ZERO = Decimal(0)
 _PRESERVED_BUCKET_STATUSES = {

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.native_payment_status import (
     NATIVE_PAYMENT_STATE_CANCELED,
@@ -87,6 +86,8 @@ from .queries import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from flask import Flask
 
 _STRIPE_SUBSCRIPTION_EVENT_TYPES = {
     "customer.subscription.created",

--- a/src/api/flaskr/service/common/profile_onboarding.py
+++ b/src/api/flaskr/service/common/profile_onboarding.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.config.funcs import add_config, get_config
 from flaskr.util.datetime import now_utc, to_utc_iso
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 PROFILE_ONBOARDING_CONFIG_KEY = "PROFILE_ONBOARDING_FLOW"
 PROFILE_ONBOARDING_STATE_KEY = "_sys_profile_onboarding_state"

--- a/src/api/flaskr/service/common/storage.py
+++ b/src/api/flaskr/service/common/storage.py
@@ -5,9 +5,8 @@ import os
 import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.oss_utils import (
     OSS_PROFILE_COURSES,
     OSS_PROFILE_DEFAULT,
@@ -17,6 +16,9 @@ from flaskr.service.common.oss_utils import (
     upload_to_oss,
 )
 from flaskr.service.config import get_config
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 STORAGE_PROVIDER_AUTO = "auto"
 STORAGE_PROVIDER_OSS = "oss"

--- a/src/api/flaskr/service/common/stripe_client.py
+++ b/src/api/flaskr/service/common/stripe_client.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.config import get_config
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class StripeClientConfigError(RuntimeError):

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.i18n import _
 from flaskr.service.billing.consts import CREDIT_SOURCE_TYPE_USAGE
 from flaskr.service.billing.models import CreditLedgerEntry
@@ -56,12 +55,14 @@ from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.permissions import get_user_shifu_permissions
 from sqlalchemy import and_, bindparam, func, select
-from sqlalchemy.sql import Select
 
 from .engine import get_analytics_engine
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
+
+    from flask import Flask
+    from sqlalchemy.sql import Select
 
 # Reuse the DSL-path error names so the HTTP wrapper maps them consistently
 # (the error name → HTTP code mapping lives in error_codes.json).

--- a/src/api/flaskr/service/creator_analytics/engine.py
+++ b/src/api/flaskr/service/creator_analytics/engine.py
@@ -14,13 +14,15 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine, Result
-from sqlalchemy.sql import Select
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from sqlalchemy.engine import Engine, Result
+    from sqlalchemy.sql import Select
 
 
 @dataclass(slots=True)

--- a/src/api/flaskr/service/creator_analytics/funcs.py
+++ b/src/api/flaskr/service/creator_analytics/funcs.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.i18n import _
 from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.shifu.permissions import get_user_shifu_permissions
@@ -13,6 +12,9 @@ from .dsl import parse_dsl
 from .engine import get_analytics_engine, run_query
 from .pii import mask_user_identify, redact_pii
 from .sql_builder import build_statement
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 ERR_NO_PERMISSION = "server.creatorAnalytics.noPermission"
 

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -33,11 +33,12 @@ from sqlalchemy import (
     func,
     select,
 )
-from sqlalchemy.sql import Select
-from sqlalchemy.sql.elements import ColumnElement
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from sqlalchemy.sql import Select
+    from sqlalchemy.sql.elements import ColumnElement
 
     from .dsl import Aggregate, Filter, OrderBy, QueryDSL
 

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -8,7 +8,6 @@ from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.dashboard.dtos import (
@@ -66,6 +65,8 @@ from sqlalchemy.orm import aliased
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from flask import Flask
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/learn/lesson_feedback.py
+++ b/src/api/flaskr/service/learn/lesson_feedback.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.common.models import raise_param_error
@@ -17,6 +17,9 @@ from flaskr.service.shifu.consts import BLOCK_TYPE_MDINTERACTION_VALUE
 from flaskr.util import generate_id
 from flaskr.util.datetime import to_utc_iso
 from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _FEEDBACK_COMMENT_MAX_LENGTH = 1000
 _VALID_MODES = {"read", "listen"}

--- a/src/api/flaskr/service/learn/listen_element_factory.py
+++ b/src/api/flaskr/service/learn/listen_element_factory.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.learn.learn_dtos import (
     ElementAudioDTO,
     ElementChangeType,
@@ -23,11 +22,14 @@ from flaskr.service.learn.listen_element_types import (
     _element_type_for_visual_kind,
     _new_element_bid,
 )
-from flaskr.service.learn.listen_slide_builder import VisualSegment
 from flaskr.service.learn.listen_source_span_utils import (
     normalize_source_span,
     slice_source_by_span,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flaskr.service.learn.listen_slide_builder import VisualSegment
 
 
 def _visuals_from_segment(

--- a/src/api/flaskr/service/learn/listen_element_history.py
+++ b/src/api/flaskr/service/learn/listen_element_history.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.learn.learn_dtos import (
     ElementAudioDTO,
     ElementDTO,
@@ -35,6 +34,8 @@ from sqlalchemy import and_, or_
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from flask import Flask
 
 
 def _load_interaction_user_input_by_block_bid(

--- a/src/api/flaskr/service/learn/listen_element_legacy.py
+++ b/src/api/flaskr/service/learn/listen_element_legacy.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.learn.learn_dtos import (
     BlockType,
@@ -42,6 +41,9 @@ from flaskr.service.learn.listen_slide_builder import (
 )
 from flaskr.service.learn.models import LearnGeneratedElement, LearnProgressRecord
 from flaskr.service.tts.pipeline import build_av_segmentation_contract
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import asdict, dataclass, field
-from typing import Any
-
-from flask import Flask
+from typing import TYPE_CHECKING, Any
 
 try:
     from markdown_flow import format_content
@@ -93,6 +91,9 @@ from flaskr.service.shifu.consts import (
     BLOCK_TYPE_MDERRORMESSAGE_VALUE,
     BLOCK_TYPE_MDINTERACTION_VALUE,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 SUPPORTED_BLOCK_TYPES = {
     BLOCK_TYPE_MDCONTENT_VALUE,

--- a/src/api/flaskr/service/learn/listen_element_types.py
+++ b/src/api/flaskr/service/learn/listen_element_types.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.learn.const import ROLE_STUDENT, ROLE_UI
 from flaskr.service.learn.learn_dtos import ElementChangeType, ElementType
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 ELEMENT_TYPE_CODES = {
     ElementType.HTML: 201,

--- a/src/api/flaskr/service/learn/listen_elements.py
+++ b/src/api/flaskr/service/learn/listen_elements.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.service.learn.learn_dtos import (
     GeneratedType,
     LearnElementRecordDTO,
@@ -27,10 +26,6 @@ from flaskr.service.learn.listen_element_run_persistence import (
 from flaskr.service.learn.listen_element_run_sidecar import (
     ListenElementRunSidecarMixin,
 )
-from flaskr.service.learn.listen_element_run_state import (
-    BlockMeta,
-    BlockState,
-)
 from flaskr.service.learn.listen_element_run_stream import (
     ListenElementRunStreamMixin,
 )
@@ -41,6 +36,12 @@ from flaskr.service.learn.type_state_machine import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from flask import Flask
+    from flaskr.service.learn.listen_element_run_state import (
+        BlockMeta,
+        BlockState,
+    )
 
 __all__ = [
     "ListenElementRunAdapter",

--- a/src/api/flaskr/service/learn/listen_slide_builder.py
+++ b/src/api/flaskr/service/learn/listen_slide_builder.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.learn.listen_source_span_utils import (
     normalize_source_span,
     slice_source_by_span,
 )
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass

--- a/src/api/flaskr/service/learn/preview_elements.py
+++ b/src/api/flaskr/service/learn/preview_elements.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.service.learn.learn_dtos import (
     ElementDTO,
     ElementPayloadDTO,
@@ -16,6 +15,8 @@ from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from flask import Flask
 
 
 class PreviewElementRunAdapter(ListenElementRunAdapter):

--- a/src/api/flaskr/service/learn/preview_permissions.py
+++ b/src/api/flaskr/service/learn/preview_permissions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from flask import Flask, request
 from flaskr.service.common import raise_error
-from flaskr.service.common.dtos import UserInfo
 from flaskr.service.config import get_config
 from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
+
+if TYPE_CHECKING:
+    from flaskr.service.common.dtos import UserInfo
 
 BUILTIN_DEMO_TITLES = {
     "AI 师傅教学引导",

--- a/src/api/flaskr/service/learn/run/emitter.py
+++ b/src/api/flaskr/service/learn/run/emitter.py
@@ -53,11 +53,11 @@ from flaskr.service.shifu.consts import (
     BLOCK_TYPE_MDCONTENT_VALUE,
     BLOCK_TYPE_MDINTERACTION_VALUE,
 )
-from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 from flaskr.util import generate_id
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
     from flaskr.service.learn.context_v2 import RunScriptContextV2
+    from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 
 
 class RunEventEmitter:

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -8,7 +8,7 @@ import traceback
 import uuid
 from collections.abc import Generator
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask
 from flaskr.common.cache_provider import cache as cache_provider
@@ -38,7 +38,6 @@ from flaskr.service.learn.learn_dtos import (
 from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 from flaskr.service.order.consts import ORDER_STATUS_SUCCESS
 from flaskr.service.order.models import Order
-from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.shifu_struct_manager import (
     ShifuInfoDto,
     ShifuOutlineItemDto,
@@ -50,6 +49,9 @@ from flaskr.service.user.repository import load_user_aggregate
 from flaskr.util.datetime import to_utc_iso
 from sqlalchemy import text as sa_text
 from sqlalchemy.exc import InterfaceError, OperationalError, ResourceClosedError
+
+if TYPE_CHECKING:
+    from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
 RUN_SCRIPT_TIMEOUT_SECONDS = 5 * 60
 RUN_SCRIPT_STATUS_REFRESH_SECONDS = 30

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -10,10 +10,11 @@ from flaskr.common.shifu_context import (
 )
 from flaskr.dao import cleanup_session_after, invalidate_session
 from flaskr.i18n import get_current_language, set_language
-from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
 
 
 class _StreamTTSFinalizeJob:

--- a/src/api/flaskr/service/metering/recorder.py
+++ b/src/api/flaskr/service/metering/recorder.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import cleanup_session_after, db, invalidate_session
 from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.util.uuid import generate_id
@@ -23,6 +22,9 @@ from .consts import (
     normalize_usage_scene,
 )
 from .models import BillUsageRecord
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -5,9 +5,8 @@ import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.common.dtos import PageNationDTO
@@ -72,6 +71,9 @@ from flaskr.service.user.repository import (
 from flaskr.service.user.utils import ensure_demo_course_permissions
 from flaskr.util.datetime import parse_naive_utc
 from sqlalchemy import case
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 ORDER_STATUS_KEY_MAP = {
     ORDER_STATUS_INIT: "server.order.orderStatusInit",

--- a/src/api/flaskr/service/order/open_api.py
+++ b/src/api/flaskr/service/order/open_api.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error
 from flaskr.service.order.admin import (
@@ -16,6 +15,9 @@ from flaskr.service.order.funs import send_revoke_feishu
 from flaskr.service.order.models import Order
 from flaskr.service.shifu.utils import get_shifu_creator_bid
 from flaskr.service.user.repository import load_user_aggregate_by_identifier
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def verify_course_ownership(app: Flask, owner_bid: str, shifu_bid: str) -> None:

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs
 
-from flask import Flask
 from flaskr.common.public_urls import build_alipay_notify_url
 from flaskr.service.config import get_config
 
@@ -19,6 +18,9 @@ from .base import (
     PaymentRefundResult,
     PaymentRequest,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class AlipayProvider(PaymentProvider):

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -7,11 +7,10 @@ import threading
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
-from flask import Flask
 from flaskr.service.config import get_config
 
 from . import register_payment_provider
@@ -22,6 +21,9 @@ from .base import (
     PaymentRequest,
     SubscriptionUpdateResult,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _PINGPP_CONFIG_LOCK = threading.RLock()
 

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.stripe_client import get_stripe_client_options
 from flaskr.service.config import get_config
 
@@ -16,6 +15,9 @@ from .base import (
     PaymentRequest,
     SubscriptionUpdateResult,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class StripeProvider(PaymentProvider):

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -5,7 +5,7 @@ import json
 import secrets
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 import requests
@@ -13,7 +13,6 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from flask import Flask
 from flaskr.common.public_urls import build_wechatpay_notify_url
 from flaskr.service.config import get_config
 
@@ -26,6 +25,9 @@ from .base import (
     PaymentRefundResult,
     PaymentRequest,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class WechatPayProvider(PaymentProvider):

--- a/src/api/flaskr/service/profile/learner_profile.py
+++ b/src/api/flaskr/service/profile/learner_profile.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from flask import Flask
 from flaskr.api.check import (
     CHECK_RESULT_PASS,
     CHECK_RESULT_REJECT,
@@ -38,6 +37,8 @@ from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from flask import Flask
 
 LEARNER_PROFILE_MAX_LENGTH = 1000
 LEARNER_PROFILE_NICKNAME_MAX_LENGTH = 64

--- a/src/api/flaskr/service/profile/learner_profile_optimizer.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.langfuse import (
     create_trace_with_root_span,
     finalize_langfuse_trace,
@@ -19,6 +18,9 @@ from flaskr.service.profile.learner_profile import (
     normalize_learner_profile,
 )
 from flaskr.util.prompt_loader import load_prompt_template
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 LEARNER_PROFILE_OPTIMIZATION_TIMEOUT_SECONDS = 15
 LEARNER_PROFILE_OPTIMIZATION_MAX_TOKENS = 1200

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -8,11 +8,12 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.service.common.models import raise_error
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from flask import Flask
 
 IN_FLIGHT_TTL_SECONDS = 360
 

--- a/src/api/flaskr/service/profile/onboarding.py
+++ b/src/api/flaskr/service/profile/onboarding.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.common.profile_onboarding import (
@@ -21,6 +20,9 @@ from flaskr.service.profile.learner_profile import has_learner_profile_or_state
 from flaskr.service.profile.models import VariableValue
 from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def _now_iso() -> str:

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -6,8 +6,8 @@ import math
 import secrets
 import string
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.order.api import (
@@ -66,6 +66,9 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.datetime import now_utc, parse_naive_utc
 from flaskr.util.uuid import generate_id
 from sqlalchemy import and_, case, func, not_, or_
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 PROMOTION_SCOPE_ALL_COURSES = "all_courses"
 PROMOTION_SCOPE_SINGLE_COURSE = "single_course"

--- a/src/api/flaskr/service/promo/creator_redemption.py
+++ b/src/api/flaskr/service/promo/creator_redemption.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.promo.admin import (
@@ -25,6 +26,9 @@ from flaskr.service.promo.admin_dtos import (
 )
 from flaskr.service.promo.models import Coupon
 from flaskr.service.shifu.models import PublishedShifu
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def list_creator_course_redemption_coupons(

--- a/src/api/flaskr/service/referral/admin.py
+++ b/src/api/flaskr/service/referral/admin.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.pagination import normalize_pagination
@@ -39,6 +38,8 @@ from .reward_queue import build_referral_reward_queue
 
 if TYPE_CHECKING:
     from decimal import Decimal
+
+    from flask import Flask
 
 ABNORMAL_STATUS_BY_LABEL = {
     "normal": REFERRAL_ABNORMAL_STATUS_NORMAL,

--- a/src/api/flaskr/service/referral/auth_hooks.py
+++ b/src/api/flaskr/service/referral/auth_hooks.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.framework.plugin.plugin_manager import extension
 
 from .service import process_referral_post_auth
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @extension("run_post_auth_extensions")

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -6,9 +6,8 @@ import json
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from math import ceil
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.billing.consts import (
     BILLING_PRODUCT_STATUS_ACTIVE,
@@ -47,6 +46,9 @@ from .models import (
     ReferralInviteRelation,
     ReferralInviteReward,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 REFERRAL_CAMPAIGN_STATUS_FILTERS = {
     "active",

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -19,9 +19,6 @@ from flaskr.service.common.models import (
 from flaskr.service.shifu.admin_course_summary_mapper import (
     build_admin_operation_course_summary,
 )
-from flaskr.service.shifu.admin_dtos_courses import (
-    AdminOperationCourseSummaryDTO,
-)
 from flaskr.service.shifu.admin_shared import (
     COURSE_QUICK_FILTER_VALUES,
     COURSE_STATUS_PUBLISHED,
@@ -51,6 +48,10 @@ from sqlalchemy.orm import defer
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from decimal import Decimal
+
+    from flaskr.service.shifu.admin_dtos_courses import (
+        AdminOperationCourseSummaryDTO,
+    )
 
 
 def _format_average_score(value: Decimal | None) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import unicodedata
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.llm import get_current_models
 from flaskr.api.tts import get_all_provider_configs
 from flaskr.dao import db
@@ -34,6 +33,9 @@ from flaskr.service.metering.consts import (
 )
 from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc, to_utc_iso
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _RATE_METRICS = {
     BILL_USAGE_TYPE_LLM: (

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_estimate.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_estimate.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from decimal import ROUND_CEILING, Decimal
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.api.llm import get_current_models
 from flaskr.api.tts import get_all_provider_configs
 from flaskr.service.billing.api import (
@@ -35,11 +34,13 @@ from flaskr.service.shifu.admin_dtos_courses import (
     AdminOperationEstimatedCreditCostDTO,
     AdminOperationEstimatedCreditModeDTO,
 )
-from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 from flaskr.util.datetime import now_utc
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from flask import Flask
+    from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 
 _ZERO = Decimal(0)
 _MARKDOWN_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -10,7 +10,6 @@ import re
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.llm import PROVIDER_STATES, get_current_models
 from flaskr.api.tts import get_all_provider_configs
 from flaskr.dao import db
@@ -78,6 +77,8 @@ from sqlalchemy import and_, case, false, literal, not_, or_
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from flask import Flask
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.common.umami_client import get_course_visit_count_30d
 from flaskr.dao import db
 from flaskr.service.common.models import (
@@ -59,13 +58,15 @@ from flaskr.service.shifu.consts import (
     UNIT_TYPE_VALUE_NORMAL,
     UNIT_TYPE_VALUE_TRIAL,
 )
-from flaskr.service.shifu.models import (
-    DraftOutlineItem,
-    PublishedOutlineItem,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from flask import Flask
+    from flaskr.service.shifu.models import (
+        DraftOutlineItem,
+        PublishedOutlineItem,
+    )
 
 
 def _resolve_learning_permission(item_type: int | None) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import (
     raise_param_error,
@@ -56,6 +55,8 @@ from sqlalchemy import and_, or_
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
+
+    from flask import Flask
 
 
 def _build_course_follow_up_base_subquery(shifu_bid: str):

--- a/src/api/flaskr/service/shifu/admin_operations/courses_ratings.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_ratings.py
@@ -6,8 +6,8 @@ Split mechanically out of the former giant module (backend overhaul B5).
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import (
     raise_param_error,
@@ -32,6 +32,9 @@ from flaskr.service.shifu.admin_operations.courses_shared import (
     _load_user_map,
     _normalize_identifier,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def _resolve_course_rating_mode(value: str) -> str:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_users.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.dtos import PageNationDTO
 from flaskr.service.common.models import (
@@ -48,6 +47,8 @@ from flaskr.util.datetime import NAIVE_DATETIME_MIN
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
+
+    from flask import Flask
 
 
 def _load_course_related_user_bids(

--- a/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
+++ b/src/api/flaskr/service/shifu/admin_operations/credit_notifications.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.billing.api import (
     dry_run_credit_notifications,
     get_credit_notification_detail,
@@ -16,6 +15,9 @@ from flaskr.service.billing.api import (
 from flaskr.service.billing.api import (
     get_operator_credit_notification_overview as build_credit_notification_overview,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def get_operator_credit_notification_overview(app: Flask) -> dict[str, Any]:

--- a/src/api/flaskr/service/shifu/admin_operations/profile_onboarding.py
+++ b/src/api/flaskr/service/shifu/admin_operations/profile_onboarding.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.profile_onboarding import (
     get_profile_onboarding_config,
     update_profile_onboarding_config,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def get_operator_profile_onboarding_config(app: Flask) -> dict[str, Any]:

--- a/src/api/flaskr/service/shifu/admin_operations/user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_operations/user_credits.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.billing.api import (
     build_billing_catalog,
@@ -99,6 +98,9 @@ from flaskr.service.shifu.admin_dtos import (
 from flaskr.util.datetime import now_utc
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import aliased
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def grant_operator_user_credits(

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
 from flaskr.service.shifu.admin_dtos import (
@@ -56,6 +57,9 @@ from flaskr.service.user.consts import (
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
 from sqlalchemy import and_, case, or_
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def _build_user_query_filter(user_query: str):

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -4,7 +4,6 @@ import math
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.tts import get_default_voice_settings, synthesize_text
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
@@ -33,6 +32,8 @@ from sqlalchemy import or_
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from flask import Flask
 
 OPERATOR_VOICE_CLONE_SOURCE_METHOD = "operator_register"
 # Short text/model used only to validate a registered voice_id against the

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -121,15 +121,16 @@ from flaskr.service.shifu.models import (
     PublishedOutlineItem,
     PublishedShifu,
 )
-from flaskr.service.user.models import (
-    UserInfo as UserEntity,
-)
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
 from sqlalchemy import case, not_, or_
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
+
+    from flaskr.service.user.models import (
+        UserInfo as UserEntity,
+    )
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:

--- a/src/api/flaskr/service/shifu/demo_courses.py
+++ b/src/api/flaskr/service/shifu/demo_courses.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.config.funcs import get_config as get_dynamic_config
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 BUILTIN_DEMO_TITLES: set[str] = {
     "AI 师傅教学引导",

--- a/src/api/flaskr/service/shifu/permissions.py
+++ b/src/api/flaskr/service/shifu/permissions.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.shifu.models import AiCourseAuth, DraftShifu, PublishedShifu
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 DEFAULT_SHIFU_PERMISSIONS = {"view", "edit", "publish"}
 

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
 from flaskr.util.datetime import now_utc
@@ -16,6 +16,9 @@ from .shifu_outline_funcs import (
     __lock_shifu_for_outline_write,
     build_outline_history_tree_from_outlines,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -8,11 +8,10 @@ import re
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 import requests
-from flask import Flask
 
 try:
     from pydub import AudioSegment
@@ -61,6 +60,9 @@ from flaskr.service.tts.models import (
 )
 from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 MINIMAX_FILE_UPLOAD_URL = "https://api.minimaxi.com/v1/files/upload"
 MINIMAX_VOICE_CLONE_URL = "https://api.minimaxi.com/v1/voice_clone"

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -24,7 +24,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.api.tts import (
     AudioSettings,
     VoiceSettings,
@@ -66,6 +65,8 @@ from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from flask import Flask
 
 _AV_LATEX_BLOCK = AV_LATEX_BLOCK
 

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.api.tts import get_tts_provider
 from flaskr.service.common.models import raise_error_with_args
 from flaskr.service.tts.cloned_voice_registry import (
     find_ready_cloned_voice,
     get_clone_provider_spec,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 SUPPORTED_TTS_PROVIDERS = {
     "minimax",

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.service.common.dtos import UserInfo, UserToken
 from flaskr.service.user.models import AuthCredential
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class _BaseDTO(BaseModel):

--- a/src/api/flaskr/service/user/auth/oauth_origins.py
+++ b/src/api/flaskr/service/user/auth/oauth_origins.py
@@ -10,14 +10,16 @@ checked against domains we actually serve, which is what this module does.
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
-from flask import Flask
 from flaskr.common.public_urls import (
     build_google_oauth_callback_url,
     resolve_public_origin,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 DEFAULT_PORTS = {"http": 80, "https": 443}
 

--- a/src/api/flaskr/service/user/auth/providers/email.py
+++ b/src/api/flaskr/service/user/auth/providers/email.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.service.user.auth.base import (
     AuthProvider,
     AuthResult,
@@ -17,6 +18,9 @@ from flaskr.service.user.auth.factory import (
 from flaskr.service.user.email_flow import verify_email_code
 from flaskr.service.user.repository import find_credential, load_user_aggregate
 from flaskr.service.user.utils import send_email_code
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class EmailAuthProvider(AuthProvider):

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -5,7 +5,8 @@ Supports login via phone number or email + password.
 
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.service.common.dtos import UserToken
 from flaskr.service.common.models import raise_error
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
@@ -26,6 +27,9 @@ from flaskr.service.user.repository import (
     load_user_aggregate_by_identifier,
 )
 from flaskr.service.user.utils import generate_token
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class PasswordAuthProvider(AuthProvider):

--- a/src/api/flaskr/service/user/auth/providers/phone.py
+++ b/src/api/flaskr/service/user/auth/providers/phone.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from flask import Flask
+from typing import TYPE_CHECKING
+
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
 from flaskr.service.user.auth.base import (
     AuthProvider,
@@ -18,6 +19,9 @@ from flaskr.service.user.auth.factory import (
 from flaskr.service.user.phone_flow import verify_phone_code
 from flaskr.service.user.repository import find_credential, load_user_aggregate
 from flaskr.service.user.utils import send_sms_code
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 class PhoneAuthProvider(AuthProvider):

--- a/src/api/flaskr/service/user/captcha.py
+++ b/src/api/flaskr/service/user/captcha.py
@@ -7,12 +7,14 @@ import json
 import random
 import secrets
 from io import BytesIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as redis
 from flaskr.service.common.models import raise_error
 from PIL import Image, ImageDraw, ImageFont
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 _CAPTCHA_ALPHABET = "ACDEFHJKLMNPRTUVWXY3479"
 _CAPTCHA_IMAGE_WIDTH = 160

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -6,7 +6,6 @@ import contextlib
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_derived_prefix
 from flaskr.dao import db
@@ -33,6 +32,8 @@ from flaskr.util.datetime import now_utc
 
 if TYPE_CHECKING:
     import datetime
+
+    from flask import Flask
 
 
 def _is_within_seconds(value: datetime.datetime, *, seconds: int) -> bool:

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import db
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.config.funcs import get_config as get_dynamic_config
@@ -13,6 +12,9 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
 from flaskr.util.datetime import now_utc, parse_naive_utc
 from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 ONBOARDING_VERSION = "v1"
 SCENE_ADMIN_HOME = "admin_home_onboarding"

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -6,7 +6,6 @@ import contextlib
 import uuid
 from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_derived_prefix
 from flaskr.dao import db
@@ -46,6 +45,8 @@ from sqlalchemy import text
 
 if TYPE_CHECKING:
     import datetime
+
+    from flask import Flask
 
 BOOTSTRAP_LOCK_NAME = "user_first_verified_bootstrap"
 

--- a/src/api/flaskr/service/user/post_auth.py
+++ b/src/api/flaskr/service/user/post_auth.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.framework.plugin.plugin_manager import get_plugin_manager
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -7,9 +7,8 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from flask import Flask
 from flaskr.dao import (
     cleanup_session_after,
     db,
@@ -29,6 +28,9 @@ from flaskr.service.user.consts import (
 from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 logger = logging.getLogger(__name__)
 

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import contextlib
 import datetime
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr.common.cache_provider import cache
 from flaskr.dao import db
 from flaskr.service.user.models import UserToken as UserTokenModel
 from flaskr.util.datetime import now_utc
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/user/verification_codes.py
+++ b/src/api/flaskr/service/user/verification_codes.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING, Literal
 
-from flask import Flask
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_derived_prefix
 from flaskr.dao import db
@@ -21,6 +20,8 @@ from flaskr.util.datetime import now_utc
 
 if TYPE_CHECKING:
     import datetime
+
+    from flask import Flask
 
 CodeKind = Literal["sms", "email"]
 

--- a/src/api/flaskr/util/timezone.py
+++ b/src/api/flaskr/util/timezone.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from flask import Flask
+if TYPE_CHECKING:
+    from flask import Flask
 
 
 def get_app_timezone(app: Flask, tz_name: str | None = None) -> ZoneInfo:

--- a/src/api/tests/service/billing/test_billing_renewal_event_basics.py
+++ b/src/api/tests/service/billing/test_billing_renewal_event_basics.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_RENEWAL_EVENT_STATUS_CANCELED,
@@ -47,6 +47,9 @@ from tests.service.billing.renewal_execution_test_helpers import (
     create_renewal_event,
     create_renewal_subscription,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.renewal_execution_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_expire_activation.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -39,6 +39,9 @@ from tests.service.billing.renewal_execution_test_helpers import (
     create_renewal_event,
     self_managed_cycle_end_after_boundary,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.renewal_execution_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_preorder_execution.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
@@ -43,6 +42,10 @@ from tests.service.billing.renewal_execution_test_helpers import (
     create_renewal_subscription,
     self_managed_cycle_end_after_boundary,
 )
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.renewal_execution_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_FAILED,
@@ -24,6 +23,10 @@ from tests.service.billing.renewal_execution_test_helpers import (
     create_renewal_event,
     create_renewal_subscription,
 )
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.renewal_execution_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing import renewal as billing_renewal
 from flaskr.service.billing.consts import (
@@ -38,6 +37,10 @@ from tests.service.billing.renewal_execution_test_helpers import (
     create_renewal_subscription,
     self_managed_cycle_end_after_boundary,
 )
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.renewal_execution_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_SUBSCRIPTION,
@@ -26,6 +25,10 @@ from flaskr.service.billing.wallets import (
 )
 from sqlalchemy.orm import attributes
 from sqlalchemy.orm.exc import ObjectDeletedError
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_TYPE_TOPUP,
@@ -29,6 +28,10 @@ from flaskr.service.billing.wallets import (
     grant_refund_return_credits,
 )
 from sqlalchemy.exc import IntegrityError
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_repair.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
@@ -46,6 +46,9 @@ from flaskr.util.datetime import to_utc_iso
 from tests.service.billing.wallet_lifecycle_test_helpers import (
     create_monthly_plan_product,
 )
+
+if TYPE_CHECKING:
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_snapshots.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -25,6 +24,10 @@ from flaskr.service.billing.models import (
 from flaskr.service.billing.wallets import (
     rebuild_credit_wallet_snapshots,
 )
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
 

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
-import pytest
-from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_METRIC_LLM_INPUT_TOKENS,
@@ -33,6 +32,10 @@ from flaskr.service.billing.wallets import (
 )
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.metering.models import BillUsageRecord
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
 
 pytest_plugins = ["tests.service.billing.wallet_lifecycle_app_fixture"]
 

--- a/src/api/tests/service/billing/test_provider_price_mappings.py
+++ b/src/api/tests/service/billing/test_provider_price_mappings.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
-from flask import Flask
 from flaskr.dao import db
+
+if TYPE_CHECKING:
+    from flask import Flask
 from flaskr.service.billing.consts import (
     BILLING_INTERVAL_MONTH,
     BILLING_MODE_RECURRING,


### PR DESCRIPTION
## Summary

- Move all 134 genuinely annotation-only third-party imports across 113 Python files behind `TYPE_CHECKING`.
- Remove the global `TC002` exception while keeping Pydantic field types covered by the shared runtime-evaluated base-class contract.
- Document the project handling pattern for third-party and standard-library type-only imports.

## Stack

This ready PR is stacked on #2584 (`sunner/ruff-tc003`). It owns only the TC002 rule unit and should merge or be retargeted after its predecessor.

## Safety evidence

- Import AST audit matched 134 removed runtime imports to 134 type-only replacements.
- The audit found zero added runtime imports, zero removed type-only imports, and zero non-import executable AST changes.
- Runtime SQLAlchemy models remain normal imports; no runtime reflection or module-attribute injection seam depends on the moved names.

## Verification

- `ruff check . --select TC002`
- `ruff check .`
- `ruff format --check .`
- 908 focused cross-service tests passed.
- Full backend suite: 3,015 passed, 17 skipped.
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files`

The stable `ALL` census falls exactly 134 findings, from 30,518 across 37 rules to 30,384 across 36 rules. TC002 and TC003 are both zero; ANN001, E501, and PLR0911 are unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->