### PR TITLE
chore: enforce Unicode confusable checks

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -357,6 +357,15 @@ configuration quieter. For a finding in new or changed code:
    fundamentally conflicts with the rule. Do not weaken `select` or `ignore`
    to make an unrelated PR pass.
 
+For `RUF001`, preserve the standard fullwidth Chinese punctuation explicitly
+allowed by `ruff.toml`: `，`, `：`, `！`, `？`, and `；`. These code points are
+intentional in Chinese prose, notification formatting, and TTS sentence-boundary
+sets; do not replace them with ASCII punctuation merely to silence lint. Treat
+every other confusable as suspicious and replace it with the intended code point
+unless an exact external protocol or regression fixture requires it. Do not add
+another globally allowed character without inventorying every occurrence and
+documenting the shared semantic contract.
+
 For `G004`, keep log message construction lazy: pass a constant message and
 its values as positional logging arguments, preserving the message text,
 argument order, and log level. Use `%s` for normal or `!s` interpolation,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -300,6 +300,25 @@ plan's progress update for that rule.
   `sunner/ruff-em101` to the EM102 branch after all local gates passed.
 - [ ] Merge or retarget EM101 PR #2592 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 05:44 CST: Prepared the RUF001 stage on
+  `sunner/ruff-ruf001`, stacked on EM101. Audited all 162 findings across 24
+  files and 106 source lines: every occurrence is one of the five standard
+  Chinese punctuation characters `，`, `：`, `！`, `？`, or `；`, used in
+  Chinese prose and notification formatting or as a TTS sentence boundary.
+- [x] 2026-08-21 05:44 CST: Removed the global RUF001 ignore and replaced it
+  with Ruff's exact five-character `allowed-confusables` list. RUF001 now
+  rejects every other confusable without rewriting runtime text or fixtures;
+  RUF002 and RUF003 remain clean. The stable `ALL` census falls exactly 162
+  findings to 28,202 across 28 rules, with every other rule count unchanged.
+- [x] 2026-08-21 05:44 CST: Documented that future agents must preserve the
+  five intentional Chinese punctuation characters, fix every other confusable
+  by default, and inventory all uses before expanding the shared allowlist.
+  The 323 focused notification, learner-profile, TTS, and LLM tests pass with
+  five skips, and the TTS report entry point exposes its help successfully.
+- [x] 2026-08-21 05:48 CST: The full backend suite passes 3,019 tests with 17
+  skips. Translation checks, collaboration and knowledge generators, repository
+  harness, architecture boundaries, development-tool validation, configured
+  Ruff and format, and every repository pre-commit hook also pass.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -394,11 +413,13 @@ plan's progress update for that rule.
   annotations, while SQLAlchemy model classes used for executable query
   construction stayed available at runtime. The exact import-movement audit
   makes that boundary explicit.
-- RUF001 is not the next safe exception-removal stage: its 162 findings are
-  deliberate full-width Chinese punctuation in customer messages, TTS boundary
-  patterns, and tests that freeze those language semantics. Replacing them with
-  ASCII punctuation would change product and speech behavior merely to shorten
-  configuration.
+- RUF001's 162 findings are deliberate full-width Chinese punctuation in
+  customer messages, TTS boundary patterns, and tests that freeze those
+  language semantics. Replacing them with ASCII punctuation would change
+  product and speech behavior merely to shorten configuration. Ruff's
+  `allowed-confusables` setting provides the narrower resolution: allow exactly
+  the five audited punctuation characters while enforcing RUF001 for every
+  other confusable.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -319,6 +319,11 @@ plan's progress update for that rule.
   skips. Translation checks, collaboration and knowledge generators, repository
   harness, architecture boundaries, development-tool validation, configured
   Ruff and format, and every repository pre-commit hook also pass.
+- [x] 2026-08-21 05:50 CST: Opened ready RUF001 PR
+  [#2593](https://github.com/ai-shifu/ai-shifu/pull/2593) from
+  `sunner/ruff-ruf001` to the EM101 branch after all local gates passed.
+- [ ] Merge or retarget RUF001 PR #2593 after its predecessors without
+  combining it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,6 +36,10 @@
 target-version = "py311"
 
 [lint]
+# These five code points are standard punctuation in Chinese prose and are
+# also meaningful TTS sentence boundaries. RUF001 still rejects every other
+# Unicode character that can be confused with an ASCII character.
+allowed-confusables = ["，", "：", "！", "？", "；"]
 select = [
     # --- Core correctness -------------------------------------------------
     "E",       # pycodestyle errors (E501 ignored below)
@@ -212,10 +216,9 @@ select = [
     "UP",
 
     # --- Ruff-native rules ------------------------------------------------
-    # RUF001 (ambiguous unicode in a string) is ignored below.
-    # RUF100 is enforced, so a `# noqa` may only name a rule this file
-    # selects: reasons for exceptions to non-selected rules (BLE001,
-    # DTZ001, SLF001) are written as plain comments instead.
+    # RUF100 is enforced, so a `# noqa` may only name a rule this file selects:
+    # reasons for exceptions to non-selected rules (BLE001, DTZ001, SLF001)
+    # are written as plain comments instead.
     "RUF",
 ]
 ignore = [
@@ -229,10 +232,6 @@ ignore = [
     "D213",    # summary on the second line -- conflicts with D212
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
-    # INP001 is enforced; see per-file-ignores for the entrypoints, Alembic
-    # revisions and boundary-check fixtures that are loaded by path rather
-    # than imported.
-    "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
 ]
 
 [lint.flake8-type-checking]


### PR DESCRIPTION
## Summary

- remove the repository-wide `RUF001` ignore
- allow only the five audited Chinese punctuation characters `，`, `：`, `！`, `？`, and `；`
- document the preferred fix and the review bar for any future allowlist expansion

## Audit

All 162 RUF001 findings span 24 files and 106 source lines. Every finding is one of those five characters, used in Chinese prose or notification formatting, or as a TTS sentence boundary. No Python source text or fixture was changed.

The stable `ALL` census falls from 28,364 findings across 29 rules to 28,202 findings across 28 rules. Only RUF001 changes; every other rule count is unchanged. RUF002 and RUF003 remain clean.

## Verification

- `ruff check . --select RUF001`
- `ruff check .`
- `ruff format --check .`
- 323 focused notification, learner-profile, TTS, and LLM tests passed; 5 skipped
- full backend suite: 3,019 passed; 17 skipped
- TTS report module help entry point
- translation and translation-usage checks
- collaboration and knowledge generators
- repository harness and architecture-boundary checks
- development-tool validation
- `lefthook run pre-commit --all-files`

## Stack

- Base: `sunner/ruff-em101`
- Predecessor: #2592
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->