### PR TITLE
test: run frontend unit tests in CI

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -42,7 +42,7 @@ jobs:
             exit 0
           fi
 
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/frontend-changed-files.txt
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" > /tmp/frontend-changed-files.txt
           if grep -Eq '^(\.github/workflows/frontend-tests\.yml$|src/cook-web/|src/i18n/)' /tmp/frontend-changed-files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,72 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/frontend-tests.yml"
+      - "src/cook-web/**"
+      - "src/i18n/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  frontend-tests:
+    name: Run frontend tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect frontend changes
+        id: frontend-changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/frontend-changed-files.txt
+          if grep -Eq '^(\.github/workflows/frontend-tests\.yml$|src/cook-web/|src/i18n/)' /tmp/frontend-changed-files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node.js
+        if: steps.frontend-changes.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.16.0"
+          cache: npm
+          cache-dependency-path: src/cook-web/package-lock.json
+
+      - name: Install frontend dependencies
+        if: steps.frontend-changes.outputs.run == 'true'
+        working-directory: src/cook-web
+        run: npm ci
+
+      - name: Run frontend tests
+        if: steps.frontend-changes.outputs.run == 'true'
+        working-directory: src/cook-web
+        run: npm run test:ci
+
+      - name: Skip frontend tests
+        if: steps.frontend-changes.outputs.run != 'true'
+        run: echo "Skipping frontend tests because this pull request has no frontend or shared i18n changes."

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -16,6 +16,7 @@ details behind those rules.
 | Start backend dev server | `flask run` | `cd src/api` |
 | Start Cook Web (frontend & CMS) | `npm run dev` | `cd src/cook-web` |
 | Run backend tests | `pytest` | `cd src/api` |
+| Run frontend unit tests | `npm run test:ci` | `cd src/cook-web` |
 | Generate DB migration | `FLASK_APP=app.py flask db migrate -m "message"` | `cd src/api` |
 | Apply DB migration | `FLASK_APP=app.py flask db upgrade` | `cd src/api` |
 | Check code quality | `lefthook run pre-commit --all-files` | Root directory |
@@ -370,6 +371,8 @@ src/api/tests/
 
 - `backend-tests.yml`: runs backend tests for `src/api/**` changes and on
   direct pushes to `main`.
+- `frontend-tests.yml`: runs Cook Web Jest tests for frontend and shared i18n
+  changes while reporting a successful no-op check for unrelated PRs.
 - `prettier-check.yml`: checks Cook Web formatting for frontend changes.
 - `repo-harness.yml`: the `Static Checks` job validates architecture
   boundaries, generated AI and knowledge artifacts, translation parity and

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -18,6 +18,7 @@
     "format:check:changed": "node scripts/prettier-check-changed.mjs",
     "precommit": "lint-staged",
     "test": "jest",
+    "test:ci": "jest --ci --silent --maxWorkers=50%",
     "test:e2e": "npx @playwright/test test",
     "test:e2e:headed": "npx @playwright/test test --headed",
     "test:watch": "jest --watch",

--- a/src/cook-web/src/app/login/page.test.tsx
+++ b/src/cook-web/src/app/login/page.test.tsx
@@ -4,6 +4,9 @@ import AuthPage from './page';
 
 const replaceMock = jest.fn();
 const logoutMock = jest.fn(() => Promise.resolve());
+const mockSearchParams = {
+  get: jest.fn(() => null),
+};
 
 const mockUserState = {
   userInfo: null as { language?: string } | null,
@@ -16,9 +19,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: replaceMock,
   }),
-  useSearchParams: () => ({
-    get: jest.fn(() => null),
-  }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 jest.mock('next/image', () => ({

--- a/src/cook-web/src/c-api/mockRunStreamFixture.test.ts
+++ b/src/cook-web/src/c-api/mockRunStreamFixture.test.ts
@@ -4,7 +4,7 @@ import {
 } from './mockRunStreamFixture';
 
 const setPageSearch = (search: string) => {
-  window.history.pushState({}, '', `/${search}`);
+  window.location.search = search;
 };
 
 describe('mock run stream fixture mode', () => {

--- a/src/cook-web/src/components/lesson-preview/previewTypewriterGate.test.ts
+++ b/src/cook-web/src/components/lesson-preview/previewTypewriterGate.test.ts
@@ -1,5 +1,4 @@
 import { ChatContentItemType, type ChatContentItem } from '@/c-types/chatUi';
-import { LIKE_STATUS } from '@/c-api/studyV2';
 import {
   buildVisiblePreviewItems,
   shouldEnablePreviewTypewriter,
@@ -30,7 +29,6 @@ describe('previewTypewriterGate', () => {
         generated_block_bid: 'text-1-feedback',
         parent_element_bid: 'text-1',
         parent_block_bid: 'text-1',
-        like_status: LIKE_STATUS.NONE,
         type: ChatContentItemType.LIKE_STATUS,
       },
       buildContentItem({
@@ -83,7 +81,6 @@ describe('previewTypewriterGate', () => {
         generated_block_bid: 'html-1-feedback',
         parent_element_bid: 'html-1',
         parent_block_bid: 'html-1',
-        like_status: LIKE_STATUS.NONE,
         type: ChatContentItemType.LIKE_STATUS,
       },
       buildContentItem({

--- a/src/cook-web/src/store/userProvider.test.tsx
+++ b/src/cook-web/src/store/userProvider.test.tsx
@@ -33,7 +33,7 @@ jest.mock('@/c-store', () => ({
     selector(mockSystemState),
 }));
 
-jest.mock('@/store', () => ({
+jest.mock('@/store/useUserStore', () => ({
   __esModule: true,
   useUserStore: (selector: (state: typeof mockUserState) => unknown) =>
     selector(mockUserState),


### PR DESCRIPTION
## Summary
- add a dedicated Frontend Tests workflow that runs Jest for Cook Web and shared i18n changes
- keep the required check present on unrelated PRs through a lightweight no-op path
- stabilize four existing Jest suites so the full suite passes and exits normally
- document the CI test command and workflow

## Verification
- 162 Jest suites / 1295 tests passed on Node 22.16.0
- npm run type-check
- npm run lint (existing warnings only)
- python3 scripts/check_repo_harness.py
- python3 scripts/check_architecture_boundaries.py
- lefthook run pre-commit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->