### PR TITLE
fix: throttle repeated password login failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Developed by the AI-Shifu Team and the Research Center of Intelligent Software E
 
 Make sure your machine has installed [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
-### Quick Start (Docker, zero config)
+### Quick Start (Docker, minimal configuration)
 
 ```bash
 git clone https://github.com/ai-shifu/ai-shifu.git
@@ -50,7 +50,10 @@ cd ai-shifu/docker
 # Use Docker-ready defaults (matches bundled MySQL service; Redis is optional)
 cp .env.example.full .env
 
-# Only required change: edit .env and set at least one LLM API key
+# Generate the required deployment-specific authentication secret
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
+
+# Edit .env and set at least one LLM API key
 # (e.g., OPENAI_API_KEY=sk-..., ERNIE_API_KEY=..., etc.)
 
 # Start all services
@@ -72,11 +75,14 @@ cd ai-shifu/docker
 # Copy the full template (contains defaults for Docker usage)
 cp .env.example.full .env
 
-# Edit .env and customize as needed (only mandatory change is an LLM key):
+# Generate the required deployment-specific authentication secret
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
+
+# Edit .env and customize as needed:
 # - OPENAI_API_KEY / ERNIE_API_KEY / GLM_API_KEY / ...
 # - SQLALCHEMY_DATABASE_URI: Defaults to docker MySQL service
 # - REDIS_HOST: Optional; set to enable Redis caching/locks (leave empty to disable)
-# - SECRET_KEY: Defaults to a demo value; change for production (generate with: python -c "import secrets; print(secrets.token_urlsafe(32))")
+# - SECRET_KEY: Required; the command above generates a strong random value
 # - UNIVERSAL_VERIFICATION_CODE: Test verification code (remove/empty in production)
 # - Any other optional integrations
 
@@ -91,6 +97,8 @@ git clone https://github.com/ai-shifu/ai-shifu.git
 cd ai-shifu/docker
 
 cp .env.example.full .env
+# Generate the required deployment-specific authentication secret
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
 # Edit .env and set your preferred LLM API key(s)
 
 ./dev_in_docker.sh

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -42,7 +42,7 @@ AI师傅面向老师、讲师、培训与教育团队，提供“可扩展的一
 
 请先确认你的机器已经安装好[Docker](https://docs.docker.com/get-docker/)和[Docker Compose](https://docs.docker.com/compose/install/)。
 
-### 一键快速启动（Docker，无需修改）
+### 一键快速启动（Docker，最少配置）
 
 ```bash
 git clone https://github.com/ai-shifu/ai-shifu.git
@@ -51,7 +51,10 @@ cd ai-shifu/docker
 # 直接使用 Docker 模板配置
 cp .env.example.full .env
 
-# 唯一需要改动的内容：在 .env 中填写至少一个大模型 API Key
+# 生成部署专用的认证密钥（必填）
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
+
+# 在 .env 中填写至少一个大模型 API Key
 # 例如：OPENAI_API_KEY=sk-xxx 或 ERNIE_API_KEY=xxx
 
 # 启动全部服务
@@ -73,11 +76,14 @@ cd ai-shifu/docker
 # 复制完整模板（已包含 Docker 默认值）
 cp .env.example.full .env
 
-# 按需修改 .env（快速启动仅需填写 LLM Key）：
+# 生成部署专用的认证密钥（必填）
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
+
+# 按需修改 .env：
 # - OPENAI_API_KEY / ERNIE_API_KEY / GLM_API_KEY / ...
 # - SQLALCHEMY_DATABASE_URI：默认指向 docker 中的 MySQL 服务
 # - REDIS_HOST：可选；如需 Redis 缓存/锁可配置外部 Redis（留空则禁用）
-# - SECRET_KEY：示例值，仅用于演示；生产环境请替换（生成：python -c "import secrets; print(secrets.token_urlsafe(32))"）
+# - SECRET_KEY：必填；上面的命令会生成高强度随机值
 # - UNIVERSAL_VERIFICATION_CODE：测试验证码（生产环境请清空/禁用）
 
 docker compose -f docker-compose.latest.yml up -d  # 若需固定版本可改用 docker-compose.yml
@@ -92,6 +98,8 @@ git clone https://github.com/ai-shifu/ai-shifu.git
 cd ai-shifu/docker
 
 cp .env.example.full .env
+# 生成部署专用的认证密钥（必填）
+python3 -c "from pathlib import Path; import secrets; p=Path('.env'); p.write_text(p.read_text().replace('SECRET_KEY=\"\"', f'SECRET_KEY=\"{secrets.token_urlsafe(32)}\"', 1))"
 # 在 .env 中填入至少一个大模型 API Key
 
 ./dev_in_docker.sh

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -247,7 +247,7 @@ MAIL_CODE_EXPIRE_TIME="300"
 # Type: int
 MAIL_CODE_INTERVAL="60"
 
-# Sliding window for failed password login counters in seconds
+# Fixed window for failed password login counters in seconds
 # (Optional - default: 900)
 # Type: int
 # (Has validation)

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -247,6 +247,24 @@ MAIL_CODE_EXPIRE_TIME="300"
 # Type: int
 MAIL_CODE_INTERVAL="60"
 
+# Sliding window for failed password login counters in seconds
+# (Optional - default: 900)
+# Type: int
+# (Has validation)
+PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS="900"
+
+# Failed password attempts allowed per account identifier before temporary throttling
+# (Optional - default: 5)
+# Type: int
+# (Has validation)
+PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT="5"
+
+# Failed password attempts allowed per client IP before temporary throttling
+# (Optional - default: 20)
+# Type: int
+# (Has validation)
+PASSWORD_LOGIN_IP_FAILURE_LIMIT="20"
+
 # Expire time for phone verification code in seconds
 # (Optional - default: 300)
 # Type: int

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -280,12 +280,13 @@ RESET_PWD_CODE_EXPIRE_TIME="300"
 # - Must be a strong random string (at least 32 characters recommended)
 # - DO NOT change in production (will invalidate all user sessions)
 # - Keep different values for dev/test/prod environments
+# - The public demo value "ai-shifu" is rejected
 # - Never commit to version control
 # Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))"
 # (REQUIRED - must be set)
 # (Has validation)
 # Secret value
-SECRET_KEY="ai-shifu"
+SECRET_KEY=""
 
 # The minimum interval time for sending text messages to the same mobile phone number
 # (Optional - default: 60)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@
 # Use docker-compose.latest.yml if you prefer to track the :latest container tags.
 x-environment: &default-env
   SQLALCHEMY_DATABASE_URI: mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4
-  SECRET_KEY: ai-shifu
+  SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in docker/.env}
   UNIVERSAL_VERIFICATION_CODE: 1024
   REDIS_HOST: ai-shifu-redis
   REDIS_PORT: 6379

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -400,6 +400,15 @@ file-level tool directives. Because adding it changes `module.__doc__`, search
 runtime introspection before a bulk adoption and verify executable AST equality
 after removing the new module docstrings.
 
+For `FIX002`, do not make an unresolved task invisible by renaming `TODO`,
+adding `noqa`, or turning the same promise into an untracked prose comment.
+Complete the work when it is part of the current change. When it genuinely
+belongs later, record the actionable task in the owning ExecPlan or issue and
+leave only a present-tense invariant or compatibility reason beside the code.
+Security gaps and rollout checkpoints require behavior-specific evidence:
+implement the missing guard, or prove the compatibility exit condition and
+delete the expired branch. A lint-only wording change is not resolution.
+
 For `TC002` and `TC003`, move a third-party or standard-library import into an
 `if TYPE_CHECKING:` block only after confirming every use is an annotation that
 Python does not need to resolve at runtime. Postponed annotations are the

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -191,8 +191,12 @@ plan's progress update for that rule.
   tests with 17 skips; translations, repository Ruff and format, the repository
   harness, the architecture-boundary check, and every repository pre-commit
   hook also pass.
-- [ ] Open the ready FIX002 PR against D100 after the full backend suite and
-  repository pre-commit gate pass.
+- [x] 2026-08-21 03:31 CST: Opened ready FIX002 PR
+  [#2587](https://github.com/ai-shifu/ai-shifu/pull/2587) from
+  `sunner/ruff-fix002` to the D100 branch after the full backend suite and
+  repository pre-commit gate passed.
+- [ ] Merge or retarget FIX002 PR #2587 after its predecessors without
+  combining it with the TD003 rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -174,6 +174,25 @@ plan's progress update for that rule.
   branch after all local gates passed.
 - [ ] Merge or retarget D100 PR #2586 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 03:21 CST: Prepared the FIX002 stage on
+  `sunner/ruff-fix002`, stacked on D100. Implemented password-login failure
+  throttling by privacy-preserving identifier and client-IP counters, and
+  removed the expired interaction-key remap after verifying both learner
+  clients submit the canonical key and the pinned MarkdownFlow release has
+  passed the documented rollout checkpoint.
+- [x] 2026-08-21 03:21 CST: Re-ran the stable `ALL` census on the FIX002 tip.
+  It reports 29,964 findings across 33 rules: FIX002 and TD003 both fall from
+  two findings to zero, while every other rule count is unchanged. FIX002 is
+  the only rule newly selected in this stage; TD003 remains a separate rule
+  PR.
+- [x] 2026-08-21 03:28 CST: Verified the affected contracts with 254 user-
+  service tests, 78 learn-context tests with four skips, 13 learner-client
+  submission tests, and 127 config tests. The full backend suite passes 3,019
+  tests with 17 skips; translations, repository Ruff and format, the repository
+  harness, the architecture-boundary check, and every repository pre-commit
+  hook also pass.
+- [ ] Open the ready FIX002 PR against D100 after the full backend suite and
+  repository pre-commit gate pass.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -257,10 +276,14 @@ plan's progress update for that rule.
   infrastructure. It is not a safe mechanical unit: adopting it requires
   behavior-specific decomposition rather than result-variable or threshold
   workarounds, so TC003 was the smaller reviewable exception-removal stage.
-- FIX002 and TD003 report the same two TODOs. One is a real password-login
-  rate-limit feature and one is a compatibility-removal checkpoint. Renaming
-  them to evade lint would hide work, and implementing either is larger than a
-  lint cleanup, so they are deliberately not the first rule unit.
+- FIX002 and TD003 reported the same two TODOs. Treating FIX002 as a semantic
+  review exposed two different exit paths: the password-login security gap
+  required a real guard with failure-path tests, while the compatibility
+  checkpoint could be deleted only after confirming current and preview
+  clients use the canonical input key and the pinned MarkdownFlow release has
+  passed one release cycle. Resolving the work removes both rule findings, but
+  only FIX002 is selected in this stage so the one-rule PR contract remains
+  intact.
 
 ## Decision Log
 
@@ -435,6 +458,19 @@ skip, both changed maintenance scripts expose their help successfully, the
 full backend suite passes 3,015 tests with 17 skips, and the stable `ALL` census
 falls to 29,968 findings across 35 rules. Future agents now document module
 ownership rather than restating filenames or inventing generic helper prose.
+
+The FIX002 stage makes unfinished-work markers enforceable only after resolving
+their actual contracts. Password login now throttles repeated failures per
+identifier and client IP using expiring HMAC-fingerprinted counters, returns a
+translated dedicated error at the configured limit, clears an account counter
+after successful authentication, and never stores or logs the raw identifier
+or address. The expired interaction-key remap is removed after focused backend
+and learner-client tests prove canonical submissions and preserve noncanonical
+keys instead of silently renaming them. The stable `ALL` census falls exactly
+four findings to 29,964 across 33 rules without transferring debt. Future
+agents are directed to complete security work, prove rollout exit conditions,
+or move genuinely future work into the owning ExecPlan or issue rather than
+hiding it through comment wording or lint suppression.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,8 +31,8 @@
 #   service and route modules exceed by design.
 # - ARG001 / ARG002 / ARG005: unused arguments are pervasive in framework
 #   callbacks, fixtures and test doubles.
-# - TD003 / FIX002: the remaining TODOs have no tracking issue to link, and
-#   inventing one (or downgrading the comment) would hide real pending work.
+# - TD003 has no remaining findings after the FIX002 stage. It stays separate
+#   only so each newly enforced rule remains one reviewable stacked PR.
 
 # Matches the Python pinned by src/api/Dockerfile and the CI workflows.
 target-version = "py311"
@@ -141,6 +141,7 @@ select = [
     # imports stay allowed. The boundary-checker fixture below must keep its
     # parent-relative imports, since detecting them is what it tests.
     "TID252",  # relative import from a parent module
+    "FIX002",  # pending work belongs in an ExecPlan or issue, not a TODO comment
     "TD002",   # TODO without an author
     # flake8-bandit is enabled as a whole. Every rule it adds beyond the ones
     # this repo already satisfied is a security audit with zero current

--- a/src/api/error_codes.json
+++ b/src/api/error_codes.json
@@ -22,6 +22,7 @@
   "server.profile.learnerProfileOptimizationTimedOut": 1025,
   "server.profile.learnerProfileOptimizationEmptyResponse": 1026,
   "server.profile.learnerProfileOptimizationModerationFailed": 1027,
+  "server.user.passwordLoginRateLimited": 1028,
 
   "server.common.unknownError": 9999,
   "server.common.paramsError": 2001,

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -890,6 +890,35 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         description="Maximum attempts allowed for a single image captcha challenge",
         group="auth",
     ),
+    "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT": EnvVar(
+        name="PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        default=5,
+        type=int,
+        description=(
+            "Failed password attempts allowed per account identifier before "
+            "temporary throttling"
+        ),
+        group="auth",
+        validator=lambda value: int(value) >= 1,
+    ),
+    "PASSWORD_LOGIN_IP_FAILURE_LIMIT": EnvVar(
+        name="PASSWORD_LOGIN_IP_FAILURE_LIMIT",
+        default=20,
+        type=int,
+        description=(
+            "Failed password attempts allowed per client IP before temporary throttling"
+        ),
+        group="auth",
+        validator=lambda value: int(value) >= 1,
+    ),
+    "PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS": EnvVar(
+        name="PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS",
+        default=900,
+        type=int,
+        description="Sliding window for failed password login counters in seconds",
+        group="auth",
+        validator=lambda value: int(value) >= 1,
+    ),
     "CAPTCHA_CODE_OVERRIDE": EnvVar(
         name="CAPTCHA_CODE_OVERRIDE",
         default="",
@@ -1788,6 +1817,7 @@ REDIS_KEY_SUFFIXES: dict[str, str] = {
     "REDIS_KEY_PREFIX_PHONE_LIMIT": "phone_limit:",
     "REDIS_KEY_PREFIX_IP_BAN": "ip_ban:",
     "REDIS_KEY_PREFIX_IP_LIMIT": "ip_limit:",
+    "REDIS_KEY_PREFIX_PASSWORD_LOGIN_FAILURE": "password_login_failure:",
 }
 
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -836,17 +836,20 @@ Example: mysql://username:password@hostname:3306/database_name?charset=utf8mb4""
     "SECRET_KEY": EnvVar(
         name="SECRET_KEY",
         required=True,
-        example="ai-shifu",
+        example="",
         description="""Secret key for JWT token signing and verification
 CRITICAL: Used to encrypt/decrypt user authentication tokens
 - Must be a strong random string (at least 32 characters recommended)
 - DO NOT change in production (will invalidate all user sessions)
 - Keep different values for dev/test/prod environments
+- The public demo value "ai-shifu" is rejected
 - Never commit to version control
 Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))" """,
         secret=True,
         group="auth",
-        validator=lambda value: bool(value and str(value).strip()),
+        validator=lambda value: bool(
+            value and str(value).strip() and str(value).strip() != "ai-shifu"
+        ),
     ),
     "TOKEN_EXPIRE_TIME": EnvVar(
         name="TOKEN_EXPIRE_TIME",

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -918,7 +918,7 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         name="PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS",
         default=900,
         type=int,
-        description="Sliding window for failed password login counters in seconds",
+        description="Fixed window for failed password login counters in seconds",
         group="auth",
         validator=lambda value: int(value) >= 1,
     ),

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -38,7 +38,7 @@ from flaskr.service.user.auth.providers.google import (
     resolve_state_return_origin,
 )
 from flaskr.service.user.auth.providers.password import (
-    clear_password_login_identifier_failures,
+    clear_password_login_user_failures,
 )
 from flaskr.service.user.captcha import (
     create_captcha_challenge,
@@ -1233,10 +1233,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             db.session.add(pwd_cred)
             set_password_hash(pwd_cred, hash_password(new_password))
 
-        clear_password_login_identifier_failures(
-            app,
-            identifier=selected_identifier,
-        )
+        clear_password_login_user_failures(app, user_bid=user_bid)
         db.session.commit()
         return make_common_response({"success": True})
 
@@ -1271,6 +1268,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             raise_error("server.user.invalidCredentials")
 
         set_password_hash(pwd_cred, hash_password(new_password))
+        clear_password_login_user_failures(app, user_bid=user_bid)
         db.session.commit()
         return make_common_response({"success": True})
 
@@ -1339,10 +1337,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             db.session.add(pwd_cred)
             set_password_hash(pwd_cred, hash_password(new_password))
 
-        clear_password_login_identifier_failures(
-            app,
-            identifier=normalized_identifier,
-        )
+        clear_password_login_user_failures(app, user_bid=user_bid)
         db.session.commit()
         return make_common_response({"success": True})
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1103,9 +1103,11 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         if not password:
             raise_param_error("password")
         provider = get_provider("password")
-        vr = VerificationRequest(identifier=identifier, code=password)
-        # TODO(geyunfei): Add rate-limiting and failed login attempt tracking
-        # (record identifier, request.remote_addr, timestamp on failure)
+        vr = VerificationRequest(
+            identifier=identifier,
+            code=password,
+            metadata={"remote_addr": request.remote_addr or ""},
+        )
         auth_result = provider.verify(app, vr)
         current_user = _best_effort_password_login_user(app)
         current_user_id = (

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1106,7 +1106,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         vr = VerificationRequest(
             identifier=identifier,
             code=password,
-            metadata={"remote_addr": request.remote_addr or ""},
+            metadata={"remote_addr": _request_client_ip()},
         )
         auth_result = provider.verify(app, vr)
         current_user = _best_effort_password_login_user(app)

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -177,6 +177,13 @@ def _request_client_ip() -> str:
     return str(request.remote_addr or "").strip()
 
 
+def _request_proxy_verified_client_ip() -> str:
+    """Return the address appended by the trusted edge proxy."""
+    if "X-Forwarded-For" in request.headers:
+        return request.headers["X-Forwarded-For"].split(",")[-1].strip()
+    return str(request.remote_addr or "").strip()
+
+
 def _extract_referral_post_auth_fields(payload: dict) -> dict[str, str]:
     return extract_referral_post_auth_fields(
         payload,
@@ -1106,7 +1113,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         vr = VerificationRequest(
             identifier=identifier,
             code=password,
-            metadata={"remote_addr": _request_client_ip()},
+            metadata={"remote_addr": _request_proxy_verified_client_ip()},
         )
         auth_result = provider.verify(app, vr)
         current_user = _best_effort_password_login_user(app)

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1233,6 +1233,10 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             db.session.add(pwd_cred)
             set_password_hash(pwd_cred, hash_password(new_password))
 
+        clear_password_login_identifier_failures(
+            app,
+            identifier=selected_identifier,
+        )
         db.session.commit()
         return make_common_response({"success": True})
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -37,6 +37,9 @@ from flaskr.service.user.auth.base import OAuthCallbackRequest, VerificationRequ
 from flaskr.service.user.auth.providers.google import (
     resolve_state_return_origin,
 )
+from flaskr.service.user.auth.providers.password import (
+    clear_password_login_identifier_failures,
+)
 from flaskr.service.user.captcha import (
     create_captcha_challenge,
     verify_captcha_code,
@@ -1332,6 +1335,10 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             db.session.add(pwd_cred)
             set_password_hash(pwd_cred, hash_password(new_password))
 
+        clear_password_login_identifier_failures(
+            app,
+            identifier=normalized_identifier,
+        )
         db.session.commit()
         return make_common_response({"success": True})
 

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2787,28 +2787,6 @@ class RunScriptContextV2:
         user_input_param = MdflowContextV2.normalize_user_input_map(
             self._input, expected_variable
         )
-        # Backward compatible: some clients may still send `{input: [...]}` or a single
-        # unnamed key even when the interaction expects a specific variable.
-        # TODO(non-assignment rollout): markdown-flow >= 0.3.0 merges values
-        # from any key for no-variable interactions, and the web client now
-        # submits the canonical "input" key. Drop this remap once the
-        # "input"-key frontend has been fully rolled out for one release
-        # cycle (older cached clients may still send the legacy keys).
-        if expected_variable and expected_variable not in user_input_param:
-            if "input" in user_input_param and len(user_input_param) == 1:
-                app.logger.warning(
-                    "Remap interaction input key 'input' -> '%s'", expected_variable
-                )
-                user_input_param = {expected_variable: user_input_param["input"]}
-            elif len(user_input_param) == 1:
-                only_key, only_values = next(iter(user_input_param.items()))
-                if only_values:
-                    app.logger.warning(
-                        "Remap interaction input key '%s' -> '%s'",
-                        only_key,
-                        expected_variable,
-                    )
-                    user_input_param = {expected_variable: only_values}
 
         generated_block.generated_content = MdflowContextV2.flatten_user_input_map(
             user_input_param

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 class _StreamTTSFinalizeJob:
     def __init__(

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
     from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 class _StreamTTSFinalizeJob:
     def __init__(

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
 
 class _StreamTTSFinalizeJob:
     def __init__(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -74,6 +74,9 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 def _resolve_learning_permission(item_type: int | None) -> str:
     if item_type == UNIT_TYPE_VALUE_GUEST:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -68,6 +68,9 @@ if TYPE_CHECKING:
         PublishedOutlineItem,
     )
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 def _resolve_learning_permission(item_type: int | None) -> str:
     if item_type == UNIT_TYPE_VALUE_GUEST:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_detail.py
@@ -71,6 +71,9 @@ if TYPE_CHECKING:
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 def _resolve_learning_permission(item_type: int | None) -> str:
     if item_type == UNIT_TYPE_VALUE_GUEST:

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -182,7 +182,7 @@ def _reject_failed_password_login(
     raise_error("server.user.invalidCredentials")
 
 
-def _clear_password_login_identifier_failures(
+def clear_password_login_identifier_failures(
     app: Flask,
     *,
     identifier: str,
@@ -258,7 +258,7 @@ class PasswordAuthProvider(AuthProvider):
                 remote_addr=remote_addr,
             )
 
-        _clear_password_login_identifier_failures(app, identifier=identifier)
+        clear_password_login_identifier_failures(app, identifier=identifier)
 
         # Build login token
         user_info = build_user_info_from_aggregate(aggregate)

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -99,8 +99,10 @@ def _increment_counter(app: Flask, key: str, window_seconds: int) -> int:
         if not acquired:
             app.logger.warning("Password login failure counter lock is busy")
             raise_error("server.user.passwordLoginRateLimited")
-        next_count = _read_counter(app, key) + 1
-        shared_cache.set(key, next_count, ex=window_seconds)
+        if shared_cache.set(key, 1, ex=window_seconds, nx=True):
+            next_count = 1
+        else:
+            next_count = int(shared_cache.incr(key))
     except (RedisError, RuntimeError, TypeError, ValueError):
         app.logger.exception("Password login failure counter update failed")
         raise_error("server.user.passwordLoginRateLimited")

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -5,8 +5,12 @@ Supports login via phone number or email + password.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 from typing import TYPE_CHECKING
 
+from flaskr.common.cache_provider import cache
+from flaskr.common.config import get_redis_derived_prefix
 from flaskr.service.common.dtos import UserToken
 from flaskr.service.common.models import raise_error
 from flaskr.service.common.phone_numbers import normalize_phone_identifier
@@ -27,9 +31,155 @@ from flaskr.service.user.repository import (
     load_user_aggregate_by_identifier,
 )
 from flaskr.service.user.utils import generate_token
+from flaskr.util.datetime import now_utc, to_utc_iso
+from redis.exceptions import RedisError
 
 if TYPE_CHECKING:
+    from typing import NoReturn
+
     from flask import Flask
+
+
+_IDENTIFIER_LIMIT_CONFIG = "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT"
+_IP_LIMIT_CONFIG = "PASSWORD_LOGIN_IP_FAILURE_LIMIT"
+_WINDOW_CONFIG = "PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS"
+_DEFAULT_IDENTIFIER_LIMIT = 5
+_DEFAULT_IP_LIMIT = 20
+_DEFAULT_WINDOW_SECONDS = 15 * 60
+
+
+def _fingerprint(app: Flask, value: str) -> str:
+    secret = str(app.config["SECRET_KEY"]).encode("utf-8")
+    normalized_value = str(value or "").strip().encode("utf-8")
+    return hmac.new(secret, normalized_value, hashlib.sha256).hexdigest()
+
+
+def _counter_key(app: Flask, scope: str, value: str) -> str:
+    prefix = get_redis_derived_prefix(
+        "REDIS_KEY_PREFIX_PASSWORD_LOGIN_FAILURE",
+        app=app,
+    )
+    return f"{prefix}{scope}:{_fingerprint(app, value)}"
+
+
+def _config_int(app: Flask, name: str, default: int) -> int:
+    return max(1, int(app.config.get(name, default)))
+
+
+def _read_counter(app: Flask, key: str) -> int:
+    try:
+        raw_value = cache.get(key)
+        return int(raw_value or 0)
+    except (RedisError, TypeError, ValueError):
+        app.logger.exception("Password login failure counter read failed")
+        return 0
+
+
+def _increment_counter(app: Flask, key: str, window_seconds: int) -> int:
+    lock = None
+    acquired = False
+    try:
+        lock = cache.lock(
+            f"{key}:lock",
+            timeout=2,
+            blocking_timeout=1,
+        )
+        acquired = bool(lock.acquire(blocking=True, blocking_timeout=1))
+        if not acquired:
+            app.logger.warning("Password login failure counter lock is busy")
+            raise_error("server.user.passwordLoginRateLimited")
+        next_count = _read_counter(app, key) + 1
+        cache.set(key, next_count, ex=window_seconds)
+    except (RedisError, RuntimeError, TypeError, ValueError):
+        app.logger.exception("Password login failure counter update failed")
+        return 0
+    else:
+        return next_count
+    finally:
+        if acquired and lock is not None:
+            try:
+                lock.release()
+            except (RedisError, RuntimeError):
+                app.logger.exception(
+                    "Password login failure counter lock release failed",
+                )
+
+
+def _ensure_password_login_allowed(
+    app: Flask,
+    *,
+    identifier: str,
+    remote_addr: str,
+) -> None:
+    identifier_limit = _config_int(
+        app,
+        _IDENTIFIER_LIMIT_CONFIG,
+        _DEFAULT_IDENTIFIER_LIMIT,
+    )
+    identifier_key = _counter_key(app, "identifier", identifier)
+    identifier_blocked = _read_counter(app, identifier_key) >= identifier_limit
+
+    ip_blocked = False
+    if remote_addr:
+        ip_limit = _config_int(app, _IP_LIMIT_CONFIG, _DEFAULT_IP_LIMIT)
+        ip_key = _counter_key(app, "ip", remote_addr)
+        ip_blocked = _read_counter(app, ip_key) >= ip_limit
+
+    if identifier_blocked or ip_blocked:
+        raise_error("server.user.passwordLoginRateLimited")
+
+
+def _reject_failed_password_login(
+    app: Flask,
+    *,
+    identifier: str,
+    remote_addr: str,
+) -> NoReturn:
+    window_seconds = _config_int(app, _WINDOW_CONFIG, _DEFAULT_WINDOW_SECONDS)
+    identifier_limit = _config_int(
+        app,
+        _IDENTIFIER_LIMIT_CONFIG,
+        _DEFAULT_IDENTIFIER_LIMIT,
+    )
+    identifier_count = _increment_counter(
+        app,
+        _counter_key(app, "identifier", identifier),
+        window_seconds,
+    )
+
+    ip_count = 0
+    ip_limit = _config_int(app, _IP_LIMIT_CONFIG, _DEFAULT_IP_LIMIT)
+    if remote_addr:
+        ip_count = _increment_counter(
+            app,
+            _counter_key(app, "ip", remote_addr),
+            window_seconds,
+        )
+
+    app.logger.warning(
+        "Password login rejected identifier=%s remote_addr=%s occurred_at=%s "
+        "identifier_failures=%d ip_failures=%d",
+        _fingerprint(app, identifier)[:12],
+        _fingerprint(app, remote_addr)[:12] if remote_addr else "none",
+        to_utc_iso(now_utc()),
+        identifier_count,
+        ip_count,
+    )
+
+    if identifier_count >= identifier_limit or (remote_addr and ip_count >= ip_limit):
+        raise_error("server.user.passwordLoginRateLimited")
+    raise_error("server.user.invalidCredentials")
+
+
+def _clear_password_login_identifier_failures(
+    app: Flask,
+    *,
+    identifier: str,
+) -> None:
+    try:
+        cache.delete(_counter_key(app, "identifier", identifier))
+    except (RedisError, RuntimeError):
+        app.logger.exception("Password login failure counter clear failed")
 
 
 class PasswordAuthProvider(AuthProvider):
@@ -46,16 +196,31 @@ class PasswordAuthProvider(AuthProvider):
             else normalize_phone_identifier(raw_identifier)
         )
         password = request.code  # reuse code field for password
+        remote_addr = str(request.metadata.get("remote_addr") or "").strip()
+
+        _ensure_password_login_allowed(
+            app,
+            identifier=identifier,
+            remote_addr=remote_addr,
+        )
 
         if not identifier or not password:
-            raise_error("server.user.invalidCredentials")
+            _reject_failed_password_login(
+                app,
+                identifier=identifier,
+                remote_addr=remote_addr,
+            )
 
         # Look up user via phone or email provider credentials
         aggregate = load_user_aggregate_by_identifier(
             identifier, providers=["phone", "email"]
         )
         if not aggregate:
-            raise_error("server.user.invalidCredentials")
+            _reject_failed_password_login(
+                app,
+                identifier=identifier,
+                remote_addr=remote_addr,
+            )
 
         # Find password credential: look up by user_bid only.
         # The password credential's identifier may differ from the login
@@ -66,12 +231,22 @@ class PasswordAuthProvider(AuthProvider):
         )
         credential = password_creds[0] if password_creds else None
         if not credential:
-            raise_error("server.user.invalidCredentials")
+            _reject_failed_password_login(
+                app,
+                identifier=identifier,
+                remote_addr=remote_addr,
+            )
 
         # Read password hash from raw_profile
         password_hash = get_password_hash(credential)
         if not password_hash or not verify_password(password, password_hash):
-            raise_error("server.user.invalidCredentials")
+            _reject_failed_password_login(
+                app,
+                identifier=identifier,
+                remote_addr=remote_addr,
+            )
+
+        _clear_password_login_identifier_failures(app, identifier=identifier)
 
         # Build login token
         user_info = build_user_info_from_aggregate(aggregate)

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -22,6 +22,7 @@ from flaskr.service.user.auth.factory import (
     has_provider,
     register_provider,
 )
+from flaskr.service.user.consts import CREDENTIAL_STATE_VERIFIED
 from flaskr.service.user.password_utils import verify_password
 from flaskr.service.user.repository import (
     build_user_info_from_aggregate,
@@ -184,16 +185,30 @@ def _reject_failed_password_login(
     raise_error("server.user.invalidCredentials")
 
 
-def clear_password_login_identifier_failures(
+def _clear_password_login_identifier_failures(
     app: Flask,
     *,
-    identifier: str,
+    identifiers: set[str],
 ) -> None:
+    keys = [_counter_key(app, "identifier", identifier) for identifier in identifiers]
+    if not keys:
+        return
     try:
-        _shared_counter_cache(app).delete(_counter_key(app, "identifier", identifier))
+        _shared_counter_cache(app).delete(*keys)
     except (RedisError, RuntimeError):
         app.logger.exception("Password login failure counter clear failed")
         raise_error("server.user.passwordLoginRateLimited")
+
+
+def clear_password_login_user_failures(app: Flask, *, user_bid: str) -> None:
+    identifiers = {
+        str(credential.identifier or "").strip()
+        for credential in list_credentials(user_bid=user_bid)
+        if credential.provider_name in {"phone", "email"}
+        and credential.state == CREDENTIAL_STATE_VERIFIED
+        and str(credential.identifier or "").strip()
+    }
+    _clear_password_login_identifier_failures(app, identifiers=identifiers)
 
 
 class PasswordAuthProvider(AuthProvider):
@@ -260,7 +275,7 @@ class PasswordAuthProvider(AuthProvider):
                 remote_addr=remote_addr,
             )
 
-        clear_password_login_identifier_failures(app, identifier=identifier)
+        clear_password_login_user_failures(app, user_bid=aggregate.user_bid)
 
         # Build login token
         user_info = build_user_info_from_aggregate(aggregate)

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -92,7 +92,7 @@ def _increment_counter(app: Flask, key: str, window_seconds: int) -> int:
         cache.set(key, next_count, ex=window_seconds)
     except (RedisError, RuntimeError, TypeError, ValueError):
         app.logger.exception("Password login failure counter update failed")
-        return 0
+        raise_error("server.user.passwordLoginRateLimited")
     else:
         return next_count
     finally:

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -9,7 +9,6 @@ import hashlib
 import hmac
 from typing import TYPE_CHECKING
 
-from flaskr.common.cache_provider import cache
 from flaskr.common.config import get_redis_derived_prefix
 from flaskr.service.common.dtos import UserToken
 from flaskr.service.common.models import raise_error
@@ -66,20 +65,32 @@ def _config_int(app: Flask, name: str, default: int) -> int:
     return max(1, int(app.config.get(name, default)))
 
 
+def _shared_counter_cache(app: Flask):
+    """Return the shared Redis backend required by password throttling."""
+    from flaskr.dao import get_redis_client
+
+    client = get_redis_client()
+    if client is None:
+        app.logger.error("Password login failure counters require Redis")
+        raise_error("server.user.passwordLoginRateLimited")
+    return client
+
+
 def _read_counter(app: Flask, key: str) -> int:
     try:
-        raw_value = cache.get(key)
+        raw_value = _shared_counter_cache(app).get(key)
         return int(raw_value or 0)
     except (RedisError, TypeError, ValueError):
         app.logger.exception("Password login failure counter read failed")
-        return 0
+        raise_error("server.user.passwordLoginRateLimited")
 
 
 def _increment_counter(app: Flask, key: str, window_seconds: int) -> int:
     lock = None
     acquired = False
     try:
-        lock = cache.lock(
+        shared_cache = _shared_counter_cache(app)
+        lock = shared_cache.lock(
             f"{key}:lock",
             timeout=2,
             blocking_timeout=1,
@@ -89,7 +100,7 @@ def _increment_counter(app: Flask, key: str, window_seconds: int) -> int:
             app.logger.warning("Password login failure counter lock is busy")
             raise_error("server.user.passwordLoginRateLimited")
         next_count = _read_counter(app, key) + 1
-        cache.set(key, next_count, ex=window_seconds)
+        shared_cache.set(key, next_count, ex=window_seconds)
     except (RedisError, RuntimeError, TypeError, ValueError):
         app.logger.exception("Password login failure counter update failed")
         raise_error("server.user.passwordLoginRateLimited")
@@ -177,9 +188,10 @@ def _clear_password_login_identifier_failures(
     identifier: str,
 ) -> None:
     try:
-        cache.delete(_counter_key(app, "identifier", identifier))
+        _shared_counter_cache(app).delete(_counter_key(app, "identifier", identifier))
     except (RedisError, RuntimeError):
         app.logger.exception("Password login failure counter clear failed")
+        raise_error("server.user.passwordLoginRateLimited")
 
 
 class PasswordAuthProvider(AuthProvider):

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -58,6 +58,12 @@ class FakeRedis:
             return None
         return self._store.get(key)
 
+    def stored_keys(self) -> list[str]:
+        """Return active keys for assertions without exposing storage internals."""
+        for key in list(self._store):
+            self._is_expired(key)
+        return list(self._store)
+
     def getex(self, key: str, ex: int | None = None, px: int | None = None):
         value = self.get(key)
         if value is None:

--- a/src/api/tests/common/test_config_integration.py
+++ b/src/api/tests/common/test_config_integration.py
@@ -221,7 +221,7 @@ class TestConfigurationExport:
 
         # Secret values should be empty in export
         lines = output.split("\n")
-        assert 'SECRET_KEY="ai-shifu"' in lines
+        assert 'SECRET_KEY=""' in lines
         assert (
             'SQLALCHEMY_DATABASE_URI="mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4"'
             in lines

--- a/src/api/tests/common/test_secret_key_validator.py
+++ b/src/api/tests/common/test_secret_key_validator.py
@@ -42,6 +42,7 @@ class TestSecretKeyValidator:
             "\t",  # Only tab
             "\n",  # Only newline
             "\t\n ",  # Mixed whitespace
+            "ai-shifu",  # Public demo key
             None,  # None value
         ]
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -2620,6 +2620,13 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
     )
     INTERACTION = "?[网络招聘网站 | 猎头公司 | 人才测评 | 培训业务]"
 
+    def test_normalizer_preserves_a_noncanonical_single_key(self) -> None:
+        """Keep old client keys visible instead of silently renaming them."""
+        assert MdflowContextV2.normalize_user_input_map(
+            {"legacy_key": ["Alice"]},
+            default_key="profile_name",
+        ) == {"legacy_key": ["Alice"]}
+
     def _blocks(self, selection):
         return [
             types.SimpleNamespace(

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import jwt
 from flaskr.service.user import phone_flow
 from flaskr.service.user.auth.providers import password as password_provider
+from redis.exceptions import RedisError
 
 if TYPE_CHECKING:
     import pytest
@@ -315,6 +316,28 @@ def test_password_login_blocks_when_failure_counter_lock_is_busy(
     assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
     lock_factory.assert_called_once()
     busy_lock.release.assert_not_called()
+
+
+def test_password_login_blocks_when_failure_counter_lock_errors(
+    test_client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail closed when Redis errors after returning a lock object."""
+    failing_lock = MagicMock()
+    failing_lock.acquire.side_effect = RedisError("redis unavailable")
+    monkeypatch.setattr(
+        password_provider.cache, "lock", MagicMock(return_value=failing_lock)
+    )
+
+    blocked, blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "redis-error@example.com", "password": "wrong-password"},
+    )
+
+    assert blocked.status_code == _HTTP_OK
+    assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+    failing_lock.release.assert_not_called()
 
 
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -29,12 +29,19 @@ _TEST_FAILURE_WINDOW_SECONDS = 300
 _PASSWORD_COUNTER_KEY_COUNT = 2
 
 
-def _post_json(client, path: str, payload: dict, headers: dict | None = None):
+def _post_json(
+    client,
+    path: str,
+    payload: dict,
+    headers: dict | None = None,
+    environ_overrides: dict | None = None,
+):
     resp = client.post(
         path,
         data=json.dumps(payload),
         content_type="application/json",
         headers=headers or {},
+        environ_overrides=environ_overrides,
     )
     return resp, json.loads(resp.data)
 
@@ -261,6 +268,8 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "first@example.com", "password": "wrong-password"},
+        headers={"X-Forwarded-For": "198.51.100.8"},
+        environ_overrides={"REMOTE_ADDR": "172.18.0.2"},
     )
     assert first_failure.status_code == _HTTP_OK
     assert first_body["code"] == _INVALID_CREDENTIALS_CODE
@@ -269,6 +278,8 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "second@example.com", "password": "wrong-password"},
+        headers={"X-Forwarded-For": "198.51.100.8"},
+        environ_overrides={"REMOTE_ADDR": "172.18.0.3"},
     )
     assert blocked.status_code == _HTTP_OK
     assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
@@ -277,6 +288,8 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "third@example.com", "password": "wrong-password"},
+        headers={"X-Forwarded-For": "198.51.100.8"},
+        environ_overrides={"REMOTE_ADDR": "172.18.0.4"},
     )
     assert still_blocked.status_code == _HTTP_OK
     assert still_blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -295,6 +295,45 @@ def test_password_login_throttles_one_ip_across_identifiers(
     assert still_blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
 
 
+def test_password_login_failure_window_does_not_slide(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_redis_client: FakeRedis,
+) -> None:
+    """Expire accumulated failures from the first attempt in the window."""
+    clock = [1000.0]
+    monkeypatch.setattr(mock_redis_client, "_now", lambda: clock[0])
+    monkeypatch.setitem(app.config, "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT", 10)
+    monkeypatch.setitem(app.config, "PASSWORD_LOGIN_IP_FAILURE_LIMIT", 10)
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS",
+        _TEST_FAILURE_WINDOW_SECONDS,
+    )
+
+    payload = {"identifier": "fixed-window@example.com", "password": "wrong"}
+    _post_json(test_client, "/api/user/login_password", payload)
+    counter_keys = [
+        key
+        for key in mock_redis_client.stored_keys()
+        if "password_login_failure:" in key
+    ]
+    assert len(counter_keys) == _PASSWORD_COUNTER_KEY_COUNT
+    assert all(
+        mock_redis_client.ttl(key) == _TEST_FAILURE_WINDOW_SECONDS
+        for key in counter_keys
+    )
+
+    clock[0] += 100
+    _post_json(test_client, "/api/user/login_password", payload)
+
+    assert all(
+        mock_redis_client.ttl(key) == _TEST_FAILURE_WINDOW_SECONDS - 100
+        for key in counter_keys
+    )
+
+
 def test_password_login_blocks_when_failure_counter_lock_is_busy(
     test_client: FlaskClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 
 import jwt
 from flaskr.service.user import phone_flow
-from flaskr.service.user.auth.providers import password as password_provider
 from redis.exceptions import RedisError
 
 if TYPE_CHECKING:
@@ -299,12 +298,13 @@ def test_password_login_throttles_one_ip_across_identifiers(
 def test_password_login_blocks_when_failure_counter_lock_is_busy(
     test_client: FlaskClient,
     monkeypatch: pytest.MonkeyPatch,
+    mock_redis_client: FakeRedis,
 ) -> None:
     """Do not let concurrent counter updates bypass password throttling."""
     busy_lock = MagicMock()
     busy_lock.acquire.return_value = False
     lock_factory = MagicMock(return_value=busy_lock)
-    monkeypatch.setattr(password_provider.cache, "lock", lock_factory)
+    monkeypatch.setattr(mock_redis_client, "lock", lock_factory)
 
     blocked, blocked_body = _post_json(
         test_client,
@@ -321,13 +321,12 @@ def test_password_login_blocks_when_failure_counter_lock_is_busy(
 def test_password_login_blocks_when_failure_counter_lock_errors(
     test_client: FlaskClient,
     monkeypatch: pytest.MonkeyPatch,
+    mock_redis_client: FakeRedis,
 ) -> None:
     """Fail closed when Redis errors after returning a lock object."""
     failing_lock = MagicMock()
     failing_lock.acquire.side_effect = RedisError("redis unavailable")
-    monkeypatch.setattr(
-        password_provider.cache, "lock", MagicMock(return_value=failing_lock)
-    )
+    monkeypatch.setattr(mock_redis_client, "lock", MagicMock(return_value=failing_lock))
 
     blocked, blocked_body = _post_json(
         test_client,
@@ -338,6 +337,70 @@ def test_password_login_blocks_when_failure_counter_lock_errors(
     assert blocked.status_code == _HTTP_OK
     assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
     failing_lock.release.assert_not_called()
+
+
+def test_password_login_blocks_without_a_shared_counter_backend(
+    test_client: FlaskClient,
+    mock_redis_client: FakeRedis,
+) -> None:
+    """Do not weaken throttling to process-local counters when Redis is absent."""
+    from flaskr.dao import set_redis_client
+
+    set_redis_client(None)
+    try:
+        blocked, blocked_body = _post_json(
+            test_client,
+            "/api/user/login_password",
+            {"identifier": "no-redis@example.com", "password": "wrong-password"},
+        )
+    finally:
+        set_redis_client(mock_redis_client)
+
+    assert blocked.status_code == _HTTP_OK
+    assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+
+
+def test_password_login_waits_for_redis_before_clearing_failures(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_redis_client: FakeRedis,
+) -> None:
+    """Do not report login success until the shared failure count is cleared."""
+    phone = "15500002224"
+    password = "Abcd1234"
+    with app.app_context():
+        user_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=phone, code="9999"
+        )
+    _post_json(
+        test_client,
+        "/api/user/set_password",
+        {"identifier": phone, "code": "9999", "new_password": password},
+        headers={"Token": user_token.token},
+    )
+
+    original_delete = mock_redis_client.delete
+    monkeypatch.setattr(
+        mock_redis_client,
+        "delete",
+        MagicMock(side_effect=RedisError("redis unavailable")),
+    )
+    _blocked, blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": password},
+    )
+    assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+
+    monkeypatch.setattr(mock_redis_client, "delete", original_delete)
+    recovered, recovered_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": password},
+    )
+    assert recovered.status_code == _HTTP_OK
+    assert recovered_body["code"] == 0
 
 
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -403,6 +403,54 @@ def test_password_login_waits_for_redis_before_clearing_failures(
     assert recovered_body["code"] == 0
 
 
+def test_password_reset_clears_identifier_failure_limit(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore password access immediately after verified credential recovery."""
+    phone = "15500002225"
+    old_password = "Abcd1234"
+    new_password = "Efgh5678"
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        _TEST_IDENTIFIER_FAILURE_LIMIT,
+    )
+    with app.app_context():
+        user_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=phone, code="9999"
+        )
+    _post_json(
+        test_client,
+        "/api/user/set_password",
+        {"identifier": phone, "code": "9999", "new_password": old_password},
+        headers={"Token": user_token.token},
+    )
+    for wrong_password in ("wrong-one", "wrong-two"):
+        _post_json(
+            test_client,
+            "/api/user/login_password",
+            {"identifier": phone, "password": wrong_password},
+        )
+
+    reset, reset_body = _post_json(
+        test_client,
+        "/api/user/reset_password",
+        {"identifier": phone, "code": "9999", "new_password": new_password},
+    )
+    assert reset.status_code == _HTTP_OK
+    assert reset_body["code"] == 0
+
+    login, login_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": new_password},
+    )
+    assert login.status_code == _HTTP_OK
+    assert login_body["code"] == 0
+
+
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):
     from flaskr.dao import db
     from flaskr.service.profile.learner_profile import (

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -1,10 +1,32 @@
 """Verify password HTTP route behavior."""
 
+from __future__ import annotations
+
 import json
 import time
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import jwt
+from flaskr.service.user import phone_flow
+from flaskr.service.user.auth.providers import password as password_provider
+
+if TYPE_CHECKING:
+    import pytest
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+    from tests.common.fixtures.fake_redis import FakeRedis
+
+
+_HTTP_OK = 200
+_INVALID_CREDENTIALS_CODE = 1016
+_PASSWORD_LOGIN_RATE_LIMITED_CODE = 1028
+_TEST_IDENTIFIER_FAILURE_LIMIT = 2
+_TEST_IP_FAILURE_LIMIT = 100
+_TEST_FAILURE_WINDOW_SECONDS = 300
+_PASSWORD_COUNTER_KEY_COUNT = 2
 
 
 def _post_json(client, path: str, payload: dict, headers: dict | None = None):
@@ -117,6 +139,169 @@ def test_password_login_after_setting_password(test_client, app):
     assert body["code"] == 0
     assert body["data"]["token"]
     assert body["data"]["userInfo"]["mobile"] == phone
+
+
+def test_password_login_throttles_identifier_and_success_resets_it(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_redis_client: FakeRedis,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Throttle repeated account failures while allowing a success to reset them."""
+    phone = "15500002223"
+    password = "Abcd1234"
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        _TEST_IDENTIFIER_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IP_FAILURE_LIMIT",
+        _TEST_IP_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS",
+        _TEST_FAILURE_WINDOW_SECONDS,
+    )
+
+    with app.app_context():
+        user_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=phone, code="9999"
+        )
+
+    _post_json(
+        test_client,
+        "/api/user/set_password",
+        {"identifier": phone, "code": "9999", "new_password": password},
+        headers={"Token": user_token.token},
+    )
+
+    first_failure, first_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": "wrong-password"},
+    )
+    assert first_failure.status_code == _HTTP_OK
+    assert first_body["code"] == _INVALID_CREDENTIALS_CODE
+
+    success, success_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": password},
+    )
+    assert success.status_code == _HTTP_OK
+    assert success_body["code"] == 0
+
+    after_reset, after_reset_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": "wrong-again"},
+    )
+    assert after_reset.status_code == _HTTP_OK
+    assert after_reset_body["code"] == _INVALID_CREDENTIALS_CODE
+
+    blocked, blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": "wrong-twice"},
+    )
+    assert blocked.status_code == _HTTP_OK
+    assert blocked_body == {
+        "code": _PASSWORD_LOGIN_RATE_LIMITED_CODE,
+        "message": "Too many failed password attempts. Try again later.",
+    }
+
+    correct_while_blocked, correct_while_blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": password},
+    )
+    assert correct_while_blocked.status_code == _HTTP_OK
+    assert correct_while_blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+
+    counter_keys = [
+        key
+        for key in mock_redis_client.stored_keys()
+        if "password_login_failure:" in key
+    ]
+    assert len(counter_keys) == _PASSWORD_COUNTER_KEY_COUNT
+    assert all(phone not in key for key in counter_keys)
+    assert all("127.0.0.1" not in key for key in counter_keys)
+    assert all(mock_redis_client.ttl(key) > 0 for key in counter_keys)
+    assert phone not in caplog.text
+    assert "127.0.0.1" not in caplog.text
+
+
+def test_password_login_throttles_one_ip_across_identifiers(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Share an IP failure budget across distinct account identifiers."""
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        _TEST_IP_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IP_FAILURE_LIMIT",
+        _TEST_IDENTIFIER_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_FAILURE_WINDOW_SECONDS",
+        _TEST_FAILURE_WINDOW_SECONDS,
+    )
+
+    first_failure, first_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "first@example.com", "password": "wrong-password"},
+    )
+    assert first_failure.status_code == _HTTP_OK
+    assert first_body["code"] == _INVALID_CREDENTIALS_CODE
+
+    blocked, blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "second@example.com", "password": "wrong-password"},
+    )
+    assert blocked.status_code == _HTTP_OK
+    assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+
+    still_blocked, still_blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "third@example.com", "password": "wrong-password"},
+    )
+    assert still_blocked.status_code == _HTTP_OK
+    assert still_blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+
+
+def test_password_login_blocks_when_failure_counter_lock_is_busy(
+    test_client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not let concurrent counter updates bypass password throttling."""
+    busy_lock = MagicMock()
+    busy_lock.acquire.return_value = False
+    lock_factory = MagicMock(return_value=busy_lock)
+    monkeypatch.setattr(password_provider.cache, "lock", lock_factory)
+
+    blocked, blocked_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "locked@example.com", "password": "wrong-password"},
+    )
+
+    assert blocked.status_code == _HTTP_OK
+    assert blocked_body["code"] == _PASSWORD_LOGIN_RATE_LIMITED_CODE
+    lock_factory.assert_called_once()
+    busy_lock.release.assert_not_called()
 
 
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -451,6 +451,54 @@ def test_password_reset_clears_identifier_failure_limit(
     assert login_body["code"] == 0
 
 
+def test_first_password_clears_identifier_failure_limit(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore password access after verified first-time password setup."""
+    phone = "15500002226"
+    password = "Abcd1234"
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        _TEST_IDENTIFIER_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IP_FAILURE_LIMIT",
+        _TEST_IP_FAILURE_LIMIT,
+    )
+    with app.app_context():
+        user_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=phone, code="9999"
+        )
+
+    for wrong_password in ("wrong-one", "wrong-two"):
+        _post_json(
+            test_client,
+            "/api/user/login_password",
+            {"identifier": phone, "password": wrong_password},
+        )
+
+    created, created_body = _post_json(
+        test_client,
+        "/api/user/set_password",
+        {"identifier": phone, "code": "9999", "new_password": password},
+        headers={"Token": user_token.token},
+    )
+    assert created.status_code == _HTTP_OK
+    assert created_body["code"] == 0
+
+    login, login_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": phone, "password": password},
+    )
+    assert login.status_code == _HTTP_OK
+    assert login_body["code"] == 0
+
+
 def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):
     from flaskr.dao import db
     from flaskr.service.profile.learner_profile import (

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -490,6 +490,75 @@ def test_password_reset_clears_identifier_failure_limit(
     assert login_body["code"] == 0
 
 
+def test_password_reset_clears_failure_limit_for_linked_email(
+    test_client: FlaskClient,
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clear linked verified identifiers after recovering a shared password."""
+    from flaskr.dao import db
+    from flaskr.service.user.repository import upsert_credential
+
+    phone = "15500002227"
+    email = "recovery-linked@example.com"
+    old_password = "Abcd1234"
+    new_password = "Efgh5678"
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT",
+        _TEST_IDENTIFIER_FAILURE_LIMIT,
+    )
+    monkeypatch.setitem(
+        app.config,
+        "PASSWORD_LOGIN_IP_FAILURE_LIMIT",
+        _TEST_IP_FAILURE_LIMIT,
+    )
+    with app.app_context():
+        user_token, _created, _ctx = phone_flow.verify_phone_code(
+            app, user_id=None, phone=phone, code="9999"
+        )
+        upsert_credential(
+            app,
+            user_bid=user_token.userInfo.user_id,
+            provider_name="email",
+            subject_id=email,
+            subject_format="email",
+            identifier=email,
+            metadata={},
+            verified=True,
+        )
+        db.session.commit()
+
+    _post_json(
+        test_client,
+        "/api/user/set_password",
+        {"identifier": phone, "code": "9999", "new_password": old_password},
+        headers={"Token": user_token.token},
+    )
+    for wrong_password in ("wrong-one", "wrong-two"):
+        _post_json(
+            test_client,
+            "/api/user/login_password",
+            {"identifier": email, "password": wrong_password},
+        )
+
+    reset, reset_body = _post_json(
+        test_client,
+        "/api/user/reset_password",
+        {"identifier": phone, "code": "9999", "new_password": new_password},
+    )
+    assert reset.status_code == _HTTP_OK
+    assert reset_body["code"] == 0
+
+    login, login_body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": email, "password": new_password},
+    )
+    assert login.status_code == _HTTP_OK
+    assert login_body["code"] == 0
+
+
 def test_first_password_clears_identifier_failure_limit(
     test_client: FlaskClient,
     app: Flask,

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -269,7 +269,7 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "first@example.com", "password": "wrong-password"},
-        headers={"X-Forwarded-For": "198.51.100.8"},
+        headers={"X-Forwarded-For": "203.0.113.10, 198.51.100.8"},
         environ_overrides={"REMOTE_ADDR": "172.18.0.2"},
     )
     assert first_failure.status_code == _HTTP_OK
@@ -279,7 +279,7 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "second@example.com", "password": "wrong-password"},
-        headers={"X-Forwarded-For": "198.51.100.8"},
+        headers={"X-Forwarded-For": "203.0.113.11, 198.51.100.8"},
         environ_overrides={"REMOTE_ADDR": "172.18.0.3"},
     )
     assert blocked.status_code == _HTTP_OK
@@ -289,7 +289,7 @@ def test_password_login_throttles_one_ip_across_identifiers(
         test_client,
         "/api/user/login_password",
         {"identifier": "third@example.com", "password": "wrong-password"},
-        headers={"X-Forwarded-For": "198.51.100.8"},
+        headers={"X-Forwarded-For": "203.0.113.12, 198.51.100.8"},
         environ_overrides={"REMOTE_ADDR": "172.18.0.4"},
     )
     assert still_blocked.status_code == _HTTP_OK

--- a/src/i18n/en-US/modules/backend/user.json
+++ b/src/i18n/en-US/modules/backend/user.json
@@ -22,6 +22,7 @@
     "mailCheckError": "Email verification code error",
     "mailSendExpired": "Email verification code expired",
     "passwordAlreadySet": "Password already set",
+    "passwordLoginRateLimited": "Too many failed password attempts. Try again later.",
     "passwordNeedsDigit": "Password must contain at least one digit",
     "passwordNeedsLetter": "Password must contain at least one letter",
     "passwordTooShort": "Password must be at least 8 characters",

--- a/src/i18n/fr-FR/modules/backend/user.json
+++ b/src/i18n/fr-FR/modules/backend/user.json
@@ -22,6 +22,7 @@
     "mailCheckError": "Erreur du code de vérification par e-mail",
     "mailSendExpired": "Le code de vérification par e-mail a expiré",
     "passwordAlreadySet": "Mot de passe déjà défini",
+    "passwordLoginRateLimited": "Trop de tentatives de mot de passe ont échoué. Réessayez plus tard.",
     "passwordNeedsDigit": "Le mot de passe doit contenir au moins un chiffre",
     "passwordNeedsLetter": "Le mot de passe doit contenir au moins une lettre",
     "passwordTooShort": "Le mot de passe doit contenir au moins 8 caractères",

--- a/src/i18n/zh-CN/modules/backend/user.json
+++ b/src/i18n/zh-CN/modules/backend/user.json
@@ -22,6 +22,7 @@
     "mailCheckError": "邮件验证码错误",
     "mailSendExpired": "邮件验证码过期",
     "passwordAlreadySet": "密码已设置",
+    "passwordLoginRateLimited": "密码尝试次数过多，请稍后重试",
     "passwordNeedsDigit": "密码需包含至少一个数字",
     "passwordNeedsLetter": "密码需包含至少一个字母",
     "passwordTooShort": "密码长度至少为8位",


### PR DESCRIPTION
## Summary

- Enable Ruff FIX002 after resolving both pending-work markers instead of renaming or suppressing them.
- Throttle failed password logins per normalized identifier and client IP with expiring HMAC-fingerprinted counters, a dedicated translated error, and safe behavior under counter-lock contention.
- Remove the expired interaction-key remap after verifying current learner and preview clients submit the canonical input key on the pinned MarkdownFlow release.
- Document the preferred FIX002 handling contract for future contributors and coding agents.

## Rule accounting

The stable ALL-rule census falls from 29,968 findings across 35 rules on D100 to 29,964 findings across 33 rules. FIX002 and its two co-located TD003 findings both fall to zero; every other rule count is unchanged. This PR selects only FIX002 so TD003 remains a separate stacked rule PR.

## Verification

- Full backend: 3,019 passed, 17 skipped
- User service: 254 passed
- Learn context: 78 passed, 4 skipped
- Learner and preview submissions: 13 passed
- Config: 127 passed
- Translation completeness and unused-key checks
- Ruff check, Ruff format, repository harness, architecture boundary check
- lefthook run pre-commit --all-files

## Stack

- Base: sunner/ruff-d100
- Predecessor: #2586
- Head: sunner/ruff-fix002


## Review follow-up

- Use a proxy-verified client address and reject spoofed first-hop forwarded values.
- Fail closed on Redis errors and require one shared Redis counter backend across workers.
- Withhold login success until the shared identifier count is cleared.
- Clear identifier failures after verified password recovery.

Latest verification: password route suite passed 17 tests; focused Ruff check/format passed; architecture and repository commit hooks passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Review follow-up

- Clear identifier failures after verified first-time password setup so the new password works immediately.
- Validation: 18 focused password-route tests passed; Ruff and format checks passed.



## Additional review follow-up

- Require a deployment-specific Docker SECRET_KEY for private throttle fingerprints.
- Keep failure-counter expiry fixed from the first attempt instead of renewing it.
- Validation: 19 focused password-route tests passed; full Ruff and format checks passed.



## Final authentication-key review follow-up

- Reject the public ai-shifu demo key and leave the generated required secret blank.
- Label failure counters consistently as a fixed window.
- Validation: 26 secret/config tests and 16 config integration tests passed; full Ruff and format checks passed.



## Docker quickstart review follow-up

- Generate a deployment-specific SECRET_KEY in every documented Docker startup flow.
- Keep the English and Chinese setup requirements aligned.
- Validation: the documented command produced a strong non-demo secret; repository harness, diff, and commit checks passed.

## Linked identifier review follow-up

- Clear password failure counters for every verified phone and email identifier after a successful password login or password update, including first-time setup, password recovery, and password change.
- Add dual-identifier recovery coverage: a password reset verified through a phone number clears an exhausted linked-email counter.
- Validation: 20 password-route tests passed; full Ruff, format, repository harness, development-tool, and pre-commit checks passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-login protection against repeated failed attempts, with separate account and IP limits.
  * Added localized messages when login attempts are temporarily limited.
* **Security**
  * Deployment now requires a unique `SECRET_KEY`; the demo value is rejected.
  * Successful authentication and password changes clear relevant failure tracking.
* **Documentation**
  * Updated Docker and development setup instructions to generate a secure secret key.
  * Clarified required configuration and password-login throttling options.
* **Bug Fixes**
  * Preserved nonstandard input keys instead of unexpectedly renaming them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->