### PR TITLE
refactor: clarify dynamic exception messages

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -366,6 +366,16 @@ cannot express exactly, pre-format only that field with `format(value, "spec")`
 and keep the rest of the message parameterized. Do not hide an f-string in a
 temporary variable merely to silence the rule.
 
+For `EM102`, assign a contextual f-string to a collision-free local immediately
+before raising it, normally `message` or `error_message`, and pass that local as
+the same constructor argument. Preserve the exception type, exact f-string,
+remaining positional and keyword arguments, and any explicit `raise ... from`
+cause. Do not evade the rule by concatenating strings, changing formatting, or
+dropping useful values from the error. Before introducing the local, check the
+whole function for that name so a new binding cannot shadow an existing local,
+free variable, or global lookup. For bulk changes, prove the rewrite is
+structurally reversible and run tests that exercise the affected error paths.
+
 For `D205`, put the complete summary on the first physical docstring line,
 then use exactly one blank line before details, sections, or embedded protocol
 content. Do not wrap the summary across source lines; line length is formatter

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -247,6 +247,29 @@ plan's progress update for that rule.
   `sunner/ruff-d101` to the N806 branch after all local gates passed.
 - [ ] Merge or retarget D101 PR #2590 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 04:52 CST: Prepared the EM102 stage on
+  `sunner/ruff-em102`, stacked on D101. Moved all 162 contextual f-string
+  exception messages across 72 Python files into collision-free locals
+  immediately before the original raise: 150 use `message`, while 12 functions
+  with an existing `message` binding use `error_message`. EM102 is now enforced
+  repository-wide with no suppression.
+- [x] 2026-08-21 04:52 CST: A reversible AST audit restored all 162 direct
+  f-string arguments and the one equivalent Coze URL conditional, then matched
+  every executable AST to the D101 parent. The stable `ALL` census falls to
+  29,175 findings across 31 rules: EM102 falls by 162, the same construct also
+  removes 136 TRY003 findings, formatter-owned COM812 falls by 60, and no rule
+  gains debt.
+- [x] 2026-08-21 04:52 CST: Translation and identifier checkers, affected
+  script help entry points, and 1,822 focused billing, payment-provider, TTS,
+  ask-provider, config, analytics, auth, migration, and error-path tests pass
+  with 10 skips. The full backend suite passes 3,019 tests with 17 skips;
+  repository Ruff and format also pass.
+- [x] 2026-08-21 04:54 CST: Collaboration and knowledge generators,
+  repository harness, architecture boundaries, development-tool validation,
+  and every repository pre-commit hook pass on the EM102 tip.
+- [ ] Open the ready EM102 PR against the D101 branch after the full repository
+  pre-commit gate passes, then merge or retarget it without combining its rule
+  unit with the next stage.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -285,6 +308,18 @@ plan's progress update for that rule.
   and inline field comments rather than `Class.__doc__`; a repository search
   found no direct runtime class-docstring consumer, and focused schema tests
   protect the framework-driven paths.
+- EM102 and TRY003 overlap on dynamic built-in exception messages: naming an
+  f-string before raising it resolves both findings at 136 sites even though
+  only EM102 is adopted in this rule unit. Ruff format also collapses 60 now-
+  simple exception calls, removing formatter-conflicting COM812 findings. One
+  Coze adapter initially crossed the PLR0915 statement threshold; an equivalent
+  lazy URL conditional kept that rule at its previous 128 findings rather than
+  adding new debt.
+- Backend audit scripts under `src/api/scripts` import `flaskr` correctly when
+  invoked as modules from `src/api`; executing their file paths directly from
+  the repository root omits the backend package from `sys.path` and fails before
+  argument parsing. The EM102 help-entry verification therefore uses
+  `python -m scripts.<name> --help` from the backend root.
 - G004's full-suite verification exposed a config fallback test that treated a
   mocked logger's first positional argument as the final rendered message. The
   test now verifies the constant message template and interpolation argument,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -267,9 +267,11 @@ plan's progress update for that rule.
 - [x] 2026-08-21 04:54 CST: Collaboration and knowledge generators,
   repository harness, architecture boundaries, development-tool validation,
   and every repository pre-commit hook pass on the EM102 tip.
-- [ ] Open the ready EM102 PR against the D101 branch after the full repository
-  pre-commit gate passes, then merge or retarget it without combining its rule
-  unit with the next stage.
+- [x] 2026-08-21 04:58 CST: Opened ready EM102 PR
+  [#2591](https://github.com/ai-shifu/ai-shifu/pull/2591) from
+  `sunner/ruff-em102` to the D101 branch after all local gates passed.
+- [ ] Merge or retarget EM102 PR #2591 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -101,6 +101,10 @@ select = [
     "TRY300",  # return at the end of a try body that belongs in `else`
     "TRY301",  # raise inside a try body that the same block then catches
     "TRY004",  # type check raising something other than TypeError
+    # Build contextual exception text immediately before raising it. Naming
+    # the message keeps the source line in the traceback concise without
+    # changing the exception type, rendered text, or explicit cause chain.
+    "EM102",   # f-string literal passed directly to an exception constructor
 
     # --- Pylint subsets ---------------------------------------------------
     "PLE",     # pylint errors (yield/return in __init__, invalid dunders, ...)

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -425,7 +425,8 @@ def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
             raise OSError("git cat-file returned a truncated header")
         header = result.stdout[offset:header_end].split()
         if len(header) != 3 or header[1] != b"blob":
-            raise OSError(f"git cat-file did not return blob {object_id}")
+            message = f"git cat-file did not return blob {object_id}"
+            raise OSError(message)
         size = int(header[2])
         content_start = header_end + 1
         content_end = content_start + size

--- a/scripts/check_translation_usage.py
+++ b/scripts/check_translation_usage.py
@@ -117,7 +117,8 @@ def collect_frontend_trans_keys(text: str) -> set[str]:
 
 def iter_locale_dirs() -> Iterable[Path]:
     if not I18N_DIR.exists():
-        raise RuntimeError(f"Translation directory not found: {I18N_DIR}")
+        message = f"Translation directory not found: {I18N_DIR}"
+        raise RuntimeError(message)
     for entry in sorted(I18N_DIR.iterdir()):
         if entry.is_dir() and not entry.name.startswith("."):
             yield entry
@@ -130,7 +131,8 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
         if isinstance(flat_section, dict):
             for key, value in flat_section.items():
                 if not isinstance(value, str):
-                    raise TypeError(f"Translation value for '{key}' must be a string")
+                    message = f"Translation value for '{key}' must be a string"
+                    raise TypeError(message)
                 composite_key = f"{namespace}.{key}" if namespace else key
                 items[composite_key] = value
         for key, value in data.items():
@@ -140,7 +142,8 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
             items.update(flatten_translation(value, next_namespace))
         return items
     if not isinstance(data, str):
-        raise TypeError(f"Translation value for '{namespace}' must be a string")
+        message = f"Translation value for '{namespace}' must be a string"
+        raise TypeError(message)
     return {namespace: data}
 
 

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -22,7 +22,8 @@ class TranslationError(Exception):
 
 def iter_locale_dirs() -> Iterable[Path]:
     if not I18N_DIR.exists():
-        raise TranslationError(f"Shared translation directory not found: {I18N_DIR}")
+        message = f"Shared translation directory not found: {I18N_DIR}"
+        raise TranslationError(message)
 
     for entry in sorted(I18N_DIR.iterdir()):
         if entry.is_dir() and not entry.name.startswith("."):
@@ -33,7 +34,8 @@ def load_json(path: Path) -> dict:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
-        raise TranslationError(f"Failed to parse JSON: {path} ({exc})") from exc
+        message = f"Failed to parse JSON: {path} ({exc})"
+        raise TranslationError(message) from exc
 
 
 def flatten_translation(data, namespace: str) -> dict[str, str]:
@@ -47,9 +49,8 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
             if isinstance(flat_section, dict):
                 for key, value in flat_section.items():
                     if not isinstance(value, str):
-                        raise TranslationError(
-                            f"Translation value for '{key}' must be string."
-                        )
+                        message = f"Translation value for '{key}' must be string."
+                        raise TranslationError(message)
                     items[key] = value
 
             for key, value in obj.items():
@@ -59,9 +60,8 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
                 items.update(_flatten(value, next_prefix))
         else:
             if not isinstance(obj, str):
-                raise TranslationError(
-                    f"Translation value for '{prefix}' must be string."
-                )
+                message = f"Translation value for '{prefix}' must be string."
+                raise TranslationError(message)
             items[prefix] = obj
         return items
 
@@ -164,7 +164,8 @@ def _require_locale_dirs() -> list[Path]:
     """Return the locale directories, or fail when none exist."""
     locale_dirs = list(iter_locale_dirs())
     if not locale_dirs:
-        raise TranslationError(f"No locale directories found under {I18N_DIR}")
+        message = f"No locale directories found under {I18N_DIR}"
+        raise TranslationError(message)
     return locale_dirs
 
 

--- a/scripts/create_translation_namespace.py
+++ b/scripts/create_translation_namespace.py
@@ -34,11 +34,13 @@ def parse_args() -> argparse.Namespace:
 
 def iter_locale_dirs() -> list[Path]:
     if not I18N_DIR.exists():
-        raise RuntimeError(f"Translation directory not found: {I18N_DIR}")
+        message = f"Translation directory not found: {I18N_DIR}"
+        raise RuntimeError(message)
 
     locales = [entry for entry in I18N_DIR.iterdir() if entry.is_dir()]
     if not locales:
-        raise RuntimeError(f"No locale directories present under {I18N_DIR}")
+        message = f"No locale directories present under {I18N_DIR}"
+        raise RuntimeError(message)
     return sorted(locales, key=lambda p: p.name)
 
 
@@ -59,7 +61,8 @@ def ensure_namespace_files(namespace: str, keys: list[str] | None, force: bool) 
         target_path = (locale_dir / relative_path).with_suffix(".json")
         target_path.parent.mkdir(parents=True, exist_ok=True)
         if target_path.exists() and not force:
-            raise RuntimeError(f"Translation file already exists: {target_path}")
+            message = f"Translation file already exists: {target_path}"
+            raise RuntimeError(message)
         target_path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",
@@ -74,7 +77,8 @@ def update_locales_metadata(namespace: str) -> None:
         try:
             data = json.loads(LOCALES_FILE.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            raise RuntimeError(f"Invalid JSON in {LOCALES_FILE}: {exc}") from exc
+            message = f"Invalid JSON in {LOCALES_FILE}: {exc}"
+            raise RuntimeError(message) from exc
 
     namespaces = set(data.get("namespaces", []))
     namespaces.add(namespace)

--- a/scripts/migrate_oss_domain.py
+++ b/scripts/migrate_oss_domain.py
@@ -122,9 +122,11 @@ def migrate(
         for table, column, is_content in TARGETS:
             # Whitelist check (defence-in-depth; values come from the constant above)
             if table not in _ALLOWED_TABLES:
-                raise ValueError(f"Unknown table: {table!r}")
+                message = f"Unknown table: {table!r}"
+                raise ValueError(message)
             if column not in _ALLOWED_COLUMNS:
-                raise ValueError(f"Unknown column: {column!r}")
+                message = f"Unknown column: {column!r}"
+                raise ValueError(message)
 
             # Check table exists in this deployment
             exists = conn.execute(

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -52,7 +52,8 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
 def collect_defined_keys() -> tuple[dict[str, Path], set[str]]:
     """Return (namespace_to_relpath, defined_keys_set) using en-US as reference for mapping."""
     if not I18N_DIR.exists():
-        raise FileNotFoundError(f"Shared i18n directory not found: {I18N_DIR}")
+        message = f"Shared i18n directory not found: {I18N_DIR}"
+        raise FileNotFoundError(message)
     # Choose en-US as mapping reference
     mapping: dict[str, Path] = {}
     defined: set[str] = set()

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -149,7 +149,8 @@ def get_tts_provider(provider_name: str = "") -> BaseTTSProvider:
     if provider_name not in _provider_instances:
         provider_cls = _PROVIDER_REGISTRY.get(provider_name)
         if not provider_cls:
-            raise ValueError(f"Unknown TTS provider: {provider_name}")
+            message = f"Unknown TTS provider: {provider_name}"
+            raise ValueError(message)
         _provider_instances[provider_name] = provider_cls()
 
     return _provider_instances[provider_name]

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -179,21 +179,22 @@ def _request_new_token(access_key_id: str, access_key_secret: str) -> AliyunNlsT
     try:
         resp = requests.get(url, headers={"Accept": "application/json"}, timeout=10)
     except requests.RequestException as exc:
-        raise ValueError(f"Aliyun NLS token request failed: {exc}") from exc
+        message = f"Aliyun NLS token request failed: {exc}"
+        raise ValueError(message) from exc
 
     if resp.status_code != 200:
         # POP errors are JSON with fields like Code/Message/RequestId.
         text = (resp.text or "").strip()
-        raise ValueError(
+        message = (
             f"Aliyun NLS token request failed: HTTP {resp.status_code}: {text[:200]}"
         )
+        raise ValueError(message)
 
     try:
         payload = resp.json()
     except Exception as exc:
-        raise ValueError(
-            f"Aliyun NLS token response is not valid JSON: {resp.text[:200]}"
-        ) from exc
+        message = f"Aliyun NLS token response is not valid JSON: {resp.text[:200]}"
+        raise ValueError(message) from exc
 
     token_obj = payload.get("Token") or {}
     token = (token_obj.get("Id") or "").strip()
@@ -208,9 +209,8 @@ def _request_new_token(access_key_id: str, access_key_secret: str) -> AliyunNlsT
     try:
         expire_int = int(expire_time)
     except Exception as exc:
-        raise ValueError(
-            f"Aliyun NLS token response has invalid ExpireTime: {expire_time}"
-        ) from exc
+        message = f"Aliyun NLS token response has invalid ExpireTime: {expire_time}"
+        raise ValueError(message) from exc
 
     return AliyunNlsToken(token=token, expire_time=expire_int)
 

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1376,17 +1376,20 @@ class AliyunTTSProvider(BaseTTSProvider):
             try:
                 result = response.json()
             except ValueError as e:
-                raise ValueError(f"Aliyun TTS API error: {response.text[:200]}") from e
+                error_message = f"Aliyun TTS API error: {response.text[:200]}"
+                raise ValueError(error_message) from e
             status = result.get("status", "unknown")
             message = result.get("message", "Unknown error")
             task_id = result.get("task_id", "")
-            raise ValueError(
+            error_message = (
                 f"Aliyun TTS API error {status}: {message} (task_id: {task_id})"
             )
+            raise ValueError(error_message)
 
         except requests.RequestException as e:
             logger.exception("Aliyun TTS request failed")
-            raise ValueError(f"Aliyun TTS request failed: {e}") from e
+            error_message = f"Aliyun TTS request failed: {e}"
+            raise ValueError(error_message) from e
 
     def get_provider_config(self) -> ProviderConfig:
         """Get Aliyun provider configuration for frontend."""

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -687,7 +687,8 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
 
         if "access_token" not in result:
             error_msg = result.get("error_description", "Unknown error")
-            raise ValueError(f"Failed to get Baidu access token: {error_msg}")
+            message = f"Failed to get Baidu access token: {error_msg}"
+            raise ValueError(message)
 
         access_token = result["access_token"]
         expires_in = result.get("expires_in", 2592000)  # Default 30 days
@@ -700,7 +701,8 @@ def _get_access_token(api_key: str, secret_key: str) -> str:
 
     except requests.RequestException as e:
         logger.exception("Failed to get Baidu access token")
-        raise ValueError(f"Failed to get Baidu access token: {e}") from e
+        message = f"Failed to get Baidu access token: {e}"
+        raise ValueError(message) from e
     else:
         return access_token
 
@@ -915,14 +917,17 @@ class BaiduTTSProvider(BaseTTSProvider):
             try:
                 result = response.json()
             except ValueError as e:
-                raise ValueError(f"Baidu TTS API error: {response.text[:200]}") from e
+                message = f"Baidu TTS API error: {response.text[:200]}"
+                raise ValueError(message) from e
             error_code = result.get("err_no", "unknown")
             error_msg = result.get("err_msg", "Unknown error")
-            raise ValueError(f"Baidu TTS API error {error_code}: {error_msg}")
+            message = f"Baidu TTS API error {error_code}: {error_msg}"
+            raise ValueError(message)
 
         except requests.RequestException as e:
             logger.exception("Baidu TTS request failed")
-            raise ValueError(f"Baidu TTS request failed: {e}") from e
+            message = f"Baidu TTS request failed: {e}"
+            raise ValueError(message) from e
 
     def get_provider_config(self) -> ProviderConfig:
         """Get Baidu provider configuration for frontend."""

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -621,11 +621,13 @@ class MinimaxTTSProvider(BaseTTSProvider):
             # or foreign clone id that passed local shape validation). Surface it
             # as an actionable message instead of a generic API error.
             if status_code == 2054:
-                raise ValueError(
+                message = (
                     "Minimax TTS voice is not available "
                     f"(voice id does not exist on provider): {status_msg}"
                 )
-            raise ValueError(f"Minimax TTS API error: {status_code} - {status_msg}")
+                raise ValueError(message)
+            message = f"Minimax TTS API error: {status_code} - {status_msg}"
+            raise ValueError(message)
 
         return result
 

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -309,7 +309,8 @@ def _coerce_app_id(app_id: Any) -> int:
     try:
         return int(app_id)
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"Invalid Tencent TTS AppId: {app_id!r}") from exc
+        message = f"Invalid Tencent TTS AppId: {app_id!r}"
+        raise ValueError(message) from exc
 
 
 def _clamp_float(value: float, minimum: float, maximum: float) -> float:

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -357,20 +357,21 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             body = response.json()
         except requests.RequestException as exc:
             logger.exception("Tencent TextToVoice request failed")
-            raise ValueError(f"Tencent TextToVoice request failed: {exc}") from exc
+            message = f"Tencent TextToVoice request failed: {exc}"
+            raise ValueError(message) from exc
         except ValueError as exc:
-            raise ValueError(
-                f"Tencent TextToVoice returned invalid JSON: {exc}"
-            ) from exc
+            message = f"Tencent TextToVoice returned invalid JSON: {exc}"
+            raise ValueError(message) from exc
 
         result = body.get("Response") or {}
         error = result.get("Error")
         if error:
             request_id = result.get("RequestId", "")
-            raise ValueError(
+            message = (
                 f"Tencent TextToVoice error {error.get('Code', 'unknown')}: "
                 f"{error.get('Message', '')} (request_id={request_id})"
             )
+            raise ValueError(message)
         audio_base64 = result.get("Audio") or ""
         if not audio_base64:
             raise ValueError("No audio data received from Tencent TextToVoice")
@@ -399,9 +400,8 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
         try:
             voice_type = int(voice_id)
         except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"Invalid Tencent TextToVoice voice id: {voice_id}"
-            ) from exc
+            message = f"Invalid Tencent TextToVoice voice id: {voice_id}"
+            raise ValueError(message) from exc
 
         sample_rate = _resolve_sample_rate(voice_id, model)
         speed = float(voice_settings.speed or 0)

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -250,7 +250,8 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
                 sample_rate,
                 len(text),
             )
-            raise ValueError(f"Volcengine HTTP TTS request failed: {exc}") from exc
+            error_message = f"Volcengine HTTP TTS request failed: {exc}"
+            raise ValueError(error_message) from exc
 
         if response.status_code != 200:
             self._log_http_error_response(
@@ -266,10 +267,11 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
                 response.raise_for_status()
             except requests.RequestException as exc:
                 body_preview = (response.text or "")[:2000]
-                raise ValueError(
+                error_message = (
                     f"Volcengine HTTP TTS HTTP {response.status_code}: "
                     f"{body_preview or response.reason}"
-                ) from exc
+                )
+                raise ValueError(error_message) from exc
 
         try:
             result = response.json()
@@ -296,7 +298,8 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
                 code,
                 message,
             )
-            raise ValueError(f"Volcengine HTTP TTS error {code}: {message}")
+            error_message = f"Volcengine HTTP TTS error {code}: {message}"
+            raise ValueError(error_message)
 
         audio_base64 = result.get("data") or ""
         if not audio_base64:

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -286,7 +286,8 @@ class VolcengineProtocol:
 
         """
         if len(data) < 4:
-            raise ValueError(f"Frame too short: {len(data)} bytes")
+            message = f"Frame too short: {len(data)} bytes"
+            raise ValueError(message)
 
         # Parse header (4 bytes)
         byte0 = data[0]

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -169,7 +169,8 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.exception("Migration failed")
-            raise click.ClickException(f"Migration failed: {e}") from e
+            message = f"Migration failed: {e}"
+            raise click.ClickException(message) from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -227,7 +228,8 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.exception("Verification failed")
-            raise click.ClickException(f"Verification failed: {e}") from e
+            message = f"Verification failed: {e}"
+            raise click.ClickException(message) from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -311,7 +313,8 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             logger.exception("Status check failed")
-            raise click.ClickException(f"Status check failed: {e}") from e
+            message = f"Status check failed: {e}"
+            raise click.ClickException(message) from e
         finally:
             if "migration_task" in locals():
                 migration_task.close()
@@ -344,7 +347,8 @@ def enable_commands(app: Flask):
                 )
         except Exception as e:
             click.echo(click.style(f"❌ Export failed: {e}", fg="red"))
-            raise click.ClickException(f"Export failed: {e}") from e
+            message = f"Export failed: {e}"
+            raise click.ClickException(message) from e
 
     @console.command(name="import_shifu")
     @click.argument("file_path")
@@ -366,7 +370,8 @@ def enable_commands(app: Flask):
 
         """
         if not Path(file_path).exists():
-            raise click.ClickException(f"File not found: {file_path}")
+            message = f"File not found: {file_path}"
+            raise click.ClickException(message)
 
         try:
             click.echo(f"Importing shifu from {file_path}...")
@@ -405,7 +410,8 @@ def enable_commands(app: Flask):
 
         except Exception as e:
             click.echo(click.style(f"❌ Import failed: {e}", fg="red"))
-            raise click.ClickException(f"Import failed: {e}") from e
+            message = f"Import failed: {e}"
+            raise click.ClickException(message) from e
 
     @console.command(name="update_demo_shifu")
     def update_demo_shifu_command():

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -40,7 +40,8 @@ def _quote_identifier(name: str) -> str:
     unexpected value fails loudly instead of reaching the database.
     """
     if not _IDENTIFIER_PATTERN.fullmatch(name or ""):
-        raise ValueError(f"Unsafe SQL identifier: {name!r}")
+        message = f"Unsafe SQL identifier: {name!r}"
+        raise ValueError(message)
     return f"`{name}`"
 
 
@@ -491,9 +492,8 @@ class UnifiedMigrationTask:
                     if (
                         error_count > self.config.batch_size * 0.5
                     ):  # If more than 50% errors
-                        raise MigrationBatchError(
-                            f"Too many errors in batch: {error_count}"
-                        ) from e
+                        message = f"Too many errors in batch: {error_count}"
+                        raise MigrationBatchError(message) from e
 
             # Commit the batch
             session.commit()

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -221,7 +221,8 @@ def _resolve_billing_crontab(
     )
     fallback_schedule = _parse_crontab_expression(default_expression)
     if fallback_schedule is None:  # pragma: no cover - guarded by constants above
-        raise ValueError(f"Invalid default cron expression for {config_key}")
+        message = f"Invalid default cron expression for {config_key}"
+        raise ValueError(message)
     return fallback_schedule
 
 

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -38,10 +38,11 @@ class EnvVar:
     def __post_init__(self) -> None:
         """Validate EnvVar configuration after initialization."""
         if self.required and self.default is not None:
-            raise ValueError(
+            message = (
                 f"Environment variable '{self.name}' is marked as required "
                 "but has a default value. Required variables must not have defaults."
             )
+            raise ValueError(message)
 
     def validate_value(self, value: Any) -> bool:
         """Validate the environment variable value."""
@@ -67,16 +68,14 @@ class EnvVar:
             try:
                 return int(value)
             except ValueError as exc:
-                raise EnvironmentConfigError(
-                    f"Invalid integer value for {self.name}: {value}"
-                ) from exc
+                message = f"Invalid integer value for {self.name}: {value}"
+                raise EnvironmentConfigError(message) from exc
         elif self.type is float:
             try:
                 return float(value)
             except ValueError as exc:
-                raise EnvironmentConfigError(
-                    f"Invalid float value for {self.name}: {value}"
-                ) from exc
+                message = f"Invalid float value for {self.name}: {value}"
+                raise EnvironmentConfigError(message) from exc
         elif self.type is list:
             if isinstance(value, str):
                 return [item.strip() for item in value.split(",") if item.strip()]

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -150,9 +150,8 @@ def _load_json_translations(app: Flask, root: Path):
 
 def _validate_json_translations(app: Flask, root: Path):
     if not root.exists():
-        raise FileNotFoundError(
-            f"Missing shared i18n directory at '{root}'. Run the migration checklist to generate JSON translations."
-        )
+        message = f"Missing shared i18n directory at '{root}'. Run the migration checklist to generate JSON translations."
+        raise FileNotFoundError(message)
 
     problems: list[str] = []
 

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -1832,9 +1832,8 @@ def grant_billing_plan_by_identify(
     with _rollback_on_error():
         aggregate = load_user_aggregate_by_identifier(normalized_identify)
         if aggregate is None:
-            raise click.ClickException(
-                f"No user found for identify: {normalized_identify}"
-            )
+            message = f"No user found for identify: {normalized_identify}"
+            raise click.ClickException(message)
 
         product = _load_active_plan_product(
             product_bid=normalized_product_bid,
@@ -2069,7 +2068,8 @@ def grant_operator_credits_by_cli(
         )
         if aggregate is None:
             target = normalized_user_bid or normalized_identify
-            raise click.ClickException(f"No user found for target: {target}")
+            message = f"No user found for target: {target}"
+            raise click.ClickException(message)
         if not normalized_request_id:
             normalized_request_id = _build_cli_credit_grant_request_id(
                 user_bid=aggregate.user_bid,
@@ -2180,11 +2180,13 @@ def _parse_optional_json_object(
     try:
         parsed = json.loads(normalized_value)
     except json.JSONDecodeError as exc:
-        raise click.ClickException(f"--{option_name} must be valid JSON.") from exc
+        message = f"--{option_name} must be valid JSON."
+        raise click.ClickException(message) from exc
     if parsed is None:
         return None
     if not isinstance(parsed, dict):
-        raise click.ClickException(f"--{option_name} must decode to a JSON object.")
+        message = f"--{option_name} must decode to a JSON object."
+        raise click.ClickException(message)
     return parsed
 
 

--- a/src/api/flaskr/service/billing/credit_audit.py
+++ b/src/api/flaskr/service/billing/credit_audit.py
@@ -130,7 +130,8 @@ def audit_credit_state(
     else:
         audit_at = coerce_datetime(as_of)
         if audit_at is None:
-            raise ValueError(f"Unable to parse as_of value: {as_of!r}")
+            message = f"Unable to parse as_of value: {as_of!r}"
+            raise ValueError(message)
     resolved_limit = int(limit or 0)
 
     with db.session.no_autoflush:

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -895,7 +895,8 @@ def _probe_provider_credentials(
         return
     if provider == "wechat_oauth":
         return
-    raise ValueError(f"Unsupported integration provider: {provider}")
+    message = f"Unsupported integration provider: {provider}"
+    raise ValueError(message)
 
 
 def _probe_stripe_credentials(
@@ -953,14 +954,16 @@ def _parse_x509_certificate(value: Any) -> None:
 def _normalize_pem(value: Any, label: str) -> bytes:
     text = str(value or "").strip()
     if not text:
-        raise ValueError(f"{label.title()} is required")
+        message = f"{label.title()} is required"
+        raise ValueError(message)
     if "-----BEGIN" in text:
         return text.encode("utf-8")
     compact = "".join(text.split())
     try:
         base64.b64decode(compact, validate=True)
     except binascii.Error as exc:
-        raise ValueError(f"{label.title()} is not valid PEM or base64") from exc
+        message = f"{label.title()} is not valid PEM or base64"
+        raise ValueError(message) from exc
     lines = "\n".join(compact[i : i + 64] for i in range(0, len(compact), 64))
     return f"-----BEGIN {label}-----\n{lines}\n-----END {label}-----\n".encode("ascii")
 

--- a/src/api/flaskr/service/billing/renewal_event_transitions.py
+++ b/src/api/flaskr/service/billing/renewal_event_transitions.py
@@ -113,9 +113,8 @@ def _update_processing_renewal_event(
     db.session.flush()
     db.session.expire(event)
     if updated_rows != 1:
-        raise RenewalEventClaimLostError(
-            f"renewal_event_claim_lost:{event.renewal_event_bid}"
-        )
+        message = f"renewal_event_claim_lost:{event.renewal_event_bid}"
+        raise RenewalEventClaimLostError(message)
 
 
 def release_renewal_event(event: BillingRenewalEvent, *, now: datetime) -> None:

--- a/src/api/flaskr/service/billing/reserved_renewal_activation.py
+++ b/src/api/flaskr/service/billing/reserved_renewal_activation.py
@@ -180,9 +180,8 @@ def sync_activated_reserved_renewal_ledger_balances(
             .first()
         )
         if grant_entry is None or _reserved_grant_state(grant_entry) != "available":
-            raise IncompleteReservedGrantActivationError(
-                f"incomplete_{target.kind}_activation:{target.order_bid}"
-            )
+            message = f"incomplete_{target.kind}_activation:{target.order_bid}"
+            raise IncompleteReservedGrantActivationError(message)
         running_balance = _quantize_credit_amount(running_balance + target.amount)
         grant_entry.balance_after = running_balance
         grant_entry.updated_at = now
@@ -339,9 +338,8 @@ def _expected_subscription_grant_amount(order: BillingOrder) -> Decimal:
 def _expected_subscription_cycle_grant_amount(order: BillingOrder) -> Decimal:
     product = _load_billing_product_by_bid(order.product_bid)
     if product is None:
-        raise IncompleteReservedGrantActivationError(
-            f"missing_subscription_product:{order.bill_order_bid}"
-        )
+        message = f"missing_subscription_product:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     return _quantize_credit_amount(_to_decimal(product.credit_amount))
 
 
@@ -362,27 +360,23 @@ def _build_reserved_activation_target(
     if kind != "subscription" and expected_amount <= 0:
         return None
     if grant_entry is None:
-        raise IncompleteReservedGrantActivationError(
-            f"missing_{kind}_ledger:{order.bill_order_bid}"
-        )
+        message = f"missing_{kind}_ledger:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
 
     state = _reserved_grant_state(grant_entry)
     if state == "available":
         return None
     if state != "reserved":
-        raise IncompleteReservedGrantActivationError(
-            f"invalid_{kind}_state:{order.bill_order_bid}:{state or 'missing'}"
-        )
+        message = f"invalid_{kind}_state:{order.bill_order_bid}:{state or 'missing'}"
+        raise IncompleteReservedGrantActivationError(message)
 
     amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
     if expected_amount > 0 and amount != expected_amount:
-        raise IncompleteReservedGrantActivationError(
-            f"{kind}_amount_mismatch:{order.bill_order_bid}"
-        )
+        message = f"{kind}_amount_mismatch:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     if amount <= 0:
-        raise IncompleteReservedGrantActivationError(
-            f"invalid_{kind}_amount:{order.bill_order_bid}"
-        )
+        message = f"invalid_{kind}_amount:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
 
     bucket = _load_reserved_activation_bucket(
         order,
@@ -390,13 +384,11 @@ def _build_reserved_activation_target(
         fallback_bucket_category=fallback_bucket_category,
     )
     if bucket is None:
-        raise IncompleteReservedGrantActivationError(
-            f"missing_{kind}_bucket:{order.bill_order_bid}"
-        )
+        message = f"missing_{kind}_bucket:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     if _quantize_credit_amount(_to_decimal(bucket.reserved_credits)) < amount:
-        raise IncompleteReservedGrantActivationError(
-            f"insufficient_{kind}_reserved:{order.bill_order_bid}"
-        )
+        message = f"insufficient_{kind}_reserved:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
 
     return ReservedActivationTarget(
         kind=kind,
@@ -418,32 +410,27 @@ def _build_reserved_completion_target(
     if kind != "subscription" and expected_amount <= 0:
         return None
     if grant_entry is None:
-        raise IncompleteReservedGrantActivationError(
-            f"missing_{kind}_ledger:{order.bill_order_bid}"
-        )
+        message = f"missing_{kind}_ledger:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     state = _reserved_grant_state(grant_entry)
     if state != "available":
-        raise IncompleteReservedGrantActivationError(
-            f"incomplete_{kind}_activation:{order.bill_order_bid}"
-        )
+        message = f"incomplete_{kind}_activation:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     amount = _quantize_credit_amount(_to_decimal(grant_entry.amount))
     if expected_amount > 0 and amount != expected_amount:
-        raise IncompleteReservedGrantActivationError(
-            f"{kind}_amount_mismatch:{order.bill_order_bid}"
-        )
+        message = f"{kind}_amount_mismatch:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     bucket = _load_reserved_activation_bucket(
         order,
         grant_entry,
         fallback_bucket_category=fallback_bucket_category,
     )
     if bucket is None:
-        raise IncompleteReservedGrantActivationError(
-            f"missing_{kind}_bucket:{order.bill_order_bid}"
-        )
+        message = f"missing_{kind}_bucket:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     if _quantize_credit_amount(_to_decimal(bucket.available_credits)) < amount:
-        raise IncompleteReservedGrantActivationError(
-            f"incomplete_{kind}_bucket:{order.bill_order_bid}"
-        )
+        message = f"incomplete_{kind}_bucket:{order.bill_order_bid}"
+        raise IncompleteReservedGrantActivationError(message)
     return ReservedActivationTarget(
         kind=kind,
         order_bid=order.bill_order_bid,
@@ -525,15 +512,13 @@ def _preflight_reserved_renewal_grants_for_cycle(
             .first()
         )
         if bucket is None:
-            raise IncompleteReservedGrantActivationError(
-                f"missing_bucket:{wallet_bucket_bid}"
-            )
+            message = f"missing_bucket:{wallet_bucket_bid}"
+            raise IncompleteReservedGrantActivationError(message)
         if _quantize_credit_amount(
             _to_decimal(bucket.reserved_credits)
         ) < _quantize_credit_amount(required_reserved):
-            raise IncompleteReservedGrantActivationError(
-                f"insufficient_reserved:{wallet_bucket_bid}"
-            )
+            message = f"insufficient_reserved:{wallet_bucket_bid}"
+            raise IncompleteReservedGrantActivationError(message)
     return tuple(targets)
 
 
@@ -585,9 +570,8 @@ def _assert_subscription_cycle_grant_amounts(
         if _quantize_credit_amount(
             subscription_amount_by_product.get(product_bid, Decimal(0))
         ) < _quantize_credit_amount(expected_amount):
-            raise IncompleteReservedGrantActivationError(
-                f"subscription_cycle_amount_mismatch:{product_bid}"
-            )
+            message = f"subscription_cycle_amount_mismatch:{product_bid}"
+            raise IncompleteReservedGrantActivationError(message)
 
 
 def _activate_reserved_subscription_grant_for_order(

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -152,7 +152,8 @@ def _serialize_task_payload(result: Any) -> Any:
         return result.to_payload()
     if hasattr(result, "__json__"):
         return result.__json__()
-    raise TypeError(f"Unsupported task payload type: {type(result)!r}")
+    message = f"Unsupported task payload type: {type(result)!r}"
+    raise TypeError(message)
 
 
 def _load_renewal_task_config() -> dict[str, Any]:

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -56,7 +56,8 @@ def get_oss_config(profile: str = OSS_PROFILE_DEFAULT) -> OSSConfig:
     profile = (profile or "").strip().lower() or OSS_PROFILE_DEFAULT
     keys = _OSS_CONFIG_KEYS.get(profile)
     if not keys:
-        raise ValueError(f"Unknown OSS profile: {profile}")
+        message = f"Unknown OSS profile: {profile}"
+        raise ValueError(message)
 
     endpoint = get_config(keys["endpoint"]) or ""
     access_key_id = get_config(keys["access_key_id"]) or ""

--- a/src/api/flaskr/service/common/storage.py
+++ b/src/api/flaskr/service/common/storage.py
@@ -42,7 +42,8 @@ class StorageUploadResult:
 def _normalize_profile(profile: str) -> str:
     resolved = (profile or "").strip().lower() or OSS_PROFILE_DEFAULT
     if resolved not in _ALLOWED_PROFILES:
-        raise ValueError(f"Unknown storage profile: {profile}")
+        message = f"Unknown storage profile: {profile}"
+        raise ValueError(message)
     return resolved
 
 
@@ -226,4 +227,5 @@ def read_storage_bytes(
         bucket = create_oss_bucket(config)
         return bucket.get_object(resolved_key).read()
 
-    raise FileNotFoundError(f"storage object not found: {resolved_key}")
+    message = f"storage object not found: {resolved_key}"
+    raise FileNotFoundError(message)

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -115,7 +115,8 @@ def _decrypt_config(app: Flask, encrypted_value: str) -> str:
             decrypted_value = fernet.decrypt(encrypted_value.encode())
             return decrypted_value.decode()
         except Exception as e:
-            raise ValueError(f"Failed to decrypt config value: {e!s}") from e
+            message = f"Failed to decrypt config value: {e!s}"
+            raise ValueError(message) from e
 
 
 def _get_config_cache_key(app: Flask, key: str) -> str:

--- a/src/api/flaskr/service/creator_analytics/sql_builder.py
+++ b/src/api/flaskr/service/creator_analytics/sql_builder.py
@@ -82,10 +82,11 @@ def build_statement(
         # silently emit a WHERE col = '' clause that would always match
         # legacy rows whose creator field is empty.
         if not dsl.caller_user_id:
-            raise ValueError(
+            message = (
                 f"caller_user_id is required for creator-scoped table "
                 f"'{dsl.spec.table_key}'"
             )
+            raise ValueError(message)
         where_clauses.append(
             table.c[dsl.spec.creator_scoped_column]
             == bindparam("__user_id", value=dsl.caller_user_id)
@@ -158,7 +159,8 @@ def _compile_filter(column: Column, filt: Filter, index: int) -> ColumnElement[b
     if op == "is_not_null":
         return column.isnot(None)
 
-    raise ValueError(f"Unexpected DSL operator at sql_builder: {op!r}")
+    message = f"Unexpected DSL operator at sql_builder: {op!r}"
+    raise ValueError(message)
 
 
 def _compile_aggregate(table, agg: Aggregate) -> ColumnElement[Any]:
@@ -180,7 +182,8 @@ def _compile_aggregate(table, agg: Aggregate) -> ColumnElement[Any]:
     elif agg.fn == "max":
         expr = func.max(table.c[agg.field])
     else:
-        raise ValueError(f"Unexpected aggregate fn at sql_builder: {agg.fn!r}")
+        message = f"Unexpected aggregate fn at sql_builder: {agg.fn!r}"
+        raise ValueError(message)
     return expr.label(agg.alias)
 
 
@@ -208,4 +211,5 @@ def _aggregate_expression_by_alias(
     for agg in aggregates:
         if agg.alias == alias:
             return _compile_aggregate(table, agg)
-    raise ValueError(f"Unknown aggregate alias: {alias!r}")
+    message = f"Unknown aggregate alias: {alias!r}"
+    raise ValueError(message)

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
@@ -53,10 +53,11 @@ class CozeAskProviderAdapter:
 
         bot_id = str(config.get("bot_id") or "").strip()
         api_path = str(config.get("api_path") or "/v3/chat").strip() or "/v3/chat"
-        if api_path.startswith("http"):
-            url = api_path
-        else:
-            url = base_url.rstrip("/") + "/" + api_path.lstrip("/")
+        url = (
+            api_path
+            if api_path.startswith("http")
+            else base_url.rstrip("/") + "/" + api_path.lstrip("/")
+        )
 
         if api_path == "/v3/chat" and not bot_id:
             raise AskProviderConfigError("coze bot_id is required")
@@ -99,7 +100,8 @@ class CozeAskProviderAdapter:
         except requests.Timeout as exc:
             raise AskProviderTimeoutError("coze request timeout") from exc
         except requests.RequestException as exc:
-            raise AskProviderError(f"coze request failed: {exc}") from exc
+            message = f"coze request failed: {exc}"
+            raise AskProviderError(message) from exc
 
         response = raise_for_provider_response(response, self.provider)
 
@@ -116,7 +118,8 @@ class CozeAskProviderAdapter:
             event = str(parsed.get("event") or parsed.get("type") or "").lower()
             if "error" in event:
                 error_message = extract_text(parsed) or str(parsed)
-                raise AskProviderError(f"coze error: {error_message}")
+                message = f"coze error: {error_message}"
+                raise AskProviderError(message)
             if event in {"done", "message_end", "chat.completed"}:
                 continue
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
@@ -234,7 +234,8 @@ class CozeWorkflowAskProviderAdapter:
         except requests.Timeout as exc:
             raise AskProviderTimeoutError("coze_workflow request timeout") from exc
         except requests.RequestException as exc:
-            raise AskProviderError(f"coze_workflow request failed: {exc}") from exc
+            message = f"coze_workflow request failed: {exc}"
+            raise AskProviderError(message) from exc
 
         response = raise_for_provider_response(response, self.provider)
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
@@ -106,7 +106,8 @@ class DifyAskProviderAdapter:
         except requests.Timeout as exc:
             raise AskProviderTimeoutError("dify request timeout") from exc
         except requests.RequestException as exc:
-            raise AskProviderError(f"dify request failed: {exc}") from exc
+            message = f"dify request failed: {exc}"
+            raise AskProviderError(message) from exc
 
         response = raise_for_provider_response(response, self.provider)
 
@@ -122,7 +123,8 @@ class DifyAskProviderAdapter:
             event = str(parsed.get("event") or "").strip().lower()
             if event == "error":
                 error_message = extract_text(parsed) or str(parsed)
-                raise AskProviderError(f"dify error: {error_message}")
+                message = f"dify error: {error_message}"
+                raise AskProviderError(message)
 
             text = extract_text(parsed)
             if text:

--- a/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
@@ -78,8 +78,9 @@ def _raise_for_api_error(payload: Any) -> None:
     if not message:
         message = extract_text(error) or extract_text(payload) or str(payload)
     detail = f"{message} (reason: {reason})" if reason else message
+    error_message = f"get_biji_knowledge error: {detail}"
     raise AskProviderError(
-        f"get_biji_knowledge error: {detail}",
+        error_message,
         user_message=_user_message_for_error(code, reason),
     )
 
@@ -164,7 +165,8 @@ class GetBijiKnowledgeAskProviderAdapter:
         except requests.Timeout as exc:
             raise AskProviderTimeoutError("get_biji_knowledge request timeout") from exc
         except requests.RequestException as exc:
-            raise AskProviderError(f"get_biji_knowledge request failed: {exc}") from exc
+            message = f"get_biji_knowledge request failed: {exc}"
+            raise AskProviderError(message) from exc
 
         try:
             payload_data = response.json()

--- a/src/api/flaskr/service/learn/ask_provider_adapters/registry.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/registry.py
@@ -55,7 +55,8 @@ def stream_ask_provider_response(
 ) -> Generator[AskProviderChunk, None, None]:
     adapter = get_ask_provider_adapter(provider)
     if not adapter:
-        raise AskProviderConfigError(f"unsupported provider: {provider}")
+        message = f"unsupported provider: {provider}"
+        raise AskProviderConfigError(message)
     yield from adapter.stream_answer(
         app, user_id, user_query, messages, provider_config, runtime
     )

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -291,7 +291,8 @@ class VolcKnowledgeAskProviderAdapter:
         except requests.Timeout as exc:
             raise AskProviderTimeoutError("volc_knowledge request timeout") from exc
         except requests.RequestException as exc:
-            raise AskProviderError(f"volc_knowledge request failed: {exc}") from exc
+            error_message = f"volc_knowledge request failed: {exc}"
+            raise AskProviderError(error_message) from exc
 
         response = raise_for_provider_response(response, self.provider)
 
@@ -305,7 +306,8 @@ class VolcKnowledgeAskProviderAdapter:
             data = payload_data.get("data")
             if code is not None and str(code) not in {"0", "200"} and data is None:
                 message = extract_text(payload_data.get("message")) or str(payload_data)
-                raise AskProviderError(f"volc_knowledge error: {message}")
+                error_message = f"volc_knowledge error: {message}"
+                raise AskProviderError(error_message)
 
         chunks = _collect_text_chunks(payload_data)
         if not chunks:

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -871,7 +871,8 @@ def _yield_tts_segments(
     if not provider_name:
         raise ValueError("TTS provider is required")
     if not is_tts_configured(provider_name):
-        raise ValueError(f"TTS provider is not configured: {provider_name}")
+        message = f"TTS provider is not configured: {provider_name}"
+        raise ValueError(message)
 
     segments = split_text_for_tts(text, provider_name=provider_name)
     if not segments:

--- a/src/api/flaskr/service/learn/listen_element_legacy.py
+++ b/src/api/flaskr/service/learn/listen_element_legacy.py
@@ -296,7 +296,8 @@ def backfill_learn_generated_elements_for_progress(
         .first()
     )
     if progress_record is None:
-        raise ValueError(f"progress record not found: {progress_record_bid}")
+        message = f"progress record not found: {progress_record_bid}"
+        raise ValueError(message)
 
     stats = LearnElementsBackfillStats(
         progress_record_bid=progress_record.progress_record_bid or progress_record_bid,

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -179,7 +179,8 @@ def _load_progress_record(progress_record_bid: str) -> LearnProgressRecord:
         .first()
     )
     if progress_record is None:
-        raise ValueError(f"progress record not found: {progress_record_bid}")
+        message = f"progress record not found: {progress_record_bid}"
+        raise ValueError(message)
     return progress_record
 
 

--- a/src/api/flaskr/service/learn/type_state_machine.py
+++ b/src/api/flaskr/service/learn/type_state_machine.py
@@ -94,9 +94,8 @@ class TypeStateMachine:
 
         """
         if self._state is TypeState.TERMINATED:
-            raise ValueError(
-                f"State machine already terminated; cannot process {trigger!r}"
-            )
+            message = f"State machine already terminated; cannot process {trigger!r}"
+            raise ValueError(message)
 
         if trigger is TypeInput.CONTENT_START:
             if is_new:
@@ -128,7 +127,8 @@ class TypeStateMachine:
             self._state = TypeState.TERMINATED
             return TYPE_ERROR
 
-        raise ValueError(f"Unknown trigger: {trigger!r}")  # pragma: no cover
+        message = f"Unknown trigger: {trigger!r}"
+        raise ValueError(message)  # pragma: no cover
 
     def reset(self) -> None:
         """Reset the machine to ``IDLE``."""

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -20,4 +20,5 @@ def __getattr__(name: str) -> Any:
         value = getattr(funs, name)
         globals()[name] = value
         return value
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    message = f"module '{__name__}' has no attribute '{name}'"
+    raise AttributeError(message)

--- a/src/api/flaskr/service/order/payment_providers/__init__.py
+++ b/src/api/flaskr/service/order/payment_providers/__init__.py
@@ -26,7 +26,8 @@ def get_payment_provider(channel: str) -> PaymentProvider:
     try:
         provider_cls = _PROVIDER_REGISTRY[channel]
     except KeyError as exc:
-        raise ValueError(f"Unsupported payment channel: {channel}") from exc
+        message = f"Unsupported payment channel: {channel}"
+        raise ValueError(message) from exc
     return provider_cls()
 
 

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -34,7 +34,8 @@ class AlipayProvider(PaymentProvider):
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
         if request.channel != "alipay_qr":
-            raise RuntimeError(f"Unsupported Alipay channel: {request.channel}")
+            message = f"Unsupported Alipay channel: {request.channel}"
+            raise RuntimeError(message)
 
         client = self._ensure_client(app)
         sdk = self._load_sdk(app)
@@ -124,7 +125,8 @@ class AlipayProvider(PaymentProvider):
     ) -> PaymentNotificationResult:
         normalized_reference_type = str(reference_type or "").strip().lower()
         if normalized_reference_type not in {"payment", "trade", "charge"}:
-            raise RuntimeError(f"Unsupported Alipay reference type: {reference_type}")
+            message = f"Unsupported Alipay reference type: {reference_type}"
+            raise RuntimeError(message)
 
         client = self._ensure_client(app)
         sdk = self._load_sdk(app)
@@ -249,7 +251,8 @@ def _read_required_key(config_name: str, inline_config_name: str = "") -> str:
         return inline_value
     key_path = str(get_config(config_name, "") or "").strip()
     if not key_path:
-        raise RuntimeError(f"{config_name} must be configured")
+        message = f"{config_name} must be configured"
+        raise RuntimeError(message)
     path = Path(key_path)
     if not path.exists():
         raise FileNotFoundError(key_path)

--- a/src/api/flaskr/service/order/payment_providers/base.py
+++ b/src/api/flaskr/service/order/payment_providers/base.py
@@ -86,33 +86,31 @@ class PaymentProvider(ABC):
         self, *, request: PaymentRequest, app
     ) -> PaymentCreationResult:
         """Create a provider-managed subscription checkout."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support subscriptions"
-        )
+        message = f"{self.__class__.__name__} does not support subscriptions"
+        raise NotImplementedError(message)
 
     def cancel_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app
     ) -> SubscriptionUpdateResult:
         """Schedule or trigger subscription cancellation at the provider."""
-        raise NotImplementedError(
+        message = (
             f"{self.__class__.__name__} does not support subscription cancellation"
         )
+        raise NotImplementedError(message)
 
     def resume_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app
     ) -> SubscriptionUpdateResult:
         """Resume a paused or cancel-scheduled provider subscription."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support subscription resumption"
-        )
+        message = f"{self.__class__.__name__} does not support subscription resumption"
+        raise NotImplementedError(message)
 
     def verify_webhook(
         self, *, headers: dict[str, str], raw_body: bytes | str, app
     ) -> PaymentNotificationResult:
         """Verify and normalize a provider webhook payload."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support webhook verification"
-        )
+        message = f"{self.__class__.__name__} does not support webhook verification"
+        raise NotImplementedError(message)
 
     def handle_notification(
         self, *, payload: dict[str, Any], app
@@ -128,7 +126,8 @@ class PaymentProvider(ABC):
         self, *, request: PaymentRefundRequest, app
     ) -> PaymentRefundResult:
         """Trigger a refund on the provider."""
-        raise NotImplementedError(f"{self.__class__.__name__} does not support refunds")
+        message = f"{self.__class__.__name__} does not support refunds"
+        raise NotImplementedError(message)
 
     def sync_payment_status(
         self, *, order_bid: str, provider_reference: str, app
@@ -144,6 +143,5 @@ class PaymentProvider(ABC):
         self, *, provider_reference: str, reference_type: str, app
     ) -> PaymentNotificationResult:
         """Synchronize a provider reference and return normalized state."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not support reference sync"
-        )
+        message = f"{self.__class__.__name__} does not support reference sync"
+        raise NotImplementedError(message)

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -237,7 +237,8 @@ class PingxxProvider(PaymentProvider):
     ) -> PaymentNotificationResult:
         normalized_reference_type = str(reference_type or "").strip().lower()
         if normalized_reference_type not in {"charge", "payment"}:
-            raise RuntimeError(f"Unsupported Pingxx reference type: {reference_type}")
+            message = f"Unsupported Pingxx reference type: {reference_type}"
+            raise RuntimeError(message)
         charge = self.retrieve_charge(charge_id=provider_reference, app=app)
         return PaymentNotificationResult(
             order_bid=str(charge.get("order_no") or ""),

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -342,7 +342,8 @@ class StripeProvider(PaymentProvider):
                 provider_payload={"subscription": subscription},
                 charge_id=None,
             )
-        raise RuntimeError(f"Unsupported Stripe reference type: {reference_type}")
+        message = f"Unsupported Stripe reference type: {reference_type}"
+        raise RuntimeError(message)
 
     def refund_payment(
         self, *, request: PaymentRefundRequest, app: Flask

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -44,7 +44,8 @@ class WechatPayProvider(PaymentProvider):
             return self._create_native_payment(request=request, app=app)
         if request.channel == "wx_pub":
             return self._create_jsapi_payment(request=request, app=app)
-        raise RuntimeError(f"Unsupported WeChat Pay channel: {request.channel}")
+        message = f"Unsupported WeChat Pay channel: {request.channel}"
+        raise RuntimeError(message)
 
     def create_subscription(
         self, *, request: PaymentRequest, app: Flask
@@ -78,9 +79,8 @@ class WechatPayProvider(PaymentProvider):
     ) -> PaymentNotificationResult:
         normalized_reference_type = str(reference_type or "").strip().lower()
         if normalized_reference_type not in {"payment", "trade", "charge"}:
-            raise RuntimeError(
-                f"Unsupported WeChat Pay reference type: {reference_type}"
-            )
+            message = f"Unsupported WeChat Pay reference type: {reference_type}"
+            raise RuntimeError(message)
 
         mch_id = _required_config("WECHATPAY_MCH_ID")
         path = f"/v3/pay/transactions/out-trade-no/{provider_reference}"
@@ -282,7 +282,8 @@ class WechatPayProvider(PaymentProvider):
             raise RuntimeError("WeChat Pay notification resource missing")
         algorithm = str(resource.get("algorithm") or "")
         if algorithm and algorithm != "AEAD_AES_256_GCM":
-            raise RuntimeError(f"Unsupported WeChat Pay algorithm: {algorithm}")
+            message = f"Unsupported WeChat Pay algorithm: {algorithm}"
+            raise RuntimeError(message)
         api_v3_key = _required_config("WECHATPAY_API_V3_KEY").encode("utf-8")
         aesgcm = AESGCM(api_v3_key)
         plaintext = aesgcm.decrypt(
@@ -305,7 +306,8 @@ def _wechatpay_app_id() -> str:
 def _required_config(name: str) -> str:
     value = str(get_config(name, "") or "").strip()
     if not value:
-        raise RuntimeError(f"{name} must be configured")
+        message = f"{name} must be configured"
+        raise RuntimeError(message)
     return value
 
 

--- a/src/api/flaskr/service/order/pingxx_order.py
+++ b/src/api/flaskr/service/order/pingxx_order.py
@@ -49,5 +49,6 @@ def create_pingxx_order(
 def _get_provider() -> PingxxProvider:
     provider = get_payment_provider("pingxx")
     if not isinstance(provider, PingxxProvider):
-        raise TypeError(f"Expected PingxxProvider, got {provider.__class__.__name__}")
+        message = f"Expected PingxxProvider, got {provider.__class__.__name__}"
+        raise TypeError(message)
     return provider

--- a/src/api/flaskr/service/order/raw_snapshots.py
+++ b/src/api/flaskr/service/order/raw_snapshots.py
@@ -61,7 +61,8 @@ def native_snapshot_model(payment_provider: str):
     provider = str(payment_provider or "").strip().lower()
     model = _NATIVE_PAYMENT_MODELS.get(provider)
     if model is None:
-        raise ValueError(f"Unsupported native payment provider: {payment_provider}")
+        message = f"Unsupported native payment provider: {payment_provider}"
+        raise ValueError(message)
     return model
 
 
@@ -69,7 +70,8 @@ def native_snapshot_bid_attr(payment_provider: str) -> str:
     provider = str(payment_provider or "").strip().lower()
     attr = _NATIVE_PAYMENT_BID_ATTRS.get(provider)
     if attr is None:
-        raise ValueError(f"Unsupported native payment provider: {payment_provider}")
+        message = f"Unsupported native payment provider: {payment_provider}"
+        raise ValueError(message)
     return attr
 
 

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -235,7 +235,8 @@ def _plan_outline_structure_repair(
         for item in siblings:
             bid = item.outline_item_bid
             if bid in visited:
-                raise RuntimeError(f"Cycle detected around outline {bid}")
+                message = f"Cycle detected around outline {bid}"
+                raise RuntimeError(message)
             visited.add(bid)
             next_suffix = _next_available_suffix(
                 used_suffixes,

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -376,9 +376,8 @@ def __save_new_item_history(
             row_id,
             parent_bid,
         )
-        raise RuntimeError(
-            f"Parent history node not found for {item_type} {item_bid} under {parent_bid}"
-        )
+        message = f"Parent history node not found for {item_type} {item_bid} under {parent_bid}"
+        raise RuntimeError(message)
 
     __save_shifu_history(app, user_id, shifu_bid, history)
 

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -136,7 +136,8 @@ def concat_audio_mp3(
 
     if failed_segments:
         failed_segment_list = ", ".join(str(index) for index in failed_segments)
-        raise ValueError(f"Failed to decode audio segments: {failed_segment_list}")
+        message = f"Failed to decode audio segments: {failed_segment_list}"
+        raise ValueError(message)
 
     # Export to bytes
     output_io = io.BytesIO()

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -720,7 +720,8 @@ def synthesize_long_text_to_oss(
         raise ValueError("TTS provider is required")
 
     if not is_tts_configured(provider):
-        raise ValueError(f"TTS provider is not configured: {provider}")
+        message = f"TTS provider is not configured: {provider}"
+        raise ValueError(message)
 
     segments = split_text_for_tts(
         text,

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -115,9 +115,8 @@ def _acquire_redis_slot(
     )
     acquired = lock.acquire(blocking=True, blocking_timeout=max_wait_seconds)
     if not acquired:
-        raise TTSRpmQueueTimeoutError(
-            f"TTS RPM queue lock timed out after {max_wait_seconds:.2f}s"
-        )
+        message = f"TTS RPM queue lock timed out after {max_wait_seconds:.2f}s"
+        raise TTSRpmQueueTimeoutError(message)
 
     try:
         now = now_fn()
@@ -125,9 +124,8 @@ def _acquire_redis_slot(
         next_available_at = _parse_timestamp(raw_next, default=now)
         scheduled_at = max(now, next_available_at)
         if scheduled_at > deadline:
-            raise TTSRpmQueueTimeoutError(
-                f"TTS RPM queue wait exceeded {max_wait_seconds:.2f}s"
-            )
+            message = f"TTS RPM queue wait exceeded {max_wait_seconds:.2f}s"
+            raise TTSRpmQueueTimeoutError(message)
 
         ttl_seconds = max(math.ceil(interval * 4 + max_wait_seconds + 60), 120)
         redis_client.set(next_key, f"{scheduled_at + interval:.6f}", ex=ttl_seconds)

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -93,9 +93,8 @@ class AuthProvider(ABC):
         self, app: Flask, request: ChallengeRequest
     ) -> ChallengeResponse:
         """Dispatch a verification challenge to the user."""
-        raise NotImplementedError(
-            f"Provider '{self.provider_name}' does not issue challenges"
-        )
+        message = f"Provider '{self.provider_name}' does not issue challenges"
+        raise NotImplementedError(message)
 
     @abstractmethod
     def verify(self, app: Flask, request: VerificationRequest) -> AuthResult:
@@ -103,14 +102,12 @@ class AuthProvider(ABC):
 
     def begin_oauth(self, app: Flask, metadata: dict[str, Any]) -> Any:
         """Initiate an OAuth flow (optional)."""
-        raise NotImplementedError(
-            f"Provider '{self.provider_name}' does not support OAuth begin"
-        )
+        message = f"Provider '{self.provider_name}' does not support OAuth begin"
+        raise NotImplementedError(message)
 
     def handle_oauth_callback(
         self, app: Flask, request: OAuthCallbackRequest
     ) -> AuthResult:
         """Complete an OAuth flow and produce an authentication result."""
-        raise NotImplementedError(
-            f"Provider '{self.provider_name}' does not support OAuth callbacks"
-        )
+        message = f"Provider '{self.provider_name}' does not support OAuth callbacks"
+        raise NotImplementedError(message)

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -29,9 +29,8 @@ def register_provider(provider_cls: type[AuthProvider]) -> None:
 
     normalized = provider_name.lower()
     if normalized in _REGISTRY:
-        raise ProviderAlreadyRegisteredError(
-            f"Provider '{provider_name}' already registered"
-        )
+        message = f"Provider '{provider_name}' already registered"
+        raise ProviderAlreadyRegisteredError(message)
 
     _REGISTRY[normalized] = provider_cls
 
@@ -41,7 +40,8 @@ def get_provider(provider_name: str) -> AuthProvider:
     normalized = provider_name.lower()
     provider_cls = _REGISTRY.get(normalized)
     if provider_cls is None:
-        raise ProviderNotFoundError(f"Provider '{provider_name}' is not registered")
+        message = f"Provider '{provider_name}' is not registered"
+        raise ProviderNotFoundError(message)
     return provider_cls()
 
 

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -414,7 +414,8 @@ def ensure_user_aggregate(
     entity, created = upsert_user_entity(user_bid=user_bid, defaults=defaults)
     aggregate = load_user_aggregate(entity.user_bid)
     if not aggregate:
-        raise RuntimeError(f"Failed to load user aggregate for {user_bid}")
+        message = f"Failed to load user aggregate for {user_bid}"
+        raise RuntimeError(message)
     return aggregate, created
 
 
@@ -442,9 +443,8 @@ def ensure_user_for_identifier(
         db.session.flush()
         refreshed = load_user_aggregate(aggregate.user_bid)
         if not refreshed:
-            raise RuntimeError(
-                f"Failed to refresh user aggregate for provider {provider}"
-            )
+            message = f"Failed to refresh user aggregate for provider {provider}"
+            raise RuntimeError(message)
         return refreshed, False
 
     user_bid = defaults.get("user_bid") or generate_id(app)
@@ -460,7 +460,8 @@ def ensure_user_for_identifier(
     db.session.flush()
     aggregate = load_user_aggregate(user_bid)
     if not aggregate:
-        raise RuntimeError(f"Failed to create user aggregate for provider {provider}")
+        message = f"Failed to create user aggregate for provider {provider}"
+        raise RuntimeError(message)
     return aggregate, True
 
 

--- a/src/api/flaskr/util/deprecation.py
+++ b/src/api/flaskr/util/deprecation.py
@@ -15,7 +15,8 @@ def deprecated_alias_getattr(
     def module_getattr(name: str) -> object:
         current = aliases.get(name)
         if current is None:
-            raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+            message = f"module {module_name!r} has no attribute {name!r}"
+            raise AttributeError(message)
         warnings.warn(
             f"{module_name}.{name} is deprecated, use {current} instead",
             DeprecationWarning,

--- a/src/api/flaskr/util/prompt_loader.py
+++ b/src/api/flaskr/util/prompt_loader.py
@@ -30,13 +30,13 @@ def load_prompt_template(template_name: str) -> str:
 
     # Check if file exists
     if not Path(template_path).exists():
-        raise FileNotFoundError(f"Prompt template file not found: {template_path}")
+        message = f"Prompt template file not found: {template_path}"
+        raise FileNotFoundError(message)
 
     # Read file content
     try:
         with Path(template_path).open(encoding="utf-8") as f:
             return f.read()
     except Exception as e:
-        raise OSError(
-            f"Failed to read prompt template file {template_path}: {e!s}"
-        ) from e
+        message = f"Failed to read prompt template file {template_path}: {e!s}"
+        raise OSError(message) from e

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -185,10 +185,11 @@ def _bootstrap_mdflow(mdflow_root: str):
     root = Path(mdflow_root)
     init_file = root / "markdown_flow" / "__init__.py"
     if not init_file.exists():
-        raise SystemExit(
+        message = (
             f"markdown-flow root not found or incomplete: {root}. "
             "Expected markdown_flow/__init__.py"
         )
+        raise SystemExit(message)
 
     sys.path.insert(0, str(root))
     for name in list(sys.modules):
@@ -197,10 +198,11 @@ def _bootstrap_mdflow(mdflow_root: str):
 
     markdown_flow = importlib.import_module("markdown_flow")
     if not hasattr(markdown_flow, "StreamFormatter"):
-        raise SystemExit(
+        message = (
             f"markdown-flow loaded from {markdown_flow.__file__} "
             "does not expose StreamFormatter"
         )
+        raise SystemExit(message)
     return markdown_flow
 
 
@@ -723,7 +725,8 @@ def main() -> int:
     args = parse_args()
     input_path = Path(args.input)
     if not input_path.exists():
-        raise SystemExit(f"Input file not found: {input_path}")
+        message = f"Input file not found: {input_path}"
+        raise SystemExit(message)
 
     chunk_sizes = (
         tuple(int(part.strip()) for part in args.chunk_sizes.split(",") if part.strip())

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -228,7 +228,8 @@ def main() -> int:
     args = parse_args()
     input_path = Path(args.input)
     if not input_path.exists():
-        raise SystemExit(f"Input file not found: {input_path}")
+        message = f"Input file not found: {input_path}"
+        raise SystemExit(message)
 
     chunk_sizes = (
         tuple(int(part.strip()) for part in args.chunk_sizes.split(",") if part.strip())

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -108,7 +108,8 @@ def _parse_codex_events(stdout: str) -> dict[str, Any]:
                 ):
                     warnings.append("code_mode_disabled_fail_closed")
                     continue
-                raise EvaluationError(f"codex CLI error item: {message[:200]}")
+                error_message = f"codex CLI error item: {message[:200]}"
+                raise EvaluationError(error_message)
             item_types.add(item_type)
         if event.get("type") == "turn.completed" and isinstance(
             event.get("usage"), dict
@@ -118,7 +119,8 @@ def _parse_codex_events(stdout: str) -> dict[str, Any]:
     disallowed_item_types = item_types - ALLOWED_CODEX_ITEM_TYPES
     if disallowed_item_types:
         disallowed = ", ".join(sorted(disallowed_item_types))
-        raise EvaluationError(f"codex CLI used disallowed tool item(s): {disallowed}")
+        error_message = f"codex CLI used disallowed tool item(s): {disallowed}"
+        raise EvaluationError(error_message)
     return {
         "item_types": sorted(item_types),
         "tool_calls_observed": False,
@@ -179,16 +181,14 @@ def _run_codex(
         except FileNotFoundError as exc:
             raise EvaluationError("codex CLI is not installed") from exc
         except subprocess.TimeoutExpired as exc:
-            raise EvaluationError(
-                f"codex CLI exceeded the {timeout_seconds}s timeout"
-            ) from exc
+            message = f"codex CLI exceeded the {timeout_seconds}s timeout"
+            raise EvaluationError(message) from exc
 
         if completed.returncode != 0:
             diagnostic = completed.stderr.strip().splitlines()
             detail = diagnostic[-1] if diagnostic else "no diagnostic output"
-            raise EvaluationError(
-                f"codex CLI exited with {completed.returncode}: {detail}"
-            )
+            message = f"codex CLI exited with {completed.returncode}: {detail}"
+            raise EvaluationError(message)
         if not output_path.exists():
             raise EvaluationError("codex CLI did not write a final response")
         result = output_path.read_text(encoding="utf-8")
@@ -392,7 +392,8 @@ def main() -> int:
         unknown_case_ids = requested_case_ids - known_case_ids
         if unknown_case_ids:
             unknown = ", ".join(sorted(unknown_case_ids))
-            raise EvaluationError(f"unknown case id(s): {unknown}")
+            message = f"unknown case id(s): {unknown}"
+            raise EvaluationError(message)
         cases = [case for case in cases if case["id"] in requested_case_ids]
 
     tasks = [

--- a/src/api/tests/common/fixtures/billing_products.py
+++ b/src/api/tests/common/fixtures/billing_products.py
@@ -303,7 +303,8 @@ def list_billing_product_rows(
     for product_bid in selected_bids:
         base_row = _TEST_BILLING_PRODUCT_ROWS_BY_BID.get(product_bid)
         if base_row is None:
-            raise AssertionError(f"unknown billing product fixture: {product_bid}")
+            message = f"unknown billing product fixture: {product_bid}"
+            raise AssertionError(message)
 
         payload = deepcopy(base_row)
         if overrides_by_bid and product_bid in overrides_by_bid:

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -322,13 +322,14 @@ def assert_or_update_golden(fixture_name: str, normalized_text: str) -> None:
         fixture_path.write_text(normalized_text, encoding="utf-8")
         return
     if not fixture_path.exists():
-        raise AssertionError(
+        message = (
             f"Golden fixture {fixture_path} is missing. "
             "Record it with UPDATE_GOLDEN=1 pytest tests/golden/ and commit the file."
         )
+        raise AssertionError(message)
     expected = fixture_path.read_text(encoding="utf-8")
     if normalized_text != expected:
-        raise AssertionError(
+        message = (
             f"Golden fixture mismatch for {fixture_name}.\n"
             "The normalized output no longer matches the recorded contract. "
             "Review the diff below; if the change is intentional, rerun with "
@@ -336,3 +337,4 @@ def assert_or_update_golden(fixture_name: str, normalized_text: str) -> None:
             f"--- expected ({fixture_path})\n{expected}\n"
             f"+++ actual\n{normalized_text}"
         )
+        raise AssertionError(message)

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -509,7 +509,8 @@ def billing_write_client(monkeypatch):
             return FakeStripeProvider()
         if channel == "pingxx":
             return FakePingxxProvider()
-        raise AssertionError(f"Unexpected provider: {channel}")
+        message = f"Unexpected provider: {channel}"
+        raise AssertionError(message)
 
     monkeypatch.setitem(
         billing_write_routes_module.create_billing_order_checkout.__globals__,

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -1562,7 +1562,8 @@ def test_billing_grant_plan_cli_returns_noop_for_same_active_plan_without_sms(
     runner = billing_cli_db_app.test_cli_runner()
 
     def _unexpected_enqueue(app: Flask, *, bill_order_bid: str) -> dict[str, object]:
-        raise AssertionError(f"unexpected enqueue for {bill_order_bid}")
+        message = f"unexpected enqueue for {bill_order_bid}"
+        raise AssertionError(message)
 
     monkeypatch.setattr(
         "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",
@@ -1626,7 +1627,8 @@ def test_billing_grant_plan_cli_rejects_when_provider_managed_subscription_exist
     runner = billing_cli_db_app.test_cli_runner()
 
     def _unexpected_enqueue(app: Flask, *, bill_order_bid: str) -> dict[str, object]:
-        raise AssertionError(f"unexpected enqueue for {bill_order_bid}")
+        message = f"unexpected enqueue for {bill_order_bid}"
+        raise AssertionError(message)
 
     monkeypatch.setattr(
         "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -168,7 +168,8 @@ def _failing_lifecycle_sync(monkeypatch: pytest.MonkeyPatch, *, failing_bids: se
 
     def fake_sync(_app, subscription):
         if subscription.subscription_bid in failing_bids:
-            raise RuntimeError(f"boom in {subscription.subscription_bid}")
+            message = f"boom in {subscription.subscription_bid}"
+            raise RuntimeError(message)
 
     monkeypatch.setattr(
         billing_renewal, "_sync_subscription_lifecycle_events", fake_sync

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -66,10 +66,11 @@ def _consume_until_streaming(generator) -> list:
         content = getattr(event, "content", "")
         if isinstance(content, str) and STREAMED_MARKER in content:
             return events
-    raise AssertionError(
+    message = (
         "generator finished without yielding a streamed LLM chunk; "
         f"events: {[getattr(e, 'type', None) for e in events]}"
     )
+    raise AssertionError(message)
 
 
 def _load_rows(app, user_bid: str):

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -96,7 +96,8 @@ def _find_nested_route(name: str) -> ast.FunctionDef:
     for node in register_fn.body:
         if isinstance(node, ast.FunctionDef) and node.name == name:
             return node
-    raise AssertionError(f"{name} not found inside register_learn_routes")
+    message = f"{name} not found inside register_learn_routes"
+    raise AssertionError(message)
 
 
 def _collect_called_names(node: ast.AST) -> set[str]:
@@ -121,7 +122,8 @@ def _find_call_by_name(node: ast.AST, name: str) -> ast.Call:
             return child
         if isinstance(func, ast.Attribute) and func.attr == name:
             return child
-    raise AssertionError(f"{name} call not found")
+    message = f"{name} call not found"
+    raise AssertionError(message)
 
 
 def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = False):

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -19,15 +19,17 @@ class _FakeSegment:
     def append(self, other, crossfade=100):
         _FakeSegment.append_crossfades.append(crossfade)
         if crossfade > len(self):
-            raise ValueError(
+            message = (
                 f"Crossfade is longer than original AudioSegment "
                 f"({crossfade}ms > {len(self)}ms)"
             )
+            raise ValueError(message)
         if crossfade > len(other):
-            raise ValueError(
+            message = (
                 f"Crossfade is longer than the appended AudioSegment "
                 f"({crossfade}ms > {len(other)}ms)"
             )
+            raise ValueError(message)
         return _FakeSegment(self.duration_ms + len(other) - crossfade)
 
     def __getitem__(self, key) -> "_FakeSegment":

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -533,7 +533,8 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
                 "prompt_audio_filename",
             }
             if name in protected and not in_context:
-                raise RuntimeError(f"{name} accessed outside app context")
+                message = f"{name} accessed outside app context"
+                raise RuntimeError(message)
             return object.__getattribute__(self, name)
 
     row = DetachedSensitiveRow()

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -130,7 +130,8 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
                     payload={},
                     error_code=None,
                 )
-            raise AssertionError(f"unexpected frame: {message!r}")
+            error_message = f"unexpected frame: {message!r}"
+            raise AssertionError(error_message)
 
     class FakeWebSocketApp:
         def __init__(


### PR DESCRIPTION
## Summary
- Move all 162 f-string exception messages across 72 Python files into collision-free locals immediately before their original raises.
- Preserve every exception type, message expression, remaining argument, and explicit cause chain while enabling Ruff EM102 repository-wide.
- Add durable guidance for choosing message names and verifying future exception-message rewrites.

## Verification
- Reversible semantic audit: restored all 162 direct f-string arguments and the one equivalent Coze URL conditional; executable ASTs match the D101 parent with zero mismatches.
- Focused billing, payment-provider, TTS, ask-provider, config, analytics, auth, migration, and error-path tests: 1,822 passed, 10 skipped.
- Full backend suite: 3,019 passed, 17 skipped.
- Stable ALL census: 29,175 findings across 31 rules. EM102 falls by 162; the same construct removes 136 TRY003 findings; formatter-owned COM812 falls by 60; no rule gains debt.
- Translation and identifier checks, script entry points, repository Ruff and format, generated knowledge, harness, architecture checks, development-tool validation, and every pre-commit hook passed.

## Stack
- Base: #2590 (D101)
- This PR contains only the EM102 rule unit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->