### PR TITLE
fix: resolve subprocess executables explicitly

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -365,6 +365,15 @@ class, and delete an exact-file exception as soon as that path disappears or a
 valid broader test pattern already owns it; a stale `per-file-ignores` entry is
 not documentation.
 
+For `S607`, application and test code should start a process through an absolute
+or already resolved executable path, such as `sys.executable`, a checked
+`shutil.which(...)` result, or a repository-local tool path. Keep arguments in a
+list and preserve the existing subprocess error contract. Contributor-facing
+maintenance scripts may rely on the controlled development `PATH` through the
+documented script-tree exception; that exception does not extend to tests. If a
+test or platform entrypoint must freeze an executable name because the name
+itself is the contract, use one explained inline suppression at that call.
+
 For `RUF001`, preserve the standard fullwidth Chinese punctuation explicitly
 allowed by `ruff.toml`: `，`, `：`, `！`, `？`, and `；`. These code points are
 intentional in Chinese prose, notification formatting, and TTS sentence-boundary

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -368,11 +368,12 @@ not documentation.
 For `S607`, application and test code should start a process through an absolute
 or already resolved executable path, such as `sys.executable`, a checked
 `shutil.which(...)` result, or a repository-local tool path. Keep arguments in a
-list and preserve the existing subprocess error contract. Contributor-facing
-maintenance scripts may rely on the controlled development `PATH` through the
-documented script-tree exception; that exception does not extend to tests. If a
-test or platform entrypoint must freeze an executable name because the name
-itself is the contract, use one explained inline suppression at that call.
+list and preserve the existing subprocess error contract. This applies equally
+to contributor-facing maintenance scripts: resolve a required executable once,
+fail with the script's existing missing-tool contract, and pass the resolved
+path to every call. If a test or platform entrypoint must freeze an executable
+name because the name itself is the contract, use one explained inline
+suppression at that call.
 
 For `RUF001`, preserve the standard fullwidth Chinese punctuation explicitly
 allowed by `ruff.toml`: `，`, `：`, `！`, `？`, and `；`. These code points are

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -424,6 +424,11 @@ plan's progress update for that rule.
   repository harness, architecture boundaries, development-tool validation,
   repository Ruff and format, and every pre-commit hook pass on the expanded
   S607 tip.
+- [x] 2026-08-21 08:13 CST: Final Backend Tests exposed that the missing-Codex
+  test entered the evaluator's macOS `/private/tmp` context before checking the
+  executable on Linux. Kept the production evaluator contract unchanged and
+  isolated that test with pytest's cross-platform `tmp_path`; it still proves
+  the missing-tool error occurs before subprocess startup.
 - [x] 2026-08-21 06:57 CST: Collaboration and knowledge generators, repository
   Ruff and format, translation checks, repository harness, architecture
   boundaries, development-tool validation, and every repository pre-commit

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -420,6 +420,11 @@ plan's progress update for that rule.
   Ruff and format, translation checks, repository harness, architecture
   boundaries, development-tool validation, and every repository pre-commit
   hook pass on the S607 tip.
+- [x] 2026-08-21 07:01 CST: Opened ready S607 PR
+  [#2599](https://github.com/ai-shifu/ai-shifu/pull/2599) from
+  `sunner/ruff-s607` to the S101 branch after all local gates passed.
+- [ ] Merge or retarget S607 PR #2599 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -398,6 +398,28 @@ plan's progress update for that rule.
   `sunner/ruff-s101` to the N803 branch after all local gates passed.
 - [ ] Merge or retarget S101 PR #2598 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 06:55 CST: Prepared the S607 stage on
+  `sunner/ruff-s607`, stacked on S101. Isolated test-tree scans with and without
+  inline suppressions report zero findings, so the inherited test-tree S607
+  exception is redundant rather than a hidden test contract.
+- [x] 2026-08-21 06:55 CST: Audited the retained boundaries before removing the
+  test exception: repository maintenance scripts have five findings, the
+  backend evaluation scripts have one, and the Windows application entrypoint
+  has one explained inline `tzutil` exception. Those contributor and platform
+  contracts remain unchanged.
+- [x] 2026-08-21 06:55 CST: Removed S607 only from the test-tree exception and
+  documented that application and test subprocess calls use an absolute or
+  resolved executable, while controlled maintenance scripts retain their
+  explicit tree-level boundary.
+- [x] 2026-08-21 06:57 CST: Configured S607 and isolated test-tree scans pass;
+  all 18 remaining per-file ignore patterns still match real files. The stable
+  `ALL` census remains exactly 28,202 findings across 28 rules because the
+  removed test exception hid no live finding. No runtime source changed, so no
+  behavior test is applicable to this policy-only stage.
+- [x] 2026-08-21 06:57 CST: Collaboration and knowledge generators, repository
+  Ruff and format, translation checks, repository harness, architecture
+  boundaries, development-tool validation, and every repository pre-commit
+  hook pass on the S607 tip.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -514,6 +536,13 @@ plan's progress update for that rule.
   `src/api/tests/conftest.py`; it is already inside the test-tree exception and
   contains no assertions today. Exact exception paths are obligations to
   validate, not durable breadcrumbs for files that no longer exist.
+- The test-tree exception grouped S607 with rules that have thousands of real
+  fixture findings, but isolated scans showed no partial executable path in any
+  backend test, even when inline suppressions were ignored. The six live S607
+  findings belong to executable maintenance scripts, while the only application
+  call is the explained Windows `tzutil` entrypoint. A broad rule list must be
+  audited code by code; a valid path pattern does not prove every listed code is
+  still necessary.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent
@@ -735,6 +764,16 @@ remaining per-file ignore pattern resolves to real files, and the stable
 assertions in tests and self-tests, use explicit exceptions for production
 guards, and delete obsolete exact-file exceptions instead of preserving them
 as historical commentary.
+
+The S607 stage removes only the test-tree exception after isolated scans prove
+that no backend test starts a process through a partial executable path, even
+when inline suppressions are ignored. Five repository-maintenance findings,
+one backend evaluation-script finding, and the explained Windows `tzutil`
+entrypoint remain inside their existing script or inline boundaries. Configured
+S607, repository Ruff, format, harness, and every pre-commit hook pass; the
+stable census remains 28,202 findings across 28 rules. Future application and
+test code now resolves executables explicitly, while contributor scripts may
+continue to rely on the controlled development `PATH` boundary.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -402,20 +402,28 @@ plan's progress update for that rule.
   `sunner/ruff-s607`, stacked on S101. Isolated test-tree scans with and without
   inline suppressions report zero findings, so the inherited test-tree S607
   exception is redundant rather than a hidden test contract.
-- [x] 2026-08-21 06:55 CST: Audited the retained boundaries before removing the
-  test exception: repository maintenance scripts have five findings, the
-  backend evaluation scripts have one, and the Windows application entrypoint
-  has one explained inline `tzutil` exception. Those contributor and platform
-  contracts remain unchanged.
-- [x] 2026-08-21 06:55 CST: Removed S607 only from the test-tree exception and
-  documented that application and test subprocess calls use an absolute or
-  resolved executable, while controlled maintenance scripts retain their
-  explicit tree-level boundary.
-- [x] 2026-08-21 06:57 CST: Configured S607 and isolated test-tree scans pass;
-  all 18 remaining per-file ignore patterns still match real files. The stable
-  `ALL` census remains exactly 28,202 findings across 28 rules because the
-  removed test exception hid no live finding. No runtime source changed, so no
-  behavior test is applicable to this policy-only stage.
+- [x] 2026-08-21 08:02 CST: Expanded the existing S607 unit after a semantic
+  audit found more shrinkage was safe. Ruff reported five repository-script
+  calls and one backend evaluator call, while the evaluator's main variable
+  command also started partial `codex` without being reported. The Windows
+  application entrypoint remains one explained inline `tzutil` exception
+  because that platform command name is the contract.
+- [x] 2026-08-21 08:02 CST: Resolved Git and Codex through `shutil.which(...)`,
+  converted the results to absolute paths, preserved each script's existing
+  missing-tool behavior, and removed S607 from both script-tree exceptions.
+  Four executable repository tests cover both Git queries, all three inventory
+  commands, and missing Git; four backend tests cover both Codex call paths and
+  both missing-Codex errors.
+- [x] 2026-08-21 08:02 CST: Configured S607 passes, and an audit that ignores
+  inline suppressions reports only the documented Windows `tzutil` call. All
+  18 remaining per-file ignore patterns still match real files, and the stable
+  `ALL` census remains exactly 28,202 findings across 28 rules without debt
+  transfer.
+- [x] 2026-08-21 08:03 CST: Focused executable tests pass 4 repository and 4
+  backend cases. Collaboration and knowledge generators, translations,
+  repository harness, architecture boundaries, development-tool validation,
+  repository Ruff and format, and every pre-commit hook pass on the expanded
+  S607 tip.
 - [x] 2026-08-21 06:57 CST: Collaboration and knowledge generators, repository
   Ruff and format, translation checks, repository harness, architecture
   boundaries, development-tool validation, and every repository pre-commit
@@ -543,11 +551,11 @@ plan's progress update for that rule.
   validate, not durable breadcrumbs for files that no longer exist.
 - The test-tree exception grouped S607 with rules that have thousands of real
   fixture findings, but isolated scans showed no partial executable path in any
-  backend test, even when inline suppressions were ignored. The six live S607
-  findings belong to executable maintenance scripts, while the only application
-  call is the explained Windows `tzutil` entrypoint. A broad rule list must be
-  audited code by code; a valid path pattern does not prove every listed code is
-  still necessary.
+  backend test, even when inline suppressions were ignored. Six literal script
+  findings and one variable-built Codex command could all use resolved absolute
+  paths; only the explained Windows `tzutil` entrypoint remains. A broad rule
+  list must be audited code by code, and a clean lint result for a variable
+  command does not replace semantic subprocess review.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent
@@ -600,6 +608,10 @@ plan's progress update for that rule.
   remove false positives from another still-ignored rule. Record that census
   effect explicitly, but do not treat the second rule as adopted until its own
   independent rule PR removes its exception and passes its acceptance suite.
+- 2026-08-21: S607 applies to contributor tooling as well as runtime code.
+  Resolve external commands once per operation, make the result absolute, keep
+  the existing missing-tool contract, and inspect variable-built subprocess
+  commands that Ruff cannot identify before retaining a directory exception.
 
 ## Outcomes & Retrospective
 
@@ -770,15 +782,15 @@ assertions in tests and self-tests, use explicit exceptions for production
 guards, and delete obsolete exact-file exceptions instead of preserving them
 as historical commentary.
 
-The S607 stage removes only the test-tree exception after isolated scans prove
-that no backend test starts a process through a partial executable path, even
-when inline suppressions are ignored. Five repository-maintenance findings,
-one backend evaluation-script finding, and the explained Windows `tzutil`
-entrypoint remain inside their existing script or inline boundaries. Configured
-S607, repository Ruff, format, harness, and every pre-commit hook pass; the
-stable census remains 28,202 findings across 28 rules. Future application and
-test code now resolves executables explicitly, while contributor scripts may
-continue to rely on the controlled development `PATH` boundary.
+The S607 stage removes the test-tree and both script-tree exceptions. Five
+repository-maintenance findings, one backend evaluator finding, and one
+variable-built Codex command now resolve absolute executable paths while
+preserving their existing missing-tool behavior. Four repository tests and
+four backend tests cover the Git and Codex success and failure contracts; the
+explained Windows `tzutil` platform entrypoint is the only inline exception.
+Configured S607, repository Ruff, format, and harness pass, and the stable
+census remains 28,202 findings across 28 rules. Future runtime, test, and
+contributor code now follows the same executable-resolution contract.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -162,7 +162,8 @@ select = [
     #   best-effort block reads better as `contextlib.suppress(...)`, which the
     #   repo already uses; a narrower `except OSError:` is not flagged either.
     # - S603/S605/S607: every subprocess and shell invocation. Application code
-    #   justifies each one inline; developer tooling is exempt below.
+    #   justifies each one inline; developer tooling resolves executables but
+    #   retains the broader S603 argument audit below.
     # - S608: every SQL string built by interpolation. Values always use bound
     #   parameters; the remaining sites interpolate table or column names, which
     #   bound parameters cannot carry, and justify it inline. Applied Alembic
@@ -277,9 +278,10 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 "src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py" = ["S608"]
 "src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py" = ["S608"]
 # Developer scripts and the backend inventory/harness tooling are console
-# programs: printing to stdout is their interface.
-"scripts/**" = ["S603", "S607", "T20"]
+# programs: printing to stdout is their interface. They resolve executable
+# paths explicitly, while the broader S603 argument audit remains separate.
+"scripts/**" = ["S603", "T20"]
 # This fixture exists so check_architecture_boundaries.py can prove it resolves
 # parent-relative imports; rewriting them would delete the test case.
 "scripts/testdata/architecture_boundaries/**" = ["TID252"]
-"src/api/scripts/**" = ["S603", "S607", "T20"]
+"src/api/scripts/**" = ["S603", "T20"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -248,7 +248,7 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # subprocess audit rules only add noise there.
 # Test suites are also full of literal fake passwords, tokens and secret keys
 # for fixtures and negative cases, which is what S105/S106 flag.
-"src/api/tests/**" = ["S101", "S105", "S106", "S603", "S607", "T20"]
+"src/api/tests/**" = ["S101", "S105", "S106", "S603", "T20"]
 # `app.py`, `celery_app.py` and `gunicorn.conf.py` are process entrypoints run
 # by path and never imported, so making `src/api` a package would only shadow
 # the top-level `flaskr` import path. `src/api/scripts` is a real package

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -76,9 +76,13 @@ class Check:
 
 def _hooks_dir() -> Path | None:
     """Return the directory git uses for hooks, honoring core.hooksPath."""
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        return None
+    git_executable = str(Path(git_executable).resolve())
     try:
         configured = subprocess.run(
-            ["git", "config", "--get", "core.hooksPath"],
+            [git_executable, "config", "--get", "core.hooksPath"],
             cwd=ROOT,
             capture_output=True,
             text=True,
@@ -90,7 +94,7 @@ def _hooks_dir() -> Path | None:
             return path if path.is_absolute() else (ROOT / path)
 
         resolved = subprocess.run(
-            ["git", "rev-parse", "--git-path", "hooks"],
+            [git_executable, "rev-parse", "--git-path", "hooks"],
             cwd=ROOT,
             capture_output=True,
             text=True,

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -368,9 +369,24 @@ def find_violations_in_text(path: str, text: str) -> list[IdentifierViolation]:
     return violations
 
 
+def _git_executable() -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        message = "git executable not found on PATH"
+        raise FileNotFoundError(message)
+    return str(Path(executable).resolve())
+
+
 def _repository_relative_paths() -> list[str]:
     result = subprocess.run(
-        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        [
+            _git_executable(),
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -384,7 +400,7 @@ def _repository_relative_paths() -> list[str]:
 
 def _index_entries() -> list[tuple[str, str]]:
     result = subprocess.run(
-        ["git", "ls-files", "--stage", "-z"],
+        [_git_executable(), "ls-files", "--stage", "-z"],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -411,7 +427,7 @@ def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
     if not unique_object_ids:
         return {}
     result = subprocess.run(
-        ["git", "cat-file", "--batch"],
+        [_git_executable(), "cat-file", "--batch"],
         cwd=ROOT,
         check=True,
         input="".join(f"{object_id}\n" for object_id in unique_object_ids).encode(),

--- a/scripts/test_resolved_executables.py
+++ b/scripts/test_resolved_executables.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright 2026 AI-Shifu
+"""Verify repository tools resolve executables before starting processes."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+import check_dev_tools
+import check_example_identifiers
+
+
+class ResolvedExecutablesTest(unittest.TestCase):
+    """Cover executable resolution and missing-tool behavior."""
+
+    def test_dev_tools_reuses_resolved_git(self) -> None:
+        """Use the resolved Git path for every hooks-directory query."""
+        with (
+            patch("check_dev_tools.shutil.which", return_value="/trusted/git"),
+            patch("check_dev_tools.subprocess.run") as run,
+        ):
+            run.side_effect = [
+                SimpleNamespace(returncode=1, stdout=""),
+                SimpleNamespace(returncode=0, stdout=".git/hooks\n"),
+            ]
+
+            hooks_dir = vars(check_dev_tools)["_hooks_dir"]()
+
+        assert hooks_dir == check_dev_tools.ROOT / ".git/hooks"
+        assert run.call_args_list == [
+            call(
+                ["/trusted/git", "config", "--get", "core.hooksPath"],
+                cwd=check_dev_tools.ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            ),
+            call(
+                ["/trusted/git", "rev-parse", "--git-path", "hooks"],
+                cwd=check_dev_tools.ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+        ]
+
+    def test_dev_tools_handles_missing_git(self) -> None:
+        """Keep the existing unavailable-hooks result when Git is absent."""
+        with (
+            patch("check_dev_tools.shutil.which", return_value=None),
+            patch("check_dev_tools.subprocess.run") as run,
+        ):
+            hooks_dir = vars(check_dev_tools)["_hooks_dir"]()
+
+        assert hooks_dir is None
+        run.assert_not_called()
+
+    def test_identifier_scans_use_resolved_git(self) -> None:
+        """Pass the resolved Git path to every repository inventory command."""
+        with (
+            patch(
+                "check_example_identifiers.shutil.which",
+                return_value="/trusted/git",
+            ),
+            patch("check_example_identifiers.subprocess.run") as run,
+        ):
+            run.side_effect = [
+                subprocess.CompletedProcess([], 0, stdout=b"one.py\0"),
+                subprocess.CompletedProcess(
+                    [],
+                    0,
+                    stdout=b"100644 abcdef 0\tone.py\0",
+                ),
+                subprocess.CompletedProcess([], 0, stdout=b"abcdef blob 3\nabc\n"),
+            ]
+
+            paths = vars(check_example_identifiers)["_repository_relative_paths"]()
+            entries = vars(check_example_identifiers)["_index_entries"]()
+            objects = vars(check_example_identifiers)["_read_index_objects"](["abcdef"])
+
+        assert paths == ["one.py"]
+        assert entries == [("one.py", "abcdef")]
+        assert objects == {"abcdef": b"abc"}
+        assert [item.args[0][0] for item in run.call_args_list] == [
+            "/trusted/git",
+            "/trusted/git",
+            "/trusted/git",
+        ]
+
+    def test_identifier_scan_reports_missing_git(self) -> None:
+        """Raise an explicit missing-tool error before starting a process."""
+        with patch("check_example_identifiers.shutil.which", return_value=None):
+            error = _capture_missing_git_error()
+
+        assert str(error) == "git executable not found on PATH"
+
+
+def _capture_missing_git_error() -> FileNotFoundError:
+    try:
+        vars(check_example_identifiers)["_git_executable"]()
+    except FileNotFoundError as exc:
+        return exc
+    message = "missing Git should fail before subprocess execution"
+    raise AssertionError(message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -14,6 +14,7 @@ import argparse
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -62,6 +63,13 @@ DISABLED_CODEX_FEATURES = (
 
 class EvaluationError(RuntimeError):
     """Raised when the local runner or model output cannot be evaluated."""
+
+
+def _codex_executable(*, missing_message: str) -> str:
+    executable = shutil.which("codex")
+    if executable is None:
+        raise EvaluationError(missing_message)
+    return str(Path(executable).resolve())
 
 
 def _build_user_message(learner_profile: str) -> str:
@@ -144,7 +152,7 @@ def _run_codex(
     ) as temporary_dir:
         output_path = Path(temporary_dir) / "last-message.txt"
         command = [
-            "codex",
+            _codex_executable(missing_message="codex CLI is not installed"),
             "exec",
             "--model",
             model,
@@ -208,7 +216,12 @@ def _run_codex(
 def _codex_version() -> str:
     try:
         completed = subprocess.run(
-            ["codex", "--version"],
+            [
+                _codex_executable(
+                    missing_message="could not determine the codex CLI version",
+                ),
+                "--version",
+            ],
             check=False,
             capture_output=True,
             text=True,

--- a/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_executable.py
+++ b/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_executable.py
@@ -1,0 +1,92 @@
+# Copyright 2026 AI-Shifu
+"""Verify the learner-profile evaluator resolves the Codex executable."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import evaluate_learner_profile_optimizer_prompt as evaluator
+
+
+def test_codex_version_uses_resolved_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the checked Codex path for a version probe."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(evaluator.shutil, "which", lambda _name: "/trusted/codex")
+
+    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(command)
+        return SimpleNamespace(returncode=0, stdout="codex-cli 1.2.3\n")
+
+    monkeypatch.setattr(evaluator.subprocess, "run", run)
+
+    version = vars(evaluator)["_codex_version"]()
+
+    assert version == "codex-cli 1.2.3"
+    assert calls == [["/trusted/codex", "--version"]]
+
+
+def test_codex_version_preserves_missing_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the evaluator's version-probe error when Codex is absent."""
+    monkeypatch.setattr(evaluator.shutil, "which", lambda _name: None)
+
+    with pytest.raises(
+        evaluator.EvaluationError,
+        match="could not determine the codex CLI version",
+    ):
+        vars(evaluator)["_codex_version"]()
+
+
+def test_codex_run_uses_resolved_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the checked Codex path for the main evaluator process."""
+    commands: list[list[str]] = []
+    monkeypatch.setattr(evaluator.shutil, "which", lambda _name: "/trusted/codex")
+    monkeypatch.setattr(
+        evaluator.tempfile,
+        "TemporaryDirectory",
+        lambda **_kwargs: contextlib.nullcontext(str(tmp_path)),
+    )
+
+    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        commands.append(command)
+        output_path = Path(command[command.index("--output-last-message") + 1])
+        output_path.write_text("optimized profile", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(evaluator.subprocess, "run", run)
+
+    result, metadata = vars(evaluator)["_run_codex"](
+        system_prompt="system",
+        user_message="user",
+        model="gpt-test",
+        timeout_seconds=10,
+    )
+
+    assert result == "optimized profile"
+    assert metadata["tool_calls_observed"] is False
+    assert commands[0][0] == "/trusted/codex"
+
+
+def test_codex_run_preserves_missing_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the evaluator's missing-CLI error before process startup."""
+    monkeypatch.setattr(evaluator.shutil, "which", lambda _name: None)
+
+    with pytest.raises(evaluator.EvaluationError, match="codex CLI is not installed"):
+        vars(evaluator)["_run_codex"](
+            system_prompt="system",
+            user_message="user",
+            model="gpt-test",
+            timeout_seconds=10,
+        )

--- a/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_executable.py
+++ b/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_executable.py
@@ -78,10 +78,16 @@ def test_codex_run_uses_resolved_executable(
 
 
 def test_codex_run_preserves_missing_tool_error(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Keep the evaluator's missing-CLI error before process startup."""
     monkeypatch.setattr(evaluator.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        evaluator.tempfile,
+        "TemporaryDirectory",
+        lambda **_kwargs: contextlib.nullcontext(str(tmp_path)),
+    )
 
     with pytest.raises(evaluator.EvaluationError, match="codex CLI is not installed"):
         vars(evaluator)["_run_codex"](


### PR DESCRIPTION
## Summary

- Enforce `S607` across repository and backend maintenance scripts instead of hiding those trees.
- Resolve Git and Codex with `shutil.which(...)`, convert the result to an absolute path, and preserve each tool missing/error contract.
- Cover all five Git call sites, both Codex call paths, and the missing-tool branches with focused tests.
- Document executable resolution as the default for runtime, tests, and contributor tooling.

## Stack

- Base: `sunner/ruff-s101` / #2598
- Head: `sunner/ruff-s607`
- Rule unit: `S607` only

## Ruff boundary

- Removed `S607` from `scripts/**` and `src/api/scripts/**`.
- The backend test-tree exception was already removed in this PR.
- The only retained S607 suppression is the explained Windows `tzutil` platform entrypoint, where the command name itself is the contract.
- Stable configured `ALL` census remains 28,202 findings across 28 rules; all 18 per-file patterns resolve to tracked paths.

## Tests

- `python3 scripts/test_resolved_executables.py` (4 passed)
- `cd src/api && /Users/sunner/src/ai-shifu/.venv/bin/python -m pytest -q tests/scripts/test_evaluate_learner_profile_optimizer_executable.py` (4 passed)

## Verification

- `ruff check . --select S607`
- `ruff check .`
- `ruff format --check .`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `python3 scripts/check_dev_tools.py`
- translation validation and usage checks
- `lefthook run pre-commit --all-files`