### PR TITLE
refactor: use snake case in token constructor

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -366,6 +366,14 @@ unless an exact external protocol or regression fixture requires it. Do not add
 another globally allowed character without inventorying every occurrence and
 documenting the shared semantic contract.
 
+For `N803`, keep Python function and method arguments in snake_case even when
+the corresponding serialized field uses camelCase. Translate from the Python
+argument to the wire-facing attribute inside the DTO and update internal
+keyword callers; do not copy JSON spelling into a Python signature or add an
+ignore-name pattern. Preserve an external callback or override signature only
+when the caller truly owns the keyword contract, and explain that exception at
+the parameter.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -351,6 +351,26 @@ plan's progress update for that rule.
   `sunner/ruff-n815` to the RUF001 branch after all local gates passed.
 - [ ] Merge or retarget N815 PR #2595 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 06:20 CST: Prepared the N803 stage on
+  `sunner/ruff-n803`, stacked on N815. Ignoring suppressions exposed exactly one
+  repository-wide finding: the `UserToken` constructor copied the camelCase
+  serialized field name into its Python parameter.
+- [x] 2026-08-21 06:20 CST: Renamed the constructor argument to `user_info`,
+  updated all five keyword call sites, and removed the only N803 suppression.
+  The annotated `userInfo` attribute and JSON/Swagger field remain unchanged.
+- [x] 2026-08-21 06:20 CST: The isolated N803 scan with `--ignore-noqa` is
+  clean, no camelCase `UserToken` keyword caller remains, and 72 focused shared
+  DTO and authentication-flow tests pass. The stable `ALL` census remains
+  exactly 28,202 findings across 28 rules with no debt transfer.
+- [x] 2026-08-21 06:21 CST: The wider user-service and shared DTO suites pass
+  266 tests, covering every authentication provider and account-flow consumer
+  of the constructor.
+- [x] 2026-08-21 06:24 CST: The full backend suite passes 3,020 tests with 17
+  skips. Translation checks, collaboration and knowledge generators, repository
+  harness, architecture boundaries, development-tool validation, configured
+  Ruff, and format also pass.
+- [x] 2026-08-21 06:25 CST: Every repository pre-commit hook passes on the
+  N803 tip.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -458,6 +478,10 @@ plan's progress update for that rule.
   name drives both `UserToken` JSON and its generated Swagger schema. Pydantic
   aliases preserve all 26 runtime-config wire keys without sacrificing Python
   naming, so the final exception can be one field rather than two files.
+- N803 did not share N815's wire constraint. A constructor parameter is an
+  internal Python API even when it is assigned to a camelCase serialized
+  attribute, so renaming the parameter and keyword callers removes the
+  suppression without changing JSON, Swagger, or positional callers.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -371,6 +371,11 @@ plan's progress update for that rule.
   Ruff, and format also pass.
 - [x] 2026-08-21 06:25 CST: Every repository pre-commit hook passes on the
   N803 tip.
+- [x] 2026-08-21 06:29 CST: Opened ready N803 PR
+  [#2596](https://github.com/ai-shifu/ai-shifu/pull/2596) from
+  `sunner/ruff-n803` to the N815 branch after all local gates passed.
+- [ ] Merge or retarget N803 PR #2596 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1123,7 +1123,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             refreshed_user = build_user_info_from_aggregate(refreshed)
             auth_result.user = refreshed_user
             auth_result.token = UserToken(
-                userInfo=refreshed_user,
+                user_info=refreshed_user,
                 token=auth_result.token.token,
             )
         db.session.commit()

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -91,9 +91,9 @@ class UserToken:
     userInfo: UserInfo  # noqa: N815 - exact serialized and Swagger field name
     token: str
 
-    def __init__(self, userInfo: UserInfo, token) -> None:  # noqa: N803 - mirrors the serialized field name
+    def __init__(self, user_info: UserInfo, token) -> None:
         """Pair serialized user information with its access token."""
-        self.userInfo = userInfo
+        self.userInfo = user_info
         self.token = token
 
     def __json__(self) -> dict:

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -391,7 +391,7 @@ class GoogleAuthProvider(AuthProvider):
                 raise RuntimeError(message)
             user_dto = build_user_info_from_aggregate(refreshed)
             token_value = generate_token(app, refreshed.user_bid)
-            user_token = UserToken(userInfo=user_dto, token=token_value)
+            user_token = UserToken(user_info=user_dto, token=token_value)
             snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
         return AuthResult(

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -221,7 +221,7 @@ def verify_email_code(
         snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
     return (
-        UserToken(userInfo=user_dto, token=token),
+        UserToken(user_info=user_dto, token=token),
         created_new_user,
         {
             "course_id": course_id,

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -460,7 +460,7 @@ def verify_phone_code(
         snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
     return (
-        UserToken(userInfo=user_dto, token=token),
+        UserToken(user_info=user_dto, token=token),
         created_new_user,
         {
             "course_id": normalized_course_id,

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -145,7 +145,7 @@ def test_user_token_keeps_camel_case_wire_and_swagger_field() -> None:
         wx_openid="openid-1",
         language="zh-CN",
     )
-    token = UserToken(userInfo=user_info, token="token-1")
+    token = UserToken(user_info=user_info, token="token-1")
 
     assert token.__json__() == {"userInfo": user_info, "token": "token-1"}
     schema = swagger_config["components"]["schemas"]["UserToken"]


### PR DESCRIPTION
## Summary

- rename the `UserToken` constructor argument from `userInfo` to `user_info`
- update all five keyword callers while leaving positional callers unchanged
- remove the sole N803 suppression
- preserve the `userInfo` JSON property and generated Swagger field
- document how Python argument names should remain separate from wire naming

## Audit

`ruff check . --isolated --select N803 --target-version py311 --ignore-noqa` exposed exactly one finding. The camelCase class attribute remains an intentional N815 wire and Swagger contract, but the constructor argument is an internal Python API and does not need to mirror it.

No camelCase `UserToken` keyword caller remains. The stable `ALL` census remains 28,202 findings across 28 rules with no debt transfer.

## Verification

- isolated N803 scan with `--ignore-noqa`
- configured Ruff and format checks
- 72 focused shared DTO and authentication-flow tests passed
- wider user-service and shared DTO suites: 266 passed
- full backend suite: 3,020 passed; 17 skipped
- translation and translation-usage checks
- collaboration and knowledge generators
- repository harness and architecture-boundary checks
- development-tool validation
- `lefthook run pre-commit --all-files`

## Stack

- Base: `sunner/ruff-n815`
- Predecessor: #2595
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->